### PR TITLE
[Block Library - Post Title]: Fix render error when setting Page to homepage

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -62,7 +62,7 @@ export default function PostTitleEdit( {
 				/>
 			) : (
 				<TagName { ...blockProps }>
-					<RawHTML key="html">{ fullTitle.rendered }</RawHTML>
+					<RawHTML key="html">{ fullTitle?.rendered }</RawHTML>
 				</TagName>
 			);
 	}
@@ -92,7 +92,7 @@ export default function PostTitleEdit( {
 						rel={ rel }
 						onClick={ ( event ) => event.preventDefault() }
 					>
-						<RawHTML key="html">{ fullTitle.rendered }</RawHTML>
+						<RawHTML key="html">{ fullTitle?.rendered }</RawHTML>
 					</a>
 				</TagName>
 			);


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36782

The issue happens because we needed to wait for the title resolve.

Testing instructions are on the issue.