### PR TITLE
[Block Library - Comment Author Avatar]: Remove extraneous color link support flag

### DIFF
--- a/packages/block-library/src/comment-author-avatar/block.json
+++ b/packages/block-library/src/comment-author-avatar/block.json
@@ -28,8 +28,7 @@
 		},
 		"color": {
 			"background": true,
-			"text": false,
-			"links": false
+			"text": false
 		},
 		"spacing": {
 			"__experimentalSkipSerialization": true,


### PR DESCRIPTION
This PR just removes the extraneous color link support flag which is not needed if we have `text:false`.