### PR TITLE
Update: Rename user preset origin to custom

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -37,7 +37,7 @@ class WP_Theme_JSON_Gutenberg {
 	const VALID_ORIGINS = array(
 		'default',
 		'theme',
-		'user',
+		'custom',
 	);
 
 	const VALID_TOP_LEVEL_KEYS = array(
@@ -281,7 +281,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * Constructor.
 	 *
 	 * @param array  $theme_json A structure that follows the theme.json schema.
-	 * @param string $origin What source of data this object represents. One of default, theme, or user. Default: theme.
+	 * @param string $origin What source of data this object represents. One of default, theme, or custom. Default: theme.
 	 */
 	public function __construct( $theme_json = array(), $origin = 'theme' ) {
 		if ( ! in_array( $origin, self::VALID_ORIGINS, true ) ) {
@@ -1265,7 +1265,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *                         'variables': only the CSS Custom Properties for presets & custom ones.
 	 *                         'styles': only the styles section in theme.json.
 	 *                         'presets': only the classes for the presets.
-	 * @param array $origins A list of origins to include. By default it includes 'default', 'theme', and 'user'.
+	 * @param array $origins A list of origins to include. By default it includes 'default', 'theme', and 'custom'.
 	 *
 	 * @return string Stylesheet.
 	 */

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -262,7 +262,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$json_decoding_error = json_last_error();
 			if ( JSON_ERROR_NONE !== $json_decoding_error ) {
 				trigger_error( 'Error when decoding a theme.json schema for user data. ' . json_last_error_msg() );
-				return new WP_Theme_JSON_Gutenberg( $config, 'user' );
+				return new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 			}
 
 			// Very important to verify if the flag isGlobalStylesUserThemeJSON is true.
@@ -276,14 +276,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				$config = $decoded_data;
 			}
 		}
-		self::$user = new WP_Theme_JSON_Gutenberg( $config, 'user' );
+		self::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 
 		return self::$user;
 	}
 
 	/**
 	 * There are three sources of data (origins) for a site:
-	 * default, theme, and user. The user's has higher priority
+	 * default, theme, and custom. The custom's has higher priority
 	 * than the theme's, and the theme's higher than defaults's.
 	 *
 	 * Unlike the getters {@link get_core_data},
@@ -298,17 +298,17 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * the user preference wins.
 	 *
 	 * @param string $origin To what level should we merge data.
-	 *                       Valid values are 'theme' or 'user'.
-	 *                       Default is 'user'.
+	 *                       Valid values are 'theme' or 'custom'.
+	 *                       Default is 'custom'.
 	 *
 	 * @return WP_Theme_JSON_Gutenberg
 	 */
-	public static function get_merged_data( $origin = 'user' ) {
+	public static function get_merged_data( $origin = 'custom' ) {
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
 		$result->merge( self::get_theme_data() );
 
-		if ( 'user' === $origin ) {
+		if ( 'custom' === $origin ) {
 			$result->merge( self::get_user_data() );
 		}
 

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -27,7 +27,7 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
 
-	$origin = 'user';
+	$origin = 'custom';
 	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
 	}
@@ -59,7 +59,7 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
 
-	$origin = 'user';
+	$origin = 'custom';
 	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
 		$origin = 'theme';
 	}
@@ -105,7 +105,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		$types = array( 'variables', 'styles', 'presets' );
 	}
 
-	$origins = array( 'default', 'theme', 'user' );
+	$origins = array( 'default', 'theme', 'custom' );
 	if ( ! $supports_theme_json && ! $supports_link_color ) {
 		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
 		$origins = array( 'default' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -110,8 +110,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];
-		$settings['colors'] = isset( $colors_by_origin['user'] ) ?
-			$colors_by_origin['user'] : (
+		$settings['colors'] = isset( $colors_by_origin['custom'] ) ?
+			$colors_by_origin['custom'] : (
 				isset( $colors_by_origin['theme'] ) ?
 					$colors_by_origin['theme'] :
 					$colors_by_origin['default']
@@ -120,8 +120,8 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( isset( $settings['__experimentalFeatures']['color']['gradients'] ) ) {
 		$gradients_by_origin   = $settings['__experimentalFeatures']['color']['gradients'];
-		$settings['gradients'] = isset( $gradients_by_origin['user'] ) ?
-			$gradients_by_origin['user'] : (
+		$settings['gradients'] = isset( $gradients_by_origin['custom'] ) ?
+			$gradients_by_origin['custom'] : (
 				isset( $gradients_by_origin['theme'] ) ?
 					$gradients_by_origin['theme'] :
 					$gradients_by_origin['default']
@@ -130,7 +130,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 	if ( isset( $settings['__experimentalFeatures']['typography']['fontSizes'] ) ) {
 		$font_sizes_by_origin  = $settings['__experimentalFeatures']['typography']['fontSizes'];
-		$settings['fontSizes'] = isset( $font_sizes_by_origin['user'] ) ?
+		$settings['fontSizes'] = isset( $font_sizes_by_origin['custom'] ) ?
 			$font_sizes_by_origin['user'] : (
 				isset( $font_sizes_by_origin['theme'] ) ?
 					$font_sizes_by_origin['theme'] :

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -172,7 +172,7 @@ const PanelColorGradientSettingsSingleSelect = ( props ) => {
 
 const PanelColorGradientSettingsMultipleSelect = ( props ) => {
 	const colorGradientSettings = useCommonSingleMultipleSelects();
-	const customColors = useSetting( 'color.palette.user' );
+	const customColors = useSetting( 'color.palette.custom' );
 	const themeColors = useSetting( 'color.palette.theme' );
 	const defaultColors = useSetting( 'color.palette.default' );
 	const shouldDisplayDefaultColors = useSetting( 'color.defaultPalette' );
@@ -213,7 +213,7 @@ const PanelColorGradientSettingsMultipleSelect = ( props ) => {
 		return result;
 	}, [ defaultColors, themeColors, customColors ] );
 
-	const customGradients = useSetting( 'color.gradients.user' );
+	const customGradients = useSetting( 'color.gradients.custom' );
 	const themeGradients = useSetting( 'color.gradients.theme' );
 	const defaultGradients = useSetting( 'color.gradients.default' );
 	const shouldDisplayDefaultGradients = useSetting(

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -117,7 +117,7 @@ export default function useSetting( path ) {
 			if ( experimentalFeaturesResult !== undefined ) {
 				if ( PATHS_WITH_MERGE[ normalizedPath ] ) {
 					return (
-						experimentalFeaturesResult.user ??
+						experimentalFeaturesResult.custom ??
 						experimentalFeaturesResult.theme ??
 						experimentalFeaturesResult.default
 					);

--- a/packages/components/src/mobile/global-styles-context/utils.native.js
+++ b/packages/components/src/mobile/global-styles-context/utils.native.js
@@ -233,10 +233,10 @@ export function parseStylesVariables( styles, mappedValues, customValues ) {
 
 export function getMappedValues( features, palette ) {
 	const typography = features?.typography;
-	const colors = { ...palette?.theme, ...palette?.user };
+	const colors = { ...palette?.theme, ...palette?.custom };
 	const fontSizes = {
 		...typography?.fontSizes?.theme,
-		...typography?.fontSizes?.user,
+		...typography?.fontSizes?.custom,
 	};
 	const mappedValues = {
 		color: {

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -32,7 +32,7 @@ export default function ColorPalettePanel( { name } ) {
 		'base'
 	);
 	const [ customColors, setCustomColors ] = useSetting(
-		'color.palette.user',
+		'color.palette.custom',
 		name
 	);
 

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -45,12 +45,14 @@ export function useSetting( path, blockName, source = 'all' ) {
 		? `settings.${ path }`
 		: `settings.blocks.${ blockName }.${ path }`;
 
+		console.log( {mergedConfig, userConfig });
 	const setSetting = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
 			const newUserConfig = cloneDeep( currentConfig );
 			const pathToSet = PATHS_WITH_MERGE[ path ]
-				? fullPath + '.user'
+				? fullPath + '.custom'
 				: fullPath;
+			console.log('setSetting', { pathToSet, newValue });
 			set( newUserConfig, pathToSet, newValue );
 
 			return newUserConfig;
@@ -65,7 +67,7 @@ export function useSetting( path, blockName, source = 'all' ) {
 		const getSettingValue = ( configToUse ) => {
 			const result = get( configToUse, currentPath );
 			if ( PATHS_WITH_MERGE[ path ] ) {
-				return result?.user ?? result?.theme ?? result?.default;
+				return result?.custom ?? result?.theme ?? result?.default;
 			}
 			return result;
 		};
@@ -218,7 +220,7 @@ export function getSupportedGlobalStylesPanels( name ) {
 }
 
 export function useColorsPerOrigin( name ) {
-	const [ customColors ] = useSetting( 'color.palette.user', name );
+	const [ customColors ] = useSetting( 'color.palette.custom', name );
 	const [ themeColors ] = useSetting( 'color.palette.theme', name );
 	const [ defaultColors ] = useSetting( 'color.palette.default', name );
 	const [ shouldDisplayDefaultColors ] = useSetting( 'color.defaultPalette' );
@@ -261,7 +263,7 @@ export function useColorsPerOrigin( name ) {
 }
 
 export function useGradientsPerOrigin( name ) {
-	const [ customGradients ] = useSetting( 'color.gradients.user', name );
+	const [ customGradients ] = useSetting( 'color.gradients.custom', name );
 	const [ themeGradients ] = useSetting( 'color.gradients.theme', name );
 	const [ defaultGradients ] = useSetting( 'color.gradients.default', name );
 	const [ shouldDisplayDefaultGradients ] = useSetting(

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -45,14 +45,12 @@ export function useSetting( path, blockName, source = 'all' ) {
 		? `settings.${ path }`
 		: `settings.blocks.${ blockName }.${ path }`;
 
-		console.log( {mergedConfig, userConfig });
 	const setSetting = ( newValue ) => {
 		setUserConfig( ( currentConfig ) => {
 			const newUserConfig = cloneDeep( currentConfig );
 			const pathToSet = PATHS_WITH_MERGE[ path ]
 				? fullPath + '.custom'
 				: fullPath;
-			console.log('setSetting', { pathToSet, newValue });
 			set( newUserConfig, pathToSet, newValue );
 
 			return newUserConfig;

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -22,7 +22,7 @@ import { useSetting } from './hooks';
 const EMPTY_COLORS = [];
 
 function Palette( { name } ) {
-	const [ colorsSetting ] = useSetting( 'color.palette.user', name );
+	const [ colorsSetting ] = useSetting( 'color.palette.custom', name );
 	const colors = colorsSetting || EMPTY_COLORS;
 	const screenPath = ! name
 		? '/colors/palette'

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -206,7 +206,7 @@ describe( 'global styles renderer', () => {
 				settings: {
 					color: {
 						palette: {
-							user: [
+							custom: [
 								{
 									name: 'White',
 									slug: 'white',

--- a/packages/edit-site/src/components/global-styles/test/utils.js
+++ b/packages/edit-site/src/components/global-styles/test/utils.js
@@ -21,7 +21,7 @@ describe( 'editor utils', () => {
 							name: 'Secondary',
 						},
 					],
-					user: [
+					custom: [
 						{
 							slug: 'primary',
 							color: '#007cba',

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -60,7 +60,7 @@ function getPresetsDeclarations( blockPresets = {} ) {
 		PRESET_METADATA,
 		( declarations, { path, valueKey, cssVarInfix } ) => {
 			const presetByOrigin = get( blockPresets, path, [] );
-			[ 'default', 'theme', 'user' ].forEach( ( origin ) => {
+			[ 'default', 'theme', 'custom' ].forEach( ( origin ) => {
 				if ( presetByOrigin[ origin ] ) {
 					presetByOrigin[ origin ].forEach( ( value ) => {
 						declarations.push(
@@ -94,7 +94,7 @@ function getPresetsClasses( blockSelector, blockPresets = {} ) {
 			}
 
 			const presetByOrigin = get( blockPresets, path, [] );
-			[ 'default', 'theme', 'user' ].forEach( ( origin ) => {
+			[ 'default', 'theme', 'custom' ].forEach( ( origin ) => {
 				if ( presetByOrigin[ origin ] ) {
 					presetByOrigin[ origin ].forEach( ( { slug } ) => {
 						classes.forEach( ( { classSuffix, propertyName } ) => {

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -90,7 +90,7 @@ function findInPresetsBy(
 	for ( const presetByOrigin of orderedPresetsByOrigin ) {
 		if ( presetByOrigin ) {
 			// Preset origins ordered by priority.
-			const origins = [ 'user', 'theme', 'default' ];
+			const origins = [ 'custom', 'theme', 'default' ];
 			for ( const origin of origins ) {
 				const presets = presetByOrigin[ origin ];
 				if ( presets ) {

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1237,7 +1237,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'color'   => array(
 						'custom'  => true,
 						'palette' => array(
-							'user' => array(
+							'custom' => array(
 								array(
 									'name'  => 'Red',
 									'slug'  => 'red',
@@ -1264,7 +1264,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'color'   => array(
 								'custom'  => true,
 								'palette' => array(
-									'user' => array(
+									'custom' => array(
 										array(
 											'name'  => 'Yellow',
 											'slug'  => 'yellow',
@@ -1297,7 +1297,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'  => array(
 					'palette' => array(
-						'user' => array(
+						'custom' => array(
 							array(
 								'name'  => 'Red',
 								'slug'  => 'red',
@@ -1320,7 +1320,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								'user' => array(
+								'custom' => array(
 									array(
 										'name'  => 'Yellow',
 										'slug'  => 'yellow',
@@ -1353,7 +1353,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'settings' => array(
 					'color'      => array(
 						'palette' => array(
-							'user' => array(
+							'custom' => array(
 								array(
 									'name'  => 'Red/><b>ok</ok>',
 									'slug'  => 'red',
@@ -1379,7 +1379,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					),
 					'typography' => array(
 						'fontFamilies' => array(
-							'user' => array(
+							'custom' => array(
 								array(
 									'name'       => 'Helvetica Arial/><b>test</b>',
 									'slug'       => 'helvetica-arial',
@@ -1407,7 +1407,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'core/group' => array(
 							'color' => array(
 								'palette' => array(
-									'user' => array(
+									'custom' => array(
 										array(
 											'name'  => 'Red/><b>ok</ok>',
 											'slug'  => 'red',
@@ -1442,7 +1442,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'settings' => array(
 				'color'      => array(
 					'palette' => array(
-						'user' => array(
+						'custom' => array(
 							array(
 								'name'  => 'Pink',
 								'slug'  => 'pink',
@@ -1453,7 +1453,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 				'typography' => array(
 					'fontFamilies' => array(
-						'user' => array(
+						'custom' => array(
 							array(
 								'name'       => 'Cambria',
 								'slug'       => 'cambria',
@@ -1466,7 +1466,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 					'core/group' => array(
 						'color' => array(
 							'palette' => array(
-								'user' => array(
+								'custom' => array(
 									array(
 										'name'  => 'Pink',
 										'slug'  => 'pink',


### PR DESCRIPTION
Follows a suggestion by @oandregal and renames the user preset origin to custom.
Similar to https://github.com/WordPress/gutenberg/pull/36645 that renamed core to default.

## How has this been tested?
I opened the site editor and verified a user can still change all three color palette origins.