### PR TITLE
Render empty Nav block if no fallback block can be utilised

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -187,13 +187,19 @@ function block_core_navigation_filter_out_empty_blocks( $parsed_blocks ) {
  * @return array the array of blocks to be used as a fallback.
  */
 function block_core_navigation_get_fallback_blocks() {
-	// Default to a list of Pages.
-	$fallback_blocks = array(
+	$page_list_fallback = array(
 		array(
 			'blockName' => 'core/page-list',
 			'attrs'     => array(),
 		),
 	);
+
+	$registry = WP_Block_Type_Registry::get_instance();
+
+	// If `core/page-list` is not registered then return empty blocks.
+	$fallback_blocks = $registry->is_registered( 'core/page-list' ) ? $page_list_fallback : array();
+
+	// Default to a list of Pages.
 
 	$navigation_post = block_core_navigation_get_first_non_empty_navigation();
 
@@ -297,6 +303,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
 
 		$fallback_blocks = block_core_navigation_get_fallback_blocks();
+
+		// May be empty if core/navigation or core/page list are not registered.
+		if ( empty( $fallback_blocks ) ) {
+			return '';
+		}
 
 		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/36740#issuecomment-978208129 we learnt that if a page list block isn't registered then the block will still render wrapping _markup_ even though it is empty.

This PR fixes things by first checking whether the `core/page-list` fallback is registered. If it is not and the fallback mechanic attempts to use it then the block will not render.



## How has this been tested?

* Delete all Navigation Menu posts from your site - http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation.
* Add several Pages to your site.
* Add a Nav block to your site. Remove all items from the Nav block.
* Save the Site Editor.
* Visit front of site. You should see the `core/page-list` block used to render the default fallback experience.
* Now..._unregister_ the `core/page-list` block. I used a `mu-plugin` on my test site. Simply copy the following into a file and save with any name you like. Then `zip` it up and upload it to your WP site as a Plugin. Then activate the Plugin.
```php
function my_plugin_deny_list_blocks() {
	$registry = WP_Block_Type_Registry::get_instance();

	if ( $registry->is_registered( 'core/page-list' ) ) {
		unregister_block_type( 'core/page-list' );
	}
}
add_action( 'wp_loaded', 'my_plugin_deny_list_blocks' );
```
* Double check you can no longer access the Page List block in the editors.
* Go to the front of your site - check that the Nav block is no longer being rendered at all. No markup or anything. 

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
