### PR TITLE
Don't try and render unstable location if Nav block has ID

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -254,7 +254,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$inner_blocks = $block->inner_blocks;
 
 	// If `__unstableLocation` is defined, create inner blocks from the classic menu assigned to that location.
-	if ( empty( $inner_blocks ) && array_key_exists( '__unstableLocation', $attributes ) ) {
+	if ( ! array_key_exists( 'navigationMenuId', $attributes ) && array_key_exists( '__unstableLocation', $attributes ) ) {
 		$menu_items = gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
 			return '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -254,13 +254,13 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	$inner_blocks = $block->inner_blocks;
 
 	// If `__unstableLocation` is defined and:
+	// - we have menu items at the defined location
 	// - we don't have a relationship to a `wp_navigation` Post (via `navigationMenuId`).
-	// - we don't have any inner blocks (e.g. a block pattern).
 	// ...then create inner blocks from the classic menu assigned to that location.
 	if (
 		array_key_exists( '__unstableLocation', $attributes ) &&
 		! array_key_exists( 'navigationMenuId', $attributes ) &&
-		empty( $inner_blocks )
+		! empty( gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] ) )
 	) {
 		$menu_items = gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -253,8 +253,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	$inner_blocks = $block->inner_blocks;
 
-	// If `__unstableLocation` is defined, create inner blocks from the classic menu assigned to that location.
-	if ( ! array_key_exists( 'navigationMenuId', $attributes ) && array_key_exists( '__unstableLocation', $attributes ) ) {
+	// If `__unstableLocation` is defined and:
+	// - we don't have a relationship to a `wp_navigation` Post (via `navigationMenuId`).
+	// - we don't have any inner blocks (e.g. a block pattern).
+	// ...then create inner blocks from the classic menu assigned to that location.
+	if (  array_key_exists( '__unstableLocation', $attributes ) && ! array_key_exists( 'navigationMenuId', $attributes ) && empty($inner_blocks) ) {
 		$menu_items = gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
 			return '';

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -257,7 +257,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// - we don't have a relationship to a `wp_navigation` Post (via `navigationMenuId`).
 	// - we don't have any inner blocks (e.g. a block pattern).
 	// ...then create inner blocks from the classic menu assigned to that location.
-	if (  array_key_exists( '__unstableLocation', $attributes ) && ! array_key_exists( 'navigationMenuId', $attributes ) && empty($inner_blocks) ) {
+	if (
+		array_key_exists( '__unstableLocation', $attributes ) &&
+		! array_key_exists( 'navigationMenuId', $attributes ) &&
+		empty( $inner_blocks )
+	) {
 		$menu_items = gutenberg_get_menu_items_at_location( $attributes['__unstableLocation'] );
 		if ( empty( $menu_items ) ) {
 			return '';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

We learnt in https://github.com/Automattic/themes/issues/5086 that if you are using a Universal Theme the Nav block can end up rendering nothing even though there are items added in the Site Editor.

Since the Navigation block now stores its inner "items" in a CPT ~there a no longer an inner blocks stored directly on the block itself.~ the only time when inner blocks are stored directly on the block is [if the block is part of a pattern](https://github.com/WordPress/gutenberg/pull/36024). If you are working with the Nav block within the editor your changes are saved to the CPT and not as inner blocks.

If `__unstableLocation` is defined (universal Themes) then even if you add "items" to the Nav block in the Site Editor, the _front end_ rendering code will try and render the menu at `__unstableLocation`. If such a Menu does not exist then nothing is shown. This is due to the conditional:

https://github.com/WordPress/gutenberg/blob/f439aefc57d9922e5d6e6f4ecf0141cab0b0360c/packages/block-library/src/navigation/index.php#L259

This is wrong. The contents of the Site Editor should take precedence. The reason they aren't is that the code is expecting the contents of the Nav block to be the inner blocks whereas this can now _also_ be indicated by the presence of a `navigationMenuId` attribute (which references the `wp_navigation` CPT where the nav "items" are stored).

Addresses https://github.com/Automattic/themes/issues/5086

Closes https://github.com/WordPress/gutenberg/issues/36865

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Install the "universal" [Blockbase Theme](https://github.com/Automattic/themes/tree/trunk/blockbase).
- Make sure you have no (classic menus defined for the site in the customizer.

### On trunk 

- Go to the Site Editor, click on the header and add a few links to the navigation block
- Check the frontend: no menu shows up

### On this PR

- Go to the Site Editor, click on the header and add a few links to the navigation block
- Check the frontend: the items you manually added in the Site Editor should show up.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
