### PR TITLE
Update function names for the public global styles API functions

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -148,8 +148,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$block_gap             = gutenberg_get_global_settings( array( 'spacing', 'blockGap' ) );
-	$default_layout        = gutenberg_get_global_settings( array( 'layout' ) );
+	$block_gap             = wp_get_global_settings( array( 'spacing', 'blockGap' ) );
+	$default_layout        = wp_get_global_settings( array( 'layout' ) );
 	$has_block_gap_support = isset( $block_gap ) ? null !== $block_gap : false;
 	$default_block_layout  = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
 	$used_layout           = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -5,124 +5,130 @@
  * @package gutenberg
  */
 
-/**
- * Function to get the settings resulting of merging core, theme, and user data.
- *
- * @param array $path    Path to the specific setting to retrieve. Optional.
- *                       If empty, will return all settings.
- * @param array $context {
- *     Metadata to know where to retrieve the $path from. Optional.
- *
- *     @type string $block_name Which block to retrieve the settings from.
- *                              If empty, it'll return the settings for the global context.
- *     @type string $origin     Which origin to take data from.
- *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
- *                              If empty or unknown, 'all' is used.
- * }
- *
- * @return array The settings to retrieve.
- */
-function gutenberg_get_global_settings( $path = array(), $context = array() ) {
-	if ( ! empty( $context['block_name'] ) ) {
-		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+if ( ! function_exists( 'wp_get_global_settings' ) ) {
+	/**
+	 * Function to get the settings resulting of merging core, theme, and user data.
+	 *
+	 * @param array $path    Path to the specific setting to retrieve. Optional.
+	 *                       If empty, will return all settings.
+	 * @param array $context {
+	 *     Metadata to know where to retrieve the $path from. Optional.
+	 *
+	 *     @type string $block_name Which block to retrieve the settings from.
+	 *                              If empty, it'll return the settings for the global context.
+	 *     @type string $origin     Which origin to take data from.
+	 *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+	 *                              If empty or unknown, 'all' is used.
+	 * }
+	 *
+	 * @return array The settings to retrieve.
+	 */
+	function wp_get_global_settings( $path = array(), $context = array() ) {
+		if ( ! empty( $context['block_name'] ) ) {
+			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+		}
+
+		$origin = 'custom';
+		if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+			$origin = 'theme';
+		}
+
+		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
+
+		return _wp_array_get( $settings, $path, $settings );
 	}
-
-	$origin = 'custom';
-	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
-		$origin = 'theme';
-	}
-
-	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
-
-	return _wp_array_get( $settings, $path, $settings );
 }
 
-/**
- * Function to get the styles resulting of merging core, theme, and user data.
- *
- * @param array $path    Path to the specific style to retrieve. Optional.
- *                       If empty, will return all styles.
- * @param array $context {
- *     Metadata to know where to retrieve the $path from. Optional.
- *
- *     @type string $block_name Which block to retrieve the styles from.
- *                              If empty, it'll return the styles for the global context.
- *     @type string $origin     Which origin to take data from.
- *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
- *                              If empty or unknown, 'all' is used.
- * }
- *
- * @return array The styles to retrieve.
- */
-function gutenberg_get_global_styles( $path = array(), $context = array() ) {
-	if ( ! empty( $context['block_name'] ) ) {
-		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+if ( ! function_exists( 'wp_get_global_styles' ) ) {
+	/**
+	 * Function to get the styles resulting of merging core, theme, and user data.
+	 *
+	 * @param array $path    Path to the specific style to retrieve. Optional.
+	 *                       If empty, will return all styles.
+	 * @param array $context {
+	 *     Metadata to know where to retrieve the $path from. Optional.
+	 *
+	 *     @type string $block_name Which block to retrieve the styles from.
+	 *                              If empty, it'll return the styles for the global context.
+	 *     @type string $origin     Which origin to take data from.
+	 *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+	 *                              If empty or unknown, 'all' is used.
+	 * }
+	 *
+	 * @return array The styles to retrieve.
+	 */
+	function wp_get_global_styles( $path = array(), $context = array() ) {
+		if ( ! empty( $context['block_name'] ) ) {
+			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
+		}
+
+		$origin = 'custom';
+		if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+			$origin = 'theme';
+		}
+
+		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
+
+		return _wp_array_get( $styles, $path, $styles );
 	}
-
-	$origin = 'custom';
-	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
-		$origin = 'theme';
-	}
-
-	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
-
-	return _wp_array_get( $styles, $path, $styles );
 }
 
