### PR TITLE
[RNMobile][iOS] Fix scroll update when typing in RichText component

### DIFF
--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -170,7 +170,7 @@ class AztecView extends Component {
 		) {
 			const caretY = event.nativeEvent.selectionEndCaretY;
 			this.props.onCaretVerticalPositionChange(
-				event.target,
+				event.nativeEvent.target,
 				caretY,
 				this.selectionEndCaretY
 			);

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -23,14 +23,14 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Fixed a race condition when autosaving content (Android) [#36072]
 
 ## 1.65.1
-- [**] Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/WordPress/gutenberg/pull/36019]
+-   [**] Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/WordPress/gutenberg/pull/36019]
 
 ## 1.65.0
-- [**] Search block - Text and background color support [#35511]
-- [*] [Embed Block] Fix loading glitch with resolver resolution approach [#35798]
-* [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [#35570]
-- [**] Block inserter indicates newly available block types [#35201]
-- [*] Add support for the Mark HTML tag [#35956]
+-   [**] Search block - Text and background color support [#35511]
+-   [*] [Embed Block] Fix loading glitch with resolver resolution approach [#35798]
+-   [*] Fixed an issue where the Help screens may not respect an iOS device's notch. [#35570]
+-   [**] Block inserter indicates newly available block types [#35201]
+-   [*] Add support for the Mark HTML tag [#35956]
 
 ## 1.64.1
 -   [**] Fix updating the block list after block removal [#35721]

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [**] [iOS] Fix scroll update when typing in RichText component [#36914]
 
 ## 1.67.0
 -   [**] Adds Clipboard Link Suggestion to Image block and Button block [#35972]


### PR DESCRIPTION
Gutenberg Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4299

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR updates how the target ID parameter is obtained from the native event ([reference](https://github.com/WordPress/gutenberg/blob/96a0dafa1c06d3785e5616a775e82df0c07403ad/packages/react-native-aztec/src/AztecView.js#L173)), which is used when notifying the `KeyboardAwareFlatList` component that the caret vertical position has changed on iOS ([reference](https://github.com/WordPress/gutenberg/blob/96a0dafa1c06d3785e5616a775e82df0c07403ad/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js#L70-L80)). 

The type of the value previously obtained was `ReactNativeFiberHostComponent`, however, the expected value is a number ([reference](https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view/blob/e5ce378011e84be0b6ea8c91e93b568fe940b846/lib/KeyboardAwareHOC.js#L463)). I noticed that the target ID is actually passed within the `nativeEvent` property of the event object, so now we'll pass that property instead.

<img width="1288" alt="Screenshot 2021-11-26 at 14 15 42" src="https://user-images.githubusercontent.com/14905380/143586828-5a184f83-0811-4168-ab9d-e686ce955b86.png">

https://github.com/WordPress/gutenberg/blob/96a0dafa1c06d3785e5616a775e82df0c07403ad/packages/components/src/mobile/keyboard-aware-flat-list/index.ios.js#L78

**NOTE:** More info about the issue can be found in comment: https://github.com/wordpress-mobile/gutenberg-mobile/issues/4069#issuecomment-979954100

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**NOTE:** The fix only applies to iOS, as on Android it couldn't be reproduced ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4069#issuecomment-933209448)).

1. Open a post/page.
1. Insert content and position a paragraph block near the bottom of the field of view (just above the keyboard).
1. Type text until the text cursor moves out of view below the keyboard.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/143586301-e6d68471-7aad-45ea-85ab-055d03d4c1fe.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
