### PR TITLE
Fix layout shift in `core/post-featured-image` block with `isLink` enabled

### DIFF
--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -2,7 +2,7 @@
 	margin-left: 0;
 	margin-right: 0;
 	a {
-		display: inline-block;
+		display: block;
 	}
 	img {
 		max-width: 100%;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The `core/post-featured-image` block currently comes with a [layout shift](https://web.dev/cls/) which is problematic for user experience. Normally a layout shift from an image can be avoided by ensuring the image has `width` and `height` attributes present, to ensure the space is already reserved in the layout before the image is actually loaded. The attributes are already present here, but the problem results from the `a` wrapper (from the `isLink` block attribute) around the image which uses `display: inline-block`, thus making the aspect ratio specified via the image attributes "useless".

Since the featured image is typically rendered as `display: block`, any `a` tag around it should as well. So the solution here is to simply adjust the CSS.

Related: #25714

Props @swissspidy for help with identifying the solution.

## How has this been tested?
You can see this problem live on this [test website](https://beckandgalo-wordpress-amp.pantheonsite.io/), which currently has Twenty Twenty-Two enabled:
* On the [home page](https://beckandgalo-wordpress-amp.pantheonsite.io/), you can see a layout shift occuring - all content below the first image shifts down as soon as that image starts loading. This is because on the homepage that `a` tag is present.
* On a [single post](https://beckandgalo-wordpress-amp.pantheonsite.io/fifth-post-with-many-images/), the problem doesn't happen - the space for the image is reserved as it should, no layout shift occurs. This is because here the `a` tag is not present, confirming that that tag is the problem (see above).

## Types of changes
* This PR changes the styling of `.wp-block-post-featured-image a` to use `display: block`, to prevent a layout shift.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
