### PR TITLE
Site Editor: Allow editing custom template title

### DIFF
--- a/packages/edit-site/src/components/template-details/edit-template-title.js
+++ b/packages/edit-site/src/components/template-details/edit-template-title.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
+
+export default function EditTemplateTitle( { template } ) {
+	const [ title, setTitle ] = useEntityProp(
+		'postType',
+		template.type,
+		'title',
+		template.id
+	);
+
+	return (
+		<TextControl
+			label={ __( 'Title' ) }
+			value={ title }
+			help={ __(
+				'Give the template a title that indicates its purpose, e.g. "Full Width".'
+			) }
+			onChange={ ( newTitle ) => {
+				setTitle( newTitle );
+			} }
+		/>
+	);
+}

--- a/packages/edit-site/src/components/template-details/edit-template-title.js
+++ b/packages/edit-site/src/components/template-details/edit-template-title.js
@@ -21,7 +21,7 @@ export default function EditTemplateTitle( { template } ) {
 				'Give the template a title that indicates its purpose, e.g. "Full Width".'
 			) }
 			onChange={ ( newTitle ) => {
-				setTitle( newTitle );
+				setTitle( newTitle || template.slug );
 			} }
 		/>
 	);

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -24,6 +24,7 @@ import {
 } from '../navigation-sidebar/navigation-panel/constants';
 import { store as editSiteStore } from '../../store';
 import TemplateAreas from './template-areas';
+import EditTemplateTitle from './edit-template-title';
 
 export default function TemplateDetails( { template, onClose } ) {
 	const { title, description } = useSelect(
@@ -55,13 +56,17 @@ export default function TemplateDetails( { template, onClose } ) {
 	return (
 		<div className="edit-site-template-details">
 			<div className="edit-site-template-details__group">
-				<Heading
-					level={ 4 }
-					weight={ 600 }
-					className="edit-site-template-details__title"
-				>
-					{ title }
-				</Heading>
+				{ template.is_custom ? (
+					<EditTemplateTitle template={ template } />
+				) : (
+					<Heading
+						level={ 4 }
+						weight={ 600 }
+						className="edit-site-template-details__title"
+					>
+						{ title }
+					</Heading>
+				) }
 
 				{ description && (
 					<Text


### PR DESCRIPTION
## Description
PR adds a way to edit custom template titles in the Site Editor. UI matches edit title component from Template Mode.

Note: Currently, you can only edit user-created template titles that aren't in the WP template hierarchy - e.g., Index, Single, etc.

Closes #36773.

## How has this been tested?
1. Create a custom template.
2. Go to Appearance > Editor
3. Click on the "Show template details" button near the template title.
4. It should display `TextControl` to edit the template title.

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-28 at 19 17 44](https://user-images.githubusercontent.com/240569/143774279-5d10ee8e-d347-4259-86a6-d42529196692.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
