### PR TITLE
ColorPalette: Improving accessibility and visibility

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -105,6 +105,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               style={
                 Object {
                   "background": "#f00",
+                  "color": "#000",
                 }
               }
             >

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fix
 
+-   Improve accessibility and visibility in `ColorPallete` ([#36925](https://github.com/WordPress/gutenberg/pull/36925))
 -   Fixed spacing between `BaseControl` fields and help text within the `ToolsPanel` ([#36334](https://github.com/WordPress/gutenberg/pull/36334))
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 -   Fixed empty `ToolsPanel` height by correcting menu button line-height ([#36895](https://github.com/WordPress/gutenberg/pull/36895)).

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -35,6 +35,7 @@ function SinglePalette( {
 	const colorOptions = useMemo( () => {
 		return map( colors, ( { color, name } ) => {
 			const colordColor = colord( color );
+
 			return (
 				<CircularOptionPicker.Option
 					key={ color }
@@ -133,6 +134,8 @@ export default function ColorPalette( {
 		/>
 	);
 
+	const colordColor = colord( value );
+
 	return (
 		<VStack spacing={ 3 } className={ className }>
 			{ ! disableCustomColors && (
@@ -151,7 +154,14 @@ export default function ColorPalette( {
 							aria-haspopup="true"
 							onClick={ onToggle }
 							aria-label={ __( 'Custom color picker' ) }
-							style={ { background: value } }
+							style={ {
+								background: value,
+								color:
+									colordColor.contrast() >
+									colordColor.contrast( '#000' )
+										? '#fff'
+										: '#000',
+							} }
 						>
 							{ value }
 						</button>

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -1,7 +1,7 @@
 .components-color-palette__custom-color {
+	position: relative;
 	border: none;
 	background: none;
-	outline: 0;
 	display: block;
 	border-radius: $radius-block-ui;
 	height: $grid-unit-60;
@@ -15,6 +15,15 @@
 	box-sizing: border-box;
 	color: $white;
 	cursor: pointer;
+	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
+	// Show a thin outline in Windows high contrast mode.
+	outline: 1px solid transparent;
+
+	&:focus {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+		// Show a outline in Windows high contrast mode.
+		outline-width: 2px;
+	}
 }
 
 .components-dropdown__content.components-color-palette__custom-color-dropdown-content .components-popover__content {

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -17,6 +17,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
   style={
     Object {
       "background": "#f00",
+      "color": "#000",
     }
   }
 >
@@ -44,6 +45,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
       style={
         Object {
           "background": "#f00",
+          "color": "#000",
         }
       }
     >
@@ -196,6 +198,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               style={
                 Object {
                   "background": "#f00",
+                  "color": "#000",
                 }
               }
             >


### PR DESCRIPTION
## Description
PR to improve the accessibility and visibility of the ColorPalette component.

I think that the new design of the `ColorPalette` component has the following three problems.

- Accessibility for keyboard users is inappropriate because the appearance of "Custom color picker" button does not change when the focus is on it.
- Not be able to see that there is a custom color picler there because it will be assimilated into the background color when you select the white color.
- The color code of the text is fixed at `#fff`, which makes the text difficult to read when a color close to white is selected.

https://user-images.githubusercontent.com/54422211/143676979-d4f246cb-f6c2-4c3a-9e2f-485d08253aab.mp4

I have taken the following actions  to solve those problems.

- Add a thin border to the palette area, similar to the Circular picker.
- Change the border style when the palette area is in focus or when the drop-down is open.
- Calculate contrast from color picker values and switch text color values.


https://user-images.githubusercontent.com/54422211/143677202-0ba18391-3318-465a-8e53-275db4fd2c08.mp4

This is the first time I've had a pull request with a specific code.
Please point it out if you find anything inappropriate, 

## Types of changes
Improving accessibility and visibility

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
