### PR TITLE
Include cascading properties in Navigation deprecation

### DIFF
--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -26,22 +26,23 @@ const migrateWithLayout = ( attributes ) => {
 		return attributes;
 	}
 
-	const { itemsJustification, orientation } = attributes;
-
-	const updatedAttributes = {
-		...attributes,
-	};
+	const {
+		itemsJustification,
+		orientation,
+		...updatedAttributes
+	} = attributes;
 
 	if ( itemsJustification || orientation ) {
 		Object.assign( updatedAttributes, {
 			layout: {
 				type: 'flex',
-				justifyContent: itemsJustification || 'left',
-				orientation: orientation || 'horizontal',
+				setCascadingProperties: 'true',
+				...( itemsJustification && {
+					justifyContent: itemsJustification,
+				} ),
+				...( orientation && { orientation } ),
 			},
 		} );
-		delete updatedAttributes.itemsJustification;
-		delete updatedAttributes.orientation;
 	}
 
 	return updatedAttributes;

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
@@ -9,7 +9,7 @@
 			"overlayMenu": "mobile",
 			"layout": {
 				"type": "flex",
-				"justifyContent": "left",
+				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"}} -->
+<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v4.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v4.json
@@ -10,7 +10,7 @@
 			"fontFamily": "cambria-georgia",
 			"layout": {
 				"type": "flex",
-				"justifyContent": "left",
+				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"overlayMenu":"never","fontFamily":"cambria-georgia","layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"}} /-->
+<!-- wp:navigation {"overlayMenu":"never","fontFamily":"cambria-georgia","layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} /-->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v5.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v5.json
@@ -9,6 +9,7 @@
 			"overlayMenu": "never",
 			"layout": {
 				"type": "flex",
+				"setCascadingProperties": "true",
 				"justifyContent": "center",
 				"orientation": "vertical"
 			}

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v5.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v5.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","justifyContent":"center","orientation":"vertical"}} /-->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":"true","justifyContent":"center","orientation":"vertical"}} /-->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.json
@@ -15,7 +15,7 @@
 			},
 			"layout": {
 				"type": "flex",
-				"justifyContent": "left",
+				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"layout":{"type":"flex","justifyContent":"left","orientation":"horizontal"}} -->
+<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The Navigation block migration that handles the change to layout isn't adding `setCascadingProperties:"true"` to the attributes, so migrated navigations are not getting the correct justification properties set. 

This PR adds that attribute and cleans up the code a little.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I think the easiest way to test this is switching to code view in the block editor, pasting in some deprecated nav markup such as `<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->` and saving. The saved content should show the updated attributes, including `setCascadingProperties`. 

Moving out of code view and adding a few items to the nav, the layout should reflect the justification/orientation attributes set.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
