### PR TITLE
Make user able to change all color palette origins

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1335,11 +1335,9 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array
 	 */
 	private static function remove_insecure_settings( $input ) {
-		$origins = array( 'default', 'theme', 'user' );
-
 		$output = array();
 		foreach ( self::PRESETS_METADATA as $preset_metadata ) {
-			foreach ( $origins as $origin ) {
+			foreach( self::VALID_ORIGINS as $origin ) {
 				$path_with_origin = array_merge( $preset_metadata['path'], array( $origin ) );
 				$presets          = _wp_array_get( $input, $path_with_origin, null );
 				if ( null === $presets ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1337,7 +1337,7 @@ class WP_Theme_JSON_Gutenberg {
 	private static function remove_insecure_settings( $input ) {
 		$output = array();
 		foreach ( self::PRESETS_METADATA as $preset_metadata ) {
-			foreach( self::VALID_ORIGINS as $origin ) {
+			foreach ( self::VALID_ORIGINS as $origin ) {
 				$path_with_origin = array_merge( $preset_metadata['path'], array( $origin ) );
 				$presets          = _wp_array_get( $input, $path_with_origin, null );
 				if ( null === $presets ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -301,7 +301,9 @@ class WP_Theme_JSON_Gutenberg {
 				$path   = array_merge( $node['path'], $preset_metadata['path'] );
 				$preset = _wp_array_get( $this->theme_json, $path, null );
 				if ( null !== $preset ) {
-					_wp_array_set( $this->theme_json, $path, array( $origin => $preset ) );
+					if ( 'user' !== $origin || isset( $preset[0] ) ) {
+						_wp_array_set( $this->theme_json, $path, array( $origin => $preset ) );
+					}
 				}
 			}
 		}
@@ -1333,48 +1335,52 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array
 	 */
 	private static function remove_insecure_settings( $input ) {
+		$origins = array( 'default', 'theme', 'user' );
+
 		$output = array();
 		foreach ( self::PRESETS_METADATA as $preset_metadata ) {
-			$presets = _wp_array_get( $input, $preset_metadata['path'], null );
-			if ( null === $presets ) {
-				continue;
-			}
+			foreach ( $origins as $origin ) {
+				$path_with_origin = array_merge( $preset_metadata['path'], array( $origin ) );
+				$presets          = _wp_array_get( $input, $path_with_origin, null );
+				if ( null === $presets ) {
+					continue;
+				}
 
-			$escaped_preset = array();
-			foreach ( $presets as $preset ) {
-				if (
-					esc_attr( esc_html( $preset['name'] ) ) === $preset['name'] &&
-					sanitize_html_class( $preset['slug'] ) === $preset['slug']
-				) {
-					$value = null;
-					if ( isset( $preset_metadata['value_key'] ) ) {
-						$value = $preset[ $preset_metadata['value_key'] ];
-					} elseif (
-						isset( $preset_metadata['value_func'] ) &&
-						is_callable( $preset_metadata['value_func'] )
+				$escaped_preset = array();
+				foreach ( $presets as $preset ) {
+					if (
+						esc_attr( esc_html( $preset['name'] ) ) === $preset['name'] &&
+						sanitize_html_class( $preset['slug'] ) === $preset['slug']
 					) {
-						$value = call_user_func( $preset_metadata['value_func'], $preset );
-					}
+						$value = null;
+						if ( isset( $preset_metadata['value_key'] ) ) {
+							$value = $preset[ $preset_metadata['value_key'] ];
+						} elseif (
+							isset( $preset_metadata['value_func'] ) &&
+							is_callable( $preset_metadata['value_func'] )
+						) {
+							$value = call_user_func( $preset_metadata['value_func'], $preset );
+						}
 
-					$preset_is_valid = true;
-					foreach ( $preset_metadata['properties'] as $property ) {
-						if ( ! self::is_safe_css_declaration( $property, $value ) ) {
-							$preset_is_valid = false;
-							break;
+						$preset_is_valid = true;
+						foreach ( $preset_metadata['properties'] as $property ) {
+							if ( ! self::is_safe_css_declaration( $property, $value ) ) {
+								$preset_is_valid = false;
+								break;
+							}
+						}
+
+						if ( $preset_is_valid ) {
+							$escaped_preset[] = $preset;
 						}
 					}
+				}
 
-					if ( $preset_is_valid ) {
-						$escaped_preset[] = $preset;
-					}
+				if ( ! empty( $escaped_preset ) ) {
+					_wp_array_set( $output, $path_with_origin, $escaped_preset );
 				}
 			}
-
-			if ( ! empty( $escaped_preset ) ) {
-				_wp_array_set( $output, $preset_metadata['path'], $escaped_preset );
-			}
 		}
-
 		return $output;
 	}
 

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import kebabCase from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -232,7 +232,7 @@ export default function ColorEdit( {
 							isSmall
 							isPressed={ isAdding }
 							icon={ plus }
-							label={ __( 'Add custom color' ) }
+							label={ __( 'Add color' ) }
 							onClick={ () => {
 								onChange( [
 									...colors,

--- a/packages/components/src/color-edit/index.js
+++ b/packages/components/src/color-edit/index.js
@@ -49,12 +49,14 @@ function ColorNameInput( { value, onChange } ) {
 }
 
 function ColorOption( {
+	canOnlyChangeValues,
 	color,
 	onChange,
 	isEditing,
 	onStartEditing,
 	onRemove,
 	onStopEditing,
+	slugPrefix,
 } ) {
 	const focusOutsideProps = useFocusOutside( onStopEditing );
 	return (
@@ -68,14 +70,14 @@ function ColorOption( {
 					<ColorIndicatorStyled colorValue={ color.color } />
 				</FlexItem>
 				<FlexItem>
-					{ isEditing ? (
+					{ isEditing && ! canOnlyChangeValues ? (
 						<ColorNameInput
 							value={ color.name }
 							onChange={ ( nextName ) =>
 								onChange( {
 									...color,
 									name: nextName,
-									slug: kebabCase( nextName ),
+									slug: slugPrefix + kebabCase( nextName ),
 								} )
 							}
 						/>
@@ -83,7 +85,7 @@ function ColorOption( {
 						<ColorNameContainer>{ color.name }</ColorNameContainer>
 					) }
 				</FlexItem>
-				{ isEditing && (
+				{ isEditing && ! canOnlyChangeValues && (
 					<FlexItem>
 						<RemoveButton
 							isSmall
@@ -119,6 +121,8 @@ function ColorPaletteEditListView( {
 	onChange,
 	editingColor,
 	setEditingColor,
+	canOnlyChangeValues,
+	slugPrefix,
 } ) {
 	// When unmounting the component if there are empty colors (the user did not complete the insertion) clean them.
 	const colorReference = useRef();
@@ -140,6 +144,7 @@ function ColorPaletteEditListView( {
 			<ItemGroup isBordered isSeparated>
 				{ colors.map( ( color, index ) => (
 					<ColorOption
+						canOnlyChangeValues={ canOnlyChangeValues }
 						key={ index }
 						color={ color }
 						onStartEditing={ () => {
@@ -177,6 +182,7 @@ function ColorPaletteEditListView( {
 								setEditingColor( null );
 							}
 						} }
+						slugPrefix={ slugPrefix }
 					/>
 				) ) }
 			</ItemGroup>
@@ -186,7 +192,15 @@ function ColorPaletteEditListView( {
 
 const EMPTY_ARRAY = [];
 
-export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
+export default function ColorEdit( {
+	colors = EMPTY_ARRAY,
+	onChange,
+	paletteLabel,
+	emptyMessage,
+	canOnlyChangeValues,
+	canReset,
+	slugPrefix = '',
+} ) {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ editingColor, setEditingColor ] = useState( null );
 	const isAdding =
@@ -200,7 +214,7 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 	return (
 		<ColorEditStyles>
 			<ColorHStackHeader>
-				<ColorHeading>{ __( 'Custom' ) }</ColorHeading>
+				<ColorHeading>{ paletteLabel }</ColorHeading>
 				<ColorActionsContainer>
 					{ isEditing && (
 						<DoneButton
@@ -213,24 +227,26 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 							{ __( 'Done' ) }
 						</DoneButton>
 					) }
-					<Button
-						isSmall
-						isPressed={ isAdding }
-						icon={ plus }
-						label={ __( 'Add custom color' ) }
-						onClick={ () => {
-							onChange( [
-								...colors,
-								{
-									color: '#000',
-									name: '',
-									slug: '',
-								},
-							] );
-							setIsEditing( true );
-							setEditingColor( colors.length );
-						} }
-					/>
+					{ ! canOnlyChangeValues && (
+						<Button
+							isSmall
+							isPressed={ isAdding }
+							icon={ plus }
+							label={ __( 'Add custom color' ) }
+							onClick={ () => {
+								onChange( [
+									...colors,
+									{
+										color: '#000',
+										name: '',
+										slug: '',
+									},
+								] );
+								setIsEditing( true );
+								setEditingColor( colors.length );
+							} }
+						/>
+					) }
 					{ ! isEditing && (
 						<Button
 							disabled={ ! hasColors }
@@ -242,10 +258,10 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 							} }
 						/>
 					) }
-					{ isEditing && (
+					{ isEditing && ( canReset || ! canOnlyChangeValues ) && (
 						<DropdownMenu
 							icon={ moreVertical }
-							label={ __( 'Custom color options' ) }
+							label={ __( 'Color options' ) }
 							toggleProps={ {
 								isSmall: true,
 							} }
@@ -253,17 +269,31 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 							{ ( { onClose } ) => (
 								<>
 									<NavigableMenu role="menu">
-										<Button
-											variant="tertiary"
-											onClick={ () => {
-												setEditingColor( null );
-												setIsEditing( false );
-												onChange();
-												onClose();
-											} }
-										>
-											{ __( 'Remove all custom colors' ) }
-										</Button>
+										{ ! canOnlyChangeValues && (
+											<Button
+												variant="tertiary"
+												onClick={ () => {
+													setEditingColor( null );
+													setIsEditing( false );
+													onChange();
+													onClose();
+												} }
+											>
+												{ __( 'Remove all colors' ) }
+											</Button>
+										) }
+										{ canReset && (
+											<Button
+												variant="tertiary"
+												onClick={ () => {
+													setEditingColor( null );
+													onChange();
+													onClose();
+												} }
+											>
+												{ __( 'Reset colors' ) }
+											</Button>
+										) }
 									</NavigableMenu>
 								</>
 							) }
@@ -275,10 +305,12 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 				<>
 					{ isEditing && (
 						<ColorPaletteEditListView
+							canOnlyChangeValues={ canOnlyChangeValues }
 							colors={ colors }
 							onChange={ onChange }
 							editingColor={ editingColor }
 							setEditingColor={ setEditingColor }
+							slugPrefix={ slugPrefix }
 						/>
 					) }
 					{ ! isEditing && (
@@ -291,10 +323,7 @@ export default function ColorEdit( { colors = EMPTY_ARRAY, onChange } ) {
 					) }
 				</>
 			) }
-			{ ! hasColors &&
-				__(
-					'Custom colors are empty! Add some colors to create your own color palette.'
-				) }
+			{ ! hasColors && emptyMessage }
 		</ColorEditStyles>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -35,6 +35,11 @@ export default function ColorPalettePanel( { name } ) {
 		'color.palette.user',
 		name
 	);
+
+	const [ defaultPaletteEnabled ] = useSetting(
+		'color.defaultPalette',
+		name
+	);
 	return (
 		<VStack
 			className="edit-site-global-styles-color-palette-panel"
@@ -49,15 +54,17 @@ export default function ColorPalettePanel( { name } ) {
 					paletteLabel={ __( 'Theme' ) }
 				/>
 			) }
-			{ !! defaultColors && !! defaultColors.length && (
-				<ColorEdit
-					canReset={ defaultColors !== baseDefaultColors }
-					canOnlyChangeValues
-					colors={ defaultColors }
-					onChange={ setDefaultColors }
-					paletteLabel={ __( 'Default' ) }
-				/>
-			) }
+			{ !! defaultColors &&
+				!! defaultColors.length &&
+				!! defaultPaletteEnabled && (
+					<ColorEdit
+						canReset={ defaultColors !== baseDefaultColors }
+						canOnlyChangeValues
+						colors={ defaultColors }
+						onChange={ setDefaultColors }
+						paletteLabel={ __( 'Default' ) }
+					/>
+				) }
 			<ColorEdit
 				colors={ customColors }
 				onChange={ setCustomColors }

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalColorEdit as ColorEdit } from '@wordpress/components';
+import {
+	__experimentalColorEdit as ColorEdit,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -9,14 +13,60 @@ import { __experimentalColorEdit as ColorEdit } from '@wordpress/components';
 import { useSetting } from './hooks';
 
 export default function ColorPalettePanel( { name } ) {
-	const [ userColors, setColors ] = useSetting(
-		'color.palette',
+	const [ themeColors, setThemeColors ] = useSetting(
+		'color.palette.theme',
+		name
+	);
+	const [ baseThemeColors ] = useSetting(
+		'color.palette.theme',
 		name,
-		'user'
+		'base'
+	);
+	const [ defaultColors, setDefaultColors ] = useSetting(
+		'color.palette.default',
+		name
+	);
+	const [ baseDefaultColors ] = useSetting(
+		'color.palette.default',
+		name,
+		'base'
+	);
+	const [ customColors, setCustomColors ] = useSetting(
+		'color.palette.user',
+		name
 	);
 	return (
-		<div className="edit-site-global-styles-color-palette-panel">
-			<ColorEdit colors={ userColors } onChange={ setColors } />
-		</div>
+		<VStack
+			className="edit-site-global-styles-color-palette-panel"
+			spacing={ 10 }
+		>
+			{ !! themeColors && !! themeColors.length && (
+				<ColorEdit
+					canReset={ themeColors !== baseThemeColors }
+					canOnlyChangeValues
+					colors={ themeColors }
+					onChange={ setThemeColors }
+					paletteLabel={ __( 'Theme' ) }
+				/>
+			) }
+			{ !! defaultColors && !! defaultColors.length && (
+				<ColorEdit
+					canReset={ defaultColors !== baseDefaultColors }
+					canOnlyChangeValues
+					colors={ defaultColors }
+					onChange={ setDefaultColors }
+					paletteLabel={ __( 'Default' ) }
+				/>
+			) }
+			<ColorEdit
+				colors={ customColors }
+				onChange={ setCustomColors }
+				paletteLabel={ __( 'Custom' ) }
+				emptyMessage={ __(
+					'Custom colors are empty! Add some colors to create your own color palette.'
+				) }
+				slugPrefix="custom-"
+			/>
+		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -2,9 +2,6 @@
  * External dependencies
  */
 import {
-	get,
-	cloneDeep,
-	set,
 	mergeWith,
 	pickBy,
 	isEmpty,
@@ -23,7 +20,6 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { PRESET_METADATA } from './utils';
 import { GlobalStylesContext } from './context';
 
 function mergeTreesCustomizer( _, srcValue ) {
@@ -39,29 +35,6 @@ function mergeBaseAndUserConfigs( base, user ) {
 	return mergeWith( {}, base, user, mergeTreesCustomizer );
 }
 
-function addUserOriginToSettings( settingsToAdd ) {
-	const newSettings = cloneDeep( settingsToAdd );
-	PRESET_METADATA.forEach( ( { path } ) => {
-		const presetData = get( newSettings, path );
-		if ( presetData ) {
-			set( newSettings, path, {
-				user: presetData,
-			} );
-		}
-	} );
-	return newSettings;
-}
-
-function removeUserOriginFromSettings( settingsToRemove ) {
-	const newSettings = cloneDeep( settingsToRemove );
-	PRESET_METADATA.forEach( ( { path } ) => {
-		const presetData = get( newSettings, path );
-		if ( presetData ) {
-			set( newSettings, path, ( presetData ?? {} ).user );
-		}
-	} );
-	return newSettings;
-}
 const cleanEmptyObject = ( object ) => {
 	if ( ! isObject( object ) || Array.isArray( object ) ) {
 		return object;
@@ -97,7 +70,7 @@ function useGlobalStylesUserConfig() {
 
 	const config = useMemo( () => {
 		return {
-			settings: addUserOriginToSettings( settings ?? {} ),
+			settings: settings ?? {},
 			styles: styles ?? {},
 		};
 	}, [ settings, styles ] );
@@ -111,15 +84,12 @@ function useGlobalStylesUserConfig() {
 			);
 			const currentConfig = {
 				styles: record?.styles ?? {},
-				settings: addUserOriginToSettings( record?.settings ?? {} ),
+				settings: record?.settings ?? {},
 			};
 			const updatedConfig = callback( currentConfig );
 			editEntityRecord( 'root', 'globalStyles', globalStylesId, {
 				styles: cleanEmptyObject( updatedConfig.styles ) || {},
-				settings:
-					cleanEmptyObject(
-						removeUserOriginFromSettings( updatedConfig.settings )
-					) || {},
+				settings: cleanEmptyObject( updatedConfig.settings ) || {},
 			} );
 		},
 		[ globalStylesId ]

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1237,20 +1237,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'color'   => array(
 						'custom'  => true,
 						'palette' => array(
-							array(
-								'name'  => 'Red',
-								'slug'  => 'red',
-								'color' => '#ff0000',
-							),
-							array(
-								'name'  => 'Green',
-								'slug'  => 'green',
-								'color' => '#00ff00',
-							),
-							array(
-								'name'  => 'Blue',
-								'slug'  => 'blue',
-								'color' => '#0000ff',
+							'user' => array(
+								array(
+									'name'  => 'Red',
+									'slug'  => 'red',
+									'color' => '#ff0000',
+								),
+								array(
+									'name'  => 'Green',
+									'slug'  => 'green',
+									'color' => '#00ff00',
+								),
+								array(
+									'name'  => 'Blue',
+									'slug'  => 'blue',
+									'color' => '#0000ff',
+								),
 							),
 						),
 					),
@@ -1262,20 +1264,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'color'   => array(
 								'custom'  => true,
 								'palette' => array(
-									array(
-										'name'  => 'Yellow',
-										'slug'  => 'yellow',
-										'color' => '#ff0000',
-									),
-									array(
-										'name'  => 'Pink',
-										'slug'  => 'pink',
-										'color' => '#00ff00',
-									),
-									array(
-										'name'  => 'Orange',
-										'slug'  => 'orange',
-										'color' => '#0000ff',
+									'user' => array(
+										array(
+											'name'  => 'Yellow',
+											'slug'  => 'yellow',
+											'color' => '#ff0000',
+										),
+										array(
+											'name'  => 'Pink',
+											'slug'  => 'pink',
+											'color' => '#00ff00',
+										),
+										array(
+											'name'  => 'Orange',
+											'slug'  => 'orange',
+											'color' => '#0000ff',
+										),
 									),
 								),
 							),
@@ -1293,20 +1297,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'  => array(
 					'palette' => array(
-						array(
-							'name'  => 'Red',
-							'slug'  => 'red',
-							'color' => '#ff0000',
-						),
-						array(
-							'name'  => 'Green',
-							'slug'  => 'green',
-							'color' => '#00ff00',
-						),
-						array(
-							'name'  => 'Blue',
-							'slug'  => 'blue',
-							'color' => '#0000ff',
+						'user' => array(
+							array(
+								'name'  => 'Red',
+								'slug'  => 'red',
+								'color' => '#ff0000',
+							),
+							array(
+								'name'  => 'Green',
+								'slug'  => 'green',
+								'color' => '#00ff00',
+							),
+							array(
+								'name'  => 'Blue',
+								'slug'  => 'blue',
+								'color' => '#0000ff',
+							),
 						),
 					),
 				),
@@ -1314,20 +1320,22 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								array(
-									'name'  => 'Yellow',
-									'slug'  => 'yellow',
-									'color' => '#ff0000',
-								),
-								array(
-									'name'  => 'Pink',
-									'slug'  => 'pink',
-									'color' => '#00ff00',
-								),
-								array(
-									'name'  => 'Orange',
-									'slug'  => 'orange',
-									'color' => '#0000ff',
+								'user' => array(
+									array(
+										'name'  => 'Yellow',
+										'slug'  => 'yellow',
+										'color' => '#ff0000',
+									),
+									array(
+										'name'  => 'Pink',
+										'slug'  => 'pink',
+										'color' => '#00ff00',
+									),
+									array(
+										'name'  => 'Orange',
+										'slug'  => 'orange',
+										'color' => '#0000ff',
+									),
 								),
 							),
 						),
@@ -1345,49 +1353,53 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'settings' => array(
 					'color'      => array(
 						'palette' => array(
-							array(
-								'name'  => 'Red/><b>ok</ok>',
-								'slug'  => 'red',
-								'color' => '#ff0000',
-							),
-							array(
-								'name'  => 'Green',
-								'slug'  => 'a" attr',
-								'color' => '#00ff00',
-							),
-							array(
-								'name'  => 'Blue',
-								'slug'  => 'blue',
-								'color' => 'var(--color, var(--unsafe-fallback))',
-							),
-							array(
-								'name'  => 'Pink',
-								'slug'  => 'pink',
-								'color' => '#FFC0CB',
+							'user' => array(
+								array(
+									'name'  => 'Red/><b>ok</ok>',
+									'slug'  => 'red',
+									'color' => '#ff0000',
+								),
+								array(
+									'name'  => 'Green',
+									'slug'  => 'a" attr',
+									'color' => '#00ff00',
+								),
+								array(
+									'name'  => 'Blue',
+									'slug'  => 'blue',
+									'color' => 'var(--color, var(--unsafe-fallback))',
+								),
+								array(
+									'name'  => 'Pink',
+									'slug'  => 'pink',
+									'color' => '#FFC0CB',
+								),
 							),
 						),
 					),
 					'typography' => array(
 						'fontFamilies' => array(
-							array(
-								'name'       => 'Helvetica Arial/><b>test</b>',
-								'slug'       => 'helvetica-arial',
-								'fontFamily' => 'Helvetica Neue, Helvetica, Arial, sans-serif',
-							),
-							array(
-								'name'       => 'Geneva',
-								'slug'       => 'geneva#asa',
-								'fontFamily' => 'Geneva, Tahoma, Verdana, sans-serif',
-							),
-							array(
-								'name'       => 'Cambria',
-								'slug'       => 'cambria',
-								'fontFamily' => 'Cambria, Georgia, serif',
-							),
-							array(
-								'name'       => 'Helvetica Arial',
-								'slug'       => 'helvetica-arial',
-								'fontFamily' => 'var(--fontFamily, var(--unsafe-fallback))',
+							'user' => array(
+								array(
+									'name'       => 'Helvetica Arial/><b>test</b>',
+									'slug'       => 'helvetica-arial',
+									'fontFamily' => 'Helvetica Neue, Helvetica, Arial, sans-serif',
+								),
+								array(
+									'name'       => 'Geneva',
+									'slug'       => 'geneva#asa',
+									'fontFamily' => 'Geneva, Tahoma, Verdana, sans-serif',
+								),
+								array(
+									'name'       => 'Cambria',
+									'slug'       => 'cambria',
+									'fontFamily' => 'Cambria, Georgia, serif',
+								),
+								array(
+									'name'       => 'Helvetica Arial',
+									'slug'       => 'helvetica-arial',
+									'fontFamily' => 'var(--fontFamily, var(--unsafe-fallback))',
+								),
 							),
 						),
 					),
@@ -1395,25 +1407,27 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'core/group' => array(
 							'color' => array(
 								'palette' => array(
-									array(
-										'name'  => 'Red/><b>ok</ok>',
-										'slug'  => 'red',
-										'color' => '#ff0000',
-									),
-									array(
-										'name'  => 'Green',
-										'slug'  => 'a" attr',
-										'color' => '#00ff00',
-									),
-									array(
-										'name'  => 'Blue',
-										'slug'  => 'blue',
-										'color' => 'var(--color, var(--unsafe--fallback))',
-									),
-									array(
-										'name'  => 'Pink',
-										'slug'  => 'pink',
-										'color' => '#FFC0CB',
+									'user' => array(
+										array(
+											'name'  => 'Red/><b>ok</ok>',
+											'slug'  => 'red',
+											'color' => '#ff0000',
+										),
+										array(
+											'name'  => 'Green',
+											'slug'  => 'a" attr',
+											'color' => '#00ff00',
+										),
+										array(
+											'name'  => 'Blue',
+											'slug'  => 'blue',
+											'color' => 'var(--color, var(--unsafe--fallback))',
+										),
+										array(
+											'name'  => 'Pink',
+											'slug'  => 'pink',
+											'color' => '#FFC0CB',
+										),
 									),
 								),
 							),
@@ -1428,19 +1442,23 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'      => array(
 					'palette' => array(
-						array(
-							'name'  => 'Pink',
-							'slug'  => 'pink',
-							'color' => '#FFC0CB',
+						'user' => array(
+							array(
+								'name'  => 'Pink',
+								'slug'  => 'pink',
+								'color' => '#FFC0CB',
+							),
 						),
 					),
 				),
 				'typography' => array(
 					'fontFamilies' => array(
-						array(
-							'name'       => 'Cambria',
-							'slug'       => 'cambria',
-							'fontFamily' => 'Cambria, Georgia, serif',
+						'user' => array(
+							array(
+								'name'       => 'Cambria',
+								'slug'       => 'cambria',
+								'fontFamily' => 'Cambria, Georgia, serif',
+							),
 						),
 					),
 				),
@@ -1448,10 +1466,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								array(
-									'name'  => 'Pink',
-									'slug'  => 'pink',
-									'color' => '#FFC0CB',
+								'user' => array(
+									array(
+										'name'  => 'Pink',
+										'slug'  => 'pink',
+										'color' => '#FFC0CB',
+									),
 								),
 							),
 						),


### PR DESCRIPTION
This PR makes the user able to edit default, theme, and custom color palettes. For the default and theme the user can only change color values.
For the custom palette, the user can change everything.
The user can reset each palette individually.

It also prefixes also custom colors slugs with "custom-".