### PR TITLE
Site Editor: Template list add rename action

### DIFF
--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -1,0 +1,95 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+import isTemplateRemovable from '../../../utils/is-template-removable';
+import isTemplateRevertable from '../../../utils/is-template-revertable';
+import RenameMenuItem from './rename-menu-item';
+
+export default function Actions( { template } ) {
+	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
+	const { saveEditedEntityRecord } = useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } = useDispatch(
+		noticesStore
+	);
+
+	const isRemovable = isTemplateRemovable( template );
+	const isRevertable = isTemplateRevertable( template );
+
+	if ( ! isRemovable && ! isRevertable ) {
+		return null;
+	}
+
+	async function revertAndSaveTemplate() {
+		try {
+			await revertTemplate( template, { allowUndo: false } );
+			await saveEditedEntityRecord(
+				'postType',
+				template.type,
+				template.id
+			);
+
+			createSuccessNotice( __( 'Template reverted.' ), {
+				type: 'snackbar',
+			} );
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while reverting the template.' );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	}
+
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Actions' ) }
+			className="edit-site-list-table__actions"
+		>
+			{ ( { onClose } ) => (
+				<MenuGroup>
+					{ isRemovable && (
+						<>
+							<RenameMenuItem
+								template={ template }
+								onClose={ onClose }
+							/>
+							<MenuItem
+								isDestructive
+								onClick={ () => {
+									removeTemplate( template );
+									onClose();
+								} }
+							>
+								{ __( 'Delete template' ) }
+							</MenuItem>
+						</>
+					) }
+					{ isRevertable && (
+						<MenuItem
+							info={ __( 'Restore template to theme default' ) }
+							onClick={ () => {
+								revertAndSaveTemplate();
+								onClose();
+							} }
+						>
+							{ __( 'Clear customizations' ) }
+						</MenuItem>
+					) }
+				</MenuGroup>
+			) }
+		</DropdownMenu>
+	);
+}

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -79,6 +79,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			<MenuItem
 				onClick={ () => {
 					setIsModalOpen( true );
+					setTitle( template.title.rendered );
 				} }
 			>
 				{ __( 'Rename' ) }
@@ -89,7 +90,6 @@ export default function RenameMenuItem( { template, onClose } ) {
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ () => {
 						setIsModalOpen( false );
-						setTitle( '' );
 					} }
 					overlayClassName="edit-site-list__rename-modal"
 				>
@@ -115,7 +115,6 @@ export default function RenameMenuItem( { template, onClose } ) {
 									variant="tertiary"
 									onClick={ () => {
 										setIsModalOpen( false );
-										setTitle( '' );
 									} }
 								>
 									{ __( 'Cancel' ) }

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -50,7 +50,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 					onRequestClose={ () => {
 						setIsModalOpen( false );
 					} }
-					overlayClassName="edit-site-template__modal"
+					overlayClassName="edit-site-list__rename-modal"
 				>
 					<form onSubmit={ onTemplateRename }>
 						<Flex align="flex-start" gap={ 8 }>
@@ -64,7 +64,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 						</Flex>
 
 						<Flex
-							className="edit-site-template__modal-actions"
+							className="edit-site-list__rename-modal-actions"
 							justify="flex-end"
 							expanded={ false }
 						>

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -27,6 +27,10 @@ export default function RenameMenuItem( { template, onClose } ) {
 		noticesStore
 	);
 
+	if ( template.is_custom ) {
+		return null;
+	}
+
 	async function onTemplateRename( event ) {
 		event.preventDefault();
 

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	MenuItem,
+	Modal,
+	TextControl,
+} from '@wordpress/components';
+
+export default function RenameMenuItem( { template, onClose } ) {
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	const { saveEditedEntityRecord } = useDispatch( coreStore );
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		template.type,
+		'title',
+		template.id
+	);
+
+	async function onTemplateRename( event ) {
+		event.preventDefault();
+		setIsModalOpen( false );
+		onClose();
+
+		// Presist edited entity.
+		await saveEditedEntityRecord( 'postType', template.type, template.id );
+	}
+
+	return (
+		<>
+			<MenuItem
+				onClick={ () => {
+					setIsModalOpen( true );
+				} }
+			>
+				{ __( 'Rename' ) }
+			</MenuItem>
+			{ isModalOpen && (
+				<Modal
+					title={ __( 'Rename template' ) }
+					closeLabel={ __( 'Close' ) }
+					onRequestClose={ () => {
+						setIsModalOpen( false );
+					} }
+					overlayClassName="edit-site-template__modal"
+				>
+					<form onSubmit={ onTemplateRename }>
+						<Flex align="flex-start" gap={ 8 }>
+							<FlexItem>
+								<TextControl
+									label={ __( 'Name' ) }
+									value={ title }
+									onChange={ setTitle }
+								/>
+							</FlexItem>
+						</Flex>
+
+						<Flex
+							className="edit-site-template__modal-actions"
+							justify="flex-end"
+							expanded={ false }
+						>
+							<FlexItem>
+								<Button
+									variant="tertiary"
+									onClick={ () => {
+										setIsModalOpen( false );
+									} }
+								>
+									{ __( 'Cancel' ) }
+								</Button>
+							</FlexItem>
+							<FlexItem>
+								<Button variant="primary" type="submit">
+									{ __( 'Save' ) }
+								</Button>
+							</FlexItem>
+						</Flex>
+					</form>
+				</Modal>
+			) }
+		</>
+	);
+}

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -27,7 +27,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 		noticesStore
 	);
 
