### PR TITLE
[Block Library - Query Pagination Next/Previous]: Remove text and link color support

### DIFF
--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -18,7 +18,8 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"link": true
+			"text": false,
+			"link": false
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -18,8 +18,7 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"text": false,
-			"link": false
+			"text": false
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -18,7 +18,8 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"link": true
+			"text": false,
+			"link": false
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -18,8 +18,7 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"text": false,
-			"link": false
+			"text": false
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/pull/36562/files#r758225518

For Query Pagination Next and Previous blocks we had enabled color support for text and link. However these two blocks are always a link and it doesn't make much sense IMO to introduce another wrapper in dom. Now it doesn't work because when we add a `link color` the selector produced searches children `a` elements to apply the style.

This PR proposes to remove the text/link color support from these individual blocks and keep this support in the parent block `Query Pagination` block. 