### PR TITLE
stylelint-config: Widen the acceptable version range for the 'stylelint' peerDependency

### DIFF
--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -36,7 +36,7 @@
 		"stylelint-scss": "^3.17.2"
 	},
 	"peerDependencies": {
-		"stylelint": "^13.7.0"
+		"stylelint": ">=13.7.0"
 	},
 	"npmpackagejsonlint": {
 		"extends": "@wordpress/npm-package-json-lint-config",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -36,7 +36,7 @@
 		"stylelint-scss": "^3.17.2"
 	},
 	"peerDependencies": {
-		"stylelint": ">=13.7.0"
+		"stylelint": "^13.7.0 || ^14"
 	},
 	"npmpackagejsonlint": {
 		"extends": "@wordpress/npm-package-json-lint-config",


### PR DESCRIPTION
fixes #36514

## Description
<!-- Please describe what you have changed or added -->
The semVer for the `stylelint` peerDependency has been updated to include the 14.x branch as valid dependency.

## How has this been tested?
This has been tested manually with `npm install stylelint`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
