### PR TITLE
Remove CSS that causes conflict with theme.json

### DIFF
--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -22,11 +22,3 @@
 		margin-left: var(--wp--style--block-gap, 2em);
 	}
 }
-
-// Individual columns do not have top and bottom margins on the frontend.
-// So we make the editor match that.
-// Needs specificity.
-.block-editor-block-list__block.wp-block-column.wp-block-column {
-	margin-top: 0;
-	margin-bottom: 0;
-}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -22,3 +22,12 @@
 		margin-left: var(--wp--style--block-gap, 2em);
 	}
 }
+
+// Individual columns do not have top and bottom margins on the frontend.
+// So we make the editor match that.
+// We use :where to provide minimum specificity, so that intentional margins,
+// such as those configured in theme.json, override and win on specificity.
+html :where(.wp-block-column) {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -28,6 +28,6 @@
 // We use :where to provide minimum specificity, so that intentional margins,
 // such as those configured in theme.json, override and win on specificity.
 html :where(.wp-block-column) {
-    margin-top: 0;
-    margin-bottom: 0;
+	margin-top: 0;
+	margin-bottom: 0;
 }


### PR DESCRIPTION
## Description
Now that theme.json supports margin for column blocks, the removed CSS takes precedent over any configured theme.json margin styles. This impedes theme.json adoption. Since this CSS served no real purpose anyway, I propose that it is removed.

## How has this been tested?
This has been tested with TT1 blocks, TT2 and custom FSE themes and Gutenberg 11.9.

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
