### PR TITLE
Navigation: Refactor and simplify setup state.

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -40,7 +40,7 @@ const ExistingMenusDropdown = ( {
 	};
 	return (
 		<DropdownMenu
-			text={ __( 'Existing menu' ) }
+			text={ __( 'Select menu' ) }
 			icon={ null }
 			toggleProps={ toggleProps }
 			popoverProps={ { isAlternate: true } }

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -13,7 +13,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { navigation, chevronDown, Icon } from '@wordpress/icons';
+import { navigation, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -34,13 +34,14 @@ const ExistingMenusDropdown = ( {
 	onCreateFromMenu,
 } ) => {
 	const toggleProps = {
-		variant: 'primary',
+		variant: 'tertiary',
+		iconPosition: 'right',
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 	return (
 		<DropdownMenu
-			text={ __( 'Select existing menu' ) }
-			icon={ chevronDown }
+			text={ __( 'Existing menu' ) }
+			icon={ null }
 			toggleProps={ toggleProps }
 			popoverProps={ { isAlternate: true } }
 		>
@@ -201,32 +202,35 @@ export default function NavigationPlaceholder( {
 								<Icon icon={ navigation } />{ ' ' }
 								{ __( 'Navigation' ) }
 							</div>
+							<hr />
 							{ hasMenus || navigationMenus.length ? (
-								<ExistingMenusDropdown
-									canSwitchNavigationMenu={
-										canSwitchNavigationMenu
-									}
-									navigationMenus={ navigationMenus }
-									setSelectedMenu={ setSelectedMenu }
-									onFinish={ onFinish }
-									menus={ menus }
-									onCreateFromMenu={ onCreateFromMenu }
-								/>
+								<>
+									<ExistingMenusDropdown
+										canSwitchNavigationMenu={
+											canSwitchNavigationMenu
+										}
+										navigationMenus={ navigationMenus }
+										setSelectedMenu={ setSelectedMenu }
+										onFinish={ onFinish }
+										menus={ menus }
+										onCreateFromMenu={ onCreateFromMenu }
+									/>
+									<hr />
+								</>
 							) : undefined }
 							{ hasPages ? (
-								<Button
-									variant={
-										hasMenus || canSwitchNavigationMenu
-											? 'tertiary'
-											: 'primary'
-									}
-									onClick={ () => {
-										setIsNewMenuModalVisible( true );
-										setCreateEmpty( false );
-									} }
-								>
-									{ __( 'Add all pages' ) }
-								</Button>
+								<>
+									<Button
+										variant="tertiary"
+										onClick={ () => {
+											setIsNewMenuModalVisible( true );
+											setCreateEmpty( false );
+										} }
+									>
+										{ __( 'Add all pages' ) }
+									</Button>
+									<hr />
+								</>
 							) : undefined }
 							<Button
 								variant="tertiary"

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -324,6 +324,11 @@ $color-control-label-height: 20px;
 		.wp-block-navigation-placeholder__actions {
 			flex-direction: column;
 		}
+
+		// Hide the separators in the vertical version.
+		.wp-block-navigation-placeholder__actions hr {
+			display: none;
+		}
 	}
 
 	.wp-block-navigation-placeholder__icon {
@@ -333,23 +338,18 @@ $color-control-label-height: 20px;
 
 	// Block title
 	.wp-block-navigation-placeholder__actions__indicator {
-		margin-right: $grid-unit-15;
-		padding: 0;
+		display: flex;
+		padding: 0 ($grid-unit-15 * 0.5) 0 0;
 		align-items: center;
 		justify-content: flex-start;
 		line-height: 0;
+		min-height: $button-size;
 
 		// Line up with the icon in the toolbar.
-		margin-left: $grid-unit-05 + $border-width;
+		margin-left: $grid-unit-05;
 
 		svg {
 			margin-right: $grid-unit-05;
-		}
-
-		// Show only in big placeholders.
-		display: none;
-		.is-large & {
-			display: inline-flex;
 		}
 	}
 }
@@ -358,21 +358,24 @@ $color-control-label-height: 20px;
 	display: flex;
 	font-size: $default-font-size;
 	font-family: $default-font;
-
-	.components-button.components-dropdown-menu__toggle.has-icon {
-		padding:
-			( $grid-unit-15 * 0.5 ) $grid-unit-05 ( $grid-unit-15 * 0.5 )
-			$grid-unit-15;
-		display: flex;
-		flex-direction: row-reverse; // This puts the chevron, which is hidden from screen readers, on the right.
-	}
+	gap: $grid-unit-15 * 0.5;
 
 	// Margins.
 	.components-dropdown,
 	> .components-button {
-		margin-right: $grid-unit-15;
+		margin-right: 0;
+	}
+
+	// Separator.
+	height: 100%; // This allows the separator to scale vertically.
+
+	&.wp-block-navigation-placeholder__actions hr {
+		margin: auto 0;
+		height: 100%;
+		max-height: $grid-unit-20;
 	}
 }
+
 
 /**
  * Mobile menu.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -369,7 +369,12 @@ $color-control-label-height: 20px;
 	// Separator.
 	height: 100%; // This allows the separator to scale vertically.
 
+	// Separator.
 	&.wp-block-navigation-placeholder__actions hr {
+		border: 0;
+		min-height: $border-width;
+		min-width: $border-width;
+		background-color: $gray-900;
 		margin: auto 0;
 		height: 100%;
 		max-height: $grid-unit-20;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -30,6 +30,14 @@
 	.components-base-control__label {
 		font-size: $default-font-size;
 	}
+
+	// Separator.
+	hr {
+		border: 0;
+		min-height: $border-width;
+		min-width: $border-width;
+		background-color: $gray-900;
+	}
 }
 
 .components-placeholder__error,

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -30,14 +30,6 @@
 	.components-base-control__label {
 		font-size: $default-font-size;
 	}
-
-	// Separator.
-	hr {
-		border: 0;
-		min-height: $border-width;
-		min-width: $border-width;
-		background-color: $gray-900;
-	}
 }
 
 .components-placeholder__error,


### PR DESCRIPTION
## Description

The navigation block setup state has a lot of complexity, both technically and visually. This PR simplifies things in light of recent refactors to the flex properties of it. Before:

<img width="787" alt="before" src="https://user-images.githubusercontent.com/1204802/141143048-a54830bc-d42d-4a1a-afaa-c6f4e3aa72ac.png">

After:

<img width="681" alt="after" src="https://user-images.githubusercontent.com/1204802/141143101-20b2ff47-9c8e-4859-b977-a9536d3beca7.png">

The addition of the primary button style was in hopes of making it clearer items inside were clickable. In effect it has primarily worked to add complexity and noise. This PR attempts at segmenting the controls inside to aid readibility, with a simpler separated design. 

This PR also starts work on the vertical version, which at the moment is only seen in narrow contexts:

<img width="692" alt="after-vertical" src="https://user-images.githubusercontent.com/1204802/141143374-4df2c871-9402-44b7-be17-fbb2bff6bfb2.png">

More work is needed here, including removing the old `is-vertical` classes, but I omitted that to keep the PR small. Theoretically though, it should be possible to inherit the orientation even in the placeholder, so that's something to look at in the followup.

Another step on the journey could be to get rid of the gray placeholders blobs:

- They have consistently been mistaken for loading states in user tests.
- With the possibility and proliferation of navigaiton block patterns, seeing the empty Navigation block should become a more rare occurrence, and in most cases (as demonstrated by TwentyTwentyTwo patterns) come pre-configured either with the Page List block, or empty navigation items to be wired up.

Finally the blobs are a great deal of CSS complexity that falls apart in a few ways in the layout, and are causing layout shifts, for example as shown here:

![gif](https://user-images.githubusercontent.com/1204802/141144306-07c30d8b-8b1d-4ff5-9d39-f64188cc1848.gif)

So I'll explore that separately, but this is a first step on the path.

## How has this been tested?

Insert a navigation block and select it. Try it also in a narrow viewport, or inside a thin column.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
