### PR TITLE
Navigation: Hide post attributes meta box

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -57,6 +57,14 @@ function gutenberg_register_navigation_post_type() {
 add_action( 'init', 'gutenberg_register_navigation_post_type' );
 
 /**
+ * Disable "Post Attributes" for wp_navigation post type.
+ *
+ * The attributes are also conditionally enabled when a site has custom templates,
+ * which is usually valid for block themes.
+ */
+add_filter( 'theme_wp_navigation_templates', '__return_empty_array' );
+
+/**
  * Disable block editor for wp_navigation type posts so they can be managed via the UI.
  *
  * @param bool   $value Whether the CPT supports block editor or not.

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -59,8 +59,8 @@ add_action( 'init', 'gutenberg_register_navigation_post_type' );
 /**
  * Disable "Post Attributes" for wp_navigation post type.
  *
- * The attributes are also conditionally enabled when a site has custom templates,
- * which is usually valid for block themes.
+ * The attributes are also conditionally enabled when a site has custom templates.
+ * Block Theme templates can be available for every post type.
  */
 add_filter( 'theme_wp_navigation_templates', '__return_empty_array' );
 


### PR DESCRIPTION
## Description
Disables "Post Attributes" for wp_navigation post type.

The attributes are also conditionally enabled when a site has custom templates. Block Theme templates can be available for every post type.

You can find the condition here: https://github.com/WordPress/wordpress-develop/blob/f22abe76100ed3647392e5b58a926e7e081d7736/src/wp-admin/includes/meta-boxes.php#L1504-L1506

Fixes #36308

## How has this been tested?
1. Go to Appearance > Navigation Menus
2. The "Post Attributes" metabox shouldn't be visible.

## Screenshots <!-- if applicable -->

![CleanShot 2021-11-09 at 22 12 28](https://user-images.githubusercontent.com/240569/140980785-93092dcf-4be5-4830-a72f-28ea6253ffd2.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
