### PR TITLE
Color Picker: Re-instate debounce and controlled value to fix issue with gradient picker

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fix
 
+-   Fixed error thrown in `ColorPicker` when used in controlled state in color gradients ([#36941](https://github.com/WordPress/gutenberg/pull/36941)).
+-   Updated readme to include default value introduced in fix for unexpected movements in the `ColorPicker` ([#35670](https://github.com/WordPress/gutenberg/pull/35670)).
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 
 ### Experimental

--- a/packages/components/src/color-picker/README.md
+++ b/packages/components/src/color-picker/README.md
@@ -22,32 +22,34 @@ function Example() {
 
 ## Props
 
-### `color`
-
-**Type**: `string`
+### `color`: `string`
 
 The current color value to display in the picker. Must be a hex or hex8 string.
 
-### `onChange`
+- Required: No
 
-**Type**: `(hex8Color: string) => void`
+### `onChange`: `(hex8Color: string) => void`
 
 Fired when the color changes. Always passes a hex8 color string.
 
-### `enableAlpha`
+- Required: No
 
-**Type**: `boolean`
+### `enableAlpha`: `boolean`
 
 Defaults to `false`. When `true` the color picker will display the alpha channel both in the bottom inputs as well as in the color picker itself.
 
-### `defaultValue`
+- Required: No
+- Default: `false`
 
-**Type**: `string | undefined`
+### `defaultValue`: `string | undefined`
 
 An optional default value to use for the color picker.
 
-### `copyFormat`
+- Required: No
+- Default: `'#fff'`
 
-**Type**: `'hex' | 'hsl' | 'rgb' | undefined`
+### `copyFormat`: `'hex' | 'hsl' | 'rgb' | undefined`
 
 The format to copy when clicking the displayed color format.
+
+- Required: No

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -66,15 +66,15 @@ const ColorPicker = (
 		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
+	// Use a safe default value for the color and remove the possibility of `undefined`.
 	const [ color, setColor ] = useControlledValue( {
 		onChange,
 		value: colorProp,
 		defaultValue,
 	} );
 
-	// Use a safe default value for the color and remove the possibility of `undefined`.
 	const safeColordColor = useMemo( () => {
-		return color ? colord( color ) : colord( defaultValue );
+		return colord( color );
 	}, [ color, defaultValue ] );
 
 	const debouncedSetColor = useDebounce( setColor );

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -11,6 +11,7 @@ import namesPlugin from 'colord/plugins/names';
  */
 import { useState, useMemo } from '@wordpress/element';
 import { settings } from '@wordpress/icons';
+import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -32,6 +33,7 @@ import {
 import { ColorDisplay } from './color-display';
 import { ColorInput } from './color-input';
 import { Picker } from './picker';
+import { useControlledValue } from '../utils/hooks';
 
 import type { ColorType } from './types';
 
@@ -57,23 +59,31 @@ const ColorPicker = (
 ) => {
 	const {
 		enableAlpha = false,
-		color,
+		color: colorProp,
 		onChange,
 		defaultValue = '#fff',
 		copyFormat,
 		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
+	const [ color, setColor ] = useControlledValue( {
+		onChange,
+		value: colorProp,
+		defaultValue,
+	} );
+
 	// Use a safe default value for the color and remove the possibility of `undefined`.
 	const safeColordColor = useMemo( () => {
 		return color ? colord( color ) : colord( defaultValue );
 	}, [ color, defaultValue ] );
 
+	const debouncedSetColor = useDebounce( setColor );
+
 	const handleChange = useCallback(
 		( nextValue: Colord ) => {
-			onChange( nextValue.toHex() );
+			debouncedSetColor( nextValue.toHex() );
 		},
-		[ onChange ]
+		[ debouncedSetColor ]
 	);
 
 	const [ showInputs, setShowInputs ] = useState< boolean >( false );

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -75,7 +75,7 @@ const ColorPicker = (
 
 	const safeColordColor = useMemo( () => {
 		return colord( color );
-	}, [ color, defaultValue ] );
+	}, [ color ] );
 
 	const debouncedSetColor = useDebounce( setColor );
 

--- a/packages/components/src/color-picker/test/index.js
+++ b/packages/components/src/color-picker/test/index.js
@@ -41,6 +41,12 @@ function moveReactColorfulSlider( sliderElement, from, to ) {
 	fireEvent( sliderElement, new FakeMouseEvent( 'mousemove', to ) );
 }
 
+const sleep = ( ms ) => {
+	const promise = new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+	jest.advanceTimersByTime( ms + 1 );
+	return promise;
+};
+
 const hslaMatcher = expect.objectContaining( {
 	h: expect.any( Number ),
 	s: expect.any( Number ),
@@ -87,6 +93,9 @@ describe( 'ColorPicker', () => {
 				{ pageX: 10, pageY: 10 }
 			);
 
+			// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+			await sleep( 1 );
+
 			expect( onChangeComplete ).toHaveBeenCalledWith(
 				legacyColorMatcher
 			);
@@ -107,6 +116,9 @@ describe( 'ColorPicker', () => {
 			{ pageX: 0, pageY: 0 },
 			{ pageX: 10, pageY: 10 }
 		);
+
+		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+		await sleep( 1 );
 
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.stringMatching( /^#([a-fA-F0-9]{8})$/ )
@@ -137,6 +149,9 @@ describe( 'ColorPicker', () => {
 			{ pageX: 0, pageY: 0 },
 			{ pageX: 10, pageY: 10 }
 		);
+
+		// `onChange` is debounced so we need to sleep for at least 1ms before checking that onChange was called
+		await sleep( 1 );
 
 		expect( onChange ).toHaveBeenCalledWith(
 			expect.stringMatching( /^#([a-fA-F0-9]{6})$/ )


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36066

## Description
<!-- Please describe what you have changed or added -->

Fixes part of #36899, possibly introduced in (or related to #35670)

When editing a gradient (e.g. attached to a background for a Group block), if you open up the color picker and click and drag quickly, prior to this PR, the picker throws an error (reported in #36899).

By reinstating the `debounce` in the color picker, when used as a controlled component (as in the case of the gradient picker) we avoid recursively updating state and causing the block and picker to throw an error.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Prior to applying this PR, add a Group block to a post, while running a theme that supports gradients.
2. Add a gradient as a background.
3. Click on one of the existing control points in the gradient to open up a controlled instance of the color picker.
4. Click and drag the color picker quickly and notice that it throws an error.
5. Apply this PR, and repeat the above steps — there should be no error thrown.

Test that this doesn't re-introduce any issues that #35670 resolved.

## Screenshots <!-- if applicable -->

### Before



https://user-images.githubusercontent.com/14988353/143816294-0c75a5bd-2579-4a93-9003-eb04fb07110c.mp4


https://user-images.githubusercontent.com/14988353/143816158-5a8eab35-843a-4297-aa45-a3814340a3f3.mp4



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
