### PR TITLE
Fix: Color palette is not being stored

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -303,7 +303,8 @@ class WP_Theme_JSON_Gutenberg {
 				$path   = array_merge( $node['path'], $preset_metadata['path'] );
 				$preset = _wp_array_get( $this->theme_json, $path, null );
 				if ( null !== $preset ) {
-					if ( 'user' !== $origin || isset( $preset[0] ) ) {
+					// If the preset is not already keyed by origin.
+					if ( isset( $preset[0] ) || empty( $preset ) ) {
 						_wp_array_set( $this->theme_json, $path, array( $origin => $preset ) );
 					}
 				}

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -220,7 +220,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		$is_global_styles_user_theme_json = isset( $raw_config['isGlobalStylesUserThemeJSON'] ) && true === $raw_config['isGlobalStylesUserThemeJSON'];
 		$config                           = array();
 		if ( $is_global_styles_user_theme_json ) {
-			$config = ( new WP_Theme_JSON_Gutenberg( $raw_config, 'user' ) )->get_raw_data();
+			$config = ( new WP_Theme_JSON_Gutenberg( $raw_config, 'custom' ) )->get_raw_data();
 		}
 
 		$fields = $this->get_fields_for_response( $request );


### PR DESCRIPTION
With https://github.com/WordPress/gutenberg/pull/36748 and https://github.com/WordPress/gutenberg/pull/36747 we made a regression and the color palettes are not being stored correctly.

This PR fixes the issue.


## How has this been tested?
I verified as a user I could change theme, default, and custom palettes and they are stored after reloading the site editor.
