### PR TITLE
[REST] Restore the missing double slash in the ID received by /templates

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -69,33 +69,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 						'id' => array(
 							'description'       => __( 'The id of a template', 'gutenberg' ),
 							'type'              => 'string',
-
-							/**
-							 * Requesting this endpoint for a template like "twentytwentytwo//home" requires using
-							 * a path like /wp/v2/templates/twentytwentytwo//home. There are special cases when
-							 * WordPress routing corrects the name to contain only a single slash like "twentytwentytwo/home".
-							 *
-							 * This method doubles the last slash if it's not already doubled. It relies on the template
-							 * ID format {theme_name}//{template_slug} and the fact that slugs cannot contain slashes.
-							 *
-							 * See https://core.trac.wordpress.org/ticket/54507 for more context
-							 */
-							'sanitize_callback' => function( $id ) {
-								$last_slash_pos = strrpos( $id, '/' );
-								if ( false === $last_slash_pos ) {
-									return $id;
-								}
-
-								$is_double_slashed = substr( $id, $last_slash_pos - 1, 1 ) === '/';
-								if ( $is_double_slashed ) {
-									return $id;
-								}
-								return (
-									substr( $id, 0, $last_slash_pos )
-									. '/'
-									. substr( $id, $last_slash_pos )
-								);
-							},
+							'sanitize_callback' => array( $this, '_sanitize_template_id' ),
 						),
 					),
 				),
