### PR TITLE
Fix Nav block editing wrong entity on creation of new Menu

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -279,14 +279,22 @@ function Navigation( {
 		setIsPlaceholderShown( ! isEntityAvailable );
 	}, [ isEntityAvailable ] );
 
+	// If the ref no longer exists the reset the inner blocks
+	// to provide a clean slate.
+	useEffect( () => {
+		if ( ref === undefined ) {
+			replaceInnerBlocks( clientId, [] );
+		}
+	}, [ clientId, ref ] );
+
 	const startWithEmptyMenu = useCallback( () => {
-		replaceInnerBlocks( clientId, [] );
 		if ( navigationArea ) {
 			setAreaMenu( 0 );
 		}
 		setAttributes( {
 			ref: undefined,
 		} );
+
 		setIsPlaceholderShown( true );
 	}, [ clientId ] );
 
@@ -476,7 +484,6 @@ function Navigation( {
 						<NavigationMenuNameControl />
 						<NavigationMenuDeleteControl
 							onDelete={ () => {
-								replaceInnerBlocks( clientId, [] );
 								if ( navigationArea ) {
 									setAreaMenu( 0 );
 								}

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -282,9 +282,11 @@ function Navigation( {
 	// If the ref no longer exists the reset the inner blocks
 	// to provide a clean slate.
 	useEffect( () => {
-		if ( ref === undefined ) {
+		if ( ref === undefined && innerBlocks.length > 0 ) {
 			replaceInnerBlocks( clientId, [] );
 		}
+		// innerBlocks are intentionally not listed as deps. This function is only concerned
+		// with the snapshot from the time when ref became undefined.
 	}, [ clientId, ref ] );
 
 	const startWithEmptyMenu = useCallback( () => {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -287,7 +287,7 @@ function Navigation( {
 		}
 		// innerBlocks are intentionally not listed as deps. This function is only concerned
 		// with the snapshot from the time when ref became undefined.
-	}, [ clientId, ref ] );
+	}, [ clientId, ref, innerBlocks ] );
 
 	const startWithEmptyMenu = useCallback( () => {
 		if ( navigationArea ) {

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -811,7 +811,7 @@ describe.skip( 'Navigation', () => {
 			newMenuButton[ 0 ].click();
 		}
 
-		it.only( 'only update the current entity linked with the block', async () => {
+		it.only( 'only update a single entity currently linked with the block', async () => {
 			// Mock the response from the Pages endpoint. This is done so that the pages returned are always
 			// consistent and to test the feature more rigorously than the single default sample page.
 			await mockPagesResponse( [
@@ -831,6 +831,7 @@ describe.skip( 'Navigation', () => {
 
 			// Add the navigation block.
 			await insertBlock( 'Navigation' );
+
 			// Create an empty nav block.
 			await createEmptyNavBlock();
 			await populateNavWithOneItem();
@@ -869,12 +870,6 @@ describe.skip( 'Navigation', () => {
 
 			await page.waitForXPath( NAV_ENTITY_SELECTOR );
 			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
-
-			// Now reset to an empty menu.
-			//
-			// // Confirm there is only one updated Navigation Menu entity.
-			// // Snapshot should contain the mocked pages.
-			// expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -811,7 +811,7 @@ describe.skip( 'Navigation', () => {
 			newMenuButton[ 0 ].click();
 		}
 
-		it.only( 'only update a single entity currently linked with the block', async () => {
+		it( 'only update a single entity currently linked with the block', async () => {
 			// Mock the response from the Pages endpoint. This is done so that the pages returned are always
 			// consistent and to test the feature more rigorously than the single default sample page.
 			await mockPagesResponse( [

--- a/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/navigation.test.js
@@ -784,4 +784,97 @@ describe.skip( 'Navigation', () => {
 
 		expect( isScriptLoaded ).toBe( true );
 	} );
+
+	describe( 'Creating and restarting', () => {
+		async function populateNavWithOneItem() {
+			// Add a Link block first.
+			await page.waitForSelector(
+				'.wp-block-navigation .block-list-appender'
+			);
+			await page.click( '.wp-block-navigation .block-list-appender' );
+			// Add a link to the Link block.
+			await updateActiveNavigationLink( {
+				url: 'https://wordpress.org',
+				label: 'WP',
+				type: 'url',
+			} );
+		}
+
+		async function resetNavBlockToInitialState() {
+			await page.waitForSelector( '[aria-label="Select Menu"]' );
+			await page.click( '[aria-label="Select Menu"]' );
+
+			await page.waitForXPath( '//span[text()="Create new menu"]' );
+			const newMenuButton = await page.$x(
+				'//span[text()="Create new menu"]'
+			);
+			newMenuButton[ 0 ].click();
+		}
+
+		it.only( 'only update the current entity linked with the block', async () => {
+			// Mock the response from the Pages endpoint. This is done so that the pages returned are always
+			// consistent and to test the feature more rigorously than the single default sample page.
+			await mockPagesResponse( [
+				{
+					title: 'Home',
+					slug: 'home',
+				},
+				{
+					title: 'About',
+					slug: 'about',
+				},
+				{
+					title: 'Contact Us',
+					slug: 'contact',
+				},
+			] );
+
+			// Add the navigation block.
+			await insertBlock( 'Navigation' );
+			// Create an empty nav block.
+			await createEmptyNavBlock();
+			await populateNavWithOneItem();
+
+			// Let's confirm that the menu entity was updated.
+			await page.waitForSelector(
+				'.editor-post-publish-panel__toggle:not([aria-disabled="true"])'
+			);
+			await page.click( '.editor-post-publish-panel__toggle' );
+
+			const NAV_ENTITY_SELECTOR =
+				'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
+			await page.waitForXPath( NAV_ENTITY_SELECTOR );
+			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+
+			// Publish the post
+			await page.click( '.editor-entities-saved-states__save-button' );
+			await page.waitForSelector( '.editor-post-publish-button' );
+			await page.click( '.editor-post-publish-button' );
+
+			// A success notice should show up
+			await page.waitForSelector( '.components-snackbar' );
+
+			// Now try inserting another Link block via the quick inserter.
+			await page.focus( '.wp-block-navigation' );
+
+			await resetNavBlockToInitialState();
+			await createEmptyNavBlock();
+			await populateNavWithOneItem();
+
+			// Let's confirm that only the last menu entity was updated.
+			await page.waitForSelector(
+				'.editor-post-publish-button__button:not([aria-disabled="true"])'
+			);
+			await page.click( '.editor-post-publish-button__button' );
+
+			await page.waitForXPath( NAV_ENTITY_SELECTOR );
+			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+
+			// Now reset to an empty menu.
+			//
+			// // Confirm there is only one updated Navigation Menu entity.
+			// // Snapshot should contain the mocked pages.
+			// expect( await getEditedPostContent() ).toMatchSnapshot();
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/36862 we learnt that if you use the `Create new` buttons within the Nav block UI to create a new Menu you can end up causing edits to the wrong `wp_navigation` entity.

How does this happen? Scenario:

- you have an existing Nav block with an existing entity that is being edited
- you click `Create new` drop the `Select menu` dropdown on the block
- at this point the code tries to reset the inner blocks of the block and give you a fresh `wp_navigation` entity for editing.
- to do this it calls `replaceInnerBlocks` but it does this before the entity is set to the freshly created one. Instead it ends up calling replaceBlocks and the _existing_ entity picks up the changes and gets marked as "dirty"
- this process isn't obvious to the user as all the blocks are nicely reset in the UI and everything looks good
- the users starts adding blocks and then hits `Save` in the Site Editor only to find they now have to save both the new and the original Nav Post entities

This PR fixes that by moving the reseting of the inner blocks to an effect which runs if the `ref` to the `wp_navigation` Post is reset. This way we ensure we have completely "unloaded" the current entity before we reset the blocks in the UI. 

⚠️ I worked on this late in my day so it will need some careful testing and reviewing to ensure I'm not introducing errors.

Closes https://github.com/WordPress/gutenberg/issues/36862

## How has this been tested?

* Delete all Navigation Menu posts.
* Go to Site Editor and add a Nav block.
* Add a few items.
* Save the Site Editor - you should see single Nav entity is being saved. Take note of the name of the entity.
* Go back to Nav block and click `Select menu -> Create new`.
* When the block is ready start adding new items.
* Save the Site Editor - you should see only a _single_ Nav entity is being saved. It should be different from the one you originally created.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
