### PR TITLE
[RNMobile][Android] Fix undo/redo functionality in links when applying text format

### DIFF
--- a/packages/react-native-aztec/android/src/main/res/values/bools.xml
+++ b/packages/react-native-aztec/android/src/main/res/values/bools.xml
@@ -3,5 +3,6 @@
 <resources>
 
     <bool name="history_enable">false</bool>
+    <bool name="use_aztec_style_html">false</bool>
 
 </resources>

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,7 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] [Embed block] Included Link in Block Settings [#36099]
 -   [**] Fix tab titles translation of inserter menu [#36534]
 -   [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases  [#36570]
--   [**]  Fix undo/redo functionality in links when applying text format [#36766]
+-   [**] Fix undo/redo functionality in links when applying text format [#36766]
 
 ## 1.66.0
 -   [**] [Image block] Add ability to quickly link images to Media Files and Attachment Pages [#34846]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -13,6 +13,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] [Embed block] Included Link in Block Settings [#36099]
 -   [**] Fix tab titles translation of inserter menu [#36534]
 -   [*] [Media&Text block] Fix an issue where the text font size would be bigger than expected in some cases  [#36570]
+-   [**]  Fix undo/redo functionality in links when applying text format [#36766]
 
 ## 1.66.0
 -   [**] [Image block] Add ability to quickly link images to Media Files and Attachment Pages [#34846]


### PR DESCRIPTION
**Gutenberg Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4279

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

**This PR relies on the changes introduced to Aztec in https://github.com/wordpress-mobile/AztecEditor-Android/pull/944.**

The undo/redo issue is caused by Aztec, as it modifies the HTML passed through the `RichText` component, specifically for links, I spotted that the function `switchToAztecStyle` ([reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1481-L1532)) is the one that modifies link elements when applying any format to it. These modifications end up producing undesired new undo actions that eventually break the undo/redo functionality of the editor (more info in the [original issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136#issuecomment-975643897)).

Fort this purpose, I decided to control the modifications done in `switchToAztecStyle` ([reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1481-L1532)) by introducing a flag in Aztec and disabling it for Gutenberg.

## Testing Aztec style HTML in the Aztec demo app

In theory, none of the transformations done in `switchToAztecStyle` ([reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1481-L1532))  affects the `RichText` component behavior, where the Aztec component is used. However, I performed a deeper investigation on each transformation as a double-check, here are my findings:

### Block formatting
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1482)
- HTML code example used
```
<ul><li>item 1</li><li>item 2</li></ul>
<ol><li>item 1</li><li>item 2</li></ol>
<blockquote>
Quoted
</blockquote>
<pre>Preformatted</pre>
<h1>heading 1</h1>
<h2>heading 1</h2>
```
<details><summary>Click here to display the screenshots</summary>

**Aztec demo app:**
Aztec style enabled|Aztec style disabled
--|--
![1-styles-enabled](https://user-images.githubusercontent.com/14905380/143006401-6a10ca19-7f3d-4901-9a7c-0af559556efa.jpg)|![1-styles-disabled](https://user-images.githubusercontent.com/14905380/143006407-b9913b75-843a-4f75-b0fb-cc0a0f210f11.jpg)

</details>

This modification is only applying styles to the following Aztec blocks:
  - List block (Ordered + Unordered)
  - Quote block
  - Header block
  - Preformat block

I noticed that some of these elements, like lists and preformat, can be used within the `RichText` component, so disabling the Aztec style actually would affect how it's rendered. However, this can only be done by manually modifying the HTML, which most likely is not common. Besides, this can't be done in the web version as when including this HTML, it displays the error message `This block contains unexpected or invalid content.`.

<details><summary>Click here to display the screenshots</summary>

**WordPress app:**
Aztec style enabled|Aztec style disabled
--|--
![Screenshot_20211123-122707_WordPress](https://user-images.githubusercontent.com/14905380/143016469-d7f90f3e-2701-4e9f-92a2-8648a10e3161.jpg)|![Screenshot_20211123-122735_WordPress Pre-Alpha](https://user-images.githubusercontent.com/14905380/143016478-f3671ea6-d707-4574-b490-6ad196853b7e.jpg)

</details>

**HTML Example:**
```
<!-- wp:paragraph -->
<p>
<ul><li>item 1</li><li>item 2</li></ul>
<ol><li>item 1</li><li>item 2</li></ol>
<pre>Preformatted</pre>
</p>
<!-- /wp:paragraph -->
```

### End of paragraph marker -  Vertical padding
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1483)
- HTML code example used
```
<p>
Line 1
Line 2

Line 3
</p>
```
<details><summary>Click here to display the screenshots</summary>

Aztec style enabled|Aztec style disabled
--|--
![2-styles-enabled](https://user-images.githubusercontent.com/14905380/143008750-dc78f9f9-e763-4f05-be8c-991d856c9dbe.jpg)|![2-styles-disabled](https://user-images.githubusercontent.com/14905380/143008753-fa01d421-a323-4567-97b8-637500da038b.jpg)

</details>

The modification only sets specific vertical padding when leaving an intermediate empty line in a paragraph. On Gutenberg, new lines within paragraph tags are not breaking lines, so this behavior doesn't apply. 

**NOTE:** For testing this in the Aztec demo app, calypso mode should be on.

### Links
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1485-L1491)
- HTML code example used
```
<p>This is a <a href="http://wordpress.com"><strong>link</strong></a></p>
```
<details><summary>Click here to display the screenshots</summary>

Aztec style enabled|Aztec style disabled
--|--
![3-styles-enabled](https://user-images.githubusercontent.com/14905380/143008892-dbeaf57e-0851-4874-aa4c-f041d97beefe.jpg)|![3-styles-disabled](https://user-images.githubusercontent.com/14905380/143008899-e06ddbe2-f0a2-4cd9-bd98-aabd8dfc81a1.jpg)

</details>

This modification is the one that causes the original issue ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136)), however, it doesn't produce any visual/render modifications.

I tried to understand the underlying code and looks like the problem comes when re-introducing the URL span in the same range where we have other spans like `strong`:
1. **Original code:** `This is a <a href="http://wordpress.com"><strong>link</strong></a>`
2. **After removing the URL span:** `This is a <strong>link</strong>`
3. **After re-introducing the URL span:** `This is a <strong><a href="http://wordpress.com">link</a></strong>`

### Code block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1493-L1499)
- HTML code example used
```
<code>if (value == 5) printf(value)</code>
```

I realized that it's possible to use the `code` tag within a paragraph block in Gutenberg, although I don't think this is a common behavior as it requires modifying the HTML manually, and it's not properly rendered. In any case, the undo/redo functionality won't be affected.

<details><summary>Click here to display the screenshots</summary>

HTML mode|Visual mode
--|--
![Screenshot_20211123-114808_WordPress Pre-Alpha](https://user-images.githubusercontent.com/14905380/143011063-9b91e6ab-8535-4cd5-8017-4401b72ddf98.jpg)|![Screenshot_20211123-114818_WordPress Pre-Alpha](https://user-images.githubusercontent.com/14905380/143011073-859bbd6e-78e5-4e41-938c-57b7af7853bf.jpg)

</details>

### Image block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1501-L1505)
- HTML code example used
```
[caption align="alignright"]<img src="https://examplebloge.files.wordpress.com/2017/02/3def4804-d9b5-11e6-88e6-d7d8864392e0.png" />Caption[/caption]
```

The function only adds listeners and no HTML is modified. I noticed images are being rendered within the `RichText` component, but as far as I checked, the listeners are not used.

### Video block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1507-L1511)
- HTML code example used
```
[video src="https://examplebloge.files.wordpress.com/2017/06/d7d88643-88e6-d9b5-11e6-92e03def4804.mp4"]
```

The function only adds listeners and no HTML is modified. Videos are not being rendered within the `RichText` component, so this modification doesn't affect it.

### Audio block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1513-L1517)
- HTML code example used
```
[audio src="https://upload.wikimedia.org/wikipedia/commons/9/94/H-Moll.ogg"]
```

The function only adds listeners and no HTML is modified. Audio clips are not being rendered within the `RichText` component, so this modification doesn't affect it.

### Unknown block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1519-L1522)
- HTML code example used
```
<iframe class="classic">Menu</iframe><br>
```

In Aztec, this block renders a question mark image, however, in Gutenberg this is not being rendered and listeners are not used.

### Comment block
- [Code reference](https://github.com/wordpress-mobile/AztecEditor-Android/blob/01da97c191e42e2289ba2170325bb64b2681d6c9/aztec/src/main/kotlin/org/wordpress/aztec/AztecText.kt#L1524-L1531)
- HTML code example used
```
<!--Comment--><br>
<!--more--><br>
<!--nextpage-->
```

This Aztec block is not being rendered within the `RichText` component, so this modification doesn't affect it.

## How has this been tested?
**Prerequisites:**
1. Use the Aztec-Android branch `add/aztec-style-html-bool` referenced in https://github.com/wordpress-mobile/AztecEditor-Android/pull/944.
2. Enable local reference to Aztec-Android ([reference](https://github.com/wordpress-mobile/WordPress-Android/blob/dabe1e4fd2f526e51f803caf52e6720fad08e6d8/local-builds.gradle-example#L22)).
3. Make a local build of WordPress-Android.

**Steps:**
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Add a a rich-text based component with content (Paragraph, Heading, Quote, Media Caption, etc...).
1. Write a word and select it.
1. Press the link format button.
1. Fill the options and dismiss to add a link.
1. Select the word.
1. Press the bold, italic or strikethrough button to apply text format.
1. Press the Undo button multiple times until all changes are reverted.
1. Observe that the undo functionality works as expected and that doesn't get blocked as described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/3136.

## Screenshots <!-- if applicable -->
Before|After
--|--
<video src=https://user-images.githubusercontent.com/14905380/143018050-c406ee2f-1a67-48a6-a454-9a4b9ba127f3.mp4>|<video src=https://user-images.githubusercontent.com/14905380/143018096-48bed996-bad4-4677-bb52-cb3e7d3f6d3d.mp4>

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
