### PR TITLE
Gallery block: Fix issue with columns and link destination not copying across when gallery updated to v2 format

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -144,7 +144,7 @@ function GalleryEdit( props ) {
 	useEffect( () => {
 		newImages?.forEach( ( newImage ) => {
 			updateBlockAttributes( newImage.clientId, {
-				...buildImageAttributes( false, newImage.attributes ),
+				...buildImageAttributes( newImage.attributes ),
 				id: newImage.id,
 				align: undefined,
 			} );
@@ -176,26 +176,24 @@ function GalleryEdit( props ) {
 	 * it already existed in the gallery. If the image is in fact new, we need
 	 * to apply the gallery's current settings to the image.
 	 *
-	 * @param {Object} existingBlock Existing Image block that still exists after gallery update.
-	 * @param {Object} image         Media object for the actual image.
-	 * @return {Object}               Attributes to set on the new image block.
+	 * @param {Object} imageAttributes Media object for the actual image.
+	 * @return {Object}                Attributes to set on the new image block.
 	 */
-	function buildImageAttributes( existingBlock, image ) {
-		if ( existingBlock ) {
-			return existingBlock.attributes;
-		}
+	function buildImageAttributes( imageAttributes ) {
+		const image = imageAttributes.id
+			? find( imageData, { id: imageAttributes.id } )
+			: null;
 
 		let newClassName;
-		if ( image.className && image.className !== '' ) {
-			newClassName = image.className;
+		if ( imageAttributes.className && imageAttributes.className !== '' ) {
+			newClassName = imageAttributes.className;
 		} else {
 			newClassName = preferredStyle
 				? `is-style-${ preferredStyle }`
 				: undefined;
 		}
-
 		return {
-			...pickRelevantMediaFiles( image, sizeSlug ),
+			...pickRelevantMediaFiles( imageAttributes, sizeSlug ),
 			...getHrefAndDestination( image, linkTo ),
 			...getUpdatedLinkTargetSettings( linkTarget, attributes ),
 			className: newClassName,

--- a/packages/block-library/src/gallery/v1/update-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/update-gallery-modal.js
@@ -14,7 +14,7 @@ import {
 	LINK_DESTINATION_ATTACHMENT,
 	LINK_DESTINATION_NONE,
 	LINK_DESTINATION_MEDIA,
-} from './constants';
+} from '../constants';
 
 export const updateGallery = ( {
 	clientId,
@@ -23,7 +23,7 @@ export const updateGallery = ( {
 } ) => () => {
 	let link;
 	const {
-		attributes: { sizeSlug, linkTo, images, caption },
+		attributes: { sizeSlug, linkTo, images, caption, columns },
 	} = getBlock( clientId );
 
 	switch ( linkTo ) {
@@ -51,7 +51,7 @@ export const updateGallery = ( {
 		clientId,
 		createBlock(
 			'core/gallery',
-			{ sizeSlug, linkTo: link, caption },
+			{ sizeSlug, linkTo: link, caption, columns },
 			innerBlocks
 		)
 	);


### PR DESCRIPTION
## Description
If a v1 Gallery block is migrated using the `Update` button the `columns` and `linkDestination` attributes are not being copied across to the new galler

## How has this been tested?

- Add a v1 Gallery block to a site ( set `wp option set use_balanceTags 1` )
- Set the Gallery link to option to Media or Attachment and set columns to 4 or 5
- Reload the Gallery block with `use_balanceTags` switched back off
- Use the `Update` button in the block toolbar to update the Gallery to v2 format
- Check that columns and link destinations copy across as expected 

## Screenshots
Before:
![update-before](https://user-images.githubusercontent.com/3629020/141224346-9f2f3bb4-3471-487e-812f-0ef9f0571034.gif)

After:
![update-after](https://user-images.githubusercontent.com/3629020/141224381-2c9c97c9-4f95-46ad-a3d9-ad973211f33a.gif)


