### PR TITLE
Improve performance of wp_navigation lookup. 

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -151,7 +151,7 @@ function block_core_navigation_get_first_non_empty_navigation() {
 		'order'          => 'ASC',
 		'orderby'        => 'name',
 		'post_status'    => 'publish',
-		'posts_per_page' => 20, // Try the first 20 posts
+		'posts_per_page' => 20, // Try the first 20 posts.
 	);
 
 	$navigation_posts = new WP_Query( $parsed_args );

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -150,6 +150,7 @@ function block_core_navigation_get_first_non_empty_navigation() {
 		'no_found_rows'  => true,
 		'order'          => 'ASC',
 		'orderby'        => 'name',
+		'post_status'    => 'publish',
 		'posts_per_page' => 20, // Try the first 20 posts
 	);
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -145,17 +145,22 @@ function block_core_navigation_get_first_non_empty_navigation() {
 	// see:
 	// - https://github.com/WordPress/wordpress-develop/blob/ba943e113d3b31b121f77a2d30aebe14b047c69d/src/wp-includes/nav-menu.php#L613-L619.
 	// - https://developer.wordpress.org/reference/classes/wp_query/#order-orderby-parameters.
-	$navigation_posts = get_posts(
-		array(
-			'post_type'      => 'wp_navigation',
-			'order'          => 'ASC',
-			'orderby'        => 'name',
-			'posts_per_page' => 1, // only the first post.
-			's'              => '<!-- wp:', // look for block indicators to ensure we only include non-empty Navigations.
-		)
+	$parsed_args = array(
+		'post_type'      => 'wp_navigation',
+		'no_found_rows'  => true,
+		'order'          => 'ASC',
+		'orderby'        => 'name',
+		'posts_per_page' => 20, // Try the first 20 posts
 	);
-	return count( $navigation_posts ) ? $navigation_posts[0] : null;
 
+	$navigation_posts = new WP_Query( $parsed_args );
+	foreach ( $navigation_posts->posts as $navigation_post ) {
+		if ( has_blocks( $navigation_post ) ) {
+			return $navigation_post;
+		}
+	}
+
+	return null;
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Improve the performance of the lookup for wp_navigation posts. This improves performance in a number of way. 

- Removes search param as it can be expensive on large sites. 
- Add `no_found_rows`, as we don't care about the number of posts here. 
- Use `WP_Query`  instead of `get_posts` should be avoided at all costs, as it is unfilterable / uncachable. 
- Do the check for `has_blocks` in php, as this check is cheap. 
- Query first 20, so we are more likely to find a navigation post this way. 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
