### PR TITLE
Add CSS fix for 33580.

### DIFF
--- a/packages/widgets/src/blocks/legacy-widget/index.php
+++ b/packages/widgets/src/blocks/legacy-widget/index.php
@@ -108,6 +108,33 @@ function handle_legacy_widget_preview_iframe() {
 				padding: 0 !important;
 				margin: 0 !important;
 			}
+
+			/* Hide root level text nodes */
+			body {
+				font-size: 0 !important;
+			}
+
+			/* Hide non-widget elements */
+			body *:not(#page):not(#content):not(.widget):not(.widget *) {
+				display: none !important;
+				font-size: 0 !important;
+				height: 0 !important;
+				left: -9999px !important;
+				max-height: 0 !important;
+				max-width: 0 !important;
+				opacity: 0 !important;
+				pointer-events: none !important;
+				position: absolute !important;
+				top: -9999px !important;
+				transform: translate(-9999px, -9999px) !important;
+				visibility: hidden !important;
+				z-index: -999 !important;
+			}
+
+			/* Restore widget font-size */
+			.widget {
+				font-size: var(--global--font-size-base);
+			}
 		</style>
 	</head>
 	<body <?php body_class(); ?>>


### PR DESCRIPTION
## Description
This PR applies the CSS fix in patch [53801_css03.diff](https://core.trac.wordpress.org/attachment/ticket/53801/53801_css03.diff) on [Trac 53801](https://core.trac.wordpress.org/ticket/53801).

Fixes #33580.

## How has this been tested?
- The patch has been manually tested [here](https://github.com/WordPress/gutenberg/issues/33580#issuecomment-930758395) and [here](https://github.com/WordPress/gutenberg/issues/33580#issuecomment-944307084).
- The patch has been reviewed by the [CSS team](https://wordpress.slack.com/archives/core-css/p1630613560084300) and the [accessibility team](https://core.trac.wordpress.org/ticket/53801#comment:34).

## Screenshots
Screenshots can be found [here](https://github.com/WordPress/gutenberg/issues/33580#issuecomment-930758395).

## Types of changes
<!-- What types of changes does your code introduce?  -->
- This PR introduces CSS rules to hide non-legacy widget content in the legacy widget previews.
- Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards.
- [x] I've tested my changes with keyboard and screen readers.
- [x] My code has proper inline documentation.