### PR TITLE
Clarify i18n context for PostTemplateActions's "New" label

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -6,7 +6,7 @@ import { kebabCase } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	Button,
 	Modal,
@@ -129,7 +129,10 @@ function PostTemplateActions() {
 					</Button>
 				) }
 				<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
-					{ __( 'New' ) }
+					{
+						/* translators: button to create a new template */
+						_x( 'New', 'action' )
+					}
 				</Button>
 			</div>
 			{ isModalOpen && (


### PR DESCRIPTION
<img width="300" alt="Captura de ecrã 2021-11-19, às 18 35 01" src="https://user-images.githubusercontent.com/150562/142674002-34e78966-943a-4fe7-93d4-34034a1f4e16.png">

The "New" action in the post editor's Template panel is missing i18n context to disambiguate the adjective. I spotted this in my local sandbox set to Portuguese when the action was rendered as a confusing "Recente" instead of "Novo".