### PR TITLE
Font Size Picker: Allow non-integers as simple CSS values and in hints

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -81,13 +81,10 @@ function FontSizePicker(
 			return isSimpleCssValue( value ) && `(${ value })`;
 		}
 		if ( shouldUseSelectControl ) {
-			if ( selectedOption?.slug === 'default' ) {
-				return false;
-			}
-
-			return isSimpleCssValue( selectedOption?.size )
-				? `(${ selectedOption?.size })`
-				: `(${ __( 'Dynamic' ) })`;
+			return (
+				isSimpleCssValue( selectedOption?.size ) &&
+				`(${ selectedOption?.size })`
+			);
 		}
 		// Calculate the `hint` for toggle group control.
 		let hint = selectedOption.name;

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -81,10 +81,13 @@ function FontSizePicker(
 			return isSimpleCssValue( value ) && `(${ value })`;
 		}
 		if ( shouldUseSelectControl ) {
-			return (
-				isSimpleCssValue( selectedOption?.size ) &&
-				`(${ selectedOption?.size })`
-			);
+			if ( selectedOption?.slug === 'default' ) {
+				return false;
+			}
+
+			return isSimpleCssValue( selectedOption?.size )
+				? `(${ selectedOption?.size })`
+				: `(${ __( 'Dynamic' ) })`;
 		}
 		// Calculate the `hint` for toggle group control.
 		let hint = selectedOption.name;

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -156,3 +156,41 @@ export const differentControlBySize = () => {
 		<FontSizePickerWithState fontSizes={ fontSizes } initialValue={ 8 } />
 	);
 };
+
+export const withComplexCSSValues = () => {
+	const fontSizes = object( 'Font Sizes', [
+		{
+			name: 'Small',
+			slug: 'small',
+			size: '0.75rem',
+		},
+		{
+			name: 'Normal',
+			slug: 'normal',
+			size: '1rem',
+		},
+		{
+			name: 'Large',
+			slug: 'large',
+			size: '2.5rem',
+		},
+		{
+			name: 'Extra Large',
+			slug: 'extra-large',
+			size: '3.5rem',
+		},
+		{
+			name: 'Huge',
+			slug: 'huge',
+			size: 'clamp(2.5rem, 4vw, 3rem)',
+		},
+	] );
+	return (
+		<div style={ { maxWidth: '248px' } }>
+			<FontSizePickerWithState
+				fontSizes={ fontSizes }
+				initialValue={ '1rem' }
+			/>
+		</div>
+	);
+};

