### PR TITLE
Try: Hide the columns inserter in pattern previews.

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -50,6 +50,9 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 						const {
 							ownerDocument: { documentElement },
 						} = bodyElement;
+						documentElement.classList.add(
+							'block-editor-block-preview__content-iframe'
+						);
 						documentElement.style.position = 'absolute';
 						documentElement.style.width = '100%';
 						bodyElement.style.padding =

--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -36,3 +36,8 @@
 		}
 	}
 }
+
+// Hide inserter from previews.
+.block-editor-block-preview__content-iframe .block-list-appender {
+	display: none;
+}

--- a/packages/block-library/src/text-columns/editor.scss
+++ b/packages/block-library/src/text-columns/editor.scss
@@ -5,9 +5,6 @@
 }
 
 // Hide inserter from previews.
-// This selector could be cleaner if we had a CSS class to target inside the preview iframe.
-html[style] body > .is-root-container .wp-block-columns {
-	.block-list-appender {
-		display: none;
-	}
+.block-editor-block-preview__content-iframe .wp-block-columns .block-list-appender {
+	display: none;
 }

--- a/packages/block-library/src/text-columns/editor.scss
+++ b/packages/block-library/src/text-columns/editor.scss
@@ -3,8 +3,3 @@
 		outline: $border-width solid $gray-300;
 	}
 }
-
-// Hide inserter from previews.
-.block-editor-block-preview__content-iframe .wp-block-columns .block-list-appender {
-	display: none;
-}

--- a/packages/block-library/src/text-columns/editor.scss
+++ b/packages/block-library/src/text-columns/editor.scss
@@ -3,3 +3,11 @@
 		outline: $border-width solid $gray-300;
 	}
 }
+
+// Hide inserter from previews.
+// This selector could be cleaner if we had a CSS class to target inside the preview iframe.
+html[style] body > .is-root-container .wp-block-columns {
+	.block-list-appender {
+		display: none;
+	}
+}


### PR DESCRIPTION
## Description

Fixes #36625. This adds a rule to the columns block editor stylesheet to hide the inserter when seen inside the preview iframe:

<img width="1178" alt="Screenshot 2021-11-18 at 19 29 40" src="https://user-images.githubusercontent.com/1204802/142475469-43caaa55-d511-4574-ac03-4588a1e0b334.png">

For now this is a small PR that fixes it for the columns block, which seems to be the primary offender. The PR could be refactored by adding a small CSS class to the preview component, so the selector to target only the contents of the preview could be simplified. (If you see this and feel lucky, you can push directly to this branch if you like.)

## How has this been tested?

Try opening the inserter and going to patterns, you should see no inserter in the Forest pattern as shown.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
