### PR TITLE
Update resize handle styling in template part focus mode

### DIFF
--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import { VisuallyHidden } from '@wordpress/components';
+import { VisuallyHidden, Button } from '@wordpress/components';
+import { dragHandle } from '@wordpress/icons';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
 
@@ -26,7 +27,8 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 
 	return (
 		<>
-			<button
+			<Button
+				icon={ dragHandle }
 				className={ `resizable-editor__drag-handle is-${ direction }` }
 				aria-label={ __( 'Drag to resize' ) }
 				aria-describedby={ `resizable-editor__resize-help-${ direction }` }

--- a/packages/edit-site/src/components/block-editor/resize-handle.js
+++ b/packages/edit-site/src/components/block-editor/resize-handle.js
@@ -3,8 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
-import { VisuallyHidden, Button } from '@wordpress/components';
-import { dragHandle } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/components';
 
 const DELTA_DISTANCE = 20; // The distance to resize per keydown in pixels.
 
@@ -27,8 +26,7 @@ export default function ResizeHandle( { direction, resizeWidthBy } ) {
 
 	return (
 		<>
-			<Button
-				icon={ dragHandle }
+			<button
 				className={ `resizable-editor__drag-handle is-${ direction }` }
 				aria-label={ __( 'Drag to resize' ) }
 				aria-describedby={ `resizable-editor__resize-help-${ direction }` }

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -55,30 +55,26 @@
 	bottom: 0;
 	padding: 0;
 	margin: auto 0;
-	width: $grid-unit-10;
+	width: $grid-unit-05;
 	height: $height;
 	appearance: none;
-	cursor: grab;
+	cursor: ew-resize;
 	outline: none;
-	background: $gray-700;
-	border-radius: 4px;
+	background: $gray-600;
+	border-radius: 2px;
 	border: 0;
 
 	&.is-left {
-		left: #{-$grid-unit-30 - $grid-unit-05};
+		left: -$grid-unit-20;
 	}
 
 	&.is-right {
-		right: #{-$grid-unit-30 - $grid-unit-05};
+		right: -$grid-unit-20;
 	}
 
-	&:hover {
-		background: $gray-600;
-	}
-
+	&:hover,
 	&:active {
-		cursor: grabbing;
-		background: $gray-600;
+		background: $gray-400;
 	}
 
 	&:focus {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -48,35 +48,37 @@
 	margin: 0 auto;
 }
 
-.components-button.resizable-editor__drag-handle {
+.resizable-editor__drag-handle {
 	$height: 100px;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	padding: 0;
 	margin: auto 0;
+	width: $grid-unit-10;
 	height: $height;
 	appearance: none;
-	cursor: ew-resize;
+	cursor: grab;
 	outline: none;
-	background: $gray-900;
+	background: $gray-700;
+	border-radius: 4px;
 	border: 0;
-	min-width: $grid-unit-05 * 5;
-	color: $gray-600;
 
 	&.is-left {
-		left: -22px;
-		border-radius: 4px 0 0 4px;
+		left: #{-$grid-unit-30 - $grid-unit-05};
 	}
 
 	&.is-right {
-		right: -22px;
-		border-radius: 0 4px 4px 0;
+		right: #{-$grid-unit-30 - $grid-unit-05};
 	}
 
-	&:hover,
+	&:hover {
+		background: $gray-600;
+	}
+
 	&:active {
-		color: var(--wp-admin-theme-color);
+		cursor: grabbing;
+		background: $gray-600;
 	}
 
 	&:focus {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -48,37 +48,35 @@
 	margin: 0 auto;
 }
 
-.resizable-editor__drag-handle {
+.components-button.resizable-editor__drag-handle {
 	$height: 100px;
 	position: absolute;
 	top: 0;
 	bottom: 0;
 	padding: 0;
 	margin: auto 0;
-	width: $grid-unit-10;
 	height: $height;
 	appearance: none;
-	cursor: grab;
+	cursor: ew-resize;
 	outline: none;
-	background: $gray-700;
-	border-radius: 4px;
+	background: $gray-900;
 	border: 0;
+	min-width: $grid-unit-05 * 5;
+	color: $gray-600;
 
 	&.is-left {
-		left: #{-$grid-unit-30 - $grid-unit-05};
+		left: -22px;
+		border-radius: 4px 0 0 4px;
 	}
 
 	&.is-right {
-		right: #{-$grid-unit-30 - $grid-unit-05};
+		right: -22px;
+		border-radius: 0 4px 4px 0;
 	}
 
-	&:hover {
-		background: $gray-600;
-	}
-
+	&:hover,
 	&:active {
-		cursor: grabbing;
-		background: $gray-600;
+		color: var(--wp-admin-theme-color);
 	}
 
 	&:focus {


### PR DESCRIPTION
Having worked in template part focus mode for some time, I have occasionally been tricked in to thinking the resize handle is a scrollbar. This PR explores some changes we could make to address that. 

* Position – handles are closer to the canvas
* Color – background is less similar to scrollbars
* Drag handle – added a handle icon to the button

I also updated the cursor to `ew-resize` which seems more appropriate.

| Before | After |
| --- | --- |
| <img width="873" alt="Screenshot 2021-11-11 at 14 30 36" src="https://user-images.githubusercontent.com/846565/141324752-682caee6-002a-43e1-baa3-d307284a3382.png"> | <img width="512" alt="Screenshot 2021-11-11 at 15 26 13" src="https://user-images.githubusercontent.com/846565/141324780-d779c4f5-a905-465e-a67a-9a21e8beac90.png"> | 

We may only need one or two of the changes above. But by adding them all initially we can refine from here.