### PR TITLE
Fix template part slug generation when creating through the block placeholder

### DIFF
--- a/packages/block-library/src/template-part/edit/placeholder/index.js
+++ b/packages/block-library/src/template-part/edit/placeholder/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find } from 'lodash';
+import { find, kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -65,7 +65,7 @@ export default function TemplatePartPlaceholder( {
 			// block attributes.
 			const record = {
 				title,
-				slug: 'template-part',
+				slug: kebabCase( title ),
 				content: serialize( startingBlocks ),
 				// `area` is filterable on the server and defaults to `UNCATEGORIZED`
 				// if provided value is not allowed.


### PR DESCRIPTION
## Description
In most cases where a template part is created, the slug is generated by using the `kebabCase` function on the title:
- https://github.com/WordPress/gutenberg/blob/e2f00ff5ed1f4042386a48eedf4eafef36c9eb29/packages/edit-site/src/components/add-new-template/new-template-part.js#L31
- https://github.com/WordPress/gutenberg/blob/e2f00ff5ed1f4042386a48eedf4eafef36c9eb29/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js#L37

But when a template part is created by inserting a template part block and following the steps in the block placeholder, the template part slug is incorrectly hard-coded, which will lead to some non-descriptive slugs:
https://github.com/WordPress/gutenberg/blob/e2f00ff5ed1f4042386a48eedf4eafef36c9eb29/packages/block-library/src/template-part/edit/placeholder/index.js#L68

This PR fixes that to also `kebabCase` the title.

## How has this been tested?
1. Add a template part block
2. Click 'Create new'
3. Give it a name and create it
4. Realise there's no way to view a template part slug in the UI and just approve the PR
5. Or if you want to go the extra mile, run `wp.data.select( 'core' ).getEntityRecords( 'postType', 'wp_template_part', { per_page: -1 } )` in the console, find the template part you created and check out its slug (and approve the PR).

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
