### PR TITLE
Add: Transparency support on global styles colors

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -44,6 +44,7 @@ function ColorGradientControlInner( {
 	gradientValue,
 	clearable,
 	showTitle = true,
+	enableAlpha,
 } ) {
 	const canChooseAColor =
 		onColorChange && ( ! isEmpty( colors ) || ! disableCustomColors );
@@ -109,6 +110,7 @@ function ColorGradientControlInner( {
 								__experimentalHasMultipleOrigins
 							}
 							clearable={ clearable }
+							enableAlpha={ enableAlpha }
 						/>
 					) }
 					{ ( currentTab === 'gradient' || ! canChooseAColor ) && (

--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -92,6 +92,7 @@ export const PanelColorGradientSettingsInner = ( {
 	title,
 	showTitle = true,
 	__experimentalHasMultipleOrigins,
+	enableAlpha,
 	...props
 } ) => {
 	if (
@@ -143,6 +144,7 @@ export const PanelColorGradientSettingsInner = ( {
 						disableCustomColors,
 						disableCustomGradients,
 						__experimentalHasMultipleOrigins,
+						enableAlpha,
 						...setting,
 					} }
 				/>

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -104,6 +104,7 @@ function ScreenBackgroundColor( { name } ) {
 				disableCustomGradients={ ! areCustomGradientsEnabled }
 				__experimentalHasMultipleOrigins
 				showTitle={ false }
+				enableAlpha
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -70,6 +70,7 @@ function ScreenLinkColor( { name } ) {
 				disableCustomColors={ ! areCustomSolidsEnabled }
 				__experimentalHasMultipleOrigins
 				showTitle={ false }
+				enableAlpha
 			/>
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -62,6 +62,7 @@ function ScreenTextColor( { name } ) {
 				disableCustomColors={ ! areCustomSolidsEnabled }
 				__experimentalHasMultipleOrigins
 				showTitle={ false }
+				enableAlpha
 			/>
 		</>
 	);


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/36774

This PR does the following actions:
- Updates PanelColorGradientSettings to support the flag enableAlpha as the ColorPalette component does. The flag can be true or false. We are keeping the default as false.
- Updates the global styles background, text, and link color panels to have alpha picking enabled.


## How has this been tested?
I went to the global styles sidebar. I verified I could pick a color with transparency for the global background, text, and link color.
