### PR TITLE
Post Featured Image: Remove withNotices HOC

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -8,7 +8,6 @@ import {
 	ToggleControl,
 	PanelBody,
 	Placeholder,
-	withNotices,
 	Button,
 } from '@wordpress/components';
 import {
@@ -54,7 +53,6 @@ function PostFeaturedImageDisplay( {
 	attributes,
 	setAttributes,
 	context: { postId, postType, queryId },
-	noticeUI,
 } ) {
 	const isDescendentOfQueryLoop = !! queryId;
 	const { isLink, height, width, scale } = attributes;
@@ -111,7 +109,6 @@ function PostFeaturedImageDisplay( {
 				allowedTypes={ ALLOWED_MEDIA_TYPES }
 				onError={ onUploadError }
 				placeholder={ placeholder }
-				notices={ noticeUI }
 				mediaLibraryButton={ ( { open } ) => {
 					return (
 						<Button
@@ -181,12 +178,10 @@ function PostFeaturedImageDisplay( {
 	);
 }
 
-const PostFeaturedImageWithNotices = withNotices( PostFeaturedImageDisplay );
-
 export default function PostFeaturedImageEdit( props ) {
 	const blockProps = useBlockProps();
 	if ( ! props.context?.postId ) {
 		return <div { ...blockProps }>{ placeholderChip }</div>;
 	}
-	return <PostFeaturedImageWithNotices { ...props } />;
+	return <PostFeaturedImageDisplay { ...props } />;
 }


### PR DESCRIPTION
## Description
The Post Featured Image block started using snackbar for its error messages, see #36517. PR removes unused `withNotices` HOC.

## How has this been tested?
1. Add the Post Featured Image to a post.
2. Drag an unsupported file like `.txt` to upload.
3. See that the error message is displayed as snackbar.

## Types of changes
Core Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
