### PR TITLE
Update navigation sidebar responsiveness

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -219,11 +219,7 @@ function Editor( { initialSettings, onError } ) {
 														<ComplementaryArea.Slot scope="core/edit-site" />
 													)
 												}
-												drawer={
-													<NavigationSidebar
-														defaultIsOpen={ false }
-													/>
-												}
+												drawer={ <NavigationSidebar /> }
 												header={
 													<Header
 														openEntitiesSavedStates={

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -5,7 +5,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
@@ -18,7 +17,6 @@ import Table from './table';
 
 export default function List( { templateType } ) {
 	useRegisterShortcuts();
-	const isDesktopViewport = useViewportMatch( 'medium' );
 
 	const { previousShortcut, nextShortcut } = useSelect( ( select ) => {
 		return {
@@ -64,8 +62,8 @@ export default function List( { templateType } ) {
 			header={ <Header templateType={ templateType } /> }
 			drawer={
 				<NavigationSidebar
-					defaultIsOpen={ isDesktopViewport }
 					activeTemplateType={ templateType }
+					isDefaultOpen
 				/>
 			}
 			content={

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { createSlotFill } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -16,10 +17,25 @@ export const {
 } = createSlotFill( 'EditSiteNavigationPanelPreview' );
 
 export default function NavigationSidebar( {
-	defaultIsOpen = false,
+	isDefaultOpen = false,
 	activeTemplateType,
 } ) {
-	const [ isNavigationOpen, setIsNavigationOpen ] = useState( defaultIsOpen );
+	const isDesktopViewport = useViewportMatch( 'medium' );
+	const [ isNavigationOpen, setIsNavigationOpen ] = useState(
+		isDefaultOpen && isDesktopViewport
+	);
+
+	useEffect( () => {
+		// When transitioning to desktop open the navigation if `isDefaultOpen` is true.
+		if ( isDefaultOpen && isDesktopViewport && ! isNavigationOpen ) {
+			setIsNavigationOpen( true );
+		}
+
+		// When transitioning to mobile/tablet, close the navigation.
+		if ( ! isDesktopViewport && isNavigationOpen ) {
+			setIsNavigationOpen( false );
+		}
+	}, [ isDefaultOpen, isDesktopViewport, isNavigationOpen ] );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -27,15 +27,15 @@ export default function NavigationSidebar( {
 
 	useEffect( () => {
 		// When transitioning to desktop open the navigation if `isDefaultOpen` is true.
-		if ( isDefaultOpen && isDesktopViewport && ! isNavigationOpen ) {
+		if ( isDefaultOpen && isDesktopViewport ) {
 			setIsNavigationOpen( true );
 		}
 
 		// When transitioning to mobile/tablet, close the navigation.
-		if ( ! isDesktopViewport && isNavigationOpen ) {
+		if ( ! isDesktopViewport ) {
 			setIsNavigationOpen( false );
 		}
-	}, [ isDefaultOpen, isDesktopViewport, isNavigationOpen ] );
+	}, [ isDefaultOpen, isDesktopViewport ] );
 
 	return (
 		<>


### PR DESCRIPTION
## Description
Updates the way the navigation sidebar works based on https://github.com/WordPress/gutenberg/issues/36597#issuecomment-972999941

It works like this:
- On the listing page, the sidebar is open by default on desktop but closed by default on mobile/tablet. It'll close and open automatically when resizing the viewport between mobile and desktop.
- In the site editor, the sidebar is closed by default on all viewports. If the viewport is resized from desktop to mobile it'll close automatically. It won't re-open when going back from mobile to desktop. I don't know if this bit is quite right, but when testing I felt like the site editor should have the same closing behavior as the listing page.

## Video
https://user-images.githubusercontent.com/677833/142594956-95815852-f86d-40f5-9961-1d20f12fe478.mp4

## Types of changes
Enhancement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
