### PR TITLE
Rename `gutenberg_` to `wp_` for some functions that land in WordPress 5.9

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -67,7 +67,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	private static function read_json_file( $file_path ) {
 		$config = array();
 		if ( $file_path ) {
-			$decoded_file = gutenberg_json_file_decode( $file_path, array( 'associative' => true ) );
+			$decoded_file = wp_json_file_decode( $file_path, array( 'associative' => true ) );
 			if ( is_array( $decoded_file ) ) {
 				$config = $decoded_file;
 			}
@@ -98,7 +98,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 */
 	private static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === self::$i18n_schema ) {
-			$i18n_schema       = gutenberg_json_file_decode( __DIR__ . '/theme-i18n.json' );
+			$i18n_schema       = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
 			self::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -102,7 +102,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			self::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
-		return gutenberg_translate_settings_using_i18n_schema( self::$i18n_schema, $theme_json, $domain );
+		return wp_translate_settings_using_i18n_schema( self::$i18n_schema, $theme_json, $domain );
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/json-file-decode.php
+++ b/lib/compat/wordpress-5.9/json-file-decode.php
@@ -5,48 +5,50 @@
  * @package gutenberg
  */
 
-/**
- * Reads and decodes a JSON file.
- *
- * @param string $filename Path to the JSON file.
- * @param array  $options  {
- *     Optional. Options to be used with `json_decode()`.
- *
- *     @type bool associative Optional. When `true`, JSON objects will be returned as associative arrays.
- *                            When `false`, JSON objects will be returned as objects.
- * }
- *
- * @return mixed Returns the value encoded in JSON in appropriate PHP type.
- *               `null` is returned if the file is not found, or its content can't be decoded.
- */
-function gutenberg_json_file_decode( $filename, $options = array() ) {
-	$result   = null;
-	$filename = wp_normalize_path( realpath( $filename ) );
-	if ( ! file_exists( $filename ) ) {
-		trigger_error(
-			sprintf(
+if ( ! function_exists( 'wp_json_file_decode' ) ) {
+	/**
+	 * Reads and decodes a JSON file.
+	 *
+	 * @param string $filename Path to the JSON file.
+	 * @param array  $options  {
+	 *     Optional. Options to be used with `json_decode()`.
+	 *
+	 *     @type bool associative Optional. When `true`, JSON objects will be returned as associative arrays.
+	 *                            When `false`, JSON objects will be returned as objects.
+	 * }
+	 *
+	 * @return mixed Returns the value encoded in JSON in appropriate PHP type.
+	 *               `null` is returned if the file is not found, or its content can't be decoded.
+	 */
+	function wp_json_file_decode( $filename, $options = array() ) {
+		$result   = null;
+		$filename = wp_normalize_path( realpath( $filename ) );
+		if ( ! file_exists( $filename ) ) {
+			trigger_error(
+				sprintf(
 				/* translators: %s: Path to the JSON file. */
-				__( "File %s doesn't exist!", 'gutenberg' ),
-				$filename
-			)
-		);
-		return $result;
-	}
+					__( "File %s doesn't exist!", 'gutenberg' ),
+					$filename
+				)
+			);
+			return $result;
+		}
 
-	$options      = wp_parse_args( $options, array( 'associative' => false ) );
-	$decoded_file = json_decode( file_get_contents( $filename ), $options['associative'] );
+		$options      = wp_parse_args( $options, array( 'associative' => false ) );
+		$decoded_file = json_decode( file_get_contents( $filename ), $options['associative'] );
 
-	if ( JSON_ERROR_NONE !== json_last_error() ) {
-		trigger_error(
-			sprintf(
+		if ( JSON_ERROR_NONE !== json_last_error() ) {
+			trigger_error(
+				sprintf(
 				/* translators: 1: Path to the JSON file, 2: Error message. */
-				__( 'Error when decoding a JSON file at path %1$s: %2$s', 'gutenberg' ),
-				$filename,
-				json_last_error_msg()
-			)
-		);
-		return $result;
-	}
+					__( 'Error when decoding a JSON file at path %1$s: %2$s', 'gutenberg' ),
+					$filename,
+					json_last_error_msg()
+				)
+			);
+			return $result;
+		}
 
-	return $decoded_file;
+		return $decoded_file;
+	}
 }

--- a/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
+++ b/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
@@ -5,44 +5,46 @@
  * @package gutenberg
  */
 
-/**
- * Translates the provided settings value using its i18n schema.
- *
- * @param string|string[]|array[]|object $i18n_schema I18n schema for the setting.
- * @param string|string[]|array[]        $settings    Value for the settings.
- * @param string                         $textdomain  Textdomain to use with translations.
- *
- * @return string|string[]|array[] Translated settings.
- */
-function gutenberg_translate_settings_using_i18n_schema( $i18n_schema, $settings, $textdomain ) {
-	if ( empty( $i18n_schema ) || empty( $settings ) || empty( $textdomain ) ) {
+if ( ! function_exists( 'wp_translate_settings_using_i18n_schema' ) ) {
+	/**
+	 * Translates the provided settings value using its i18n schema.
+	 *
+	 * @param string|string[]|array[]|object $i18n_schema I18n schema for the setting.
+	 * @param string|string[]|array[]        $settings    Value for the settings.
+	 * @param string                         $textdomain  Textdomain to use with translations.
+	 *
+	 * @return string|string[]|array[] Translated settings.
+	 */
+	function wp_translate_settings_using_i18n_schema( $i18n_schema, $settings, $textdomain ) {
+		if ( empty( $i18n_schema ) || empty( $settings ) || empty( $textdomain ) ) {
+			return $settings;
+		}
+
+		if ( is_string( $i18n_schema ) && is_string( $settings ) ) {
+			//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
+			return translate_with_gettext_context( $settings, $i18n_schema, $textdomain );
+		}
+		if ( is_array( $i18n_schema ) && is_array( $settings ) ) {
+			$translated_settings = array();
+			foreach ( $settings as $value ) {
+				$translated_settings[] = wp_translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
+			}
+			return $translated_settings;
+		}
+		if ( is_object( $i18n_schema ) && is_array( $settings ) ) {
+			$group_key           = '*';
+			$translated_settings = array();
+			foreach ( $settings as $key => $value ) {
+				if ( isset( $i18n_schema->$key ) ) {
+					$translated_settings[ $key ] = wp_translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
+				} elseif ( isset( $i18n_schema->$group_key ) ) {
+					$translated_settings[ $key ] = wp_translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
+				} else {
+					$translated_settings[ $key ] = $value;
+				}
+			}
+			return $translated_settings;
+		}
 		return $settings;
 	}
-
-	if ( is_string( $i18n_schema ) && is_string( $settings ) ) {
-		//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
-		return translate_with_gettext_context( $settings, $i18n_schema, $textdomain );
-	}
-	if ( is_array( $i18n_schema ) && is_array( $settings ) ) {
-		$translated_settings = array();
-		foreach ( $settings as $value ) {
-			$translated_settings[] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
-		}
-		return $translated_settings;
-	}
-	if ( is_object( $i18n_schema ) && is_array( $settings ) ) {
-		$group_key           = '*';
-		$translated_settings = array();
-		foreach ( $settings as $key => $value ) {
-			if ( isset( $i18n_schema->$key ) ) {
-				$translated_settings[ $key ] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
-			} elseif ( isset( $i18n_schema->$group_key ) ) {
-				$translated_settings[ $key ] = gutenberg_translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
-			} else {
-				$translated_settings[ $key ] = $value;
-			}
-		}
-		return $translated_settings;
-	}
-	return $settings;
 }

--- a/phpunit/translate-settings-using-i18n-schema.php
+++ b/phpunit/translate-settings-using-i18n-schema.php
@@ -61,7 +61,7 @@ class Tests_L10n_TranslateSettingsUsingI18nSchema extends WP_UnitTestCase {
 				),
 			),
 		);
-		$result      = gutenberg_translate_settings_using_i18n_schema(
+		$result      = wp_translate_settings_using_i18n_schema(
 			$i18n_schema,
 			$settings,
 			$textdomain


### PR DESCRIPTION
A follow up to https://github.com/WordPress/gutenberg/pull/36907

This PR renames `gutenberg_*` to `wp_*` in some functions that are part of `lib/compat/wordpress-5.9`. The rationale is the same as in https://github.com/WordPress/gutenberg/pull/36907 (function name stability, make it available to WordPress 5.8, and making it easy to do the backports and remove the folder once the minimum plugin version is updated).

