### PR TITLE
Navigation: Try inheriting orientation in setup state.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -216,15 +216,6 @@ $color-control-label-height: 20px;
 	background: none;
 	min-height: 0;
 
-	// Inherit orientation.
-	&,
-	.components-placeholder__fieldset,
-	.wp-block-navigation-placeholder__controls,
-	.wp-block-navigation-placeholder__preview,
-	.wp-block-navigation-placeholder__actions {
-		flex-direction: inherit;
-	}
-
 	// Needed for the preview menu items to match actual menu items.
 	.components-placeholder__fieldset {
 		font-size: inherit;
@@ -293,8 +284,6 @@ $color-control-label-height: 20px;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
-	flex-direction: row;
-	align-items: flex-start;
 	display: none;
 	position: relative;
 	z-index: 1;
@@ -310,26 +299,25 @@ $color-control-label-height: 20px;
 	float: left;
 	width: 100%;
 
-	// Show stacked for the vertical navigation, or small placeholders.
+	// Hide the navigation indicator when in small contexts.
 	.is-small &,
 	.is-medium & {
 		.wp-block-navigation-placeholder__actions__indicator,
-		.wp-block-navigation-placeholder__actions__indicator + hr,
-		.wp-block-navigation-placeholder__actions > :nth-last-child(3), // Add all pages.
-		.wp-block-navigation-placeholder__actions > :nth-last-child(2) { // hr separator after it.
+		.wp-block-navigation-placeholder__actions__indicator + hr {
 			display: none;
 		}
 	}
 
-	// Show stacked for the vertical navigation, or small placeholders.
-	.is-small & {
+	// Vertical orientation or small context.
+	.is-small &,
+	.wp-block-navigation.is-vertical & {
 		.wp-block-navigation-placeholder__actions {
 			flex-direction: column;
-		}
+			align-items: flex-start;
 
-		// Hide the separators in the vertical version.
-		.wp-block-navigation-placeholder__actions hr {
-			display: none;
+			hr {
+				display: none;
+			}
 		}
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -216,6 +216,15 @@ $color-control-label-height: 20px;
 	background: none;
 	min-height: 0;
 
+	// Inherit orientation.
+	&,
+	.components-placeholder__fieldset,
+	.wp-block-navigation-placeholder__controls,
+	.wp-block-navigation-placeholder__preview,
+	.wp-block-navigation-placeholder__actions {
+		flex-direction: inherit;
+	}
+
 	// Needed for the preview menu items to match actual menu items.
 	.components-placeholder__fieldset {
 		font-size: inherit;
@@ -284,6 +293,8 @@ $color-control-label-height: 20px;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
+	flex-direction: row;
+	align-items: flex-start;
 	display: none;
 	position: relative;
 	z-index: 1;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -272,12 +272,28 @@ $color-control-label-height: 20px;
 	}
 }
 
+// Prevent layout shift for vertical variant.
+.wp-block-navigation.is-vertical .is-small,
+.wp-block-navigation.is-vertical .is-medium {
+	.components-placeholder__fieldset {
+		// The size of two buttons, with top and bottom padding, and gap.
+		min-height: ($button-size * 2) + $grid-unit-15 + ($grid-unit-15 * 0.5);
+	}
+}
+
+.wp-block-navigation.is-vertical .is-large {
+	.components-placeholder__fieldset {
+		// The size of three buttons, with top and bottom padding, and gap.
+		min-height: ($button-size * 3) + $grid-unit-15 + $grid-unit-15;
+	}
+}
+
 // Selected state.
 .wp-block-navigation-placeholder__preview,
 .wp-block-navigation-placeholder__controls {
 	padding: ($grid-unit-15 * 0.5) $grid-unit-10;
 	flex-direction: row;
-	align-items: center;
+	align-items: flex-start;
 }
 
 .wp-block-navigation-placeholder__controls {
@@ -334,7 +350,7 @@ $color-control-label-height: 20px;
 	align-items: center;
 	justify-content: flex-start;
 	line-height: 0;
-	min-height: $button-size;
+	height: $button-size;
 
 	// Line up with the icon in the toolbar.
 	margin-left: $grid-unit-05;


### PR DESCRIPTION
## Description

The navigation setup state used to have a vertical orientation, relying on an `is-vertical` class. That class has been retired with the flex layout orientation, so this needs a different approach. This PR takes a step towards getting it to work. Before:

<img width="1270" alt="navigation placeholder locked in horizontal orientation" src="https://user-images.githubusercontent.com/1204802/143023426-106716f6-9864-4ee1-8109-4b86ed8cacb3.png">

After:

![inheriting orientation, shifting between vertical and horizontal states for the navigation](https://user-images.githubusercontent.com/1204802/143023482-90a0344b-fab1-47a7-954e-3f1d5474512c.gif)

I suspect the placeholder for the navigation block will need a bit more work, notably around the gray blobs. Feedback time and again have suggested they look like a "loading state", when in fact they are meant to represent an unconfigured block.  In that light, I'd like to explore separately to remove those blobs entirely. (In retiring these, it would also remove the layout shift that happens when selecting and deselecting the block!)

## How has this been tested?

Insert a navigation block, then test changing the orientation.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
