### PR TITLE
Allow filtering of Nav block fallback

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -214,7 +214,7 @@ function block_core_navigation_get_fallback_blocks() {
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
 
-	return $fallback_blocks;
+	return apply_filters( 'block_core_navigation_render_fallback', $fallback_blocks );
 }
 
 /**
@@ -310,12 +310,13 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 		$fallback_blocks = block_core_navigation_get_fallback_blocks();
 
-		// May be empty if core/navigation or core/page list are not registered.
-		if ( empty( $fallback_blocks ) ) {
+		// Fallback my have been filtered so do basic test for validity.
+		if ( empty( $fallback_blocks ) || ! is_array( $fallback_blocks ) ) {
 			return '';
 		}
 
 		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
+
 	}
 
 	// Restore legacy classnames for submenu positioning.
@@ -424,8 +425,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 /**
  * Register the navigation block.
  *
- * @throws WP_Error An WP_Error exception parsing the block definition.
  * @uses render_block_core_navigation()
+ * @throws WP_Error An WP_Error exception parsing the block definition.
  */
 function register_block_core_navigation() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -214,6 +214,15 @@ function block_core_navigation_get_fallback_blocks() {
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 	}
 
+	/**
+	 * Filters the fallback experience for the Navigation block.
+	 *
+	 * Returning a falsey value will opt out of the fallback and cause the block not to render.
+	 * To customise the blocks provided return an array of blocks - these should be valid
+	 * children of the `core/navigation` block.
+	 *
+	 * @param array[] default fallback blocks provided by the default block mechanic.
+	 */
 	return apply_filters( 'block_core_navigation_render_fallback', $fallback_blocks );
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/36740#issuecomment-978208129 we introduced a specific fallback mechanic for the Nav block front-of-site rendering for the case where a Menu was not specifically assigned to the block.

This aimed to follow the existing code patterns set by `wp_nav_menu`.

That PR [didn't handle allowing developers to filter the fallback output of the block](https://github.com/WordPress/gutenberg/issues/36721#issuecomment-978035597). This PR enables that via the introduction of a block-specific filter `block_core_navigation_render_fallback`.

This is important because traditionally Theme developers have had the option to opt-out of the `wp_nav_menu`'s fallback mechanic via the `fallback_cb` argument that you can pass to that function.

This PR replicates that. Developers can now do this to opt out of rendering a fallback:

```php
add_filter('block_core_navigation_render_fallback', '__return_false');
```

Alternatively they can return their own list of blocks to act as a fallback with the caveat that these blocks must be valid as children of the `core/navigation` block.

If folks are in favour of merging this PR then I'll document the filter.

Note this overlaps with https://github.com/WordPress/gutenberg/pull/36849. If/when that is merged then we'll consolidate the "empty" checking mechanics.

## How has this been tested?

* Delete all Navigation Menu posts from your site - http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation.
* Add several Pages to your site.
* Add a Nav block to your site. Remove all items from the Nav block.
* Save the Site Editor.
* Visit front of site. You should see the `core/page-list` block used to render the default fallback experience.
* Now add the filter - I did this in a test `mu-plugin`, but you could simply add to your Theme's `functions.php`:

```php
add_filter('block_core_navigation_render_fallback', '__return_false');
```
* Visit front of site. You should see that no navigation block is rendered at all - you've opted out of the the fallback experience.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