@@ -141,6 +115,36 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Requesting this endpoint for a template like "twentytwentytwo//home" requires using
+	 * a path like /wp/v2/templates/twentytwentytwo//home. There are special cases when
+	 * WordPress routing corrects the name to contain only a single slash like "twentytwentytwo/home".
+	 *
+	 * This method doubles the last slash if it's not already doubled. It relies on the template
+	 * ID format {theme_name}//{template_slug} and the fact that slugs cannot contain slashes.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/54507 for more context
+	 *
+	 * @param string $id Template ID.
+	 * @return string Sanitized template ID.
+	 */
+	public function _sanitize_template_id( $id ) {
+		$last_slash_pos = strrpos( $id, '/' );
+		if ( false === $last_slash_pos ) {
+			return $id;
+		}
+
+		$is_double_slashed = substr( $id, $last_slash_pos - 1, 1 ) === '/';
+		if ( $is_double_slashed ) {
+			return $id;
+		}
+		return (
+			substr( $id, 0, $last_slash_pos )
+			. '/'
+			. substr( $id, $last_slash_pos )
+		);
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -67,8 +67,8 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description' => __( 'The id of a template', 'gutenberg' ),
-							'type'        => 'string',
+							'description'       => __( 'The id of a template', 'gutenberg' ),
+							'type'              => 'string',
 
 							/**
 							 * Requesting this endpoint for a template like "twentytwentytwo//home" requires using
@@ -82,20 +82,20 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 							 */
 							'sanitize_callback' => function( $id ) {
 								$last_slash_pos = strrpos( $id, '/' );
-								if ( $last_slash_pos === false ) {
+								if ( false === $last_slash_pos ) {
 									return $id;
 								}
 
-								$is_double_slashed = substr($id, $last_slash_pos - 1, 1 ) === '/';
-								if ( ! $is_double_slashed ) {
-									$id =
-										substr( $id, 0, $last_slash_pos )
-										. '/'
-										. substr( $id, $last_slash_pos );
+								$is_double_slashed = substr( $id, $last_slash_pos - 1, 1 ) === '/';
+								if ( $is_double_slashed ) {
+									return $id;
 								}
-
-								return $id;
-							}
+								return (
+									substr( $id, 0, $last_slash_pos )
+									. '/'
+									. substr( $id, $last_slash_pos )
+								);
+							},
 						),
 					),
 				),

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -350,14 +350,15 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		$getter   = $from_file ? 'get_block_file_template' : 'gutenberg_get_block_template';
 		$template = $getter( $id, $this->post_type );
 		if ( ! $template ) {
-			$uri = $_SERVER['REQUEST_URI'];
 			// Make sure REQUEST_URI is set.
-			if ( ! $uri ) {
+			if ( empty( $_SERVER['REQUEST_URI'] ) ) {
 				return;
 			}
+
+			$uri       = $_SERVER['REQUEST_URI'];
 			$delimiter = $this->namespace . '/' . $this->rest_base . '/';
 
-			// Extract part of the path that comes after /wp/v2/templates/.
+			// Extract the part of the path that comes after /wp/v2/templates/.
 			$start = strpos( $uri, $delimiter );
 			if ( false === $start ) {
 				return;

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -338,7 +338,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 * WordPress routing corrects the name to contain only a single slash like "twentytwentytwo/home".
 	 *
 	 * This method attempts to find a template with a specific ID, and if it's missing then it
-	 * falls back to a double-slashed version of the ID.
+	 * falls back to parsing REQUEST_URI in an attempt to grab the verbatim ID passed by the user.
 	 *
 	 * See https://core.trac.wordpress.org/ticket/54507 for more context
 	 *

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -163,7 +163,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	/**
 	 * Ticket 54507
 	 *
-	 * @dataProvider template_endpoint_urls
+	 * @dataProvider get_template_endpoint_urls
 	 */
 	public function test_get_item_works_with_a_single_slash( $endpoint_url ) {
 		wp_set_current_user( self::$admin_id );

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -165,14 +165,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	 */
 	public function test_get_item_works_with_a_single_slash() {
 		wp_set_current_user( self::$admin_id );
-		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
-		$old_uri = $_SERVER['REQUEST_URI'];
-
-		$_SERVER['REQUEST_URI'] = '/index.php/wp-json/wp/v2/templates/tt1-blocks//index/?context=edit&_locale=user';
-
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
 		$response = rest_get_server()->dispatch( $request );
-
-		$_SERVER['REQUEST_URI'] = $old_uri;
 
 		$data = $response->get_data();
 		unset( $data['content'] );

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -204,6 +204,32 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 		);
 	}
 
+	/**
+	 * Ticket 54507
+	 *
+	 * @dataProvider get_template_ids_to_sanitize
+	 */
+	public function test_sanitize_template_id( $input_id, $sanitized_id ) {
+		$endpoint = new Gutenberg_REST_Templates_Controller( 'wp_template' );
+		$this->assertEquals(
+			$sanitized_id,
+			$endpoint->_sanitize_template_id( $input_id )
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function get_template_ids_to_sanitize() {
+		return array(
+			array( 'tt1-blocks/index', 'tt1-blocks//index' ),
+			array( 'tt1-blocks//index', 'tt1-blocks//index' ),
+
+			array( 'theme-experiments/tt1-blocks/index', 'theme-experiments/tt1-blocks//index' ),
+			array( 'theme-experiments/tt1-blocks//index', 'theme-experiments/tt1-blocks//index' ),
+		);
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -165,9 +165,16 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	 */
 	public function test_get_item_works_with_a_single_slash() {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
+		$old_uri = $_SERVER['REQUEST_URI'];
+
+		$_SERVER['REQUEST_URI'] = '/index.php/wp-json/wp/v2/templates/tt1-blocks//index/?context=edit&_locale=user';
+
 		$response = rest_get_server()->dispatch( $request );
-		$data     = $response->get_data();
+
+		$_SERVER['REQUEST_URI'] = $old_uri;
+
+		$data = $response->get_data();
 		unset( $data['content'] );
 		unset( $data['_links'] );
 

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -162,10 +162,12 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 
 	/**
 	 * Ticket 54507
+	 *
+	 * @dataProvider template_endpoint_urls
 	 */
-	public function test_get_item_works_with_a_single_slash() {
+	public function test_get_item_works_with_a_single_slash( $endpoint_url ) {
 		wp_set_current_user( self::$admin_id );
-		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
+		$request  = new WP_REST_Request( 'GET', $endpoint_url );
 		$response = rest_get_server()->dispatch( $request );
 
 		$data = $response->get_data();
@@ -189,6 +191,16 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'has_theme_file' => true,
 			),
 			$data
+		);
+	}
+
+	/**
+	 *
+	 */
+	public function template_endpoint_urls() {
+		return array(
+			array( '/wp/v2/templates/tt1-blocks/index' ),
+			array( '/wp/v2/templates/tt1-blocks//index' ),
 		);
 	}
 

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -197,7 +197,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 	/**
 	 *
 	 */
-	public function template_endpoint_urls() {
+	public function get_template_endpoint_urls() {
 		return array(
 			array( '/wp/v2/templates/tt1-blocks/index' ),
 			array( '/wp/v2/templates/tt1-blocks//index' ),

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -160,6 +160,37 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 		);
 	}
 
+	/**
+	 * Ticket 54507
+	 */
+	public function test_get_item_works_with_a_single_slash() {
+		wp_set_current_user( self::$admin_id );
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/tt1-blocks/index' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+		unset( $data['content'] );
+		unset( $data['_links'] );
+
+		$this->assertEquals(
+			array(
+				'id'             => 'tt1-blocks//index',
+				'theme'          => 'tt1-blocks',
+				'slug'           => 'index',
+				'title'          => array(
+					'raw'      => 'Index',
+					'rendered' => 'Index',
+				),
+				'description'    => 'The default template used when no other template is available. This is a required template in WordPress.',
+				'status'         => 'publish',
+				'source'         => 'theme',
+				'type'           => 'wp_template',
+				'wp_id'          => null,
+				'has_theme_file' => true,
+			),
+			$data
+		);
+	}
+
 	public function test_create_item() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'POST', '/wp/v2/templates' );


### PR DESCRIPTION
## Description

Solves https://core.trac.wordpress.org/ticket/54507 

When the permalink structure is set to `/index.php/%year%/%monthnum%/%day%/%postname%/`, requests to `/wp/v2/templates/twentytwentytwo//home` fail, breaking the full site editor. The problem is double slash in the request path. WordPress resolves `$request['id']` as `twentytwentytwo/home` instead of `twentytwentytwo//home`. The endpoint has already been shipped in WordPress 5.8, so changing the URLs structure isn't really an option. This PR proposes a way of processing the received ID so the slashes are always correct regardless of how they came in.

## Test plan

1. Go to WP Admin → Settings → Permalinks.
1. Select Custom Structure and enter `/index.php/%year%/%monthnum%/%day%/%postname%/` into the text field.
1. Go to WP Admin → Appearance → Editor.
1. Confirm the editor loads as expected with no WSOD in sight.

If this PR gets merged, it needs to also be backported into WP Beta.