### PR TITLE
Toggle Group Control: add tooltip

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 
+### Enhancements
+-   Added a `showTooltip` prop to `ToggleGroupControlOption` in order to display tooltip text (using `<Tooltip />`). ([36726](https://github.com/WordPress/gutenberg/pull/36726)).
+
 ### Experimental
 
 -   Reinstated the ability to pass additional props to the `ToolsPanel` ([36428](https://github.com/WordPress/gutenberg/pull/36428)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,21 +7,21 @@
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 
 ### Enhancements
--   Added a `showTooltip` prop to `ToggleGroupControlOption` in order to display tooltip text (using `<Tooltip />`). ([36726](https://github.com/WordPress/gutenberg/pull/36726)).
+-   Added a `showTooltip` prop to `ToggleGroupControlOption` in order to display tooltip text (using `<Tooltip />`). ([#36726](https://github.com/WordPress/gutenberg/pull/36726)).
 
 ### Experimental
 
--   Reinstated the ability to pass additional props to the `ToolsPanel` ([36428](https://github.com/WordPress/gutenberg/pull/36428)).
+-   Reinstated the ability to pass additional props to the `ToolsPanel` ([#36428](https://github.com/WordPress/gutenberg/pull/36428)).
 -   Added an `__unstable-large` size variant to `InputControl`, `SelectControl`, and `UnitControl` for selective migration to the larger 40px heights. ([#35646](https://github.com/WordPress/gutenberg/pull/35646)).
 -   Fixed inconsistent padding in `UnitControl` ([#35646](https://github.com/WordPress/gutenberg/pull/35646)).
 -   Added support for RTL behavior for the `ZStack`'s `offset` prop ([#36769](https://github.com/WordPress/gutenberg/pull/36769))
--   Fixed race conditions causing conditionally displayed `ToolsPanelItem` components to be erroneously deregistered ([36588](https://github.com/WordPress/gutenberg/pull/36588)).
+-   Fixed race conditions causing conditionally displayed `ToolsPanelItem` components to be erroneously deregistered ([#36588](https://github.com/WordPress/gutenberg/pull/36588)).
 -   Added `__experimentalHideHeader` prop to `Modal` component ([#36831](https://github.com/WordPress/gutenberg/pull/36831)).
 -   Added experimental `ConfirmDialog` component ([#34153](https://github.com/WordPress/gutenberg/pull/34153)).
 
 ### Bug Fix
 
--   Fixed spacing between `BaseControl` fields and help text within the `ToolsPanel` ([36334](https://github.com/WordPress/gutenberg/pull/36334))
+-   Fixed spacing between `BaseControl` fields and help text within the `ToolsPanel` ([#36334](https://github.com/WordPress/gutenberg/pull/36334))
 
 ### Enhancements
 

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -186,6 +186,7 @@ function FontSizePicker(
 								value={ option.value }
 								label={ option.label }
 								aria-label={ option.name }
+								tooltipText={ option.name }
 							/>
 						) ) }
 					</ToggleGroupControl>

--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -186,7 +186,7 @@ function FontSizePicker(
 								value={ option.value }
 								label={ option.label }
 								aria-label={ option.name }
-								tooltipText={ option.name }
+								showTooltip={ true }
 							/>
 						) ) }
 					</ToggleGroupControl>

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -71,6 +71,11 @@ const _default = ( { options } ) => {
 				opt[ 'aria-label' ],
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
 			) }
+			tooltipText={ text(
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }: tooltipText`,
+				opt.tooltipText,
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
+			) }
 		/>
 	) );
 
@@ -98,6 +103,16 @@ Default.args = {
 		{ value: 'center', label: 'Center' },
 		{ value: 'right', label: 'Right' },
 		{ value: 'justify', label: 'Justify' },
+	],
+};
+
+export const WithTooltipText = _default.bind( {} );
+WithTooltipText.args = {
+	...Default.args,
+	options: [
+		{ value: 1, label: '1', tooltipText: 'One' },
+		{ value: 2, label: '2', tooltipText: 'Two' },
+		{ value: 3, label: '3', tooltipText: 'Three' },
 	],
 };
 

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -71,9 +71,9 @@ const _default = ( { options } ) => {
 				opt[ 'aria-label' ],
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
 			) }
-			tooltipText={ text(
-				`${ KNOBS_GROUPS.ToggleGroupControlOption }: tooltipText`,
-				opt.tooltipText,
+			showTooltip={ boolean(
+				`${ KNOBS_GROUPS.ToggleGroupControlOption }: showTooltip`,
+				opt.showTooltip,
 				`${ KNOBS_GROUPS.ToggleGroupControlOption }-${ index + 1 }`
 			) }
 		/>
@@ -106,13 +106,13 @@ Default.args = {
 	],
 };
 
-export const WithTooltipText = _default.bind( {} );
-WithTooltipText.args = {
+export const WithTooltip = _default.bind( {} );
+WithTooltip.args = {
 	...Default.args,
 	options: [
-		{ value: 1, label: '1', tooltipText: 'One' },
-		{ value: 2, label: '2', tooltipText: 'Two' },
-		{ value: 3, label: '3', tooltipText: 'Three' },
+		{ value: 1, label: '1', showTooltip: true, 'aria-label': 'One' },
+		{ value: 2, label: '2', showTooltip: true, 'aria-label': 'Two' },
+		{ value: 3, label: '3', showTooltip: true, 'aria-label': 'Three' },
 	],
 };
 

--- a/packages/components/src/toggle-group-control/test/index.js
+++ b/packages/components/src/toggle-group-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 
 /**
  * Internal dependencies
@@ -13,6 +13,21 @@ describe( 'ToggleGroupControl', () => {
 		<>
 			<ToggleGroupControlOption value="rigas" label="R" />
 			<ToggleGroupControlOption value="jack" label="J" />
+		</>
+	);
+	const optionsWithTooltip = (
+		<>
+			<ToggleGroupControlOption
+				value="gnocchi"
+				label="Delicious Gnocchi"
+				aria-label="Click for Delicious Gnocchi"
+				showTooltip={ true }
+			/>
+			<ToggleGroupControlOption
+				value="caponata"
+				label="Sumptuous Caponata"
+				aria-label="Click for Sumptuous Caponata"
+			/>
 		</>
 	);
 	it( 'should render correctly', () => {
@@ -37,5 +52,37 @@ describe( 'ToggleGroupControl', () => {
 		const firstRadio = screen.getByRole( 'radio', { name: 'R' } );
 		fireEvent.click( firstRadio );
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
+	} );
+	it( 'should render tooltip where `showTooltip` === `true`', async () => {
+		render(
+			<ToggleGroupControl label="Test Toggle Group Control">
+				{ optionsWithTooltip }
+			</ToggleGroupControl>
+		);
+		const firstRadio = screen.getByLabelText(
+			'Click for Delicious Gnocchi'
+		);
+		fireEvent.mouseOver( firstRadio );
+		await waitFor( () =>
+			expect(
+				screen.getByText( 'Click for Delicious Gnocchi' )
+			).toBeInTheDocument()
+		);
+	} );
+	it( 'should not render tooltip', async () => {
+		render(
+			<ToggleGroupControl label="Test Toggle Group Control">
+				{ optionsWithTooltip }
+			</ToggleGroupControl>
+		);
+		const secondRadio = screen.getByLabelText(
+			'Click for Sumptuous Caponata'
+		);
+		fireEvent.mouseOver( secondRadio );
+		await waitFor( () =>
+			expect(
+				screen.queryByText( 'Click for Sumptuous Caponata' )
+			).not.toBeInTheDocument()
+		);
 	} );
 } );

--- a/packages/components/src/toggle-group-control/test/index.js
+++ b/packages/components/src/toggle-group-control/test/index.js
@@ -1,14 +1,23 @@
 /**
  * External dependencies
  */
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * Internal dependencies
  */
 import { ToggleGroupControl, ToggleGroupControlOption } from '../index';
+import { TOOLTIP_DELAY } from '../../tooltip';
 
 describe( 'ToggleGroupControl', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
 	const options = (
 		<>
 			<ToggleGroupControlOption value="rigas" label="R" />
@@ -30,16 +39,20 @@ describe( 'ToggleGroupControl', () => {
 			/>
 		</>
 	);
+
 	it( 'should render correctly', () => {
 		const { container } = render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ options }
 			</ToggleGroupControl>
 		);
+
 		expect( container.firstChild ).toMatchSnapshot();
 	} );
+
 	it( 'should call onChange with proper value', () => {
 		const mockOnChange = jest.fn();
+
 		render(
 			<ToggleGroupControl
 				value="jack"
@@ -49,40 +62,50 @@ describe( 'ToggleGroupControl', () => {
 				{ options }
 			</ToggleGroupControl>
 		);
+
 		const firstRadio = screen.getByRole( 'radio', { name: 'R' } );
+
 		fireEvent.click( firstRadio );
+
 		expect( mockOnChange ).toHaveBeenCalledWith( 'rigas' );
 	} );
-	it( 'should render tooltip where `showTooltip` === `true`', async () => {
+	it( 'should render tooltip where `showTooltip` === `true`', () => {
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
 			</ToggleGroupControl>
 		);
+
 		const firstRadio = screen.getByLabelText(
 			'Click for Delicious Gnocchi'
 		);
-		fireEvent.mouseOver( firstRadio );
-		await waitFor( () =>
+
+		fireEvent.mouseEnter( firstRadio );
+
+		setTimeout( () => {
 			expect(
 				screen.getByText( 'Click for Delicious Gnocchi' )
-			).toBeInTheDocument()
-		);
+			).toBeInTheDocument();
+		}, TOOLTIP_DELAY );
 	} );
-	it( 'should not render tooltip', async () => {
+
+	it( 'should not render tooltip', () => {
 		render(
 			<ToggleGroupControl label="Test Toggle Group Control">
 				{ optionsWithTooltip }
 			</ToggleGroupControl>
 		);
+
 		const secondRadio = screen.getByLabelText(
 			'Click for Sumptuous Caponata'
 		);
-		fireEvent.mouseOver( secondRadio );
-		await waitFor( () =>
+
+		fireEvent.mouseEnter( secondRadio );
+
+		setTimeout( () => {
 			expect(
 				screen.queryByText( 'Click for Sumptuous Caponata' )
-			).not.toBeInTheDocument()
-		);
+			).not.toBeInTheDocument();
+		}, TOOLTIP_DELAY );
 	} );
 } );

--- a/packages/components/src/toggle-group-control/test/index.js
+++ b/packages/components/src/toggle-group-control/test/index.js
@@ -7,17 +7,8 @@ import { render, fireEvent, screen } from '@testing-library/react';
  * Internal dependencies
  */
 import { ToggleGroupControl, ToggleGroupControlOption } from '../index';
-import { TOOLTIP_DELAY } from '../../tooltip';
 
 describe( 'ToggleGroupControl', () => {
-	beforeEach( () => {
-		jest.useFakeTimers();
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
-	} );
-
 	const options = (
 		<>
 			<ToggleGroupControlOption value="rigas" label="R" />
@@ -80,13 +71,11 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Delicious Gnocchi'
 		);
 
-		fireEvent.mouseEnter( firstRadio );
+		fireEvent.focus( firstRadio );
 
-		setTimeout( () => {
-			expect(
-				screen.getByText( 'Click for Delicious Gnocchi' )
-			).toBeInTheDocument();
-		}, TOOLTIP_DELAY );
+		expect(
+			screen.getByText( 'Click for Delicious Gnocchi' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should not render tooltip', () => {
@@ -100,12 +89,10 @@ describe( 'ToggleGroupControl', () => {
 			'Click for Sumptuous Caponata'
 		);
 
-		fireEvent.mouseEnter( secondRadio );
+		fireEvent.focus( secondRadio );
 
-		setTimeout( () => {
-			expect(
-				screen.queryByText( 'Click for Sumptuous Caponata' )
-			).not.toBeInTheDocument();
-		}, TOOLTIP_DELAY );
+		expect(
+			screen.queryByText( 'Click for Sumptuous Caponata' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/README.md
@@ -18,7 +18,7 @@ import {
 function Example() {
 	return (
 		<ToggleGroupControl label="my label" value="vertical" isBlock>
-			<ToggleGroupControlOption value="horizontal" label="Horizontal" />
+			<ToggleGroupControlOption value="horizontal" label="Horizontal" showTooltip={ true } />
 			<ToggleGroupControlOption value="vertical" label="Vertical" />
 		</ToggleGroupControl>
 	);
@@ -38,3 +38,10 @@ Label for the option. If needed, the `aria-label` prop can be used in addition t
 The value of the `ToggleGroupControlOption`.
 
 - Required: Yes
+
+### `showTooltip`: `boolean`
+
+Whether to show a tooltip when hovering over the option. The tooltip will attempt to use the `aria-label` prop text first, then the `label` prop text if no `aria-label` prop is found.
+
+- Required: No
+

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -24,6 +24,7 @@ import type { ToggleGroupControlOptionProps } from '../types';
 import { useToggleGroupControlContext } from '../context';
 import * as styles from './styles';
 import { useCx } from '../../utils/hooks';
+import Tooltip from '../../tooltip';
 
 const { ButtonContentView, LabelPlaceholderView, LabelView } = styles;
 
@@ -57,20 +58,25 @@ function ToggleGroupControlOption(
 
 	return (
 		<LabelView className={ labelViewClasses } data-active={ isActive }>
-			<Radio
-				{ ...radioProps }
-				as="button"
-				aria-label={ radioProps[ 'aria-label' ] ?? label }
-				className={ classes }
-				data-value={ value }
-				ref={ forwardedRef }
-				value={ value }
+			<Tooltip
+				text={ radioProps[ 'aria-label' ] ?? label }
+				position="top center"
 			>
-				<ButtonContentView>{ label }</ButtonContentView>
-				<LabelPlaceholderView aria-hidden>
-					{ label }
-				</LabelPlaceholderView>
-			</Radio>
+				<Radio
+					{ ...radioProps }
+					as="button"
+					aria-label={ radioProps[ 'aria-label' ] ?? label }
+					className={ classes }
+					data-value={ value }
+					ref={ forwardedRef }
+					value={ value }
+				>
+					<ButtonContentView>{ label }</ButtonContentView>
+					<LabelPlaceholderView aria-hidden>
+						{ label }
+					</LabelPlaceholderView>
+				</Radio>
+			</Tooltip>
 		</LabelView>
 	);
 }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -20,13 +20,27 @@ import {
 	useContextSystem,
 	WordPressComponentProps,
 } from '../../ui/context';
-import type { ToggleGroupControlOptionProps } from '../types';
+import type { ToggleGroupControlOptionProps, WithToolTipProps } from '../types';
 import { useToggleGroupControlContext } from '../context';
 import * as styles from './styles';
 import { useCx } from '../../utils/hooks';
 import Tooltip from '../../tooltip';
 
 const { ButtonContentView, LabelPlaceholderView, LabelView } = styles;
+
+const WithToolTip = ( {
+	text,
+	children,
+}: WordPressComponentProps< WithToolTipProps, 'div' > ) => {
+	if ( !! text ) {
+		return (
+			<Tooltip text={ text } position="top center">
+				{ children }
+			</Tooltip>
+		);
+	}
+	return <>{ children }</>;
+};
 
 function ToggleGroupControlOption(
 	props: WordPressComponentProps< ToggleGroupControlOptionProps, 'button' >,
@@ -42,7 +56,14 @@ function ToggleGroupControlOption(
 		'ToggleGroupControlOption'
 	);
 
-	const { className, isBlock = false, label, value, ...radioProps } = {
+	const {
+		className,
+		isBlock = false,
+		label,
+		value,
+		tooltipText,
+		...radioProps
+	} = {
 		...toggleGroupControlContext,
 		...buttonProps,
 	};
@@ -58,10 +79,7 @@ function ToggleGroupControlOption(
 
 	return (
 		<LabelView className={ labelViewClasses } data-active={ isActive }>
-			<Tooltip
-				text={ radioProps[ 'aria-label' ] ?? label }
-				position="top center"
-			>
+			<WithToolTip text={ tooltipText }>
 				<Radio
 					{ ...radioProps }
 					as="button"
@@ -76,7 +94,7 @@ function ToggleGroupControlOption(
 						{ label }
 					</LabelPlaceholderView>
 				</Radio>
-			</Tooltip>
+			</WithToolTip>
 		</LabelView>
 	);
 }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -9,7 +9,6 @@ import { Radio } from 'reakit';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -28,11 +27,8 @@ import Tooltip from '../../tooltip';
 
 const { ButtonContentView, LabelPlaceholderView, LabelView } = styles;
 
-const WithToolTip = ( {
-	text,
-	children,
-}: WordPressComponentProps< WithToolTipProps, 'div' > ) => {
-	if ( !! text ) {
+const WithToolTip = ( { showTooltip, text, children }: WithToolTipProps ) => {
+	if ( showTooltip && text ) {
 		return (
 			<Tooltip text={ text } position="top center">
 				{ children }
@@ -61,7 +57,7 @@ function ToggleGroupControlOption(
 		isBlock = false,
 		label,
 		value,
-		tooltipText,
+		showTooltip = false,
 		...radioProps
 	} = {
 		...toggleGroupControlContext,
@@ -76,14 +72,17 @@ function ToggleGroupControlOption(
 		className,
 		isActive && styles.buttonActive
 	);
+	const optionLabel = !! radioProps[ 'aria-label' ]
+		? radioProps[ 'aria-label' ]
+		: label;
 
 	return (
 		<LabelView className={ labelViewClasses } data-active={ isActive }>
-			<WithToolTip text={ tooltipText }>
+			<WithToolTip showTooltip={ showTooltip } text={ optionLabel }>
 				<Radio
 					{ ...radioProps }
 					as="button"
-					aria-label={ radioProps[ 'aria-label' ] ?? label }
+					aria-label={ optionLabel }
 					className={ classes }
 					data-value={ value }
 					ref={ forwardedRef }

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -18,6 +18,21 @@ export type ToggleGroupControlOptionProps = {
 	 * to specify a different label for assistive technologies.
 	 */
 	label: string;
+	/**
+	 * Label for the Tooltip component. If set, determines whether the tooltip is displayed.
+	 */
+	tooltipText?: string;
+};
+
+export type WithToolTipProps = {
+	/**
+	 * React children
+	 */
+	children: ReactNode;
+	/**
+	 * Label for the Tooltip component. If set, determines whether the tooltip is displayed.
+	 */
+	text?: string;
 };
 
 export type ToggleGroupControlProps = Omit<

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -19,9 +19,12 @@ export type ToggleGroupControlOptionProps = {
 	 */
 	label: string;
 	/**
-	 * Label for the Tooltip component. If set, determines whether the tooltip is displayed.
+	 * Whether to display a Tooltip for the control option. If set to `true`, the tooltip will
+	 * show the aria-label or the label prop text.
+	 *
+	 * @default false
 	 */
-	tooltipText?: string;
+	showTooltip?: boolean;
 };
 
 export type WithToolTipProps = {
@@ -30,9 +33,15 @@ export type WithToolTipProps = {
 	 */
 	children: ReactNode;
 	/**
-	 * Label for the Tooltip component. If set, determines whether the tooltip is displayed.
+	 * Label for the Tooltip component.
 	 */
-	text?: string;
+	text: string;
+	/**
+	 * Whether to wrap the control option in a Tooltip component.
+	 *
+	 * @default false
+	 */
+	showTooltip?: boolean;
 };
 
 export type ToggleGroupControlProps = Omit<

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -96,7 +96,7 @@ function Tooltip( {
 	children,
 	position,
 	text,
-	shortcut,
+	shortcut = null,
 	delay = TOOLTIP_DELAY,
 } ) {
 	/**

--- a/packages/components/src/tooltip/index.js
+++ b/packages/components/src/tooltip/index.js
@@ -92,13 +92,8 @@ const emitToChild = ( children, eventName, event ) => {
 	}
 };
 
-function Tooltip( {
-	children,
-	position,
-	text,
-	shortcut = null,
-	delay = TOOLTIP_DELAY,
-} ) {
+function Tooltip( props ) {
+	const { children, position, text, shortcut, delay = TOOLTIP_DELAY } = props;
 	/**
 	 * Whether a mouse is currently pressed, used in determining whether
 	 * to handle a focus event as displaying the tooltip immediately.


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/36545

## Description

Hey ho.

This PR takes a stab at adding tooltips to the font size segmented control.

The gist is that we're giving the user additional information about their font-size selection only otherwise available via `aria-label` (and not immediately visible in the browser).

Here's a sneak preview:

<img width="390" alt="Screen Shot 2021-11-22 at 9 05 41 pm" src="https://user-images.githubusercontent.com/6458278/142844574-940ef61f-197b-4ffb-a5ae-338471a353df.png">

<img width="403" alt="Screen Shot 2021-11-22 at 9 05 20 pm" src="https://user-images.githubusercontent.com/6458278/142844578-81ba3034-bcce-45e6-89c3-643eaf0108c9.png">

Why? At present the font size segmented control displays numerical values that are not the same as their descriptions. 

So `42` is `'Huge'`. 


```js
		{
			name: _x( 'Huge', 'font size name' ),
			size: 42,
			slug: 'huge',
		},
```

To achieve what we need, we've extended `ToggleGroupControlOption` to add a Tooltip wrapper around the radio component in the presence of a `tooltipText` prop.

There might be other use cases for this, for example, adding extra descriptive power 🚀 or visible hints to options. The limit is your imagination!


## How has this been tested?
`npm run storybook:dev`

Take a look at `FontSizePicker` and `ToggleGroupControl` (With Tooltip variation) : check that the tooltip appears.

Check that there are no regressions for existing usage of `ToggleGroupControlOption`. For example, inset a Navigation Block into the editor. The Overlay menu in the right-hand sidebar should look and work as expected. There should be no tooltips here.

<img width="285" alt="Screen Shot 2021-11-22 at 9 56 52 pm" src="https://user-images.githubusercontent.com/6458278/142943229-eeb612ad-806c-4020-9de3-b20b1f6d9252.png">

Another one is the Post Featured Image Block. Adjust the height dimensions and check the options group:

<img width="277" alt="Screen Shot 2021-11-23 at 9 19 30 am" src="https://user-images.githubusercontent.com/6458278/142943586-b00de2f5-37de-4217-870d-2270607f8f98.png">

Run the unit test:
`npm run test-unit packages/components/src/toggle-group-control/test/index.js`


## Types of changes
Adding a feature to an existing component.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
