### PR TITLE
Site Editor: Set the <title> on the list page to be same as the CPT name

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -263,3 +263,18 @@ function register_site_editor_homepage_settings() {
 	);
 }
 add_action( 'init', 'register_site_editor_homepage_settings', 10 );
+
+/**
+ * Sets the HTML <title> in the Site Editor list page to be the title of the CPT
+ * being edited, e.g. 'Templates'.
+ */
+function gutenberg_set_site_editor_list_page_title( $hook ) {
+	global $title;
+	if ( gutenberg_is_edit_site_list_page() ) {
+		$post_type = get_post_type_object( $_GET['postType'] );
+		if ( $post_type ) {
+			$title = $post_type->labels->name;
+		}
+	}
+}
+add_action( 'load-appearance_page_gutenberg-edit-site', 'gutenberg_set_site_editor_list_page_title' );

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -268,7 +268,7 @@ add_action( 'init', 'register_site_editor_homepage_settings', 10 );
  * Sets the HTML <title> in the Site Editor list page to be the title of the CPT
  * being edited, e.g. 'Templates'.
  */
-function gutenberg_set_site_editor_list_page_title( $hook ) {
+function gutenberg_set_site_editor_list_page_title() {
 	global $title;
 	if ( gutenberg_is_edit_site_list_page() ) {
 		$post_type = get_post_type_object( $_GET['postType'] );


### PR DESCRIPTION
## Description

See https://github.com/WordPress/gutenberg/issues/36597.

Changes the `<title>` on the list page to be the name of the CPT being edited, e.g. 'Templates'.

## How has this been tested?

1. Open the site editor.
2. Open the W menu.
3. Browse to Templates or Template Parts.
4. Notice that the window title is _Templates_ or _Template Parts_.

## Screenshots 

| Before | After |
| - | - |
| <img width="1433" alt="Screen Shot 2021-11-24 at 3 18 25 pm" src="https://user-images.githubusercontent.com/612155/143174444-341f99e9-9ba3-41d1-b82a-42156dc98771.png"> | <img width="1433" alt="Screen Shot 2021-11-24 at 3 18 30 pm" src="https://user-images.githubusercontent.com/612155/143174621-c41b48f4-fee7-40ef-9017-b253778918e0.png"> |

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->