### PR TITLE
Navigation: Add clearance for appender in submenus.

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -520,7 +520,7 @@ export default function NavigationSubmenuEdit( {
 					! selectedBlockHasDescendants ) ||
 				// Show the appender while dragging to allow inserting element between item and the appender.
 				hasDescendants
-					? InnerBlocks.DefaultAppender
+					? InnerBlocks.ButtonBlockAppender
 					: false,
 		}
 	);

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -96,6 +96,19 @@
 	}
 }
 
+// Show even when a child is selected. This is an edgecase just for navigation submenus.
+.is-editing > .wp-block-navigation__submenu-container {
+	.block-list-appender {
+		position: static;
+		margin-left: auto;
+
+		> .block-list-appender__toggle {
+			display: block;
+		}
+	}
+}
+
+
 /**
  * Colors Selector component
  */

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -97,15 +97,14 @@
 }
 
 // Show even when a child is selected. This is an edgecase just for navigation submenus.
-.is-editing > .wp-block-navigation__submenu-container {
-	.block-list-appender {
-		position: static;
-		margin-left: auto;
+.is-editing > .wp-block-navigation__submenu-container > .block-list-appender {
+	display: block;
+	position: static;
+}
 
-		> .block-list-appender__toggle {
-			display: block;
-		}
-	}
+// Hide when hovering.
+.wp-block-navigation__submenu-container .block-list-appender {
+	display: none;
 }
 
 


### PR DESCRIPTION
## Description

Followup to #36605, which was important for avoiding layout shifts, but should be considered a step on the way to greater things. This PR fixes what I'd describe as an edgecase for the navigation block, where building submenus benefitted from the previous behavior, and the abs positioned behavior becomes a bit clunky:

<img width="553" alt="Screenshot 2021-11-22 at 09 54 13" src="https://user-images.githubusercontent.com/1204802/142837613-3f2a9739-fabf-40d2-a9a2-7044a3fcb258.png">

This PR adds an edgecase explicitly for the navigation block:

![clearance](https://user-images.githubusercontent.com/1204802/142837718-6db79541-90d7-48f4-be9f-b9b663bcbd16.gif)

The CSS works fine for this, but the particular use case, building vertically expanding lists, is something we should consider when we explore the next iteration of the appender.

## How has this been tested?

Build a submenu with the navigation block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
