### PR TITLE
Add icons to navigation sidebar items

### DIFF
--- a/packages/components/src/navigation/item/base-content.js
+++ b/packages/components/src/navigation/item/base-content.js
@@ -1,13 +1,20 @@
 /**
+ * WordPress dependencies
+ */
+import { Icon } from '@wordpress/icons';
+
+/**
  * Internal dependencies
  */
 import { ItemBadgeUI, ItemTitleUI } from '../styles/navigation-styles';
 
 export default function NavigationItemBaseContent( props ) {
-	const { badge, title } = props;
+	const { badge, title, icon } = props;
 
 	return (
 		<>
+			{ icon && <Icon icon={ icon } /> }
+
 			{ title && (
 				<ItemTitleUI
 					className="components-navigation__item-title"

--- a/packages/components/src/navigation/item/base-content.js
+++ b/packages/components/src/navigation/item/base-content.js
@@ -1,20 +1,13 @@
 /**
- * WordPress dependencies
- */
-import { Icon } from '@wordpress/icons';
-
-/**
  * Internal dependencies
  */
 import { ItemBadgeUI, ItemTitleUI } from '../styles/navigation-styles';
 
 export default function NavigationItemBaseContent( props ) {
-	const { badge, title, icon } = props;
+	const { badge, title } = props;
 
 	return (
 		<>
-			{ icon && <Icon icon={ icon } /> }
-
 			{ title && (
 				<ItemTitleUI
 					className="components-navigation__item-title"

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -15,7 +15,7 @@ import { isRTL } from '@wordpress/i18n';
  */
 import Button from '../../button';
 import { useNavigationContext } from '../context';
-import { ItemUI } from '../styles/navigation-styles';
+import { ItemUI, ItemIconUI } from '../styles/navigation-styles';
 import NavigationItemBaseContent from './base-content';
 import NavigationItemBase from './base';
 
@@ -73,7 +73,11 @@ export default function NavigationItem( props ) {
 		<NavigationItemBase { ...baseProps } className={ classes }>
 			{ children || (
 				<ItemUI { ...itemProps }>
-					{ icon && <Icon icon={ icon } /> }
+					{ icon && (
+						<ItemIconUI>
+							<Icon icon={ icon } />
+						</ItemIconUI>
+					) }
 
 					<NavigationItemBaseContent
 						title={ title }

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -29,6 +29,7 @@ export default function NavigationItem( props ) {
 		navigateToMenu,
 		onClick = noop,
 		title,
+		icon,
 		hideIfTargetMenuEmpty,
 		isText,
 		...restProps
@@ -62,7 +63,7 @@ export default function NavigationItem( props ) {
 
 		onClick( event );
 	};
-	const icon = isRTL() ? chevronLeft : chevronRight;
+	const navigationIcon = isRTL() ? chevronLeft : chevronRight;
 	const baseProps = children ? props : { ...props, onClick: undefined };
 	const itemProps = isText
 		? restProps
@@ -75,9 +76,10 @@ export default function NavigationItem( props ) {
 					<NavigationItemBaseContent
 						title={ title }
 						badge={ badge }
+						icon={ icon }
 					/>
 
-					{ navigateToMenu && <Icon icon={ icon } /> }
+					{ navigateToMenu && <Icon icon={ navigationIcon } /> }
 				</ItemUI>
 			) }
 		</NavigationItemBase>

--- a/packages/components/src/navigation/item/index.js
+++ b/packages/components/src/navigation/item/index.js
@@ -73,10 +73,11 @@ export default function NavigationItem( props ) {
 		<NavigationItemBase { ...baseProps } className={ classes }>
 			{ children || (
 				<ItemUI { ...itemProps }>
+					{ icon && <Icon icon={ icon } /> }
+
 					<NavigationItemBaseContent
 						title={ title }
 						badge={ badge }
-						icon={ icon }
 					/>
 
 					{ navigateToMenu && <Icon icon={ navigationIcon } /> }

--- a/packages/components/src/navigation/stories/more-examples.js
+++ b/packages/components/src/navigation/stories/more-examples.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
-import { Icon, wordpress } from '@wordpress/icons';
+import { Icon, wordpress, home } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ export function MoreExamplesStory() {
 				</NavigationGroup>
 				<NavigationGroup title="Items with Unusual Features">
 					<NavigationItem
+						icon={ home }
 						item="item-sub-menu"
 						navigateToMenu="sub-menu"
 						title="Sub-Menu with Custom Back Label"

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -183,7 +183,7 @@ export const ItemUI = styled.div`
 	color: inherit;
 	opacity: 0.7;
 
-	> svg {
+	> svg:first-child {
 		margin-right: ${ space( 2 ) };
 	}
 `;

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -182,10 +182,11 @@ export const ItemUI = styled.div`
 	width: 100%;
 	color: inherit;
 	opacity: 0.7;
+`;
 
-	> svg:first-of-type {
-		margin-right: ${ space( 2 ) };
-	}
+export const ItemIconUI = styled.span`
+	display: flex;
+	margin-right: ${ space( 2 ) };
 `;
 
 export const ItemBadgeUI = styled.span`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -182,6 +182,10 @@ export const ItemUI = styled.div`
 	width: 100%;
 	color: inherit;
 	opacity: 0.7;
+
+	> svg {
+		margin-right: ${ space( 2 ) };
+	}
 `;
 
 export const ItemBadgeUI = styled.span`

--- a/packages/components/src/navigation/styles/navigation-styles.js
+++ b/packages/components/src/navigation/styles/navigation-styles.js
@@ -183,7 +183,7 @@ export const ItemUI = styled.div`
 	color: inherit;
 	opacity: 0.7;
 
-	> svg:first-child {
+	> svg:first-of-type {
 		margin-right: ${ space( 2 ) };
 	}
 `;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -23,7 +23,7 @@ import { addQueryArgs } from '@wordpress/url';
 import {
 	home as siteIcon,
 	layout as templateIcon,
-	header as templatePartIcon,
+	symbolFilled as templatePartIcon,
 } from '@wordpress/icons';
 
 /**

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/index.js
@@ -20,6 +20,11 @@ import { __ } from '@wordpress/i18n';
 import { ESCAPE } from '@wordpress/keycodes';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
+import {
+	home as siteIcon,
+	layout as templateIcon,
+	header as templatePartIcon,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -87,6 +92,7 @@ const NavigationPanel = ( {
 						<NavigationMenu>
 							<NavigationGroup title={ __( 'Editor' ) }>
 								<NavigationItem
+									icon={ siteIcon }
 									title={ __( 'Site' ) }
 									item={ SITE_EDITOR_KEY }
 									href={ addQueryArgs( window.location.href, {
@@ -95,6 +101,7 @@ const NavigationPanel = ( {
 									} ) }
 								/>
 								<NavigationItem
+									icon={ templateIcon }
 									title={ __( 'Templates' ) }
 									item="wp_template"
 									href={ addQueryArgs( window.location.href, {
@@ -103,6 +110,7 @@ const NavigationPanel = ( {
 									} ) }
 								/>
 								<NavigationItem
+									icon={ templatePartIcon }
 									title={ __( 'Template Parts' ) }
 									item="wp_template_part"
 									href={ addQueryArgs( window.location.href, {


### PR DESCRIPTION
## Description
Adds icons to navigation sidebar items:
<img width="300" alt="Screenshot 2021-11-26 at 11 52 22 am" src="https://user-images.githubusercontent.com/677833/143524250-3dd21e2b-4780-4a6f-a8e5-5b61f211f5a6.png">

This required adding an `icon` prop to the navigation item component.

I'm not completely familiar with how these components are written (particularly the styles), so this may need some feedback.

This works fine in the Navigation Sidebar in the site editor at the moment.

In terms of the navigation component itself, there are a few things to think about, like how an implementer would mix navigation items that have icons with those that don't:
<img width="266" alt="Screenshot 2021-11-26 at 11 13 50 am" src="https://user-images.githubusercontent.com/677833/143522523-1b6e11e7-720f-4ddf-beae-255d63c6e5f4.png">

But it doesn't have to be solved straight away.

## How has this been tested?
1. Open the site editor
2. Open the navigation sidebar
3. The icons look like the ones in this design - https://cloudup.com/chpQIrvKePJ

## Screenshots <!-- if applicable -->


## Types of changes
Enhancement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
