### PR TITLE
Use first non-empty Nav post as primary fallback for Nav block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -218,8 +218,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering the Page List block.
 	if ( empty( $inner_blocks ) ) {
-		$is_fallback                      = true; // indicate we are rendering the fallback.
-		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
+		$is_fallback = true; // indicate we are rendering the fallback.
 
 		$navigation_posts = get_posts(
 			array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -138,7 +138,7 @@ function block_core_navigation_render_submenu_icon() {
  *
  * @return WP_Post|null the first non-empty Navigation or null.
  */
-function get_non_empty_navigation_post() {
+function block_core_navigation_get_non_empty_navigation() {
 	$navigation_posts = get_posts(
 		array(
 			'post_type' => 'wp_navigation',
@@ -167,8 +167,8 @@ function get_non_empty_navigation_post() {
  *
  * @return array the array of blocks to be used as a fallback.
  */
-function get_fallback() {
-	$navigation_post = get_non_empty_navigation_post();
+function block_core_navigation_get_fallback() {
+	$navigation_post = block_core_navigation_get_non_empty_navigation();
 
 	// Use non-empty Navigation if available.
 	if ( $navigation_post ) {
@@ -275,7 +275,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$is_fallback                      = true; // indicate we are rendering the fallback.
 		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
 
-		$fallback_blocks = get_fallback();
+		$fallback_blocks = block_core_navigation_get_fallback();
 
 		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
 	}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -200,7 +200,11 @@ function block_core_navigation_get_fallback() {
 
 	// Prefer using the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
-		$fallback_blocks = block_core_navigation_normalize_parsed_blocks( parse_blocks( $navigation_post->post_content ) );
+		$maybe_fallback = block_core_navigation_normalize_parsed_blocks( parse_blocks( $navigation_post->post_content ) );
+
+		// Normalizing blocks may result in an empty array of blocks if they were all `null` blocks.
+		// In this case default to the (Page List) fallback.
+		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
 
 	return $fallback_blocks;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -132,6 +132,32 @@ function block_core_navigation_render_submenu_icon() {
 	return '<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12" fill="none" role="img" aria-hidden="true" focusable="false"><path d="M1.50002 4L6.00002 8L10.5 4" stroke-width="1.5"></path></svg>';
 }
 
+
+/**
+ * Finds the first non-empty `wp_navigation` Post.
+ *
+ * @return WP_Post|null the first non-empty Navigation or null.
+ */
+function get_non_empty_navigation_post() {
+	$navigation_posts = get_posts(
+		array(
+			'post_type' => 'wp_navigation',
+		)
+	);
+
+	$navigation_post = null;
+
+	// Pick first non-empty Navigation.
+	foreach ( $navigation_posts as $navigation_maybe ) {
+		if ( ! empty( $navigation_maybe->post_content ) ) {
+			$navigation_post = $navigation_maybe;
+			break;
+		}
+	}
+
+	return $navigation_post;
+}
+
 /**
  * Renders the `core/navigation` block on server.
  *
@@ -220,21 +246,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	if ( empty( $inner_blocks ) ) {
 		$is_fallback = true; // indicate we are rendering the fallback.
 
-		$navigation_posts = get_posts(
-			array(
-				'post_type' => 'wp_navigation',
-			)
-		);
-
-		$navigation_post = null;
-
-		// Pick first non-empty Navigation.
-		foreach ( $navigation_posts as $navigation_maybe ) {
-			if ( ! empty( $navigation_maybe->post_content ) ) {
-				$navigation_post = $navigation_maybe;
-				break;
-			}
-		}
+		$navigation_post = get_non_empty_navigation_post();
 
 		// Use non-empty Navigation if available.
 		if ( $navigation_post ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -168,19 +168,25 @@ function block_core_navigation_get_non_empty_navigation() {
  * @return array the array of blocks to be used as a fallback.
  */
 function block_core_navigation_get_fallback() {
+
+	// Default to a list of Pages.
+	$fallback_blocks = array(
+		array(
+			'blockName' => 'core/page-list',
+			'attrs'     => array(),
+		),
+	);
+
 	$navigation_post = block_core_navigation_get_non_empty_navigation();
 
-	// Use non-empty Navigation if available.
+	// Prefer using the first non-empty Navigation as fallback if available.
 	if ( $navigation_post ) {
-		$fallback_blocks = parse_blocks( $navigation_post->post_content );
-	} else {
-		// Requires wrapping array.
-		$fallback_blocks = array(
-			array(
-				'blockName' => 'core/page-list',
-				'attrs'     => array(),
-			),
-		);
+		$maybe_fallback = parse_blocks( $navigation_post->post_content );
+
+		// If block is unable to be parsed the parser fallsback to a null blockname. This can happen if the block
+		// in the content is not registered or is invalid.
+		// Add additional safety check to avoid invalid block being treated as valid fallback.
+		$fallback_blocks = ! empty( $maybe_fallback[0] ) && null !== $maybe_fallback[0]['blockName'] ? $maybe_fallback : $fallback_blocks;
 	}
 
 	return $fallback_blocks;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -221,12 +221,38 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$is_fallback                      = true; // indicate we are rendering the fallback.
 		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
 
-		$page_list_block = array(
-			'blockName' => 'core/page-list',
-			'attrs'     => array(),
+		$navigation_posts = get_posts(
+			array(
+				'post_type' => 'wp_navigation',
+			)
 		);
 
-		$inner_blocks = new WP_Block_List( array( $page_list_block ), $attributes );
+		$navigation_post = null;
+
+		// Pick first non-empty Navigation.
+		foreach ( $navigation_posts as $navigation_maybe ) {
+			if ( ! empty( $navigation_maybe->post_content ) ) {
+				$navigation_post = $navigation_maybe;
+				break;
+			}
+		}
+
+		// Use non-empty Navigation if available.
+		if ( $navigation_post ) {
+			$fallback_blocks = parse_blocks( $navigation_post->post_content );
+		} else {
+			$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
+
+			// Requires wrapping array.
+			$fallback_blocks = array(
+				array(
+					'blockName' => 'core/page-list',
+					'attrs'     => array(),
+				),
+			);
+		}
+
+		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
 	}
 
 	// Restore legacy classnames for submenu positioning.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -148,7 +148,7 @@ function block_core_navigation_get_non_empty_navigation() {
 			'post_type'      => 'wp_navigation',
 			'order'          => 'ASC',
 			'orderby'        => 'name',
-			'posts_per_page' => -1, // include all posts.
+			'posts_per_page' => 1, // only the first post
 			's'              => '<!--', // look for block indicators to ensure we only include non-empty Navigations.
 		)
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -139,10 +139,15 @@ function block_core_navigation_render_submenu_icon() {
  * @return WP_Post|null the first non-empty Navigation or null.
  */
 function block_core_navigation_get_non_empty_navigation() {
+	// Order and orderby args set to mirror those in `wp_get_nav_menus`
+	// see:
+	// - https://github.com/WordPress/wordpress-develop/blob/ba943e113d3b31b121f77a2d30aebe14b047c69d/src/wp-includes/nav-menu.php#L613-L619.
+	// - https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters.
 	$navigation_posts = get_posts(
 		array(
 			'post_type' => 'wp_navigation',
-			'order'     => 'DESC',
+			'order'     => 'ASC',
+			'orderby'   => 'name',
 		)
 	);
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -148,7 +148,7 @@ function block_core_navigation_get_non_empty_navigation() {
 			'post_type'      => 'wp_navigation',
 			'order'          => 'ASC',
 			'orderby'        => 'name',
-			'posts_per_page' => 1, // only the first post
+			'posts_per_page' => 1, // only the first post.
 			's'              => '<!--', // look for block indicators to ensure we only include non-empty Navigations.
 		)
 	);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -221,7 +221,10 @@ function block_core_navigation_get_fallback() {
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
 
+	// Flag used to indicate whether the rendered output is considered to be
+	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
+
 	/**
 	 * Deprecated:
 	 * The rgbTextColor and rgbBackgroundColor attributes

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -145,23 +145,15 @@ function block_core_navigation_get_non_empty_navigation() {
 	// - https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters.
 	$navigation_posts = get_posts(
 		array(
-			'post_type' => 'wp_navigation',
-			'order'     => 'ASC',
-			'orderby'   => 'name',
+			'post_type'      => 'wp_navigation',
+			'order'          => 'ASC',
+			'orderby'        => 'name',
+			'posts_per_page' => -1, // include all posts.
+			's'              => '<!--', // look for block indicators to ensure we only include non-empty Navigations.
 		)
 	);
+	return count( $navigation_posts ) ? $navigation_posts[0] : null;
 
-	$navigation_post = null;
-
-	// Pick first non-empty Navigation.
-	foreach ( $navigation_posts as $navigation_maybe ) {
-		if ( ! empty( $navigation_maybe->post_content ) ) {
-			$navigation_post = $navigation_maybe;
-			break;
-		}
-	}
-
-	return $navigation_post;
 }
 
 /**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -187,7 +187,6 @@ function block_core_navigation_normalize_parsed_blocks( $parsed_blocks ) {
  * @return array the array of blocks to be used as a fallback.
  */
 function block_core_navigation_get_fallback() {
-
 	// Default to a list of Pages.
 	$fallback_blocks = array(
 		array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -142,6 +142,7 @@ function block_core_navigation_get_non_empty_navigation() {
 	$navigation_posts = get_posts(
 		array(
 			'post_type' => 'wp_navigation',
+			'order'     => 'DESC',
 		)
 	);
 
@@ -159,8 +160,10 @@ function block_core_navigation_get_non_empty_navigation() {
 }
 
 /**
+ * Filter out empty "null" blocks from the block list.
  * 'parse_blocks' includes a null block with '\n\n' as the content when
- * it encounters whitespace. This code strips it.
+ * it encounters whitespace. This is not a bug but rather how the parser
+ * is designed.
  *
  * @param array $parsed_blocks the parsed blocks to be normalized.
  * @return array the normalized parsed blocks.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/36724 we added the Page List block as a fallback for when the Nav block has no menu selected.

This PR iterates on that idea by preferring to use the first non-empty Navigation (i.e. `wp_navigation` Post) as the primary fallback. Only if a suitable Navigation Post is not found do we fallback (again!) to the Page List.

This aims to mirror how the fallback mechanic for `wp_nav_menu` works currently in Core (as [described in the Issue](https://github.com/WordPress/gutenberg/issues/36721)).

Closes https://github.com/WordPress/gutenberg/issues/36721

## How has this been tested?

Testing is as follows:

### Preparation

* Before testing use Fakerpress Plugin (or similar) to add a load of pages to your site. Some should be nested parent/child.
* Also use the Nav block to create one or two Menus on your site being sure to add some items. Make sure they are saved as Navigation post types (check by going to `Appearance -> Navigation`).

### Testing
- Open Site Editor.
- Remove any existing Nav block.
-  Add Nav block from scratch. Don't add any items!
- Save your empty Nav block and publish the post.
- Go to front of site.
- See that the first of your Navigation Menus is rendered by _default_ even though no Menu has been selected.
-  Remove _all of the items_ from the Navigation Post that is currently being used as the fallback - this should make it ineligible to be used as a fallback.
-  Go to front of site. Check that a different Navigation Post is being used as a fallback.
- Remove _all_ your Navigation Posts - that's right, ditch them all!
- Go to front of site. Check that it falls back to the Page List.


## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality) 
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
