### PR TITLE
Update layout toggle label

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -79,7 +79,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 				<PanelBody title={ __( 'Layout' ) }>
 					{ allowInheriting && !! defaultThemeLayout && (
 						<ToggleControl
-							label={ __( 'Inherit default layout' ) }
+							label={ __( 'Use inner block alignment' ) }
 							checked={ !! inherit }
 							onChange={ () =>
 								setAttributes( {


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
As originally brought up [here](https://github.com/WordPress/gutenberg/issues/34558), I wanted to iterate on the label we're currently using for the layout control's "Inherit default layout". The current label of "Inherit default layout" does not provide enough context to what's actually happening when that control is enabled. 

When active, the blocks within the Group block have their own alignment controls available (essentially how Group blocks functioned before introducing this control). 

When inactive, the user cannot set wide/full width alignments for those child blocks. 

I don't know that I'm sold on the label I'm suggesting entirely, but does anyone else have another idea that could work better?

## Screenshots <!-- if applicable -->

**Previous:**
<img width="798" alt="Screen Shot 2021-11-19 at 12 14 57 PM" src="https://user-images.githubusercontent.com/1813435/142663793-c85bd438-78f9-4dd8-807f-7ee04e964f21.png">

**This PR:** 
<img width="722" alt="Screen Shot 2021-11-19 at 12 02 01 PM" src="https://user-images.githubusercontent.com/1813435/142663338-797daef7-363f-4576-a78a-d43ff84abe91.png">

## Types of changes
Copy change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
