### PR TITLE
Navigation: Try removing gray blobs, round 2

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -169,7 +169,6 @@ export default function NavigationPlaceholder( {
 			) }
 			{ hasResolvedNavigationMenus && ! isStillLoading && (
 				<Placeholder className="wp-block-navigation-placeholder">
-					<PlaceholderPreview />
 					<div className="wp-block-navigation-placeholder__controls">
 						<div className="wp-block-navigation-placeholder__actions">
 							<div className="wp-block-navigation-placeholder__actions__indicator">

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -6,24 +6,25 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Icon, search } from '@wordpress/icons';
+import { Icon, navigation } from '@wordpress/icons';
+import { Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const PlaceholderPreview = ( { isLoading } ) => {
 	return (
-		<ul
-			className={ classnames(
-				'wp-block-navigation-placeholder__preview',
-				'wp-block-navigation__container',
-				{ 'is-loading': isLoading }
-			) }
+		<Placeholder
+			className={ classnames( 'wp-block-navigation-placeholder', {
+				'is-loading': isLoading,
+			} ) }
 		>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-placeholder__preview-search-icon">
-				<Icon icon={ search } />
-			</li>
-		</ul>
+			<div className="wp-block-navigation-placeholder__controls">
+				<div className="wp-block-navigation-placeholder__actions">
+					<div className="wp-block-navigation-placeholder__actions__indicator">
+						<Icon icon={ navigation } /> { __( 'Navigation' ) }
+					</div>
+				</div>
+			</div>
+		</Placeholder>
 	);
 };
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -96,6 +96,7 @@
 	}
 }
 
+
 /**
  * Colors Selector component
  */
@@ -179,9 +180,23 @@ $color-control-label-height: 20px;
 	justify-content: flex-start;
 }
 
+
 /**
  * Setup state
  */
+
+// Loading state.
+@keyframes loadingpulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
 
 // Unstyle some inherited placeholder component styles.
 .components-placeholder.wp-block-navigation-placeholder {
@@ -206,87 +221,19 @@ $color-control-label-height: 20px;
 	.is-selected & {
 		color: $gray-900;
 	}
-}
 
-// Spinner.
-.wp-block-navigation-placeholder .components-spinner {
-	margin-top: -4px;
-	margin-left: 4px;
-	vertical-align: middle;
-	margin-right: 7px;
-}
+	// Hide most placeholder content until selected.
+	.wp-block-navigation-placeholder__actions > * {
+		display: none;
 
-@keyframes loadingpulse {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-
-// Unselected state.
-.wp-block-navigation-placeholder__preview {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	flex-wrap: nowrap;
-	width: 100%;
-	overflow: hidden;
-
-	&.is-loading {
-		animation: loadingpulse 1s linear infinite;
-		animation-delay: 0.5s; // avoid animating for fast network responses
-	}
-
-	// Style skeleton elements to mostly match the metrics of actual menu items.
-	// Needs specificity.
-	.wp-block-navigation-item.wp-block-navigation-item {
-		position: relative;
-		min-width: 72px;
-
-		&::before {
-			display: block;
-			content: "";
-			border-radius: $radius-block-ui;
-			background: currentColor;
-			height: $grid-unit-20;
-			width: 100%;
-		}
-	}
-
-	.wp-block-navigation-placeholder__preview-search-icon {
-		height: $icon-size;
-		svg {
-			fill: currentColor;
-		}
-	}
-
-	.wp-block-navigation-item.wp-block-navigation-item,
-	.wp-block-navigation-placeholder__preview-search-icon {
-		opacity: 0.3;
-	}
-
-	&:not(.is-loading) {
-		// Don't show the preview boxes for an empty nav block,
-		// but be technically present to help size the empty state.
-		.wp-block-navigation.is-selected & {
+		.is-selected & {
 			display: flex;
-			opacity: 0;
-			width: 0;
-			overflow: hidden;
-			flex-wrap: nowrap;
-			flex: 0;
 		}
+	}
 
-		// Hide entirely when vertical.
-		.wp-block-navigation.is-selected .is-small &,
-		.wp-block-navigation.is-selected .is-medium & {
-			display: none;
-		}
+	// Always show the block logo.
+	.wp-block-navigation-placeholder__actions__indicator {
+		display: flex;
 	}
 }
 
@@ -298,9 +245,13 @@ $color-control-label-height: 20px;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	flex-direction: row;
 	align-items: center;
-	display: none;
 	position: relative;
 	z-index: 1;
+
+	// Unhide actions when selected.
+	.wp-block-navigation-placeholder__actions > * {
+		display: flex;
+	}
 
 	// Adjust padding for when shown horizontally.
 	.is-large & {


### PR DESCRIPTION
## Description

_This PR replaces #36809 with a better approach._

When you start fresh with a navigation block and insert an empty one, you get these gray blobs:

<img width="760" alt="Screenshot 2021-11-24 at 09 19 09" src="https://user-images.githubusercontent.com/1204802/143205480-0341b482-f4e8-493d-8e3a-6375c1142cce.png">

The initial idea was to let themes preinsert a navigation block at an appropriate place in the theme, but leave it otherwise unconfigured. With that goal in mind, the gray blobs were meant to help the placeholder state pass the "squint test", to look at least a little bit like the end result at least when the block was unselected.

Feedback suggested this didn't quite work as intended, though: the blobs looked like a "skeleton loading state", that they would be replaced with the real menu once loading had completed. 

There's persistence in the navigation block now, with contents saved separately, and options for providing defaults and fallbacks. Depending on where that lands, we might be able to provide better first run experiences. In any case, it changes the equation from before, where an empty and unconfigured navigation block was more likely to appear in themes. 

In light of this, it feels worth it to explore removing those blobs entirely, which this PR does:

![gray blobs](https://user-images.githubusercontent.com/1204802/143206531-085cdce0-0daa-4f1f-860b-781e00c5aaa0.gif)

As an added benefit, this simpler setup state entirely avoids a layout shift when selecting and unselecting.

Related PRs:

- #36778
- #36775

## How has this been tested?

Insert a navigation block and observe a setup state that shows "Navigation" when unselected, and "Navigation" with some options when selected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
