### PR TITLE
Writing Flow: Double escape unselects all blocks

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -100,6 +100,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		getMultiSelectedBlocksEndClientId,
 		getPreviousBlockClientId,
 		getNextBlockClientId,
+		isNavigationMode,
 	} = useSelect( blockEditorStore );
 	const {
 		selectBlock,
@@ -157,7 +158,10 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 				selectedBlockClientId;
 		}
 		const startingBlockClientId = hasBlockMovingClientId();
-
+		if ( isEscape && isNavigationMode() ) {
+			clearSelectedBlock();
+			event.preventDefault();
+		}
 		if ( isEscape && startingBlockClientId && ! event.defaultPrevented ) {
 			setBlockMovingClientId( null );
 			event.preventDefault();

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -13,7 +13,7 @@ import {
 
 const getActiveBlockName = async () =>
 	page.evaluate(
-		() => wp.data.select( 'core/block-editor' ).getSelectedBlock().name
+		() => wp.data.select( 'core/block-editor' ).getSelectedBlock()?.name
 	);
 
 const addParagraphsAndColumnsDemo = async () => {
@@ -629,5 +629,25 @@ describe( 'Writing Flow', () => {
 				document.activeElement.getAttribute( 'aria-label' )
 			)
 		).toBe( 'Table' );
+	} );
+
+	it( 'Should unselect all blocks when hitting double escape', async () => {
+		// Add demo content.
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Random Paragraph' );
+
+		// Select a block.
+		let activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/paragraph' );
+
+		// First escape enters navigaiton mode.
+		await page.keyboard.press( 'Escape' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( 'core/paragraph' );
+
+		// Second escape unselects the blocks.
+		await page.keyboard.press( 'Escape' );
+		activeBlockName = await getActiveBlockName();
+		expect( activeBlockName ).toBe( undefined );
 	} );
 } );


### PR DESCRIPTION
closes #36535 

This is especially important for the site editor where there's not much white space to click on.

**Notes**

Right now Space (or shift space) enter edit mode while in navigation mode, I'm happy to change these to match Craft's behavior if needed (inserter after/before) but could also be done separately and only add this requirement for 5.9.