### PR TITLE
Add origin and author to template rest api

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -567,6 +567,7 @@ if ( ! function_exists( '_build_block_template_result_from_post' ) ) {
 		$template->status         = $post->post_status;
 		$template->has_theme_file = $has_theme_file;
 		$template->is_custom      = true;
+		$template->post_author    = $post->post_author;
 
 		if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 			$template->is_custom = false;

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -550,6 +550,8 @@ if ( ! function_exists( '_build_block_template_result_from_post' ) ) {
 			return new WP_Error( 'template_missing_theme', __( 'No theme is defined for this template.', 'gutenberg' ) );
 		}
 
+		$origin = get_post_meta( $post->ID, 'origin', true );
+
 		$theme          = $terms[0]->name;
 		$has_theme_file = wp_get_theme()->get_stylesheet() === $theme &&
 			null !== _get_block_template_file( $post->post_type, $post->post_name );
@@ -561,6 +563,7 @@ if ( ! function_exists( '_build_block_template_result_from_post' ) ) {
 		$template->content        = $post->post_content;
 		$template->slug           = $post->post_name;
 		$template->source         = 'custom';
+		$template->origin         = ! empty( $origin ) ? $origin : null;
 		$template->type           = $post->post_type;
 		$template->description    = $post->post_excerpt;
 		$template->title          = $post->post_title;

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -570,7 +570,7 @@ if ( ! function_exists( '_build_block_template_result_from_post' ) ) {
 		$template->status         = $post->post_status;
 		$template->has_theme_file = $has_theme_file;
 		$template->is_custom      = true;
-		$template->post_author    = $post->post_author;
+		$template->author         = $post->post_author;
 
 		if ( 'wp_template' === $post->post_type && isset( $default_template_types[ $template->slug ] ) ) {
 			$template->is_custom = false;

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -416,6 +416,24 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			}
 		}
 
+		if ( ! empty( $request['author'] ) ) {
+			$post_author = (int) $request['author'];
+
+			if ( get_current_user_id() !== $post_author ) {
+				$user_obj = get_userdata( $post_author );
+
+				if ( ! $user_obj ) {
+					return new WP_Error(
+						'rest_invalid_author',
+						__( 'Invalid author ID.' ),
+						array( 'status' => 400 )
+					);
+				}
+			}
+
+			$changes->post_author = $post_author;
+		}
+
 		return $changes;
 	}
 
@@ -443,6 +461,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
 			'has_theme_file' => $template->has_theme_file,
+			'author'         => (int) $template->post_author,
 		);
 
 		if ( 'wp_template' === $template->type ) {
@@ -613,6 +632,11 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'type'        => 'bool',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
+				),
+				'author'         => array(
+					'description' => __( 'The ID for the author of the template.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'embed' ),
 				),
 			),
 		);

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -245,6 +245,10 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 		$changes = $this->prepare_item_for_database( $request );
 
