### PR TITLE
Typography Panel: Make letter spacing jsDoc and prop use consistent 

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -15,10 +15,10 @@ import useSetting from '../../components/use-setting';
 /**
  * Control for letter-spacing.
  *
- * @param {Object}             props                      Component props.
- * @param {string}             props.value                Currently selected letter-spacing.
- * @param {Function}           props.onChange             Handles change in letter-spacing selection.
- * @param {string|number|null} props.__unstableInputWidth Input width to pass through to inner UnitControl.
+ * @param {Object}                  props                      Component props.
+ * @param {string}                  props.value                Currently selected letter-spacing.
+ * @param {Function}                props.onChange             Handles change in letter-spacing selection.
+ * @param {string|number|undefined} props.__unstableInputWidth Input width to pass through to inner UnitControl. Should be a valid CSS value.
  *
  * @return {WPElement} Letter-spacing control.
  */

--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -15,12 +15,12 @@ import useSetting from '../../components/use-setting';
 /**
  * Control for letter-spacing.
  *
- * @param {Object}   props                      Component props.
- * @param {string}   props.value                Currently selected letter-spacing.
- * @param {Function} props.onChange             Handles change in letter-spacing selection.
- * @param {boolean}  props.__unstableInputWidth Input width to pass through to inner UnitControl.
+ * @param {Object}             props                      Component props.
+ * @param {string}             props.value                Currently selected letter-spacing.
+ * @param {Function}           props.onChange             Handles change in letter-spacing selection.
+ * @param {string|number|null} props.__unstableInputWidth Input width to pass through to inner UnitControl.
  *
- * @return {WPElement}                          Letter-spacing control.
+ * @return {WPElement} Letter-spacing control.
  */
 export default function LetterSpacingControl( {
 	value,

--- a/packages/block-editor/src/hooks/letter-spacing.js
+++ b/packages/block-editor/src/hooks/letter-spacing.js
@@ -45,7 +45,7 @@ export function LetterSpacingEdit( props ) {
 		<LetterSpacingControl
 			value={ style?.typography?.letterSpacing }
 			onChange={ onChange }
-			__unstableInputWidth={ null }
+			__unstableInputWidth={ '100%' }
 		/>
 	);
 }

--- a/packages/block-editor/src/hooks/letter-spacing.js
+++ b/packages/block-editor/src/hooks/letter-spacing.js
@@ -45,7 +45,7 @@ export function LetterSpacingEdit( props ) {
 		<LetterSpacingControl
 			value={ style?.typography?.letterSpacing }
 			onChange={ onChange }
-			__unstableInputWidth={ false }
+			__unstableInputWidth={ null }
 		/>
 	);
 }


### PR DESCRIPTION
## Description

This PR addresses concerns raised in https://github.com/WordPress/gutenberg/pull/35911#pullrequestreview-801594292 where the default `__unstableWidth` value for the letter spacing control is overridden so that `100%` width can be restored when in the context of the Typography `ToolsPanel`.

## How has this been tested?

- Confirmed that the Letter Spacing control in the block editor's typography panel remains `100%` width
- Confirmed that the Letter Spacing control in the site editor's global styles panel keeps the default `60px` width
- Tested in storybook as well
- Tested with the Site Title block

## Screenshots <!-- if applicable -->

| Block Editor | Site Editor |
|---|---|
| <img width="282" alt="Screen Shot 2021-11-10 at 12 58 22 pm" src="https://user-images.githubusercontent.com/60436221/141041526-a5183622-e59f-49d7-a991-b7f3490d62ca.png"> | <img width="283" alt="Screen Shot 2021-11-10 at 12 58 29 pm" src="https://user-images.githubusercontent.com/60436221/141041545-78225472-7f80-4218-a623-47d861ffbe1c.png"> |


## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
