### PR TITLE
[Global Styles]: Add block icon next to blocks list

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -3,6 +3,11 @@
  */
 import { getBlockTypes } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import {
+	FlexItem,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
+import { BlockIcon } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -29,7 +34,12 @@ function BlockMenuItem( { block } ) {
 
 	return (
 		<NavigationButton path={ '/blocks/' + block.name }>
-			{ block.title }
+			<HStack justify="flex-start">
+				<FlexItem>
+					<BlockIcon icon={ block.icon } />
+				</FlexItem>
+				<FlexItem>{ block.title }</FlexItem>
+			</HStack>
 		</NavigationButton>
 	);
 }


### PR DESCRIPTION
This PR just adds the block icon next to the blocks list in Global Styles sidebar.
<img width="279" alt="Screenshot 2021-11-16 at 2 23 57 PM" src="https://user-images.githubusercontent.com/16275880/141993536-fabd950d-d47b-49ce-8665-75e2ce0ee2cc.png">


