### PR TITLE
Add translators note about not translating <StylesIconImage /> component name

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/editor.js
+++ b/packages/edit-site/src/components/welcome-guide/editor.js
@@ -41,6 +41,7 @@ export default function WelcomeGuideEditor() {
 							</p>
 							<p className="edit-site-welcome-guide__text">
 								{ createInterpolateElement(
+								 	// translators: <StylesIconImage /> is the icon for Styles. Do not translate.
 									__(
 										'Click <StylesIconImage /> to start designing your blocks, and choose your typography, layout, and colors.'
 									),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
https://github.com/WordPress/gutenberg/blob/c207ec00599b6445788a217196eb2c782df248ba/packages/edit-site/src/components/welcome-guide/editor.js#L45
Component names are not common for WordPress.org translators so when they appear in a string, some may wonder if it has to be translated or not. See such a question [here](https://wordpress.slack.com/archives/C02QB8GMM/p1637863363241500).

This adds a translators note to let them know not to translate this.

<!-- Please describe what you have changed or added -->

## How has this been tested?
N/A

## Types of changes
Translators note
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
