### PR TITLE
Global Styles: Call "palettes" and not "color palettes" on panel label

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -23,9 +23,9 @@ function ScreenColorPalette( { name } ) {
 		<>
 			<ScreenHeader
 				back={ parentMenu + '/colors' }
-				title={ __( 'Color Palette' ) }
+				title={ __( 'Palette' ) }
 				description={ __(
-					'Color palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'
+					'Palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'
 				) }
 			/>
 			<ToggleGroupControl


### PR DESCRIPTION
This PR just updates the denomination of the "palettes" panel.

Part of: https://github.com/WordPress/gutenberg/issues/36543