### PR TITLE
Implement suitable fallback for Nav block on front end of site when no menu selected

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -56,7 +56,7 @@
 		"customOverlayTextColor": {
 			"type": "string"
 		},
-		"maxPages": {
+		"__unstableMaxPages": {
 			"type": "number"
 		}
 	},
@@ -76,7 +76,7 @@
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
 		"orientation": "orientation",
-		"maxPages": "maxPages"
+		"__unstableMaxPages": "__unstableMaxPages"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -55,6 +55,9 @@
 		},
 		"customOverlayTextColor": {
 			"type": "string"
+		},
+		"maxPages": {
+			"type": "number"
 		}
 	},
 	"usesContext": [ "navigationArea" ],
@@ -72,7 +75,8 @@
 		"showSubmenuIcon": "showSubmenuIcon",
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
-		"orientation": "orientation"
+		"orientation": "orientation",
+		"maxPages": "maxPages"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -217,7 +217,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
-		$is_fallback     = true; // indicate we are rendering the fallback.
+		$is_fallback = true; // indicate we are rendering the fallback.
 
 		$page_list_block = array(
 			'blockName' => 'core/page-list',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -219,7 +219,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
 		$is_fallback            = true; // indicate we are rendering the fallback.
-		$attributes['maxPages'] = 4; // set value to be passed as context to Page List block.
+		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
 
 		$page_list_block = array(
 			'blockName' => 'core/page-list',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -218,8 +218,13 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
 		$is_fallback     = true; // indicate we are rendering the fallback.
-		$page_list_block = parse_blocks( '<!-- wp:page-list /-->' );
-		$inner_blocks    = new WP_Block_List( $page_list_block, $attributes );
+
+		$page_list_block = array(
+			'blockName' => 'core/page-list',
+			'attrs'     => array(),
+		);
+
+		$inner_blocks = new WP_Block_List( array( $page_list_block ), $attributes );
 	}
 
 	// Restore legacy classnames for submenu positioning.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -183,7 +183,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks            = new WP_Block_List( $parsed_blocks, $attributes );
 	}
 
