### PR TITLE
Add actions which fire during the loading process of block template parts

### DIFF
--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -50,6 +50,17 @@ function render_block_core_template_part( $attributes ) {
 			if ( ! is_wp_error( $area_terms ) && false !== $area_terms ) {
 				$area = $area_terms[0]->name;
 			}
+			/**
+			 * Fires when a block template part is loaded from a template post stored in the database.
+			 *
+			 * @since 5.9.0
+			 *
+			 * @param string  $template_part_id   The requested template part namespaced to the theme.
+			 * @param array   $attributes         The block attributes.
+			 * @param WP_Post $template_part_post The template part post object.
+			 * @param string  $content            The template part content.
+			 */
+			do_action( 'render_block_core_template_part_post', $template_part_id, $attributes, $template_part_post, $content );
 		} else {
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
@@ -60,6 +71,31 @@ function render_block_core_template_part( $attributes ) {
 				$content = is_string( $content ) && '' !== $content
 						? _inject_theme_attribute_in_block_template_content( $content )
 						: '';
+			}
+
+			if ( '' !== $content && null !== $content ) {
+				/**
+				 * Fires when a block template part is loaded from a template part in the theme.
+				 *
+				 * @since 5.9.0
+				 *
+				 * @param string $template_part_id        The requested template part namespaced to the theme.
+				 * @param array  $attributes              The block attributes.
+				 * @param string $template_part_file_path Absolute path to the template path.
+				 * @param string $content                 The template part content.
+				 */
+				do_action( 'render_block_core_template_part_file', $template_part_id, $attributes, $template_part_file_path, $content );
+			} else {
+				/**
+				 * Fires when a requested block template part does not exist in the database nor in the theme.
+				 *
+				 * @since 5.9.0
+				 *
+				 * @param string $template_part_id        The requested template part namespaced to the theme.
+				 * @param array  $attributes              The block attributes.
+				 * @param string $template_part_file_path Absolute path to the not found template path.
+				 */
+				do_action( 'render_block_core_template_part_none', $template_part_id, $attributes, $template_part_file_path );
 			}
 		}
 	}


### PR DESCRIPTION
## Description

The template hierarchy and template part system in WordPress core is mature and over the years actions and filters have been introduced which allow developers to debug template file and template part loading.

The template part block introduced a new way of loading template parts which the existing actions and filters don't cover. This means, for example, it's not possible for a debugging plugin such as Query Monitor to identify which template parts were loaded during a given request.

The addition of these actions covers all three potential situations with the template part block:

* The template part is found and loaded from a `wp_template_part` post in the database
* The template part is found and loaded from a `.html` file in the theme
* The template part is not found

I think it would be a good idea to get this into WP 5.9. Developers who are new to FSE are going to be interested in seeing how their pages are constructed with these new paradigms, and this debugging info will help with that.

I did consider implementing this as a filter on the `$content` variable, but that becomes an API change that warrants a bit more discussion. An action solves the immediate problem without affecting the architecture.

## How has this been tested?

I've been testing this with a development version of [Query Monitor](https://wordpress.org/plugins/query-monitor/) while using FSE. It allows QM to additionally show all the post- and HTML-based template parts loaded during the request just like it does for PHP-based template parts when FSE isn't in use. Example screenshot:

<img width="315" alt="" src="https://user-images.githubusercontent.com/208434/143486214-fb1511ca-d0af-4b35-8ce4-5dfe17757071.png">

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
