### PR TITLE
Nav block menu switcher - decode HTML entities and utilise accessible markup pattern

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -3,7 +3,8 @@
  */
 import { MenuGroup, MenuItem, MenuItemsChoice } from '@wordpress/components';
 import { useEntityId } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -26,10 +27,18 @@ export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
 							)
 						)
 					}
-					choices={ navigationMenus.map( ( { id, title } ) => ( {
-						value: id,
-						label: title.rendered,
-					} ) ) }
+					choices={ navigationMenus.map( ( { id, title } ) => {
+						const label = decodeEntities( title.rendered );
+						return {
+							value: id,
+							label,
+							'aria-label': sprintf(
+								/* translators: %s: The name of a menu. */
+								__( "Switch to '%s'" ),
+								label
+							),
+						};
+					} ) }
 				/>
 			</MenuGroup>
 			<MenuGroup>

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -14,6 +14,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { navigation, Icon } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -59,7 +60,9 @@ const ExistingMenusDropdown = ( {
 										onClose={ onClose }
 										key={ menu.id }
 									>
-										{ menu.title.rendered }
+										{ decodeEntities(
+											menu.title.rendered
+										) }
 									</MenuItem>
 								);
 							} ) }
@@ -75,7 +78,7 @@ const ExistingMenusDropdown = ( {
 									onClose={ onClose }
 									key={ menu.id }
 								>
-									{ menu.name }
+									{ decodeEntities( menu.name ) }
 								</MenuItem>
 							);
 						} ) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Currently when you click `Select Menu` on a Nav block the menu names are not decoded in multiple places which means you may see entities in the rendered output.

This PR decodes the title and also applies a more accessible markup pattern.

<img width="545" alt="Screen Shot 2021-11-11 at 09 47 04" src="https://user-images.githubusercontent.com/444434/141278101-c65e1be5-2b5e-4ed4-82c0-0e921d7148e0.png">

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Create some Menus that contain entities (e.g. `Dave's & Entity Menu`).
* Add Nav block.
* Click `Select Menu` within the _placeholder_.
* See that all entities are correctly decoded.
* Select one of the Menus.
* Now click on the `Select Menu` on _block toolbar._
* See that all entities are correctly decoded here also.
* Compare to `trunk` where this doesn't happen and you can see entities.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
