### PR TITLE
Update some small style regressions in the template list

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -61,10 +61,12 @@
 
 .edit-site-list-table {
 	width: 100%;
-	border: $border-width solid $gray-200;
+	border: $border-width solid $gray-300;
 	border-radius: 2px;
 	margin: 0;
 	overflow: hidden;
+	border-spacing: 0;
+	max-width: 960px;
 
 	tr {
 		display: flex;
@@ -74,17 +76,18 @@
 		border-top: $border-width solid $gray-100;
 		margin: 0;
 
+		&:first-child {
+			border-top: 0;
+		}
+
 		@include break-medium() {
 			padding: $grid-unit-30 $grid-unit-40;
 		}
 
 		// Template.
 		.edit-site-list-table-column:nth-child(1) {
-			width: calc(60% - 36px);
-			flex-grow: 1;
-			display: flex;
-			flex-direction: column;
-			align-items: flex-start;
+			width: calc(60% - 18px);
+			padding-right: $grid-unit-30;
 
 			a {
 				display: inline-block;
@@ -96,7 +99,7 @@
 
 		// Added by.
 		.edit-site-list-table-column:nth-child(2) {
-			width: calc(40% - 36px);
+			width: calc(40% - 18px);
 		}
 
 		// Actions.
@@ -110,7 +113,12 @@
 		font-size: 16px;
 		font-weight: 600;
 		text-align: left;
-		color: #050505;
+		color: $gray-900;
 		border-top: none;
+		border-bottom: $border-width solid $gray-300;
+
+		th {
+			font-weight: inherit;
+		}
 	}
 }

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -9,6 +9,7 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
@@ -146,14 +147,16 @@ export default function Table( { templateType } ) {
 						role="row"
 					>
 						<td className="edit-site-list-table-column" role="cell">
-							<a
-								href={ addQueryArgs( window.location.href, {
-									postId: template.id,
-									postType: template.type,
-								} ) }
-							>
-								{ template.title.rendered }
-							</a>
+							<Heading level={ 4 }>
+								<a
+									href={ addQueryArgs( window.location.href, {
+										postId: template.id,
+										postType: template.type,
+									} ) }
+								>
+									{ template.title.rendered }
+								</a>
+							</Heading>
 							{ template.description }
 						</td>
 


### PR DESCRIPTION
When we [switched back](https://github.com/WordPress/gutenberg/pull/36707) to using a `table` for the list layout some style regressions seeped in. This PR fixes them.

### Before
<img width="1593" alt="Screenshot 2021-11-24 at 14 53 55" src="https://user-images.githubusercontent.com/846565/143261198-57e99bfb-3fc6-44a7-a5af-b9604568f887.png">


### After
<img width="1594" alt="Screenshot 2021-11-24 at 14 53 28" src="https://user-images.githubusercontent.com/846565/143261229-f5f8de8f-7632-437c-9ba6-47e868d0d2f8.png">
