### PR TITLE
Tools Panel: Fix race conditions caused by conditionally displayed ToolsPanelItems

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Added an `__unstable-large` size variant to `InputControl`, `SelectControl`, and `UnitControl` for selective migration to the larger 40px heights. ([#35646](https://github.com/WordPress/gutenberg/pull/35646)).
 -   Fixed inconsistent padding in `UnitControl` ([#35646](https://github.com/WordPress/gutenberg/pull/35646)).
 -   Added support for RTL behavior for the `ZStack`'s `offset` prop ([#36769](https://github.com/WordPress/gutenberg/pull/36769))
+-   Fixed race conditions causing conditionally displayed `ToolsPanelItem` components to be erroneously deregistered ([36588](https://github.com/WordPress/gutenberg/pull/36588)).
 
 ### Bug Fix
 

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -7,6 +7,10 @@ import styled from '@emotion/styled';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -254,6 +258,185 @@ export const WithSlotFillItems = () => {
 				<Panel>
 					<ToolsPanel
 						label="Tools Panel With SlotFill Items"
+						resetAll={ resetAll }
+						panelId={ panelId }
+					>
+						<Slot />
+					</ToolsPanel>
+				</Panel>
+			</PanelWrapperView>
+		</SlotFillProvider>
+	);
+};
+
+export const WithConditionalDefaultControl = () => {
+	const [ attributes, setAttributes ] = useState( {} );
+	const { height, scale } = attributes;
+
+	const resetAll = ( resetFilters = [] ) => {
+		let newAttributes = {};
+
+		resetFilters.forEach( ( resetFilter ) => {
+			newAttributes = {
+				...newAttributes,
+				...resetFilter( newAttributes ),
+			};
+		} );
+
+		setAttributes( newAttributes );
+	};
+
+	const updateAttribute = ( name, value ) => {
+		setAttributes( {
+			...attributes,
+			[ name ]: value,
+		} );
+	};
+
+	return (
+		<SlotFillProvider>
+			<ToolsPanelItems>
+				<SingleColumnItem
+					hasValue={ () => !! height }
+					label="Injected Height"
+					onDeselect={ () => updateAttribute( 'height', undefined ) }
+					resetAllFilter={ () => ( { height: undefined } ) }
+					panelId={ panelId }
+					isShownByDefault={ true }
+				>
+					<UnitControl
+						label="Injected Height"
+						value={ height }
+						onChange={ ( next ) =>
+							updateAttribute( 'height', next )
+						}
+					/>
+				</SingleColumnItem>
+				<ToolsPanelItem
+					hasValue={ () => !! scale }
+					label="Scale"
+					onDeselect={ () => updateAttribute( 'scale', undefined ) }
+					resetAllFilter={ () => ( { scale: undefined } ) }
+					panelId={ panelId }
+					isShownByDefault={ !! height }
+				>
+					<ToggleGroupControl
+						label="Scale"
+						value={ scale }
+						onChange={ ( next ) =>
+							updateAttribute( 'scale', next )
+						}
+						isBlock
+					>
+						<ToggleGroupControlOption value="cover" label="Cover" />
+						<ToggleGroupControlOption
+							value="contain"
+							label="Contain"
+						/>
+						<ToggleGroupControlOption value="fill" label="Fill" />
+					</ToggleGroupControl>
+				</ToolsPanelItem>
+			</ToolsPanelItems>
+			<PanelWrapperView>
+				<Panel>
+					<ToolsPanel
+						label="Tools Panel With Conditional Default via SlotFill"
+						resetAll={ resetAll }
+						panelId={ panelId }
+					>
+						<Slot />
+					</ToolsPanel>
+				</Panel>
+			</PanelWrapperView>
+		</SlotFillProvider>
+	);
+};
+
+export const WithConditionallyRenderedControl = () => {
+	const [ attributes, setAttributes ] = useState( {} );
+	const { height, scale } = attributes;
+
+	const resetAll = ( resetFilters = [] ) => {
+		let newAttributes = {};
+
+		resetFilters.forEach( ( resetFilter ) => {
+			newAttributes = {
+				...newAttributes,
+				...resetFilter( newAttributes ),
+			};
+		} );
+
+		setAttributes( newAttributes );
+	};
+
+	const updateAttribute = ( name, value ) => {
+		setAttributes( {
+			...attributes,
+			[ name ]: value,
+		} );
+	};
+
+	return (
+		<SlotFillProvider>
+			<ToolsPanelItems>
+				<SingleColumnItem
+					hasValue={ () => !! height }
+					label="Injected Height"
+					onDeselect={ () => {
+						updateAttribute( 'scale', undefined );
+						updateAttribute( 'height', undefined );
+					} }
+					resetAllFilter={ () => ( { height: undefined } ) }
+					panelId={ panelId }
+					isShownByDefault={ true }
+				>
+					<UnitControl
+						label="Injected Height"
+						value={ height }
+						onChange={ ( next ) =>
+							updateAttribute( 'height', next )
+						}
+					/>
+				</SingleColumnItem>
+				{ !! height && (
+					<ToolsPanelItem
+						hasValue={ () => !! scale }
+						label="Scale"
+						onDeselect={ () =>
+							updateAttribute( 'scale', undefined )
+						}
+						resetAllFilter={ () => ( { scale: undefined } ) }
+						panelId={ panelId }
+						isShownByDefault={ true }
+					>
+						<ToggleGroupControl
+							label="Scale"
+							value={ scale }
+							onChange={ ( next ) =>
+								updateAttribute( 'scale', next )
+							}
+							isBlock
+						>
+							<ToggleGroupControlOption
+								value="cover"
+								label="Cover"
+							/>
+							<ToggleGroupControlOption
+								value="contain"
+								label="Contain"
+							/>
+							<ToggleGroupControlOption
+								value="fill"
+								label="Fill"
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				) }
+			</ToolsPanelItems>
+			<PanelWrapperView>
+				<Panel>
+					<ToolsPanel
+						label="Tools Panel With Conditional Default via SlotFill"
 						resetAll={ resetAll }
 						panelId={ panelId }
 					>

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -436,7 +436,7 @@ export const WithConditionallyRenderedControl = () => {
 			<PanelWrapperView>
 				<Panel>
 					<ToolsPanel
-						label="Tools Panel With Conditional Default via SlotFill"
+						label="Tools Panel With Conditionally Rendered Item via SlotFill"
 						resetAll={ resetAll }
 						panelId={ panelId }
 					>

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -361,7 +361,7 @@ describe( 'ToolsPanel', () => {
 				onSelect: jest.fn(),
 			};
 
-			const testPanel = () => (
+			const TestPanel = () => (
 				<ToolsPanel { ...defaultProps }>
 					<ToolsPanelItem
 						{ ...altControlProps }
@@ -378,7 +378,7 @@ describe( 'ToolsPanel', () => {
 				</ToolsPanel>
 			);
 
-			const { rerender } = render( testPanel() );
+			const { rerender } = render( <TestPanel /> );
 
 			// The linked control should start out as an optional control and is
 			// not rendered because it does not have a value.
@@ -402,7 +402,7 @@ describe( 'ToolsPanel', () => {
 			// conditional `isShownByDefault` prop.
 			altControlProps.attributes.value = true;
 
-			rerender( testPanel() );
+			rerender( <TestPanel /> );
 
 			// The linked control should now be a default control and rendered
 			// despite not having a value.
@@ -442,7 +442,7 @@ describe( 'ToolsPanel', () => {
 				onSelect: jest.fn(),
 			};
 
-			const testPanel = () => (
+			const TestPanel = () => (
 				<ToolsPanel { ...defaultProps }>
 					<ToolsPanelItem
 						{ ...altControlProps }
@@ -461,7 +461,7 @@ describe( 'ToolsPanel', () => {
 				</ToolsPanel>
 			);
 
-			const { rerender } = render( testPanel() );
+			const { rerender } = render( <TestPanel /> );
 
 			// The conditional control should not yet be rendered.
 			let conditionalItem = screen.queryByText( 'Conditional control' );
@@ -480,7 +480,7 @@ describe( 'ToolsPanel', () => {
 			// render the new default control into the ToolsPanel.
 			altControlProps.attributes.value = true;
 
-			rerender( testPanel() );
+			rerender( <TestPanel /> );
 
 			// The conditional control should now be rendered and included in
 			// the panel's menu.
@@ -525,7 +525,7 @@ describe( 'ToolsPanel', () => {
 				areAllOptionalControlsHidden: true,
 			};
 
-			const testPanel = () => (
+			const TestPanel = () => (
 				<ToolsPanelContext.Provider value={ context }>
 					<ToolsPanelItem { ...altControlProps } panelId="1234">
 						<div>Item</div>
@@ -535,7 +535,7 @@ describe( 'ToolsPanel', () => {
 
 			// On the initial render of the panel, the ToolsPanelItem should
 			// be registered.
-			const { rerender } = render( testPanel() );
+			const { rerender } = render( <TestPanel /> );
 
 			expect( context.registerPanelItem ).toHaveBeenCalledWith(
 				expect.objectContaining( {
@@ -552,7 +552,7 @@ describe( 'ToolsPanel', () => {
 			// Rerender the panel item. Because we are switching away from this
 			// panel, its panelItem should NOT be registered, but it SHOULD be
 			// deregistered.
-			rerender( testPanel() );
+			rerender( <TestPanel /> );
 
 			// registerPanelItem has still only been called once.
 			expect( context.registerPanelItem ).toHaveBeenCalledTimes( 1 );
@@ -568,7 +568,7 @@ describe( 'ToolsPanel', () => {
 
 			// Rerender the panel and ensure that the panelItem is registered
 			// again, and it is not de-registered.
-			rerender( testPanel() );
+			rerender( <TestPanel /> );
 
 			expect( context.registerPanelItem ).toHaveBeenCalledWith(
 				expect.objectContaining( {

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -168,6 +168,7 @@ const selectMenuItem = async ( label ) => {
 describe( 'ToolsPanel', () => {
 	afterEach( () => {
 		controlProps.attributes.value = true;
+		altControlProps.attributes.value = false;
 	} );
 
 	describe( 'basic rendering', () => {
@@ -347,6 +348,153 @@ describe( 'ToolsPanel', () => {
 			// there holding its position but the inner text etc should not be
 			// there.
 			expect( optionalItem ).not.toBeInTheDocument();
+		} );
+
+		it( 'should render default controls with conditional isShownByDefault', async () => {
+			const linkedControlProps = {
+				attributes: { value: false },
+				hasValue: jest.fn().mockImplementation( () => {
+					return !! linkedControlProps.attributes.value;
+				} ),
+				label: 'Linked',
+				onDeselect: jest.fn(),
+				onSelect: jest.fn(),
+			};
+
+			const testPanel = () => (
+				<ToolsPanel { ...defaultProps }>
+					<ToolsPanelItem
+						{ ...altControlProps }
+						isShownByDefault={ true }
+					>
+						<div>Default control</div>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						{ ...linkedControlProps }
+						isShownByDefault={ !! altControlProps.attributes.value }
+					>
+						<div>Linked control</div>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			);
+
+			const { rerender } = render( testPanel() );
+
+			// The linked control should start out as an optional control and is
+			// not rendered because it does not have a value.
+			let linkedItem = screen.queryByText( 'Linked control' );
+			expect( linkedItem ).not.toBeInTheDocument();
+
+			openDropdownMenu();
+
+			// The linked control should initially appear in the optional controls
+			// menu group. There should be three menu groups: default controls,
+			// optional controls, and the group to reset all options.
+			let menuGroups = screen.getAllByRole( 'group' );
+			expect( menuGroups.length ).toEqual( 3 );
+
+			// The linked control should be in the second group, of optional controls.
+			let optionalItem = within( menuGroups[ 1 ] ).getByText( 'Linked' );
+			expect( optionalItem ).toBeInTheDocument();
+
+			// Simulate the main control having a value set which should
+			// trigger the linked control becoming a default control via the
+			// conditional `isShownByDefault` prop.
+			altControlProps.attributes.value = true;
+
+			rerender( testPanel() );
+
+			// The linked control should now be a default control and rendered
+			// despite not having a value.
+			linkedItem = screen.getByText( 'Linked control' );
+			expect( linkedItem ).toBeInTheDocument();
+
+			// The linked control should now appear in the default controls
+			// menu group and have been removed from the optional group.
+			menuGroups = screen.getAllByRole( 'group' );
+
+			// There should now only be two groups. The default controls and
+			// and the group for the reset all option.
+			expect( menuGroups.length ).toEqual( 2 );
+
+			// The new default control item for the Linked control should be
+			// within the first menu group.
+			const defaultItem = within( menuGroups[ 0 ] ).getByText( 'Linked' );
+			expect( defaultItem ).toBeInTheDocument();
+
+			// Optional controls have an additional aria-label. This can be used
+			// to confirm the conditional default control has been removed from
+			// the optional menu item group.
+			optionalItem = screen.queryByRole( 'menuitemcheckbox', {
+				name: 'Show Linked',
+			} );
+			expect( optionalItem ).not.toBeInTheDocument();
+		} );
+
+		it( 'should handle conditionally rendered default control', async () => {
+			const conditionalControlProps = {
+				attributes: { value: false },
+				hasValue: jest.fn().mockImplementation( () => {
+					return !! conditionalControlProps.attributes.value;
+				} ),
+				label: 'Conditional',
+				onDeselect: jest.fn(),
+				onSelect: jest.fn(),
+			};
+
+			const testPanel = () => (
+				<ToolsPanel { ...defaultProps }>
+					<ToolsPanelItem
+						{ ...altControlProps }
+						isShownByDefault={ true }
+					>
+						<div>Default control</div>
+					</ToolsPanelItem>
+					{ !! altControlProps.attributes.value && (
+						<ToolsPanelItem
+							{ ...conditionalControlProps }
+							isShownByDefault={ true }
+						>
+							<div>Conditional control</div>
+						</ToolsPanelItem>
+					) }
+				</ToolsPanel>
+			);
+
+			const { rerender } = render( testPanel() );
+
+			// The conditional control should not yet be rendered.
+			let conditionalItem = screen.queryByText( 'Conditional control' );
+			expect( conditionalItem ).not.toBeInTheDocument();
+
+			// The conditional control should not yet appear in the default controls
+			// menu group.
+			openDropdownMenu();
+			let menuGroups = screen.getAllByRole( 'group' );
+			let defaultItem = within( menuGroups[ 0 ] ).queryByText(
+				'Conditional'
+			);
+			expect( defaultItem ).not.toBeInTheDocument();
+
+			// Simulate the main control having a value set which will now
+			// render the new default control into the ToolsPanel.
+			altControlProps.attributes.value = true;
+
+			rerender( testPanel() );
+
+			// The conditional control should now be rendered and included in
+			// the panel's menu.
+			conditionalItem = screen.getByText( 'Conditional control' );
+			expect( conditionalItem ).toBeInTheDocument();
+
+			// The conditional control should now appear in the default controls
+			// menu group.
+			menuGroups = screen.getAllByRole( 'group' );
+
+			// The new default control item for the Conditional control should
+			// be within the first menu group.
+			defaultItem = within( menuGroups[ 0 ] ).getByText( 'Conditional' );
+			expect( defaultItem ).toBeInTheDocument();
 		} );
 	} );
 

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -499,13 +499,14 @@ describe( 'ToolsPanel', () => {
 	} );
 
 	describe( 'registration of panel items', () => {
-		it( 'should register and deregister items when switching between panels', () => {
-			// This test adds a `panelId` prop to two panels, to simulate
-			// the registration and de-registration of panelItems when
-			// switching between panels and test for any issues.
+		it( 'should register and deregister items when panelId changes', () => {
+			// This test simulates switching block selection, which causes the
+			// `ToolsPanel` to rerender with a new panelId, necessitating the
+			// registration and deregistration of appropriate `ToolsPanelItem`
+			// children.
 			//
-			// When you switch from panel A to panel B, only panel A items
-			// should be deregistered, and only panel B items should be registered.
+			// When the `panelId` changes, only items matching the new ID register
+			// themselves, while those for the old panelId deregister.
 			//
 			// See: https://github.com/WordPress/gutenberg/pull/36588
 
@@ -543,14 +544,14 @@ describe( 'ToolsPanel', () => {
 					panelId: '1234',
 				} )
 			);
-			expect( context.deregisterPanelItem ).toHaveBeenCalledTimes( 0 );
+			expect( context.deregisterPanelItem ).not.toHaveBeenCalled();
 
 			// Simulate a change in panel, e.g. a switch of block selection.
 			context.panelId = '4321';
 			context.menuItems.optional[ altControlProps.label ] = false;
 
-			// Rerender the panel item. Because we are switching away from this
-			// panel, its panelItem should NOT be registered, but it SHOULD be
+			// Rerender the panel item. Because we have a new panelId, this
+			// panelItem should NOT be registered, but it SHOULD be
 			// deregistered.
 			rerender( <TestPanel /> );
 
@@ -561,7 +562,7 @@ describe( 'ToolsPanel', () => {
 				altControlProps.label
 			);
 
-			// Simulate switching back to the original panel, e.g. by selecting
+			// Simulate switching back to the original panelId, e.g. by selecting
 			// the original block again.
 			context.panelId = '1234';
 			context.menuItems.optional[ altControlProps.label ] = true;

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -70,8 +70,8 @@ export function useToolsPanelItem(
 	// If this item represents a default control it will need to notify the
 	// panel when a custom value has been set.
 	useEffect( () => {
-		if ( isShownByDefault && isValueSet && ! wasValueSet ) {
-			flagItemCustomization( label );
+		if ( isShownByDefault && isValueSet !== wasValueSet ) {
+			flagItemCustomization( label, 'default', isValueSet );
 		}
 	}, [ isValueSet, wasValueSet, isShownByDefault, label ] );
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -74,8 +74,8 @@ export function useToolsPanelItem(
 	// If this item represents a default control it will need to notify the
 	// panel when a custom value has been set.
 	useEffect( () => {
-		if ( isShownByDefault && isValueSet !== wasValueSet ) {
-			flagItemCustomization( label, 'default', isValueSet );
+		if ( isShownByDefault && isValueSet && ! wasValueSet ) {
+			flagItemCustomization( label );
 		}
 	}, [ isValueSet, wasValueSet, isShownByDefault, label ] );
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -54,7 +54,11 @@ export function useToolsPanelItem(
 			} );
 		}
 
-		return () => deregisterPanelItem( label );
+		return () => {
+			if ( currentPanelId === panelId ) {
+				deregisterPanelItem( label );
+			}
+		}
 	}, [
 		currentPanelId,
 		panelId,

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -58,7 +58,7 @@ export function useToolsPanelItem(
 			if ( currentPanelId === panelId ) {
 				deregisterPanelItem( label );
 			}
-		}
+		};
 	}, [
 		currentPanelId,
 		panelId,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -72,16 +72,17 @@ export function useToolsPanel(
 
 	const registerPanelItem = ( item: ToolsPanelItem ) => {
 		setPanelItems( ( items ) => {
+			const newItems = [ ...items ];
 			// If an item with this label is already registered, remove it first.
 			// This can happen when an item is moved between the default and optional
 			// groups.
-			const existingIndex = items.findIndex(
+			const existingIndex = newItems.findIndex(
 				( oldItem ) => oldItem.label === item.label
 			);
 			if ( existingIndex !== -1 ) {
-				items.splice( existingIndex, 1 );
+				newItems.splice( existingIndex, 1 );
 			}
-			return [ ...items, item ];
+			return [ ...newItems, item ];
 		} );
 	};
 

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -126,18 +126,17 @@ export function useToolsPanel(
 	// Force a menu item to be checked.
 	// This is intended for use with default panel items. They are displayed
 	// separately to optional items and have different display states,
-	//.we need to update that when their value is customized.
+	// we need to update that when their value is customized.
 	const flagItemCustomization = (
 		label: string,
-		group: ToolsPanelMenuItemKey = 'default',
-		value: boolean = true
+		group: ToolsPanelMenuItemKey = 'default'
 	) => {
 		setMenuItems( ( items ) => {
 			const newState = {
 				...items,
 				[ group ]: {
 					...items[ group ],
-					[ label ]: value,
+					[ label ]: true,
 				},
 			};
 			return newState;

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -22,12 +22,21 @@ const DEFAULT_COLUMNS = 2;
 const generateMenuItems = ( {
 	panelItems,
 	shouldReset,
+	currentMenuItems,
 }: ToolsPanelMenuItemsConfig ) => {
 	const menuItems: ToolsPanelMenuItems = { default: {}, optional: {} };
 
 	panelItems.forEach( ( { hasValue, isShownByDefault, label } ) => {
 		const group = isShownByDefault ? 'default' : 'optional';
-		menuItems[ group ][ label ] = shouldReset ? false : hasValue();
+
+		// If a menu item for this label already exists, do not overwrite its value.
+		// This can cause default controls that have been flagged as customized to
+		// lose their value.
+		const existingItemValue = currentMenuItems?.[ group ]?.[ label ];
+		const value =
+			existingItemValue !== undefined ? existingItemValue : hasValue();
+
+		menuItems[ group ][ label ] = shouldReset ? false : value;
 	} );
 
 	return menuItems;
@@ -62,7 +71,18 @@ export function useToolsPanel(
 	const [ panelItems, setPanelItems ] = useState< ToolsPanelItem[] >( [] );
 
 	const registerPanelItem = ( item: ToolsPanelItem ) => {
-		setPanelItems( ( items ) => [ ...items, item ] );
+		setPanelItems( ( items ) => {
+			// If an item with this label is already registered, remove it first.
+			// This can happen when an item is moved between the default and optional
+			// groups.
+			const existingIndex = items.findIndex(
+				( oldItem ) => oldItem.label === item.label
+			);
+			if ( existingIndex !== -1 ) {
+				items.splice( existingIndex, 1 );
+			}
+			return [ ...items, item ];
+		} );
 	};
 
 	// Panels need to deregister on unmount to avoid orphans in menu state.
@@ -72,11 +92,16 @@ export function useToolsPanel(
 		// controls, e.g. both panels have a "padding" control, the
 		// deregistration of the first panel doesn't occur until after the
 		// registration of the next.
-		const index = panelItems.findIndex( ( item ) => item.label === label );
-
-		if ( index !== -1 ) {
-			setPanelItems( ( items ) => items.splice( index, 1 ) );
-		}
+		setPanelItems( ( items ) => {
+			const newItems = [ ...items ];
+			const index = newItems.findIndex(
+				( item ) => item.label === label
+			);
+			if ( index !== -1 ) {
+				newItems.splice( index, 1 );
+			}
+			return newItems;
+		} );
 	};
 
 	// Manage and share display state of menu items representing child controls.
@@ -87,11 +112,14 @@ export function useToolsPanel(
 
 	// Setup menuItems state as panel items register themselves.
 	useEffect( () => {
-		const items = generateMenuItems( {
-			panelItems,
-			shouldReset: false,
+		setMenuItems( ( prevState ) => {
+			const items = generateMenuItems( {
+				panelItems,
+				shouldReset: false,
+				currentMenuItems: prevState,
+			} );
+			return items;
 		} );
-		setMenuItems( items );
 	}, [ panelItems ] );
 
 	// Force a menu item to be checked.
@@ -100,14 +128,18 @@ export function useToolsPanel(
 	//.we need to update that when their value is customized.
 	const flagItemCustomization = (
 		label: string,
-		group: ToolsPanelMenuItemKey = 'default'
+		group: ToolsPanelMenuItemKey = 'default',
+		value: boolean = true
 	) => {
-		setMenuItems( {
-			...menuItems,
-			[ group ]: {
-				...menuItems[ group ],
-				[ label ]: true,
-			},
+		setMenuItems( ( items ) => {
+			const newState = {
+				...items,
+				[ group ]: {
+					...items[ group ],
+					[ label ]: value,
+				},
+			};
+			return newState;
 		} );
 	};
 

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -124,7 +124,11 @@ export type ToolsPanelContext = {
 	hasMenuItems: boolean;
 	registerPanelItem: ( item: ToolsPanelItem ) => void;
 	deregisterPanelItem: ( label: string ) => void;
-	flagItemCustomization: ( label: string ) => void;
+	flagItemCustomization: (
+		label: string,
+		group: ToolsPanelMenuItemKey,
+		value: boolean
+	) => void;
 	isResetting: boolean;
 	shouldRenderPlaceholderItems: boolean;
 	areAllOptionalControlsHidden: boolean;
@@ -139,4 +143,5 @@ export type ToolsPanelControlsGroupProps = {
 export type ToolsPanelMenuItemsConfig = {
 	panelItems: ToolsPanelItem[];
 	shouldReset: boolean;
+	currentMenuItems?: ToolsPanelMenuItems;
 };

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -126,8 +126,7 @@ export type ToolsPanelContext = {
 	deregisterPanelItem: ( label: string ) => void;
 	flagItemCustomization: (
 		label: string,
-		group: ToolsPanelMenuItemKey,
-		value: boolean
+		group?: ToolsPanelMenuItemKey
 	) => void;
 	isResetting: boolean;
 	shouldRenderPlaceholderItems: boolean;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### Problem
In #36540 it was discovered that attempting to conditionally display a ToolsPanelItem causes unreliable panel behavior such as controls suddenly disappearing. This happens both when:
* An entire ToolsPanelItem is rendered conditionally, meaning that it is registered/deregistered based on some condition:
```
{ !! height && (
    <ToolsPanelItem ... 
```
* A ToolsPanelItem is shown by default conditionally, meaning that depending on some condition it is moved back and forth between the `default` and `optional` controls in the Menu:
```
<ToolsPanelItem
    isShownByDefault={ !! height }
    ....
```

This behavior is caused by race conditions in setting the state of the panel and menu items in quick sequence.

### Fixes in this PR
* updates state changes to rely on previous state, so that subsequent updates do not overwrite one another
* fixes an issue with item de-registration, which was de-registering all items _except_ the intended item
* ~~default controls will now indicate that they do not have a value when the control is cleared~~


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Unit tests:
Run `npm run test-unit "./packages/components/src/tools-panel/test/index.js"`

* Open the storybook with `npm run storybook:dev`
* Under the experimental Components section, check out the two new examples:
    * **With Conditional Default Control**: this shows a control which is conditionally moved between the default and optional controls
    * **With Conditionally Rendered Control**: in this example the entire control is conditionally rendered in the panel
* Play around with the examples, resetting values

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/63313398/142296303-6533cf46-c66e-49e1-a319-0ed20fc24be1.mov

https://user-images.githubusercontent.com/63313398/142296327-c1df36cc-50cb-4710-b854-0a84f2920580.mov



## Types of changes


<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
