### PR TITLE
Site Editor: Update hrefs to not specifically refer to themes.php?page=gutenberg-edit-site

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -36,8 +36,7 @@ export default function NewTemplatePart( { postType } ) {
 		} );
 
 		// Navigate to the created template part editor.
-		window.location.search = addQueryArgs( '', {
-			page: 'gutenberg-edit-site',
+		window.location.href = addQueryArgs( window.location.href, {
 			postId: templatePart.id,
 			postType: 'wp_template_part',
 		} );

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -58,8 +58,7 @@ export default function NewTemplate( { postType } ) {
 		} );
 
 		// Navigate to the created template editor.
-		window.location.search = addQueryArgs( '', {
-			page: 'gutenberg-edit-site',
+		window.location.href = addQueryArgs( window.location.href, {
 			postId: template.id,
 			postType: 'wp_template',
 		} );

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -95,8 +95,7 @@ export default function Table( { templateType } ) {
 					<HStack className="edit-site-list-table-row">
 						<FlexItem className="edit-site-list-table-column">
 							<a
-								href={ addQueryArgs( '', {
-									page: 'gutenberg-edit-site',
+								href={ addQueryArgs( window.location.href, {
 									postId: template.id,
 									postType: template.type,
 								} ) }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -82,23 +82,24 @@ const NavigationPanel = ( { isOpen, setIsOpen, activeTemplateType } ) => {
 							<NavigationGroup title={ __( 'Editor' ) }>
 								<NavigationItem
 									title={ __( 'Site' ) }
-									href={ addQueryArgs( '', {
-										page: 'gutenberg-edit-site',
+									href={ addQueryArgs( window.location.href, {
+										postId: undefined,
+										postType: undefined,
 									} ) }
 								/>
 								<NavigationItem
 									title={ __( 'Templates' ) }
 									item="wp_template"
-									href={ addQueryArgs( '', {
-										page: 'gutenberg-edit-site',
+									href={ addQueryArgs( window.location.href, {
+										postId: undefined,
 										postType: 'wp_template',
 									} ) }
 								/>
 								<NavigationItem
 									title={ __( 'Template Parts' ) }
 									item="wp_template_part"
-									href={ addQueryArgs( '', {
-										page: 'gutenberg-edit-site',
+									href={ addQueryArgs( window.location.href, {
+										postId: undefined,
 										postType: 'wp_template_part',
 									} ) }
 								/>

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -90,9 +90,9 @@ export default function TemplateDetails( { template, onClose } ) {
 
 			<Button
 				className="edit-site-template-details__show-all-button"
-				href={ addQueryArgs( '', {
-					page: 'gutenberg-edit-site',
+				href={ addQueryArgs( window.location.href, {
 					// TODO: We should update this to filter by template part's areas as well.
+					postId: undefined,
 					postType: template.type,
 				} ) }
 			>


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/pull/36379/files#r753881439.

This allows the JavaScript to work in Core where the URL will be `site-editor.php`, not `themes.php?page=gutenberg-edit-site`.

## How has this been tested?

1. Open the site editor.
2. Click on the W menu.
3. Browse to _Templates_. 
4. Browse to a template.
5. Click on the details dropdown and select _Browse all templates_.
6. Browse to _Template Parts_.
7. Browse to a template part.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->