+		if ( is_wp_error( $changes ) ) {
+			return $changes;
+		}
+
 		if ( 'custom' === $template->source ) {
 			$result = wp_update_post( wp_slash( (array) $changes ), true );
 		} else {
@@ -283,7 +287,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		$changes            = $this->prepare_item_for_database( $request );
+		$changes = $this->prepare_item_for_database( $request );
+
+		if ( is_wp_error( $changes ) ) {
+			return $changes;
+		}
+
 		$changes->post_name = $request['slug'];
 		$result             = wp_insert_post( wp_slash( (array) $changes ), true );
 		if ( is_wp_error( $result ) ) {
@@ -385,7 +394,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->tax_input   = array(
 				'wp_theme' => $template->theme,
 			);
-			$changes->origin      = $template->source;
+			$changes->meta_input  = array(
+				'origin' => $template->source,
+			);
 		} else {
 			$changes->post_name   = $template->slug;
 			$changes->ID          = $template->wp_id;
@@ -599,7 +610,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'source'         => array(
+				'origin'         => array(
 					'description' => __( 'Source of customized template', 'gutenberg' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -385,6 +385,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->tax_input   = array(
 				'wp_theme' => $template->theme,
 			);
+			$changes->origin      = $template->source;
 		} else {
 			$changes->post_name   = $template->slug;
 			$changes->ID          = $template->wp_id;
@@ -452,6 +453,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'content'        => array( 'raw' => $template->content ),
 			'slug'           => $template->slug,
 			'source'         => $template->source,
+			'origin'         => $template->origin,
 			'type'           => $template->type,
 			'description'    => $template->description,
 			'title'          => array(
@@ -593,6 +595,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 				),
 				'source'         => array(
 					'description' => __( 'Source of template', 'gutenberg' ),
+					'type'        => 'string',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'source'         => array(
+					'description' => __( 'Source of customized template', 'gutenberg' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -463,7 +463,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
 			'has_theme_file' => $template->has_theme_file,
-			'author'         => (int) $template->post_author,
+			'author'         => (int) $template->author,
 		);
 
 		if ( 'wp_template' === $template->type ) {

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -426,7 +426,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 				if ( ! $user_obj ) {
 					return new WP_Error(
 						'rest_invalid_author',
-						__( 'Invalid author ID.' ),
+						__( 'Invalid author ID.', 'gutenberg' ),
 						array( 'status' => 400 )
 					);
 				}
@@ -642,7 +642,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 				),
 				'author'         => array(
-					'description' => __( 'The ID for the author of the template.' ),
+					'description' => __( 'The ID for the author of the template.', 'gutenberg' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -72,7 +72,6 @@ class WP_Block_Template {
 	 * When customized, origin takes on the value of source and source becomes
 	 * 'custom'.
 	 *
-	 * @since 5.9.0
 	 * @var string
 	 */
 	public $origin;

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -108,7 +108,9 @@ class WP_Block_Template {
 	/**
 	 * Author.
 	 *
+	 * A value of 0 means no author.
+	 *
 	 * @var int
 	 */
-	public $post_author = 0;
+	public $author = 0;
 }

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -94,4 +94,11 @@ class WP_Block_Template {
 	 * @var bool
 	 */
 	public $is_custom = true;
+
+	/**
+	 * Author.
+	 *
+	 * @var int
+	 */
+	public $post_author = 0;
 }

--- a/lib/full-site-editing/class-wp-block-template.php
+++ b/lib/full-site-editing/class-wp-block-template.php
@@ -68,6 +68,16 @@ class WP_Block_Template {
 	public $source = 'theme';
 
 	/**
+	 * Origin of the content when the content has been customized.
+	 * When customized, origin takes on the value of source and source becomes
+	 * 'custom'.
+	 *
+	 * @since 5.9.0
+	 * @var string
+	 */
+	public $origin;
+
+	/**
 	 * Post Id.
 	 *
 	 * @var integer|null

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -13,12 +13,6 @@ function gutenberg_register_template_part_post_type() {
 		return;
 	}
 
-	// If the post type has already been registered (by WordPress core), skip
-	// registration.
-	if ( post_type_exists( 'wp_template_part' ) ) {
-		return;
-	}
-
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
 		'singular_name'         => __( 'Template Part', 'gutenberg' ),

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -13,6 +13,12 @@ function gutenberg_register_template_part_post_type() {
 		return;
 	}
 
+	// If the post type has already been registered (by WordPress core), skip
+	// registration.
+	if ( post_type_exists( 'wp_template_part' ) ) {
+		return;
+	}
+
 	$labels = array(
 		'name'                  => __( 'Template Parts', 'gutenberg' ),
 		'singular_name'         => __( 'Template Part', 'gutenberg' ),

--- a/lib/full-site-editing/template-parts.php
+++ b/lib/full-site-editing/template-parts.php
@@ -54,6 +54,7 @@ function gutenberg_register_template_part_post_type() {
 			'excerpt',
 			'editor',
 			'revisions',
+			'author',
 		),
 	);
 

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -13,12 +13,6 @@ function gutenberg_register_template_post_type() {
 		return;
 	}
 
-	// If the post type has already been registered (by WordPress core), skip
-	// registration.
-	if ( post_type_exists( 'wp_template' ) ) {
-		return;
-	}
-
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
 		'singular_name'         => __( 'Template', 'gutenberg' ),

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -13,6 +13,12 @@ function gutenberg_register_template_post_type() {
 		return;
 	}
 
+	// If the post type has already been registered (by WordPress core), skip
+	// registration.
+	if ( post_type_exists( 'wp_template' ) ) {
+		return;
+	}
+
 	$labels = array(
 		'name'                  => __( 'Templates', 'gutenberg' ),
 		'singular_name'         => __( 'Template', 'gutenberg' ),

--- a/lib/full-site-editing/templates.php
+++ b/lib/full-site-editing/templates.php
@@ -55,6 +55,7 @@ function gutenberg_register_template_post_type() {
 			'excerpt',
 			'editor',
 			'revisions',
+			'author',
 		),
 	);
 

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -77,6 +77,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'has_theme_file' => true,
 				'is_custom'      => false,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//index' )
 		);
@@ -102,6 +104,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -131,6 +135,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'has_theme_file' => true,
 				'is_custom'      => false,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			$data
 		);
@@ -157,6 +163,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			$data
 		);
@@ -192,6 +200,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'has_theme_file' => true,
 				'is_custom'      => false,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			$data
 		);
@@ -267,6 +277,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				),
 				'has_theme_file' => false,
 				'is_custom'      => true,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			$data
 		);
@@ -305,6 +317,8 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				),
 				'area'           => 'header',
 				'has_theme_file' => false,
+				'origin'         => null,
+				'author'         => 0,
 			),
 			$data
 		);


### PR DESCRIPTION
## Description
This replicates the changes to the core REST API proposed by https://github.com/WordPress/wordpress-develop/pull/1937 for Gutenberg.

related UI changes - https://github.com/WordPress/gutenberg/pull/36763