### PR TITLE
Add "none" as a valid alignment only when there are options

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -14,7 +14,7 @@ const DEFAULT_CONTROLS = [ 'none', 'left', 'center', 'right', 'wide', 'full' ];
 const WIDE_CONTROLS = [ 'wide', 'full' ];
 
 export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
-	// Always add the `none` option if not exists.
+	// If the options list is not empty but is missing the 'none' option add it to the list.
 	if ( controls.length > 0 && ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
 	}

--- a/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
+++ b/packages/block-editor/src/components/block-alignment-control/use-available-alignments.js
@@ -15,7 +15,7 @@ const WIDE_CONTROLS = [ 'wide', 'full' ];
 
 export default function useAvailableAlignments( controls = DEFAULT_CONTROLS ) {
 	// Always add the `none` option if not exists.
-	if ( ! controls.includes( 'none' ) ) {
+	if ( controls.length > 0 && ! controls.includes( 'none' ) ) {
 		controls = [ 'none', ...controls ];
 	}
 	const { wideControlsEnabled = false, themeSupportsLayout } = useSelect(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
I had a pretty rough time trying to get rid of the `blockEdit` wrapper that adds the `data-align` attribute while trying to make my blocks use (as much as possible) the same markup in the editor and in the frontend. After some digging I found that 'none' was always being added to the [validAlignments](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/hooks/align.js#L180) list in the `withDataAlign` filter.

Even though I believe that if a block does not declare support for the 'none' alignment, the options should be added to the block alignment control, I believe that, for the time being we can add the 'none' option only when there are already some options to work with and the `controls` array is not empty.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
I've tested some core blocks which don't seem to be affected, but if anyone knows or can think of any use cases where this might fail please let me know.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
