### PR TITLE
Fix Nav block fallback DB query to match on full block grammar start tag

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -149,7 +149,7 @@ function block_core_navigation_get_first_non_empty_navigation() {
 			'order'          => 'ASC',
 			'orderby'        => 'name',
 			'posts_per_page' => 1, // only the first post.
-			's'              => '<!--', // look for block indicators to ensure we only include non-empty Navigations.
+			's'              => '<!-- wp:', // look for block indicators to ensure we only include non-empty Navigations.
 		)
 	);
 	return count( $navigation_posts ) ? $navigation_posts[0] : null;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Currently when seeking [fallback Navigation Menus to use as the front-of-site fallback](https://github.com/WordPress/gutenberg/issues/36721) for the block rendering the Nav block looks for opening `<!--` tags to fetch the first post that has blocks.

However this is vulnerable to error because the post might contain a non-block HTML comment which would then be treated as valid.

Whilst we are protected by the code which filters out the resulting `null` blocks that would be returned by the block parser we can safe guard against this in advance by searching for the full block comment `<!-- wp:`.

I checked and this comment is used by all blocks, even those which aren't core blocks. Here's an example using Kadence blocks:

<img width="528" alt="Screen Shot 2021-11-25 at 10 23 34" src="https://user-images.githubusercontent.com/444434/143425442-a529d16a-830c-4b97-a139-8d6499104a38.png">



## How has this been tested?
* Delete all Navigation Menu posts from your site - http://localhost:8888/wp-admin/edit.php?post_type=wp_navigation.
* Add several Pages to your site.
* Add a Nav block to your site. Add some items.
* Save the Site Editor and thus the Nav Menu.
* Reload the Site Editor.
* Go to the Nav block and delete it. Then re-add an _empty_ Nav block and save the Editor.
* Now [go into your database](https://github.com/WordPress/gutenberg/blob/1714d93487a3301b922f12f425cbc87ce7d7a252/docs/contributors/code/getting-started-with-code-contribution.md#accessing-the-mysql-database) and modify the Navigation Menu post to contain an HTML comment that is not block grammar. Eg:
```
<!-- Some other random HTML comment -->And some stuff here!
```
* Visit front of site. You should see the `core/page-list` block used to render the default fallback experience.
* You should _not_ see the Navigation used  because it is invalid as blocks.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
