### PR TITLE
Offset the parent iframe when computing Popover position 

### DIFF
--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -133,7 +133,7 @@ function computeAnchorRect(
 	const { parentNode } = anchorRefFallback.current;
 	const rect = offsetIframe(
 		parentNode.getBoundingClientRect(),
-		parentNode.ownerDocument || anchorRefFallback.current.ownerDocument,
+		parentNode.ownerDocument,
 		container
 	);
 

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -131,7 +131,11 @@ function computeAnchorRect(
 	}
 
 	const { parentNode } = anchorRefFallback.current;
-	const rect = parentNode.getBoundingClientRect();
+	const rect = offsetIframe(
+		parentNode.getBoundingClientRect(),
+		parentNode.ownerDocument || anchorRefFallback.current.ownerDocument,
+		container
+	);
 
 	if ( shouldAnchorIncludePadding ) {
 		return rect;


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/36634

## The problem:

The tooltip is rendered far away from the link:

<img width="379" alt="142558290-52e179e4-c3f8-40e1-9e57-8b249c21fa63" src="https://user-images.githubusercontent.com/205419/143468519-8c08a678-40b4-403d-8052-4c0570196a2c.png">


## Root cause:

Site editor is inside of an iframe, and `.popover-slot` where the Popovers are rendered is outside of the iframe. Popover only offsets the parent iframe position, when it receives either a `anchorRef` or `getAnchorRect` property, but the `Tooltip` component pass neither. 


## Solution

Call `offsetIframe` even when Popover doesn't receive either `anchorRef` or `getAnchorRect`, but relies on `anchorRefFallback`.


## Test plan

Add a nav block in the s

1. ite editor
2. Start empty
3. Click the plus button
4. Hover over the 'Add Link' text
5. Confirm the tooltip is closer to the link like on the screenshot below

<img width="230" alt="CleanShot 2021-11-25 at 16 34 44@2x" src="https://user-images.githubusercontent.com/205419/143469067-54e096d4-d919-4ca7-9755-6f07d62cf956.png">


