### PR TITLE
[RNMobile] Enable child block caption field to be hidden by parent blocks 

### DIFF
--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -54,6 +54,10 @@ export default compose( [
 		const { caption } = getBlockAttributes( clientId ) || {};
 		const isBlockSelected = getSelectedBlockClientId() === clientId;
 
+		// Detect whether the block is an inner block by checking if it has a parent block.
+		// getBlockRootClientId() will return an empty string for all top-level blocks.
+		// If the block is an inner block, its parent may explicitly hide child block controls.
+		// See: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4256
 		const parentId = getBlockRootClientId( clientId );
 		const parentBlockName = getBlockName( parentId );
 

--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -9,6 +9,7 @@ import { View } from 'react-native';
 import { Caption, RichText } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
+import { hasBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -44,11 +45,23 @@ const BlockCaption = ( {
 
 export default compose( [
 	withSelect( ( select, { clientId } ) => {
-		const { getBlockAttributes, getSelectedBlockClientId } = select(
-			blockEditorStore
-		);
+		const {
+			getBlockAttributes,
+			getSelectedBlockClientId,
+			getBlockName,
+			getBlockRootClientId,
+		} = select( blockEditorStore );
 		const { caption } = getBlockAttributes( clientId ) || {};
 		const isBlockSelected = getSelectedBlockClientId() === clientId;
+
+		const parentId = getBlockRootClientId( clientId );
+		const parentBlockName = getBlockName( parentId );
+
+		hasBlockSupport(
+			parentBlockName,
+			'__experimentalHideChildBlockControls',
+			false
+		);
 
 		// We'll render the caption so that the soft keyboard is not forced to close on Android
 		// but still hide it by setting its display style to none. See wordpress-mobile/gutenberg-mobile#1221

--- a/packages/block-editor/src/components/block-caption/index.native.js
+++ b/packages/block-editor/src/components/block-caption/index.native.js
@@ -57,7 +57,7 @@ export default compose( [
 		const parentId = getBlockRootClientId( clientId );
 		const parentBlockName = getBlockName( parentId );
 
-		hasBlockSupport(
+		const hideCaption = hasBlockSupport(
 			parentBlockName,
 			'__experimentalHideChildBlockControls',
 			false
@@ -66,7 +66,8 @@ export default compose( [
 		// We'll render the caption so that the soft keyboard is not forced to close on Android
 		// but still hide it by setting its display style to none. See wordpress-mobile/gutenberg-mobile#1221
 		const shouldDisplay =
-			! RichText.isEmpty( caption ) > 0 || isBlockSelected;
+			! hideCaption &&
+			( ! RichText.isEmpty( caption ) > 0 || isBlockSelected );
 
 		return {
 			shouldDisplay,


### PR DESCRIPTION
Fixes: https://github.com/wordpress-mobile/gutenberg-mobile/issues/4190

`Gutenberg Mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4256

## Description

This PR provides a way for parent blocks to hide [the block caption component](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-caption/index.native.js) (if used) in any inner child block.

The code builds on the work done in #36371, which introduced a new `__experimentalHideChildBlockControls` [block support](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/). The purpose of the new block support is to hide child block settings/controls, which is helpful in cases when native blocks need to customize inner blocks. A further outline of the use case for this support can be found [here](https://github.com/WordPress/gutenberg/pull/36371#issuecomment-967043840).

With this PR, the block caption component now also listens for `__experimentalHideChildBlockControls`. If it is set to true then any captions are hidden from child blocks. 

The thoughts behind using an existing block support, instead of creating a new one, are as follows:

* If a parent block indicates a need to hide child block controls, it's reasonable to assume that that would include the option to edit the child block's caption. This is because the need to hide controls would usually stem from being unable to support HTML changes in inner blocks (and editing the caption involved HTML changes).
* There is a possibility that we'll try [a different approach](https://github.com/WordPress/gutenberg/pull/36371#issuecomment-968928831) in the future. It's hoped that only having a single block support will make future changes simple to implement.

## How has this been tested?

_Note: The Gallery block is being used as a proof of concept here and for the purposes of testing. We are not planning to actually remove the caption from its inner Image blocks. The following steps can be repurposed for any block using inner blocks and a caption field._

_Prequisite: Enable the flag for the refactored Gallery block. on mobile. At the time of writing, the way to enable the block on the Gutenberg Mobile demo app is to comment out [this section of code](https://github.com/WordPress/gutenberg/blob/5c9e84d66419c75900b8e6c5addc6eb2326e203e/packages/block-library/src/gallery/edit-wrapper.js#L33-L44)._

* Add `"__experimentalHideChildBlockControls": true` to the Gallery block's `block.json` file. It should be added to [the block supports object here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/gallery/block.json#L107).
* With the change saved, add a new Gallery block to the editor in the Android or iOS apps.
* Edit an inner image block to confirm that the caption field is **_not_** available for the individual inner blocks.

We should also test other blocks that make use of the block caption component to verify there are no regressions. Those blocks are all native and include:

* Audio
* Video
* Embed 
* Image

## Screenshots <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/142488894-6dbdb624-c231-4147-8098-02d5961c2341.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/142488852-c4fa7e65-051d-4add-8ee0-1b1b3b16bbbb.png" width="100%"> |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This PR introduces a non-breaking change, with the following high-level overview of the code:

* A check for whether `__experimentalHideChildBlockControls` is true has been added to the block caption component's `shouldDisplay` boolean. This will now enable parent blocks to set the value to `true` if the caption should be hidden from child blocks. [`hasBlockSupport`](https://developer.wordpress.org/block-editor/reference-guides/data/data-core-blocks/#hasblocksupport) is used to achieve this.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