-	if ( ! empty( $block->context['navigationArea'] ) ) {
+	if ( false && ! empty( $block->context['navigationArea'] ) ) {
 		$area    = $block->context['navigationArea'];
 		$mapping = get_option( 'wp_navigation_areas', array() );
 		if ( ! empty( $mapping[ $area ] ) ) {
@@ -215,7 +215,34 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	if ( empty( $inner_blocks ) ) {
-		return '';
+		$all_pages = get_pages(
+			array(
+				'sort_column' => 'menu_order,post_title',
+				'order'       => 'asc',
+				'number'      => 4,
+			)
+		);
+
+		// If thare are no pages, there is nothing to show.
+		if ( empty( $all_pages ) ) {
+			return;
+		}
+
+		$wrapper_markup = '<ul class="wp-block-navigation__container">%s</ul>';
+
+		$items_markup = array_reduce(
+			$all_pages,
+			function( $acc, $page ) {
+				$acc .= '<li class="wp-block-navigation-item"><a href="' . esc_url( get_permalink( $page->ID ) ) . '">' . esc_attr( $page->post_title ) . '</a></li>';
+				return $acc;
+			},
+			''
+		);
+
+		return sprintf(
+			$wrapper_markup,
+			$items_markup
+		);
 	}
 
 	// Restore legacy classnames for submenu positioning.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,6 +142,7 @@ function block_core_navigation_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
+
 	$is_fallback = false;
 	/**
 	 * Deprecated:
@@ -218,6 +219,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
 		$is_fallback = true; // indicate we are rendering the fallback.
+		$attributes['maxPages'] = 4; // set value to be passed as context to Page List block.
 
 		$page_list_block = array(
 			'blockName' => 'core/page-list',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -218,7 +218,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
-		$is_fallback = true; // indicate we are rendering the fallback.
+		$is_fallback            = true; // indicate we are rendering the fallback.
 		$attributes['maxPages'] = 4; // set value to be passed as context to Page List block.
 
 		$page_list_block = array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -218,7 +218,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
-		$is_fallback            = true; // indicate we are rendering the fallback.
+		$is_fallback                      = true; // indicate we are rendering the fallback.
 		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
 
 		$page_list_block = array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,6 +142,7 @@ function block_core_navigation_render_submenu_icon() {
  * @return string Returns the post content with the legacy widget added.
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
+	$is_fallback = false;
 	/**
 	 * Deprecated:
 	 * The rgbTextColor and rgbBackgroundColor attributes
@@ -216,8 +217,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
+		$is_fallback     = true; // indicate we are rendering the fallback.
 		$page_list_block = parse_blocks( '<!-- wp:page-list /-->' );
-		$inner_blocks = new WP_Block_List( $page_list_block, $attributes );
+		$inner_blocks    = new WP_Block_List( $page_list_block, $attributes );
 	}
 
 	// Restore legacy classnames for submenu positioning.
@@ -236,7 +238,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$colors['css_classes'],
 		$font_sizes['css_classes'],
 		$is_responsive_menu ? array( 'is-responsive' ) : array(),
-		$layout_class ? array( $layout_class ) : array()
+		$layout_class ? array( $layout_class ) : array(),
+		$is_fallback ? array( 'is-fallback' ) : array()
 	);
 
 	$inner_blocks_html = '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -214,35 +214,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks = new WP_Block_List( $compacted_blocks, $attributes );
 	}
 
+	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
-		$all_pages = get_pages(
-			array(
-				'sort_column' => 'menu_order,post_title',
-				'order'       => 'asc',
-				'number'      => 4,
-			)
-		);
-
-		// If thare are no pages, there is nothing to show.
-		if ( empty( $all_pages ) ) {
-			return;
-		}
-
-		$wrapper_markup = '<ul class="wp-block-navigation__container">%s</ul>';
-
-		$items_markup = array_reduce(
-			$all_pages,
-			function( $acc, $page ) {
-				$acc .= '<li class="wp-block-navigation-item"><a href="' . esc_url( get_permalink( $page->ID ) ) . '">' . esc_attr( $page->post_title ) . '</a></li>';
-				return $acc;
-			},
-			''
-		);
-
-		return sprintf(
-			$wrapper_markup,
-			$items_markup
-		);
+		$page_list_block = parse_blocks( '<!-- wp:page-list /-->' );
+		$inner_blocks = new WP_Block_List( $page_list_block, $attributes );
 	}
 
 	// Restore legacy classnames for submenu positioning.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -185,7 +185,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$inner_blocks            = new WP_Block_List( $parsed_blocks, $attributes );
 	}
 
-	if ( false && ! empty( $block->context['navigationArea'] ) ) {
+	if ( ! empty( $block->context['navigationArea'] ) ) {
 		$area    = $block->context['navigationArea'];
 		$mapping = get_option( 'wp_navigation_areas', array() );
 		if ( ! empty( $mapping[ $area ] ) ) {

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -21,7 +21,8 @@
 		"customFontSize",
 		"showSubmenuIcon",
 		"style",
-		"openSubmenusOnClick"
+		"openSubmenusOnClick",
+		"maxPages"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -22,7 +22,7 @@
 		"showSubmenuIcon",
 		"style",
 		"openSubmenusOnClick",
-		"maxPages"
+		"__unstableMaxPages"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -293,6 +293,10 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
+	if ( array_key_exists( 'maxPages', $block->context ) ) {
+		$nested_pages = array_slice( $nested_pages, 0, $block->context['maxPages'] );
+	}
+
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );
 
 	$open_submenus_on_click = array_key_exists( 'openSubmenusOnClick', $block->context ) ? $block->context['openSubmenusOnClick'] : false;

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -293,8 +293,8 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	if ( array_key_exists( 'maxPages', $block->context ) ) {
-		$nested_pages = array_slice( $nested_pages, 0, $block->context['maxPages'] );
+	if ( array_key_exists( '__unstableMaxPages', $block->context ) ) {
+		$nested_pages = array_slice( $nested_pages, 0, $block->context['__unstableMaxPages'] );
 	}
 
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/issues/36721 we learnt that the Nav block doesn't currently have a suitable fallback on the front end of the site when a menu is not selected.

This PR implements in the simplest way possible by falling back to rendering a `core/page-list` block with it's default attributes.

As Nav is already set up to handle displaying this block the styles all work perfectly out of the box.

~if we want to limit the number of items shown then we'll need to modify `core/page-list` to have a `maxPages` prop so we can control the number of items. We might be able to provide this via context. I suggest we do this in a separate PR.~ **Update**: I added a commit which introduces a `maxPages` attribute to the Nav block. We can then pass this to the Page List block via context to control the number of items that are displayed.  

Addresses _part of_ https://github.com/WordPress/gutenberg/issues/36721

## How has this been tested?

Before testing use Fakerpress Plugin (or similar) to add a load of pages to your site. Some should be nested parent/child.

1. Open Site Editor.
2. Remove any existing Nav block.
3. Add Nav block from scratch. Don't add any items!
4. Save your empty Nav block and publish the post.
5. Go to front of site.
6. See Page List rendered by default even though no Menu has been selected.
7. Return to Editor and add a menu for your nav block.
8. Save and return to front of site.
9. Check that your menu is rendered.

## Screenshots <!-- if applicable -->


<img width="1252" alt="Screenshot 2021-11-22 at 13 16 37" src="https://user-images.githubusercontent.com/444434/142868262-a8a2b271-9b3d-4c28-90bb-a9a914f2613e.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
