### PR TITLE
Site Editor: Validate the postType query argument

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -86,13 +86,16 @@ function gutenberg_edit_site_list_init( $settings ) {
 	wp_enqueue_style( 'wp-edit-site' );
 	wp_enqueue_media();
 
-	$template_type = $_GET['postType'];
-	$post_type     = get_post_type_object( $template_type );
+	$post_type = get_post_type_object( $_GET['postType'] );
+
+	if ( ! $post_type ) {
+		wp_die( __( 'Invalid post type.', 'gutenberg' ) );
+	}
 
 	$preload_data = array_reduce(
 		array(
 			'/',
-			"/wp/v2/types/$template_type?context=edit",
+			"/wp/v2/types/$post_type->name?context=edit",
 			'/wp/v2/types?context=edit',
 			"/wp/v2/$post_type->rest_base?context=edit",
 		),
@@ -116,7 +119,7 @@ function gutenberg_edit_site_list_init( $settings ) {
 				wp.editSite.initializeList( "%s", "%s", %s );
 			} );',
 			'edit-site-editor',
-			$template_type,
+			$post_type->name,
 			wp_json_encode( $settings )
 		)
 	);


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/gutenberg/pull/36379/files#r753949616.

This bails if an invalid post type is provided via the `postType` query argument when loading the Site Editor's list view.

## How has this been tested?

1. Open the site editor.
2. Click on the W menu.
3. Browse to _Templates_. 
4. Change the `postType` argument in the URL to some gibberish e.g. `asdf`.
5. An error should appear.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->