### PR TITLE
Site Editor: Templates list render notices

### DIFF
--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -3,6 +3,7 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { EditorSnackbars } from '@wordpress/editor';
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -66,6 +67,7 @@ export default function List( { templateType } ) {
 					isDefaultOpen
 				/>
 			}
+			notices={ <EditorSnackbars /> }
 			content={
 				<main className="edit-site-list-main">
 					<Table templateType={ templateType } />


### PR DESCRIPTION
## Description
Add `EditorSnackbars` component to template list interface skeleton. I'm only adding snackbars since this is the only type of notices we're using on this screen.

P.S. @jameskoster, I think snackbars aren't visible when the navigation sidebar drawer is open. Should we add a rule to move them left to the content area?

## How has this been tested?
Paste the following snippet in the DevTools console.

```
wp.data.dispatch( 'core/notices' ).createErrorNotice( 'Template revert failed. Please reload.',  { type: 'snackbar', isDissmisable: true } )
```

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-24 at 14 53 40](https://user-images.githubusercontent.com/240569/143225369-d68c01e3-8279-4233-b563-54f192c28fd3.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
