### PR TITLE
Only render the site editor canvas when the global styles are ready.

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -192,7 +192,7 @@ function gutenberg_edit_site_init( $hook ) {
 					'/wp/v2/themes?context=edit&status=active',
 					'/wp/v2/global-styles/' . $active_global_styles_id . '?context=edit',
 					'/wp/v2/global-styles/' . $active_global_styles_id,
-					'/wp/v2/themes/' . $active_theme . '/global-styles',
+					'/wp/v2/global-styles/themes/' . $active_theme,
 				)
 			),
 			'initializer_name' => 'initializeEditor',

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -135,7 +135,7 @@ function useGlobalStylesBaseConfig() {
 		).__experimentalGetCurrentThemeBaseGlobalStyles();
 	}, [] );
 
-	return baseConfig;
+	return [ !! baseConfig, baseConfig ];
 }
 
 function useGlobalStylesContext() {
@@ -144,7 +144,7 @@ function useGlobalStylesContext() {
 		userConfig,
 		setUserConfig,
 	] = useGlobalStylesUserConfig();
-	const baseConfig = useGlobalStylesBaseConfig();
+	const [ isBaseConfigReady, baseConfig ] = useGlobalStylesBaseConfig();
 	const mergedConfig = useMemo( () => {
 		if ( ! baseConfig || ! userConfig ) {
 			return {};
@@ -153,7 +153,7 @@ function useGlobalStylesContext() {
 	}, [ userConfig, baseConfig ] );
 	const context = useMemo( () => {
 		return {
-			isReady: isUserConfigReady,
+			isReady: isUserConfigReady && isBaseConfigReady,
 			user: userConfig,
 			base: baseConfig,
 			merged: mergedConfig,
@@ -165,6 +165,7 @@ function useGlobalStylesContext() {
 		baseConfig,
 		setUserConfig,
 		isUserConfigReady,
+		isBaseConfigReady,
 	] );
 
 	return context;


### PR DESCRIPTION
closes #36594 

While previously, we had a behavior in place to wait for "user global styles" to be loaded, we didn't have the same behavior for the "base global styles" that come directly from theme.json, meaning it was possible to notice a switch in the applied styled in the site editor canvas after some milliseconds.

I also noticed that the base styles where not reloaded properly (wrong url used there). This PR solves both of these issues.

**Testing instructions**

 - Use a block based theme with a colored background (ex: Tove)
 - Ensure that you don't have any custom styles (user)
 - Load the site editor
 - While being loaded, you shouldn't see a change in background color, the right color should appear directly.