### PR TITLE
Various inline docblock corrections

### DIFF
--- a/lib/compat/wordpress-5.8/block-editor.php
+++ b/lib/compat/wordpress-5.8/block-editor.php
@@ -322,7 +322,8 @@ function gutenberg_block_editor_rest_api_preload( array $preload_paths, $block_e
 	 *
 	 * @since 5.8.0
 	 *
-	 * @param string[] $preload_paths Array of paths to preload.
+	 * @param string[]                $preload_paths        Array of paths to preload.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 */
 	$preload_paths = apply_filters( 'block_editor_rest_api_preload_paths', $preload_paths, $block_editor_context );
 	if ( ! empty( $block_editor_context->post ) ) {

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -709,7 +709,7 @@ function gutenberg_get_block_templates( $query = array(), $template_type = 'wp_t
  */
 function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	/**
-	 * Filters the block templates array before the query takes place.
+	 * Filters the block template object before the query takes place.
 	 *
 	 * Return a non-null value to bypass the WordPress queries.
 	 *
@@ -758,11 +758,11 @@ function gutenberg_get_block_template( $id, $template_type = 'wp_template' ) {
 	$block_template = get_block_file_template( $id, $template_type );
 
 	/**
-	 * Filters the array of queried block templates array after they've been fetched.
+	 * Filters the queried block template object after it's been fetched.
 	 *
 	 * @since 10.8
 	 *
-	 * @param WP_Block_Template $block_template The found block template.
+	 * @param WP_Block_Template|null $block_template The found block template, or null if there isn't one.
 	 * @param string $id Template unique identifier (example: theme_slug//template_slug).
 	 * @param array  $template_type wp_template or wp_template_part.
 	 */


### PR DESCRIPTION
## Description

Corrects a few docblocks.

## Types of changes

Inline documentation fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
