### PR TITLE
[Mobile] - Font size - Only set font sizes for block based themes

### DIFF
--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -162,7 +162,7 @@ export function getBlockTypography(
 		}
 	}
 
-	if ( blockStyleAttributes?.fontSize ) {
+	if ( blockStyleAttributes?.fontSize && baseGlobalStyles ) {
 		const mappedFontSize = find( fontSizes, {
 			slug: blockStyleAttributes?.fontSize,
 		} );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,6 +12,7 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 -   [*] [Embed block] Included Link in Block Settings [#36099]
 -   [**] Fix tab titles translation of inserter menu [#36534]
+-   [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases  [#36570]
 
 ## 1.66.0
 -   [**] [Image block] Add ability to quickly link images to Media Files and Attachment Pages [#34846]


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36529

- Gutenberg Mobile PR -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4252

## Description
Support for font sizes on mobile was recently added under a development flag and one of those changes included adding the default font sizes for the editor. An issue was reported where a `Media&Text` block added from the web editor was rendering a bigger font size on mobile for a standard theme. 

Since it's a standard theme the mobile editor doesn't have the font sizes values for it so it uses the default ones and in this case, it matches the font size `large` making the text to be shown bigger than expected.

This PR limits the font size functionality to **not** render font sizes values set to blocks when the current theme is not a block-based one.

## How has this been tested?

### Test case 1 - Standard theme

- Using a site with a standard theme e.g. `Twenty Twenty-One`
- Create a post on the web editor
- Add a Media&Text block and set some text content in the Paragraph block
- Open the post on the mobile app
- Expect to see the font size of the text to be the same as the default font size of the editor

### Test case 2 - Block-based theme

- Using a site with a block-based theme e.g. `Quadrat`
- Create a post on the web editor
- Add a Media&Text block and set some text content in the Paragraph block
- Open the post on the mobile app
- Expect to see the font size of the text to be the same as it was on the web editor

## Screenshots <!-- if applicable -->

Test case 1 | Test case 2
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/142223885-0cfbc3c3-4819-42e7-8e15-26b24f364e28.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/142223901-f15c5ad1-b4ea-4f5e-bdb3-f37534973959.png" width="200" /></kbd>


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
