### PR TITLE
Dimensions panel: remove BoxControl Visualizer callbacks

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -124,26 +124,12 @@ export function MarginEdit( props ) {
 		} );
 	};
 
-	const onChangeShowVisualizer = ( next ) => {
-		const newStyle = {
-			...style,
-			visualizers: {
-				margin: next,
-			},
-		};
-
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
-	};
-
 	return Platform.select( {
 		web: (
 			<>
 				<BoxControl
 					values={ style?.spacing?.margin }
 					onChange={ onChange }
-					onChangeShowVisualizer={ onChangeShowVisualizer }
 					label={ __( 'Margin' ) }
 					sides={ sides }
 					units={ units }

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -124,26 +124,12 @@ export function PaddingEdit( props ) {
 		} );
 	};
 
-	const onChangeShowVisualizer = ( next ) => {
-		const newStyle = {
-			...style,
-			visualizers: {
-				padding: next,
-			},
-		};
-
-		setAttributes( {
-			style: cleanEmptyObject( newStyle ),
-		} );
-	};
-
 	return Platform.select( {
 		web: (
 			<>
 				<BoxControl
 					values={ style?.spacing?.padding }
 					onChange={ onChange }
-					onChangeShowVisualizer={ onChangeShowVisualizer }
 					label={ __( 'Padding' ) }
 					sides={ sides }
 					units={ units }

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -140,7 +140,7 @@ A callback function when an input value changes.
 A callback function for visualizer changes, based on input hover interactions.
 
 -   Type: `Function`
--   Required: Yes
+-   Required: No
 
 ### resetValues
 


### PR DESCRIPTION
Maybe, possibly resolves https://github.com/WordPress/gutenberg/issues/36418

## Description
Here we're removing `onChangeShowVisualizer` callbacks passed down to `<BoxControl />` for margin and padding block support controls temporarily until we can work out why triggering these callbacks onHover sets the post to dirty.

See how the "**Update**" button is activated when we hover over a `<BoxControl />`, in this case the padding control in the dimensions panel.

https://user-images.githubusercontent.com/6458278/142294471-e9ff3162-e1f9-4c83-9a95-5e9962580a51.mp4

Ideally we'd track down where/how the post is being made dirty. 

My suspicion, after playing with the component in [Storybook](https://wordpress.github.io/gutenberg/?path=/story/components-boxcontrol--visualizer), is that it's due to the dynamic CSS class updates that occur on the `<Visualizer />` component `onHover`.

![Nov-18-2021 09-51-08](https://user-images.githubusercontent.com/6458278/142295116-975cb890-6658-425d-969a-789cad280760.gif)

As far I can see the Visualizer isn't yet used anywhere in accordance with the dimensions panel, so I don't think there are any side-effects. I'm not sure. 

Furthermore, attempts to add a Box Control `<Visualizer />` to a couple of blocks in order to test out the functionality crashed my editor. 🤷 

Quite possibly I'm doing things wrong, so maybe we can dump this PR altogether if folks can think of a better way.

We're also updating the README.md for `<BoxControl />` to communicate that `onChangeShowVisualizer` is not a required prop. The default is `noop`

## How has this been tested?

1. In the Site or Post editor, select any block that has spatial settings. Try **Group** or **Columns**.
2. Hover over the padding or margin inputs
3. Check that the "**Save**" (or "**Update**" for already-saved posts) button state remains unchanged 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
