### PR TITLE
Update: Migrate global styles user database data on the rest endpoint

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -216,8 +216,12 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response $data
 	 */
 	public function prepare_item_for_response( $post, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$config                           = json_decode( $post->post_content, true );
-		$is_global_styles_user_theme_json = isset( $config['isGlobalStylesUserThemeJSON'] ) && true === $config['isGlobalStylesUserThemeJSON'];
+		$raw_config                       = json_decode( $post->post_content, true );
+		$is_global_styles_user_theme_json = isset( $raw_config['isGlobalStylesUserThemeJSON'] ) && true === $raw_config['isGlobalStylesUserThemeJSON'];
+		$config;
+		if( $is_global_styles_user_theme_json ) {
+			$config = ( new WP_Theme_JSON_Gutenberg( $raw_config, 'user' ) )->get_raw_data();
+		}
 
 		$fields = $this->get_fields_for_response( $request );
 

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -218,8 +218,8 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 	public function prepare_item_for_response( $post, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$raw_config                       = json_decode( $post->post_content, true );
 		$is_global_styles_user_theme_json = isset( $raw_config['isGlobalStylesUserThemeJSON'] ) && true === $raw_config['isGlobalStylesUserThemeJSON'];
-		$config;
-		if( $is_global_styles_user_theme_json ) {
+		$config                           = array();
+		if ( $is_global_styles_user_theme_json ) {
 			$config = ( new WP_Theme_JSON_Gutenberg( $raw_config, 'user' ) )->get_raw_data();
 		}
 


### PR DESCRIPTION
After merging https://github.com/WordPress/gutenberg/pull/36674, I noticed although we were back-compatible on the frontend we were not being back-compatible on the site editor because our migration logic was not being called on the rest endpoint. This PR fixes the issue and makes sure that the data returned by the endpoint passes by the WP_Theme_JSON_Gutenberg constructor which includes migration and back-compatibility logic.



## How has this been tested?
I made the global styles CPT equal to:
```
{"styles":{"color":{"background":"var:preset|color|red"}},"settings":{"color":{"palette":[{"color":"#000","name":"black","slug":"black"},{"color":"#f51b1b","name":"red","slug":"red"}]}},"isGlobalStylesUserThemeJSON":true,"version":2}
```
To force global styles CPT to have the previous value I changed show_ui to true in lib/class-wp-theme-json-resolver-gutenberg.php and opened the CPT on the editor and pasted the data. Changing the post using phpmyadmin or a similar tool is also ok.

I opened the site editor and verified everything looks as excepted and the palette provided is assumed to be the user one.
