### PR TITLE
Add client side routing for Site Editor

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -77,28 +77,6 @@ function gutenberg_get_editor_styles() {
 }
 
 /**
- * Get the Gutenberg Templates List Page preload paths.
- */
-function gutenberg_edit_site_list_preload_paths() {
-	if ( ! gutenberg_is_edit_site_list_page() ) {
-		return array();
-	}
-
-	$post_type = get_post_type_object( $_GET['postType'] );
-
-	if ( ! $post_type ) {
-		wp_die( __( 'Invalid post type.', 'gutenberg' ) );
-	}
-
-	return array(
-		'/',
-		"/wp/v2/types/$post_type->name?context=edit",
-		'/wp/v2/types?context=edit',
-		"/wp/v2/$post_type->rest_base?context=edit&per_page=-1",
-	);
-}
-
-/**
  * Initialize the Gutenberg Site Editor.
  *
  * @since 7.2.0
@@ -110,6 +88,14 @@ function gutenberg_edit_site_init( $hook ) {
 
 	if ( ! gutenberg_is_edit_site_page( $hook ) ) {
 		return;
+	}
+
+	if ( gutenberg_is_edit_site_list_page() ) {
+		$post_type = get_post_type_object( $_GET['postType'] );
+
+		if ( ! $post_type ) {
+			wp_die( __( 'Invalid post type.', 'gutenberg' ) );
+		}
 	}
 
 	// Default to is-fullscreen-mode to avoid rendering wp-admin navigation menu while loading and
@@ -130,8 +116,6 @@ function gutenberg_edit_site_init( $hook ) {
 		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	);
-
-	$list_page_preload_paths = gutenberg_edit_site_list_preload_paths();
 
 	/**
 	 * Make the WP Screen object aware that this is a block editor page.
@@ -154,20 +138,21 @@ function gutenberg_edit_site_init( $hook ) {
 					array( '/wp/v2/media', 'OPTIONS' ),
 					'/',
 					'/wp/v2/types?context=edit',
+					'/wp/v2/types/wp_template?context=edit',
+					'/wp/v2/types/wp_template-part?context=edit',
 					'/wp/v2/taxonomies?context=edit',
 					'/wp/v2/pages?context=edit',
 					'/wp/v2/categories?context=edit',
 					'/wp/v2/posts?context=edit',
 					'/wp/v2/tags?context=edit',
-					'/wp/v2/templates?context=edit',
-					'/wp/v2/template-parts?context=edit',
+					'/wp/v2/templates?context=edit&per_page=-1',
+					'/wp/v2/template-parts?context=edit&per_page=-1',
 					'/wp/v2/settings',
 					'/wp/v2/themes?context=edit&status=active',
 					'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
 					'/wp/v2/global-styles/' . $active_global_styles_id,
 					'/wp/v2/global-styles/themes/' . $active_theme,
 				),
-				$list_page_preload_paths
 			),
 			'initializer_name' => 'initializeEditor',
 			'editor_settings'  => $settings,

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -152,7 +152,7 @@ function gutenberg_edit_site_init( $hook ) {
 					'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
 					'/wp/v2/global-styles/' . $active_global_styles_id,
 					'/wp/v2/global-styles/themes/' . $active_theme,
-				),
+				)
 			),
 			'initializer_name' => 'initializeEditor',
 			'editor_settings'  => $settings,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19233,6 +19233,7 @@
 				"classnames": "^2.3.1",
 				"downloadjs": "^1.4.7",
 				"file-saver": "^2.0.2",
+				"history": "^5.1.0",
 				"jszip": "^3.2.2",
 				"lodash": "^4.17.21",
 				"rememo": "^3.0.0"
@@ -38626,6 +38627,14 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
 			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
 			"dev": true
+		},
+		"history": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+			"integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
+			"requires": {
+				"@babel/runtime": "^7.7.6"
+			}
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -56,6 +56,7 @@
 		"classnames": "^2.3.1",
 		"downloadjs": "^1.4.7",
 		"file-saver": "^2.0.2",
+		"history": "^5.1.0",
 		"jszip": "^3.2.2",
 		"lodash": "^4.17.21",
 		"rememo": "^3.0.0"

--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -9,7 +9,6 @@ import { kebabCase } from 'lodash';
 import { useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -17,9 +16,11 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { useHistory } from '../routes';
 import CreateTemplatePartModal from '../create-template-part-modal';
 
 export default function NewTemplatePart( { postType } ) {
+	const history = useHistory();
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
@@ -44,10 +45,12 @@ export default function NewTemplatePart( { postType } ) {
 			} );
 
 			// Navigate to the created template part editor.
-			window.location.href = addQueryArgs( window.location.href, {
+			history.push( {
 				postId: templatePart.id,
-				postType: 'wp_template_part',
+				postType: templatePart.type,
 			} );
+
+			// TODO: Add a success notice?
 		} catch ( error ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'

--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -26,7 +26,7 @@ export default function NewTemplatePart( { postType } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { getLastEntitySaveError } = useSelect( coreStore );
 
-	async function createTemplatePart( { title, area } ) {
+	async function createTemplatePart( { title, area }, { closeModal } ) {
 		if ( ! title ) {
 			createErrorNotice( __( 'Title is not defined.' ), {
 				type: 'snackbar',
@@ -55,6 +55,8 @@ export default function NewTemplatePart( { postType } ) {
 				throw lastEntitySaveError;
 			}
 
+			closeModal();
+
 			// Navigate to the created template part editor.
 			history.push( {
 				postId: templatePart.id,
@@ -71,6 +73,8 @@ export default function NewTemplatePart( { postType } ) {
 					  );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
+
+			closeModal();
 		}
 	}
 

--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -26,7 +26,7 @@ export default function NewTemplatePart( { postType } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { getLastEntitySaveError } = useSelect( coreStore );
 
-	async function createTemplatePart( { title, area }, { closeModal } ) {
+	async function createTemplatePart( { title, area } ) {
 		if ( ! title ) {
 			createErrorNotice( __( 'Title is not defined.' ), {
 				type: 'snackbar',
@@ -55,7 +55,7 @@ export default function NewTemplatePart( { postType } ) {
 				throw lastEntitySaveError;
 			}
 
-			closeModal();
+			setIsModalOpen( false );
 
 			// Navigate to the created template part editor.
 			history.push( {
@@ -74,7 +74,7 @@ export default function NewTemplatePart( { postType } ) {
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 
-			closeModal();
+			setIsModalOpen( false );
 		}
 	}
 

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -15,10 +15,14 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
-import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { useHistory } from '../routes';
 
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
@@ -31,6 +35,7 @@ const DEFAULT_TEMPLATE_SLUGS = [
 ];
 
 export default function NewTemplate( { postType } ) {
+	const history = useHistory();
 	const { templates, defaultTemplateTypes } = useSelect(
 		( select ) => ( {
 			templates: select( coreStore ).getEntityRecords(
@@ -65,13 +70,12 @@ export default function NewTemplate( { postType } ) {
 			} );
 
 			// Navigate to the created template editor.
-			window.location.href = addQueryArgs( window.location.href, {
+			history.push( {
 				postId: template.id,
-				postType: 'wp_template',
+				postType: template.type,
 			} );
 
-			// Wait for async navigation to happen before closing the modal.
-			await new Promise( () => {} );
+			// TODO: Add a success notice?
 		} catch ( error ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { SlotFillProvider } from '@wordpress/components';
+import { UnsavedChangesWarning } from '@wordpress/editor';
+
+/**
+ * Internal dependencies
+ */
+import { Routes } from '../routes';
+import Editor from '../editor';
+import List from '../list';
+import NavigationSidebar from '../navigation-sidebar';
+import getIsListPage from '../../utils/get-is-list-page';
+
+export default function EditSiteApp( { reboot } ) {
+	return (
+		<SlotFillProvider>
+			<UnsavedChangesWarning />
+
+			<Routes>
+				{ ( { params } ) => {
+					const isListPage = getIsListPage( params );
+
+					return (
+						<>
+							{ isListPage ? (
+								<List />
+							) : (
+								<Editor onError={ reboot } />
+							) }
+							{ /* Keep the instance of the sidebar to ensure focus will not be lost
+							 * when navigating to other pages. */ }
+							<NavigationSidebar
+								// Open the navigation sidebar by default when in the list page.
+								isDefaultOpen={ !! isListPage }
+								activeTemplateType={
+									isListPage ? params.postType : undefined
+								}
+							/>
+						</>
+					);
+				} }
+			</Routes>
+		</SlotFillProvider>
+	);
+}

