### PR TITLE
React to any errors coming up in gutenberg_migrate_menu_to_navigation_post

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -272,7 +272,7 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 			);
 			$navigation_post_id      = wp_insert_post( $post_data );
 			// If wp_insert_post failed, return early and don't call update_option.
-			if ( is_wp_error( $navigation_post_id) ) {
+			if ( is_wp_error( $navigation_post_id ) ) {
 				return $navigation_post_id;
 			}
 		}

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -271,6 +271,10 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 				'post_status'  => $post_status,
 			);
 			$navigation_post_id      = wp_insert_post( $post_data );
+			// If wp_insert_post failed, return early and don't call update_option.
+			if ( is_wp_error( $navigation_post_id) ) {
+				return $navigation_post_id;
+			}
 		}
 
 		$area_mapping[ $location_name ] = $navigation_post_id;
@@ -280,7 +284,7 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 	update_option( 'fse_navigation_areas', $area_mapping );
 }
 
-add_action( 'switch_theme', 'gutenberg_migrate_menu_to_navigation_post', 200, 3 );
+add_action( 'switch_theme', 'gutenberg_migrate_menu_to_navigation_post', 99, 3 );
 
 // The functions below are copied over from packages/block-library/src/navigation/index.php
 // Let's figure out a better way of managing these global PHP dependencies.

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -271,7 +271,8 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 				'post_status'  => $post_status,
 			);
 			$navigation_post_id      = wp_insert_post( $post_data );
-			// If wp_insert_post failed, return early and don't call update_option.
+			// If wp_insert_post fails *at any time*, then bale out of the entire
+			// migration attempt returning the WP_Error object.
 			if ( is_wp_error( $navigation_post_id ) ) {
 				return $navigation_post_id;
 			}


### PR DESCRIPTION
As @spacedmonkey mentioned in [a review](https://github.com/WordPress/wordpress-develop/pull/1865/files#r747384378) of [the navigation areas PR](https://github.com/WordPress/wordpress-develop/pull/1865), migrating menu locations to navigation areas on theme switch, `wp_insert_post` may fail and return WP_Error instance. This must be handled somehow, and I propose to just short-circuit the entire migration. There isn't a fully functional mapping available, so I'd rather abort than set a half-baked one.