--- a/packages/components/src/font-size-picker/test/util.js
+++ b/packages/components/src/font-size-picker/test/util.js
@@ -1,0 +1,74 @@
+/**
+ * Internal dependencies
+ */
+import { isSimpleCssValue, splitValueAndUnitFromSize } from '../utils';
+
+const simpleCSSCases = [
+	// Test integers and non-integers.
+	[ 1, true ],
+	[ 1.25, true ],
+	[ '123', true ],
+	[ '1.5', true ],
+	[ '0.75', true ],
+	// CSS unit tests.
+	[ '20px', true ],
+	[ '0.8em', true ],
+	[ '2rem', true ],
+	[ '1.4vw', true ],
+	[ '0.4vh', true ],
+	// Invalid negative values,
+	[ '-5px', false ],
+	// Complex CSS values that should fail.
+	[ 'abs(-10px)', false ],
+	[ 'calc(10px + 1)', false ],
+	[ 'clamp(2.5rem, 4vw, 3rem)', false ],
+	[ 'max(4.5em, 3vh)', false ],
+	[ 'min(10px, 1rem)', false ],
+	[ 'minmax(30px, auto)', false ],
+	[ 'var(--wp--font-size)', false ],
+];
+
+describe( 'isSimpleCssValue', () => {
+	test.each( simpleCSSCases )(
+		'given %p as argument, returns %p',
+		( cssValue, result ) => {
+			expect( isSimpleCssValue( cssValue ) ).toBe( result );
+		}
+	);
+} );
+
+const splitValuesCases = [
+	// Test integers and non-integers.
+	[ 1, '1', undefined ],
+	[ 1.25, '1.25', undefined ],
+	[ '123', '123', undefined ],
+	[ '1.5', '1.5', undefined ],
+	[ '0.75', '0.75', undefined ],
+	// Valid simple CSS values.
+	[ '20px', '20', 'px' ],
+	[ '0.8em', '0.8', 'em' ],
+	[ '2rem', '2', 'rem' ],
+	[ '1.4vw', '1.4', 'vw' ],
+	[ '0.4vh', '0.4', 'vh' ],
+	// Invalid negative values,
+	[ '-5px', undefined, undefined ],
+	// Complex CSS values that shouldn't parse.
+	[ 'abs(-15px)', undefined, undefined ],
+	[ 'calc(10px + 1)', undefined, undefined ],
+	[ 'clamp(2.5rem, 4vw, 3rem)', undefined, undefined ],
+	[ 'max(4.5em, 3vh)', undefined, undefined ],
+	[ 'min(10px, 1rem)', undefined, undefined ],
+	[ 'minmax(30px, auto)', undefined, undefined ],
+	[ 'var(--wp--font-size)', undefined, undefined ],
+];
+
+describe( 'splitValueAndUnitFromSize', () => {
+	test.each( splitValuesCases )(
+		'given %p as argument, returns value = %p and unit = %p',
+		( cssValue, expectedValue, expectedUnit ) => {
+			const [ value, unit ] = splitValueAndUnitFromSize( cssValue );
+			expect( value ).toBe( expectedValue );
+			expect( unit ).toBe( expectedUnit );
+		}
+	);
+} );

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -22,12 +22,13 @@ const CUSTOM_FONT_SIZE_OPTION = {
  * @return {[number, string]} An array with the numeric value and the unit if exists.
  */
 export function splitValueAndUnitFromSize( size ) {
-	/**
-	 * The first matched result is ignored as it's the left
-	 * hand side of the capturing group in the regex.
-	 */
-	const [ , numericValue, unit ] = size.split( /(\d+)/ );
-	return [ numericValue, unit ];
+	const [ numericValue, unit ] = `${ size }`.match( /[\d\.]+|\D+/g );
+
+	if ( ! isNaN( parseFloat( numericValue ) ) && isFinite( numericValue ) ) {
+		return [ numericValue, unit ];
+	}
+
+	return [];
 }
 
 /**
@@ -38,7 +39,7 @@ export function splitValueAndUnitFromSize( size ) {
  * @return {boolean} Whether the value is a simple css value.
  */
 export function isSimpleCssValue( value ) {
-	const sizeRegex = /^(?!0)\d+(px|em|rem|vw|vh|%)?$/i;
+	const sizeRegex = /^[\d\.]+(px|em|rem|vw|vh|%)?$/i;
 	return sizeRegex.test( value );
 }
 
@@ -74,8 +75,6 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		key: slug,
 		name,
 		size,
-		__experimentalHint:
-			size && isSimpleCssValue( size ) && parseInt( size ),
 	} ) );
 }
 

--- a/packages/components/src/font-size-picker/utils.js
+++ b/packages/components/src/font-size-picker/utils.js
@@ -75,6 +75,8 @@ function getSelectOptions( optionsArray, disableCustomFontSizes ) {
 		key: slug,
 		name,
 		size,
+		__experimentalHint:
+			size && isSimpleCssValue( size ) && parseFloat( size ),
 	} ) );
 }
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/36545
- https://github.com/WordPress/gutenberg/pull/36420

## Description

This PR:
- Allows for non-integer font-size values such as `1.5rem` to be accepted as simple CSS values
- Allows for non-integer values that are < 1. e.g. `0.75em`
- Adds a new FontSizePicker story that includes complex CSS and non-integer values
- Adds unit tests for `isSimpleCssValue` and `splitValueAndUnitFromSize` util functions

**Note: This PR builds upon the approach taken and discussion in https://github.com/WordPress/gutenberg/pull/36420. Credit goes to @ndiego**

**Earlier iterations of this PR removed the hints from the select control however upon further discussion they have been reinstated.**

## How has this been tested?
Unit Tests:
1. Run `npm run test-unit:watch packages/components/src/font-size-picker/test`
2. Ensure all the original component tests pass as well as the new `utils.js` tests

Storybook:
1. Fire up the Storybook: `npm run storybook:dev`
2. Visit: http://localhost:50240/?path=/story/components-fontsizepicker--with-complex-css-values
3. Ensure the control behaves as you'd expect
4. Adjust the font-size config via the "Knobs" tab and try different font-size values

Block Editor:
1. Set your active theme to TwentyTwentyTwo
2. Create a new post in the block editor and a paragraph with text
3. In the inspector controls manipulate the paragraph's font-size
4. Ensure that various font-size selections are reflected correctly in the control's label and each option's hint appears correctly.

## Screenshots <!-- if applicable -->

| Storybook | Editor |
|---|---|
| ![FontSizePickers-HintsReinstatedStory](https://user-images.githubusercontent.com/60436221/143794382-6762a010-89c9-4829-bcd7-33b18dea8cac.gif) | ![FontSizePickers-HintsReinstatedEditor](https://user-images.githubusercontent.com/60436221/143794390-254c5f29-f053-442a-abbe-02b91aa54557.gif) |


## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
