### PR TITLE
[Icons]: Fix Comment Author Name icon

### DIFF
--- a/packages/icons/src/library/comment-author-name.js
+++ b/packages/icons/src/library/comment-author-name.js
@@ -4,7 +4,7 @@
 import { SVG, Path, Circle } from '@wordpress/primitives';
 
 const commentAuthorName = (
-	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="#FFFFFF">
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 		<Path
 			d="M18 4H6c-1.1 0-2 .9-2 2v12.9c0 .6.5 1.1 1.1 1.1.3 0 .5-.1.8-.3L8.5 17H18c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 11c0 .3-.2.5-.5.5H7.9l-2.4 2.4V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v9z"
 			fillRule="evenodd"


### PR DESCRIPTION
Noticed this as well while reviewing another PR. You can see the problem in GS sidebar when clicking `block` to see the list of all of the blocks.