### PR TITLE
Gradients: Enable adding custom gradient when gradients are disabled

### DIFF
--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -36,6 +36,8 @@ const withCustomColorPalette = ( colorsArray ) =>
 		'withCustomColorPalette'
 	);
 
+const EMPTY_OBJECT = {};
+
 /**
  * Higher order component factory for injecting the editor colors as the
  * `colors` prop in the `withColors` HOC.
@@ -45,7 +47,11 @@ const withCustomColorPalette = ( colorsArray ) =>
 const withEditorColorPalette = () =>
 	createHigherOrderComponent(
 		( WrappedComponent ) => ( props ) => {
-			const { palette: colorPerOrigin } = useSetting( 'color' ) || {};
+			// Some color settings have a special handling for deprecated flags in `useSetting`,
+			// so we can't unwrap them by doing const { ... } = useSetting('color')
+			// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
+			const colorPerOrigin =
+				useSetting( 'color.palette' ) || EMPTY_OBJECT;
 			const allColors = useMemo(
 				() => [
 					...( colorPerOrigin?.custom || [] ),

--- a/packages/block-editor/src/components/gradients/use-gradient.js
+++ b/packages/block-editor/src/components/gradients/use-gradient.js
@@ -59,13 +59,15 @@ export function getGradientSlugByValue( gradients, value ) {
 	return gradient && gradient.slug;
 }
 
+const EMPTY_OBJECT = {};
+
 export function __experimentalUseGradient( {
 	gradientAttribute = 'gradient',
 	customGradientAttribute = 'customGradient',
 } = {} ) {
 	const { clientId } = useBlockEditContext();
 
-	const { gradients: gradientsPerOrigin } = useSetting( 'color' ) || {};
+	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
 	const allGradients = useMemo(
 		() => [
 			...( gradientsPerOrigin?.custom || [] ),

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -219,12 +219,15 @@ export function ColorEdit( props ) {
 	const {
 		palette: solidsPerOrigin,
 		gradients: gradientsPerOrigin,
-		customGradient: areCustomGradientsEnabled,
-		custom: areCustomSolidsEnabled,
 		text: isTextEnabled,
 		background: isBackgroundEnabled,
 		link: isLinkEnabled,
 	} = useSetting( 'color' ) || {};
+
+	// The following color settings need to be accessed explicitly due to
+	// special handling for deprecated flags for these paths in `useSetting`.
+	const areCustomSolidsEnabled = useSetting( 'color.custom' );
+	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
 
 	const solidsEnabled =
 		areCustomSolidsEnabled ||

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -32,6 +32,8 @@ import useSetting from '../components/use-setting';
 
 export const COLOR_SUPPORT_KEY = 'color';
 
+const EMPTY_OBJECT = {};
+
 const hasColorSupport = ( blockType ) => {
 	const colorSupport = getBlockSupport( blockType, COLOR_SUPPORT_KEY );
 	return (
@@ -216,18 +218,16 @@ function immutableSet( object, path, value ) {
  */
 export function ColorEdit( props ) {
 	const { name: blockName, attributes } = props;
-	const {
-		palette: solidsPerOrigin,
-		gradients: gradientsPerOrigin,
-		text: isTextEnabled,
-		background: isBackgroundEnabled,
-		link: isLinkEnabled,
-	} = useSetting( 'color' ) || {};
-
-	// The following color settings need to be accessed explicitly due to
-	// special handling for deprecated flags for these paths in `useSetting`.
+	// Some color settings have a special handling for deprecated flags in `useSetting`,
+	// so we can't unwrap them by doing const { ... } = useSetting('color')
+	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
+	const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
+	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
 	const areCustomSolidsEnabled = useSetting( 'color.custom' );
 	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
+	const isBackgroundEnabled = useSetting( 'color.background' );
+	const isLinkEnabled = useSetting( 'color.link' );
+	const isTextEnabled = useSetting( 'color.text' );
 
 	const solidsEnabled =
 		areCustomSolidsEnabled ||
@@ -444,7 +444,7 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
 		const { backgroundColor, textColor } = attributes;
-		const { palette: solidsPerOrigin } = useSetting( 'color' ) || {};
+		const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
 		const colors = useMemo(
 			() => [
 				...( solidsPerOrigin?.custom || [] ),

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -73,6 +73,8 @@ export function getColorClassesAndStyles( attributes ) {
 	};
 }
 
+const EMPTY_OBJECT = {};
+
 /**
  * Determines the color related props for a block derived from its color block
  * support attributes.
@@ -87,8 +89,12 @@ export function getColorClassesAndStyles( attributes ) {
 export function useColorProps( attributes ) {
 	const { backgroundColor, textColor, gradient } = attributes;
 
-	const { palette: solidsPerOrigin, gradients: gradientsPerOrigin } =
-		useSetting( 'color' ) || {};
+	// Some color settings have a special handling for deprecated flags in `useSetting`,
+	// so we can't unwrap them by doing const { ... } = useSetting('color')
+	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
+	const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
+	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
+
 	const colors = useMemo(
 		() => [
 			...( solidsPerOrigin?.custom || [] ),

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   Fixed `GradientPicker` not displaying `CustomGradientPicker` when no gradients are provided ([#36900](https://github.com/WordPress/gutenberg/pull/36900)).
 -   Fixed error thrown in `ColorPicker` when used in controlled state in color gradients ([#36941](https://github.com/WordPress/gutenberg/pull/36941)).
 -   Updated readme to include default value introduced in fix for unexpected movements in the `ColorPicker` ([#35670](https://github.com/WordPress/gutenberg/pull/35670)).
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -113,31 +113,42 @@ export default function GradientPicker( {
 	const Component = __experimentalHasMultipleOrigins
 		? MultipleOrigin
 		: SingleOrigin;
+
+	const actions = clearable && (
+		<CircularOptionPicker.ButtonAction onClick={ clearGradient }>
+			{ __( 'Clear' ) }
+		</CircularOptionPicker.ButtonAction>
+	);
+
+	if ( gradients?.length ) {
+		return (
+			<Component
+				className={ className }
+				clearable={ clearable }
+				clearGradient={ clearGradient }
+				gradients={ gradients }
+				onChange={ onChange }
+				value={ value }
+				actions={ actions }
+				content={
+					! disableCustomGradients && (
+						<CustomGradientPicker
+							value={ value }
+							onChange={ onChange }
+						/>
+					)
+				}
+			/>
+		);
+	}
+
 	return (
-		<Component
+		<CircularOptionPicker
 			className={ className }
-			clearable={ clearable }
-			clearGradient={ clearGradient }
-			gradients={ gradients }
-			onChange={ onChange }
-			value={ value }
-			actions={
-				clearable && (
-					<CircularOptionPicker.ButtonAction
-						onClick={ clearGradient }
-					>
-						{ __( 'Clear' ) }
-					</CircularOptionPicker.ButtonAction>
-				)
-			}
-			content={
-				! disableCustomGradients && (
-					<CustomGradientPicker
-						value={ value }
-						onChange={ onChange }
-					/>
-				)
-			}
-		/>
+			options={ [] }
+			actions={ actions }
+		>
+			<CustomGradientPicker value={ value } onChange={ onChange } />
+		</CircularOptionPicker>
 	);
 }

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -124,7 +124,8 @@ export default function GradientPicker( {
 			onChange={ onChange }
 			value={ value }
 			actions={
-				clearable && (
+				clearable &&
+				( gradients?.length || ! disableCustomGradients ) && (
 					<CircularOptionPicker.ButtonAction
 						onClick={ clearGradient }
 					>

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -110,45 +110,36 @@ export default function GradientPicker( {
 	const clearGradient = useCallback( () => onChange( undefined ), [
 		onChange,
 	] );
-	const Component = __experimentalHasMultipleOrigins
-		? MultipleOrigin
-		: SingleOrigin;
-
-	const actions = clearable && (
-		<CircularOptionPicker.ButtonAction onClick={ clearGradient }>
-			{ __( 'Clear' ) }
-		</CircularOptionPicker.ButtonAction>
-	);
-
-	if ( gradients?.length ) {
-		return (
-			<Component
-				className={ className }
-				clearable={ clearable }
-				clearGradient={ clearGradient }
-				gradients={ gradients }
-				onChange={ onChange }
-				value={ value }
-				actions={ actions }
-				content={
-					! disableCustomGradients && (
-						<CustomGradientPicker
-							value={ value }
-							onChange={ onChange }
-						/>
-					)
-				}
-			/>
-		);
-	}
+	const Component =
+		__experimentalHasMultipleOrigins && gradients?.length
+			? MultipleOrigin
+			: SingleOrigin;
 
 	return (
-		<CircularOptionPicker
+		<Component
 			className={ className }
-			options={ [] }
-			actions={ actions }
-		>
-			<CustomGradientPicker value={ value } onChange={ onChange } />
-		</CircularOptionPicker>
+			clearable={ clearable }
+			clearGradient={ clearGradient }
+			gradients={ gradients }
+			onChange={ onChange }
+			value={ value }
+			actions={
+				clearable && (
+					<CircularOptionPicker.ButtonAction
+						onClick={ clearGradient }
+					>
+						{ __( 'Clear' ) }
+					</CircularOptionPicker.ButtonAction>
+				)
+			}
+			content={
+				! disableCustomGradients && (
+					<CustomGradientPicker
+						value={ value }
+						onChange={ onChange }
+					/>
+				)
+			}
+		/>
 	);
 }

--- a/packages/components/src/gradient-picker/stories/index.js
+++ b/packages/components/src/gradient-picker/stories/index.js
@@ -84,3 +84,26 @@ export const _default = () => {
 		/>
 	);
 };
+
+export const WithNoExistingGradients = () => {
+	const disableCustomGradients = boolean( 'Disable Custom Gradients', false );
+	const __experimentalHasMultipleOrigins = boolean(
+		'Experimental Has Multiple Origins',
+		true
+	);
+	const clearable = boolean( 'Clearable', true );
+	const className = text( 'Class Name', '' );
+	const gradients = object( 'Gradients', [] );
+
+	return (
+		<GradientPickerWithState
+			__experimentalHasMultipleOrigins={
+				__experimentalHasMultipleOrigins
+			}
+			disableCustomGradients={ disableCustomGradients }
+			gradients={ gradients }
+			clearable={ clearable }
+			className={ className }
+		/>
+	);
+};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #36640

This PR adds the ability to set a custom gradient when no gradients are provided by the theme (and the `defaultGradients` setting is switched off). It turns out the bug was due to the `MultipleOrigin` component expecting there to be at least one gradient, so the fix is to check that at least one gradient exists before using that component, otherwise fallback to `SingleOrigin`.

Note: I noticed some outstanding issues with the gradient picker, raised in: https://github.com/WordPress/gutenberg/issues/36899 — the console error thrown when clearing a gradient exists on trunk, and doesn't appear to affect the user experience.  I figure we can look at fixing that separately.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

With a blocks theme active, update the following settings in the `theme.json`:

* `settings.color.defaultGradients` should be set to `false`.
* `settings.color.gradients` should be set to an empty array.

Open up the post editor and add a Group block. Go to set the background color, and select Gradient — you should be able to add a custom gradient as in the screengrab below.

I've also added a Storybook example to make sure it's easy to quickly glance at the component without having to make the above changes to a `theme.json` file. To see the Storybook example:

1. Run `npm run storybook:dev`
2. Go to `http://localhost:50240/?path=/story/components-gradientpicker--with-no-existing-gradients` and check that the custom gradient is displayed and usable.

## Screenshots <!-- if applicable -->

![Kapture 2021-11-26 at 16 47 07](https://user-images.githubusercontent.com/14988353/143533542-ee871391-8112-42fe-85a1-cbf3b63506f2.gif)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
