### PR TITLE
ToolsPanel: Standardize input control label margin

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   Fixed spacing between `BaseControl` fields and help text within the `ToolsPanel` ([#36334](https://github.com/WordPress/gutenberg/pull/36334))
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 -   Fixed empty `ToolsPanel` height by correcting menu button line-height ([#36895](https://github.com/WordPress/gutenberg/pull/36895)).
+-   Normalized label line-height and spacing within the `ToolsPanel` ([36387](https://github.com/WordPress/gutenberg/pull/36387))
 
 ### Enhancements
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -136,6 +136,14 @@ export const ToolsPanelItem = css`
 		}
 	}
 
+	/**
+	 * The targeting of .components-custom-select-control__label here is a
+	 * temporary measure only.
+	 *
+	 * It should be replaced once CustomSelectControl component has been
+	 * refactored and can be targeted via component interpolation.
+	 */
+	.components-custom-select-control__label,
 	${ BaseControlLabel } {
 		line-height: 1.4em;
 	}

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -9,6 +9,7 @@ import { css } from '@emotion/react';
 import {
 	StyledField as BaseControlField,
 	StyledHelp as BaseControlHelp,
+	StyledLabel as BaseControlLabel,
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
 import { LabelWrapper } from '../input-control/styles/input-control-styles';
@@ -121,7 +122,8 @@ export const ToolsPanelItem = css`
 	}
 
 	/**
-	 * Standardize InputControl labels with other labels inside ToolsPanel.
+	 * Standardize InputControl and BaseControl labels with other labels when
+	 * inside ToolsPanel.
 	 *
 	 * This is a temporary fix until the different control components have their
 	 * labels normalized.
@@ -132,6 +134,10 @@ export const ToolsPanelItem = css`
 			padding-bottom: 0;
 			line-height: 1.4em;
 		}
+	}
+
+	${ BaseControlLabel } {
+		line-height: 1.4em;
 	}
 `;
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -11,6 +11,7 @@ import {
 	StyledHelp as BaseControlHelp,
 	Wrapper as BaseControlWrapper,
 } from '../base-control/styles/base-control-styles';
+import { LabelWrapper } from '../input-control/styles/input-control-styles';
 import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 
@@ -117,6 +118,20 @@ export const ToolsPanelItem = css`
 
 	${ BaseControlHelp } {
 		margin-bottom: 0;
+	}
+
+	/**
+	 * Standardize InputControl labels with other labels inside ToolsPanel.
+	 *
+	 * This is a temporary fix until the different control components have their
+	 * labels normalized.
+	 */
+	&& ${ LabelWrapper } {
+		label {
+			margin-bottom: ${ space( 2 ) };
+			padding-bottom: 0;
+			line-height: 1.4em;
+		}
 	}
 `;
 


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/36334

## Description

This PR standardizes the line-height and margin of `InputControl` labels within the `ToolsPanel` to improve consistency.

See: https://github.com/WordPress/gutenberg/pull/36334#issuecomment-965806487

## How has this been tested?

1. Open editor and add text to a paragraph
2. With paragraph block selected, toggle on display of both line height and letter spacing controls from the typography panel
3. Ensure the labels and spacing looks consistent

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| <img width="278" alt="Screen Shot 2021-11-11 at 11 39 16 am" src="https://user-images.githubusercontent.com/60436221/141223497-daf100e1-3fd2-4526-bec5-c55a1bfdccb6.png"> | <img width="281" alt="Screen Shot 2021-11-11 at 11 38 55 am" src="https://user-images.githubusercontent.com/60436221/141223519-6c249873-c099-43dc-b38b-d03f37601d9f.png"> |

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
