### PR TITLE
Add support for custom Block Editor settings.

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -8,6 +8,7 @@ import { pick, defaultTo } from 'lodash';
  */
 import { Platform, useMemo } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 import {
 	store as coreStore,
 	__experimentalFetchLinkSuggestions as fetchLinkSuggestions,
@@ -87,47 +88,54 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		return saveEntityRecord( 'postType', 'page', options );
 	};
 
+	let supportedEditorSettings = [
+		'__experimentalBlockDirectory',
+		'__experimentalBlockPatternCategories',
+		'__experimentalBlockPatterns',
+		'__experimentalFeatures',
+		'__experimentalPreferredStyleVariations',
+		'__experimentalSetIsInserterOpened',
+		'__unstableGalleryWithImageBlocks',
+		'alignWide',
+		'allowedBlockTypes',
+		'bodyPlaceholder',
+		'codeEditingEnabled',
+		'colors',
+		'disableCustomColors',
+		'disableCustomFontSizes',
+		'disableCustomGradients',
+		'enableCustomLineHeight',
+		'enableCustomSpacing',
+		'enableCustomUnits',
+		'focusMode',
+		'fontSizes',
+		'gradients',
+		'hasFixedToolbar',
+		'hasReducedUI',
+		'imageDefaultSize',
+		'imageDimensions',
+		'imageEditing',
+		'imageSizes',
+		'isRTL',
+		'keepCaretInsideBlock',
+		'maxWidth',
+		'onUpdateDefaultBlockStyles',
+		'styles',
+		'template',
+		'templateLock',
+		'titlePlaceholder',
+		'supportsLayout',
+		'widgetTypesToHideFromLegacyWidgetBlock',
+	];
+
+	supportedEditorSettings = applyFilters(
+		'editor.SupportedEditorSettings',
+		supportedEditorSettings
+	);
+
 	return useMemo(
 		() => ( {
-			...pick( settings, [
-				'__experimentalBlockDirectory',
-				'__experimentalBlockPatternCategories',
-				'__experimentalBlockPatterns',
-				'__experimentalFeatures',
-				'__experimentalPreferredStyleVariations',
-				'__experimentalSetIsInserterOpened',
-				'__unstableGalleryWithImageBlocks',
-				'alignWide',
-				'allowedBlockTypes',
-				'bodyPlaceholder',
-				'codeEditingEnabled',
-				'colors',
-				'disableCustomColors',
-				'disableCustomFontSizes',
-				'disableCustomGradients',
-				'enableCustomLineHeight',
-				'enableCustomSpacing',
-				'enableCustomUnits',
-				'focusMode',
-				'fontSizes',
-				'gradients',
-				'hasFixedToolbar',
-				'hasReducedUI',
-				'imageDefaultSize',
-				'imageDimensions',
-				'imageEditing',
-				'imageSizes',
-				'isRTL',
-				'keepCaretInsideBlock',
-				'maxWidth',
-				'onUpdateDefaultBlockStyles',
-				'styles',
-				'template',
-				'templateLock',
-				'titlePlaceholder',
-				'supportsLayout',
-				'widgetTypesToHideFromLegacyWidgetBlock',
-			] ),
+			...pick( settings, supportedEditorSettings ),
 			mediaUpload: hasUploadPermissions ? mediaUpload : undefined,
 			__experimentalReusableBlocks: reusableBlocks,
 			__experimentalFetchLinkSuggestions: ( search, searchOptions ) =>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes #36749. 

With the existing `block_editor_settings_all` filter, users can modify any supported Block Editor setting. However, if you add your own settings via this filter, they are ignored in the Block Editor. Allowing users to register support for their own custom Block Editor settings would greatly increase the extensibility of the Block Editor and provide developers with an easy way to surface data without the need to write their own REST API endpoints.

This PR simply adds the JS filter `editor.SupportedEditorSettings` to the array of support Block Editor settings. The naming of this filter might need tweaking for consistency.

## How has this been tested?
Tested with the latest version of Gutenberg and WordPress.

To test, add support your a test setting. Something like the following.

```
function addTestSettingSupport( settings ) {
	settings.push( 'myTestSetting' );
	return settings;
}

addFilter(
	'editor.SupportedEditorSettings',
	'example/my-test-setting',
	addTestSettingSupport
);
```

Then using the `block_editor_settings_all` add this custom setting. Something like the following.

```
function example_add_test_settings( $editor_settings, $block_editor_context ) {
	$editor_settings['myTestSetting'] = 'This is a test value';

	return $editor_settings;
}
add_filter( 'block_editor_settings_all', 'example_add_test_settings', 10, 2 );
```

Finally in the Block Editor, you can retrieve the custom setting like this:

```
const { myTestSetting } = useSelect(
	( select ) => {
		const { getSettings } = select( blockEditorStore );

		return {
			customApiKey: getSettings().myTestSetting
		};
	},
	[ rootClientId ]
);
```

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
