### PR TITLE
query-pagination-next and previous: Changing the markup on the first and last pages of a pagination

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -160,13 +160,15 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$id    = uniqid();
-	$style = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
+	$id              = uniqid();
+	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
+	$container_class = 'wp-container-' . $id;
+	$justify_class   = 'wp-justify-' . $used_layout['justifyContent'];
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="wp-container-' . $id . ' ',
+		'class="' . $container_class . ' ' . $justify_class . ' ',
 		$block_content,
 		1
 	);

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -162,13 +162,13 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$id              = uniqid();
 	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
-	$container_class = 'wp-container-' . $id;
-	$justify_class   = 'wp-justify-' . $used_layout['justifyContent'];
+	$container_class = 'wp-container-' . $id . ' ';
+	$justify_class   = $used_layout['justifyContent'] ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . $container_class . ' ' . $justify_class . ' ',
+		'class="' . $container_class . $justify_class,
 		$block_content,
 		1
 	);

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -26,7 +26,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
-	$content = '';
+	$content = '<span></span>';
 
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
@@ -40,7 +40,10 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $wp_query->max_num_pages ) {
 			$max_page = $wp_query->max_num_pages;
 		}
-		$content = get_next_posts_link( $label, $max_page );
+		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+		if((int) $wp_query->max_num_pages !== $paged){
+			$content = get_next_posts_link( $label, $max_page );
+		}
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
 		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -26,7 +26,15 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
-	$content = '<span></span>';
+	$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+	if( (int) $wp_query->max_num_pages === $paged ){
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'last-page' ) );
+	}
+	$content = sprintf(
+		'<span %1$s>%2$s</span>',
+		$wrapper_attributes,
+		$label
+	);
 
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
@@ -40,7 +48,6 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $wp_query->max_num_pages ) {
 			$max_page = $wp_query->max_num_pages;
 		}
-		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		if((int) $wp_query->max_num_pages !== $paged){
 			$content = get_next_posts_link( $label, $max_page );
 		}

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -20,17 +20,19 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes = get_block_wrapper_attributes();
-	$default_label      = __( 'Next Page' );
-	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow   = get_query_pagination_arrow( $block, true );
+	$wrapper_attributes        = get_block_wrapper_attributes();
+	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
+	$default_label             = __( 'Next Page' );
+	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow          = get_query_pagination_arrow( $block, true );
+
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
 
