### PR TITLE
Navigation: Scale submenu icon.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -91,8 +91,8 @@
 
 		// Scale to font size.
 		margin-left: 0.25em;
-		width: 0.8em;
-		height: 0.8em;
+		width: 0.6em;
+		height: 0.6em;
 
 		svg {
 			display: inline-block;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -78,10 +78,10 @@
 
 	// Submenu indicator.
 	.wp-block-navigation__submenu-icon {
-		align-self: center;
-		height: inherit;
+		align-self: center; // This one affects nested submenu indicators.
 		line-height: 0;
-		margin-left: 6px;
+		display: inline-block;
+		vertical-align: middle;
 
 		// Affect the button as well.
 		padding: 0;
@@ -89,9 +89,16 @@
 		color: currentColor;
 		border: none;
 
+		// Scale to font size.
+		margin-left: 0.25em;
+		width: 0.8em;
+		height: 0.8em;
+
 		svg {
 			display: inline-block;
 			stroke: currentColor;
+			width: inherit;
+			height: inherit;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fixes #36700. Updates the submenu icon to scale according to the font size applied. Before:

<img width="621" alt="before" src="https://user-images.githubusercontent.com/1204802/142829985-03bc61a2-53d4-4628-9b1e-cc9dff6e339a.png">

After:

![0 8](https://user-images.githubusercontent.com/1204802/142829995-25689272-2766-4e86-b60c-da8159e5253a.gif)

Note, the above sets the dimensions of the icon to 0.8em (80% of the font size), which feels like a right balance. But that does occasionally render the icon at subpixel integers. Visually I think that's acceptable for the icon. But we can also set the dimensions to 1em:

![1em](https://user-images.githubusercontent.com/1204802/142830120-db815d22-d549-41e3-bb2a-a82a97873e32.gif)

A third option is to set the dimensions to 1em, but scale down the icon inside the SVG. All of these should be easy, so would be happy to address per feedback.

## How has this been tested?

Insert a navigation block with submenus and change the font size.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
