### PR TITLE
Move the theme editor under tools for FSE themes

### DIFF
--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Moves the theme editor menu items for FSE themes.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Moves the "theme editor" under "tools" in FSE themes.
+ */
+function gutenberg_move_theme_editor_in_block_themes() {
+	if ( ! gutenberg_is_fse_theme() || is_multisite() ) {
+		return;
+	}
+	remove_submenu_page( 'themes.php', 'theme-editor.php' );
+	add_submenu_page( 'tools.php', __( 'Theme Editor', 'default' ), __( 'Theme Editor', 'default' ), 'edit_themes', 'theme-editor.php' );
+}
+
+add_action( 'admin_menu', 'gutenberg_move_theme_editor_in_block_themes', 102 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -122,6 +122,7 @@ require __DIR__ . '/full-site-editing/edit-site-page.php';
 require __DIR__ . '/compat/wordpress-5.9/default-theme-supports.php';
 require __DIR__ . '/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php';
 require __DIR__ . '/compat/wordpress-5.9/rest-active-global-styles.php';
+require __DIR__ . '/compat/wordpress-5.9/move-theme-editor-menu-item.php';
 
 require __DIR__ . '/blocks.php';
 require __DIR__ . '/block-patterns.php';


### PR DESCRIPTION
closes #36354 

I hesitated between this or removing that page entirely (because the site editor is actually a different kind of theme editor) but I guess this is less disruptive. 

**Testing instructions**

 - Make sure the theme editor is under "tools" and not "appearance" for FSE themes.