### PR TITLE
Add constants for link entry types

### DIFF
--- a/packages/block-editor/src/components/link-control/constants.js
+++ b/packages/block-editor/src/components/link-control/constants.js
@@ -7,6 +7,17 @@ import { __ } from '@wordpress/i18n';
 // Used to help distinguish the "Create" suggestion within the search results in
 // order to handle it as a unique case.
 export const CREATE_TYPE = '__CREATE__';
+export const TEL_TYPE = 'tel';
+export const URL_TYPE = 'URL';
+export const MAILTO_TYPE = 'mailto';
+export const INTERNAL_TYPE = 'internal';
+
+export const LINK_ENTRY_TYPES = [
+	URL_TYPE,
+	MAILTO_TYPE,
+	TEL_TYPE,
+	INTERNAL_TYPE,
+];
 
 export const DEFAULT_LINK_SETTINGS = [
 	{

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -15,7 +15,7 @@ import { createElement, Fragment } from '@wordpress/element';
  */
 import LinkControlSearchCreate from './search-create-button';
 import LinkControlSearchItem from './search-item';
-import { CREATE_TYPE } from './constants';
+import { CREATE_TYPE, LINK_ENTRY_TYPES } from './constants';
 
 export default function LinkControlSearchResults( {
 	instanceId,
@@ -38,10 +38,9 @@ export default function LinkControlSearchResults( {
 		}
 	);
 
-	const directLinkEntryTypes = [ 'url', 'mailto', 'tel', 'internal' ];
 	const isSingleDirectEntryResult =
 		suggestions.length === 1 &&
-		directLinkEntryTypes.includes( suggestions[ 0 ].type.toLowerCase() );
+		LINK_ENTRY_TYPES.includes( suggestions[ 0 ].type );
 	const shouldShowCreateSuggestion =
 		withCreateSuggestion &&
 		! isSingleDirectEntryResult &&
@@ -127,8 +126,8 @@ export default function LinkControlSearchResults( {
 								handleSuggestionClick( suggestion );
 							} }
 							isSelected={ index === selectedSuggestion }
-							isURL={ directLinkEntryTypes.includes(
-								suggestion.type.toLowerCase()
+							isURL={ LINK_ENTRY_TYPES.includes(
+								suggestion.type
 							) }
 							searchTerm={ currentInputValue }
 							shouldShowType={ shouldShowSuggestionsTypes }

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -14,26 +14,32 @@ import { startsWith } from 'lodash';
  * Internal dependencies
  */
 import isURLLike from './is-url-like';
-import { CREATE_TYPE } from './constants';
+import {
+	CREATE_TYPE,
+	TEL_TYPE,
+	MAILTO_TYPE,
+	INTERNAL_TYPE,
+	URL_TYPE,
+} from './constants';
 import { store as blockEditorStore } from '../../store';
 
 export const handleNoop = () => Promise.resolve( [] );
 
 export const handleDirectEntry = ( val ) => {
-	let type = 'URL';
+	let type = URL_TYPE;
 
 	const protocol = getProtocol( val ) || '';
 
 	if ( protocol.includes( 'mailto' ) ) {
-		type = 'mailto';
+		type = MAILTO_TYPE;
 	}
 
 	if ( protocol.includes( 'tel' ) ) {
-		type = 'tel';
+		type = TEL_TYPE;
 	}
 
 	if ( startsWith( val, '#' ) ) {
-		type = 'internal';
+		type = INTERNAL_TYPE;
 	}
 
 	return Promise.resolve( [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

DRY's up the usage of strings for the link entry types by moving them to constant values.

Closes https://github.com/WordPress/gutenberg/issues/20051

## How has this been tested?

Try adding some links of various types to ensure that you can still do so without error:

* standard URL
* internal `#anchor` based.
* `tel` number.
* email with `mailto`.


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
