### PR TITLE
Remove unstable max pages attribute from Nav block

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -55,9 +55,6 @@
 		},
 		"customOverlayTextColor": {
 			"type": "string"
-		},
-		"__unstableMaxPages": {
-			"type": "number"
 		}
 	},
 	"usesContext": [ "navigationArea" ],
@@ -75,8 +72,7 @@
 		"showSubmenuIcon": "showSubmenuIcon",
 		"openSubmenusOnClick": "openSubmenusOnClick",
 		"style": "style",
-		"orientation": "orientation",
-		"__unstableMaxPages": "__unstableMaxPages"
+		"orientation": "orientation"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -192,7 +192,9 @@ function block_core_navigation_get_fallback_blocks() {
 	$page_list_fallback = array(
 		array(
 			'blockName' => 'core/page-list',
-			'attrs'     => array(),
+			'attrs'     => array(
+				'__unstableMaxPages' => 4,
+			),
 		),
 	);
 
@@ -305,8 +307,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	// If there are no inner blocks then fallback to rendering an appropriate fallback.
 	if ( empty( $inner_blocks ) ) {
-		$is_fallback                      = true; // indicate we are rendering the fallback.
-		$attributes['__unstableMaxPages'] = 4; // set value to be passed as context to Page List block.
+		$is_fallback = true; // indicate we are rendering the fallback.
 
 		$fallback_blocks = block_core_navigation_get_fallback_blocks();
 

--- a/packages/block-library/src/page-list/block.json
+++ b/packages/block-library/src/page-list/block.json
@@ -7,7 +7,11 @@
 	"description": "Display a list of all pages.",
 	"keywords": [ "menu", "navigation" ],
 	"textdomain": "default",
-	"attributes": {},
+	"attributes": {
+		"__unstableMaxPages": {
+			"type": "number"
+		}
+	},
 	"usesContext": [
 		"textColor",
 		"customTextColor",
@@ -21,8 +25,7 @@
 		"customFontSize",
 		"showSubmenuIcon",
 		"style",
-		"openSubmenusOnClick",
-		"__unstableMaxPages"
+		"openSubmenusOnClick"
 	],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -293,8 +293,9 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
-	if ( array_key_exists( '__unstableMaxPages', $block->context ) ) {
-		$nested_pages = array_slice( $nested_pages, 0, $block->context['__unstableMaxPages'] );
+	// Limit the number of items to be visually displayed.
+	if ( array_key_exists( '__unstableMaxPages', $attributes ) ) {
+		$nested_pages = array_slice( $nested_pages, 0, $attributes['__unstableMaxPages'] );
 	}
 
 	$is_navigation_child = array_key_exists( 'showSubmenuIcon', $block->context );

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -294,7 +294,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$nested_pages = block_core_page_list_nest_pages( $top_level_pages, $pages_with_children );
 
 	// Limit the number of items to be visually displayed.
-	if ( array_key_exists( '__unstableMaxPages', $attributes ) ) {
+	if ( ! empty( $attributes['__unstableMaxPages'] ) ) {
 		$nested_pages = array_slice( $nested_pages, 0, $attributes['__unstableMaxPages'] );
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/36724 we added a `__unstableMaxPages` attribute to both Page List and Navigation blocks. When used inside the Nav block the Page List would receive the property value via context from the Nav block.

This seems like overengineering things...and it is(!), but only because we assumed that a lack of existing attributes on the Page List block was an _intentional_ architectural decision so we decided using context was more appropriate and followed prior art in the code.

In hindsight all we achieved was propagating a potentially unstable attribute onto two blocks instead of one. Moreover @talldan explained to us that the Page List block is entirely open for extension using attributes and does not need to rely on context.

This PR reverses the original decision and removes the attribute from the Nav block. It retains it on the Page List block and updates the Nav block front end rendering to set the attribute directly on the Page List block itself rather than via context on the Nav block.



## How has this been tested?

* Add Pages to your site.
* Delete all Navigation Menus `wp_navigation` Posts from your site.
* Add an empty Nav block into the Site Editor and hit `Save`.
* Go to frontend of site. 
* Check that the Page List block renders with `4` items displayed.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
