### PR TITLE
Replace get_theme_file_path in theme_has_support

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -347,8 +347,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	public static function theme_has_support() {
 		if ( ! isset( self::$theme_has_support ) ) {
 			self::$theme_has_support = (
-				is_readable( get_stylesheet_directory() . '/theme.json' ) ||
-				is_readable( get_template_directory() . '/theme.json' )
+				is_readable( self::get_file_path_from_theme( 'theme.json' ) ) ||
+				is_readable( self::get_file_path_from_theme( 'theme.json', true ) )
 			);
 		}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -346,7 +346,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 */
 	public static function theme_has_support() {
 		if ( ! isset( self::$theme_has_support ) ) {
-			self::$theme_has_support = is_readable( get_theme_file_path( 'theme.json' ) );
+			self::$theme_has_support = (
+				is_readable( get_stylesheet_directory() . '/theme.json' ) ||
+				is_readable( get_template_directory() . '/theme.json' )
+			);
 		}
 
 		return self::$theme_has_support;


### PR DESCRIPTION
## Description
PR replaces `get_theme_file_path` in `theme_has_support` with a custom logical operator that checks `theme.json` existence in parent and child themes.

We can't use `get_theme_file_path` since it causes a fatal error in `load-styles.php.` See [Core-54401](https://core.trac.wordpress.org/ticket/54401) for more details.

Alternative to #36359.

I will create the WP Core patch shortly.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
