### PR TITLE
Fix missing link for shortcut documentation

### DIFF
--- a/packages/components/src/menu-item/README.md
+++ b/packages/components/src/menu-item/README.md
@@ -67,10 +67,10 @@ Whether or not the menu item is currently selected.
 
 ### `shortcut`
 
--   Type: `string`
+-   Type: `string` or `object`
 -   Required: No
 
-Refer to documentation for [Shortcut's `shortcut` prop](/packages/components/src/shortcut/README.md#shortcut).
+If shortcut is a string, it is expecting the display text. If shortcut is an object, it will accept the properties of `display` (string) and `ariaLabel` (string).
 
 ### `role`
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes documentation for shortcut in the MenuItem component to resolve this issue: https://github.com/WordPress/gutenberg/issues/35690  The document being linked to, does not exist. The new details in this PR were taken from the information in the shortcut component here: https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/shortcut/index.js#L25

