### PR TITLE
Show all templates and template parts on the site editor list screens

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -97,7 +97,7 @@ function gutenberg_edit_site_list_init( $settings ) {
 			'/',
 			"/wp/v2/types/$post_type->name?context=edit",
 			'/wp/v2/types?context=edit',
-			"/wp/v2/$post_type->rest_base?context=edit",
+			"/wp/v2/$post_type->rest_base?context=edit&per_page=-1",
 		),
 		'rest_preload_api_request',
 		array()

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -33,7 +33,8 @@ export default function NewTemplate( { postType } ) {
 		( select ) => ( {
 			templates: select( coreStore ).getEntityRecords(
 				'postType',
-				'wp_template'
+				'wp_template',
+				{ per_page: -1 }
 			),
 			defaultTemplateTypes: select(
 				editorStore

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -46,10 +46,13 @@ export default function Table( { templateType } ) {
 			} = select( coreStore );
 
 			return {
-				templates: getEntityRecords( 'postType', templateType ),
+				templates: getEntityRecords( 'postType', templateType, {
+					per_page: -1,
+				} ),
 				isLoading: ! hasFinishedResolution( 'getEntityRecords', [
 					'postType',
 					templateType,
+					{ per_page: -1 },
 				] ),
 				postType: getPostType( templateType ),
 			};

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -309,10 +309,9 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 			templateId
 		);
 
-		const templateParts = select( coreDataStore ).getEntityRecords(
-			'postType',
-			'wp_template_part'
-		);
+		const templateParts = select(
+			coreDataStore
+		).getEntityRecords( 'postType', 'wp_template_part', { per_page: -1 } );
 		const templatePartsById = keyBy(
 			templateParts,
 			( templatePart ) => templatePart.id


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Close https://github.com/WordPress/gutenberg/issues/36563.

Add `per_page=-1` to return all (max 100) templates in `/wp/v2/templates` and `/wp/v2/template-parts` REST APIs.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go to Appearance -> Editor -> top left corner W menu -> Templates/Template Parts
3. Add to more than 10 templates
4. The table should list all the templates available

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/142972802-90353862-6dd8-4fce-b7de-4e243e890ab6.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
