### PR TITLE
Fix image size output for post-featured-image block

### DIFF
--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,7 +19,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$featured_image = get_the_post_thumbnail( $post_ID );
+	$featured_image = get_the_post_thumbnail( $post_ID, 'thumbnail' );
 	if ( ! $featured_image ) {
 		return '';
 	}


### PR DESCRIPTION
Ensures that the “real” post thumbnail image size is used. 

## Description
The workflow of core function `get_the_post_thumbnail` is flawed and returns the full-sized image instead of the thumbnail-sized image. This change explicitly specifies the correct post thumbnail image size, to avoid the error documented at https://core.trac.wordpress.org/ticket/17262. 

## How has this been tested?
Comparison of the block output using a standard full-site-editing theme.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. 
- [ ] I've tested my changes with keyboard and screen readers.
- [ ] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate.
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).