### PR TITLE
Border Panel: Combine width and style in panel menu

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -75,9 +75,14 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		}
 	}
 
+	// Border width support is enforced if border style support is opted into.
+	$has_border_style_support = gutenberg_has_border_feature_support( $block_type, 'style' );
+	$has_border_width_support = $has_border_style_support ||
+		gutenberg_has_border_feature_support( $block_type, 'width' );
+
 	// Border style.
 	if (
-		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
+		$has_border_style_support &&
 		isset( $block_attributes['style']['border']['style'] )
 	) {
 		$border_style = $block_attributes['style']['border']['style'];
@@ -86,7 +91,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 
 	// Border width.
 	if (
-		gutenberg_has_border_feature_support( $block_type, 'width' ) &&
+		$has_border_width_support &&
 		isset( $block_attributes['style']['border']['width'] )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/33743


## Description

This PR:
- Combines the border width and style options within the border panel in both the block editor and global styles.
- Enforces border-width support if border-style is supported ( [requesting comment](https://github.com/WordPress/gutenberg/pull/36942#issuecomment-981362431) )

The desire for combing controls stems from the switch to the `ToolsPanel` for the border block support: https://github.com/WordPress/gutenberg/pull/33743#issuecomment-979777875


#### Notes

- In the last iteration on the border panel, the repetition in labels was removed e.g. "Border color" and "Border Radius" being renamed to "color" and "radius" respectively. 
    - The proposal in https://github.com/WordPress/gutenberg/pull/33743#issuecomment-979777875 reintroduces that repetition. 
    - This PR opts instead to label the menu item "Width & Style" for the moment until naming is confirmed.
    - The [suggested labelling](https://github.com/WordPress/gutenberg/pull/33743#issuecomment-979777875) appears to go against the previous direction and looks odd to me (screenshots below).
    
| Suggested | This PR | 
|---|---|
| <img width="279" alt="Screen Shot 2021-11-29 at 4 34 10 pm" src="https://user-images.githubusercontent.com/60436221/143819831-916b4705-3961-41bb-afb9-0acdfdb6f7eb.png"> | <img width="279" alt="Screen Shot 2021-11-29 at 4 33 47 pm" src="https://user-images.githubusercontent.com/60436221/143819847-1693985e-112a-4174-b76f-34410e6e7fec.png"> |

 

## How has this been tested?

#### Block Editor
1. Create a post, add a group block and select it
2. Ensure the border controls within the sidebar's border panel function correctly
3. Test various combinations of support (block.json) and UI disabling (theme.json)
    - Width and style supported
        - Menu item label is: "Width & style"
        - Menu item toggles both width and style control display
        - Menu item resets both width and style controls
    - Width only
        - Menu item label is: "Width"
        - Menu item toggles width control display
        - Menu item resets width control
    - Style only ( width will be automatically supported )
        - Menu item label is: "Width & style"
        - Menu item toggles both width and style control display
        - Menu item resets both width and style controls
    - No width/style support
        - Confirm no width/style controls displayed
        - Confirm no width/style menu item present
4. Tested various default control display configurations via `__experimentalBorder.__experimentalDefaultControls` in block.json
    - `"widthAndstyle": "true"` --> controls displayed by default
    - `"width": "true"` --> controls displayed by default if width supported
    - `"style": "true"` --> controls displayed by default if style supported
5. Confirm dynamic blocks still have borders rendered correctly on the frontend.

#### Global Styles
1. Load site editor and select "Blocks > Group" from Global Styles sidebar
2. Confirm all border controls are still shown by default
3. Test various combinations of support and UI disabling

## Screenshots <!-- if applicable -->

![BorderCombinedWidthAndStyleItem](https://user-images.githubusercontent.com/60436221/143820663-1a8cb376-726f-47ca-aae0-c3f40fe8ed9d.gif)

## Types of changes
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
