### PR TITLE
Try using a user-specific variable for blockGap

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -89,7 +89,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style  = "$selector {";
 		$style .= 'display: flex;';
 		if ( $has_block_gap_support ) {
-			$style .= 'gap: var( --wp--style--block-gap, 0.5em );';
+			$style .= 'gap: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 0.5em));';
 		} else {
 			$style .= 'gap: 0.5em;';
 		}

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -116,7 +116,7 @@ function gutenberg_render_spacing_gap_support( $block_content, $block ) {
 	}
 
 	$style = sprintf(
-		'--wp--style--block-gap: %s',
+		'--wp--style--block-gap--self: %s',
 		esc_attr( $gap_value )
 	);
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -133,7 +133,7 @@ export default {
 					display: flex;
 					gap: ${
 						hasBlockGapStylesSupport
-							? 'var( --wp--style--block-gap, 0.5em )'
+							? 'var(--wp--style--block-gap--self, var(--wp--style--block-gap, 0.5em))'
 							: '0.5em'
 					};
 					flex-wrap: ${ flexWrap };

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -50,15 +50,15 @@ $blocks-block__margin: 0.5em;
 	}
 
 	&.wp-block-button__width-25 {
-		width: calc(25% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75));
+		width: calc(25% - (var(--wp--style--block-gap--self, var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.75)));
 	}
 
 	&.wp-block-button__width-50 {
-		width: calc(50% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5));
+		width: calc(50% - (var(--wp--style--block-gap--self, var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.5)));
 	}
 
 	&.wp-block-button__width-75 {
-		width: calc(75% - (var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25));
+		width: calc(75% - (var(--wp--style--block-gap--self, var(--wp--style--block-gap, #{$blocks-block__margin}) * 0.25)));
 	}
 
 	&.wp-block-button__width-100 {

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -12,14 +12,14 @@
 @include break-small() {
 	.editor-styles-wrapper
 	.block-editor-block-list__block.wp-block-column:nth-child(even) {
-		margin-left: var(--wp--style--block-gap, 2em);
+		margin-left: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 	}
 }
 
 @include break-medium() {
 	.editor-styles-wrapper
 	.block-editor-block-list__block.wp-block-column:not(:first-child) {
-		margin-left: var(--wp--style--block-gap, 2em);
+		margin-left: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 	}
 }
 

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -43,14 +43,14 @@
 				// As with mobile styles, this must be important since the Column
 				// assigns its own width as an inline style, which should take effect
 				// starting at `break-medium`.
-				flex-basis: calc(50% - calc(var(--wp--style--block-gap, 2em) / 2)) !important;
+				flex-basis: calc(50% - calc(var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em)) / 2)) !important;
 				flex-grow: 0;
 			}
 
 			// Add space between the multiple columns. Themes can customize this if they wish to work differently.
 			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
 			&:nth-child(even) {
-				margin-left: var(--wp--style--block-gap, 2em);
+				margin-left: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 			}
 		}
 
@@ -74,7 +74,7 @@
 
 			// When columns are in a single row, add space before all except the first.
 			&:not(:first-child) {
-				margin-left: var(--wp--style--block-gap, 2em);
+				margin-left: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 			}
 		}
 	}
@@ -95,7 +95,7 @@
 
 			// When columns are in a single row, add space before all except the first.
 			&:not(:first-child) {
-				margin-left: var(--wp--style--block-gap, 2em);
+				margin-left: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 			}
 		}
 	}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -258,7 +258,7 @@ button.wp-block-navigation-item__content {
 .wp-block-navigation .wp-block-page-list,
 .wp-block-navigation__container,
 .wp-block-navigation__responsive-container-content {
-	gap: var(--wp--style--block-gap, 2em);
+	gap: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 2em));
 }
 
 // Menu items with background.
@@ -269,7 +269,7 @@ button.wp-block-navigation-item__content {
 	&,
 	.wp-block-navigation .wp-block-page-list,
 	.wp-block-navigation__container {
-		gap: var(--wp--style--block-gap, 0.5em);
+		gap: var(--wp--style--block-gap--self, var(--wp--style--block-gap, 0.5em));
 	}
 }
 

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -112,7 +112,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 		value: [ 'typography', 'letterSpacing' ],
 		support: [ 'typography', '__experimentalLetterSpacing' ],
 	},
-	'--wp--style--block-gap': {
+	'--wp--style--block-gap--self': {
 		value: [ 'spacing', 'blockGap' ],
 		support: [ 'spacing', 'blockGap' ],
 	},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
As reported in #36521, there's a bug with custom blockGap values overriding the margin-top applied to a block.

This proposed solution adds a CSS property `--wp--style--block-gap--self` that is only used if a custom blockGap exists. This allows the original `--wp--style--block-gap` to still function properly as a top-level vertical  spacing mechanism between blocks, while also allowing users to customize the blockGap of a block, without inadvertently affecting the custom value affecting that block's top-level vertical spacing. 

## How has this been tested?
Tested with blocks that support blockGap (Buttons, Columns, Social Links, Navigation). 

## Screenshots <!-- if applicable -->
**Editor, no blockGap assigned:**
<img width="1172" alt="Screen Shot 2021-11-19 at 1 39 36 PM" src="https://user-images.githubusercontent.com/1813435/142675021-5aede398-a431-4da3-b92e-02f922b3a3ba.png">

**Front-end, no blockGap assigned:**
<img width="1170" alt="Screen Shot 2021-11-19 at 1 39 51 PM" src="https://user-images.githubusercontent.com/1813435/142675082-f8647ae5-66d7-4db2-8a80-437ae743e529.png">

**Editor, custom blockGap:**
<img width="1172" alt="Screen Shot 2021-11-19 at 1 40 59 PM" src="https://user-images.githubusercontent.com/1813435/142675133-ff71802d-e978-44f9-8d89-c9169c1eab8b.png">

**Front-end, custom blockGap:**
<img width="1170" alt="Screen Shot 2021-11-19 at 1 41 07 PM" src="https://user-images.githubusercontent.com/1813435/142675226-99f8f65c-c0d4-4b2f-8dfd-5efe89943ffd.png">


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instruct
ions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
