### PR TITLE
Make the core color palette opt-in for themes with not `theme.json`

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -157,9 +157,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		* So we take theme supports, transform it to theme.json shape
 		* and merge the self::$theme upon that.
 		*/
-		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
+		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
 		// We don't want the core palette&gradients enabled for themes without theme.json support.
-		if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+		if ( ! self::theme_has_support() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();
 			}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -158,6 +158,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		* and merge the self::$theme upon that.
 		*/
 		$theme_support_data  = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
+		// We don't want the core palette&gradients enabled for themes without theme.json support.
+		if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
+				$theme_support_data['settings']['color'] = array();
+			}
+			$theme_support_data['settings']['color']['corePalette']   = false;
+			$theme_support_data['settings']['color']['coreGradients'] = false;
+		}
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( self::$theme );
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -158,13 +158,30 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		* and merge the self::$theme upon that.
 		*/
 		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( gutenberg_get_default_block_editor_settings() );
-		// We don't want the core palette&gradients enabled for themes without theme.json support.
 		if ( ! self::theme_has_support() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();
 			}
-			$theme_support_data['settings']['color']['corePalette']   = false;
-			$theme_support_data['settings']['color']['coreGradients'] = false;
+
+			$default_palette = false;
+			if ( current_theme_supports( 'default-color-palette' ) ) {
+				$default_palette = true;
+			}
+			if ( ! isset( $theme_support_data['settings']['color']['palette'] ) ) {
+				// If the theme does not have any palette, we still want to show the core one.
+				$default_palette = true;
+			}
+			$theme_support_data['settings']['color']['corePalette'] = $default_palette;
+
+			$default_gradients = false;
+			if ( current_theme_supports( 'default-gradient-presets' ) ) {
+				$default_gradients = true;
+			}
+			if ( ! isset( $theme_support_data['settings']['color']['gradients'] ) ) {
+				// If the theme does not have any gradients, we still want to show the core ones.
+				$default_gradients = true;
+			}
+			$theme_support_data['settings']['color']['coreGradients'] = $default_gradients;
 		}
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
 		$with_theme_supports->merge( self::$theme );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -118,8 +118,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_switching_themes_recalculates_data() {
-		// By default, the theme for unit tests is "default",
-		// which doesn't have theme.json support.
+		// The "default" theme doesn't have theme.json support.
+		switch_theme( 'default' );
 		$default = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
 
 		// Switch to a theme that does have support.


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/36492 https://github.com/WordPress/gutenberg/pull/35970

In https://github.com/WordPress/gutenberg/pull/35970 we introduced the ability to show three different palettes (default, theme, user) in the color UI component. We also have a couple of flags for themes to disable this should they want (`corePalette`, `coreGradients`). However, by introducing this change, themes that don't use `theme.json` will now see the default colors as well.

This PR introduces the following changes:

- Hides the default palette for themes with no `theme.json` that declare its own palette.
- Adds new theme supports for themes with no `theme.json` to opt-in into the default solid and gradient palettes, so they can show both the default and the theme one:
  - `default-color-palette` which mimic the existing `editor-color-palette` theme supports
  - `default-gradient-presets` which mimics the existing `editor-gradient-presets` theme support

## How to test

Test a theme that does not provide a palette:

- Use Storefront.
- Load the editor and verify that the color component shows the default palette.

Test a theme that provides a palette:

- Use TwentyTwentyOne.
- Load the editor and verify that the color component only shows the theme solids&gradients but not the default ones (they'll be shown without this PR).

Test a theme that provides a palette and opts-in into the core palette:

- Use TwentyTwentyOne.
- Add `add_theme_support( 'default-color-palette' )` and `add_theme_support( 'default-gradient-presets' )` in its `functions.php`.
- Load the editor and verify that the color component shows both the default and the theme palettes for solids & gradients.
