### PR TITLE
Fix initial theme content not showing for navigation block within navigation area

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -136,19 +136,19 @@ function Navigation( {
 		`navigationMenu/${ navigationMenuId }`
 	);
 
-	const { innerBlocks, isInnerBlockSelected } = useSelect(
+	const { unsavedInnerBlocks, isInnerBlockSelected } = useSelect(
 		( select ) => {
-			const { getBlocks, hasSelectedInnerBlock } = select(
+			const { getBlock, hasSelectedInnerBlock } = select(
 				blockEditorStore
 			);
 			return {
-				innerBlocks: getBlocks( clientId ),
+				unsavedInnerBlocks: getBlock( clientId ).innerBlocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};
 		},
 		[ clientId ]
 	);
-	const hasExistingNavItems = !! innerBlocks.length;
+	const hasUnsavedInnerBlocks = !! unsavedInnerBlocks.length;
 	const {
 		replaceInnerBlocks,
 		selectBlock,
@@ -163,7 +163,7 @@ function Navigation( {
 	const isWithinUnassignedArea = navigationArea && ! navigationMenuId;
 
 	const [ isPlaceholderShown, setIsPlaceholderShown ] = useState(
-		! hasExistingNavItems || isWithinUnassignedArea
+		! hasUnsavedInnerBlocks || isWithinUnassignedArea
 	);
 
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] = useState(
@@ -223,6 +223,15 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
+	// Update the menu id attribute if the one provided by the navigation area
+	// is different to the one stored in the block.
+	useEffect( () => {
+		if ( navigationMenuId !== attributes.navigationMenuId ) {
+			__unstableMarkNextChangeAsNotPersistent();
+			setAttributes( { navigationMenuId } );
+		}
+	}, [ navigationMenuId, attributes.navigationMenuId ] );
+
 	// Spacer block needs orientation from context. This is a patch until
 	// https://github.com/WordPress/gutenberg/issues/36197 is addressed.
 	useEffect( () => {
@@ -263,13 +272,12 @@ function Navigation( {
 	// Either this block was saved in the content or inserted by a pattern.
 	// Consider this 'unsaved'. Offer an uncontrolled version of inner blocks,
 	// that automatically saves the menu.
-	const hasUnsavedBlocks =
-		hasExistingNavItems && ! isEntityAvailable && ! isWithinUnassignedArea;
+	const hasUnsavedBlocks = hasUnsavedInnerBlocks && ! isEntityAvailable;
 	if ( hasUnsavedBlocks ) {
 		return (
 			<UnsavedInnerBlocks
 				blockProps={ blockProps }
-				blocks={ innerBlocks }
+				blocks={ unsavedInnerBlocks }
 				clientId={ clientId }
 				navigationMenus={ navigationMenus }
 				hasSelection={ isSelected || isInnerBlockSelected }


### PR DESCRIPTION
## Description
Fixes #36306

As described in that issue, themes should be able to implement a navigation area containing a navigation block with some initial starter content using something like the following markup:
```html
<!-- wp:navigation-area {"area":"primary"} -->
<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->
<!-- /wp:navigation-area -->
```

This was working on the frontend (the page list would be rendered), but the editor was still showing the block placeholder for this HTML. It should instead show the Page List block and allow the user to edit and save this initial content.

The fix is a matter of adjusting some (slightly complicated) boolean logic in the navigation block for when the 'UnsavedInnerBlocks' should be shown.

## How has this been tested?
This should be an easier way to validate the fix without needing to edit site templates, but some fuller testing on Twenty Twenty would be welcome too:
1. Ensure the Primary navigation area is unassigned (Currently the way to do this is to add a navigation area, select the navigation block inside it, select 'Create new menu' from the 'Select Menu' option on the toolbar, and then save everything.)
2. Create a new post in the post editor
3. Paste this HTML into the code editor
```html
<!-- wp:navigation-area {"area":"primary"} -->
<!-- wp:navigation {"itemsJustification":"right","isResponsive":true} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->
<!-- /wp:navigation-area -->
```
4. The Page List should be visible in the editor
5. Save and reload, the page list should still be visible.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
