### PR TITLE
Update featured image placeholder graphic.

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -33,12 +33,9 @@ const placeholderIllustration = (
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 60 60"
-		preserveAspectRatio="xMidYMid slice" // @todo: "slice" matches the "cover" behavior, "meet" could be used for "container" and "fill" values.
+		preserveAspectRatio="none"
 	>
-		<Path
-			vectorEffect="non-scaling-stroke"
-			d="m61 32.622-13.555-9.137-15.888 9.859a5 5 0 0 1-5.386-.073l-9.095-5.989L1 37.5"
-		/>
+		<Path vectorEffect="non-scaling-stroke" d="M60 60 0 0" />
 	</SVG>
 );
 

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -48,7 +48,7 @@
 			bottom: 0;
 			left: 0;
 			border: $border-width dashed currentColor;
-			opacity: 0.3;
+			opacity: 0.4;
 			pointer-events: none;
 
 			// Inherit border radius from style variations.
@@ -93,7 +93,7 @@
 			height: 100%;
 			stroke: currentColor;
 			stroke-dasharray: 3;
-			opacity: 0.3;
+			opacity: 0.4;
 		}
 
 		// Show default placeholder height when not resized.

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -110,7 +110,7 @@
 			bottom: 0;
 			left: 0;
 			border: $border-width dashed currentColor;
-			opacity: 0.3;
+			opacity: 0.4;
 			pointer-events: none;
 
 			// Inherit border radius from style variations.
@@ -155,7 +155,7 @@
 			height: 100%;
 			stroke: currentColor;
 			stroke-dasharray: 3;
-			opacity: 0.3;
+			opacity: 0.4;
 		}
 	}
 


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/36517#issuecomment-974878655. 

The mountain range works well for the site logo placeholder as it matches the icon. For the featured image, it becomes less clear what it's about. This PR takes feedback from above and embraces classic DTP layout principles to create a literal placeholder for the Featured Image block:

![featured](https://user-images.githubusercontent.com/1204802/142826337-eba4c893-45f6-41d6-bd89-d8bc6566b5a7.gif)

Note, the diagonal here is intentionally set to _stretch_ (the dashed line should still be correct and update its spacing to match resized dimensions). But if we wanted to, I could make it not stretch:

<img width="748" alt="Screenshot 2021-11-22 at 09 13 08" src="https://user-images.githubusercontent.com/1204802/142826453-48841db9-20d2-4f6d-a8a9-13066bb12d65.png">

Note that I've also updated the opacity of the dashed line, including for the featured image:

<img width="188" alt="Screenshot 2021-11-22 at 09 13 53" src="https://user-images.githubusercontent.com/1204802/142826484-86879477-e985-4418-a402-eae6c8b61ef7.png">

## How has this been tested?

Try the featured image and site logo blocks.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
