### PR TITLE
Site Editor: Add global styles to export file

### DIFF
--- a/lib/compat/wordpress-5.9/edit-site-export.php
+++ b/lib/compat/wordpress-5.9/edit-site-export.php
@@ -30,6 +30,19 @@ if ( ! function_exists( 'wp_generate_edit_site_export_file' ) ) {
 		$zip->addEmptyDir( 'theme/block-templates' );
 		$zip->addEmptyDir( 'theme/block-template-parts' );
 
+		// Load theme and user styles.
+		$theme_data = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+		$user_data  = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
+
+		// Merge the user config into the theme data.
+		// The user config takes precedence over the theme.
+		$theme_data->merge( $user_data );
+
+		$zip->addFromString(
+			'theme/theme.json',
+			wp_json_encode( $theme_data->get_raw_data(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		);
+
 		// Load templates into the zip file.
 		$templates = gutenberg_get_block_templates();
 		foreach ( $templates as $template ) {

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -13,7 +13,7 @@ class Edit_Site_Export_Test extends WP_UnitTestCase {
 
 		// Open ZIP file and make sure the directories exist.
 		$zip = new ZipArchive();
-		$zip->open( $filename, ZipArchive::RDONLY );
+		$zip->open( $filename );
 		$has_theme_json               = $zip->locateName( 'theme/theme.json' ) !== false;
 		$has_theme_dir                = $zip->locateName( 'theme/' ) !== false;
 		$has_block_templates_dir      = $zip->locateName( 'theme/block-templates/' ) !== false;

--- a/phpunit/class-edit-site-export-test.php
+++ b/phpunit/class-edit-site-export-test.php
@@ -8,15 +8,17 @@
 class Edit_Site_Export_Test extends WP_UnitTestCase {
 	function test_wp_generate_edit_site_export_file() {
 		$filename = wp_generate_edit_site_export_file();
-		$this->assertTrue( file_exists( $filename ), 'zip file is created at the specified path' );
+		$this->assertFileExists( $filename, 'zip file is created at the specified path' );
 		$this->assertTrue( filesize( $filename ) > 0, 'zip file is larger than 0 bytes' );
 
 		// Open ZIP file and make sure the directories exist.
 		$zip = new ZipArchive();
 		$zip->open( $filename, ZipArchive::RDONLY );
+		$has_theme_json               = $zip->locateName( 'theme/theme.json' ) !== false;
 		$has_theme_dir                = $zip->locateName( 'theme/' ) !== false;
 		$has_block_templates_dir      = $zip->locateName( 'theme/block-templates/' ) !== false;
 		$has_block_template_parts_dir = $zip->locateName( 'theme/block-template-parts/' ) !== false;
+		$this->assertTrue( $has_theme_json, 'theme.json file exists' );
 		$this->assertTrue( $has_theme_dir, 'theme directory exists' );
 		$this->assertTrue( $has_block_templates_dir, 'theme/block-templates directory exists' );
 		$this->assertTrue( $has_block_template_parts_dir, 'theme/block-template-parts directory exists' );


### PR DESCRIPTION
## Description
Fixes #27528.

Adds global style settings (as theme.json) to the site export file.

P.S. I'm preparing the WP core patch for the missing export REST API. I think this will be a good addition to the functionality. We can polish the export feature after 5.9 - #27941.

## How has this been tested?
1. Go to Appearance > Editor
2. Open the "More tools and Options" dropdown and export.
3. Confirm that the archive contains the theme.json
4. Confirm that user-applied changes are correctly exported.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
