### PR TITLE
date: Add a new filter hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18990,6 +18990,7 @@
 			"version": "file:packages/date",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "file:packages/hooks",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.31"
 			}

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -27,6 +27,7 @@
 	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@wordpress/hooks": "file:../hooks",
 		"moment": "^2.22.1",
 		"moment-timezone": "^0.5.31"
 	},

--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -5,6 +5,11 @@ import momentLib from 'moment';
 import 'moment-timezone/moment-timezone';
 import 'moment-timezone/moment-timezone-utils';
 
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
 /** @typedef {import('moment').Moment} Moment */
 /** @typedef {import('moment').LocaleSpecification} MomentLocaleSpecification */
 
@@ -409,7 +414,17 @@ export function format( dateFormat, dateValue = new Date() ) {
 	}
 	// Join with [] between to separate characters, and replace
 	// unneeded separators with static text.
-	return momentDate.format( newFormat.join( '[]' ) );
+	const dateString = momentDate.format( newFormat.join( '[]' ) );
+	/**
+	 * Filters the formatted date like 'wp_date()'
+	 *
+	 * @param {string} dateString Formatted result.
+	 * @param {string} dateFormat Format string.
+	 * @param {Moment} momentDate Parsed date by moment.js.
+	 */
+	return String(
+		applyFilters( 'date.format', dateString, dateFormat, momentDate )
+	);
 }
 
 /**


### PR DESCRIPTION
## Description
Add a new filter hook named `date.format`.

I need new format string to display Japanese Calendar. In WordPress written in PHP, I just use `add_filter('wp_date', function(){})`, but Gutenberg cannot.

## How has this been tested?
WP version: 5.8.2
OS: Ubuntu 20.04
Browser: Chromium 96.0 (snap x86_64)

## Screenshots
![Screenshot from 2021-11-22 14-22-01](https://user-images.githubusercontent.com/13865617/142805470-7a308208-febb-4548-a47b-48d2540bcc81.png)

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation.
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
