### PR TITLE
Stabilise block-navigation-areas endpoint

### DIFF
--- a/lib/class-wp-rest-block-navigation-areas-controller.php
+++ b/lib/class-wp-rest-block-navigation-areas-controller.php
@@ -17,7 +17,7 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-navigation-areas';
 	}
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -182,7 +182,7 @@ function gutenberg_get_navigation_areas_paths_to_preload() {
 	$areas        = get_option( 'fse_navigation_areas', array() );
 	$active_areas = array_intersect_key( $areas, gutenberg_get_navigation_areas() );
 	$paths        = array(
-		'/__experimental/block-navigation-areas?context=edit',
+		'/wp/v2/block-navigation-areas?context=edit',
 	);
 	foreach ( $active_areas as $post_id ) {
 		if ( 0 !== $post_id ) {

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -130,7 +130,7 @@ export const defaultEntities = [
 	{
 		name: 'navigationArea',
 		kind: 'root',
-		baseURL: '/__experimental/block-navigation-areas',
+		baseURL: '/wp/v2/block-navigation-areas',
 		baseURLParams: { context: 'edit' },
 		plural: 'navigationAreas',
 		label: __( 'Navigation Area' ),

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -120,7 +120,7 @@ describe( 'saveEditedEntityRecord', () => {
 			{
 				kind: 'root',
 				name: 'navigationArea',
-				baseURL: '/__experimental/block-navigation-areas',
+				baseURL: '/wp/v2/block-navigation-areas',
 			},
 		];
 		const select = {
@@ -160,7 +160,7 @@ describe( 'saveEditedEntityRecord', () => {
 			{
 				kind: 'root',
 				name: 'navigationArea',
-				baseURL: '/__experimental/block-navigation-areas',
+				baseURL: '/wp/v2/block-navigation-areas',
 				key: 'area',
 			},
 		];


### PR DESCRIPTION
## Description

Renames `__experimental/block-navigation-areas` to `/wp/v2/block-navigation-areas`. This [aligns with how the endpoint is named in Core](https://core.trac.wordpress.org/changeset/52133) and means we won't get 404 errors while running the plugin against the latest Core trunk.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->