### PR TITLE
Fix mobile horizontal scrollbar.

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/style.scss
+++ b/packages/block-editor/src/components/inner-blocks/style.scss
@@ -4,16 +4,10 @@
 	&::after {
 		content: "";
 		position: absolute;
-		top: -$block-padding;
-		right: -$block-padding;
-		bottom: -$block-padding;
-		left: -$block-padding;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
 		z-index: z-index(".block-editor-block-list__layout.has-overlay::after");
 	}
-}
-
-// On fullwide blocks, don't go beyond the canvas.
-[data-align="full"] .has-overlay::after {
-	right: 0;
-	left: 0;
 }


### PR DESCRIPTION
## Description

Mobile viewports have "clicthrough" on nested blocks. That is, an overlay that makes it easier to select each layer as you click down the hierarchy. Due to an oversight, this overlay was too big, causing horizontal scrollbars:

<img width="612" alt="before" src="https://user-images.githubusercontent.com/1204802/142202399-161e9b4b-135c-41ee-b78a-829edd335808.png">

This PR fixes it:

<img width="612" alt="after" src="https://user-images.githubusercontent.com/1204802/142202413-d99e1236-7542-4cb5-b896-c981b85b7bbd.png">

## How has this been tested?

Insert a nesting container such as a group, and insert child blocks, then view the mobile breakpoint (<600px) and you should see no horizontal scrollbar.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
