### PR TITLE
Insertion point bar: hide onBlur and onMouseLeave

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -32,7 +32,7 @@ function InsertionPointPopover( {
 	__unstablePopoverSlot,
 	__unstableContentRef,
 } ) {
-	const { selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock, hideInsertionPoint } = useDispatch( blockEditorStore );
 	const openRef = useContext( InsertionPointOpenRef );
 	const ref = useRef();
 	const {
@@ -195,6 +195,12 @@ function InsertionPointPopover( {
 		}
 	}
 
+	function maybeHideInserterPoint() {
+		if ( ! openRef.current ) {
+			hideInsertionPoint();
+		}
+	}
+
 	// Only show the in-between inserter between blocks, so when there's a
 	// previous and a next element.
 	const showInsertionPointInserter =
@@ -294,6 +300,8 @@ function InsertionPointPopover( {
 			// Forces a remount of the popover when its position changes
 			// This makes sure the popover doesn't animate from its previous position.
 			key={ nextClientId + '--' + rootClientId }
+			onFocusOutside={ maybeHideInserterPoint }
+			onMouseLeave={ maybeHideInserterPoint }
 		>
 			<motion.div
 				layout={ ! disableMotion }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -195,8 +195,10 @@ function InsertionPointPopover( {
 		}
 	}
 
-	function maybeHideInserterPoint() {
-		if ( ! openRef.current ) {
+	function maybeHideInserterPoint( event ) {
+		// Only hide the inserter if it's triggered on the wrapper,
+		// and the inserter is not open.
+		if ( event.target === ref.current && ! openRef.current ) {
 			hideInsertionPoint();
 		}
 	}
@@ -300,8 +302,6 @@ function InsertionPointPopover( {
 			// Forces a remount of the popover when its position changes
 			// This makes sure the popover doesn't animate from its previous position.
 			key={ nextClientId + '--' + rootClientId }
-			onFocusOutside={ maybeHideInserterPoint }
-			onMouseLeave={ maybeHideInserterPoint }
 		>
 			<motion.div
 				layout={ ! disableMotion }
@@ -317,6 +317,7 @@ function InsertionPointPopover( {
 				className={ classnames( className, {
 					'is-with-inserter': showInsertionPointInserter,
 				} ) }
+				onHoverEnd={ maybeHideInserterPoint }
 				style={ style }
 			>
 				<motion.div


### PR DESCRIPTION
Possibly, in some way, resolves https://github.com/WordPress/gutenberg/issues/35536
Also resolves https://github.com/WordPress/gutenberg/issues/36882

## Description

This PR hides the inserter point via the `hideInsertionPoint` action when the horizontal inserter bar loses focus, or when the mouse leaves.

`hideInsertionPoint` will not fire when the block inserter panel is open.

![Kapture 2021-11-25 at 11 49 00](https://user-images.githubusercontent.com/6458278/143332274-9b2fe4eb-6bfc-4d6e-a479-668632a91cb1.gif)

We might not have covered all cases documented in https://github.com/WordPress/gutenberg/issues/35536, and there is no timeout, but it might help to avoid some of the concerns with the persistent inserter bar.

Try it out today!

## How has this been tested?

Take a look at the various scenarios over at https://github.com/WordPress/gutenberg/issues/35536

With the right mouse artistry you might find that the bar persists, but, at least in my testing, it doesn't persist as often with these changes.


## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
