### PR TITLE
Add support for non-integer font size hints in the Font Size Picker component.

### DIFF
--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -18,15 +18,11 @@ const CUSTOM_FONT_SIZE_OPTION = {
  * Helper util to split a font size to its numeric value
  * and its `unit`, if exists.
  *
- * @param {string|number} size Font size.
+ * @param {string} size Font size.
  * @return {[number, string]} An array with the numeric value and the unit if exists.
  */
 export function splitValueAndUnitFromSize( size ) {
-	/**
-	 * The first matched result is ignored as it's the left
-	 * hand side of the capturing group in the regex.
-	 */
-	const [ , numericValue, unit ] = size.split( /(\d+)/ );
+	const [ numericValue, unit ] = size.match( /[\d\.]+|\D+/g );
 	return [ numericValue, unit ];
 }
 
@@ -38,7 +34,7 @@ export function splitValueAndUnitFromSize( size ) {
  * @return {boolean} Whether the value is a simple css value.
  */
 export function isSimpleCssValue( value ) {
-	const sizeRegex = /^(?!0)\d+(px|em|rem|vw|vh|%)?$/i;
+	const sizeRegex = /^(?!0)[\d\.]+(px|em|rem|vw|vh|%)?$/i;
 	return sizeRegex.test( value );
 }
 
@@ -75,7 +71,7 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		name,
 		size,
 		__experimentalHint:
-			size && isSimpleCssValue( size ) && parseInt( size ),
+			size && isSimpleCssValue( size ) && parseFloat( size ),
 	} ) );
 }
 


### PR DESCRIPTION
## Description
The Font Size Picker component displays hints which alert the user to the numerical value of the font size. For example a registered font size of `Large` with a size of `32px`, should show a "32" in the font size menu and the hint in the header would display "32px" when `Large` is chosen. 

Currently, this setup does not work for values that are not integers. For example `1.25rem` does not display any hints whatsoever. This PR fixes that and adds support for font sizes that include decimal points, much like those provided in the upcoming Twenty Twenty-Two theme. 

Further PRs can explore how to handle values that include `var( ... )`, `clamp( ... )`, etc. As before, no hints are provided for font sizes with such values. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots 
Twenty Twenty-Two theme without fix. 
![image](https://user-images.githubusercontent.com/4832319/141369877-dcbded57-bf95-4fac-9346-a505e9598764.png)

Twenty Twenty-Two theme with fix. (note the Large and Huge sizes use `clamp()`)
![image](https://user-images.githubusercontent.com/4832319/141369713-e8faa5f4-6c38-40df-9e4f-8c74854e70fa.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
