### PR TITLE
ToolsPanel: Allow additional props on ToolsPanel

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Experimental
+
+-   Reinstated the ability to pass additional props to the `ToolsPanel` ([36428](https://github.com/WordPress/gutenberg/pull/36428)).
+
 ## 19.0.1 (2021-11-07)
 
 ### Experimental

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -24,14 +24,11 @@ const ToolsPanel = (
 		panelContext,
 		resetAllItems,
 		toggleItem,
-		className,
+		...toolsPanelProps
 	} = useToolsPanel( props );
 
-	// Props are not directly passed through to avoid exposing Grid props
-	// until agreement has been reached on how ToolsPanel layout should be
-	// handled.
 	return (
-		<Grid columns={ 2 } className={ className } ref={ forwardedRef }>
+		<Grid { ...toolsPanelProps } columns={ 2 } ref={ forwardedRef }>
 			<ToolsPanelContext.Provider value={ panelContext }>
 				<ToolsPanelHeader
 					label={ label }


### PR DESCRIPTION
## Description

Reintroduces the ability to apply custom props to a `ToolsPanel`. 

It was previously removed to avoid expose `Grid` component props. Credit for the change goes to @ciampo.

See discussion here: https://github.com/WordPress/gutenberg/pull/35621#discussion_r745830577

## How has this been tested?

1. Manually added custom props to the `ToolsPanel` within the Storybook example and confirmed props were applied.
2. Confirmed that the `ToolsPanel` still functions correctly in the block and site editors.

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
