### PR TITLE
[Docs]: Add docs for `schema` in block API

### DIFF
--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -223,13 +223,22 @@ transforms: {
 
 <h4 id="schemas-and-content-models">Schemas and Content Models</h4>
 
-When pasting content it's possible to define a [content model](https://html.spec.whatwg.org/multipage/dom.html#content-models) that will be used to validate and process pasted content.
-It's often the case that HTML pasted into the editor will contain a mixture of elements that _should_ transfer as well as elements that _shouldn't_.
-For example, consider pasting `<span class="time">12:04 pm</span>` into the editor.
-We want to copy `12:04 pm` and omit the `<span>` and its `class` attribute because those won't carry the same meaning or structure as they originally did from where they were copied.
+When pasting content it's possible to define
+a [content model](https://html.spec.whatwg.org/multipage/dom.html#content-models) that will be used to validate and
+process pasted content. It's often the case that HTML pasted into the editor will contain a mixture of elements that _
+should_ transfer as well as elements that _shouldn't_. For example, consider
+pasting `<span class="time">12:04 pm</span>` into the editor. We want to copy `12:04 pm` and omit the `<span>` and
+its `class` attribute because those won't carry the same meaning or structure as they originally did from where they
+were copied.
 
-When writing `raw` transforms you can control this by supplying a `schema` which describes allowable content and which will be applied to clean up the pasted content before attempting to match with your block.
-The schemas are passed into `cleanNodeList` from `@wordpress/dom`; check there for a complete description of the schema.
+When writing `raw` transforms you can control this by supplying a `schema` which describes allowable content and which
+will be applied to clean up the pasted content before attempting to match with your block. The schemas are passed
+into [`cleanNodeList` from `@wordpress/dom`](/packages/dom/src/dom/clean-node-list.js); check there for
+a [complete description of the schema](/packages/dom/src/phrasing-content.js).
+
+```js
+schema = { span: { children: { '#text': {} } } }
+```
 
 **Example: a custom content model**
 
@@ -242,11 +251,12 @@ Suppose we want to match the following HTML snippet and turn it into some kind o
  </div>
  ```
 
-We want to tell the editor to allow the inner `h2` and `p` elements.
-We do this by supplying the following schema.
-In this example we're using the function form, which accepts an argument supplying `phrasingContentSchema` (as well as a boolean `isPaste` indicating if the transformation operation started with pasting text).
-The `phrasingContentSchema` is pre-defined to match HTML phrasing elements, such as `<strong>` and `<sup>` and `<kbd>`.
-Anywhere we expect a `<RichText />` component is a good place to allow phrasing content otherwise we'll lose all text formatting on conversion.
+We want to tell the editor to allow the inner `h2` and `p` elements. We do this by supplying the following schema. In
+this example we're using the function form, which accepts an argument supplying `phrasingContentSchema` (as well as a
+boolean `isPaste` indicating if the transformation operation started with pasting text). The `phrasingContentSchema` is
+pre-defined to match HTML phrasing elements, such as `<strong>` and `<sup>` and `<kbd>`. Anywhere we expect
+a `<RichText />` component is a good place to allow phrasing content otherwise we'll lose all text formatting on
+conversion.
 
  ```js
  schema = ({ phrasingContentSchema }) => {
@@ -261,11 +271,13 @@ Anywhere we expect a `<RichText />` component is a good place to allow phrasing 
  }
  ```
 
-When we successfully match this content every HTML attribute will be stripped away except for `data-post-id` and if we have other arrangements of HTML inside of a given `div` then it won't match our transformer.
-Likewise we'd fail to match if we found an `<h3>` in there instead of an `<h2>`.
+When we successfully match this content every HTML attribute will be stripped away except for `data-post-id` and if we
+have other arrangements of HTML inside of a given `div` then it won't match our transformer. Likewise we'd fail to match
+if we found an `<h3>` in there instead of an `<h2>`.
 
-Schemas are most-important when wanting to match HTML snippets containing non-phrasing content, such as `<details>` with a `<summary>`.
-Without declaring the custom schema the editor will skip over these other contructions before attempting to run them through any block transforms.
+Schemas are most-important when wanting to match HTML snippets containing non-phrasing content, such as `<details>` with
+a `<summary>`. Without declaring the custom schema the editor will skip over these other contructions before attempting
+to run them through any block transforms.
 
 ### Shortcode
 

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -233,8 +233,8 @@ were copied.
 
 When writing `raw` transforms you can control this by supplying a `schema` which describes allowable content and which
 will be applied to clean up the pasted content before attempting to match with your block. The schemas are passed
-into [`cleanNodeList` from `@wordpress/dom`](/packages/dom/src/dom/clean-node-list.js); check there for
-a [complete description of the schema](/packages/dom/src/phrasing-content.js).
+into [`cleanNodeList` from `@wordpress/dom`](https://github.com/wordpress/gutenberg/blob/trunk/packages/dom/src/dom/clean-node-list.js); check there for
+a [complete description of the schema](https://github.com/wordpress/gutenberg/blob/trunk/packages/dom/src/phrasing-content.js).
 
 ```js
 schema = { span: { children: { '#text': {} } } }

--- a/docs/reference-guides/block-api/block-transforms.md
+++ b/docs/reference-guides/block-api/block-transforms.md
@@ -194,7 +194,7 @@ A transformation of type `raw` is an object that takes the following parameters:
 
 -   **type** _(string)_: the value `raw`.
 -   **transform** _(function, optional)_: a callback that receives the node being processed. It should return a block object or an array of block objects.
--   **schema** _(object|function, optional)_: it defines the attributes and children of the node that will be preserved on paste, according to its [HTML content model](https://html.spec.whatwg.org/multipage/dom.html#content-models). Take a look at [pasteHandler](/packages/blocks/README.md#pasteHandler) for more info.
+-   **schema** _(object|function, optional)_: defines an [HTML content model](https://html.spec.whatwg.org/multipage/dom.html#content-models) used to detect and process pasted contents. See [below](#schemas-and-content-models).
 -   **selector** _(string, optional)_: a CSS selector string to determine whether the element matches according to the [element.matches](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches) method. The transform won't be executed if the element doesn't match. This is a shorthand and alternative to using `isMatch`, which, if present, will take precedence.
 -   **isMatch** _(function, optional)_: a callback that receives the node being processed and should return a boolean. Returning `false` from this function will prevent the transform from being applied.
 -   **priority** _(number, optional)_: controls the priority with which a transform is applied, where a lower value will take precedence over higher values. This behaves much like a [WordPress hook](https://codex.wordpress.org/Plugin_API#Hook_to_WordPress). Like hooks, the default priority is `10` when not otherwise set.
@@ -220,6 +220,52 @@ transforms: {
     ],
 }
 ```
+
+<h4 id="schemas-and-content-models">Schemas and Content Models</h4>
+
+When pasting content it's possible to define a [content model](https://html.spec.whatwg.org/multipage/dom.html#content-models) that will be used to validate and process pasted content.
+It's often the case that HTML pasted into the editor will contain a mixture of elements that _should_ transfer as well as elements that _shouldn't_.
+For example, consider pasting `<span class="time">12:04 pm</span>` into the editor.
+We want to copy `12:04 pm` and omit the `<span>` and its `class` attribute because those won't carry the same meaning or structure as they originally did from where they were copied.
+
+When writing `raw` transforms you can control this by supplying a `schema` which describes allowable content and which will be applied to clean up the pasted content before attempting to match with your block.
+The schemas are passed into `cleanNodeList` from `@wordpress/dom`; check there for a complete description of the schema.
+
+**Example: a custom content model**
+
+Suppose we want to match the following HTML snippet and turn it into some kind of custom post preview block.
+
+ ```html
+ <div data-post-id="13">
+     <h2>The Post Title</h2>
+     <p>Some <em>great</em> content.</p>
+ </div>
+ ```
+
+We want to tell the editor to allow the inner `h2` and `p` elements.
+We do this by supplying the following schema.
+In this example we're using the function form, which accepts an argument supplying `phrasingContentSchema` (as well as a boolean `isPaste` indicating if the transformation operation started with pasting text).
+The `phrasingContentSchema` is pre-defined to match HTML phrasing elements, such as `<strong>` and `<sup>` and `<kbd>`.
+Anywhere we expect a `<RichText />` component is a good place to allow phrasing content otherwise we'll lose all text formatting on conversion.
+
+ ```js
+ schema = ({ phrasingContentSchema }) => {
+     div: {
+         required: true,
+         attributes: [ 'data-post-id' ],
+         children: {
+             h2: { children: phrasingContentSchema },
+             p: { children: phrasingContentSchema }
+         }
+     }
+ }
+ ```
+
+When we successfully match this content every HTML attribute will be stripped away except for `data-post-id` and if we have other arrangements of HTML inside of a given `div` then it won't match our transformer.
+Likewise we'd fail to match if we found an `<h3>` in there instead of an `<h2>`.
+
+Schemas are most-important when wanting to match HTML snippets containing non-phrasing content, such as `<details>` with a `<summary>`.
+Without declaring the custom schema the editor will skip over these other contructions before attempting to run them through any block transforms.
 
 ### Shortcode
 


### PR DESCRIPTION
## Description

While the `schema` property is mentioned in the block API documentation
for `raw` transforms it's not explained.

In this patch we're adding a short sub-section to expand on the purpose
and implementation of the `schema` in a way that can hopefully give
developers a stronger starting point for when they need to implement
new raw transformations.

## How has this been tested?

This is a documentation-only change and does not touch the code.
Please review the new explanations and provide feedback on the
wording and example and whether or not you find the structure of
inlining the subsection into the existing block API document to be
a helpful move, or whether you think it belongs elsewhere.

## Types of changes
This change adds an explanation to existing block API documentation.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
