### PR TITLE
Strip meta tags from pasted links in Chromium

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -91,6 +91,8 @@ export function usePasteHandler( props ) {
 			// Remove Windows-specific metadata appended within copied HTML text.
 			html = removeWindowsFragments( html );
 
+			html = removeCharsetMetaTag( html );
+
 			event.preventDefault();
 
 			// Allows us to ask for this information when we get a report.
@@ -256,4 +258,17 @@ function removeWindowsFragments( html ) {
 	const endReg = /<!--EndFragment-->.*/s;
 
 	return html.replace( startReg, '' ).replace( endReg, '' );
+}
+
+/**
+ * Removes the charset meta tag inserted by Google Chrome.
+ * See:
+ * - https://github.com/WordPress/gutenberg/issues/33585
+ * - https://bugs.chromium.org/p/chromium/issues/detail?id=1264616#c4
+ *
+ * @param {string} html the html to be stripped of the meta tag.
+ * @return {string} the cleaned html
+ */
+function removeCharsetMetaTag( html ) {
+	return html.replace( /^<meta charset=["']utf-8["']>/, '' );
 }

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -271,5 +271,11 @@ function removeWindowsFragments( html ) {
  * @return {string} the cleaned html
  */
 function removeCharsetMetaTag( html ) {
-	return html.replace( /^<meta charset=["']utf-8["']>/, '' );
+	const metaTag = `<meta charset='utf-8'>`;
+
+	if ( html.startsWith( metaTag ) ) {
+		return html.slice( metaTag.length );
+	}
+
+	return html;
 }

--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -91,6 +91,7 @@ export function usePasteHandler( props ) {
 			// Remove Windows-specific metadata appended within copied HTML text.
 			html = removeWindowsFragments( html );
 
+			// Strip meta tag.
 			html = removeCharsetMetaTag( html );
 
 			event.preventDefault();
@@ -261,7 +262,7 @@ function removeWindowsFragments( html ) {
 }
 
 /**
- * Removes the charset meta tag inserted by Google Chrome.
+ * Removes the charset meta tag inserted by Chromium.
  * See:
  * - https://github.com/WordPress/gutenberg/issues/33585
  * - https://bugs.chromium.org/p/chromium/issues/detail?id=1264616#c4


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/33585 we learnt that Chromium appends a meta tag to the start of pasted HTML. This means when you copy and paste a link (even one you created within Gutenberg) the underlying post's HTML contains a meta tag.

This PR fixes that by stripping out that meta tag but only if it's at the very beginning of the pasted string. 

Edge case - this will of course mean that if someone is trying to paste a string with that exact meta tag then it will be impossible, but I'm not sure we can work around that one and it is very much an edge case.

## How has this been tested?

* Create post
* Create paragraph block.
* Create a link in that block.
* Copy the link. 
* Paste it into the same block (or another block if you like).
* Inspect the underlying HTML in code view. 
* See there is no meta tag.

Contrast that with `trunk` where the bug is still manifesting itself.

Fixes https://github.com/WordPress/gutenberg/issues/33585



## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/140979534-1a1377e3-4af1-4697-a525-c849592b42c8.mp4


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
