### PR TITLE
Fix non existent menu handling in nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -283,20 +283,6 @@ function Navigation( {
 		);
 	}
 
-	// Show a warning if the selected menu is no longer available.
-	// TODO - the user should be able to select a new one?
-	if ( navigationMenuId && isNavigationMenuMissing ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __(
-						'Navigation menu has been deleted or is unavailable'
-					) }
-				</Warning>
-			</div>
-		);
-	}
-
 	if ( isEntityAvailable && hasAlreadyRendered ) {
 		return (
 			<div { ...blockProps }>

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -8,6 +8,7 @@ export default function useNavigationMenu( navigationMenuId ) {
 	return useSelect(
 		( select ) => {
 			const {
+				getEntityRecord,
 				getEditedEntityRecord,
 				getEntityRecords,
 				hasFinishedResolution,
@@ -18,6 +19,9 @@ export default function useNavigationMenu( navigationMenuId ) {
 				'wp_navigation',
 				navigationMenuId,
 			];
+			const rawNavigationMenu = navigationMenuId
+				? getEntityRecord( ...navigationMenuSingleArgs )
+				: null;
 			const navigationMenu = navigationMenuId
 				? getEditedEntityRecord( ...navigationMenuSingleArgs )
 				: null;
@@ -45,7 +49,7 @@ export default function useNavigationMenu( navigationMenuId ) {
 				isNavigationMenuResolved: hasResolvedNavigationMenu,
 				isNavigationMenuMissing:
 					! navigationMenuId ||
-					( hasResolvedNavigationMenu && ! navigationMenu ),
+					( hasResolvedNavigationMenu && ! rawNavigationMenu ),
 				canSwitchNavigationMenu,
 				hasResolvedNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',


### PR DESCRIPTION
## Description
When the `wp_navigation` post associated with a navigation block no longer exists (for example, a user deleted it using wp-admin), the block is designed to show a message:
<img width="533" alt="Screenshot 2021-11-16 at 4 28 26 pm" src="https://user-images.githubusercontent.com/677833/141949448-f3820441-af99-41ec-b556-c04d833e563e.png">

There are two problems:
1. This warning is never actually shown, instead when an `wp_navigation` doesn't exist the user ends up with an empty block that can't be saved.
2. The warning isn't useful. The user can't fix the problem without removing and adding the block again.

This fixes both of those issues:
1. The first solution is to use `getEntityRecord` to determine if an entity exists instead of `getEditedEntityRecord`. `getEditedEntityRecord` always returns an object once resolved which makes it hard to tell if an entity is missing. `getEntityRecord` returns `undefined`. This fix is in the `useNavigationMenu` hook.
2. The second fix is to remove the warning, and when the associated entity no longer exists the block naturally falls back to the block placeholder. All that was required is to delete the code associated with this.

Note - the template part block also has this issue. The navigation block's code was copied from the template part block. I'll make an issue about this.

## How has this been tested?
1. Add a navigation block in a post
2. Start empty and name the menu.
3. In the code editor mode, edit the `navigationMenuId` to be an id that doesn't exist on your site (e.g. `999999`).
4. Select the navigation block and observe the placeholder is shown

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
