### PR TITLE
Docs: Update GIF image in docs with wp.org schema URL

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -985,7 +985,7 @@ It can be difficult to remember the theme.json settings and properties while you
 
 Code editors can pick up the schema and can provide help like tooltips, autocomplete, or schema validation in the editor. To use the schema in Visual Studio Code, add `"$schema": "https://schemas.wp.org/trunk/theme.json"` to the beginning of your theme.json file.
 
-![Example using validation with schema](https://developer.wordpress.org/files/2021/10/schema-validation.gif)
+![Example using validation with schema](https://developer.wordpress.org/files/2021/11/theme-json-schema-updated.gif)
 
 
 ## Frequently Asked Questions


### PR DESCRIPTION

## Description

We updated the URL for the schemas to the schemas.wp.org domain, the URL shown in the previous GIF had the older SchemaStore reference.

This PR updates the image with the new reference.


## How has this been tested?

Confirm image and URL look correct.


## Types of changes

Image in documentation update.
