### PR TITLE
Use table layout in templates list screen

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -66,7 +66,7 @@
 	margin: 0;
 	overflow: hidden;
 
-	li {
+	tr {
 		display: flex;
 		align-items: center;
 		padding: $grid-unit-20;
@@ -78,36 +78,39 @@
 			padding: $grid-unit-30 $grid-unit-40;
 		}
 
+		// Template.
 		.edit-site-list-table-column:nth-child(1) {
 			width: calc(60% - 36px);
+			flex-grow: 1;
+			display: flex;
+			flex-direction: column;
+			align-items: flex-start;
 
 			a {
-				display: block;
+				display: inline-block;
 				text-decoration: none;
 				font-weight: 500;
 				margin-bottom: $grid-unit-05;
 			}
 		}
 
+		// Added by.
 		.edit-site-list-table-column:nth-child(2) {
 			width: calc(40% - 36px);
 		}
 
+		// Actions.
 		.edit-site-list-table-column:nth-child(3) {
 			min-width: $button-size;
+			flex-shrink: 0;
 		}
 	}
 
-	li.edit-site-list-table-head {
-		border-bottom: $border-width solid $gray-200;
+	tr.edit-site-list-table-head {
 		font-size: 16px;
-		font-weight: 500;
+		font-weight: 600;
 		text-align: left;
-		color: $black;
+		color: #050505;
 		border-top: none;
-
-		& + li {
-			border-top: 0;
-		}
 	}
 }

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -6,9 +6,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	VisuallyHidden,
-	FlexItem,
-	__experimentalHStack as HStack,
-	__experimentalHeading as Heading,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
@@ -77,23 +74,28 @@ export default function Table( { templateType } ) {
 	}
 
 	return (
-		<ul className="edit-site-list-table">
-			<HStack className="edit-site-list-table-head" as="li">
-				<FlexItem className="edit-site-list-table-column">
-					<Heading level={ 4 }>{ __( 'Template' ) }</Heading>
-				</FlexItem>
-				<FlexItem className="edit-site-list-table-column">
-					<Heading level={ 4 }>{ __( 'Added by' ) }</Heading>
-				</FlexItem>
-				<FlexItem className="edit-site-list-table-column">
-					<VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>
-				</FlexItem>
-			</HStack>
+		<table className="edit-site-list-table">
+			<thead>
+				<tr className="edit-site-list-table-head">
+					<th className="edit-site-list-table-column">
+						{ __( 'Template' ) }
+					</th>
+					<th className="edit-site-list-table-column">
+						{ __( 'Added by' ) }
+					</th>
+					<th className="edit-site-list-table-column">
+						<VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>
+					</th>
+				</tr>
+			</thead>
 
-			{ templates.map( ( template ) => (
-				<li key={ template.id }>
-					<HStack className="edit-site-list-table-row">
-						<FlexItem className="edit-site-list-table-column">
+			<tbody>
+				{ templates.map( ( template ) => (
+					<tr
+						key={ template.id }
+						className="edit-site-list-table-row"
+					>
+						<td className="edit-site-list-table-column">
 							<a
 								href={ addQueryArgs( '', {
 									page: 'gutenberg-edit-site',
@@ -104,12 +106,12 @@ export default function Table( { templateType } ) {
 								{ template.title.rendered }
 							</a>
 							{ template.description }
-						</FlexItem>
+						</td>
 
-						<FlexItem className="edit-site-list-table-column">
+						<td className="edit-site-list-table-column">
 							{ template.theme }
-						</FlexItem>
-						<FlexItem className="edit-site-list-table-column">
+						</td>
+						<td className="edit-site-list-table-column">
 							{ isTemplateRemovable( template ) && (
 								<DropdownMenu
 									icon={ moreVertical }
@@ -124,10 +126,10 @@ export default function Table( { templateType } ) {
 									) }
 								</DropdownMenu>
 							) }
-						</FlexItem>
-					</HStack>
-				</li>
-			) ) }
-		</ul>
+						</td>
+					</tr>
+				) ) }
+			</tbody>
+		</table>
 	);
 }

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -74,6 +74,8 @@ export default function Table( { templateType } ) {
 	}
 
 	return (
+		// These explicit aria roles are needed for Safari.
+		// See https://developer.mozilla.org/en-US/docs/Web/CSS/display#tables
 		<table className="edit-site-list-table" role="table">
 			<thead>
 				<tr className="edit-site-list-table-head" role="row">

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -74,16 +74,25 @@ export default function Table( { templateType } ) {
 	}
 
 	return (
-		<table className="edit-site-list-table">
+		<table className="edit-site-list-table" role="table">
 			<thead>
-				<tr className="edit-site-list-table-head">
-					<th className="edit-site-list-table-column">
+				<tr className="edit-site-list-table-head" role="row">
+					<th
+						className="edit-site-list-table-column"
+						role="columnheader"
+					>
 						{ __( 'Template' ) }
 					</th>
-					<th className="edit-site-list-table-column">
+					<th
+						className="edit-site-list-table-column"
+						role="columnheader"
+					>
 						{ __( 'Added by' ) }
 					</th>
-					<th className="edit-site-list-table-column">
+					<th
+						className="edit-site-list-table-column"
+						role="columnheader"
+					>
 						<VisuallyHidden>{ __( 'Actions' ) }</VisuallyHidden>
 					</th>
 				</tr>
@@ -94,8 +103,9 @@ export default function Table( { templateType } ) {
 					<tr
 						key={ template.id }
 						className="edit-site-list-table-row"
+						role="row"
 					>
-						<td className="edit-site-list-table-column">
+						<td className="edit-site-list-table-column" role="cell">
 							<a
 								href={ addQueryArgs( '', {
 									page: 'gutenberg-edit-site',
@@ -108,10 +118,10 @@ export default function Table( { templateType } ) {
 							{ template.description }
 						</td>
 
-						<td className="edit-site-list-table-column">
+						<td className="edit-site-list-table-column" role="cell">
 							{ template.theme }
 						</td>
-						<td className="edit-site-list-table-column">
+						<td className="edit-site-list-table-column" role="cell">
 							{ isTemplateRemovable( template ) && (
 								<DropdownMenu
 									icon={ moreVertical }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close #36702.

Use `<table>` layout in templates list page to follow accessibility best practices.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go to Appearance -> Editor
3. Click on top left W menu and go to either "Templates" or "Template Parts"
4. The table should be using `<table>` tag and it should have implicit aria roles (Chrome devtools -> Elements -> Accessibility)
5. The styling should match how it looks currently in trunk

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
