### PR TITLE
Fix icon scaling.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -82,6 +82,7 @@
 		line-height: 0;
 		display: inline-block;
 		vertical-align: middle;
+		font-size: inherit;
 
 		// Affect the button as well.
 		padding: 0;


### PR DESCRIPTION
## Description

Fixes #36923. Followup to #36714. The dropdown menu icon should scale with the font size. The previous fix failed to include the frontend. This PR addresses that. Editor:

<img width="779" alt="Screenshot 2021-11-29 at 11 45 56" src="https://user-images.githubusercontent.com/1204802/143854449-784fd354-034f-4f9b-ab0d-468b415c2296.png">

Frontend:

<img width="672" alt="Screenshot 2021-11-29 at 11 46 00" src="https://user-images.githubusercontent.com/1204802/143854483-ba4b39b3-444b-4c51-9c49-62344346fbea.png">

## How has this been tested?

Insert a navigation menu with submenus, change the font size, verify the arrow icon looks the same size in editor and frontend.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
