### PR TITLE
Add template list preloading for users, themes and plugins

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -76,21 +76,7 @@ function gutenberg_get_editor_styles() {
 	return $styles;
 }
 
-/**
- * Initialize the Gutenberg Templates List Page.
- *
- * @param array $settings The editor settings.
- */
-function gutenberg_edit_site_list_init( $settings ) {
-	wp_enqueue_script( 'wp-edit-site' );
-	wp_enqueue_style( 'wp-edit-site' );
-	wp_enqueue_media();
-
-	$post_type = get_post_type_object( $_GET['postType'] );
-
-	if ( ! $post_type ) {
-		wp_die( __( 'Invalid post type.', 'gutenberg' ) );
-	}
+function gutenberg_edit_site_list_preload_data( $post_type ) {
 
 	$preload_data = array_reduce(
 		array(
@@ -111,6 +97,25 @@ function gutenberg_edit_site_list_init( $settings ) {
 		),
 		'after'
 	);
+}
+
+/**
+ * Initialize the Gutenberg Templates List Page.
+ *
+ * @param array $settings The editor settings.
+ */
+function gutenberg_edit_site_list_init( $settings ) {
+	wp_enqueue_script( 'wp-edit-site' );
+	wp_enqueue_style( 'wp-edit-site' );
+	wp_enqueue_media();
+
+	$post_type = get_post_type_object( $_GET['postType'] );
+
+	if ( ! $post_type ) {
+		wp_die( __( 'Invalid post type.', 'gutenberg' ) );
+	}
+
+	gutenberg_edit_site_list_preload_data( $post_type );
 
 	wp_add_inline_script(
 		'wp-edit-site',


### PR DESCRIPTION
## Description
Adds preloading for some of the requests made in the site editor template list.

This builds on #36763. I've separated it out because it wasn't easy. I think the code is complex enough to question whether it's worth doing this.

Most of the complexity comes from the fact that a REST request is required to get the data needed to preload user, theme and plugin details that are displayed in the Added By column. 

Better solutions to this would be server side rendering of the page or using something like GraphQL to fetch all the required info in one go.

## How has this been tested?
1. Open the site editor
2. Go to Templates or Template Parts in the navigation sidebar.
3. Data in the Added By column should load straight away (apart from images, which naturally take some time)
4. Check the network tab in the dev tools, there should be any requests for users, themes or plugins
5. Visit http://localhost:8889/wp-admin/themes.php?page=gutenberg-edit-site&postType=post (make sure you have some posts first
6. The author name should load straight away.

## Types of changes
Enhancement
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
