### PR TITLE
Block Editor: Compare the values and not the keys when diffing block attributes

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -182,6 +182,19 @@ function getMutateSafeObject( original, working ) {
 }
 
 /**
+ * Returns true if the two object arguments have the same keys, or false
+ * otherwise.
+ *
+ * @param {Object} a First object.
+ * @param {Object} b Second object.
+ *
+ * @return {boolean} Whether the two objects have the same keys.
+ */
+export function hasSameKeys( a, b ) {
+	return isEqual( keys( a ), keys( b ) );
+}
+
+/**
  * Returns true if, given the currently dispatching action and the previously
  * dispatched action, the two actions are updating the same block attribute, or
  * false otherwise.
@@ -197,7 +210,7 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 		lastAction !== undefined &&
 		lastAction.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
 		isEqual( action.clientIds, lastAction.clientIds ) &&
-		isEqual( action.attributes, lastAction.attributes )
+		hasSameKeys( action.attributes, lastAction.attributes )
 	);
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -182,19 +182,6 @@ function getMutateSafeObject( original, working ) {
 }
 
 /**
- * Returns true if the two object arguments have the same keys, or false
- * otherwise.
- *
- * @param {Object} a First object.
- * @param {Object} b Second object.
- *
- * @return {boolean} Whether the two objects have the same keys.
- */
-export function hasSameKeys( a, b ) {
-	return isEqual( keys( a ), keys( b ) );
-}
-
-/**
  * Returns true if, given the currently dispatching action and the previously
  * dispatched action, the two actions are updating the same block attribute, or
  * false otherwise.
@@ -210,7 +197,7 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 		lastAction !== undefined &&
 		lastAction.type === 'UPDATE_BLOCK_ATTRIBUTES' &&
 		isEqual( action.clientIds, lastAction.clientIds ) &&
-		hasSameKeys( action.attributes, lastAction.attributes )
+		isEqual( action.attributes, lastAction.attributes )
 	);
 }
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -214,6 +214,19 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 	);
 }
 
+/**
+ * Returns true if the currently dispatched action is modifying the
+ * content block attribute
+ *
+ * @param {Object} action Currently dispatching action.
+ *
+ * @return {boolean} Whether or not actions are updating block content
+ */
+export function isUpdatingContent( action ) {
+	const { attributes } = action;
+	return Boolean( attributes.content );
+}
+
 function buildBlockTree( state, blocks ) {
 	const result = {};
 	const stack = [ ...blocks ];
@@ -526,11 +539,15 @@ function withPersistentBlockChange( reducer ) {
 			};
 		}
 
+		const shouldPersistBlockAttributeUpdates =
+			! isUpdatingSameBlockAttribute( action, lastAction ) ||
+			! isUpdatingContent( action );
+
 		nextState = {
 			...nextState,
 			isPersistentChange: isExplicitPersistentChange
 				? ! markNextChangeAsNotPersistent
-				: ! isUpdatingSameBlockAttribute( action, lastAction ),
+				: shouldPersistBlockAttributeUpdates,
 		};
 
 		// In comparing against the previous action, consider only those which

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -17,7 +17,6 @@ import {
  * Internal dependencies
  */
 import {
-	hasSameKeys,
 	isUpdatingSameBlockAttribute,
 	blocks,
 	isTyping,
@@ -36,22 +35,6 @@ import {
 } from '../reducer';
 
 describe( 'state', () => {
-	describe( 'hasSameKeys()', () => {
-		it( 'returns false if two objects do not have the same keys', () => {
-			const a = { foo: 10 };
-			const b = { bar: 10 };
-
-			expect( hasSameKeys( a, b ) ).toBe( false );
-		} );
-
-		it( 'returns false if two objects have the same keys', () => {
-			const a = { foo: 10 };
-			const b = { foo: 20 };
-
-			expect( hasSameKeys( a, b ) ).toBe( true );
-		} );
-	} );
-
 	describe( 'isUpdatingSameBlockAttribute()', () => {
 		it( 'should return false if not updating block attributes', () => {
 			const action = {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import {
+	hasSameKeys,
 	isUpdatingSameBlockAttribute,
 	blocks,
 	isTyping,
@@ -35,6 +36,22 @@ import {
 } from '../reducer';
 
 describe( 'state', () => {
+	describe( 'hasSameKeys()', () => {
+		it( 'returns false if two objects do not have the same keys', () => {
+			const a = { foo: 10 };
+			const b = { bar: 10 };
+
+			expect( hasSameKeys( a, b ) ).toBe( false );
+		} );
+
+		it( 'returns false if two objects have the same keys', () => {
+			const a = { foo: 10 };
+			const b = { foo: 20 };
+
+			expect( hasSameKeys( a, b ) ).toBe( true );
+		} );
+	} );
+
 	describe( 'isUpdatingSameBlockAttribute()', () => {
 		it( 'should return false if not updating block attributes', () => {
 			const action = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Addresses https://github.com/WordPress/gutenberg/issues/36417

Updating certain block settings (typography, text color, link color, padding etc.) will allow us to save the first set of edits.

Subsequent changes to the same block settings **_will not_** refresh the save / update button, and **_will not_** let us persist modifications.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Enable the full site editor
2. Navigate to full site editor
3. Select a block and try to adjust padding width without making other changes
4. Save the changes
5. Return to the same block. Select it and try to adjust padding width without making other changes.
6. Verify that option to update doesn't reset

## Screenshots <!-- if applicable -->
### Before
![2021-11-11 12 26 23](https://user-images.githubusercontent.com/5414230/141364296-12a2e203-ebb5-4670-92a7-6fd002a34bb2.gif)

### After
![2021-11-11 12 21 59](https://user-images.githubusercontent.com/5414230/141364280-1c2c4b93-b22e-4096-9ec9-7c490aaaa238.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
