### PR TITLE
Gallery block: disable the v2 Gallery block for the 5.9 release

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -98,7 +98,7 @@ function gutenberg_display_experiment_section() {
  */
 function gutenberg_experiments_editor_settings( $settings ) {
 	// The refactored gallery is disabled by default on WordPress 5.9.
-	// To run the refactored Gallery with nested Image blocks install the 
+	// To run the refactored Gallery with nested Image blocks install the
 	// Gutenberg plugin >= 11.9.
 	$experiments_settings = array(
 		'__unstableGalleryWithImageBlocks' => false,

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -97,11 +97,11 @@ function gutenberg_display_experiment_section() {
  * @return array Filtered editor settings.
  */
 function gutenberg_experiments_editor_settings( $settings ) {
-	// The refactored gallery currently can't be run on sites with use_balanceTags option set.
-	// This bypass needs to remain in place until this is resolved and a patch released.
-	// https://core.trac.wordpress.org/ticket/54130.
+	// The refactored gallery is disabled by default on WordPress 5.9.
+	// To run the refactored Gallery with nested Image blocks install the 
+	// Gutenberg plugin >= 11.9.
 	$experiments_settings = array(
-		'__unstableGalleryWithImageBlocks' => (int) get_option( 'use_balanceTags' ) !== 1,
+		'__unstableGalleryWithImageBlocks' => false,
 	);
 	return array_merge( $settings, $experiments_settings );
 }


### PR DESCRIPTION
## Description
There have been issues with getting auto migration of v1 gallery blocks stabilised for the 5.9 release so this PR disables the v2 Gallery block. If the decision is made to pull the v2 Gallery block from 5.9 then this PR would be merged and cherry picked to 5.9 and then this commit would be reverted on trunk so the v2 Gallery blocks are still available in the plugin. 

## How has this been tested?

- Check out this PR to a local dev env
- Add a Gallery block and make sure it is the v1 format - it will have move icons in the image as in the screenshot and nested images in a `<ul>` structure rather than nested image blocks.
- Check that block remains as v1 when editor refreshed and that it displays as expected in the frontend

## Screenshots <!-- if applicable -->
<img width="664" alt="Screen Shot 2021-11-16 at 9 50 57 PM" src="https://user-images.githubusercontent.com/3629020/141953185-a7708318-f6f1-4a8e-b2cb-dae60aee931f.png">

