### PR TITLE
Identify the site frontpage in link UI search results

### DIFF
--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -67,7 +67,7 @@ export const LinkControlSearchItem = ( {
 
 function getVisualTypeName( suggestion ) {
 	if ( suggestion.isFrontPage ) {
-		return 'Front Page';
+		return 'front page';
 	}
 
 	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { Button, TextHighlight } from '@wordpress/components';
-import { Icon, globe, home } from '@wordpress/icons';
+import { Icon, globe } from '@wordpress/icons';
 
 export const LinkControlSearchItem = ( {
 	itemProps,
@@ -19,7 +19,6 @@ export const LinkControlSearchItem = ( {
 	isURL = false,
 	searchTerm = '',
 	shouldShowType = false,
-	isFrontPage = false,
 } ) => {
 	return (
 		<Button
@@ -38,12 +37,6 @@ export const LinkControlSearchItem = ( {
 				/>
 			) }
 
-			{ ! isURL && isFrontPage && (
-				<Icon
-					className="block-editor-link-control__search-item-icon"
-					icon={ home }
-				/>
-			) }
 			<span className="block-editor-link-control__search-item-header">
 				<span className="block-editor-link-control__search-item-title">
 					<TextHighlight

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { safeDecodeURI, filterURLForDisplay } from '@wordpress/url';
 import { __ } from '@wordpress/i18n';
 import { Button, TextHighlight } from '@wordpress/components';
-import { Icon, globe } from '@wordpress/icons';
+import { Icon, globe, home } from '@wordpress/icons';
 
 export const LinkControlSearchItem = ( {
 	itemProps,
@@ -19,6 +19,7 @@ export const LinkControlSearchItem = ( {
 	isURL = false,
 	searchTerm = '',
 	shouldShowType = false,
+	isFrontPage = false,
 } ) => {
 	return (
 		<Button
@@ -34,6 +35,13 @@ export const LinkControlSearchItem = ( {
 				<Icon
 					className="block-editor-link-control__search-item-icon"
 					icon={ globe }
+				/>
+			) }
+
+			{ ! isURL && isFrontPage && (
+				<Icon
+					className="block-editor-link-control__search-item-icon"
+					icon={ home }
 				/>
 			) }
 			<span className="block-editor-link-control__search-item-header">
@@ -57,12 +65,20 @@ export const LinkControlSearchItem = ( {
 			</span>
 			{ shouldShowType && suggestion.type && (
 				<span className="block-editor-link-control__search-item-type">
-					{ /* Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label. */ }
-					{ suggestion.type === 'post_tag' ? 'tag' : suggestion.type }
+					{ getVisualTypeName( suggestion ) }
 				</span>
 			) }
 		</Button>
 	);
 };
+
+function getVisualTypeName( suggestion ) {
+	if ( suggestion.isFrontPage ) {
+		return 'Front Page';
+	}
+
+	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.
+	return suggestion.type === 'post_tag' ? 'tag' : suggestion.type;
+}
 
 export default LinkControlSearchItem;

--- a/packages/block-editor/src/components/link-control/search-results.js
+++ b/packages/block-editor/src/components/link-control/search-results.js
@@ -132,6 +132,7 @@ export default function LinkControlSearchResults( {
 							) }
 							searchTerm={ currentInputValue }
 							shouldShowType={ shouldShowSuggestionsTypes }
+							isFrontPage={ suggestion?.isFrontPage }
 						/>
 					);
 				} ) }

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -287,6 +287,7 @@ $preview-image-height: 140px;
 		font-size: 0.9em;
 		background-color: $gray-100;
 		border-radius: 2px;
+		white-space: nowrap; // tags shouldn't go over two lines.
 	}
 
 	.block-editor-link-control__search-item-description {

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -35,12 +35,18 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		hasUploadPermissions,
 		canUseUnfilteredHTML,
 		userCanCreatePages,
+		pageOnFront,
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
-		const { canUser, getUnstableBase, hasFinishedResolution } = select(
-			coreStore
-		);
+		const {
+			canUser,
+			getUnstableBase,
+			hasFinishedResolution,
+			getEntityRecord,
+		} = select( coreStore );
+
+		const siteSettings = getEntityRecord( 'root', 'site' );
 
 		const siteData = getUnstableBase();
 
@@ -64,6 +70,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			hasResolvedLocalSiteData: hasFinishedResolvingSiteData,
 			baseUrl: siteData?.url || '',
 			userCanCreatePages: canUser( 'create', 'pages' ),
+			pageOnFront: siteSettings?.page_on_front,
 		};
 	}, [] );
 
@@ -139,6 +146,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			outlineMode: hasTemplate,
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
+			pageOnFront,
 		} ),
 		[
 			settings,
@@ -148,6 +156,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			undo,
 			hasTemplate,
 			userCanCreatePages,
+			pageOnFront,
 		]
 	);
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -156,7 +156,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			undo,
 			hasTemplate,
 			userCanCreatePages,
-			pageOnFront,
 		]
 	);
 }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -156,6 +156,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			undo,
 			hasTemplate,
 			userCanCreatePages,
+			pageOnFront,
 		]
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR scratches a personal itch.

When searching for a page using the Link UI it is not always clear which one of the results is your "Home" page (i.e. the one set as "Front page" in WPAdmin `Settings -> Reading`.

This PR updates the UI to 

- identifies the search result that matches the currently assigned front page (if any).
- use a "Home" icon next to that search result.
- uses a visual "tag" of `Front page` on that search result.
- removes the URL suggestion.

This makes it a lot easier to see when you have the correct page. The primary use case is when your page is called `Home` and you search for "Home" - it's now a lot clearer that you are about to set the correct page. 

## How has this been tested?

- Create a few pages - random names.
- Create a page called `Home`.
- Create a page called `Make me one please`.
- in WPAdmin Go to `Settings -> Reading`.
- set your `Home` page to be the Front page.
- Create a new Post.
- Add a link and type "Home` into the Link UI.
- You should see a special result for the "home" item (as shown in screenshot).
- You should _not_ see a URL suggestion.
- Try setting your `Make me one please` page as the front page.
- Repeat but this time search for "Make me one".

## Screenshots <!-- if applicable -->
<img width="537" alt="Screen Shot 2022-01-06 at 16 53 24" src="https://user-images.githubusercontent.com/444434/148419801-999411af-604d-45be-a2f3-fc5a055dc19c.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
