### PR TITLE
Templates Controller: Add missing 'is_custom' prop

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -412,6 +412,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
 			'has_theme_file' => $template->has_theme_file,
+			'is_custom'      => $template->is_custom,
 		);
 
 		if ( 'wp_template_part' === $template->type ) {
@@ -575,6 +576,12 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 				),
 				'has_theme_file' => array(
 					'description' => __( 'Theme file exists.', 'gutenberg' ),
+					'type'        => 'bool',
+					'context'     => array( 'embed', 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'is_custom'      => array(
+					'description' => __( 'Whether a template is a custom template.', 'gutenberg' ),
 					'type'        => 'bool',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -412,8 +412,11 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'status'         => $template->status,
 			'wp_id'          => $template->wp_id,
 			'has_theme_file' => $template->has_theme_file,
-			'is_custom'      => $template->is_custom,
 		);
+
+		if ( 'wp_template' === $template->type ) {
+			$result['is_custom'] = $template->is_custom;
+		}
 
 		if ( 'wp_template_part' === $template->type ) {
 			$result['area'] = $template->area;
@@ -580,14 +583,17 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'is_custom'      => array(
-					'description' => __( 'Whether a template is a custom template.', 'gutenberg' ),
-					'type'        => 'bool',
-					'context'     => array( 'embed', 'view', 'edit' ),
-					'readonly'    => true,
-				),
 			),
 		);
+
+		if ( 'wp_template' === $this->post_type ) {
+			$schema['properties']['is_custom'] = array(
+				'description' => __( 'Whether a template is a custom template.', 'gutenberg' ),
+				'type'        => 'bool',
+				'context'     => array( 'embed', 'view', 'edit' ),
+				'readonly'    => true,
+			);
+		}
 
 		if ( 'wp_template_part' === $this->post_type ) {
 			$schema['properties']['area'] = array(

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -76,6 +76,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'type'           => 'wp_template',
 				'wp_id'          => null,
 				'has_theme_file' => true,
+				'is_custom'      => false,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//index' )
 		);
@@ -101,6 +102,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'is_custom'      => true,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -129,6 +131,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'type'           => 'wp_template',
 				'wp_id'          => null,
 				'has_theme_file' => true,
+				'is_custom'      => false,
 			),
 			$data
 		);
@@ -155,6 +158,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
+				'is_custom'      => true,
 			),
 			$data
 		);
@@ -193,6 +197,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 					'raw' => 'Content',
 				),
 				'has_theme_file' => false,
+				'is_custom'      => true,
 			),
 			$data
 		);
@@ -231,6 +236,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				),
 				'area'           => 'header',
 				'has_theme_file' => false,
+				'is_custom'      => true,
 			),
 			$data
 		);

--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -102,7 +102,6 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
-				'is_custom'      => true,
 			),
 			find_and_normalize_template_by_id( $data, 'tt1-blocks//header' )
 		);
@@ -158,7 +157,6 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'wp_id'          => null,
 				'area'           => WP_TEMPLATE_PART_AREA_HEADER,
 				'has_theme_file' => true,
-				'is_custom'      => true,
 			),
 			$data
 		);
@@ -236,7 +234,6 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				),
 				'area'           => 'header',
 				'has_theme_file' => false,
-				'is_custom'      => true,
 			),
 			$data
 		);


### PR DESCRIPTION
## Description
The prop was originally introduced in #35802. It returns a boolean value whether a template is a custom template and isn't part of WP default templates.

## How has this been tested?
Unit tests should pass.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