-/**
- * Returns the stylesheet resulting of merging core, theme, and user data.
- *
- * @param array $types Types of styles to load. Optional.
- *                     It accepts 'variables', 'styles', 'presets' as values.
- *                     If empty, it'll load all for themes with theme.json support
- *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
- *
- * @return string Stylesheet.
- */
-function gutenberg_get_global_stylesheet( $types = array() ) {
-	// Return cached value if it can be used and exists.
-	// It's cached by theme to make sure that theme switching clears the cache.
-	$can_use_cached = (
+if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
+	/**
+	 * Returns the stylesheet resulting of merging core, theme, and user data.
+	 *
+	 * @param array $types Types of styles to load. Optional.
+	 *                     It accepts 'variables', 'styles', 'presets' as values.
+	 *                     If empty, it'll load all for themes with theme.json support
+	 *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
+	 *
+	 * @return string Stylesheet.
+	 */
+	function wp_get_global_stylesheet( $types = array() ) {
+		// Return cached value if it can be used and exists.
+		// It's cached by theme to make sure that theme switching clears the cache.
+		$can_use_cached = (
 		( empty( $types ) ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
 		! is_admin()
-	);
-	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
-	if ( $can_use_cached ) {
-		$cached = get_transient( $transient_name );
-		if ( $cached ) {
-			return $cached;
+		);
+		$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
+		if ( $can_use_cached ) {
+			$cached = get_transient( $transient_name );
+			if ( $cached ) {
+				return $cached;
+			}
 		}
+
+		$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+		$supports_link_color = get_theme_support( 'experimental-link-color' );
+		if ( empty( $types ) && ! $supports_theme_json ) {
+			$types = array( 'variables', 'presets' );
+		} elseif ( empty( $types ) ) {
+			$types = array( 'variables', 'styles', 'presets' );
+		}
+
+		$origins = array( 'default', 'theme', 'custom' );
+		if ( ! $supports_theme_json && ! $supports_link_color ) {
+			// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
+			$origins = array( 'default' );
+		} elseif ( ! $supports_theme_json && $supports_link_color ) {
+			// For the legacy link color feature to work, the CSS Custom Properties
+			// should be in scope (either the core or the theme ones).
+			$origins = array( 'default', 'theme' );
+		}
+
+		$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$stylesheet = $tree->get_stylesheet( $types, $origins );
+
+		if ( $can_use_cached ) {
+			// Cache for a minute.
+			// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
+			set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
+		}
+
+		return $stylesheet;
 	}
-
-	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	$supports_link_color = get_theme_support( 'experimental-link-color' );
-	if ( empty( $types ) && ! $supports_theme_json ) {
-		$types = array( 'variables', 'presets' );
-	} elseif ( empty( $types ) ) {
-		$types = array( 'variables', 'styles', 'presets' );
-	}
-
-	$origins = array( 'default', 'theme', 'custom' );
-	if ( ! $supports_theme_json && ! $supports_link_color ) {
-		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-		$origins = array( 'default' );
-	} elseif ( ! $supports_theme_json && $supports_link_color ) {
-		// For the legacy link color feature to work, the CSS Custom Properties
-		// should be in scope (either the core or the theme ones).
-		$origins = array( 'default', 'theme' );
-	}
-
-	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$stylesheet = $tree->get_stylesheet( $types, $origins );
-
-	if ( $can_use_cached ) {
-		// Cache for a minute.
-		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
-	}
-
-	return $stylesheet;
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,7 +10,7 @@
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	$stylesheet = gutenberg_get_global_stylesheet();
+	$stylesheet = wp_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -52,7 +52,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
+		$settings['__experimentalStyles'] = wp_get_global_styles();
 	}
 
 	if ( 'other' === $context ) {
@@ -83,7 +83,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			),
 		);
 		foreach ( $new_presets as $new_style ) {
-			$style_css = gutenberg_get_global_stylesheet( array( $new_style['css'] ) );
+			$style_css = wp_get_global_stylesheet( array( $new_style['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_style['css']    = $style_css;
 				$new_global_styles[] = $new_style;
@@ -95,7 +95,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			'__unstableType' => 'theme',
 		);
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$style_css = gutenberg_get_global_stylesheet( array( $new_block_classes['css'] ) );
+			$style_css = wp_get_global_stylesheet( array( $new_block_classes['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_block_classes['css'] = $style_css;
 				$new_global_styles[]      = $new_block_classes;
@@ -106,7 +106,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
+	$settings['__experimentalFeatures'] = wp_get_global_settings();
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/34843 and https://github.com/WordPress/gutenberg/pull/36610

This PR updates the names of the public functions to access global styles data. It substitutes the `gutenberg_*` prefix with the `wp_*` one.

## Changes

Before, we had:

- in Gutenberg we used `gutenberg_get_global_settings`, ` gutenberg_get_global_styles` and ` gutenberg_get_global_stylesheet`.
- in WordPress 5.9 we used `wp_get_global_settings`, `wp_get_global_styles`, `wp_get_global_stylesheet`.

After, we have:

- only  `wp_get_global_settings`, `wp_get_global_styles`, `wp_get_global_stylesheet`, both in Gutenberg and WordPress 5.9.

## Why we need to do this

By doing this, we fix two issues:

- We make the `wp_*` functions available in all WordPress versions supported by the plugin (e.g. WordPress 5.8). These are expected to be used by 3rd parties and we can't have them to change between `gutenberg_*` or `wp_*` depending on the environment.

- We align these with the rationale laid out for how the `lib/compat/wordpress-X.X` code should work. This is meant to minimize the backport efforts by having in this folder code with the same name as core and checking for `function_exist`. This way, once the minimum version of the plugin is updated, we just can remove the folder completely and Gutenberg will work nicely, without any other change.
