### PR TITLE
Hide visilibility and status for navigation posts

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -399,7 +399,8 @@ function gutenberg_parse_blocks_from_menu_items( $menu_items, $menu_items_by_par
  * @param string $hook The current admin page.
  */
 function gutenberg_hide_visibility_and_status_for_navigation_posts( $hook ) {
-	if ( 'post.php' !== $hook ) {
+	$allowed_hooks = array( 'post.php', 'post-new.php' );
+	if ( ! in_array( $hook, $allowed_hooks, true ) ) {
 		return;
 	}
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -386,3 +386,35 @@ function gutenberg_parse_blocks_from_menu_items( $menu_items, $menu_items_by_par
 
 	return $blocks;
 }
+
+/**
+ * Shim that hides ability to edit visibility and status for wp_navigation type posts.
+ * When merged to Core, the CSS below should be moved to wp-admin/css/edit.css.
+ *
+ * This shim can be removed when the Gutenberg plugin requires a WordPress
+ * version that has the ticket below.
+ *
+ * @see https://core.trac.wordpress.org/ticket/54407
+ *
+ * @param string $hook The current admin page.
+ */
+function gutenberg_hide_visibility_and_status_for_navigation_posts( $hook ) {
+	if ( 'post.php' !== $hook ) {
+		return;
+	}
+
+	/**
+	 * HACK: We're hiding the description field using CSS because this
+	 * cannot be done using a filter or an action.
+	 */
+
+	$css = <<<CSS
+			body.post-type-wp_navigation div#minor-publishing {
+				display: none;
+			}
+CSS;
+
+	wp_add_inline_style( 'common', $css );
+}
+
+add_action( 'admin_enqueue_scripts', 'gutenberg_hide_visibility_and_status_for_navigation_posts' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Visiblity and status fields are not appropriate for navigation posts.
We should hide them.
Fixes https://github.com/WordPress/gutenberg/issues/36309.

## How has this been tested?
1. Enable a theme that supports full-site-editing (tested with tt1 blocks theme).
2. Go to `Appearance -> Navigation Menus`. Create a new menu.
3. Make sure you don't see visibility,  status, published on and revisions options.
4. Try to edit your newly created navigation menu.
3. Make sure you don't see visibility,  status, published on and revisions options.
6. Make sure you are able to edit visibility,  status, published on and revisions for non-navigation posts.

## Types of changes
Bug fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Screenshots:
![Screenshot 2021-11-09 at 23 53 36](https://user-images.githubusercontent.com/43744263/141018532-441ba7e6-314b-424a-872f-696a18877802.png)
![Screenshot 2021-11-09 at 23 53 15](https://user-images.githubusercontent.com/43744263/141018540-92757d38-99e9-4b21-b83e-2137b003732b.png)



## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
