### PR TITLE
Docs: Improvements on `Create a Block Tutorial` from `Block Editor handbook`

### DIFF
--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -81,7 +81,7 @@ export default function save( { attributes } ) {
 }
 ```
 
-If you have run the start script before `npm start` and the script is still running, you can reload the editor now and add the block to test.
+If you have previously run `npm start`, and the script is still running, you can reload the editor now and add the block to test.
 Otherwise rebuild the block using `npm run build`, reload the editor and add the block. Type a message in the editor, save, and view it in the post.
 
 Next Section: [Code Implementation](/docs/getting-started/create-block/block-code.md)

--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -41,7 +41,7 @@ The component is added similar to an HTML tag, setting a label, the `value` is s
 
 The save function will simply write the `attributes.message` as a div tag since that is how we defined it to be parsed.
 
-Install the components module in order to be able to use the TextControl component:
+OPTIONAL: For IDE support (code completion and hints), you can install the `@wordpress/components` module which is where the TextControl component is imported from. This install command is optional since the build process automatically detects `@wordpress/*` imports and specifies as dependencies in the assets file.
 
 ```shell
 npm install @wordpress/components --save

--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -41,6 +41,12 @@ The component is added similar to an HTML tag, setting a label, the `value` is s
 
 The save function will simply write the `attributes.message` as a div tag since that is how we defined it to be parsed.
 
+Install the components module in order to be able to use the TextControl component:
+
+```shell
+npm install @wordpress/components --save
+```
+
 Update the edit.js and save.js files to the following, replacing the existing functions.
 
 **edit.js** file:
@@ -75,6 +81,7 @@ export default function save( { attributes } ) {
 }
 ```
 
-Rebuild the block using `npm run build`, reload the editor and add the block. Type a message in the editor, save, and view it in the post.
+If you have run the start script before `npm run start` and the script is still running, you can reload the editor now and add the block to test.
+Otherwise rebuild the block using `npm run build`, reload the editor and add the block. Type a message in the editor, save, and view it in the post.
 
 Next Section: [Code Implementation](/docs/getting-started/create-block/block-code.md)

--- a/docs/getting-started/create-block/attributes.md
+++ b/docs/getting-started/create-block/attributes.md
@@ -81,7 +81,7 @@ export default function save( { attributes } ) {
 }
 ```
 
-If you have run the start script before `npm run start` and the script is still running, you can reload the editor now and add the block to test.
+If you have run the start script before `npm start` and the script is still running, you can reload the editor now and add the block to test.
 Otherwise rebuild the block using `npm run build`, reload the editor and add the block. Type a message in the editor, save, and view it in the post.
 
 Next Section: [Code Implementation](/docs/getting-started/create-block/block-code.md)


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

At `Block Attributes` section, added instructions on how to install the @wordpress/components dependence and added instruction to use `npm run start` on local environment despite of running a production build.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

N/A.

## Screenshots <!-- if applicable -->

N/A.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Documentation improvement.

