### PR TITLE
Add feature flag to toggle the new site editor sidebar

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -35,6 +35,7 @@ import Header from '../header';
 import { SidebarComplementaryAreaFills } from '../sidebar';
 import BlockEditor from '../block-editor';
 import KeyboardShortcuts from '../keyboard-shortcuts';
+import NavigationSidebar from '../navigation-sidebar';
 import URLQueryController from '../url-query-controller';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
@@ -46,6 +47,7 @@ import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 
 const interfaceLabels = {
 	secondarySidebar: __( 'Block Library' ),
+	drawer: __( 'Navigation Sidebar' ),
 };
 
 function Editor( { initialSettings, onError } ) {
@@ -111,7 +113,11 @@ function Editor( { initialSettings, onError } ) {
 	// so that they can be selected with core/editor selectors in any editor.
 	// This is needed because edit-site doesn't initialize with EditorProvider,
 	// which internally uses updateEditorSettings as well.
-	const { defaultTemplateTypes, defaultTemplatePartAreas } = settings;
+	const {
+		defaultTemplateTypes,
+		defaultTemplatePartAreas,
+		__experimentalNewMenuSidebar: newMenuSidebar,
+	} = settings;
 	useEffect( () => {
 		updateEditorSettings( {
 			defaultTemplateTypes,
@@ -213,6 +219,11 @@ function Editor( { initialSettings, onError } ) {
 											<SidebarComplementaryAreaFills />
 											<InterfaceSkeleton
 												labels={ interfaceLabels }
+												drawer={
+													newMenuSidebar ? undefined : (
+														<NavigationSidebar />
+													)
+												}
 												secondarySidebar={ secondarySidebar() }
 												sidebar={
 													sidebarIsOpened && (

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -47,6 +47,7 @@ export default function Header( {
 		isListViewOpen,
 		listViewShortcut,
 		isLoaded,
+		newMenuSidebar,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -54,6 +55,7 @@ export default function Header( {
 			getEditedPostId,
 			isInserterOpened,
 			isListViewOpened,
+			getSettings,
 		} = select( editSiteStore );
 		const { getEditedEntityRecord } = select( coreStore );
 		const { __experimentalGetTemplateInfo: getTemplateInfo } = select(
@@ -77,6 +79,7 @@ export default function Header( {
 			listViewShortcut: getShortcutRepresentation(
 				'core/edit-site/toggle-list-view'
 			),
+			newMenuSidebar: getSettings().__experimentalNewMenuSidebar,
 		};
 	}, [] );
 
@@ -107,9 +110,11 @@ export default function Header( {
 	return (
 		<div className="edit-site-header">
 			<div className="edit-site-header_start">
-				<MainDashboardButton.Slot>
-					<NavigationLink />
-				</MainDashboardButton.Slot>
+				{ newMenuSidebar && (
+					<MainDashboardButton.Slot>
+						<NavigationLink />
+					</MainDashboardButton.Slot>
+				) }
 
 				<div className="edit-site-header__toolbar">
 					<Button

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -31,7 +31,13 @@ export default function TemplateDetails( { template, onClose } ) {
 			select( editorStore ).__experimentalGetTemplateInfo( template ),
 		[]
 	);
-	const { revertTemplate } = useDispatch( editSiteStore );
+	const newMenuSidebar = useSelect(
+		( select ) =>
+			select( editSiteStore ).getSettings().__experimentalNewMenuSidebar
+	);
+	const { openNavigationPanelToMenu, revertTemplate } = useDispatch(
+		editSiteStore
+	);
 
 	const templateSubMenu = useMemo( () => {
 		if ( template?.type === 'wp_template' ) {
@@ -46,6 +52,11 @@ export default function TemplateDetails( { template, onClose } ) {
 	if ( ! template ) {
 		return null;
 	}
+
+	const showTemplateInSidebar = () => {
+		onClose();
+		openNavigationPanelToMenu( templateSubMenu.menu );
+	};
 
 	const revert = () => {
 		revertTemplate( template );
@@ -90,10 +101,23 @@ export default function TemplateDetails( { template, onClose } ) {
 
 			<Button
 				className="edit-site-template-details__show-all-button"
-				href={ addQueryArgs( 'edit.php', {
-					// TODO: We should update this to filter by template part's areas as well.
-					post_type: template.type,
-				} ) }
+				{ ...( newMenuSidebar
+					? {
+							href: addQueryArgs( 'edit.php', {
+								// TODO: We should update this to filter by template part's areas as well.
+								post_type: template.type,
+							} ),
+					  }
+					: {
+							onClick: showTemplateInSidebar,
+							'aria-label': sprintf(
+								/* translators: %1$s: the template part's area name ("Headers", "Sidebars") or "templates". */
+								__(
+									'Browse all %1$s. This will open the %1$s menu in the navigation side panel.'
+								),
+								templateSubMenu.title
+							),
+					  } ) }
 			>
 				{ sprintf(
 					/* translators: the template part's area name ("Headers", "Sidebars") or "templates". */

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -49,6 +49,8 @@ export function initialize( id, settings ) {
 		fetchLinkSuggestions( search, searchOptions, settings );
 	settings.__experimentalFetchRichUrlData = fetchUrlData;
 	settings.__experimentalSpotlightEntityBlocks = [ 'core/template-part' ];
+	// Feature flag for the new menu sidebar which isn't stable yet.
+	settings.__experimentalNewMenuSidebar = false;
 
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind( null, target, settings );

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -6,6 +6,8 @@
 @import "./components/header/document-actions/style.scss";
 @import "./components/header/more-menu/style.scss";
 @import "./components/header/navigation-link/style.scss";
+@import "./components/navigation-sidebar/navigation-toggle/style.scss";
+@import "./components/navigation-sidebar/navigation-panel/style.scss";
 @import "./components/sidebar/style.scss";
 @import "./components/sidebar/settings-header/style.scss";
 @import "./components/sidebar/template-card/style.scss";


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Adding a feature flag to revert #36194 to the old navigation panel in site editor.

This is meant to be a temporary solution until https://github.com/WordPress/gutenberg/pull/36379 is merged. And we can still develop the new screen by switching the flag.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate a FSE theme like `tt1-blocks`
2. Go to Appearance -> Editor
3. The navigation panel should behave the same as the old one
4. Switch `__experimentalNewMenuSidebar` to `true` in `edit-site/src/index.js` and reload
5. The navigation panel is now gone

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
