### PR TITLE
Writing Flow Multi-select: ensure post title content editable after multi-select

### DIFF
--- a/packages/block-editor/src/components/writing-flow/test/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/test/use-multi-selection.js
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import { toggleRichText } from '../use-multi-selection';
+
+describe( 'toggleRichText', () => {
+	function getContainer( isContentEditible ) {
+		const container = document.createDocumentFragment();
+		[
+			'rich-text',
+			'rich-text editor-post-title__input',
+			'some-other-class',
+		].forEach( ( className ) => {
+			const element = document.createElement( 'div' );
+			element.setAttribute( 'class', className );
+			if ( isContentEditible ) {
+				element.setAttribute( 'contenteditable', true );
+			}
+			container.appendChild( element );
+		} );
+		return container;
+	}
+
+	it( 'should set the `contenteditable` attribute on eligible rich text nodes', () => {
+		const container = getContainer();
+		toggleRichText( container, true );
+		let nodes = container.querySelectorAll( '[contenteditable=true]' );
+
+		expect( nodes ).toHaveLength( 1 );
+		expect( nodes[ 0 ].className ).toBe( 'rich-text' );
+
+		toggleRichText( container, false );
+		nodes = container.querySelectorAll( '[contenteditable=true]' );
+		expect( nodes ).toHaveLength( 0 );
+	} );
+} );

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -15,7 +15,7 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
-function toggleRichText( container, toggle ) {
+export function toggleRichText( container, toggle ) {
 	Array.from(
 		container.querySelectorAll(
 			// Exclude the Post Editor from multi-select disable.

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -16,15 +16,18 @@ import { store as blockEditorStore } from '../../store';
 import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-props/use-block-refs';
 
 function toggleRichText( container, toggle ) {
-	Array.from( container.querySelectorAll( '.rich-text' ) ).forEach(
-		( node ) => {
-			if ( toggle ) {
-				node.setAttribute( 'contenteditable', true );
-			} else {
-				node.removeAttribute( 'contenteditable' );
-			}
+	Array.from(
+		container.querySelectorAll(
+			// Exclude the Post Editor from multi-select disable.
+			'.rich-text:not( .editor-post-title__input )'
+		)
+	).forEach( ( node ) => {
+		if ( toggle ) {
+			node.setAttribute( 'contenteditable', true );
+		} else {
+			node.removeAttribute( 'contenteditable' );
 		}
-	);
+	} );
 }
 
 /**

--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -18,7 +18,7 @@ import { __unstableUseBlockRef as useBlockRef } from '../block-list/use-block-pr
 export function toggleRichText( container, toggle ) {
 	Array.from(
 		container.querySelectorAll(
-			// Exclude the Post Editor from multi-select disable.
+			// Exclude the Post Title from multi-select disable.
 			'.rich-text:not( .editor-post-title__input )'
 		)
 	).forEach( ( node ) => {


### PR DESCRIPTION
## Description

Can you, after multi-selecting blocks in the post editor, edit your formerly-editable post title?

I can't. I've tried block and non-block themes, including TwentyNineteen, TwentyTwentyTwo and TT1. 

This PR tries to fix that by excluding the post title rich text element from the collection of elements whose content may not be edited during a multi-select.

This is my first look into this area, so I'd welcome advice as to whether there's a better way.

| Before  | After |
| ------------- | ------------- |
| ![Kapture 2021-11-25 at 14 39 54](https://user-images.githubusercontent.com/6458278/143375910-7a7383e2-f8c0-4fbd-b6f5-c7ebad954230.gif)  | ![Kapture 2021-11-25 at 14 32 16](https://user-images.githubusercontent.com/6458278/143375524-c78bc1bf-35f9-4ec0-8b17-168470e863a9.gif)  |


## Testing
Create a new post. Give it a title, e.g., `' Let Your Love Flow, by the Bellamy Brothers'`

Now include a few blocks, maybe a couple of paragraphs. Write what you will. My topic was "miscreants".

Select two or more blocks by dragging your mouse over them. Also try using the keyboard via SHIFT + Arrow keys. You'll know they're selected if they all have a blue border.

Now click elsewhere on the document. 

You should still be able to update your site title, where you could not before.

Run `npm run test-unit packages/block-editor/src/components/writing-flow/test/use-multi-selection.js` and leave some room in your life for old style country music.


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
