### PR TITLE
Remove the emoji script for block themes

### DIFF
--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -320,7 +320,7 @@ function _gutenberg_maybe_remove_emoji_detection_script( $html ) {
 	// This regex should be improved in the future to be more precice,
 	// but even this wide net should be enough to remove the script
 	// in a lot of sites that don't need it.
-	preg_match( "/$anychar/", $html, $match );
+	preg_match( "/$anychar/", $html, $matches );
 
 	// If there are no 4-byte characters, it's safe to remove the emoji script.
 	if ( empty( $matches ) ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -317,6 +317,9 @@ function _gutenberg_maybe_remove_emoji_detection_script( $html ) {
 	// Detect all 3-byte and 4-byte characters.
 	// Not all 3/4-byte characters are emojis, but this casts a wide net
 	// to check if it's safe to remove the emojis script.
+	// This regex should be improved in the future to be more precice,
+	// but even this wide net should be enough to remove the script
+	// in a lot of sites that don't need it.
 	preg_match( "/$anychar/", $html, $match );
 
 	// If there are no 4-byte characters, it's safe to remove the emoji script.

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -310,10 +310,14 @@ add_filter( 'get_edit_post_link', 'gutenberg_get_edit_template_link', 10, 2 );
  * @return string The HTML.
  */
 function _gutenberg_maybe_remove_emoji_detection_script( $html ) {
-	// Detect all 4-byte characters.
-	// Not all 4-byte characters are emojis, but this casts a wide net
+	$multi3  = '(?:[\xE0-\xEF]..)';
+	$multi4  = '(?:[\xF0-\xF4]...)';
+	$anychar = "(?:$multi4|$multi3)";
+
+	// Detect all 3-byte and 4-byte characters.
+	// Not all 3/4-byte characters are emojis, but this casts a wide net
 	// to check if it's safe to remove the emojis script.
-	preg_match( '/[\x{10000}-\x{1FFFF}]/u', $html, $matches );
+	preg_match( "/$anychar/", $html, $match );
 
 	// If there are no 4-byte characters, it's safe to remove the emoji script.
 	if ( empty( $matches ) ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -302,5 +302,5 @@ function _gutenberg_maybe_remove_emoji_detection_script() {
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	}
 }
-add_filter( 'wp_loaded', '_gutenberg_maybe_remove_emoji_detection_script', 20 );
+add_filter( 'wp_loaded', '_gutenberg_maybe_remove_emoji_detection_script' );
 

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -293,12 +293,9 @@ function gutenberg_get_edit_template_link( $link, $post_id ) {
 add_filter( 'get_edit_post_link', 'gutenberg_get_edit_template_link', 10, 2 );
 
 /**
- * Checks the HTML to be rendered for any emojis.
- * If there are none, then the emoji script is removed from the `<head>`.
+ * Remove the emoji script for themes that support block templates.
  *
- * @param string $html The HTML to be rendered.
- *
- * @return string The HTML.
+ * @return void
  */
 function _gutenberg_maybe_remove_emoji_detection_script() {
 	if ( gutenberg_supports_block_templates() ) {

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -302,5 +302,5 @@ function _gutenberg_maybe_remove_emoji_detection_script() {
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	}
 }
-add_filter( 'wp_loaded', '_gutenberg_maybe_remove_emoji_detection_script' );
+add_action( 'wp_loaded', '_gutenberg_maybe_remove_emoji_detection_script' );
 

--- a/lib/full-site-editing/template-loader.php
+++ b/lib/full-site-editing/template-loader.php
@@ -180,16 +180,7 @@ function gutenberg_get_the_template_html() {
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles
 	// (e.g. `.wp-site-blocks > *`).
-	$content = '<div class="wp-site-blocks">' . $content . '</div>';
-
-	/**
-	 * Filters the markup for the current template.
-	 *
-	 * @param string $result The markup for the current template.
-	 *
-	 * @return string The markup for the current template.
-	 */
-	return apply_filters( 'template_html', $content );
+	return '<div class="wp-site-blocks">' . $content . '</div>';
 }
 
 /**
@@ -309,25 +300,10 @@ add_filter( 'get_edit_post_link', 'gutenberg_get_edit_template_link', 10, 2 );
  *
  * @return string The HTML.
  */
-function _gutenberg_maybe_remove_emoji_detection_script( $html ) {
-	$multi3  = '(?:[\xE0-\xEF]..)';
-	$multi4  = '(?:[\xF0-\xF4]...)';
-	$anychar = "(?:$multi4|$multi3)";
-
-	// Detect all 3-byte and 4-byte characters.
-	// Not all 3/4-byte characters are emojis, but this casts a wide net
-	// to check if it's safe to remove the emojis script.
-	// This regex should be improved in the future to be more precice,
-	// but even this wide net should be enough to remove the script
-	// in a lot of sites that don't need it.
-	preg_match( "/$anychar/", $html, $matches );
-
-	// If there are no 4-byte characters, it's safe to remove the emoji script.
-	if ( empty( $matches ) ) {
+function _gutenberg_maybe_remove_emoji_detection_script() {
+	if ( gutenberg_supports_block_templates() ) {
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 	}
-
-	return $html;
 }
-add_filter( 'template_html', '_gutenberg_maybe_remove_emoji_detection_script', 20 );
+add_filter( 'wp_loaded', '_gutenberg_maybe_remove_emoji_detection_script', 20 );
 


### PR DESCRIPTION
## Description

WP currently loads an emoji-detection script on every page-load.
~In block themes however, we know before the `<head>` the entire contents of the page, so it's possible to detect if the page contains emojis or not, and if not then remove the script to improve performance.~

~This PR checks if the page contains any 3 or 4-byte characters, and if not then removes the script.~
~Note: Not all 3/4-byte characters are emojis, but all emojis are 3/4-byte characters.~
~This casts a wide net to check if it's safe to remove the emojis script without causing any backwards-compatibility issues.~
~The regex should be improved in the future to be more precise, but even this wide net should be enough to remove the script in a lot of sites that don't need it.~

_EDIT: The script was added for backwards-compatibility with browsers that we stopped supporting a long time ago. With that in mind and based on the comments below, the script is directly dequeued if the theme supports block templates._

## How has this been tested?
~Tested by adding an emoji to a post loaded in a block theme. If an emoji exists the script gets loaded, otherwise it does not.~

_EDIT: The implementation changed to always remove the script in themes that support block templates, so it was tested and confirmed that this happens._

## Types of changes
* ~Added a `template_html` filter in the `gutenberg_get_the_template_html` function~
* Added a `_gutenberg_maybe_remove_emoji_detection_script` which removes the `print_emoji_detection_script` hook from `wp_head` ~if there are no 3/4-byte characters in the page~.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards.
- [x] ~I've tested my changes with keyboard and screen readers.~
- [x] My code has proper inline documentation.
- [x] I've included developer documentation if appropriate.
- [x] ~I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).~