### PR TITLE
Gallery block: Enable new format by default for 5.9

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -97,11 +97,10 @@ function gutenberg_display_experiment_section() {
  * @return array Filtered editor settings.
  */
 function gutenberg_experiments_editor_settings( $settings ) {
-	// The refactored gallery currently can't be run on sites with use_balanceTags option set.
-	// This bypass needs to remain in place until this is resolved and a patch released.
-	// https://core.trac.wordpress.org/ticket/54130.
+	// Currently the refactored Gallery blocks will only be enabled for new blocks.
+	// Existing Gallery blocks will be edited and viewed in the v1 format.
 	$experiments_settings = array(
-		'__unstableGalleryWithImageBlocks' => (int) get_option( 'use_balanceTags' ) !== 1,
+		'__unstableGalleryWithImageBlocks' => true,
 	);
 	return array_merge( $settings, $experiments_settings );
 }


### PR DESCRIPTION
## Description
There have been issues with getting auto migration of v1 gallery blocks stabilised for the 5.9 release so this PR disables the v2 Gallery block. If the decision is made to pull the v2 Gallery block from 5.9 then this PR would be merged and cherry picked to 5.9 and then this commit would be reverted on trunk so the v2 Gallery blocks are still available in the plugin. 

**Important** If this is cherry picked into 5.9 it is critical that https://github.com/WordPress/wordpress-develop/pull/1678 is also included.

Once this is cherry picked to 5.9 this flag should be updated on trunk to disabled the option for sites where `use_balanceTags` is set.

## How has this been tested?

- Revert to a gutenberg plugin <= 11.7 with gallery experiment turned off and add some gallery blocks
- Check out this PR to a local dev env
- Reload the previous added galleries and make sure they stay in v1 format. They will have move icons in the image as in the first screenshot and nested images in a `<ul>` structure rather than nested image blocks.
- Add a Gallery block and make sure it is the v2 format - it will have nested individual image blocks, and each image will have its own block toolbar like the second screenshot below.
- Make sure when refreshing the editor the two different types of blocks stay in the correct format
- Try clicking the `Update` button in the block toolbar of a v1 Gallery block and check that it converts to a v2 Gallery block successfully

## Screenshots 
v1 Gallery block
<img width="664" alt="Screen Shot 2021-11-16 at 9 50 57 PM" src="https://user-images.githubusercontent.com/3629020/141955650-6a97d515-6620-4bfc-a991-96391e6eeb24.png">

V2 Gallery block
<img width="645" alt="Screen Shot 2021-11-16 at 9 58 45 PM" src="https://user-images.githubusercontent.com/3629020/141955678-80d669b9-74f7-4cb6-8408-a712332cc9d4.png">