--- a/packages/edit-site/src/components/block-editor/back-button.js
+++ b/packages/edit-site/src/components/block-editor/back-button.js
@@ -3,26 +3,18 @@
  */
 import { Button } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
+import { useLocation, useHistory } from '../routes';
 
 function BackButton() {
-	const { isTemplatePart, previousTemplateId } = useSelect( ( select ) => {
-		const { getEditedPostType, getPreviousEditedPostId } = select(
-			editSiteStore
-		);
-
-		return {
-			isTemplatePart: getEditedPostType() === 'wp_template_part',
-			previousTemplateId: getPreviousEditedPostId(),
-		};
-	}, [] );
-	const { goBack } = useDispatch( editSiteStore );
+	const location = useLocation();
+	const history = useHistory();
+	const isTemplatePart = location.params.postType === 'wp_template_part';
+	const previousTemplateId = location.state?.fromTemplateId;
 
 	if ( ! isTemplatePart || ! previousTemplateId ) {
 		return null;
@@ -33,7 +25,7 @@ function BackButton() {
 			className="edit-site-visual-editor__back-button"
 			icon={ arrowLeft }
 			onClick={ () => {
-				goBack();
+				history.back();
 			} }
 		>
 			{ __( 'Back' ) }

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -51,9 +51,7 @@ export default function CreateTemplatePartModal( { closeModal, onCreate } ) {
 						return;
 					}
 					setIsSubmitting( true );
-					await onCreate( { title, area } );
-					setIsSubmitting( false );
-					closeModal();
+					await onCreate( { title, area }, { closeModal } );
 				} }
 			>
 				<TextControl

--- a/packages/edit-site/src/components/create-template-part-modal/index.js
+++ b/packages/edit-site/src/components/create-template-part-modal/index.js
@@ -51,7 +51,7 @@ export default function CreateTemplatePartModal( { closeModal, onCreate } ) {
 						return;
 					}
 					setIsSubmitting( true );
-					await onCreate( { title, area }, { closeModal } );
+					await onCreate( { title, area } );
 				} }
 			>
 				<TextControl

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import {
 	store as blockEditorStore,
 	BlockSettingsMenuControls,
@@ -14,7 +14,8 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
+import { useLocation } from '../routes';
+import { useLink } from '../routes/link';
 
 export default function EditTemplatePartMenuButton() {
 	return (
@@ -30,6 +31,7 @@ export default function EditTemplatePartMenuButton() {
 }
 
 function EditTemplatePartMenuItem( { selectedClientId, onClose } ) {
+	const { params } = useLocation();
 	const selectedTemplatePart = useSelect(
 		( select ) => {
 			const block = select( blockEditorStore ).getBlock(
@@ -50,7 +52,15 @@ function EditTemplatePartMenuItem( { selectedClientId, onClose } ) {
 		[ selectedClientId ]
 	);
 
-	const { pushTemplatePart } = useDispatch( editSiteStore );
+	const linkProps = useLink(
+		{
+			postId: selectedTemplatePart.id,
+			postType: selectedTemplatePart.type,
+		},
+		{
+			fromTemplateId: params.postId,
+		}
+	);
 
 	if ( ! selectedTemplatePart ) {
 		return null;
@@ -58,8 +68,9 @@ function EditTemplatePartMenuItem( { selectedClientId, onClose } ) {
 
 	return (
 		<MenuItem
-			onClick={ () => {
-				pushTemplatePart( selectedTemplatePart.id );
+			{ ...linkProps }
+			onClick={ ( event ) => {
+				linkProps.onClick( event );
 				onClose();
 			} }
 		>

--- a/packages/edit-site/src/components/edit-template-part-menu-button/index.js
+++ b/packages/edit-site/src/components/edit-template-part-menu-button/index.js
@@ -54,8 +54,8 @@ function EditTemplatePartMenuItem( { selectedClientId, onClose } ) {
 
 	const linkProps = useLink(
 		{
-			postId: selectedTemplatePart.id,
-			postType: selectedTemplatePart.type,
+			postId: selectedTemplatePart?.id,
+			postType: selectedTemplatePart?.type,
 		},
 		{
 			fromTemplateId: params.postId,

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -21,7 +21,6 @@ import {
 	EditorSnackbars,
 	EntitiesSavedStates,
 	UnsavedChangesWarning,
-	store as editorStore,
 } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
@@ -46,13 +45,14 @@ import WelcomeGuide from '../welcome-guide';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from './global-styles-renderer';
 import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
+import useTitle from '../routes/use-title';
 
 const interfaceLabels = {
 	secondarySidebar: __( 'Block Library' ),
 	drawer: __( 'Navigation Sidebar' ),
 };
 
-function Editor( { initialSettings, onError } ) {
+function Editor( { onError } ) {
 	const {
 		isInserterOpen,
 		isListViewOpen,
@@ -110,26 +110,7 @@ function Editor( { initialSettings, onError } ) {
 			).getAllShortcutKeyCombinations( 'core/edit-site/next-region' ),
 		};
 	}, [] );
-	const { updateEditorSettings } = useDispatch( editorStore );
-	const { setPage, setIsInserterOpened, updateSettings } = useDispatch(
-		editSiteStore
-	);
-
-	useEffect( () => {
-		updateSettings( initialSettings );
-	}, [] );
-
-	// Keep the defaultTemplateTypes in the core/editor settings too,
-	// so that they can be selected with core/editor selectors in any editor.
-	// This is needed because edit-site doesn't initialize with EditorProvider,
-	// which internally uses updateEditorSettings as well.
-	const { defaultTemplateTypes, defaultTemplatePartAreas } = settings;
-	useEffect( () => {
-		updateEditorSettings( {
-			defaultTemplateTypes,
-			defaultTemplatePartAreas,
-		} );
-	}, [ defaultTemplateTypes, defaultTemplatePartAreas ] );
+	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
 
 	const [
 		isEntitiesSavedStatesOpen,
@@ -142,6 +123,8 @@ function Editor( { initialSettings, onError } ) {
 	const closeEntitiesSavedStates = useCallback( () => {
 		setIsEntitiesSavedStatesOpen( false );
 	}, [] );
+
+	useTitle( __( 'Editor (beta)' ) );
 
 	const blockContext = useMemo(
 		() => ( {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -12,7 +12,6 @@ import {
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
 import {
-	FullscreenMode,
 	InterfaceSkeleton,
 	ComplementaryArea,
 	store as interfaceStore,
@@ -207,7 +206,6 @@ function Editor( { initialSettings, onError } ) {
 									>
 										<GlobalStylesRenderer />
 										<ErrorBoundary onError={ onError }>
-											<FullscreenMode isActive />
 											<UnsavedChangesWarning />
 											<KeyboardShortcuts.Register />
 											<SidebarComplementaryAreaFills />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -3,12 +3,7 @@
  */
 import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	SlotFillProvider,
-	Popover,
-	Button,
-	Notice,
-} from '@wordpress/components';
+import { Popover, Button, Notice } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
 import {
@@ -176,114 +171,112 @@ function Editor( { onError } ) {
 			<URLQueryController />
 			{ isReady && (
 				<ShortcutProvider>
-					<SlotFillProvider>
-						<EntityProvider kind="root" type="site">
-							<EntityProvider
-								kind="postType"
-								type={ templateType }
-								id={ entityId }
-							>
-								<GlobalStylesProvider>
-									<BlockContextProvider
-										value={ blockContext }
-									>
-										<GlobalStylesRenderer />
-										<ErrorBoundary onError={ onError }>
-											<UnsavedChangesWarning />
-											<KeyboardShortcuts.Register />
-											<SidebarComplementaryAreaFills />
-											<InterfaceSkeleton
-												labels={ interfaceLabels }
-												secondarySidebar={ secondarySidebar() }
-												sidebar={
-													sidebarIsOpened && (
-														<ComplementaryArea.Slot scope="core/edit-site" />
-													)
-												}
-												drawer={ <NavigationSidebar /> }
-												header={
-													<Header
+					<EntityProvider kind="root" type="site">
+						<EntityProvider
+							kind="postType"
+							type={ templateType }
+							id={ entityId }
+						>
+							<GlobalStylesProvider>
+								<BlockContextProvider value={ blockContext }>
+									<GlobalStylesRenderer />
+									<ErrorBoundary onError={ onError }>
+										<UnsavedChangesWarning />
+										<KeyboardShortcuts.Register />
+										<SidebarComplementaryAreaFills />
+										<InterfaceSkeleton
+											labels={ interfaceLabels }
+											secondarySidebar={ secondarySidebar() }
+											sidebar={
+												sidebarIsOpened && (
+													<ComplementaryArea.Slot scope="core/edit-site" />
+												)
+											}
+											drawer={
+												<NavigationSidebar.Slot />
+											}
+											header={
+												<Header
+													openEntitiesSavedStates={
+														openEntitiesSavedStates
+													}
+												/>
+											}
+											notices={ <EditorSnackbars /> }
+											content={
+												<>
+													<EditorNotices />
+													{ template && (
+														<BlockEditor
+															setIsInserterOpen={
+																setIsInserterOpened
+															}
+														/>
+													) }
+													{ templateResolved &&
+														! template &&
+														settings?.siteUrl &&
+														entityId && (
+															<Notice
+																status="warning"
+																isDismissible={
+																	false
+																}
+															>
+																{ __(
+																	"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+																) }
+															</Notice>
+														) }
+													<KeyboardShortcuts
 														openEntitiesSavedStates={
 															openEntitiesSavedStates
 														}
 													/>
-												}
-												notices={ <EditorSnackbars /> }
-												content={
-													<>
-														<EditorNotices />
-														{ template && (
-															<BlockEditor
-																setIsInserterOpen={
-																	setIsInserterOpened
-																}
-															/>
-														) }
-														{ templateResolved &&
-															! template &&
-															settings?.siteUrl &&
-															entityId && (
-																<Notice
-																	status="warning"
-																	isDismissible={
-																		false
-																	}
-																>
-																	{ __(
-																		"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-																	) }
-																</Notice>
-															) }
-														<KeyboardShortcuts
-															openEntitiesSavedStates={
-																openEntitiesSavedStates
+												</>
+											}
+											actions={
+												<>
+													{ isEntitiesSavedStatesOpen ? (
+														<EntitiesSavedStates
+															close={
+																closeEntitiesSavedStates
 															}
 														/>
-													</>
-												}
-												actions={
-													<>
-														{ isEntitiesSavedStatesOpen ? (
-															<EntitiesSavedStates
-																close={
-																	closeEntitiesSavedStates
+													) : (
+														<div className="edit-site-editor__toggle-save-panel">
+															<Button
+																variant="secondary"
+																className="edit-site-editor__toggle-save-panel-button"
+																onClick={
+																	openEntitiesSavedStates
 																}
-															/>
-														) : (
-															<div className="edit-site-editor__toggle-save-panel">
-																<Button
-																	variant="secondary"
-																	className="edit-site-editor__toggle-save-panel-button"
-																	onClick={
-																		openEntitiesSavedStates
-																	}
-																	aria-expanded={
-																		false
-																	}
-																>
-																	{ __(
-																		'Open save panel'
-																	) }
-																</Button>
-															</div>
-														) }
-													</>
-												}
-												footer={ <BlockBreadcrumb /> }
-												shortcuts={ {
-													previous: previousShortcut,
-													next: nextShortcut,
-												} }
-											/>
-											<WelcomeGuide />
-											<Popover.Slot />
-											<PluginArea />
-										</ErrorBoundary>
-									</BlockContextProvider>
-								</GlobalStylesProvider>
-							</EntityProvider>
+																aria-expanded={
+																	false
+																}
+															>
+																{ __(
+																	'Open save panel'
+																) }
+															</Button>
+														</div>
+													) }
+												</>
+											}
+											footer={ <BlockBreadcrumb /> }
+											shortcuts={ {
+												previous: previousShortcut,
+												next: nextShortcut,
+											} }
+										/>
+										<WelcomeGuide />
+										<Popover.Slot />
+										<PluginArea />
+									</ErrorBoundary>
+								</BlockContextProvider>
+							</GlobalStylesProvider>
 						</EntityProvider>
-					</SlotFillProvider>
+					</EntityProvider>
 				</ShortcutProvider>
 			) }
 		</>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -119,8 +119,6 @@ function Editor( { onError } ) {
 		setIsEntitiesSavedStatesOpen( false );
 	}, [] );
 
-	useTitle( __( 'Editor (beta)' ) );
-
 	const blockContext = useMemo(
 		() => ( {
 			...page?.context,
@@ -165,6 +163,10 @@ function Editor( { onError } ) {
 		}
 		return null;
 	};
+
+	// Only announce the title once the editor is ready to prevent "Replace"
+	// action in <URlQueryController> from double-announcing.
+	useTitle( isReady && __( 'Editor (beta)' ) );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -15,7 +15,6 @@ import {
 	EditorNotices,
 	EditorSnackbars,
 	EntitiesSavedStates,
-	UnsavedChangesWarning,
 } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
@@ -183,7 +182,6 @@ function Editor( { onError } ) {
 								<BlockContextProvider value={ blockContext }>
 									<GlobalStylesRenderer />
 									<ErrorBoundary onError={ onError }>
-										<UnsavedChangesWarning />
 										<KeyboardShortcuts.Register />
 										<SidebarComplementaryAreaFills />
 										<InterfaceSkeleton

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -21,9 +21,14 @@ import Header from './header';
 import NavigationSidebar from '../navigation-sidebar';
 import Table from './table';
 import { store as editSiteStore } from '../../store';
+import { useLocation } from '../routes';
 import useTitle from '../routes/use-title';
 
-export default function List( { templateType } ) {
+export default function List() {
+	const {
+		params: { postType: templateType },
+	} = useLocation();
+
 	useRegisterShortcuts();
 
 	const { previousShortcut, nextShortcut, isNavigationOpen } = useSelect(
@@ -78,12 +83,7 @@ export default function List( { templateType } ) {
 				...detailedRegionLabels,
 			} }
 			header={ <Header templateType={ templateType } /> }
-			drawer={
-				<NavigationSidebar
-					activeTemplateType={ templateType }
-					isDefaultOpen
-				/>
-			}
+			drawer={ <NavigationSidebar.Slot /> }
 			notices={ <EditorSnackbars /> }
 			content={
 				<main className="edit-site-list-main">

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -21,6 +21,7 @@ import Header from './header';
 import NavigationSidebar from '../navigation-sidebar';
 import Table from './table';
 import { store as editSiteStore } from '../../store';
+import useTitle from '../routes/use-title';
 
 export default function List( { templateType } ) {
 	useRegisterShortcuts();
@@ -46,6 +47,8 @@ export default function List( { templateType } ) {
 		( select ) => select( coreStore ).getPostType( templateType ),
 		[ templateType ]
 	);
+
+	useTitle( postType?.labels?.name );
 
 	// `postType` could load in asynchronously. Only provide the detailed region labels if
 	// the postType has loaded, otherwise `InterfaceSkeleton` will fallback to the defaults.

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -85,11 +85,7 @@ export default function List() {
 			header={ <Header templateType={ templateType } /> }
 			drawer={ <NavigationSidebar.Slot /> }
 			notices={ <EditorSnackbars /> }
-			content={
-				<main className="edit-site-list-main">
-					<Table templateType={ templateType } />
-				</main>
-			}
+			content={ <Table templateType={ templateType } /> }
 			shortcuts={ {
 				previous: previousShortcut,
 				next: nextShortcut,

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -44,18 +44,13 @@
 
 		.interface-interface-skeleton__content {
 			background: $white;
+			align-items: center;
+			padding: $grid-unit-20;
+
+			@include break-medium() {
+				padding: $grid-unit * 9;
+			}
 		}
-	}
-}
-
-.edit-site-list-main {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	padding: $grid-unit-20;
-
-	@include break-medium() {
-		padding: $grid-unit * 9;
 	}
 }
 

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -8,11 +8,11 @@ import {
 	VisuallyHidden,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
+import Link from '../routes/link';
 import Actions from './actions';
 import AddedBy from './added-by';
 
@@ -92,15 +92,15 @@ export default function Table( { templateType } ) {
 					>
 						<td className="edit-site-list-table-column" role="cell">
 							<Heading level={ 4 }>
-								<a
-									href={ addQueryArgs( window.location.href, {
+								<Link
+									params={ {
 										postId: template.id,
 										postType: template.type,
-									} ) }
+									} }
 								>
 									{ template.title?.rendered ||
 										template.slug }
-								</a>
+								</Link>
 							</Heading>
 							{ template.description }
 						</td>

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -18,30 +18,31 @@ export const {
 	Slot: NavigationPanelPreviewSlot,
 } = createSlotFill( 'EditSiteNavigationPanelPreview' );
 
-export default function NavigationSidebar( {
-	isDefaultOpen = false,
-	activeTemplateType,
-} ) {
+const {
+	Fill: NavigationSidebarFill,
+	Slot: NavigationSidebarSlot,
+} = createSlotFill( 'EditSiteNavigationSidebar' );
+
+function NavigationSidebar( { isDefaultOpen = false, activeTemplateType } ) {
 	const isDesktopViewport = useViewportMatch( 'medium' );
 	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
 
-	useEffect( () => {
-		// When transitioning to desktop open the navigation if `isDefaultOpen` is true.
-		if ( isDefaultOpen && isDesktopViewport ) {
-			setIsNavigationPanelOpened( true );
-		}
-
-		// When transitioning to mobile/tablet, close the navigation.
-		if ( ! isDesktopViewport ) {
-			setIsNavigationPanelOpened( false );
-		}
-	}, [ isDefaultOpen, isDesktopViewport, setIsNavigationPanelOpened ] );
+	useEffect(
+		function autoOpenNavigationPanelOnViewportChange() {
+			setIsNavigationPanelOpened( isDefaultOpen && isDesktopViewport );
+		},
+		[ isDefaultOpen, isDesktopViewport, setIsNavigationPanelOpened ]
+	);
 
 	return (
-		<>
+		<NavigationSidebarFill>
 			<NavigationToggle />
 			<NavigationPanel activeItem={ activeTemplateType } />
 			<NavigationPanelPreviewSlot />
-		</>
+		</NavigationSidebarFill>
 	);
 }
+
+NavigationSidebar.Slot = NavigationSidebarSlot;
+
+export default NavigationSidebar;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -19,7 +19,6 @@ import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 import { decodeEntities } from '@wordpress/html-entities';
-import { addQueryArgs } from '@wordpress/url';
 import {
 	home as siteIcon,
 	layout as templateIcon,
@@ -29,10 +28,17 @@ import {
 /**
  * Internal dependencies
  */
+import { useLink } from '../../routes/link';
 import MainDashboardButton from '../../main-dashboard-button';
 import { store as editSiteStore } from '../../../store';
 
 const SITE_EDITOR_KEY = 'site-editor';
+
+function NavLink( { params, replace, ...props } ) {
+	const linkProps = useLink( params, replace );
+
+	return <NavigationItem { ...linkProps } { ...props } />;
+}
 
 const NavigationPanel = ( { activeItem = SITE_EDITOR_KEY } ) => {
 	const { isNavigationOpen, siteTitle } = useSelect( ( select ) => {
@@ -92,32 +98,32 @@ const NavigationPanel = ( { activeItem = SITE_EDITOR_KEY } ) => {
 
 						<NavigationMenu>
 							<NavigationGroup title={ __( 'Editor' ) }>
-								<NavigationItem
+								<NavLink
 									icon={ siteIcon }
 									title={ __( 'Site' ) }
 									item={ SITE_EDITOR_KEY }
-									href={ addQueryArgs( window.location.href, {
+									params={ {
 										postId: undefined,
 										postType: undefined,
-									} ) }
+									} }
 								/>
-								<NavigationItem
+								<NavLink
 									icon={ templateIcon }
 									title={ __( 'Templates' ) }
 									item="wp_template"
-									href={ addQueryArgs( window.location.href, {
+									params={ {
 										postId: undefined,
 										postType: 'wp_template',
-									} ) }
+									} }
 								/>
-								<NavigationItem
+								<NavLink
 									icon={ templatePartIcon }
 									title={ __( 'Template Parts' ) }
 									item="wp_template_part"
-									href={ addQueryArgs( window.location.href, {
+									params={ {
 										postId: undefined,
 										postType: 'wp_template_part',
-									} ) }
+									} }
 								/>
 							</NavigationGroup>
 						</NavigationMenu>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -15,7 +15,6 @@ import {
 } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -54,15 +53,6 @@ const NavigationPanel = ( { activeItem = SITE_EDITOR_KEY } ) => {
 	}, [] );
 	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
 
-	// Ensures focus is moved to the panel area when it is activated
-	// from a separate component (such as document actions in the header).
-	const panelRef = useRef();
-	useEffect( () => {
-		if ( isNavigationOpen ) {
-			panelRef.current.focus();
-		}
-	}, [ activeItem, isNavigationOpen ] );
-
 	const closeOnEscape = ( event ) => {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
 			event.preventDefault();
@@ -76,8 +66,6 @@ const NavigationPanel = ( { activeItem = SITE_EDITOR_KEY } ) => {
 			className={ classnames( `edit-site-navigation-panel`, {
 				'is-open': isNavigationOpen,
 			} ) }
-			ref={ panelRef }
-			tabIndex="-1"
 			onKeyDown={ closeOnEscape }
 		>
 			<div className="edit-site-navigation-panel__inner">

--- a/packages/edit-site/src/components/routes/index.js
+++ b/packages/edit-site/src/components/routes/index.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createContext,
+	useState,
+	useEffect,
+	useContext,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import history from '../../utils/history';
+
+const RoutesContext = createContext();
+const HistoryContext = createContext();
+
+export function useLocation() {
+	return useContext( RoutesContext );
+}
+
+export function useHistory() {
+	return useContext( HistoryContext );
+}
+
+function getLocationWithParams( location ) {
+	const searchParams = new URLSearchParams( location.search );
+	return {
+		...location,
+		params: Object.fromEntries( searchParams.entries() ),
+	};
+}
+
+export function Routes( { children } ) {
+	const [ location, setLocation ] = useState( () =>
+		getLocationWithParams( history.location )
+	);
+
+	useEffect( () => {
+		return history.listen( ( { location: updatedLocation } ) => {
+			setLocation( getLocationWithParams( updatedLocation ) );
+		} );
+	}, [] );
+
+	return (
+		<HistoryContext.Provider value={ history }>
+			<RoutesContext.Provider value={ location }>
+				{ children( location ) }
+			</RoutesContext.Provider>
+		</HistoryContext.Provider>
+	);
+}

--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { useHistory } from './index';
+
+export function useLink( params = {}, state, shouldReplace = false ) {
+	const history = useHistory();
+
+	function onClick( event ) {
+		event.preventDefault();
+
+		if ( shouldReplace ) {
+			history.replace( params, state );
+		} else {
+			history.push( params, state );
+		}
+	}
+
+	return {
+		href: addQueryArgs( window.location.href, params ),
+		onClick,
+	};
+}
+
+export default function Link( {
+	params = {},
+	state,
+	replace: shouldReplace = false,
+	children,
+	...props
+} ) {
+	const { href, onClick } = useLink( params, state, shouldReplace );
+
+	return (
+		<a href={ href } onClick={ onClick } { ...props }>
+			{ children }
+		</a>
+	);
+}

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -5,6 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 export default function useTitle( title ) {
 	const siteTitle = useSelect(
@@ -26,7 +27,8 @@ export default function useTitle( title ) {
 			if ( document.title !== formattedTitle ) {
 				document.title = formattedTitle;
 
-				// TODO: We might want to also add accessibility-related announcements here.
+				// Announce title on route change for screen readers.
+				speak( document.title );
 			}
 		}
 	}, [ title, siteTitle ] );

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+
+export default function useTitle( title ) {
+	const siteTitle = useSelect(
+		( select ) =>
+			select( coreStore ).getEntityRecord( 'root', 'site' )?.title,
+		[]
+	);
+
+	useEffect( () => {
+		if ( title && siteTitle ) {
+			// @see https://github.com/WordPress/wordpress-develop/blob/94849898192d271d533e09756007e176feb80697/src/wp-admin/admin-header.php#L67-L68
+			const formattedTitle = sprintf(
+				/* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
+				__( '%1$s ‹ %2$s — WordPress' ),
+				title,
+				siteTitle
+			);
+
+			if ( document.title !== formattedTitle ) {
+				document.title = formattedTitle;
+
+				// TODO: We might want to also add accessibility-related announcements here.
+			}
+		}
+	}, [ title, siteTitle ] );
+}

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -1,20 +1,36 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
+/**
+ * Internal dependencies
+ */
+import { useLocation } from './index';
+
 export default function useTitle( title ) {
+	const location = useLocation();
 	const siteTitle = useSelect(
 		( select ) =>
 			select( coreStore ).getEntityRecord( 'root', 'site' )?.title,
 		[]
 	);
+	const isInitialLocationRef = useRef( true );
 
 	useEffect( () => {
+		isInitialLocationRef.current = false;
+	}, [ location ] );
+
+	useEffect( () => {
+		// Don't update or announce the title for initial page load.
+		if ( isInitialLocationRef.current ) {
+			return;
+		}
+
 		if ( title && siteTitle ) {
 			// @see https://github.com/WordPress/wordpress-develop/blob/94849898192d271d533e09756007e176feb80697/src/wp-admin/admin-header.php#L67-L68
 			const formattedTitle = sprintf(
@@ -24,12 +40,10 @@ export default function useTitle( title ) {
 				siteTitle
 			);
 
-			if ( document.title !== formattedTitle ) {
-				document.title = formattedTitle;
+			document.title = formattedTitle;
 
-				// Announce title on route change for screen readers.
-				speak( document.title, 'assertive' );
-			}
+			// Announce title on route change for screen readers.
+			speak( document.title, 'assertive' );
 		}
-	}, [ title, siteTitle ] );
+	}, [ title, siteTitle, location ] );
 }

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -43,7 +43,14 @@ export default function useTitle( title ) {
 			document.title = formattedTitle;
 
 			// Announce title on route change for screen readers.
-			speak( document.title, 'assertive' );
+			speak(
+				sprintf(
+					/* translators: The page title that is currently displaying. */
+					__( 'Now displaying: %s' ),
+					document.title
+				),
+				'assertive'
+			);
 		}
 	}, [ title, siteTitle, location ] );
 }

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -28,7 +28,7 @@ export default function useTitle( title ) {
 				document.title = formattedTitle;
 
 				// Announce title on route change for screen readers.
-				speak( document.title );
+				speak( document.title, 'assertive' );
 			}
 		}
 	}, [ title, siteTitle ] );

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -12,7 +12,6 @@ import {
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -25,6 +24,7 @@ import {
 import { store as editSiteStore } from '../../store';
 import TemplateAreas from './template-areas';
 import EditTemplateTitle from './edit-template-title';
+import { useLink } from '../routes/link';
 
 export default function TemplateDetails( { template, onClose } ) {
 	const { title, description } = useSelect(
@@ -43,6 +43,12 @@ export default function TemplateDetails( { template, onClose } ) {
 			( { area } ) => area === template?.area
 		);
 	}, [ template ] );
+
+	const browseAllLinkProps = useLink( {
+		// TODO: We should update this to filter by template part's areas as well.
+		postType: template.type,
+		postId: undefined,
+	} );
 
 	if ( ! template ) {
 		return null;
@@ -95,11 +101,7 @@ export default function TemplateDetails( { template, onClose } ) {
 
 			<Button
 				className="edit-site-template-details__show-all-button"
-				href={ addQueryArgs( window.location.href, {
-					// TODO: We should update this to filter by template part's areas as well.
-					postId: undefined,
-					postType: template.type,
-				} ) }
+				{ ...browseAllLinkProps }
 			>
 				{ sprintf(
 					/* translators: the template part's area name ("Headers", "Sidebars") or "templates". */

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -14,16 +14,21 @@ import { moreVertical } from '@wordpress/icons';
 import { store as editSiteStore } from '../../store';
 import { TEMPLATE_PART_AREA_TO_NAME } from '../../store/constants';
 import isTemplateRevertable from '../../utils/is-template-revertable';
+import { useLink } from '../routes/link';
 
 function TemplatePartItemMore( {
 	onClose,
 	templatePart,
 	closeTemplateDetailsDropdown,
 } ) {
-	const { pushTemplatePart, revertTemplate } = useDispatch( editSiteStore );
+	const { revertTemplate } = useDispatch( editSiteStore );
+	const editLinkProps = useLink( {
+		postId: templatePart.id,
+		postType: templatePart.type,
+	} );
 
-	function editTemplatePart() {
-		pushTemplatePart( templatePart.id );
+	function editTemplatePart( event ) {
+		editLinkProps.onClick( event );
 		onClose();
 		closeTemplateDetailsDropdown();
 	}
@@ -37,7 +42,7 @@ function TemplatePartItemMore( {
 	return (
 		<>
 			<MenuGroup>
-				<MenuItem onClick={ editTemplatePart }>
+				<MenuItem { ...editLinkProps } onClick={ editTemplatePart }>
 					{ sprintf(
 						/* translators: %s: template part title */
 						__( 'Edit %s' ),

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -50,16 +50,18 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 		createSuccessNotice( __( 'Template part created.' ), {
 			type: 'snackbar',
 		} );
+
+		// The modal and this component will be unmounted because of `replaceBlocks` above,
+		// so no need to call `closeModal` or `onClose`.
 	};
 
 	return (
 		<>
 			<BlockSettingsMenuControls>
-				{ ( { onClose } ) => (
+				{ () => (
 					<MenuItem
 						onClick={ () => {
 							setIsModalOpen( true );
-							onClose();
 						} }
 					>
 						{ __( 'Make template part' ) }

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -3,29 +3,29 @@
  */
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { getQueryArg, addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
+import { useLocation } from '../routes';
 import { store as editSiteStore } from '../../store';
 
 export default function URLQueryController() {
 	const { setTemplate, setTemplatePart, showHomepage, setPage } = useDispatch(
 		editSiteStore
 	);
+	const {
+		params: { postId, postType },
+	} = useLocation();
 
-	// Set correct entity on load.
+	// Set correct entity on page navigation.
 	useEffect( () => {
-		const url = window.location.href;
-		const postId = getQueryArg( url, 'postId' );
-
 		if ( ! postId ) {
 			showHomepage();
 			return;
 		}
 
-		const postType = getQueryArg( url, 'postType' );
 		if ( 'page' === postType || 'post' === postType ) {
 			setPage( { context: { postType, postId } } ); // Resolves correct template based on ID.
 		} else if ( 'wp_template' === postType ) {
@@ -35,7 +35,7 @@ export default function URLQueryController() {
 		} else {
 			showHomepage();
 		}
-	}, [] );
+	}, [ postId, postType ] );
 
 	// Update page URL when context changes.
 	const pageContext = useCurrentPageContext();

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -18,55 +18,28 @@ export default function URLQueryController() {
 	const {
 		params: { postId, postType },
 	} = useLocation();
+	const homeTemplateId = useSelect(
+		( select ) => select( editSiteStore ).getHomeTemplateId(),
+		[]
+	);
 
 	// Set correct entity on page navigation.
 	useEffect( () => {
-		if ( ! postId ) {
-			showHomepage();
-			return;
-		}
-
 		if ( 'page' === postType || 'post' === postType ) {
 			setPage( { context: { postType, postId } } ); // Resolves correct template based on ID.
 		} else if ( 'wp_template' === postType ) {
 			setTemplate( postId );
 		} else if ( 'wp_template_part' === postType ) {
 			setTemplatePart( postId );
+		} else if ( homeTemplateId ) {
+			history.replace( {
+				postType: 'wp_template',
+				postId: homeTemplateId,
+			} );
 		} else {
 			showHomepage();
 		}
-	}, [ postId, postType ] );
-
-	// Update page URL when context changes.
-	const pageContext = useCurrentPageContext();
-	useEffect( () => {
-		history.replace( pageContext );
-	}, [ pageContext ] );
+	}, [ postId, postType, homeTemplateId, history ] );
 
 	return null;
-}
-
-function useCurrentPageContext() {
-	return useSelect( ( select ) => {
-		const { getEditedPostType, getEditedPostId, getPage } = select(
-			editSiteStore
-		);
-
-		const page = getPage();
-		let _postId = getEditedPostId(),
-			_postType = getEditedPostType();
-		// This doesn't seem right to me,
-		// we shouldn't be using the "page" and the "template" in the same way.
-		// This need to be investigated.
-		if ( page?.context?.postId && page?.context?.postType ) {
-			_postId = page.context.postId;
-			_postType = page.context.postType;
-		}
-
-		if ( _postId && _postType ) {
-			return { postId: _postId, postType: _postType };
-		}
-
-		return null;
-	}, [] );
 }

--- a/packages/edit-site/src/components/url-query-controller/index.js
+++ b/packages/edit-site/src/components/url-query-controller/index.js
@@ -3,18 +3,18 @@
  */
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { useLocation } from '../routes';
+import { useLocation, useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
 
 export default function URLQueryController() {
 	const { setTemplate, setTemplatePart, showHomepage, setPage } = useDispatch(
 		editSiteStore
 	);
+	const history = useHistory();
 	const {
 		params: { postId, postType },
 	} = useLocation();
@@ -40,11 +40,7 @@ export default function URLQueryController() {
 	// Update page URL when context changes.
 	const pageContext = useCurrentPageContext();
 	useEffect( () => {
-		const newUrl = pageContext
-			? addQueryArgs( window.location.href, pageContext )
-			: removeQueryArgs( window.location.href, 'postType', 'postId' );
-
-		window.history.replaceState( {}, '', newUrl );
+		history.replace( pageContext );
 	}, [ pageContext ] );
 
 	return null;

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -8,7 +8,6 @@ import {
 } from '@wordpress/block-library';
 import { dispatch, select } from '@wordpress/data';
 import { render, unmountComponentAtNode } from '@wordpress/element';
-import { SlotFillProvider } from '@wordpress/components';
 import {
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
 	__experimentalFetchUrlData as fetchUrlData,
@@ -23,14 +22,8 @@ import { getQueryArgs } from '@wordpress/url';
 import './plugins';
 import './hooks';
 import { store as editSiteStore } from './store';
-import { Routes } from './components/routes';
-import Editor from './components/editor';
-import List from './components/list';
-import NavigationSidebar from './components/navigation-sidebar';
-
-function getIsListPage( { postId, postType } ) {
-	return !! ( ! postId && postType );
-}
+import EditSiteApp from './components/app';
+import getIsListPage from './utils/get-is-list-page';
 
 /**
  * Reinitializes the editor after the user chooses to reboot the editor after
@@ -71,35 +64,7 @@ export function reinitializeEditor( target, settings ) {
 		}
 	}
 
-	render(
-		<SlotFillProvider>
-			<Routes>
-				{ ( { params } ) => {
-					const isListPage = getIsListPage( params );
-
-					return (
-						<>
-							{ isListPage ? (
-								<List />
-							) : (
-								<Editor onError={ reboot } />
-							) }
-							{ /* Keep the instance of the sidebar to ensure focus will not be lost
-							 * when navigating to other pages. */ }
-							<NavigationSidebar
-								// Open the navigation sidebar by default when in the list page.
-								isDefaultOpen={ !! isListPage }
-								activeTemplateType={
-									isListPage ? params.postType : undefined
-								}
-							/>
-						</>
-					);
-				} }
-			</Routes>
-		</SlotFillProvider>,
-		target
-	);
+	render( <EditSiteApp reboot={ reboot } />, target );
 }
 
 /**

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -173,20 +173,6 @@ export function setTemplatePart( templatePartId ) {
 }
 
 /**
- * Returns an action object used to push a template part to navigation history.
- *
- * @param {string} templatePartId The template part ID.
- *
- * @return {Object} Action object.
- */
-export function pushTemplatePart( templatePartId ) {
-	return {
-		type: 'PUSH_TEMPLATE_PART',
-		templatePartId,
-	};
-}
-
-/**
  * Updates the homeTemplateId state with the templateId of the page resolved
  * from the given path.
  *
@@ -242,15 +228,6 @@ export function* setPage( page ) {
 		templateId,
 	};
 	return templateId;
-}
-
-/**
- * Go back to the current editing page.
- */
-export function goBack() {
-	return {
-		type: 'GO_BACK',
-	};
 }
 
 /**

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -72,39 +72,25 @@ export function settings( state = {}, action ) {
  * Reducer keeping track of the currently edited Post Type,
  * Post Id and the context provided to fill the content of the block editor.
  *
- * @param {Array}  state  Current state history.
+ * @param {Object} state  Current edited post.
  * @param {Object} action Dispatched action.
  *
- * @return {Array} Updated state.
+ * @return {Object} Updated state.
  */
-export function editedPost( state = [], action ) {
+export function editedPost( state = {}, action ) {
 	switch ( action.type ) {
 		case 'SET_TEMPLATE':
 		case 'SET_PAGE':
-			return [
-				{
-					type: 'wp_template',
-					id: action.templateId,
-					page: action.page,
-				},
-			];
+			return {
+				type: 'wp_template',
+				id: action.templateId,
+				page: action.page,
+			};
 		case 'SET_TEMPLATE_PART':
-			return [
-				{
-					type: 'wp_template_part',
-					id: action.templatePartId,
-				},
-			];
-		case 'PUSH_TEMPLATE_PART':
-			return [
-				...state,
-				{
-					type: 'wp_template_part',
-					id: action.templatePartId,
-				},
-			];
-		case 'GO_BACK':
-			return state.slice( 0, -1 );
+			return {
+				type: 'wp_template_part',
+				id: action.templatePartId,
+			};
 	}
 
 	return state;

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -135,11 +135,7 @@ export function getHomeTemplateId( state ) {
 }
 
 function getCurrentEditedPost( state ) {
-	return state.editedPost[ state.editedPost.length - 1 ] || {};
-}
-
-function getPreviousEditedPost( state ) {
-	return state.editedPost[ state.editedPost.length - 2 ] || {};
+	return state.editedPost;
 }
 
 /**
@@ -162,28 +158,6 @@ export function getEditedPostType( state ) {
  */
 export function getEditedPostId( state ) {
 	return getCurrentEditedPost( state ).id;
-}
-
-/**
- * Returns the previous edited post type (wp_template or wp_template_part).
- *
- * @param {Object} state Global application state.
- *
- * @return {TemplateType?} Template type.
- */
-export function getPreviousEditedPostType( state ) {
-	return getPreviousEditedPost( state ).type;
-}
-
-/**
- * Returns the ID of the previous edited template or template part.
- *
- * @param {Object} state Global application state.
- *
- * @return {string?} Post ID.
- */
-export function getPreviousEditedPostId( state ) {
-	return getPreviousEditedPost( state ).id;
 }
 
 /**

--- a/packages/edit-site/src/store/test/reducer.js
+++ b/packages/edit-site/src/store/test/reducer.js
@@ -88,7 +88,7 @@ describe( 'state', () => {
 
 	describe( 'editedPost()', () => {
 		it( 'should apply default state', () => {
-			expect( editedPost( undefined, {} ) ).toEqual( [] );
+			expect( editedPost( undefined, {} ) ).toEqual( {} );
 		} );
 
 		it( 'should default to returning the same state', () => {
@@ -98,56 +98,39 @@ describe( 'state', () => {
 
 		it( 'should update when a template is set', () => {
 			expect(
-				editedPost( [ { id: 1, type: 'wp_template' } ], {
-					type: 'SET_TEMPLATE',
-					templateId: 2,
-				} )
-			).toEqual( [ { id: 2, type: 'wp_template' } ] );
+				editedPost(
+					{ id: 1, type: 'wp_template' },
+					{
+						type: 'SET_TEMPLATE',
+						templateId: 2,
+					}
+				)
+			).toEqual( { id: 2, type: 'wp_template' } );
 		} );
 
 		it( 'should update when a page is set', () => {
 			expect(
-				editedPost( [ { id: 1, type: 'wp_template' } ], {
-					type: 'SET_PAGE',
-					templateId: 2,
-					page: {},
-				} )
-			).toEqual( [ { id: 2, type: 'wp_template', page: {} } ] );
+				editedPost(
+					{ id: 1, type: 'wp_template' },
+					{
+						type: 'SET_PAGE',
+						templateId: 2,
+						page: {},
+					}
+				)
+			).toEqual( { id: 2, type: 'wp_template', page: {} } );
 		} );
 
 		it( 'should update when a template part is set', () => {
 			expect(
-				editedPost( [ { id: 1, type: 'wp_template' } ], {
-					type: 'SET_TEMPLATE_PART',
-					templatePartId: 2,
-				} )
-			).toEqual( [ { id: 2, type: 'wp_template_part' } ] );
-		} );
-
-		it( 'should update when a template part is pushed', () => {
-			expect(
-				editedPost( [ { id: 1, type: 'wp_template' } ], {
-					type: 'PUSH_TEMPLATE_PART',
-					templatePartId: 2,
-				} )
-			).toEqual( [
-				{ id: 1, type: 'wp_template' },
-				{ id: 2, type: 'wp_template_part' },
-			] );
-		} );
-
-		it( 'should go back to the previous page', () => {
-			expect(
 				editedPost(
-					[
-						{ id: 1, type: 'wp_template' },
-						{ id: 2, type: 'wp_template_part' },
-					],
+					{ id: 1, type: 'wp_template' },
 					{
-						type: 'GO_BACK',
+						type: 'SET_TEMPLATE_PART',
+						templatePartId: 2,
 					}
 				)
-			).toEqual( [ { id: 1, type: 'wp_template' } ] );
+			).toEqual( { id: 2, type: 'wp_template_part' } );
 		} );
 	} );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -13,8 +13,6 @@ import {
 	getHomeTemplateId,
 	getEditedPostType,
 	getEditedPostId,
-	getPreviousEditedPostType,
-	getPreviousEditedPostId,
 	getPage,
 	getNavigationPanelActiveMenu,
 	getReusableBlocks,
@@ -152,51 +150,22 @@ describe( 'selectors', () => {
 
 	describe( 'getEditedPostId', () => {
 		it( 'returns the template ID', () => {
-			const state = { editedPost: [ { id: 10 } ] };
+			const state = { editedPost: { id: 10 } };
 			expect( getEditedPostId( state ) ).toBe( 10 );
 		} );
 	} );
 
 	describe( 'getEditedPostType', () => {
 		it( 'returns the template type', () => {
-			const state = { editedPost: [ { type: 'wp_template' } ] };
+			const state = { editedPost: { type: 'wp_template' } };
 			expect( getEditedPostType( state ) ).toBe( 'wp_template' );
-		} );
-	} );
-
-	describe( 'getPreviousEditedPostId', () => {
-		it( 'returns the previous template ID', () => {
-			const state = { editedPost: [ { id: 10 }, { id: 20 } ] };
-			expect( getPreviousEditedPostId( state ) ).toBe( 10 );
-		} );
-
-		it( 'returns undefined when there are no previous pages', () => {
-			const state = { editedPost: [ { id: 10 } ] };
-			expect( getPreviousEditedPostId( state ) ).toBeUndefined();
-		} );
-	} );
-
-	describe( 'getPreviousEditedPostType', () => {
-		it( 'returns the previous template type', () => {
-			const state = {
-				editedPost: [
-					{ type: 'wp_template' },
-					{ type: 'wp_template_part' },
-				],
-			};
-			expect( getPreviousEditedPostType( state ) ).toBe( 'wp_template' );
-		} );
-
-		it( 'returns undefined when there are no previous pages', () => {
-			const state = { editedPost: [ { type: 'wp_template' } ] };
-			expect( getPreviousEditedPostType( state ) ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'getPage', () => {
 		it( 'returns the page object', () => {
 			const page = {};
-			const state = { editedPost: [ { page } ] };
+			const state = { editedPost: { page } };
 			expect( getPage( state ) ).toBe( page );
 		} );
 	} );

--- a/packages/edit-site/src/utils/get-is-list-page.js
+++ b/packages/edit-site/src/utils/get-is-list-page.js
@@ -1,0 +1,11 @@
+/**
+ * Returns if the params match the list page route.
+ *
+ * @param {Object} params          The search params.
+ * @param {string} params.postId   The post ID.
+ * @param {string} params.postType The post type.
+ * @return {boolean} Is list page or not.
+ */
+export default function getIsListPage( { postId, postType } ) {
+	return !! ( ! postId && postType );
+}

--- a/packages/edit-site/src/utils/history.js
+++ b/packages/edit-site/src/utils/history.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { createBrowserHistory } from 'history';
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+const history = createBrowserHistory();
+
+function push( params, state ) {
+	history.push( addQueryArgs( window.location.href, params ), state );
+}
+
+function replace( params, state ) {
+	history.replace( addQueryArgs( window.location.href, params ), state );
+}
+
+export default {
+	...history,
+	push,
+	replace,
+};

--- a/packages/edit-site/src/utils/history.js
+++ b/packages/edit-site/src/utils/history.js
@@ -10,16 +10,26 @@ import { addQueryArgs } from '@wordpress/url';
 
 const history = createBrowserHistory();
 
+const originalHistoryPush = history.push;
+const originalHistoryReplace = history.replace;
+
 function push( params, state ) {
-	history.push( addQueryArgs( window.location.href, params ), state );
+	return originalHistoryPush.call(
+		history,
+		addQueryArgs( window.location.href, params ),
+		state
+	);
 }
 
 function replace( params, state ) {
-	history.replace( addQueryArgs( window.location.href, params ), state );
+	return originalHistoryReplace.call(
+		history,
+		addQueryArgs( window.location.href, params ),
+		state
+	);
 }
 
-export default {
-	...history,
-	push,
-	replace,
-};
+history.push = push;
+history.replace = replace;
+
+export default history;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Close https://github.com/WordPress/gutenberg/issues/37075. Based on #36379. Part of https://github.com/WordPress/gutenberg/issues/36597.

Add client side routing for the site editor to improve navigation performance.

This is not based on a traditional routing rule though, the path is determined by query params, which is how WP works currently.

This PR also changes how https://github.com/WordPress/gutenberg/pull/34732 works by leveraging the router we have now to control the back button.

We obviously still need to pay extra attention to accessibility to ensure that it's still accessible. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate a FSE theme like `tt1-blocks`
2. Go to Appearance -> Editor
3. Navigate around within the editor

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/7753001/144541088-6432b995-5758-42b4-b692-d7ce4ebe58da.mp4


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
