### PR TITLE
Fix CSS Custom Properties for presets in the site editor

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -713,12 +713,17 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
 function gutenberg_extend_block_editor_styles_html() {
 	global $pagenow;
 
+	$gs_css_vars = 'global-styles-css-custom-properties';
+	wp_register_style( $gs_css_vars, false, array(), true, true );
+	wp_add_inline_style( $gs_css_vars, wp_get_global_stylesheet( array( 'variables' ) ) );
+
 	$script_handles = array();
 	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',
 		'wp-block-library-theme',
 		'wp-edit-blocks',
+		$gs_css_vars,
 	);
 
 	if ( 'widgets.php' === $pagenow || 'customize.php' === $pagenow ) {

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -713,17 +713,12 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
 function gutenberg_extend_block_editor_styles_html() {
 	global $pagenow;
 
-	$gs_css_vars = 'global-styles-css-custom-properties';
-	wp_register_style( $gs_css_vars, false, array(), true, true );
-	wp_add_inline_style( $gs_css_vars, wp_get_global_stylesheet( array( 'variables' ) ) );
-
 	$script_handles = array();
 	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',
 		'wp-block-library-theme',
 		'wp-edit-blocks',
-		$gs_css_vars,
 	);
 
 	if ( 'widgets.php' === $pagenow || 'customize.php' === $pagenow ) {

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -276,16 +276,6 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
 }
 
-/**
- * Function to enqueue the CSS Custom Properties
- * coming from theme.json.
- */
-function gutenberg_load_css_custom_properties() {
-	wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
-	wp_add_inline_style( 'global-styles-css-custom-properties', gutenberg_get_global_stylesheet( array( 'variables' ) ) );
-	wp_enqueue_style( 'global-styles-css-custom-properties' );
-}
-
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.
 if ( function_exists( 'get_block_editor_settings' ) ) {
 	add_filter( 'block_editor_settings_all', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
@@ -302,5 +292,3 @@ add_action( 'set_current_user', 'gutenberg_global_styles_kses_init' );
 add_filter( 'force_filtered_html_on_import', 'gutenberg_global_styles_force_filtered_html_on_import_filter', 999 );
 add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_global_styles_include_support_for_wp_variables', 10, 2 );
 // This filter needs to be executed last.
-
-add_filter( 'enqueue_block_editor_assets', 'gutenberg_load_css_custom_properties' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -282,7 +282,7 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
  */
 function gutenberg_load_css_custom_properties() {
 	wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
-	wp_add_inline_style( 'global-styles-css-custom-properties', gutenberg_get_global_stylesheet( array( 'variables' ) ) );
+	wp_add_inline_style( 'global-styles-css-custom-properties', wp_get_global_stylesheet( array( 'variables' ) ) );
 	wp_enqueue_style( 'global-styles-css-custom-properties' );
 }
 

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -276,6 +276,16 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
 }
 
+/**
+ * Function to enqueue the CSS Custom Properties
+ * coming from theme.json.
+ */
+function gutenberg_load_css_custom_properties() {
+	wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
+	wp_add_inline_style( 'global-styles-css-custom-properties', gutenberg_get_global_stylesheet( array( 'variables' ) ) );
+	wp_enqueue_style( 'global-styles-css-custom-properties' );
+}
+
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.
 if ( function_exists( 'get_block_editor_settings' ) ) {
 	add_filter( 'block_editor_settings_all', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
@@ -292,3 +302,5 @@ add_action( 'set_current_user', 'gutenberg_global_styles_kses_init' );
 add_filter( 'force_filtered_html_on_import', 'gutenberg_global_styles_force_filtered_html_on_import_filter', 999 );
 add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_global_styles_include_support_for_wp_variables', 10, 2 );
 // This filter needs to be executed last.
+
+add_filter( 'enqueue_block_editor_assets', 'gutenberg_load_css_custom_properties' );

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -71,34 +71,22 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 		}
 
 		$new_global_styles = array();
-		$new_presets       = array(
-			array(
-				'css'                     => 'variables',
-				'__unstableType'          => 'presets',
-				'__experimentalNoWrapper' => true,
-			),
-			array(
-				'css'            => 'presets',
+
+		$style_css = wp_get_global_stylesheet( array( 'presets' ) );
+		if ( '' !== $style_css ) {
+			$new_global_styles[] = array(
+				'css'            => $style_css,
 				'__unstableType' => 'presets',
-			),
-		);
-		foreach ( $new_presets as $new_style ) {
-			$style_css = wp_get_global_stylesheet( array( $new_style['css'] ) );
-			if ( '' !== $style_css ) {
-				$new_style['css']    = $style_css;
-				$new_global_styles[] = $new_style;
-			}
+			);
 		}
 
-		$new_block_classes = array(
-			'css'            => 'styles',
-			'__unstableType' => 'theme',
-		);
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$style_css = wp_get_global_stylesheet( array( $new_block_classes['css'] ) );
+			$style_css = wp_get_global_stylesheet( array( 'styles' ) );
 			if ( '' !== $style_css ) {
-				$new_block_classes['css'] = $style_css;
-				$new_global_styles[]      = $new_block_classes;
+				$new_global_styles[] = array(
+					'css'            => $style_css,
+					'__unstableType' => 'theme',
+				);
 			}
 		}
 
@@ -288,6 +276,16 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
 }
 
+/**
+ * Function to enqueue the CSS Custom Properties
+ * coming from theme.json.
+ */
+function gutenberg_load_css_custom_properties() {
+	wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
+	wp_add_inline_style( 'global-styles-css-custom-properties', gutenberg_get_global_stylesheet( array( 'variables' ) ) );
+	wp_enqueue_style( 'global-styles-css-custom-properties' );
+}
+
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.
 if ( function_exists( 'get_block_editor_settings' ) ) {
 	add_filter( 'block_editor_settings_all', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
@@ -304,3 +302,5 @@ add_action( 'set_current_user', 'gutenberg_global_styles_kses_init' );
 add_filter( 'force_filtered_html_on_import', 'gutenberg_global_styles_force_filtered_html_on_import_filter', 999 );
 add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_global_styles_include_support_for_wp_variables', 10, 2 );
 // This filter needs to be executed last.
+
+add_filter( 'enqueue_block_editor_assets', 'gutenberg_load_css_custom_properties' );

--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -23,23 +23,20 @@ import wrap from './transforms/wrap';
  * @return {Array} converted rules.
  */
 const transformStyles = ( styles, wrapperClassName = '' ) => {
-	return map(
-		styles,
-		( { css, baseURL, __experimentalNoWrapper = false } ) => {
-			const transforms = [];
-			if ( wrapperClassName && ! __experimentalNoWrapper ) {
-				transforms.push( wrap( wrapperClassName ) );
-			}
-			if ( baseURL ) {
-				transforms.push( urlRewrite( baseURL ) );
-			}
-			if ( transforms.length ) {
-				return traverse( css, compose( transforms ) );
-			}
-
-			return css;
+	return map( styles, ( { css, baseURL } ) => {
+		const transforms = [];
+		if ( wrapperClassName ) {
+			transforms.push( wrap( wrapperClassName ) );
 		}
-	);
+		if ( baseURL ) {
+			transforms.push( urlRewrite( baseURL ) );
+		}
+		if ( transforms.length ) {
+			return traverse( css, compose( transforms ) );
+		}
+
+		return css;
+	} );
 };
 
 export default transformStyles;

--- a/packages/edit-site/src/components/global-styles/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/use-global-styles-output.js
@@ -378,7 +378,6 @@ export function useGlobalStylesOutput() {
 			{
 				css: customProperties,
 				isGlobalStyles: true,
-				__experimentalNoWrapper: true,
 			},
 			{
 				css: globalStyles,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/30642

This PR enqueues the CSS Custom Properties coming from the `theme.json` in a different way.

**Before**

We enqueued them via the `styles` key in the block editor settings. By doing this the styles are wrapped with the `.editor-styles-wrapper` class, for them to be scoped to the content canvas. This was problematic for the CSS Custom Properties, as they wouldn't be available in the sidebar, hence, we added `__experimentalNoWrapper` to the styles transformation, a scape hatch for certain styles not to be wrapped via `.editor-styles-wrapper`.

**After**

We enqueue the vars via the `enqueue_block_editor_assets` that is unaffected by the `.editor-styles-wrapper` mechanism.

## How to test

See testing instructions in the issue.

In addition to testing that the gradients are visible, I've also tested that, in the site editor, modifications to the solid colors are reflected in the own component  (sidebar) and in the content canvas. I've also applied this PR on top of https://github.com/WordPress/gutenberg/pull/36820 to make sure gradients work as expected as well.
