### PR TITLE
Multi-entity save: Only set site entity to pending if really saving

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -151,7 +151,14 @@ export default function EntitiesSavedStates( { close } ) {
 				saveEditedEntityRecord( kind, name, key );
 			}
 		} );
-		saveSpecifiedEntityEdits( 'root', 'site', undefined, siteItemsToSave );
+		if ( siteItemsToSave.length ) {
+			saveSpecifiedEntityEdits(
+				'root',
+				'site',
+				undefined,
+				siteItemsToSave
+			);
+		}
 	};
 
 	// Explicitly define this with no argument passed.  Using `close` on


### PR DESCRIPTION
## Description

Currently, the multi-entity save panel is unconditionally attempting to save changes to the site entity, even if there aren't any. This causes the site entity saving state to be set to "pending" at least for a short period of time. 

This PR makes it so that we only save the site entity if there are any changes to it.

I'm not aware of bugs resulting directly from this, but I've noticed that it _would_ affect checkboxes shown in the discard panel introduced in #36185. Furthermore, the erroneous behavior was found by @ramonjd in https://github.com/WordPress/gutenberg/issues/36096#issuecomment-964753551 (although it doesn't seem to be the root cause for #36096).

## How has this been tested?

- Create a new post
- Insert a Site Title block. Change the site title to a different value.
- Hit Publish to publish the post.
- In the pre-publish save menu, deselect the site title, then hit Save, then Publish.
- In your browser's Redux devtools, select the `core` store, and filter for the `SAVE_ENTITY_RECORD_START` action. Verify that there are no such actions affecting the site entity (`root.entities.data.root.site.saving`).
(Compare to `trunk` where there _are_ `SAVE_ENTITY_RECORD_START` that affect that part of the state tree.)

## Types of changes
Bug fix