### PR TITLE
[Edit Post]: Remove EditPostSettings context provider

### DIFF
--- a/packages/edit-post/src/components/edit-post-settings/index.js
+++ b/packages/edit-post/src/components/edit-post-settings/index.js
@@ -1,7 +1,0 @@
-/**
- * WordPress dependencies
- */
-import { createContext } from '@wordpress/element';
-
-const EditPostSettings = createContext( {} );
-export default EditPostSettings;

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -25,7 +25,6 @@ import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
 import preventEventDiscovery from './prevent-event-discovery';
 import Layout from './components/layout';
 import EditorInitialization from './components/editor-initialization';
-import EditPostSettings from './components/edit-post-settings';
 import { store as editPostStore } from './store';
 
 function Editor( {
@@ -127,6 +126,9 @@ function Editor( {
 			// This is marked as experimental to give time for the quick inserter to mature.
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			keepCaretInsideBlock,
+			// Keep a reference of the `allowedBlockTypes` from the server to handle use cases
+			// where we need to differentiate if a block is disabled by the user or some plugin.
+			defaultAllowedBlockTypes: settings.allowedBlockTypes,
 		};
 
 		// Omit hidden block types if exists and non-empty.
@@ -186,29 +188,27 @@ function Editor( {
 	return (
 		<StrictMode>
 			<ShortcutProvider>
-				<EditPostSettings.Provider value={ settings }>
-					<SlotFillProvider>
-						<EditorProvider
-							settings={ editorSettings }
-							post={ post }
-							initialEdits={ initialEdits }
-							useSubRegistry={ false }
-							__unstableTemplate={
-								isTemplateMode ? template : undefined
-							}
-							{ ...props }
-						>
-							<ErrorBoundary onError={ onError }>
-								<EditorInitialization postId={ postId } />
-								<Layout styles={ styles } />
-								<KeyboardShortcuts
-									shortcuts={ preventEventDiscovery }
-								/>
-							</ErrorBoundary>
-							<PostLockedModal />
-						</EditorProvider>
-					</SlotFillProvider>
-				</EditPostSettings.Provider>
+				<SlotFillProvider>
+					<EditorProvider
+						settings={ editorSettings }
+						post={ post }
+						initialEdits={ initialEdits }
+						useSubRegistry={ false }
+						__unstableTemplate={
+							isTemplateMode ? template : undefined
+						}
+						{ ...props }
+					>
+						<ErrorBoundary onError={ onError }>
+							<EditorInitialization postId={ postId } />
+							<Layout styles={ styles } />
+							<KeyboardShortcuts
+								shortcuts={ preventEventDiscovery }
+							/>
+						</ErrorBoundary>
+						<PostLockedModal />
+					</EditorProvider>
+				</SlotFillProvider>
 			</ShortcutProvider>
 		</StrictMode>
 	);


### PR DESCRIPTION
By working on post-editor for another issue, I noticed that we had a context provider that was used [only to differentiate if a block is disabled by the user or some plugin](https://github.com/WordPress/gutenberg/pull/16586/files#r309598781).

This PR removes this provider by adding the original value in editor settings and also refactors a bit the `BlockManagerCategory` to stop using `withSelect, withDispatch, etc...