-	$content            = sprintf(
+	$content = sprintf(
 		'<span %1$s>%2$s</span>',
-		$wrapper_attributes,
+		$hidden_wrapper_attributes,
 		$label
 	);
 

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -43,7 +43,6 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		add_filter( 'next_posts_link_attributes', $filter_link_attributes );
 
 		// If there are pages to paginate.
-		var_dump( $wp_query->max_num_pages );
 		if ( 1 < $max_page ) {
 			if ( (int) $max_page !== $paged ) { // If we are NOT in the last one.
 				$content = get_next_posts_link( $label, $max_page );

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -17,6 +17,7 @@
 function render_block_core_query_pagination_next( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
 	$wrapper_attributes = get_block_wrapper_attributes();
@@ -26,11 +27,9 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
-	$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
-	if( (int) $wp_query->max_num_pages === $paged ){
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'last-page' ) );
-	}
-	$content = sprintf(
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$content            = sprintf(
 		'<span %1$s>%2$s</span>',
 		$wrapper_attributes,
 		$label

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -25,42 +25,56 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	$default_label             = __( 'Next Page' );
 	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$pagination_arrow          = get_query_pagination_arrow( $block, true );
+	$content                   = '';
 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
 
-	$content = sprintf(
-		'<span %1$s>%2$s</span>',
-		$hidden_wrapper_attributes,
-		$label
-	);
-
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+		global $wp_query;
+		// Take into account if we have set a bigger `max page`
+		// than what the query has.
+		$max_page               = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 		add_filter( 'next_posts_link_attributes', $filter_link_attributes );
-		// Take into account if we have set a bigger `max page`
-		// than what the query has.
-		global $wp_query;
-		if ( $max_page > $wp_query->max_num_pages ) {
-			$max_page = $wp_query->max_num_pages;
-		}
-		if ( (int) $wp_query->max_num_pages !== $paged ) {
-			$content = get_next_posts_link( $label, $max_page );
+
+		// If there are pages to paginate.
+		var_dump( $wp_query->max_num_pages );
+		if ( 1 < $max_page ) {
+			if ( (int) $max_page !== $paged ) { // If we are NOT in the last one.
+				$content = get_next_posts_link( $label, $max_page );
+			} else { // If we are in the last one.
+				$content = sprintf(
+					'<span %1$s>%2$s</span>',
+					$hidden_wrapper_attributes,
+					$label
+				);
+			}
 		}
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		if ( (int) $custom_query->max_num_pages !== $page ) {
-			$content = sprintf(
-				'<a href="%1$s" %2$s>%3$s</a>',
-				esc_url( add_query_arg( $page_key, $page + 1 ) ),
-				$wrapper_attributes,
-				$label
-			);
+		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		$max_num_pages = $custom_query->max_num_pages ? $custom_query->max_num_pages : 1;
+		// If there are pages to paginate.
+		if ( 1 < $max_num_pages ) {
+			if ( (int) $max_num_pages !== $page ) { // If we are NOT in the last one.
+				$content = sprintf(
+					'<a href="%1$s" %2$s>%3$s</a>',
+					esc_url( add_query_arg( $page_key, $page + 1 ) ),
+					$wrapper_attributes,
+					$label
+				);
+			} else { // If we are in the last one.
+				$content = sprintf(
+					'<span %1$s>%2$s</span>',
+					$hidden_wrapper_attributes,
+					$label
+				);
+			}
 		}
 		wp_reset_postdata(); // Restore original Post Data.
 	}

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -47,7 +47,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		if ( $max_page > $wp_query->max_num_pages ) {
 			$max_page = $wp_query->max_num_pages;
 		}
-		if((int) $wp_query->max_num_pages !== $paged){
+		if ( (int) $wp_query->max_num_pages !== $paged ) {
 			$content = get_next_posts_link( $label, $max_page );
 		}
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -28,7 +28,6 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$label .= $pagination_arrow;
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes();
 	$content            = sprintf(
 		'<span %1$s>%2$s</span>',
 		$wrapper_attributes,

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -25,15 +25,18 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
-	$content = '';
+	$content = '<span></span>';
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-		$content = get_previous_posts_link( $label );
+		if( 1 !== $paged ){
+			$content = get_previous_posts_link( $label );
+		}
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} elseif ( 1 !== $page ) {
 		$content = sprintf(

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -25,11 +25,18 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
-	$content = '<span></span>';
+	$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
+	if( 1 === $paged ){
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'first-page' ) );
+	}
+	$content = sprintf(
+		'<span %1$s>%2$s</span>',
+		$wrapper_attributes,
+		$label
+	);
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		$paged = (get_query_var('paged')) ? get_query_var('paged') : 1;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -25,7 +25,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	$default_label             = __( 'Previous Page' );
 	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$pagination_arrow          = get_query_pagination_arrow( $block, false );
-	
+
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -20,10 +20,12 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes = get_block_wrapper_attributes();
-	$default_label      = __( 'Previous Page' );
-	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow   = get_query_pagination_arrow( $block, false );
+	$wrapper_attributes        = get_block_wrapper_attributes();
+	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
+	$default_label             = __( 'Previous Page' );
+	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow          = get_query_pagination_arrow( $block, false );
+	
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
@@ -43,7 +45,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			// Prints the link only if there are pages to paginate.
 			$content = $max_page > 1 ? sprintf(
 				'<span %1$s>%2$s</span>',
-				$wrapper_attributes,
+				$hidden_wrapper_attributes,
 				$label
 			) : '';
 		}
@@ -56,7 +58,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			$label
 		) : sprintf(
 			'<span %1$s>%2$s</span>',
-			$wrapper_attributes,
+			$hidden_wrapper_attributes,
 			$label
 		);
 

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -49,7 +49,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		}
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 	} else {
-		$content = 1 !== $page ? sprintf(
+		$content = ( 1 !== $page ) ? sprintf(
 			'<a href="%1$s" %2$s>%3$s</a>',
 			esc_url( add_query_arg( $page_key, $page - 1 ) ),
 			$wrapper_attributes,

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -40,7 +40,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		if ( 1 !== $paged ) {
 			$content = get_previous_posts_link( $label );
 		} else {
-			// Prints the link only if there are pages to paginate
+			// Prints the link only if there are pages to paginate.
 			$content = $max_page > 1 ? sprintf(
 				'<span %1$s>%2$s</span>',
 				$wrapper_attributes,

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -32,6 +32,12 @@ $pagination-margin: 0.5em;
 		}
 	}
 
+	// Non-clickeable previous and next elements are not visible
+	>span.wp-block-query-pagination-next,
+	>span.wp-block-query-pagination-previous {
+		visibility: hidden;
+	}
+
 	&.aligncenter {
 		justify-content: center;
 	}

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -33,8 +33,8 @@ $pagination-margin: 0.5em;
 	}
 
 	// Non-clickeable previous and next elements are not visible
-	> span.wp-block-query-pagination-next,
-	> span.wp-block-query-pagination-previous {
+	>span.wp-block-query-pagination-next,
+	>span.wp-block-query-pagination-previous {
 		visibility: hidden;
 	}
 

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -38,6 +38,13 @@ $pagination-margin: 0.5em;
 		visibility: hidden;
 	}
 
+	&.wp-justify-left,
+	&.wp-justify-right {
+		> [aria-hidden="true"] {
+			display: none;
+		}
+	}
+
 	&.aligncenter {
 		justify-content: center;
 	}

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -33,8 +33,8 @@ $pagination-margin: 0.5em;
 	}
 
 	// Non-clickeable previous and next elements are not visible
-	>span.wp-block-query-pagination-next,
-	>span.wp-block-query-pagination-previous {
+	> span.wp-block-query-pagination-next,
+	> span.wp-block-query-pagination-previous {
 		visibility: hidden;
 	}
 
@@ -45,7 +45,4 @@ $pagination-margin: 0.5em;
 		}
 	}
 
-	&.aligncenter {
-		justify-content: center;
-	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Hi :wave:

## Description
<!-- Please describe what you have changed or added -->
This PR changes the rendering of `core/query-pagination-next` and `core/query-pagination-previous` for 2 "edge cases". These cases are when the user is navigating the **first or last page** of a paginated query. In these cases, we render a `<span>` instead of nothing as we commonly do with the pagination numbers where the number matching the pagination's current number renders a `<span>` instead of an `<a>`.

After the changes featured in this PR the expected behaviour is:
- While navigating a first page of a pagination:
    - `core/query-pagination-previous` renders a `<span>` element instead of nothing.
    - `core/query-pagination-next` renders an `<a>` element as always.
    
- While navigating a last page of a pagination:
    - `core/query-pagination-previous` renders an `<a>` element as always.
    - `core/query-pagination-next` renders a `<span>` element instead of nothing.
    
- While navigating any page of pagination that is not the first or the last one:
    - `core/query-pagination-previous` renders an `<a>` element as always.
    - `core/query-pagination-next` renders an `<a>` element as always.
    
-  While navigating a page with a `core/query-pagination` block in place but no data to paginate:
    - Nothing is rendered as always.

This is just a continuation of a [work started](https://github.com/WordPress/gutenberg/pull/35430) by @MaggieCabrera

### Why are we introducing this change?
The intention is to fix the problems around the use of  `space-around` justification in the flex container of the `core/query-pagination` block as described [in this issue (#34997)](https://github.com/WordPress/gutenberg/issues/34997).



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested with normal and inherit wp queries using Empty, TT1, and Blockbase themes.

Block code:
```
<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
	<!-- wp:query-pagination-previous /-->
	<!-- wp:query-pagination-numbers /-->
	<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->
```

## Screenshots <!-- if applicable -->

- First page (Empty theme):

| Before      | After |
| ----------- | ----------- |
| <img width="450" alt="image" src="https://user-images.githubusercontent.com/1310626/142674854-0396f781-bed2-492c-a0c3-021215c156ca.png">  | <img width="455" alt="image" src="https://user-images.githubusercontent.com/1310626/142674191-28e2203c-a5de-415d-b54c-213d737ab6aa.png">     |



- Last page (Empty theme):

| Before      | After |
| ----------- | ----------- |
| <img width="451" alt="image" src="https://user-images.githubusercontent.com/1310626/142674765-ba4b5d9f-c877-41a1-9e8e-c219d36875ff.png">  | <img width="460" alt="image" src="https://user-images.githubusercontent.com/1310626/142674484-a800c249-4b3d-4227-a622-55d78564bf74.png"> |




- First page (TT1 theme):

| Before      | After |
| ----------- | ----------- |
| <img width="329" alt="image" src="https://user-images.githubusercontent.com/1310626/142677319-974e9046-96fe-4978-8617-21f6e0e2e79b.png"> | <img width="324" alt="image" src="https://user-images.githubusercontent.com/1310626/142676911-27ddcfae-8ca4-48c5-840d-83f87b43afb3.png">    |






- Last page (TT1 theme):

| Before      | After |
| ----------- | ----------- |
| <img width="323" alt="image" src="https://user-images.githubusercontent.com/1310626/142677161-4f1e2219-d0af-4192-9c5f-4ee91889a4f3.png">  | <img width="318" alt="image" src="https://user-images.githubusercontent.com/1310626/142676990-30d2d651-2002-450a-8dbc-22a3d4bf8f22.png"> |




## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
