### PR TITLE
Global Styles: Move the 'Edit colors' button to a standard menu item

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -292,22 +292,8 @@ export default function PaletteEdit( {
 							} }
 						/>
 					) }
-					{ ! isEditing && (
-						<Button
-							disabled={ ! hasElements }
-							isSmall
-							icon={ moreVertical }
-							label={
-								isGradient
-									? __( 'Edit gradients' )
-									: __( 'Edit colors' )
-							}
-							onClick={ () => {
-								setIsEditing( true );
-							} }
-						/>
-					) }
-					{ isEditing && ( canReset || ! canOnlyChangeValues ) && (
+
+					{ hasElements && ( canReset || ! canOnlyChangeValues ) && (
 						<DropdownMenu
 							icon={ moreVertical }
 							label={
@@ -322,6 +308,17 @@ export default function PaletteEdit( {
 							{ ( { onClose } ) => (
 								<>
 									<NavigableMenu role="menu">
+										<Button
+											variant="tertiary"
+											disabled={ isEditing }
+											onClick={ () => {
+												setIsEditing( true );
+												onClose();
+											} }
+											className="edit-palette-menu-button"
+										>
+											{ __( 'Edit custom colors' ) }
+										</Button>
 										{ ! canOnlyChangeValues && (
 											<Button
 												variant="tertiary"
@@ -331,6 +328,7 @@ export default function PaletteEdit( {
 													onChange();
 													onClose();
 												} }
+												className="edit-palette-menu-button"
 											>
 												{ isGradient
 													? __(

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -315,7 +315,7 @@ export default function PaletteEdit( {
 												setIsEditing( true );
 												onClose();
 											} }
-											className="edit-palette-menu-button"
+											className="components-palette-edit__menu-button"
 										>
 											{ __( 'Edit custom colors' ) }
 										</Button>
@@ -328,7 +328,7 @@ export default function PaletteEdit( {
 													onChange();
 													onClose();
 												} }
-												className="edit-palette-menu-button"
+												className="components-palette-edit__menu-button"
 											>
 												{ isGradient
 													? __(

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -16,4 +16,12 @@
 		width: 280px;
 		padding: 8px;
 	}
+	.components-button.edit-palette-menu-button {
+		width: 100%;
+	}
+}
+.components-dropdown-menu__menu {
+	.components-button.edit-palette-menu-button {
+		width: 100%;
+	}
 }

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -16,9 +16,6 @@
 		width: 280px;
 		padding: 8px;
 	}
-	.components-button.edit-palette-menu-button {
-		width: 100%;
-	}
 }
 .components-dropdown-menu__menu {
 	.components-button.edit-palette-menu-button {

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -18,7 +18,7 @@
 	}
 }
 .components-dropdown-menu__menu {
-	.components-button.edit-palette-menu-button {
+	.components-palette-edit__menu-button {
 		width: 100%;
 	}
 }


### PR DESCRIPTION
## Description
Moves the `Edit colors` button from the ellipsis to a standard menu item to reduce confusion around the UI for editing custom colors.

Immediate fix for https://github.com/WordPress/gutenberg/issues/36519 ahead of wider redesign of this panel.

## How has this been tested?

- Check out PR to local dev env and add an FSE enabled theme
- Go into Global Styles - Colors and add some custom colors
- Save and reload the editor and go back into colors and check that the ellipses menu makes more sense with this change

Remember, as noted in https://github.com/WordPress/gutenberg/issues/36519 this is not intended to be the full and final fix, but a quick update to reduce confusion ahead of more detailed UX fixes.

## Screenshots 

Before:

![edit-colors-before](https://user-images.githubusercontent.com/3629020/143376937-4b079af8-d0e9-435b-8345-675a031b7ff2.gif)

After:

![edit-colors-after](https://user-images.githubusercontent.com/3629020/143376962-246bb379-4cb8-41d4-9cd9-34328d53cd68.gif)

