### PR TITLE
[RNMobile] Inserter menu: Fix tab titles translation

### DIFF
--- a/packages/block-editor/src/components/inserter/tabs.native.js
+++ b/packages/block-editor/src/components/inserter/tabs.native.js
@@ -63,7 +63,7 @@ function InserterTabs( {
 	}, [ tabIndex ] );
 
 	const { tabs, tabKeys } = useMemo( () => {
-		const filteredTabs = InserterTabs.TABS.filter(
+		const filteredTabs = InserterTabs.getTabs().filter(
 			( { name } ) => showReusableBlocks || name !== 'reusable'
 		);
 		return {
@@ -114,8 +114,9 @@ function InserterTabs( {
 }
 
 function TabsControl( { onChangeTab, showReusableBlocks } ) {
+	const tabs = InserterTabs.getTabs();
 	const segments = useMemo( () => {
-		const filteredTabs = InserterTabs.TABS.filter(
+		const filteredTabs = tabs.filter(
 			( { name } ) => showReusableBlocks || name !== 'reusable'
 		);
 		return filteredTabs.map( ( { title } ) => title );
@@ -123,7 +124,7 @@ function TabsControl( { onChangeTab, showReusableBlocks } ) {
 
 	const segmentHandler = useCallback(
 		( selectedTab ) => {
-			const tabTitles = InserterTabs.TABS.map( ( { title } ) => title );
+			const tabTitles = tabs.map( ( { title } ) => title );
 			onChangeTab( tabTitles.indexOf( selectedTab ) );
 		},
 		[ onChangeTab ]
@@ -139,7 +140,7 @@ function TabsControl( { onChangeTab, showReusableBlocks } ) {
 
 InserterTabs.Control = TabsControl;
 
-InserterTabs.TABS = [
+InserterTabs.getTabs = () => [
 	{ name: 'blocks', title: __( 'Blocks' ), component: BlockTypesTab },
 	{ name: 'reusable', title: __( 'Reusable' ), component: ReusableBlocksTab },
 ];

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] [Embed block] Included Link in Block Settings [#36099]
+-   [**] Fix tab titles translation of inserter menu [#36534]
 
 ## 1.66.0
 -   [**] [Image block] Add ability to quickly link images to Media Files and Attachment Pages [#34846]


### PR DESCRIPTION
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4248

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The titles of the tabs displayed in the inserter menu are not being localized even though they're using the [translation function `__`](https://github.com/WordPress/gutenberg/blob/trunk/packages/i18n/README.md#__).

After debugging this issue, I found out that it's caused by the fact that the titles are defined in a global constant in the inserter tabs file ([reference](https://github.com/WordPress/gutenberg/blob/f323d9620845068751ad60742fc16e0e8fc1e76b/packages/block-editor/src/components/inserter/tabs.native.js#L142-L145)) and by the time the translation functions are called, the translations haven't been defined yet. 

The translations are set before the editor is rendered ([reference](https://github.com/WordPress/gutenberg/blob/f323d9620845068751ad60742fc16e0e8fc1e76b/packages/react-native-editor/src/index.js#L58)), however, due to imports located in the initialization parts of the native version of the editor, the inserter menu and the inserter tabs components are imported before translations are ready.

I haven't found the dependency path from the initialization code but looks like it might be related to the `@wordpress/blocks` package and importing `@wordpress/edit-post` which leads to importing the inserter tabs component.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**NOTE:** The tabs are only displayed when there's at least one reusable block on the site, so before testing, please verify the existence of reusable blocks by clicking [this link](https://wordpress.com/types/wp_block) and selecting your site.

1. Change the language of your device to non-English.
2. Open a post/page.
3. Open the inserter menu by tapping the ➕ button.
4. Observe that the titles of the tabs are translated to the selected language.

## Screenshots <!-- if applicable -->

Before|After
--|--
<img src=https://user-images.githubusercontent.com/14905380/142041588-fbea8010-1943-458e-aca3-807f05d5de21.png>|<img src=https://user-images.githubusercontent.com/14905380/142041595-81cb67bf-e5f3-48f7-bfa0-454cf0818cc1.png>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
