### PR TITLE
Cover: move BoxControlVisualizer in the markup to make it visible

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -39,6 +39,7 @@ $z-layers: (
 	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
+	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
 	".wp-block-cover__image-background": 0, // Image background inside cover block.
 	".wp-block-cover__video-background": 0, // Video background inside cover block.
 	".wp-block-template-part__placeholder-preview-filter-input": 1,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -699,6 +699,11 @@ function CoverEdit( {
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>
+				<BoxControlVisualizer
+					values={ styleAttribute?.spacing?.padding }
+					showValues={ styleAttribute?.visualizers?.padding }
+					className="block-library-cover__padding-visualizer"
+				/>
 				<ResizableCover
 					className="block-library-cover__resize-container"
 					onResizeStart={ () => {
@@ -729,10 +734,7 @@ function CoverEdit( {
 					) }
 					style={ { backgroundImage: gradientValue, ...bgStyle } }
 				/>
-				<BoxControlVisualizer
-					values={ styleAttribute?.spacing?.padding }
-					showValues={ styleAttribute?.visualizers?.padding }
-				/>
+
 				{ url && isImageBackground && isImgElement && (
 					<img
 						ref={ isDarkElement }

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -699,10 +699,6 @@ function CoverEdit( {
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>
-				<BoxControlVisualizer
-					values={ styleAttribute?.spacing?.padding }
-					showValues={ styleAttribute?.visualizers?.padding }
-				/>
 				<ResizableCover
 					className="block-library-cover__resize-container"
 					onResizeStart={ () => {
@@ -733,7 +729,10 @@ function CoverEdit( {
 					) }
 					style={ { backgroundImage: gradientValue, ...bgStyle } }
 				/>
-
+				<BoxControlVisualizer
+					values={ styleAttribute?.spacing?.padding }
+					showValues={ styleAttribute?.visualizers?.padding }
+				/>
 				{ url && isImageBackground && isImgElement && (
 					<img
 						ref={ isDarkElement }

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -76,6 +76,10 @@
 		}
 	}
 
+	.block-library-cover__padding-visualizer {
+		z-index: z-index(".block-library-cover__padding-visualizer");
+	}
+
 	// Apply max-width to floated items that have no intrinsic width
 	&.alignleft,
 	&.alignright {


### PR DESCRIPTION
## Description
This commit ~moves the BoxControlVisualizer component, which has a z-index of `1` below~ add a `z-index` if `2` to the Cover Block's BoxControlVisualizer so that it sits above the opacity div, which has a z-index of `1`. 

We do this so the Visualizer appears above the opacity layer.

![Nov-19-2021 15-47-53](https://user-images.githubusercontent.com/6458278/142566674-f74f5d2f-a34f-4fd7-8e03-2dc184012021.gif)

## How has this been tested?

1. In trunk, insert a Cover Block in the editor. It's best tested with a solid background with `0` opacity.
2. Adjust the padding of your block using the Dimensions ToolsPanel control.
3. Can you see the padding visualizer helpers?


Now checkout this branch and repeat the above steps.

You should be able to see the visualizer hovering over the cover block (opaque, blue rectangles indicating the current padding values)

4. Yeah!

## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
