### PR TITLE
Fix: theme colors cannot override defaults

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1387,8 +1387,8 @@ class WP_Theme_JSON_Gutenberg {
 		$nodes        = self::get_setting_nodes( $incoming_data );
 		$slugs_global = self::get_slugs_not_to_override( $this->theme_json );
 		foreach ( $nodes as $node ) {
-			$slugs_for_context = self::get_slugs_not_to_override( $this->theme_json, $node['path'] );
-			$slugs             = array_merge_recursive( $slugs_global, $slugs_for_context );
+			$slugs_node = self::get_slugs_not_to_override( $this->theme_json, $node['path'] );
+			$slugs      = array_merge_recursive( $slugs_global, $slugs_node );
 
 			// Replace the spacing.units.
 			$path    = array_merge( $node['path'], array( 'spacing', 'units' ) );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1392,7 +1392,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * than an existing default preset. This is the list of slugs present
 		 * in the global config we'll use to filter the incoming slugs.
 		 */
-		$slugs_global = self::get_slugs_from_default_origin( $this->theme_json );
+		$slugs_global = self::get_slugs_not_to_override( $this->theme_json );
 
 		$nodes = self::get_setting_nodes( $this->theme_json );
 		foreach ( $nodes as $metadata ) {
@@ -1401,7 +1401,7 @@ class WP_Theme_JSON_Gutenberg {
 				$node = _wp_array_get( $incoming_data, $path, null );
 				if ( isset( $node ) ) {
 					if ( 'theme' === $path[ count( $path ) - 1 ] ) {
-						$slugs_for_context = self::get_slugs_from_default_origin( $this->theme_json, $metadata['path'] );
+						$slugs_for_context = self::get_slugs_not_to_override( $this->theme_json, $metadata['path'] );
 						$slugs_to_filter   = array_merge_recursive( $slugs_global, $slugs_for_context );
 						$node              = self::filter_slugs( $node, $property_path, $slugs_to_filter );
 					}
@@ -1413,8 +1413,9 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Returns the slugs for all the presets in the given path
-	 * as an associative array whose keys are the preset paths.
+	 * Returns the slugs for all the presets that cannot be overriden
+	 * in the given path. It returns an associative array
+	 * whose keys are the preset paths and the leafs is the list of slugs.
 	 *
 	 * For example:
 	 *
@@ -1433,7 +1434,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @return array An associative array containing the slugs for the given path.
 	 */
-	private static function get_slugs_from_default_origin( $data, $node_path = array( 'settings' ) ) {
+	private static function get_slugs_not_to_override( $data, $node_path = array( 'settings' ) ) {
 		$slugs = array();
 		foreach ( self::PRESETS_METADATA as $metadata ) {
 			if ( $metadata['override'] ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1394,7 +1394,7 @@ class WP_Theme_JSON_Gutenberg {
 		 */
 		$slugs_global = self::get_slugs_not_to_override( $this->theme_json );
 
-		$nodes = self::get_setting_nodes( $this->theme_json );
+		$nodes = self::get_setting_nodes( $incoming_data );
 		foreach ( $nodes as $metadata ) {
 			foreach ( $to_replace as $property_path ) {
 				$path = array_merge( $metadata['path'], $property_path );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -146,6 +146,9 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * - path       => where to find the preset within the settings section
 	 *
+	 * - override   => whether a theme preset with the same slug as a default preset
+	 *                 can override it
+	 *
 	 * - value_key  => the key that represents the value
 	 *
 	 * - value_func => optionally, instead of value_key, a function to generate
@@ -174,6 +177,7 @@ class WP_Theme_JSON_Gutenberg {
 	const PRESETS_METADATA = array(
 		array(
 			'path'       => array( 'color', 'palette' ),
+			'override'   => false,
 			'value_key'  => 'color',
 			'css_vars'   => '--wp--preset--color--$slug',
 			'classes'    => array(
@@ -185,6 +189,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		array(
 			'path'       => array( 'color', 'gradients' ),
+			'override'   => false,
 			'value_key'  => 'gradient',
 			'css_vars'   => '--wp--preset--gradient--$slug',
 			'classes'    => array( '.has-$slug-gradient-background' => 'background' ),
@@ -192,6 +197,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		array(
 			'path'       => array( 'color', 'duotone' ),
+			'override'   => true,
 			'value_func' => 'gutenberg_render_duotone_filter_preset',
 			'css_vars'   => '--wp--preset--duotone--$slug',
 			'classes'    => array(),
@@ -199,6 +205,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		array(
 			'path'       => array( 'typography', 'fontSizes' ),
+			'override'   => true,
 			'value_key'  => 'size',
 			'css_vars'   => '--wp--preset--font-size--$slug',
 			'classes'    => array( '.has-$slug-font-size' => 'font-size' ),
@@ -206,6 +213,7 @@ class WP_Theme_JSON_Gutenberg {
 		),
 		array(
 			'path'       => array( 'typography', 'fontFamilies' ),
+			'override'   => true,
 			'value_key'  => 'fontFamily',
 			'css_vars'   => '--wp--preset--font-family--$slug',
 			'classes'    => array( '.has-$slug-font-family' => 'font-family' ),
@@ -1428,6 +1436,10 @@ class WP_Theme_JSON_Gutenberg {
 	private static function get_slugs_from_default_origin( $data, $node_path = array( 'settings' ) ) {
 		$slugs = array();
 		foreach ( self::PRESETS_METADATA as $metadata ) {
+			if ( $metadata['override'] ) {
+				continue;
+			}
+
 			$slugs_for_preset = array();
 			$path             = array_merge( $node_path, $metadata['path'], array( 'default' ) );
 			$preset           = _wp_array_get( $data, $path, null );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1470,11 +1470,11 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Removes the preset values whose slug is equal to any of default presets.
+	 * Removes the preset values whose slug is equal to any of given slugs.
 	 *
 	 * @param array $node The node with the presets to validate.
-	 * @param array $path The path to the preset to inspect.
-	 * @param array $slugs The slugs to remove.
+	 * @param array $path The path to the preset type to inspect.
+	 * @param array $slugs The slugs that should not be overriden.
 	 *
 	 * @return array The new node
 	 */

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1373,12 +1373,10 @@ class WP_Theme_JSON_Gutenberg {
 		 */
 		$to_replace   = array();
 		$to_replace[] = array( 'spacing', 'units' );
-		foreach ( self::VALID_ORIGINS as $origin ) {
-			$to_replace[] = array( 'color', 'duotone', $origin );
-			$to_replace[] = array( 'color', 'palette', $origin );
-			$to_replace[] = array( 'color', 'gradients', $origin );
-			$to_replace[] = array( 'typography', 'fontSizes', $origin );
-			$to_replace[] = array( 'typography', 'fontFamilies', $origin );
+		foreach ( self::PRESETS_METADATA as $metadata ) {
+			foreach ( self::VALID_ORIGINS as $origin ) {
+				$to_replace[] = array_merge( $metadata['path'], array( $origin ) );
+			}
 		}
 
 		$nodes = self::get_setting_nodes( $this->theme_json );

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1354,9 +1354,23 @@ class WP_Theme_JSON_Gutenberg {
 		$incoming_data    = $incoming->get_raw_data();
 		$this->theme_json = array_replace_recursive( $this->theme_json, $incoming_data );
 
-		// The array_replace_recursive algorithm merges at the leaf level.
-		// For leaf values that are arrays it will use the numeric indexes for replacement.
-		// In those cases, we want to replace the existing with the incoming value, if it exists.
+		/*
+		 * The array_replace_recursive algorithm merges at the leaf level,
+		 * but we don't want leaf arrays to be merged, so we overwrite it.
+		 *
+		 * For leaf values that are sequential arrays it will use the numeric indexes for replacement.
+		 * We rather replace the existing with the incoming value, if it exists.
+		 * This is the case of spacing.units.
+		 *
+		 * For leaf values that are associative arrays it will merge them as expected.
+		 * This is also not the behavior we want for the current associative arrays (presets).
+		 * We rather replace the existing with the incoming value, if it exists.
+		 * This happens, for example, when we merge data from theme.json upon existing
+		 * theme supports or when we merge anything coming from the same source twice.
+		 * This is the case of color.palette, color.gradients, color.duotone,
+		 * typography.fontSizes, or typography.fontFamilies.
+		 *
+		 */
 		$to_replace   = array();
 		$to_replace[] = array( 'spacing', 'units' );
 		foreach ( self::VALID_ORIGINS as $origin ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1384,7 +1384,7 @@ class WP_Theme_JSON_Gutenberg {
 		 * than an existing default preset. This is the list of slugs present
 		 * in the global config we'll use to filter the incoming slugs.
 		 */
-		$slugs_global = self::get_slugs_from_path( $this->theme_json );
+		$slugs_global = self::get_slugs_from_default_origin( $this->theme_json );
 
 		$nodes = self::get_setting_nodes( $this->theme_json );
 		foreach ( $nodes as $metadata ) {
@@ -1393,7 +1393,7 @@ class WP_Theme_JSON_Gutenberg {
 				$node = _wp_array_get( $incoming_data, $path, null );
 				if ( isset( $node ) ) {
 					if ( 'theme' === $path[ count( $path ) - 1 ] ) {
-						$slugs_for_context = self::get_slugs_from_path( $this->theme_json, $metadata['path'] );
+						$slugs_for_context = self::get_slugs_from_default_origin( $this->theme_json, $metadata['path'] );
 						$slugs_to_filter   = array_merge_recursive( $slugs_global, $slugs_for_context );
 						$node              = self::filter_slugs( $node, $property_path, $slugs_to_filter );
 					}
@@ -1425,7 +1425,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @return array An associative array containing the slugs for the given path.
 	 */
-	private static function get_slugs_from_path( $data, $node_path = array( 'settings' ) ) {
+	private static function get_slugs_from_default_origin( $data, $node_path = array( 'settings' ) ) {
 		$slugs = array();
 		foreach ( self::PRESETS_METADATA as $metadata ) {
 			$slugs_for_preset = array();

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1419,7 +1419,6 @@ class WP_Theme_JSON_Gutenberg {
 					}
 				}
 			}
-
 		}
 
 	}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1424,9 +1424,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *     'palette'   => array( 'slug-1', 'slug-2' ),
 	 *     'gradients' => array( 'slug-3', 'slug-4' ),
 	 *   ),
-	 *   'typography' => array(
-	 *     'fontSizes' => array( 'slug-5', 'slug-6'),
-	 *   )
 	 * )
 	 *
 	 * @param array $data A theme.json like structure to inspect.

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1081,6 +1081,144 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_merge_incoming_data_removes_theme_presets_with_slugs_as_default_presets() {
+		$defaults = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'  => array(
+						'palette' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+								'name'  => 'Red',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Green',
+							),
+						),
+					),
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Blue',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$theme    = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color'  => array(
+						'palette' => array(
+							array(
+								'slug'  => 'pink',
+								'color' => 'pink',
+								'name'  => 'Pink',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Greenish',
+							),
+						),
+					),
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Bluish',
+									),
+									array(
+										'slug'  => 'yellow',
+										'color' => 'yellow',
+										'name'  => 'Yellow',
+									),
+									array(
+										'slug'  => 'green',
+										'color' => 'green',
+										'name'  => 'Block Green',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color'  => array(
+					'palette' => array(
+						'default' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+								'name'  => 'Red',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Green',
+							),
+						),
+						'theme'   => array(
+							array(
+								'slug'  => 'pink',
+								'color' => 'pink',
+								'name'  => 'Pink',
+							),
+						),
+					),
+				),
+				'blocks' => array(
+					'core/paragraph' => array(
+						'color' => array(
+							'palette' => array(
+								'default' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Blue',
+									),
+								),
+								'theme'   => array(
+									array(
+										'slug'  => 'yellow',
+										'color' => 'yellow',
+										'name'  => 'Yellow',
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$defaults->merge( $theme );
+		$actual = $defaults->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	function test_remove_insecure_properties_removes_unsafe_styles() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36772

This PR removes the theme presets that have the same slug as a core preset of the same type. For example, the color theme presets can't have a `black` slug, which is already part of the color default presets.

## How to test

### Global presets are filtered

- Use the TT1-blocks theme.
- In its `theme.json` update the value of the colors whose slug is `black` and `white` to a color that is easily inspectable for debugging purposes. For example:
```json
{
  "slug": "black",
  "color": "#FF69B4",
  "name": "Black"
},
{
  "slug": "white",
  "color": "#FF69B4",
  "name": "White"
}
```
- Go to the front-end and inspect the `global-styles-inline-css` embedded stylesheet.
  - Verify that there's only a single `--wp--preset--color--black` whose value is `#000000` and a single `--wp--preset--color--white` whose value is `#FFFFFF` (they come from the default palette).
  - Before this PR the value for both would be `#FF69B4`.
- Go to the editors and verify that the theme palette does not contain the black & white colors in the theme palette.

| Before | After |
| --------- | ------- |
| ![Captura de ecrã de 2021-11-24 10-35-44](https://user-images.githubusercontent.com/583546/143213063-2bfb5a46-ed29-4e20-9bdf-5bee4f45e5c0.png) |  ![Captura de ecrã de 2021-11-24 10-38-16](https://user-images.githubusercontent.com/583546/143213179-f7b82479-7944-47a5-9b39-296883619718.png) |

### Block-level presets are filtered

- In the `theme.json` file of the TT1-blocks, add the following palette under `settings.blocks.core/paragraph.color.palette`:
```json
[
  {
    "slug": "black",
    "color": "#FF69B4",
    "name": "Black"
  },
  {
    "slug": "yellow",
    "color": "#EEEADD",
    "name": "Yellow"
  },
  {
    "slug": "white",
    "color": "#FF69B4",
    "name": "White"
  }
]

```

- In the editors, the expected result is that the palette for the paragraph only contains one color (the yellow).
- In the front, within the `global-styles-inline-css` embedded stylesheet the expected result is that there's new CSS Custom Properties and classes scoped to the paragraph block:

```css
p {
  --wp--preset--color--yellow: #eeeadd;
}

p.has-yellow-color {
  color: var(--wp--preset--color--yellow) !important;
}
p.has-yellow-background-color {
  background-color: var(--wp--preset--color--yellow) !important;
}
p.has-yellow-border-color {
  border-color: var(--wp--preset--color--yellow) !important;
}
```
