### PR TITLE
Only mark nav menu as dialog when open

### DIFF
--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -36,8 +36,17 @@ export default function ResponsiveWrapper( {
 		'wp-block-navigation__responsive-container-open',
 		{ 'always-shown': isHiddenByDefault }
 	);
+	const plainMenuClasses = classnames( 'wp-block-navigation__plain-menu', {
+		'always-shown': isHiddenByDefault,
+	} );
 
 	const modalId = `${ id }-modal`;
+
+	const dialogProps = {
+		className: 'wp-block-navigation__responsive-dialog',
+		'aria-labelledby': `${ modalId }-title`,
+		...( isOpen && { role: 'dialog', 'aria-modal': true } ),
+	};
 
 	return (
 		<>
@@ -64,6 +73,8 @@ export default function ResponsiveWrapper( {
 				</Button>
 			) }
 
+			<div className={ plainMenuClasses }>{ children }</div>
+
 			<div
 				className={ responsiveContainerClasses }
 				style={ styles }
@@ -73,12 +84,7 @@ export default function ResponsiveWrapper( {
 					className="wp-block-navigation__responsive-close"
 					tabIndex="-1"
 				>
-					<div
-						className="wp-block-navigation__responsive-dialog"
-						role="dialog"
-						aria-modal="true"
-						aria-labelledby={ `${ modalId }-title` }
-					>
+					<div { ...dialogProps }>
 						<Button
 							className="wp-block-navigation__responsive-container-close"
 							aria-label={ __( 'Close menu' ) }

--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -53,8 +53,7 @@ export default function ResponsiveWrapper( {
 			{ ! isOpen && (
 				<Button
 					aria-haspopup="true"
-					aria-expanded={ isOpen }
-					aria-label={ __( 'Open menu' ) }
+					aria-label={ __( 'Open navigation menu' ) }
 					className={ openButtonClasses }
 					onClick={ () => onToggle( true ) }
 				>

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -526,9 +526,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		'wp-block-navigation__responsive-container-open',
 		$is_hidden_by_default ? 'always-shown' : '',
 	);
-	$plain_menu_classes 					= array(
+	$plain_menu_classes           = array(
 		'wp-block-navigation__plain-menu',
-		$is_hidden_by_default ? 'always-shown' : ''
+		$is_hidden_by_default ? 'always-shown' : '',
 	);
 
 	$responsive_container_markup = sprintf(
@@ -551,7 +551,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		implode( ' ', $responsive_container_classes ),
 		implode( ' ', $open_button_classes ),
 		$colors['overlay_inline_styles'],
-		implode(' ', $plain_menu_classes)
+		implode( ' ', $plain_menu_classes )
 	);
 
 	return sprintf(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -546,8 +546,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			</div>',
 		$modal_unique_id,
 		$inner_blocks_html,
-		__( 'Open menu' ), // Open button label.
-		__( 'Close menu' ), // Close button label.
+		__( 'Open' ), // Open button label.
+		__( 'Close' ), // Close button label.
 		implode( ' ', $responsive_container_classes ),
 		implode( ' ', $open_button_classes ),
 		$colors['overlay_inline_styles'],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -526,9 +526,14 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		'wp-block-navigation__responsive-container-open',
 		$is_hidden_by_default ? 'always-shown' : '',
 	);
+	$plain_menu_classes 					= array(
+		'wp-block-navigation__plain-menu',
+		$is_hidden_by_default ? 'always-shown' : ''
+	);
 
 	$responsive_container_markup = sprintf(
 		'<button aria-expanded="false" aria-haspopup="true" aria-label="%3$s" class="%6$s" data-micromodal-trigger="modal-%1$s"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg></button>
+			<div class="%8$s">%2$s</div>
 			<div class="%5$s" style="%7$s" id="modal-%1$s">
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-%1$s-title" >
@@ -545,7 +550,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		__( 'Close menu' ), // Close button label.
 		implode( ' ', $responsive_container_classes ),
 		implode( ' ', $open_button_classes ),
-		$colors['overlay_inline_styles']
+		$colors['overlay_inline_styles'],
+		implode(' ', $plain_menu_classes)
 	);
 
 	return sprintf(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -532,11 +532,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	);
 
 	$responsive_container_markup = sprintf(
-		'<button aria-expanded="false" aria-haspopup="true" aria-label="%3$s" class="%6$s" data-micromodal-trigger="modal-%1$s"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg></button>
+		'<button aria-haspopup="true" aria-label="%3$s" class="%6$s" data-micromodal-trigger="modal-%1$s"><svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" role="img" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg></button>
 			<div class="%8$s">%2$s</div>
 			<div class="%5$s" style="%7$s" id="modal-%1$s">
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
-					<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-labelledby="modal-%1$s-title" >
+					<div class="wp-block-navigation__responsive-dialog" role="dialog" aria-modal="true" aria-label="Navigation Menu" >
 							<button aria-label="%4$s" data-micromodal-close class="wp-block-navigation__responsive-container-close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" role="img" aria-hidden="true" focusable="false"><path d="M13 11.8l6.1-6.3-1-1-6.1 6.2-6.1-6.2-1 1 6.1 6.3-6.5 6.7 1 1 6.5-6.6 6.5 6.6 1-1z"></path></svg></button>
 						<div class="wp-block-navigation__responsive-container-content" id="modal-%1$s-content">
 							%2$s
@@ -546,8 +546,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 			</div>',
 		$modal_unique_id,
 		$inner_blocks_html,
-		__( 'Open' ), // Open button label.
-		__( 'Close' ), // Close button label.
+		__( 'Open navigation menu' ), // Open button label.
+		__( 'Close navigation menu' ), // Close button label.
 		implode( ' ', $responsive_container_classes ),
 		implode( ' ', $open_button_classes ),
 		$colors['overlay_inline_styles'],

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -511,7 +511,6 @@ button.wp-block-navigation-item__content {
 	@include break-small() {
 		&:not(.hidden-by-default) {
 			&:not(.is-menu-open) {
-				display: block;
 				width: 100%;
 				position: relative;
 				z-index: auto;
@@ -566,6 +565,16 @@ button.wp-block-navigation-item__content {
 	&:not(.always-shown) {
 		@include break-small {
 			display: none;
+		}
+	}
+}
+
+.wp-block-navigation__plain-menu {
+	display: none;
+
+	&:not(.always-shown) {
+		@include break-small {
+			display: block;
 		}
 	}
 }

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -388,10 +388,6 @@ button.wp-block-navigation-item__content {
 
 	.wp-block-navigation__responsive-container-content {
 		display: flex;
-		flex-wrap: var(--layout-wrap, wrap);
-		flex-direction: var(--layout-direction, initial);
-		justify-content: var(--layout-justify, initial);
-		align-items: var(--layout-align, initial);
 	}
 
 	// If the responsive wrapper is present but overlay is not open,
@@ -569,14 +565,24 @@ button.wp-block-navigation-item__content {
 	}
 }
 
+// Show/hide the basic non-modal menu when set to "Mobile".
 .wp-block-navigation__plain-menu {
 	display: none;
 
 	&:not(.always-shown) {
 		@include break-small {
-			display: block;
+			display: flex;
 		}
 	}
+}
+
+// Both the modal inner container, and the plain menu, should inherit layout properties.
+.wp-block-navigation__plain-menu,
+.wp-block-navigation__responsive-container .wp-block-navigation__responsive-container-content {
+	flex-wrap: var(--layout-wrap, wrap);
+	flex-direction: var(--layout-direction, initial);
+	justify-content: var(--layout-justify, initial);
+	align-items: var(--layout-align, initial);
 }
 
 // Button to close the menus.


### PR DESCRIPTION
## Description

This PR addresses part of the problem described in https://github.com/WordPress/gutenberg/issues/36600, where an incorrectly labeled menu was being identified as a dialog, when in fact it was an unopened menu. This caused screen readers such as NVDA to read out the word "dialog" in places where it shouldn't have.

I would really appreciate feedback on how we can further address the problems described on the issue.

## How has this been tested?
### Navigating through a Navigation Menu which is not collapsed reads:
"Navigation landmark with N items", and then reads the text for the first link on the list.

Submenu arrows read "Button Collapsed", pressing this would open a submenu. This can be improved by more accurately describing the button with something like "Button, Collapsed Submenu".

### Navigating to a button to open the Overlay Menu reads:
"Navigation landmark, open menu button, collapsed submenu".
After pressing enter on this button, screen reader reads:

"Expanded, Dialog, List, List with N items", and then it reads the text on each item.
The menu can be navigated using the Tab key.
