### PR TITLE
Try: Hide the in-canvas appender in the site editor.

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/style.scss
+++ b/packages/block-editor/src/components/block-list-appender/style.scss
@@ -60,3 +60,13 @@
 		transform: scale(0);
 	}
 }
+
+// Hide entirely in the site editor.
+// This appender, being part of the DOM, appears to the CSS as if it is another block.
+// In doing so, it causes big layout shifts when selecting nesting containers, which is
+// problematic in both post and site editors, though by nature, most so in the site editor.
+// @todo: this is meant to be a temporary measure, letting us find a better solution for
+// both editors in the process.
+.edit-site-block-editor__block-list .block-editor-block-list__block .block-list-appender {
+	display: none;
+}


### PR DESCRIPTION
## Description

Alternative to #36037. Entirely removes/hides the in-canvas inserter — the little black plus that appears when you select a nesting container — when you're using the site editor. 

<img width="1073" alt="Screenshot 2021-11-18 at 10 52 06" src="https://user-images.githubusercontent.com/1204802/142393770-67a27588-b296-4469-8ba2-2799957f60db.png">

The layout shifts that this element is causing are very disruptive to the site editing flow, enough that a temporary measure such as this might be worth employing. 

The measure is meant to be temporary until such a time as we can find a better replacement that works for both editors. See also #26404.

## How has this been tested?

Verify that the black plus button appears in the post editor, when seleting a nesting container:

<img width="770" alt="Screenshot 2021-11-18 at 11 00 18" src="https://user-images.githubusercontent.com/1204802/142393895-8302cddc-b517-4a2b-aa96-9aad8d6da754.png">

Verify that it _doesn't_ appear in the site editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
