### PR TITLE
Move WP_REST_Block_Navigation_Areas_Controller from Gutenberg to Core.

### DIFF
--- a/lib/class-wp-rest-block-navigation-areas-controller.php
+++ b/lib/class-wp-rest-block-navigation-areas-controller.php
@@ -37,7 +37,8 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_collection_params(),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'schema'      => array( $this, 'get_public_item_schema' ),
+				'allow_batch' => array( 'v1' => true ),
 			)
 		);
 

--- a/lib/class-wp-rest-block-navigation-areas-controller.php
+++ b/lib/class-wp-rest-block-navigation-areas-controller.php
@@ -17,7 +17,7 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-navigation-areas';
 	}
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -190,7 +190,7 @@ function gutenberg_get_navigation_areas_paths_to_preload() {
 	$areas        = get_option( 'fse_navigation_areas', array() );
 	$active_areas = array_intersect_key( $areas, gutenberg_get_navigation_areas() );
 	$paths        = array(
-		'/__experimental/block-navigation-areas?context=edit',
+		'/wp/v2/block-navigation-areas?context=edit',
 	);
 	foreach ( $active_areas as $post_id ) {
 		if ( 0 !== $post_id ) {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -130,7 +130,7 @@ export const defaultEntities = [
 	{
 		name: 'navigationArea',
 		kind: 'root',
-		baseURL: '/__experimental/block-navigation-areas',
+		baseURL: '/wp/v2/block-navigation-areas',
 		baseURLParams: { context: 'edit' },
 		plural: 'navigationAreas',
 		label: __( 'Navigation Area' ),

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -120,7 +120,7 @@ describe( 'saveEditedEntityRecord', () => {
 			{
 				kind: 'root',
 				name: 'navigationArea',
-				baseURL: '/__experimental/block-navigation-areas',
+				baseURL: '/wp/v2/block-navigation-areas',
 			},
 		];
 		const select = {
@@ -160,7 +160,7 @@ describe( 'saveEditedEntityRecord', () => {
 			{
 				kind: 'root',
 				name: 'navigationArea',
-				baseURL: '/__experimental/block-navigation-areas',
+				baseURL: '/wp/v2/block-navigation-areas',
 				key: 'area',
 			},
 		];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR aims to change the route of the `__experimental/block-navigation-areas` REST API endpoint.
It has to be renamed to `/wp/v2/block-navigation-areas` because we have to merge the `WP_REST_Block_Navigation_Areas_Controller` controller into Core.
Also, this PR enables batching for this new (old) REST route.

## How has this been tested?
1. Go to `Gutenberg -> Experiments` and enable `Navigation Screen`.
2. Go to `Gutenberg -> Navigation` page.
3. Open the console in your browser, and execute the following code:
```js
wp.apiFetch( { path: '/wp/v2/block-navigation-areas' } ).then( ( posts ) => {
    console.log( posts );
} );
```
4. You should see a valid response in the console (HTTP status 200).

## Screenshots <!-- if applicable -->
No screenshots are needed.

## Types of changes
New feature
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
