### PR TITLE
Update micromodal, include click-through fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18827,7 +18827,7 @@
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"micromodal": "^0.4.6",
+				"micromodal": "^0.4.9",
 				"moment": "^2.22.1"
 			},
 			"dependencies": {
@@ -47901,9 +47901,9 @@
 			}
 		},
 		"micromodal": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.6.tgz",
-			"integrity": "sha512-2VDso2a22jWPpqwuWT/4RomVpoU3Bl9qF9D01xzwlNp5UVsImeA0gY4nSpF44vqcQtQOtkiMUV9EZkAJSRxBsg=="
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.9.tgz",
+			"integrity": "sha512-6sWcdAhzUOiu88LRz+HgGM2cfvwQjrOBXx+3BilqWg3Lr+bTNEgCUMME5OqgeoWckRk2klDkT0sPqjJzDB1ffw=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -67,7 +67,7 @@
 		"fast-average-color": "4.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"micromodal": "^0.4.6",
+		"micromodal": "^0.4.9",
 		"moment": "^2.22.1"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description
Fixes https://github.com/WordPress/gutenberg/issues/31957

A `touchstart` event bug on MicroModal was causing the close button to click the avatar button on the admin bar.
Tested on Firefox and Safari, and it seems to work correctly now.

## How has this been tested?
- Create a responsive navigation menu.
- Open it by clicking the Burger Icon, then close it clicking on the close button.
- Menu should be closed, and the link to the Profile page should not be followed.
- Clicking on the Avatar icon on the admin bar should still take you to the Profile page.

## Screenshots
![Kapture 2021-11-24 at 17 27 35](https://user-images.githubusercontent.com/1157901/143308787-d2bfa78d-cc40-4fea-bbdb-ad2d2db37565.gif)
