### PR TITLE
Query Loop: Remove the `Next Page` link on empty query

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -45,7 +45,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	} elseif ( ! $max_page || $max_page > $page ) {
 		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		$max_num_pages = (int) $custom_query->max_num_pages;
-		if ( !$max_num_pages ) {
+		if ( ! $max_num_pages ) {
 			return '';
 		}
 		if ( $max_num_pages !== $page ) {

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -43,7 +43,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$content = get_next_posts_link( $label, $max_page );
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		$max_num_pages = (int) $custom_query->max_num_pages;
 		if ( ! $max_num_pages ) {
 			return '';

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -44,7 +44,11 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
 		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		if ( (int) $custom_query->max_num_pages !== $page ) {
+		$max_num_pages = (int) $custom_query->max_num_pages;
+		if ( !$max_num_pages ) {
+			return '';
+		}
+		if ( $max_num_pages !== $page ) {
 			$content = sprintf(
 				'<a href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),


### PR DESCRIPTION
## Description

There's an issue (https://github.com/Automattic/wp-calypso/issues/56504) that keeps the `Next Page` link in the Query Loop / Query Loop Pagination block visible in the front-end even in case when there is no content to be displayed:

![no-content](https://user-images.githubusercontent.com/25105483/143272129-3cf98245-934d-47e8-af3f-ee0b7b0cbe26.jpg)

The proposed change adjusts the logic that handles the display of the `Next Page` link in a way that when there are no query results (`0 === max_num_pages` / no pages to display), the `Next Page` link won't be displayed.

When it comes to back-end, I think it would be worth leaving the default pagination displayed there even when there are no posts to be displayed at the time. This would make sure the user can still click on the pagination block and adjust its settings (e.g. label) for the time when the new posts meeting the filter criteria are published.

![Markup on 2021-11-24 at 15:01:18](https://user-images.githubusercontent.com/25105483/143272380-fcf93229-90f8-42dc-bb0d-56a36bfcb1f8.png)

## How has this been tested?

1. Create a new page and insert the Query Loop block into the content.
2. Make sure there's also the Query Loop Pagination block present. This can be accomplished by clicking on "Start blank" and then selecting one of the options, e.g. "Title & Date" - as can be seen in the following screen recording:

https://user-images.githubusercontent.com/25105483/143267977-0f973103-453e-4dc2-8027-37d83b0f3c95.mp4

3. Next, we need to make sure that no posts are displayed. One of the ways to make this happen is to create a new tag (Posts → Tags) that doesn't have any posts linked to it. Once the tag is created, we can select it in the Query Loop block settings:
![Markup on 2021-11-24 at 16:38:33](https://user-images.githubusercontent.com/25105483/143269116-76a93ffa-1e41-41d2-9316-f4c529fa2acd.png)

4. Save the changes and take a look at the page in the front-end. There should be no `Next Page` link visible. In other words, it shouldn't be possible to reproduce the https://github.com/Automattic/wp-calypso/issues/56504 issue.

I have tested the change locally with `npm run lint` and `npm test`.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- N/A I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
