### PR TITLE
Post Comments Form: ensure typography styles are applied to child elements

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -6,6 +6,7 @@
 	&[style*="font-family"] :where(.comment-reply-title) {
 		font-family: inherit;
 	}
+	&[class*="-font-size"] :where(.comment-reply-title),
 	&[style*="font-size"] :where(.comment-reply-title) {
 		font-size: inherit;
 	}

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -1,4 +1,3 @@
-// Styles copied from button block styles.
 .wp-block-post-comments-form {
 	&[style*="font-weight"] :where(.comment-reply-title) {
 		font-weight: inherit;
@@ -20,6 +19,7 @@
 		letter-spacing: inherit;
 	}
 
+	// Styles copied from button block styles.
 	input[type="submit"] {
 		border: none;
 		box-shadow: none;

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -1,5 +1,23 @@
 // Styles copied from button block styles.
 .wp-block-post-comments-form {
+	&[style*="font-weight"] :where(.comment-reply-title) {
+		font-weight: inherit;
+	}
+	&[style*="font-family"] :where(.comment-reply-title) {
+		font-family: inherit;
+	}
+	&[style*="font-size"] :where(.comment-reply-title) {
+		font-size: inherit;
+	}
+	&[style*="line-height"] :where(.comment-reply-title) {
+		line-height: inherit;
+	}
+	&[style*="font-style"] :where(.comment-reply-title) {
+		font-style: inherit;
+	}
+	&[style*="letter-spacing"] :where(.comment-reply-title) {
+		letter-spacing: inherit;
+	}
 
 	input[type="submit"] {
 		border: none;


### PR DESCRIPTION
## Description

This patch introduces some wildcard CSS selectors to ensure that the post comments heading inherits from typography inline styles on the block's container.

<img width="700" alt="Screen Shot 2021-11-12 at 2 45 34 pm" src="https://user-images.githubusercontent.com/6458278/141405655-c598dca2-33ad-4296-aced-08504b6d3b15.png">

Resolves https://github.com/WordPress/gutenberg/issues/36188

A more long-term approach might be to create a core block to replace the comments form.

## How has this been tested?

Using TT1/TwentyTwenty[One|Two], insert a Post Comments Form Block and play around with the typography controls for that block.

<img width="280" alt="Screen Shot 2021-11-12 at 2 49 51 pm" src="https://user-images.githubusercontent.com/6458278/141406036-6f69fd62-130d-4bb4-8930-4ba6b55ff794.png">

Publish the post and ensure that all the typography styles overwrite the theme's defaults.

## Types of changes
Adding CSS declarations

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