-	if ( template.is_custom ) {
+	if ( template.has_theme_file ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -27,7 +27,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 		noticesStore
 	);
 
-	if ( template.has_theme_file ) {
+	if ( ! template.is_custom ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -128,3 +128,29 @@
 		margin-left: $nav-sidebar-width;
 	}
 }
+
+.edit-site-template__modal {
+	.components-base-control {
+		@include break-medium() {
+			width: $grid-unit * 40;
+		}
+	}
+
+	.components-modal__header {
+		border-bottom: none;
+	}
+
+	.components-modal__content::before {
+		margin-bottom: $grid-unit-05;
+	}
+}
+
+.edit-site-template__modal-actions {
+	margin-top: $grid-unit-15;
+}
+
+.edit-site-template__actions {
+	button:not(:last-child) {
+		margin-right: $grid-unit-10;
+	}
+}

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -129,7 +129,7 @@
 	}
 }
 
-.edit-site-template__modal {
+.edit-site-list__rename-modal {
 	.components-base-control {
 		@include break-medium() {
 			width: $grid-unit * 40;
@@ -145,7 +145,7 @@
 	}
 }
 
-.edit-site-template__modal-actions {
+.edit-site-list__rename-modal-actions {
 	margin-top: $grid-unit-15;
 }
 

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -1,98 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	VisuallyHidden,
-	DropdownMenu,
-	MenuGroup,
-	MenuItem,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
 import { addQueryArgs } from '@wordpress/url';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
-import { store as editSiteStore } from '../../store';
-import isTemplateRemovable from '../../utils/is-template-removable';
-import isTemplateRevertable from '../../utils/is-template-revertable';
-
-function Actions( { template } ) {
-	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
-	const { saveEditedEntityRecord } = useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } = useDispatch(
-		noticesStore
-	);
-
-	const isRemovable = isTemplateRemovable( template );
-	const isRevertable = isTemplateRevertable( template );
-
-	if ( ! isRemovable && ! isRevertable ) {
-		return null;
-	}
-
-	async function revertAndSaveTemplate() {
-		try {
-			await revertTemplate( template, { allowUndo: false } );
-			await saveEditedEntityRecord(
-				'postType',
-				template.type,
-				template.id
-			);
-
-			createSuccessNotice( __( 'Template reverted.' ), {
-				type: 'snackbar',
-			} );
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while reverting the template.' );
-
-			createErrorNotice( errorMessage, { type: 'snackbar' } );
-		}
-	}
-
-	return (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Actions' ) }
-			className="edit-site-list-table__actions"
-		>
-			{ ( { onClose } ) => (
-				<MenuGroup>
-					{ isRemovable && (
-						<MenuItem
-							isDestructive
-							onClick={ () => {
-								removeTemplate( template );
-								onClose();
-							} }
-						>
-							{ __( 'Delete template' ) }
-						</MenuItem>
-					) }
-					{ isRevertable && (
-						<MenuItem
-							info={ __( 'Restore template to theme default' ) }
-							onClick={ () => {
-								revertAndSaveTemplate();
-								onClose();
-							} }
-						>
-							{ __( 'Clear customizations' ) }
-						</MenuItem>
-					) }
-				</MenuGroup>
-			) }
-		</DropdownMenu>
-	);
-}
+import Actions from './actions';
 
 export default function Table( { templateType } ) {
 	const { templates, isLoading, postType } = useSelect(


### PR DESCRIPTION
## Description
Part of #36773.

Adds new "Rename" action to the template list that will display modal. The modal design matches "Create new template" and "Add to Reusable blocks" modal designs.

## Notes
* I moved actions into a separate component since it's was getting a little bit large :)
* Changing template re-renders whole list. I'm not sure if we can avoid it.

## How has this been tested?
1. Go to Appearance > Editor > Templates
2. Custom template should have "Rename" action.
3. Clicking on it should display the modal.

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-25 at 20 30 32](https://user-images.githubusercontent.com/240569/143476726-e186d6d7-1bc5-4044-803e-77c9cc498a40.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
