### PR TITLE
Rename fse_navigation_area to wp_navigation_area

### DIFF
--- a/lib/class-wp-rest-block-navigation-areas-controller.php
+++ b/lib/class-wp-rest-block-navigation-areas-controller.php
@@ -165,9 +165,9 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 	public function update_item( $request ) {
 		$name = $request['area'];
 
-		$mapping          = get_option( 'fse_navigation_areas', array() );
+		$mapping          = gutenberg_get_navigation_areas_menus();
 		$mapping[ $name ] = $request['navigation'];
-		update_option( 'fse_navigation_areas', $mapping );
+		update_option( 'wp_navigation_areas', $mapping );
 
 		$area = $this->get_navigation_area_object( $name );
 		$data = $this->prepare_item_for_response( $area, $request );
@@ -182,7 +182,7 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 	 */
 	private function get_navigation_area_object( $name ) {
 		$available_areas   = gutenberg_get_navigation_areas();
-		$mapping           = get_option( 'fse_navigation_areas', array() );
+		$mapping           = gutenberg_get_navigation_areas_menus();
 		$area              = new stdClass();
 		$area->name        = $name;
 		$area->navigation  = ! empty( $mapping[ $name ] ) ? $mapping[ $name ] : null;

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -187,7 +187,7 @@ function gutenberg_get_navigation_areas() {
  * @return array A list of paths.
  */
 function gutenberg_get_navigation_areas_paths_to_preload() {
-	$areas        = get_option( 'fse_navigation_areas', array() );
+	$areas        = get_navigation_areas();
 	$active_areas = array_intersect_key( $areas, gutenberg_get_navigation_areas() );
 	$paths        = array(
 		'/wp/v2/block-navigation-areas?context=edit',
@@ -225,7 +225,7 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 	add_filter( 'option_stylesheet', $get_old_theme_stylesheet );
 
 	$locations    = get_nav_menu_locations();
-	$area_mapping = get_option( 'fse_navigation_areas', array() );
+	$area_mapping = get_navigation_areas();
 
 	foreach ( $locations as $location_name => $menu_id ) {
 		// Get the menu from the location, skipping if there is no
@@ -277,10 +277,23 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 	}
 	remove_filter( 'option_stylesheet', $get_old_theme_stylesheet );
 
-	update_option( 'fse_navigation_areas', $area_mapping );
+	update_option( 'wp_navigation_areas', $area_mapping );
 }
 
 add_action( 'switch_theme', 'gutenberg_migrate_menu_to_navigation_post', 200, 3 );
+
+/**
+ * Retrieves navigation areas.
+ *
+ * @return array Navigation areas.
+ */
+function gutenberg_get_navigation_areas_menus() {
+	$areas = get_option( 'wp_navigation_areas', array() );
+	if ( ! $areas ) {
+		$areas = get_option( 'fse_navigation_areas', array() );
+	}
+	return $areas;
+}
 
 // The functions below are copied over from packages/block-library/src/navigation/index.php
 // Let's figure out a better way of managing these global PHP dependencies.

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -187,7 +187,7 @@ function gutenberg_get_navigation_areas() {
  * @return array A list of paths.
  */
 function gutenberg_get_navigation_areas_paths_to_preload() {
-	$areas        = get_navigation_areas();
+	$areas        = gutenberg_get_navigation_areas_menus();
 	$active_areas = array_intersect_key( $areas, gutenberg_get_navigation_areas() );
 	$paths        = array(
 		'/wp/v2/block-navigation-areas?context=edit',
@@ -225,7 +225,7 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 	add_filter( 'option_stylesheet', $get_old_theme_stylesheet );
 
 	$locations    = get_nav_menu_locations();
-	$area_mapping = get_navigation_areas();
+	$area_mapping = gutenberg_get_navigation_areas_menus();
 
 	foreach ( $locations as $location_name => $menu_id ) {
 		// Get the menu from the location, skipping if there is no

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -291,10 +291,10 @@ function gutenberg_get_navigation_areas_menus() {
 	$areas = get_option( 'wp_navigation_areas', array() );
 	if ( ! $areas ) {
 		// Original key used `fse` prefix but Core options should use `wp`.
-		// We fallback to the legacy option to catch sites with values in the 
+		// We fallback to the legacy option to catch sites with values in the
 		// original location.
 		$legacy_option_key = 'fse_navigation_areas';
-		$areas = get_option( $legacy_option_key, array() );
+		$areas             = get_option( $legacy_option_key, array() );
 	}
 	return $areas;
 }

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -290,7 +290,11 @@ add_action( 'switch_theme', 'gutenberg_migrate_menu_to_navigation_post', 200, 3 
 function gutenberg_get_navigation_areas_menus() {
 	$areas = get_option( 'wp_navigation_areas', array() );
 	if ( ! $areas ) {
-		$areas = get_option( 'fse_navigation_areas', array() );
+		// Original key used `fse` prefix but Core options should use `wp`.
+		// We fallback to the legacy option to catch sites with values in the 
+		// original location.
+		$legacy_option_key = 'fse_navigation_areas';
+		$areas = get_option( $legacy_option_key, array() );
 	}
 	return $areas;
 }

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -147,7 +147,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	if ( ! empty( $block->context['navigationArea'] ) ) {
 		$area    = $block->context['navigationArea'];
-		$mapping = get_option( 'fse_navigation_areas', array() );
+		$mapping = get_option( 'wp_navigation_areas', array() );
 		if ( ! empty( $mapping[ $area ] ) ) {
 			$attributes['navigationMenuId'] = $mapping[ $area ];
 		}


### PR DESCRIPTION
As mentioned in https://github.com/WordPress/wordpress-develop/pull/1865/files#r747291800, the naming convention for options is such that they start with `wp_` prefix and not with `fse_` prefix. This PR renames `fse_navigation_areas` to `wp_navigation_areas` by adding a getter function that falls back to the older name. This way the feature keeps working for anyone who had already upgraded to Gutenberg 11.9.