### PR TITLE
Add plugin meta data to Nav Area block deprecation notice

### DIFF
--- a/packages/block-library/src/navigation-area/edit.js
+++ b/packages/block-library/src/navigation-area/edit.js
@@ -54,6 +54,7 @@ function NavigationAreaBlock( { attributes, setAttributes } ) {
 
 	deprecated( 'wp.blockLibrary.NavigationArea', {
 		since: '5.9',
+		plugin: 'gutenberg',
 	} );
 
 	return (

--- a/packages/block-library/src/navigation-area/edit.js
+++ b/packages/block-library/src/navigation-area/edit.js
@@ -53,7 +53,7 @@ function NavigationAreaBlock( { attributes, setAttributes } ) {
 	);
 
 	deprecated( 'wp.blockLibrary.NavigationArea', {
-		since: '5.9',
+		since: '12.0',
 		plugin: 'gutenberg',
 	} );
 


### PR DESCRIPTION
Addresses feedback in https://github.com/WordPress/gutenberg/pull/36727#discussion_r755057979

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Addresses feedback from @youknowriad in https://github.com/WordPress/gutenberg/pull/36727#discussion_r755057979 to mark the deprecation notice with `plugin` metadata to denote that this has never landed in a stable release of Core.

## How has this been tested?

Check I typed things correctly and there are no errors in the console.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
