### PR TITLE
Add: Uneditable duotone palette on the palette gradient panel

### DIFF
--- a/packages/components/src/duotone-picker/duotone-picker.js
+++ b/packages/components/src/duotone-picker/duotone-picker.js
@@ -19,6 +19,7 @@ import CustomDuotoneBar from './custom-duotone-bar';
 import { getDefaultColors, getGradientFromCSSColors } from './utils';
 
 function DuotonePicker( {
+	clearable = true,
 	colorPalette,
 	duotonePalette,
 	disableCustomColors,
@@ -69,11 +70,13 @@ function DuotonePicker( {
 				);
 			} ) }
 			actions={
-				<CircularOptionPicker.ButtonAction
-					onClick={ () => onChange( undefined ) }
-				>
-					{ __( 'Clear' ) }
-				</CircularOptionPicker.ButtonAction>
+				!! clearable && (
+					<CircularOptionPicker.ButtonAction
+						onClick={ () => onChange( undefined ) }
+					>
+						{ __( 'Clear' ) }
+					</CircularOptionPicker.ButtonAction>
+				)
 			}
 		>
 			{ ! disableCustomColors && ! disableCustomDuotone && (

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -1,9 +1,16 @@
 /**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
 	__experimentalVStack as VStack,
 	__experimentalPaletteEdit as PaletteEdit,
+	DuotonePicker,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -40,11 +47,24 @@ export default function GradientPalettePanel( { name } ) {
 		'color.defaultGradients',
 		name
 	);
+	const [ duotonePalette ] = useSetting( 'color.duotone' ) || [];
 	return (
 		<VStack
 			className="edit-site-global-styles-gradient-palette-panel"
 			spacing={ 10 }
 		>
+			<div>
+				<Heading className="edit-site-global-styles-gradient-palette-panel__duotone-heading">
+					{ __( 'Duotone' ) }
+				</Heading>
+				<DuotonePicker
+					duotonePalette={ duotonePalette }
+					disableCustomDuotone={ true }
+					disableCustomColors={ true }
+					clearable={ false }
+					onChange={ noop }
+				/>
+			</div>
 			{ !! themeGradients && !! themeGradients.length && (
 				<PaletteEdit
 					canReset={ themeGradients !== baseThemeGradients }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -77,3 +77,11 @@
 		min-height: $grid-unit-40;
 	}
 }
+
+h2.edit-site-global-styles-gradient-palette-panel__duotone-heading.components-heading {
+	text-transform: uppercase;
+	line-height: $grid-unit-30;
+	font-weight: 500;
+	font-size: 11px;
+	margin-bottom: $grid-unit-10;
+}


### PR DESCRIPTION
This PR adds uneditable duotone palette information on the palette gradient panel.

It also adds clearable flag (defaulting to true) to the DuotonePicker component, to match what the other color/palette related components already have.

Part of: https://github.com/WordPress/gutenberg/issues/36543

## How has this been tested?
I opened the global styles sidebar and verified the duotones are shown as the way the following screenshot shows.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/143632070-6f399697-0250-4d97-a685-b629ccfc778f.png)
