### PR TITLE
ToolsPanel: Prevent tools panel menu increasing empty panel height

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Fixed error thrown in `ColorPicker` when used in controlled state in color gradients ([#36941](https://github.com/WordPress/gutenberg/pull/36941)).
 -   Updated readme to include default value introduced in fix for unexpected movements in the `ColorPicker` ([#35670](https://github.com/WordPress/gutenberg/pull/35670)).
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
+-   Fixed empty `ToolsPanel` height by correcting menu button line-height ([#36895](https://github.com/WordPress/gutenberg/pull/36895)).
 
 ### Experimental
 

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -70,6 +70,7 @@ export const ToolsPanelHeader = css`
 	 */
 	.components-dropdown-menu {
 		margin: ${ space( -1 ) } 0;
+		line-height: 0;
 	}
 	&&&& .components-dropdown-menu__toggle {
 		padding: 0;


### PR DESCRIPTION
## Description

This PR tweaks the `ToolsPanel` so that an empty panel's height is consistent with a collapsed panel.

This issue was raised through the review process of switch the border panel over to use the `ToolsPanel`.

See: https://github.com/WordPress/gutenberg/pull/33743#issuecomment-979027043

## How has this been tested?

1. Via the Storybook and inspecting the empty panel's height is `49px`
    - `npm run storybook:dev`
    - Visit [storybook example containing empty panel](http://localhost:50240/?path=/story/components-experimental-toolspanel--with-optional-items-plus-icon)
    - Inspect via dev tools
2. Cherry-picking this change onto the [Border panel switch to ToolsPanel PR](https://github.com/WordPress/gutenberg/pull/33743)
    - Open block editor, add group block, and select it.
    - Confirm the collapsed color panel's height is the same as the empty border panel's.

## Screenshots <!-- if applicable -->

<img width="285" alt="Screen Shot 2021-11-26 at 3 07 11 pm" src="https://user-images.githubusercontent.com/60436221/143530846-1d4f7bca-0cbe-4b84-b702-f7e9d9334a31.png">

<img width="323" alt="Screen Shot 2021-11-26 at 3 08 58 pm" src="https://user-images.githubusercontent.com/60436221/143530858-6adb8659-77ef-4e99-9964-64ace3ab3abf.png">

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
