### PR TITLE
Navigation: Try removing "Add all pages" from placeholder.

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { createBlock } from '@wordpress/blocks';
 import {
 	Placeholder,
 	Button,
@@ -124,7 +123,6 @@ export default function NavigationPlaceholder( {
 		isResolvingPages,
 		menus,
 		isResolvingMenus,
-		hasPages,
 		hasMenus,
 	} = useNavigationEntities();
 
@@ -132,11 +130,6 @@ export default function NavigationPlaceholder( {
 
 	const onCreateEmptyMenu = () => {
 		onFinishMenuCreation( [] );
-	};
-
-	const onCreateAllPages = () => {
-		const block = [ createBlock( 'core/page-list' ) ];
-		onFinishMenuCreation( block );
 	};
 
 	const { navigationMenus } = useNavigationMenu();
@@ -181,18 +174,6 @@ export default function NavigationPlaceholder( {
 									<hr />
 								</>
 							) : undefined }
-							{ canUserCreateNavigation && hasPages ? (
-								<>
-									<Button
-										variant="tertiary"
-										onClick={ onCreateAllPages }
-									>
-										{ __( 'Add all pages' ) }
-									</Button>
-									<hr />
-								</>
-							) : undefined }
-
 							{ canUserCreateNavigation && (
 								<Button
 									variant="tertiary"

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -42,8 +42,6 @@ exports[`Navigation placeholder allows a navigation block to be created from exi
 <!-- /wp:navigation-submenu -->"
 `;
 
-exports[`Navigation placeholder allows a navigation block to be created using existing pages 1`] = `"<!-- wp:page-list /-->"`;
-
 exports[`Navigation placeholder creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
 
 exports[`Navigation supports navigation blocks that have inner blocks within their markup and converts them to wp_navigation posts 1`] = `"<!-- wp:page-list /-->"`;

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -124,7 +124,6 @@ async function selectClassicMenu( optionText ) {
 const PLACEHOLDER_ACTIONS_CLASS = 'wp-block-navigation-placeholder__actions';
 const PLACEHOLDER_ACTIONS_XPATH = `//*[contains(@class, '${ PLACEHOLDER_ACTIONS_CLASS }')]`;
 const START_EMPTY_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Start empty']`;
-const ADD_ALL_PAGES_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Add all pages']`;
 const SELECT_MENU_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Select menu']`;
 
 /**
@@ -151,24 +150,6 @@ async function deleteAll( endpoints ) {
 				path: `${ path }/${ item.id }?force=true`,
 			} );
 		}
-	}
-}
-
-/**
- * Create a set of pages using the REST API.
- *
- * @param {Array} pages An array of page objects.
- */
-async function createPages( pages ) {
-	for ( const page of pages ) {
-		await rest( {
-			method: 'POST',
-			path: PAGES_ENDPOINT,
-			data: {
-				status: 'publish',
-				...page,
-			},
-		} );
 	}
 }
 
@@ -257,37 +238,6 @@ describe( 'Navigation', () => {
 	} );
 
 	describe( 'placeholder', () => {
-		it( 'allows a navigation block to be created using existing pages', async () => {
-			await createPages( [
-				{
-					title: 'About',
-					menu_order: 0,
-				},
-				{
-					title: 'Contact Us',
-					menu_order: 1,
-				},
-				{
-					title: 'FAQ',
-					menu_order: 2,
-				},
-			] );
-
-			await createNewPost();
-
-			// Add the navigation block.
-			await insertBlock( 'Navigation' );
-			const allPagesButton = await page.waitForXPath(
-				ADD_ALL_PAGES_XPATH
-			);
-			await allPagesButton.click();
-
-			// Wait for the page list block to be present
-			await page.waitForSelector( 'ul[aria-label="Block: Page List"]' );
-
-			expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
-		} );
-
 		it( 'allows a navigation block to be created from existing menus', async () => {
 			await createClassicMenu( { name: 'Test Menu 1' } );
 			await createClassicMenu(


### PR DESCRIPTION
## Description

As the navigation block is evolving with persistance, the placeholder state may play a smaller role in favor of pre-built menus and patterns that leverage them. These patterns might include the Page List by default, or the menu does. What remains are two ways to start a new menu: empty or with the "All Pages" block preinserted:

<img width="739" alt="Screenshot 2021-11-23 at 12 54 09" src="https://user-images.githubusercontent.com/1204802/143020593-ad0d863d-5d1e-4f1a-9c89-4c23538763a6.png">

Recent anecdotal feedback from a friend, "Why did it create all these pages that I don’t need?", suggests that the "Add all pages" option isn't necessarily the most obvious one. And in light of the changes to persistence, it might indeed make sense to just not include the option at all: it can still be added manually, or as part of a pattern. So this PR removes it:

<img width="687" alt="Screenshot 2021-11-23 at 12 57 00" src="https://user-images.githubusercontent.com/1204802/143021149-4382c066-471b-4ed4-a996-03b0ff263869.png">

What do you think?

## How has this been tested?

Add a navigation block, see that it includes only two options.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
