### PR TITLE
Return wp error from wp_insert_post

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -270,7 +270,7 @@ function gutenberg_migrate_menu_to_navigation_post( $new_name, $new_theme, $old_
 				'post_content' => serialize_blocks( $parsed_blocks ),
 				'post_status'  => $post_status,
 			);
-			$navigation_post_id      = wp_insert_post( $post_data );
+			$navigation_post_id      = wp_insert_post( $post_data, true );
 			// If wp_insert_post fails *at any time*, then bale out of the entire
 			// migration attempt returning the WP_Error object.
 			if ( is_wp_error( $navigation_post_id ) ) {


### PR DESCRIPTION
Follows up on https://github.com/WordPress/gutenberg/pull/36461 to address the fact that:

> We need to pass, true as the second param to wp_insert_post for it return a wp_error.

See:
* https://developer.wordpress.org/reference/functions/wp_insert_post/
* https://github.com/WordPress/gutenberg/pull/36461#discussion_r748778916

Thank you @spacedmonkey for flagging it!


cc @noisysocks @getdave 