### PR TITLE
[Block Library - Template Part]:Remove support for conversion to Reusable block

### DIFF
--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -30,7 +30,8 @@
 		"spacing": {
 			"padding": true
 		},
-		"__experimentalLayout": true
+		"__experimentalLayout": true,
+		"reusable": false
 	},
 	"editorStyle": "wp-block-template-part-editor"
 }


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/36916

This PR just removes support for conversion from Template Part to Reusable block.