### PR TITLE
Add filters to shortcircuit the public API of global styles

### DIFF
--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -24,6 +24,11 @@ if ( ! function_exists( 'wp_get_global_settings' ) ) {
 	 * @return array The settings to retrieve.
 	 */
 	function wp_get_global_settings( $path = array(), $context = array() ) {
+		$pre_global_settings = apply_filters( 'pre_wp_get_global_settings', null, $path, $context );
+		if ( null !== $pre_global_settings ) {
+			return $pre_global_settings;
+		}
+
 		if ( ! empty( $context['block_name'] ) ) {
 			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 		}
@@ -58,6 +63,11 @@ if ( ! function_exists( 'wp_get_global_styles' ) ) {
 	 * @return array The styles to retrieve.
 	 */
 	function wp_get_global_styles( $path = array(), $context = array() ) {
+		$pre_global_styles = apply_filters( 'pre_wp_get_global_styles', null, $path, $context );
+		if ( null !== $pre_global_styles ) {
+			return $pre_global_styles;
+		}
+
 		if ( ! empty( $context['block_name'] ) ) {
 			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 		}
@@ -85,6 +95,11 @@ if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
 	 * @return string Stylesheet.
 	 */
 	function wp_get_global_stylesheet( $types = array() ) {
+		$pre_global_stylesheet = apply_filters( 'pre_wp_get_global_stylesheet', null, $types );
+		if ( null !== $pre_global_stylesheet ) {
+			return $pre_global_stylesheet;
+		}
+
 		// Return cached value if it can be used and exists.
 		// It's cached by theme to make sure that theme switching clears the cache.
 		$can_use_cached = (


### PR DESCRIPTION
A follow-up to #34843 #36610 #36907

This PR introduces a shortcircuit filter for each one of the public functions we're introducing for global styles in WordPress 5.9.

It works this way (pseudo-code):

```php
function wp_get_global_* ( ... ) {
  $pre_global_* = apply_filters( 'pre_wp_get_global_*', null, ... );
  if ( null !== $pre_global_* ) {
    return $pre_global_*;
  }

  // Normal operation.
  // ...
}
```

By doing this, we allow the Gutenberg plugin (and any 3rd party) to modify the behavior of these functions once they are in WordPress core. This is useful especially for Gutenberg, where we may need the ability to introduce future changes to how these functions work. Examples of changes that we're considering: support for multiple `theme.json` files ("global styles variations"), new schema versions, etc.

It's inspired by the `pre_render_block` filter.
