### PR TITLE
Only show submenu options and Show arrow button when relevant.

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -142,12 +142,12 @@ function Navigation( {
 				blockEditorStore
 			);
 			const blocks = getBlocks( clientId );
-			const firstSubmenu = blocks.find(
+			const didFindSubmenu = !! blocks.find(
 				( block ) => block.name === 'core/navigation-submenu'
 			);
 
 			return {
-				hasSubmenus: !! firstSubmenu,
+				hasSubmenus: didFindSubmenu,
 				innerBlocks: blocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};
@@ -420,21 +420,26 @@ function Navigation( {
 										onChange={ ( value ) => {
 											setAttributes( {
 												openSubmenusOnClick: value,
+												...( value && {
+													showSubmenuIcon: true,
+												} ), // make sure arrows are shown when we toggle this on.
 											} );
 										} }
 										label={ __( 'Open on click' ) }
 									/>
-									{ ! attributes.openSubmenusOnClick && (
-										<ToggleControl
-											checked={ showSubmenuIcon }
-											onChange={ ( value ) => {
-												setAttributes( {
-													showSubmenuIcon: value,
-												} );
-											} }
-											label={ __( 'Show icons' ) }
-										/>
-									) }
+
+									<ToggleControl
+										checked={ showSubmenuIcon }
+										onChange={ ( value ) => {
+											setAttributes( {
+												showSubmenuIcon: value,
+											} );
+										} }
+										disabled={
+											attributes.openSubmenusOnClick
+										}
+										label={ __( 'Show arrow' ) }
+									/>
 								</>
 							) }
 						</PanelBody>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -142,12 +142,12 @@ function Navigation( {
 				blockEditorStore
 			);
 			const blocks = getBlocks( clientId );
-			const didFindSubmenu = !! blocks.find(
+			const firstSubmenu = !! blocks.find(
 				( block ) => block.name === 'core/navigation-submenu'
 			);
 
 			return {
-				hasSubmenus: didFindSubmenu,
+				hasSubmenus: firstSubmenu,
 				innerBlocks: blocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};
@@ -422,7 +422,7 @@ function Navigation( {
 												openSubmenusOnClick: value,
 												...( value && {
 													showSubmenuIcon: true,
-												} ), // make sure arrows are shown when we toggle this on.
+												} ), // Make sure arrows are shown when we toggle this on.
 											} );
 										} }
 										label={ __( 'Open on click' ) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -136,13 +136,19 @@ function Navigation( {
 		`navigationMenu/${ navigationMenuId }`
 	);
 
-	const { innerBlocks, isInnerBlockSelected } = useSelect(
+	const { innerBlocks, isInnerBlockSelected, hasSubmenus } = useSelect(
 		( select ) => {
 			const { getBlocks, hasSelectedInnerBlock } = select(
 				blockEditorStore
 			);
+			const blocks = getBlocks( clientId );
+			const firstSubmenu = blocks.find(
+				( block ) => block.name === 'core/navigation-submenu'
+			);
+
 			return {
-				innerBlocks: getBlocks( clientId ),
+				hasSubmenus: !! firstSubmenu,
+				innerBlocks: blocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};
 		},
@@ -406,26 +412,30 @@ function Navigation( {
 									label={ __( 'Always' ) }
 								/>
 							</ToggleGroupControl>
-							<h3>{ __( 'Submenus' ) }</h3>
-							<ToggleControl
-								checked={ openSubmenusOnClick }
-								onChange={ ( value ) => {
-									setAttributes( {
-										openSubmenusOnClick: value,
-									} );
-								} }
-								label={ __( 'Open on click' ) }
-							/>
-							{ ! attributes.openSubmenusOnClick && (
-								<ToggleControl
-									checked={ showSubmenuIcon }
-									onChange={ ( value ) => {
-										setAttributes( {
-											showSubmenuIcon: value,
-										} );
-									} }
-									label={ __( 'Show icons' ) }
-								/>
+							{ hasSubmenus && (
+								<>
+									<h3>{ __( 'Submenus' ) }</h3>
+									<ToggleControl
+										checked={ openSubmenusOnClick }
+										onChange={ ( value ) => {
+											setAttributes( {
+												openSubmenusOnClick: value,
+											} );
+										} }
+										label={ __( 'Open on click' ) }
+									/>
+									{ ! attributes.openSubmenusOnClick && (
+										<ToggleControl
+											checked={ showSubmenuIcon }
+											onChange={ ( value ) => {
+												setAttributes( {
+													showSubmenuIcon: value,
+												} );
+											} }
+											label={ __( 'Show icons' ) }
+										/>
+									) }
+								</>
 							) }
 						</PanelBody>
 					) }


### PR DESCRIPTION
## Description
Addresses https://github.com/WordPress/gutenberg/issues/36698.

- The "Submenus" sidebar options is only shown if the Navigation 

block has at least  one Submenu.
- Rename Show icons to Show arrow.
- Disable the option to toggle "Show arrow" instead of hiding the button when Open on Click is on.
- Make sure that Show arrow is toggled on when Open on Click is on.

## Screenshots
|With submenus|Without submenus|
|-|-|
|<img width="834" alt="withsubmenus" src="https://user-images.githubusercontent.com/1157901/143263526-bb84aa7a-466e-4a2c-baa4-9dc945c40b46.PNG">|<img width="845" alt="nosubmenus" src="https://user-images.githubusercontent.com/1157901/143263561-ad4a424a-6840-4330-adfe-af3a4891580b.PNG">|

### Open on click and Show arrow interaction

https://user-images.githubusercontent.com/1157901/143263350-a69d825d-a9d6-4161-8b9d-b590823daffd.mp4


