### PR TITLE
[RNMobile] Added auto opening of media upload options to Gallery block v2

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -123,6 +123,13 @@ function GalleryEdit( props ) {
 		[ clientId ]
 	);
 
+	const wasBlockJustInserted = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).wasBlockJustInserted( clientId, 'inserter_menu' );
+		},
+		[ clientId ]
+	);
+
 	const images = useMemo(
 		() =>
 			innerBlockImages?.map( ( block ) => ( {
@@ -437,6 +444,9 @@ function GalleryEdit( props ) {
 			value={ hasImageIds ? images : {} }
 			onError={ onUploadError }
 			notices={ hasImages ? undefined : noticeUI }
+			autoOpenMediaUpload={
+				! hasImages && isSelected && wasBlockJustInserted
+			}
 		/>
 	);
 

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -125,7 +125,10 @@ function GalleryEdit( props ) {
 
 	const wasBlockJustInserted = useSelect(
 		( select ) => {
-			return select( blockEditorStore ).wasBlockJustInserted( clientId, 'inserter_menu' );
+			return select( blockEditorStore ).wasBlockJustInserted(
+				clientId,
+				'inserter_menu'
+			);
 		},
 		[ clientId ]
 	);

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -12,7 +12,8 @@ For each user feature we should also add a importance categorization label  to i
 ## Unreleased
 -   [*] [Embed block] Included Link in Block Settings [#36099]
 -   [**] Fix tab titles translation of inserter menu [#36534]
--   [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases  [#36570]
+-   [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases [#36570]
+-   [**] [Gallery block] When a gallery block is added, the media options are auto opened for v2 of the Gallery block. [#36757]
 
 ## 1.66.0
 -   [**] [Image block] Add ability to quickly link images to Media Files and Attachment Pages [#34846]


### PR DESCRIPTION
`Gutenberg-Mobile PR` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4277
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

In https://github.com/WordPress/gutenberg/pull/25940 the `autoOpenMediaUpload` functionality for the Gallery block was removed in the v2 implementation that allows the Gallery block to be a wrapper around Image blocks utilizing InnerBlocks.

This PR reintroduces this functionality since it is currently supported by v1, and is causing inconsistency with the different WordPress sites that utilize the Gallery block functionality, as self-hosted sites and non self-hosted sites are utilizing the different versions of the Gallery block. 

## How has this been tested?

### Pre-requisite
Utilize a Simple Site for these tests.

1. Tap (+) (inserter) – this shows the Block Library sheet
2. Tap Gallery to add the block's media placeholder to canvas – which triggers the media upload options sheet.
3. Notice the media upload options auto open.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

### Before
https://user-images.githubusercontent.com/1509205/142964901-1a59e219-8de8-408e-83ea-4c71fe8556c6.mov

### After
https://user-images.githubusercontent.com/1509205/142964908-68493f58-cc51-4ace-be5f-05c65fa83e81.mov

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
The changes introduce `MediaPlaceholder` functionality from `v1` `edit.js` to the current `edit.js`.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
