### PR TITLE
Fix Performance CI tests and make them always use the latest major as base branch

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -54,7 +54,11 @@ jobs:
 
             - name: Compare performance with base branch
               if: github.event_name == 'push'
-              run: ./bin/plugin/cli.js perf --ci $GITHUB_SHA wp/5.8 --tests-branch $GITHUB_SHA
+              run: |
+                  WP_VERSION=$(awk -F ': ' '/^Tested up to/{print $2}' readme.txt)
+                  IFS=. read -ra WP_VERSION_ARRAY <<< "$WP_VERSION"
+                  WP_MAJOR="${WP_VERSION_ARRAY[0]}.${WP_VERSION_ARRAY[1]}"
+                  ./bin/plugin/cli.js perf --ci $GITHUB_SHA wp/5.8 --tests-branch $GITHUB_SHA  --wp-version "$WP_MAJOR"
 
             - uses: actions/github-script@0.3.0
               if: github.event_name == 'push'


### PR DESCRIPTION
This PR attempts to always use the latest major as a base WP version in the performance tests. The idea is that the plugin always supports the latest WP version meaning, this wouldn't fail due to conflicts like the one happening now on trunk.