### PR TITLE
Assign a unique slug to navigation blocks and wp_navigation posts

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -449,3 +449,29 @@ CSS;
 }
 
 add_action( 'admin_enqueue_scripts', 'gutenberg_hide_visibility_and_status_for_navigation_posts' );
+
+/**
+ * Sets a custom slug when creating auto-draft wp_navigatino posts.
+ * This is only needed for auto-drafts created by the regular WP editor.
+ * If this page is to be removed, this won't be necessary.
+ *
+ * @param int $post_id Post ID.
+ */
+function gutenberg_set_unique_slug_on_create_wp_navigation( $post_id ) {
+	// This is the core function with the same functionality.
+	if ( function_exists( 'gutenberg_set_unique_slug_on_create_wp_navigation' ) ) {
+		return;
+	}
+
+	$post = get_post( $post_id );
+	if ( ! $post->post_name ) {
+		wp_update_post(
+			array(
+				'ID'        => $post_id,
+				'post_name' => $post_id . '',
+			)
+		);
+	}
+}
+
+add_action( 'save_post_wp_navigation', 'gutenberg_set_unique_slug_on_create_wp_navigation' );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -449,29 +449,3 @@ CSS;
 }
 
 add_action( 'admin_enqueue_scripts', 'gutenberg_hide_visibility_and_status_for_navigation_posts' );
-
-/**
- * Sets a custom slug when creating auto-draft wp_navigatino posts.
- * This is only needed for auto-drafts created by the regular WP editor.
- * If this page is to be removed, this won't be necessary.
- *
- * @param int $post_id Post ID.
- */
-function gutenberg_set_unique_slug_on_create_wp_navigation( $post_id ) {
-	// This is the core function with the same functionality.
-	if ( function_exists( 'gutenberg_set_unique_slug_on_create_wp_navigation' ) ) {
-		return;
-	}
-
-	$post = get_post( $post_id );
-	if ( ! $post->post_name ) {
-		wp_update_post(
-			array(
-				'ID'        => $post_id,
-				'post_name' => $post_id . '',
-			)
-		);
-	}
-}
-
-add_action( 'save_post_wp_navigation', 'gutenberg_set_unique_slug_on_create_wp_navigation' );

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -9,7 +9,10 @@
 	"textdomain": "default",
 	"attributes": {
 		"navigationMenuId": {
-			"type": "number"
+		  	"type": "number"
+		},
+		"slug": {
+		  	"type": "string"
 		},
 		"textColor": {
 			"type": "string"

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -312,6 +312,7 @@ function Navigation( {
 					setHasSavedUnsavedInnerBlocks( true );
 					// Switch to using the wp_navigation entity.
 					setNavigationMenuId( post.id );
+					setAttributes( { slug: post.slug } );
 				} }
 			/>
 		);
@@ -365,8 +366,9 @@ function Navigation( {
 							>
 								{ ( { onClose } ) => (
 									<NavigationMenuSelector
-										onSelect={ ( { id } ) => {
+										onSelect={ ( { id, slug } ) => {
 											setNavigationMenuId( id );
+											setAttributes( { slug } );
 											onClose();
 										} }
 										onCreateNew={ startWithEmptyMenu }
@@ -501,6 +503,7 @@ function Navigation( {
 								setIsPlaceholderShown( false );
 								if ( post ) {
 									setNavigationMenuId( post.id );
+									setAttributes( { slug: post.slug } );
 								}
 								selectBlock( clientId );
 							} }


### PR DESCRIPTION
# Description

Related to https://github.com/WordPress/gutenberg/issues/36524.

This PR sets the ground for using slugs in the navigation block in WordPress 6.0. Right now, the navigation block refers to the underlying data using a numerical ID, like `684`:

```html
<!-- wp:navigation {"menuId": 642 } /-->
```

With slugs, it would refer to it using a string:

```html
<!-- wp:navigation {"slug": "header-menu" } /-->
```

This would enable an automated transfer of menus between themes. It's the same idea as in template parts.

The problem is that WP 5.9 will use numerical IDs, which means there will be many "legacy" blocks created by the time WP 6.0 is released. How could they be migrated to slugs in 6.0? Enter this PR.

I propose setting `post_name` of every created `wp_navigation` post to the slug fetched from the backend on wp_navigation post creation. This way, in WP 6.0 we could migrate this:

```html
<!-- wp:navigation {"menuId": 642, "slug": "header-navigation" } /-->
```

to this:

```html
<!-- wp:navigation {"slug": "header-navigation" } /-->
```

Even if slugs won't be shipped in the end, that's okay – the migration would just go in this direction insted:

```html
<!-- wp:navigation {"menuId": 642 } /-->
```

# Test plan

1. Confirm all the existing navigation blocks continue to work. Ideally they would receive the slug attribute as well, but that milk is already spilled so this PR doesn't have to solve it right now.
2. Confirm that adding a new navigation block stores "slug" as a block attribute.

cc @getdave @tellthemachines @talldan @noisysocks @mtias @draganescu 
