### PR TITLE
theme.json: add `appearanceTools` flag to opt-in into appearance UI controls

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -218,6 +218,7 @@ The settings section has the following structure:
 {
 	"version": 1,
 	"settings": {
+		"appearanceTools": true,
 		"border": {
 			"color": false,
 			"radius": false,
@@ -282,9 +283,9 @@ Each block can configure any of these settings separately, providing a more fine
 
 Note, however, that not all settings are relevant for all blocks. The settings section provides an opt-in/opt-out mechanism for themes, but it's the block's responsibility to add support for the features that are relevant to it. For example, if a block doesn't implement the `dropCap` feature, a theme can't enable it for such a block through `theme.json`.
 
-### Opt-in into appearance controls
+### Opt-in into UI controls
 
-There's one special setting property, `appareance`, which can be a boolean and its default value is true. When this is enabled, the following setting properties will be on by default:
+There's one special setting property, `appearanceTools`, which is a boolean and its default value is true. When this is enabled, the following setting properties will be on by default:
 
 - border: color, radius, style, width
 - spacing: margin, padding, units

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -285,11 +285,12 @@ Note, however, that not all settings are relevant for all blocks. The settings s
 
 ### Opt-in into UI controls
 
-There's one special setting property, `appearanceTools`, which is a boolean and its default value is true. When this is enabled, the following setting properties will be on by default:
+There's one special setting property, `appearanceTools`, which is a boolean and its default value is false. Themes can use this setting to enable the following ones:
 
 - border: color, radius, style, width
-- spacing: margin, padding, units
-- typography: customFontSize, lineHeight
+- color: link
+- spacing: blockGap, margin, padding
+- typography: lineHeight
 
 #### Backward compatibility with add_theme_support
 

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -218,7 +218,7 @@ The settings section has the following structure:
 {
 	"version": 1,
 	"settings": {
-		"appearanceTools": true,
+		"appearanceTools": false,
 		"border": {
 			"color": false,
 			"radius": false,

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -282,6 +282,14 @@ Each block can configure any of these settings separately, providing a more fine
 
 Note, however, that not all settings are relevant for all blocks. The settings section provides an opt-in/opt-out mechanism for themes, but it's the block's responsibility to add support for the features that are relevant to it. For example, if a block doesn't implement the `dropCap` feature, a theme can't enable it for such a block through `theme.json`.
 
+### Opt-in into appearance controls
+
+There's one special setting property, `appareance`, which can be a boolean and its default value is true. When this is enabled, the following setting properties will be on by default:
+
+- border: color, radius, style, width
+- spacing: margin, padding, units
+- typography: customFontSize, lineHeight
+
 #### Backward compatibility with add_theme_support
 
 To retain backward compatibility, the existing `add_theme_support` declarations that configure the block editor are retrofit in the proper categories for the top-level section. For example, if a theme uses `add_theme_support('disable-custom-colors')`, it'll be the same as setting `settings.color.custom` to `false`. If the `theme.json` contains any settings, these will take precedence over the values declared via `add_theme_support`. This is the complete list of equivalences:

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -81,14 +81,14 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	const VALID_SETTINGS = array(
-		'appearance' => null,
-		'border'     => array(
+		'appearanceTools' => null,
+		'border'          => array(
 			'color'  => null,
 			'radius' => null,
 			'style'  => null,
 			'width'  => null,
 		),
-		'color'      => array(
+		'color'           => array(
 			'background'       => null,
 			'custom'           => null,
 			'customDuotone'    => null,
@@ -101,18 +101,18 @@ class WP_Theme_JSON_Gutenberg {
 			'palette'          => null,
 			'text'             => null,
 		),
-		'custom'     => null,
-		'layout'     => array(
+		'custom'          => null,
+		'layout'          => array(
 			'contentSize' => null,
 			'wideSize'    => null,
 		),
-		'spacing'    => array(
+		'spacing'         => array(
 			'blockGap' => null,
 			'margin'   => null,
 			'padding'  => null,
 			'units'    => null,
 		),
-		'typography' => array(
+		'typography'      => array(
 			'customFontSize' => null,
 			'dropCap'        => null,
 			'fontFamilies'   => null,
@@ -318,13 +318,13 @@ class WP_Theme_JSON_Gutenberg {
 	private static function maybe_opt_in_into_settings( $theme_json ) {
 		$new_theme_json = $theme_json;
 
-		if ( isset( $new_theme_json['settings']['appearance'] ) ) {
+		if ( isset( $new_theme_json['settings']['appearanceTools'] ) ) {
 			self::do_opt_in_into_settings( $new_theme_json['settings'] );
 		}
 
 		if ( isset( $new_theme_json['settings']['blocks'] ) && is_array( $new_theme_json['settings']['blocks'] ) ) {
 			foreach ( $new_theme_json['settings']['blocks'] as &$block ) {
-				if ( isset( $block['appearance'] ) ) {
+				if ( isset( $block['appearanceTools'] ) ) {
 					self::do_opt_in_into_settings( $block );
 				}
 			}
@@ -339,7 +339,10 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $context The context to which the settings belong.
 	 */
 	private static function do_opt_in_into_settings( &$context ) {
-		gutenberg_experimental_set( $context, array( 'border', 'color' ), true );
+		// todo: take into account existing settings, if they exists
+		if ( ! isset( _wp_array_get( $context, array( 'border', 'color' ) ) ) {
+			gutenberg_experimental_set( $context, array( 'border', 'color' ), true );
+		}
 		gutenberg_experimental_set( $context, array( 'border', 'radius' ), true );
 		gutenberg_experimental_set( $context, array( 'border', 'style' ), true );
 		gutenberg_experimental_set( $context, array( 'border', 'width' ), true );
@@ -348,7 +351,7 @@ class WP_Theme_JSON_Gutenberg {
 		gutenberg_experimental_set( $context, array( 'spacing', 'units' ), true );
 		gutenberg_experimental_set( $context, array( 'typography', 'customFontSize' ), true );
 		gutenberg_experimental_set( $context, array( 'typography', 'lineHeight' ), true );
-		unset( $context['appearance'] );
+		unset( $context['appearanceTools'] );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -81,6 +81,7 @@ class WP_Theme_JSON_Gutenberg {
 	);
 
 	const VALID_SETTINGS = array(
+		'appearance' => null,
 		'border'     => array(
 			'color'  => null,
 			'radius' => null,
@@ -292,7 +293,8 @@ class WP_Theme_JSON_Gutenberg {
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
 		$valid_element_names = array_keys( self::ELEMENTS );
-		$this->theme_json    = self::sanitize( $theme_json, $valid_block_names, $valid_element_names );
+		$theme_json          = self::sanitize( $theme_json, $valid_block_names, $valid_element_names );
+		$this->theme_json    = self::maybe_opt_in_into_settings( $theme_json );
 
 		// Internally, presets are keyed by origin.
 		$nodes = self::get_setting_nodes( $this->theme_json );
@@ -305,6 +307,48 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Enables some opt-in settings if theme declared support.
+	 *
+	 * @param array $theme_json A theme.json structure to modify.
+	 * @return array The modified theme.json structure.
+	 */
+	private static function maybe_opt_in_into_settings( $theme_json ) {
+		$new_theme_json = $theme_json;
+
+		if ( isset( $new_theme_json['settings']['appearance'] ) ) {
+			self::do_opt_in_into_settings( $new_theme_json['settings'] );
+		}
+
+		if ( isset( $new_theme_json['settings']['blocks'] ) && is_array( $new_theme_json['settings']['blocks'] ) ) {
+			foreach ( $new_theme_json['settings']['blocks'] as &$block ) {
+				if ( isset( $block['appearance'] ) ) {
+					self::do_opt_in_into_settings( $block );
+				}
+			}
+		}
+
+		return $new_theme_json;
+	}
+
+	/**
+	 * Enables some settings.
+	 *
+	 * @param array $context The context to which the settings belong.
+	 */
+	private static function do_opt_in_into_settings( &$context ) {
+		gutenberg_experimental_set( $context, array( 'border', 'color' ), true );
+		gutenberg_experimental_set( $context, array( 'border', 'radius' ), true );
+		gutenberg_experimental_set( $context, array( 'border', 'style' ), true );
+		gutenberg_experimental_set( $context, array( 'border', 'width' ), true );
+		gutenberg_experimental_set( $context, array( 'spacing', 'margin' ), true );
+		gutenberg_experimental_set( $context, array( 'spacing', 'padding' ), true );
+		gutenberg_experimental_set( $context, array( 'spacing', 'units' ), true );
+		gutenberg_experimental_set( $context, array( 'typography', 'customFontSize' ), true );
+		gutenberg_experimental_set( $context, array( 'typography', 'lineHeight' ), true );
+		unset( $context['appearance'] );
 	}
 
 	/**

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -345,9 +345,9 @@ class WP_Theme_JSON_Gutenberg {
 			array( 'border', 'style' ),
 			array( 'border', 'width' ),
 			array( 'color', 'link' ),
+			array( 'spacing', 'blockGap' ),
 			array( 'spacing', 'margin' ),
 			array( 'spacing', 'padding' ),
-			array( 'spacing', 'units' ),
 			array( 'typography', 'lineHeight' ),
 		);
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -339,18 +339,24 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $context The context to which the settings belong.
 	 */
 	private static function do_opt_in_into_settings( &$context ) {
-		// todo: take into account existing settings, if they exists
-		if ( ! isset( _wp_array_get( $context, array( 'border', 'color' ) ) ) {
-			gutenberg_experimental_set( $context, array( 'border', 'color' ), true );
+		$to_opt_in = array(
+			array( 'border', 'color' ),
+			array( 'border', 'radius' ),
+			array( 'border', 'style' ),
+			array( 'border', 'width' ),
+			array( 'spacing', 'margin' ),
+			array( 'spacing', 'padding' ),
+			array( 'spacing', 'units' ),
+			array( 'typography', 'customFontSize' ),
+			array( 'typography', 'lineHeight' ),
+		);
+
+		foreach ( $to_opt_in as $path ) {
+			if ( null === _wp_array_get( $context, $path, null ) ) {
+				_wp_array_set( $context, $path, true );
+			}
 		}
-		gutenberg_experimental_set( $context, array( 'border', 'radius' ), true );
-		gutenberg_experimental_set( $context, array( 'border', 'style' ), true );
-		gutenberg_experimental_set( $context, array( 'border', 'width' ), true );
-		gutenberg_experimental_set( $context, array( 'spacing', 'margin' ), true );
-		gutenberg_experimental_set( $context, array( 'spacing', 'padding' ), true );
-		gutenberg_experimental_set( $context, array( 'spacing', 'units' ), true );
-		gutenberg_experimental_set( $context, array( 'typography', 'customFontSize' ), true );
-		gutenberg_experimental_set( $context, array( 'typography', 'lineHeight' ), true );
+
 		unset( $context['appearanceTools'] );
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -344,10 +344,10 @@ class WP_Theme_JSON_Gutenberg {
 			array( 'border', 'radius' ),
 			array( 'border', 'style' ),
 			array( 'border', 'width' ),
+			array( 'color', 'link' ),
 			array( 'spacing', 'margin' ),
 			array( 'spacing', 'padding' ),
 			array( 'spacing', 'units' ),
-			array( 'typography', 'customFontSize' ),
 			array( 'typography', 'lineHeight' ),
 		);
 

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,6 +1,7 @@
 {
 	"version": 2,
 	"settings": {
+		"appearance": true,
 		"color": {
 			"background": true,
 			"palette": [

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,7 +1,7 @@
 {
 	"version": 2,
 	"settings": {
-		"appearance": true,
+		"appearanceTools": true,
 		"color": {
 			"background": true,
 			"palette": [

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -1,7 +1,7 @@
 {
 	"version": 2,
 	"settings": {
-		"appearanceTools": true,
+		"appearanceTools": false,
 		"color": {
 			"background": true,
 			"palette": [

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -188,6 +188,75 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected_no_origin, $actual_no_origin );
 	}
 
+	function test_get_settings_using_opt_in_key() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'appearance' => true,
+					'blocks'     => array(
+						'core/paragraph' => array(
+							'typography' => array(
+								'lineHeight' => false,
+							),
+						),
+						'core/group'     => array(
+							'appearance' => true,
+							'typography' => array(
+								'lineHeight' => false, // This is overridden by appearance.
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual   = $theme_json->get_settings();
+		$expected = array(
+			'border'     => array(
+				'width'  => true,
+				'style'  => true,
+				'radius' => true,
+				'color'  => true,
+			),
+			'spacing'    => array(
+				'margin'  => true,
+				'padding' => true,
+				'units'   => true,
+			),
+			'typography' => array(
+				'customFontSize' => true,
+				'lineHeight'     => true,
+			),
+			'blocks'     => array(
+				'core/paragraph' => array(
+					'typography' => array(
+						'lineHeight' => false,
+					),
+				),
+				'core/group'     => array(
+					'border'     => array(
+						'width'  => true,
+						'style'  => true,
+						'radius' => true,
+						'color'  => true,
+					),
+					'spacing'    => array(
+						'margin'  => true,
+						'padding' => true,
+						'units'   => true,
+					),
+					'typography' => array(
+						'customFontSize' => true,
+						'lineHeight'     => true,
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	function test_get_stylesheet_support_for_shorthand_and_longhand_values() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -219,14 +219,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'radius' => true,
 				'color'  => true,
 			),
+			'color'      => array(
+				'link' => true,
+			),
 			'spacing'    => array(
-				'margin'  => true,
-				'padding' => true,
-				'units'   => true,
+				'blockGap' => true,
+				'margin'   => true,
+				'padding'  => true,
 			),
 			'typography' => array(
-				'customFontSize' => true,
-				'lineHeight'     => true,
+				'lineHeight' => true,
 			),
 			'blocks'     => array(
 				'core/paragraph' => array(
@@ -241,14 +243,16 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'radius' => true,
 						'color'  => true,
 					),
+					'color'      => array(
+						'link' => true,
+					),
 					'spacing'    => array(
-						'margin'  => true,
-						'padding' => true,
-						'units'   => true,
+						'blockGap' => true,
+						'margin'   => true,
+						'padding'  => true,
 					),
 					'typography' => array(
-						'customFontSize' => true,
-						'lineHeight'     => false,
+						'lineHeight' => false,
 					),
 				),
 			),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -193,17 +193,17 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'appearance' => true,
-					'blocks'     => array(
+					'appearanceTools' => true,
+					'blocks'          => array(
 						'core/paragraph' => array(
 							'typography' => array(
 								'lineHeight' => false,
 							),
 						),
 						'core/group'     => array(
-							'appearance' => true,
-							'typography' => array(
-								'lineHeight' => false, // This is overridden by appearance.
+							'appearanceTools' => true,
+							'typography'      => array(
+								'lineHeight' => false, // This should override appearanceTools.
 							),
 						),
 					),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -248,7 +248,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'customFontSize' => true,
-						'lineHeight'     => true,
+						'lineHeight'     => false,
 					),
 				),
 			),

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -9,6 +9,11 @@
 		},
 		"settingsProperties": {
 			"properties": {
+				"appearanceTools": {
+					"description": "Setting that enables ui tools. \nGutenberg plugin required.",
+					"type": "boolean",
+					"default": false
+				},
 				"border": {
 					"description": "Settings related to borders.\nGutenberg plugin required.",
 					"type": "object",


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36187
Follow-up to https://github.com/WordPress/gutenberg/pull/36246 and https://github.com/WordPress/gutenberg/pull/36477

This PR adds a new setting property in `theme.json` called `appearanceTools` whose function is to opt-in into all appearance UI controls.

The result is that a theme.json like this one:

```
{
  'version': 2,
  'settings': {
    'appearanceTools': true
  }
}
```

is the same as this other:

```
{
  'version': 2,
  'settings': {
    'border': {
      'color': true,
      'radius': true,
      'style': true,
      'width': true
    },
   'color': {
     'link': true
   },
    'spacing': {
      'blockGap': true,
      'margin': true,
      'padding': true
    },
    'typography': {
      'lineHeight': true
    } 
  }
}
```

Themes that don't use this flag need to individually enable the opt-in features, which is the same behavior as of now in `trunk`.

## Notes

### Name

After some discussion in the first PR https://github.com/WordPress/gutenberg/pull/36246 and consulting other people, we're going with `appearanceTools` for the name, which leaves `appearance` free for the future and clarifies the purpose of the flag.

### Cascade behavior

Themes can still set anything to false and will be respected. So, this `theme.json`:

```
{
  'version': 2,
  'settings': {
    'appearanceTools': true,
    'typography': {
      'lineHeight': false
    }
  }
}
```

is the same as:

```
{
  'version': 2,
  'settings': {
    'border': {
      'color': true,
      'radius': true,
      'style': true,
      'width': true
    },
    'color': {
      'link': true
    },
    'spacing': {
      'blockGap': true,
      'margin': true,
      'padding': true
    },
    'typography': {
      'lineHeight': false
    } 
  }
}
```
