### PR TITLE
Gallery v1: Allow clicks within replace media placeholder state

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -128,6 +128,7 @@ figure.wp-block-gallery {
 			bottom: 0;
 			left: 0;
 			z-index: 1;
+			pointer-events: none;
 		}
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

While testing #36191, I noticed that if I use the replace media flow in the v1 Gallery block, then the buttons in the image's placeholder state cannot be clicked. This appears to be because the `::before` content (with `z-index: 1`) is preventing clicks to the elements beneath it. The fix is to add `pointer-events: none` to this content so that it doesn't prevent clicks from reaching the target elements.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

To use the v1 version of the Gallery block, set `use_balanceTags` option to `1` for your test site. If you're using `wp-env`, you can do so by running:

```
wp-env run cli wp option set use_balanceTags 1
```

Add a gallery block to a post or page and select a few images. Click on one of the images and select the button to replace the image. With this PR applied, you should be able to replace the image.

## Screenshots <!-- if applicable -->

| Before (unclickable) | After (clicks work) |
| --- | --- |
| ![Kapture 2021-11-24 at 14 55 45](https://user-images.githubusercontent.com/14988353/143173292-bad3c53e-e157-4dfc-9189-b9bed102fe77.gif) | ![Kapture 2021-11-24 at 15 10 18](https://user-images.githubusercontent.com/14988353/143173541-399c39b2-43c3-4209-9c94-c41f8a29dfa7.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (manually)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
