### PR TITLE
Refactor the colors UI in the inspector to use the navigator approach

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -9,7 +9,6 @@ import { __ } from '@wordpress/i18n';
  */
 import PanelColorGradientSettings from '../components/colors-gradients/panel-color-gradient-settings';
 import ContrastChecker from '../components/contrast-checker';
-import InspectorControls from '../components/inspector-controls';
 import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
 
 function getComputedStyle( node ) {
@@ -20,7 +19,6 @@ export default function ColorPanel( {
 	settings,
 	clientId,
 	enableContrastChecking = true,
-	showTitle = true,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -54,21 +52,18 @@ export default function ColorPanel( {
 	} );
 
 	return (
-		<InspectorControls>
-			<PanelColorGradientSettings
-				title={ __( 'Color' ) }
-				initialOpen={ false }
-				settings={ settings }
-				showTitle={ showTitle }
-				__experimentalHasMultipleOrigins
-			>
-				{ enableContrastChecking && (
-					<ContrastChecker
-						backgroundColor={ detectedBackgroundColor }
-						textColor={ detectedColor }
-					/>
-				) }
-			</PanelColorGradientSettings>
-		</InspectorControls>
+		<PanelColorGradientSettings
+			showTitle={ false }
+			title={ __( 'Color' ) }
+			settings={ settings }
+			__experimentalHasMultipleOrigins
+		>
+			{ enableContrastChecking && (
+				<ContrastChecker
+					backgroundColor={ detectedBackgroundColor }
+					textColor={ detectedColor }
+				/>
+			) }
+		</PanelColorGradientSettings>
 	);
 }

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,14 +1,23 @@
-.block-editor__hooks-colors-panel .component-color-indicator {
-	margin-left: 0;
-	display: block;
-	border-radius: 50%;
-	border: 0;
-	height: 24px;
-	width: 24px;
-	padding: 0;
-	background-image:
-		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-	background-position: 0 0, 25px 25px;
-	background-size: calc(2 * 5px) calc(2 * 5px);
+.block-editor__hooks-colors-panel {
+
+	// Allow horizontal overflow so the size-increasing color indicators don't cause a scrollbar.
+	.components-navigator-screen {
+		overflow-x: visible;
+	}
+
+	// @todo: this can be removed when https://github.com/WordPress/gutenberg/pull/37028 lands.
+	.component-color-indicator {
+		margin-left: 0;
+		display: block;
+		border-radius: 50%;
+		border: 0;
+		height: 24px;
+		width: 24px;
+		padding: 0;
+		background-image:
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+		background-position: 0 0, 25px 25px;
+		background-size: calc(2 * 5px) calc(2 * 5px);
+	}
 }

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,0 +1,14 @@
+.block-editor__hooks-colors-panel .component-color-indicator {
+	margin-left: 0;
+	display: block;
+	border-radius: 50%;
+	border: 0;
+	height: 24px;
+	width: 24px;
+	padding: 0;
+	background-image:
+		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+	background-position: 0 0, 25px 25px;
+	background-size: calc(2 * 5px) calc(2 * 5px);
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -58,6 +58,7 @@
 @import "./hooks/border.scss";
 @import "./hooks/dimensions.scss";
 @import "./hooks/typography.scss";
+@import "./hooks/color.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -28,6 +28,11 @@
 	&.is-opened {
 		padding: $grid-unit-20;
 	}
+
+	// Don't cascade the padding into nested panels.
+	.components-panel__body {
+		padding: 0;
+	}
 }
 
 .components-panel__header {


### PR DESCRIPTION
This begins to implement the ability to group color elements in the block inspector based on the design flow of #34574.

<img width="295" alt="Screen Shot 2021-11-29 at 12 55 15 PM" src="https://user-images.githubusercontent.com/272444/143863710-219a24be-f794-482a-94d9-9bcbb6e86892.png">

This is just a naive approach to see what it would give as a result.