### PR TITLE
Navigation: Fix space-between

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -323,9 +323,12 @@
 	.is-responsive {
 		display: none;
 	}
+}
 
-	// Horizontal layout
-	.items-justified-space-between & {
+// Allow the container to grow when space-between is applied.
+.items-justified-space-between {
+	.wp-block-navigation__container,
+	.wp-block-page-list {
 		flex-grow: 1;
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -323,7 +323,13 @@
 	.is-responsive {
 		display: none;
 	}
+
+	// Horizontal layout
+	.items-justified-space-between & {
+		flex-grow: 1;
+	}
 }
+
 
 /**
  * Mobile menu.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -325,12 +325,10 @@
 	}
 }
 
-// Allow the container to grow when space-between is applied.
-.items-justified-space-between {
-	.wp-block-navigation__container,
-	.wp-block-page-list {
-		flex-grow: 1;
-	}
+// Allow menu items to be spaced out by space-between when only navigation links are present.
+.wp-block-navigation__container:only-child,
+.wp-block-page-list:only-child {
+	flex-grow: 1;
 }
 
 


### PR DESCRIPTION
## Description

Fixes #36440.

Restores a justificiation rule to the navigation block that was [removed](https://github.com/WordPress/gutenberg/pull/36169/files#diff-d66a4ed73d0d50a799547b78db235a4bad3428a0decb8895752032cd849d01f0L335) in a refactor. This fixes the justification:

<img width="806" alt="Screenshot 2021-11-12 at 13 10 44" src="https://user-images.githubusercontent.com/1204802/141465335-a9a50873-0750-493b-8236-0383a4212eea.png">

## How has this been tested?

Insert a horizontal navigation block with 3 items then apply space-between on it. The stretching of the space between items should be visible in editor and frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
