### PR TITLE
Fix site editor reset styles in WP 5.9

### DIFF
--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -20,7 +20,8 @@ html.wp-toolbar {
 	background: $white;
 }
 
-body.appearance_page_gutenberg-edit-site {
+body.appearance_page_gutenberg-edit-site,
+body.site-editor-php {
 	@include wp-admin-reset(".edit-site");
 }
 


### PR DESCRIPTION
## Description

In Core the site editor's body class is `.site-editor-php`, not `.appearance_page_gutenberg-edit-site`.  This causes the WP Admin footer to erroneously appear.

<img width="1120" alt="Screen Shot 2021-11-11 at 15 39 39" src="https://user-images.githubusercontent.com/612155/141238177-b1e35b8f-01ec-46fe-8856-76733b51a733.png">

## How has this been tested?
1. Install and activate the Gutenberg plugin on latest Core trunk.
2. Browse to `wp-admin/site-editor.php`.
3. You shouldn't be able to see the WP Admin footer at the bottom of the page

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->