### PR TITLE
Highlight "Site" in the navigation panel

### DIFF
--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -46,7 +46,7 @@ export default function NavigationSidebar( {
 			<NavigationPanel
 				isOpen={ isNavigationOpen }
 				setIsOpen={ setIsNavigationOpen }
-				activeTemplateType={ activeTemplateType }
+				activeItem={ activeTemplateType }
 			/>
 			<NavigationPanelPreviewSlot />
 		</>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -26,7 +26,13 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import MainDashboardButton from '../../main-dashboard-button';
 
-const NavigationPanel = ( { isOpen, setIsOpen, activeTemplateType } ) => {
+const SITE_EDITOR_KEY = 'site-editor';
+
+const NavigationPanel = ( {
+	isOpen,
+	setIsOpen,
+	activeItem = SITE_EDITOR_KEY,
+} ) => {
 	const siteTitle = useSelect( ( select ) => {
 		const { getEntityRecord } = select( coreDataStore );
 
@@ -43,7 +49,7 @@ const NavigationPanel = ( { isOpen, setIsOpen, activeTemplateType } ) => {
 		if ( isOpen ) {
 			panelRef.current.focus();
 		}
-	}, [ activeTemplateType, isOpen ] );
+	}, [ activeItem, isOpen ] );
 
 	const closeOnEscape = ( event ) => {
 		if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
@@ -69,7 +75,7 @@ const NavigationPanel = ( { isOpen, setIsOpen, activeTemplateType } ) => {
 					</div>
 				</div>
 				<div className="edit-site-navigation-panel__scroll-container">
-					<Navigation activeItem={ activeTemplateType }>
+					<Navigation activeItem={ activeItem }>
 						<MainDashboardButton.Slot>
 							<NavigationBackButton
 								backButtonLabel={ __( 'Dashboard' ) }
@@ -82,6 +88,7 @@ const NavigationPanel = ( { isOpen, setIsOpen, activeTemplateType } ) => {
 							<NavigationGroup title={ __( 'Editor' ) }>
 								<NavigationItem
 									title={ __( 'Site' ) }
+									item={ SITE_EDITOR_KEY }
 									href={ addQueryArgs( window.location.href, {
 										postId: undefined,
 										postType: undefined,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Part of https://github.com/WordPress/gutenberg/issues/36597.

> Active state isn't currently applied to the "Site" link

Highlight the "Site" link when using the editor. Currently every page other than the list pages are considered to be inside the editor so I just highlight the link in all of them. Not sure if it's desirable though.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme
2. Go Appearance -> Editor
3. See the "Site" link is active and highlighted

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/7753001/142977465-babce4b5-e33d-4bdf-8eb3-0b7e1336baad.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
