### PR TITLE
Fix site editor region navigation

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -26,7 +26,10 @@ import {
 } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
-import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
+import {
+	ShortcutProvider,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -62,6 +65,8 @@ function Editor( { initialSettings, onError } ) {
 		template,
 		templateResolved,
 		isNavigationOpen,
+		previousShortcut,
+		nextShortcut,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -98,6 +103,12 @@ function Editor( { initialSettings, onError } ) {
 				: false,
 			entityId: postId,
 			isNavigationOpen: isNavigationOpened(),
+			previousShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-site/previous-region' ),
+			nextShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-site/next-region' ),
 		};
 	}, [] );
 	const { updateEditorSettings } = useDispatch( editorStore );
@@ -295,6 +306,10 @@ function Editor( { initialSettings, onError } ) {
 													</>
 												}
 												footer={ <BlockBreadcrumb /> }
+												shortcuts={ {
+													previous: previousShortcut,
+													next: nextShortcut,
+												} }
 											/>
 											<WelcomeGuide />
 											<Popover.Slot />

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -136,6 +136,38 @@ function KeyboardShortcutsRegister() {
 				character: ',',
 			},
 		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/next-region',
+			category: 'global',
+			description: __( 'Navigate to the next part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrl',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'n',
+				},
+			],
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/previous-region',
+			category: 'global',
+			description: __( 'Navigate to the previous part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrlShift',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'p',
+				},
+			],
+		} );
 	}, [ registerShortcut ] );
 
 	return null;

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -36,23 +36,30 @@ export default function List( { templateType } ) {
 		[ templateType ]
 	);
 
+	// `postType` could load in asynchronously. Only provide the detailed region labels if
+	// the postType has loaded, otherwise `InterfaceSkeleton` will fallback to the defaults.
 	const itemsListLabel = postType?.labels?.items_list;
-
-	return (
-		<InterfaceSkeleton
-			className="edit-site-list"
-			labels={ {
+	const detailedRegionLabels = postType
+		? {
 				header: sprintf(
 					// translators: %s - the name of the page, 'Header' as in the header area of that page.
 					__( '%s - Header' ),
 					itemsListLabel
 				),
-				drawer: __( 'Navigation Sidebar' ),
 				body: sprintf(
 					// translators: %s - the name of the page, 'Content' as in the content area of that page.
 					__( '%s - Content' ),
 					itemsListLabel
 				),
+		  }
+		: undefined;
+
+	return (
+		<InterfaceSkeleton
+			className="edit-site-list"
+			labels={ {
+				drawer: __( 'Navigation Sidebar' ),
+				...detailedRegionLabels,
 			} }
 			header={ <Header templateType={ templateType } /> }
 			drawer={

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -48,7 +48,7 @@ export default function List( { templateType } ) {
 					itemsListLabel
 				),
 				drawer: __( 'Navigation Sidebar' ),
-				content: sprintf(
+				body: sprintf(
 					// translators: %s - the name of the page, 'Content' as in the content area of that page.
 					__( '%s - Content' ),
 					itemsListLabel

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -1,25 +1,58 @@
 /**
  * WordPress dependencies
  */
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { InterfaceSkeleton } from '@wordpress/interface';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
+import useRegisterShortcuts from './use-register-shortcuts';
 import Header from './header';
 import NavigationSidebar from '../navigation-sidebar';
 import Table from './table';
 
 export default function List( { templateType } ) {
+	useRegisterShortcuts();
 	const isDesktopViewport = useViewportMatch( 'medium' );
+
+	const { previousShortcut, nextShortcut } = useSelect( ( select ) => {
+		return {
+			previousShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-site/previous-region' ),
+			nextShortcut: select(
+				keyboardShortcutsStore
+			).getAllShortcutKeyCombinations( 'core/edit-site/next-region' ),
+		};
+	}, [] );
+
+	const postType = useSelect(
+		( select ) => select( coreStore ).getPostType( templateType ),
+		[ templateType ]
+	);
+
+	const itemsListLabel = postType?.labels?.items_list;
 
 	return (
 		<InterfaceSkeleton
 			className="edit-site-list"
 			labels={ {
+				header: sprintf(
+					// translators: %s - the name of the page, 'Header' as in the header area of that page.
+					__( '%s - Header' ),
+					itemsListLabel
+				),
 				drawer: __( 'Navigation Sidebar' ),
+				content: sprintf(
+					// translators: %s - the name of the page, 'Content' as in the content area of that page.
+					__( '%s - Content' ),
+					itemsListLabel
+				),
 			} }
 			header={ <Header templateType={ templateType } /> }
 			drawer={
@@ -33,6 +66,10 @@ export default function List( { templateType } ) {
 					<Table templateType={ templateType } />
 				</main>
 			}
+			shortcuts={ {
+				previous: previousShortcut,
+				next: nextShortcut,
+			} }
 		/>
 	);
 }

--- a/packages/edit-site/src/components/list/use-register-shortcuts.js
+++ b/packages/edit-site/src/components/list/use-register-shortcuts.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+
+export default function useRegisterShortcuts() {
+	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
+	useEffect( () => {
+		registerShortcut( {
+			name: 'core/edit-site/next-region',
+			category: 'global',
+			description: __( 'Navigate to the next part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrl',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'n',
+				},
+			],
+		} );
+
+		registerShortcut( {
+			name: 'core/edit-site/previous-region',
+			category: 'global',
+			description: __( 'Navigate to the previous part of the editor.' ),
+			keyCombination: {
+				modifier: 'ctrlShift',
+				character: '`',
+			},
+			aliases: [
+				{
+					modifier: 'access',
+					character: 'p',
+				},
+			],
+		} );
+	}, [] );
+}

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -83,6 +83,7 @@ function InterfaceSkeleton(
 					className="interface-interface-skeleton__drawer"
 					role="region"
 					aria-label={ mergedLabels.drawer }
+					tabIndex="-1"
 				>
 					{ drawer }
 				</div>


### PR DESCRIPTION
## Description
Fixes a few issues with region navigation in the site editor:
- The 'drawer' region that's used for the navigation sidebar was missing `tabIndex=-1` which meant it couldn't be focused when navigating regions
- Register shortcuts for navigating regions so that they're shown in the shortcut modal (when that's implemented)
- Improve region labels

The outline styles for the regions could still be improved in the site editor. I haven't tackled that in this PR, because I need to work on some other important tasks.

## How has this been tested?
Testing steps depend on which OS you're using. I think on a mac it's recommended to use <kbd>ctrl</kbd> + <kbd>`</kbd> because the alternative shortcut (ctrl+alt+n) seems to toggle a setting in voiceover that you really don't want to toggle. Also best to test in Safari on a mac.

1. Open the editor with screenreader active
2. Use the navigate regions shortcuts to cycle through the regions
3. Observe the Navigation Sidebar can be focused
4. Open the Template Parts page (open the Navigation Sidebar, select Template Parts)
5. Cycle through the regions

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
