### PR TITLE
Templates: Search for old template names in the parent theme too

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -36,7 +36,11 @@ if ( ! function_exists( 'get_block_theme_folders' ) ) {
 		$root_dir   = get_theme_root( $theme_name );
 		$theme_dir  = "$root_dir/$theme_name";
 
-		if ( is_readable( $theme_dir . '/block-templates/index.html' ) ) {
+		$parent_theme_name = get_template();
+		$parent_root_dir   = get_theme_root( $parent_theme_name );
+		$parent_theme_dir  = "$parent_root_dir/$parent_theme_name";
+
+		if ( is_readable( $theme_dir . '/block-templates/index.html' ) || is_readable( $parent_theme_dir . '/block-templates/index.html' ) ) {
 			return array(
 				'wp_template'      => 'block-templates',
 				'wp_template_part' => 'block-template-parts',

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -40,7 +40,7 @@ if ( ! function_exists( 'get_block_theme_folders' ) ) {
 		$parent_root_dir   = get_theme_root( $parent_theme_name );
 		$parent_theme_dir  = "$parent_root_dir/$parent_theme_name";
 
-		if ( is_readable( $theme_dir . '/block-templates/index.html' ) || is_readable( $parent_theme_dir . '/block-templates/index.html' ) ) {
+		if ( is_readable( $theme_dir . '/block-templates/' ) || is_readable( $parent_theme_dir . '/block-templates/' ) ) {
 			return array(
 				'wp_template'      => 'block-templates',
 				'wp_template_part' => 'block-template-parts',

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -36,11 +36,7 @@ if ( ! function_exists( 'get_block_theme_folders' ) ) {
 		$root_dir   = get_theme_root( $theme_name );
 		$theme_dir  = "$root_dir/$theme_name";
 
-		$parent_theme_name = get_template();
-		$parent_root_dir   = get_theme_root( $parent_theme_name );
-		$parent_theme_dir  = "$parent_root_dir/$parent_theme_name";
-
-		if ( is_readable( $theme_dir . '/block-templates/' ) || is_readable( $parent_theme_dir . '/block-templates/' ) ) {
+		if ( file_exists( $theme_dir . '/block-templates' ) || file_exists( $theme_dir . '/block-template-parts' ) ) {
 			return array(
 				'wp_template'      => 'block-templates',
 				'wp_template_part' => 'block-template-parts',

--- a/packages/block-library/src/template-part/index.php
+++ b/packages/block-library/src/template-part/index.php
@@ -64,8 +64,11 @@ function render_block_core_template_part( $attributes ) {
 		} else {
 			// Else, if the template part was provided by the active theme,
 			// render the corresponding file content.
-			$theme_folders           = get_block_theme_folders();
-			$template_part_file_path = get_theme_file_path( '/' . $theme_folders['wp_template_part'] . '/' . $attributes['slug'] . '.html' );
+			$parent_theme_folders        = get_block_theme_folders( get_template() );
+			$child_theme_folders         = get_block_theme_folders( get_stylesheet() );
+			$child_theme_part_file_path  = get_theme_file_path( '/' . $child_theme_folders['wp_template_part'] . '/' . $attributes['slug'] . '.html' );
+			$parent_theme_part_file_path = get_theme_file_path( '/' . $parent_theme_folders['wp_template_part'] . '/' . $attributes['slug'] . '.html' );
+			$template_part_file_path     = 0 === validate_file( $attributes['slug'] ) && file_exists( $child_theme_part_file_path ) ? $child_theme_part_file_path : $parent_theme_part_file_path;
 			if ( 0 === validate_file( $attributes['slug'] ) && file_exists( $template_part_file_path ) ) {
 				$content = file_get_contents( $template_part_file_path );
 				$content = is_string( $content ) && '' !== $content


### PR DESCRIPTION
## Description
In https://github.com/WordPress/gutenberg/pull/36647 we added a fallback for themes that don't have templates in the new directory structure. However the checks only looked in the child theme, not the parent. This adds the same check to the parent theme, so that templates in child themes continue to load as before

## How has this been tested?
This is quite hard to test as most child themes specify their own index.html.
This PR is an example of theme that doesn't: https://github.com/Automattic/themes/pull/5094

## Screenshots <!-- if applicable -->
Before:
<img width="1440" alt="Screenshot 2021-11-26 at 12 16 40" src="https://user-images.githubusercontent.com/275961/143579840-e953f1de-3b75-4224-88e1-2969a68847a7.png">

After:
<img width="1440" alt="Screenshot 2021-11-26 at 12 15 45" src="https://user-images.githubusercontent.com/275961/143579854-bf09e2b3-fbe9-4829-86c2-a9de02f590b4.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
