### PR TITLE
Gallery: Fix stuck image size options loader

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -511,7 +511,7 @@ function GalleryEdit( props ) {
 							hideCancelButton={ true }
 						/>
 					) }
-					{ Platform.isWeb && ! imageSizeOptions && (
+					{ Platform.isWeb && ! imageSizeOptions && hasImageIds && (
 						<BaseControl className={ 'gallery-image-sizes' }>
 							<BaseControl.VisualLabel>
 								{ __( 'Image size' ) }

--- a/packages/block-library/src/gallery/v1/update-gallery-modal.js
+++ b/packages/block-library/src/gallery/v1/update-gallery-modal.js
@@ -39,7 +39,7 @@ export const updateGallery = ( {
 	}
 	const innerBlocks = images.map( ( image ) =>
 		createBlock( 'core/image', {
-			id: parseInt( image.id, 10 ),
+			id: image.id ? parseInt( image.id, 10 ) : null,
 			url: image.url,
 			alt: image.alt,
 			caption: image.caption,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #36554

This PR fixes the two instances I could find where the Image size options in the Gallery block results in a stuck loader:

* When the gallery contains only external images, then `imageSizeOptions` will always be falsy, which results in the loader always displaying. In this case, because we can't set image sizes for external images, let's hide the control altogether.
* When using the Update button on a v1 gallery containing external images (you might need to use the fix in https://github.com/WordPress/gutenberg/pull/36804 in order to create the v1 gallery with external images), currently the update logic results in the id being set to `NaN` when `parseInt` is called. This change explicitly sets it to `null`. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Test a v2 gallery block with all external images

1. With a v2 gallery running (e.g. `use_balanceTags` is set to `0`), insert a gallery block into a post or page, add a couple of images, and then replace every image with an externally linked image.
2. Save the post and reload the editor. Click on the gallery block and notice the stuck loader reported in #36554
3. With this PR applied, there should be no stuck loader, and also no option to adjust the image size

### Test the update button on a v1 gallery block

1. On a post or page containing a v1 gallery block with an external image (you may need to follow steps in #36804 to get this working), click the Update button in the block toolbar to update to a v2 gallery block
2. After the block is transformed if you select the gallery block, the Image size options should not be stuck loading

## Screenshots <!-- if applicable -->

| Before (note the stuck loader on the right) | After (No image size section) |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/143182389-8b733c09-87b3-4453-969a-f0f46547a738.png) | ![image](https://user-images.githubusercontent.com/14988353/143182417-4fd650b1-febe-40c4-b8b8-b8525da2aff5.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested. (manually tested)
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
