### PR TITLE
Site Editor: Templat list fallback to slug

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -98,7 +98,8 @@ export default function Table( { templateType } ) {
 										postType: template.type,
 									} ) }
 								>
-									{ template.title.rendered }
+									{ template.title?.rendered ||
+										template.slug }
 								</a>
 							</Heading>
 							{ template.description }


### PR DESCRIPTION
## Description
The title isn't required for post types. While we have a "soft" requirement for template titles, it's still possible to have one without it.

Currently, when a template has no title, it's not possible to access it for editing. PR adds fallback to template slug for similar scenarios.

## How has this been tested?
1. Edit the custom template in Template Mode and remove the title.
2. Go to Appearance > Editor > Templates.
3. Check that the template slug is displayed.

## Screenshots <!-- if applicable -->
![CleanShot 2021-11-29 at 14 33 12](https://user-images.githubusercontent.com/240569/143852362-a337f9b7-8f86-4fd9-ad1b-447d1f40f99d.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
