### PR TITLE
Post Featured Image: Move width and height controls into the Dimensions panel via SlotFill

### DIFF
--- a/packages/block-editor/src/hooks/dimensions.scss
+++ b/packages/block-editor/src/hooks/dimensions.scss
@@ -1,0 +1,5 @@
+.dimensions-block-support-panel {
+	.single-column {
+		grid-column: span 1;
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -56,6 +56,7 @@
 @import "./hooks/anchor.scss";
 @import "./hooks/layout.scss";
 @import "./hooks/border.scss";
+@import "./hooks/dimensions.scss";
 @import "./hooks/typography.scss";
 
 @import "./components/block-toolbar/style.scss";

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -129,7 +129,7 @@ const DimensionControls = ( {
 					resetAllFilter={ () => ( {
 						scale: 'cover',
 					} ) }
-					isShownByDefault={ !! height }
+					isShownByDefault={ true }
 					panelId={ clientId }
 				>
 					<ToggleGroupControl

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -31,6 +31,8 @@ const SCALE_OPTIONS = (
 	</>
 );
 
+const DEFAULT_SCALE = 'cover';
+
 const scaleHelp = {
 	cover: __(
 		'Image is scaled and cropped to fill the entire space without being distorted.'
@@ -74,12 +76,12 @@ const DimensionControls = ( {
 				onDeselect={ () =>
 					setAttributes( {
 						height: undefined,
-						scale: 'cover',
+						scale: DEFAULT_SCALE,
 					} )
 				}
 				resetAllFilter={ () => ( {
 					height: undefined,
-					scale: 'cover',
+					scale: DEFAULT_SCALE,
 				} ) }
 				isShownByDefault={ true }
 				panelId={ clientId }
@@ -119,15 +121,15 @@ const DimensionControls = ( {
 			</ToolsPanelItem>
 			{ !! height && (
 				<ToolsPanelItem
-					hasValue={ () => !! scale }
+					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }
 					label={ scaleLabel }
 					onDeselect={ () =>
 						setAttributes( {
-							scale: 'cover',
+							scale: DEFAULT_SCALE,
 						} )
 					}
 					resetAllFilter={ () => ( {
-						scale: 'cover',
+						scale: DEFAULT_SCALE,
 					} ) }
 					isShownByDefault={ true }
 					panelId={ clientId }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -71,9 +71,15 @@ const DimensionControls = ( {
 				className="single-column"
 				hasValue={ () => !! height }
 				label={ __( 'Height' ) }
-				onDeselect={ () => setAttributes( { height: undefined } ) }
+				onDeselect={ () =>
+					setAttributes( {
+						height: undefined,
+						scale: 'cover',
+					} )
+				}
 				resetAllFilter={ () => ( {
 					height: undefined,
+					scale: 'cover',
 				} ) }
 				isShownByDefault={ true }
 				panelId={ clientId }
@@ -82,6 +88,7 @@ const DimensionControls = ( {
 					label={ __( 'Height' ) }
 					labelPosition="top"
 					value={ height || '' }
+					min={ 0 }
 					onChange={ ( nextHeight ) =>
 						onDimensionChange( 'height', nextHeight )
 					}
@@ -103,6 +110,7 @@ const DimensionControls = ( {
 					label={ __( 'Width' ) }
 					labelPosition="top"
 					value={ width || '' }
+					min={ 0 }
 					onChange={ ( nextWidth ) =>
 						onDimensionChange( 'width', nextWidth )
 					}
@@ -115,11 +123,11 @@ const DimensionControls = ( {
 					label={ scaleLabel }
 					onDeselect={ () =>
 						setAttributes( {
-							scale: undefined,
+							scale: 'cover',
 						} )
 					}
 					resetAllFilter={ () => ( {
-						scale: undefined,
+						scale: 'cover',
 					} ) }
 					isShownByDefault={ !! height }
 					panelId={ clientId }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -73,15 +73,9 @@ const DimensionControls = ( {
 				className="single-column"
 				hasValue={ () => !! height }
 				label={ __( 'Height' ) }
-				onDeselect={ () =>
-					setAttributes( {
-						height: undefined,
-						scale: DEFAULT_SCALE,
-					} )
-				}
+				onDeselect={ () => setAttributes( { height: undefined } ) }
 				resetAllFilter={ () => ( {
 					height: undefined,
-					scale: DEFAULT_SCALE,
 				} ) }
 				isShownByDefault={ true }
 				panelId={ clientId }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -1,22 +1,15 @@
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
 import {
-	PanelBody,
 	__experimentalUnitControl as UnitControl,
-	Flex,
-	FlexItem,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { useSetting } from '@wordpress/block-editor';
+import { InspectorControls, useSetting } from '@wordpress/block-editor';
 
 const SCALE_OPTIONS = (
 	<>
@@ -51,6 +44,7 @@ const scaleHelp = {
 };
 
 const DimensionControls = ( {
+	clientId,
 	attributes: { width, height, scale },
 	setAttributes,
 } ) => {
@@ -72,53 +66,80 @@ const DimensionControls = ( {
 	};
 	const scaleLabel = _x( 'Scale', 'Image scaling options' );
 	return (
-		<PanelBody title={ __( 'Dimensions' ) }>
-			<Flex
-				justify="space-between"
-				className={ classNames(
-					'block-library-post-featured-image-dimension-controls',
-					{ 'scale-control-is-visible': !! height }
-				) }
+		<InspectorControls __experimentalGroup="dimensions">
+			<ToolsPanelItem
+				className="single-column"
+				hasValue={ () => !! height }
+				label={ __( 'Height' ) }
+				onDeselect={ () => setAttributes( { height: undefined } ) }
+				resetAllFilter={ () => ( {
+					height: undefined,
+				} ) }
+				isShownByDefault={ true }
+				panelId={ clientId }
 			>
-				<FlexItem>
-					<UnitControl
-						label={ __( 'Height' ) }
-						labelPosition="top"
-						value={ height || '' }
-						onChange={ ( nextHeight ) => {
-							onDimensionChange( 'height', nextHeight );
-						} }
-						units={ units }
-					/>
-				</FlexItem>
-				<FlexItem>
-					<UnitControl
-						label={ __( 'Width' ) }
-						labelPosition="top"
-						value={ width || '' }
-						onChange={ ( nextWidth ) => {
-							onDimensionChange( 'width', nextWidth );
-						} }
-						units={ units }
-					/>
-				</FlexItem>
-			</Flex>
+				<UnitControl
+					label={ __( 'Height' ) }
+					labelPosition="top"
+					value={ height || '' }
+					onChange={ ( nextHeight ) =>
+						onDimensionChange( 'height', nextHeight )
+					}
+					units={ units }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				className="single-column"
+				hasValue={ () => !! width }
+				label={ __( 'Width' ) }
+				onDeselect={ () => setAttributes( { width: undefined } ) }
+				resetAllFilter={ () => ( {
+					width: undefined,
+				} ) }
+				isShownByDefault={ true }
+				panelId={ clientId }
+			>
+				<UnitControl
+					label={ __( 'Width' ) }
+					labelPosition="top"
+					value={ width || '' }
+					onChange={ ( nextWidth ) =>
+						onDimensionChange( 'width', nextWidth )
+					}
+					units={ units }
+				/>
+			</ToolsPanelItem>
 			{ !! height && (
-				<ToggleGroupControl
+				<ToolsPanelItem
+					hasValue={ () => !! scale }
 					label={ scaleLabel }
-					value={ scale }
-					help={ scaleHelp[ scale ] }
-					onChange={ ( value ) => {
+					onDeselect={ () =>
 						setAttributes( {
-							scale: value,
-						} );
-					} }
-					isBlock
+							scale: undefined,
+						} )
+					}
+					resetAllFilter={ () => ( {
+						scale: undefined,
+					} ) }
+					isShownByDefault={ !! height }
+					panelId={ clientId }
 				>
-					{ SCALE_OPTIONS }
-				</ToggleGroupControl>
+					<ToggleGroupControl
+						label={ scaleLabel }
+						value={ scale }
+						help={ scaleHelp[ scale ] }
+						onChange={ ( value ) =>
+							setAttributes( {
+								scale: value,
+							} )
+						}
+						isBlock
+					>
+						{ SCALE_OPTIONS }
+					</ToggleGroupControl>
+				</ToolsPanelItem>
 			) }
-		</PanelBody>
+		</InspectorControls>
 	);
 };
 

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -47,6 +47,7 @@ const placeholderChip = (
 );
 
 function PostFeaturedImageDisplay( {
+	clientId,
 	attributes,
 	setAttributes,
 	context: { postId, postType, queryId },
@@ -137,11 +138,12 @@ function PostFeaturedImageDisplay( {
 
 	return (
 		<>
+			<DimensionControls
+				clientId={ clientId }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
 			<InspectorControls>
-				<DimensionControls
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-				/>
 				<PanelBody title={ __( 'Link settings' ) }>
 					<ToggleControl
 						label={ sprintf(

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -128,11 +128,3 @@ div[data-type="core/post-featured-image"] {
 		display: block;
 	}
 }
-
-.block-library-post-featured-image-dimension-controls {
-	margin-bottom: $grid-unit-10;
-
-	&.scale-control-is-visible {
-		margin-bottom: $grid-unit-20;
-	}
-}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Fixes #36536

## Description
<!-- Please describe what you have changed or added -->
The Post Featured Image block had its Height/Width/Scale controls in its own Dimensions panel. With the addition of the new Dimensions ToolsPanel, this meant we had two panels with the same name. This PR moves the custom height/width/scale controls into the Dimensions ToolsPanel via the SlotFill.

~~Because it conditionally displays the Scale control, it depends on #36588 which fixes some bugs with panel item registration and de-registration.~~ Updated: necessary fixes have been merged

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

~~Important: rebase on #36588 to get some ToolsPanel fixes.~~

1. Edit a post and add the Post Featured Image block. There should only be one 'Dimensions' panel in the sidebar.
2. The Height and Width controls should be visible by default
3. Confirm the height control continues to function correctly when adjusted.
4. Confirm the height control behaves appropriately within the context of the ToolsPanel e.g. it can be reset etc.
5. Confirm the width control continues to function correctly when adjusted.
6. Confirm the width control behaves appropriately within the context of the ToolsPanel e.g. it can be reset etc.
7. Confirm the scale control continues to function correctly when adjusted. Confirm that the scale control is visible when the height control has a value, and is not when there is no height value.
8. Confirm the scale control behaves appropriately within the context of the ToolsPanel e.g. it can be reset etc.

Some things to call out in particular:
* The Scale control should not be visible by default, nor should it be visible in the menu. It only appears when a Height value is set
* When the Height value is reset, the Scale control should disappear. This includes resetting by deselecting the Height item in the menu, by resetting all from the menu, and by backspacing out the value within the control.
* The Scale control can only be reset when its value is not the default ('cover')
* ~~The scale control is reset to its default 'cover' value when the height is reset~~ For consistency with the way the controls used to work, Scale is not reset when Height is reset:
    * Select a non-default Scale (eg "Contain")
    * Reset the height. The Scale control disappears
    * Set a new height value. The Scale control reappears; it is still set to "Contain"

## Screenshots <!-- if applicable -->

<img width="280" alt="Screen Shot 2021-11-16 at 11 07 57 AM" src="https://user-images.githubusercontent.com/63313398/142049697-52833731-a35d-46c4-ae7f-751a962b3461.png">

<img width="284" alt="Screen Shot 2021-11-16 at 11 08 13 AM" src="https://user-images.githubusercontent.com/63313398/142049706-2a071f79-3d52-4772-a091-0af8a5a03939.png">

Video:

https://user-images.githubusercontent.com/63313398/142299048-c4a9a31f-2141-491a-aec3-8eb54d55a47f.mov

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
