### PR TITLE
Update global styles public API

### DIFF
--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -40,25 +40,28 @@ function gutenberg_get_global_settings( $path = array(), $context ) {
 /**
  * Function to get the styles resulting of merging core, theme, and user data.
  *
- * @param array  $path              Path to the specific style to retrieve. Optional.
- *                                  If empty, will return all styles.
- * @param string $block_name        Which block to retrieve the styles from. Optional.
- *                                  If empty, it'll return the styles for the global context.
- * @param string $origin            Which origin to take data from. Optional.
- *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
- *                                  If empty or unknown, 'all' is used.
+ * @param array  $path   Path to the specific style to retrieve. Optional.
+ *                       If empty, will return all styles.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the styles from.
+ *                              If empty, it'll return the styles for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
  *
  * @return array The styles to retrieve.
  */
-function gutenberg_get_global_styles( $path = array(), $block_name = '', $origin = 'all' ) {
-	if ( '' !== $block_name ) {
+function gutenberg_get_global_styles( $path = array(), $context ) {
+	if ( ! empty( $context['block_name'] ) ) {
 		$path = array_merge( array( 'blocks', $block_name ), $path );
 	}
 
-	if ( 'base' === $origin ) {
+	$origin = 'user';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
-	} else {
-		$origin = 'user';
 	}
 
 	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -40,7 +40,7 @@ function gutenberg_get_global_settings( $path = array(), $context ) {
 /**
  * Function to get the styles resulting of merging core, theme, and user data.
  *
- * @param array  $path   Path to the specific style to retrieve. Optional.
+ * @param array $path    Path to the specific style to retrieve. Optional.
  *                       If empty, will return all styles.
  * @param array $context {
  *     Metadata to know where to retrieve the $path from. Optional.
@@ -56,7 +56,7 @@ function gutenberg_get_global_settings( $path = array(), $context ) {
  */
 function gutenberg_get_global_styles( $path = array(), $context ) {
 	if ( ! empty( $context['block_name'] ) ) {
-		$path = array_merge( array( 'blocks', $block_name ), $path );
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
 
 	$origin = 'user';

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -8,25 +8,28 @@
 /**
  * Function to get the settings resulting of merging core, theme, and user data.
  *
- * @param array  $path              Path to the specific setting to retrieve. Optional.
- *                                  If empty, will return all settings.
- * @param string $block_name        Which block to retrieve the settings from. Optional
- *                                  If empty, it'll return the settings for the global context.
- * @param string $origin            Which origin to take data from. Optional.
- *                                  It can be 'all' (core, theme, and user) or 'base' (core and theme).
- *                                  If empty or unknown, 'all' is used.
+ * @param array $path    Path to the specific setting to retrieve. Optional.
+ *                       If empty, will return all settings.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the settings from.
+ *                              If empty, it'll return the settings for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
  *
  * @return array The settings to retrieve.
  */
-function gutenberg_get_global_settings( $path = array(), $block_name = '', $origin = 'all' ) {
-	if ( '' !== $block_name ) {
-		$path = array_merge( array( 'blocks', $block_name ), $path );
+function gutenberg_get_global_settings( $path = array(), $context ) {
+	if ( ! empty( $context['block_name'] ) ) {
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
 
-	if ( 'base' === $origin ) {
+	$origin = 'user';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
-	} else {
-		$origin = 'user';
 	}
 
 	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -22,7 +22,7 @@
  *
  * @return array The settings to retrieve.
  */
-function gutenberg_get_global_settings( $path = array(), $context ) {
+function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 	if ( ! empty( $context['block_name'] ) ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
@@ -54,7 +54,7 @@ function gutenberg_get_global_settings( $path = array(), $context ) {
  *
  * @return array The styles to retrieve.
  */
-function gutenberg_get_global_styles( $path = array(), $context ) {
+function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 	if ( ! empty( $context['block_name'] ) ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}


### PR DESCRIPTION
This simplifies the public API of the newly introduced methods in WordPress 5.9. It's based on feedback received as per https://github.com/WordPress/gutenberg/issues/36556 and future improvements (such as having [multiple theme.json files](https://github.com/WordPress/gutenberg/issues/34349#issuecomment-939036550)).

## How to test

- Verify that tests still pass.
- Load the front and editors (post, site) and verify that it works as expected (presets and styles are loaded, etc).
