### PR TITLE
Revert "Update function names for the public global styles API functions"

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -148,8 +148,8 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$block_gap             = wp_get_global_settings( array( 'spacing', 'blockGap' ) );
-	$default_layout        = wp_get_global_settings( array( 'layout' ) );
+	$block_gap             = gutenberg_get_global_settings( array( 'spacing', 'blockGap' ) );
+	$default_layout        = gutenberg_get_global_settings( array( 'layout' ) );
 	$has_block_gap_support = isset( $block_gap ) ? null !== $block_gap : false;
 	$default_block_layout  = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
 	$used_layout           = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;

--- a/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-5.9/get-global-styles-and-settings.php
@@ -5,130 +5,124 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'wp_get_global_settings' ) ) {
-	/**
-	 * Function to get the settings resulting of merging core, theme, and user data.
-	 *
-	 * @param array $path    Path to the specific setting to retrieve. Optional.
-	 *                       If empty, will return all settings.
-	 * @param array $context {
-	 *     Metadata to know where to retrieve the $path from. Optional.
-	 *
-	 *     @type string $block_name Which block to retrieve the settings from.
-	 *                              If empty, it'll return the settings for the global context.
-	 *     @type string $origin     Which origin to take data from.
-	 *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
-	 *                              If empty or unknown, 'all' is used.
-	 * }
-	 *
-	 * @return array The settings to retrieve.
-	 */
-	function wp_get_global_settings( $path = array(), $context = array() ) {
-		if ( ! empty( $context['block_name'] ) ) {
-			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
-		}
-
-		$origin = 'custom';
-		if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
-			$origin = 'theme';
-		}
-
-		$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
-
-		return _wp_array_get( $settings, $path, $settings );
+/**
+ * Function to get the settings resulting of merging core, theme, and user data.
+ *
+ * @param array $path    Path to the specific setting to retrieve. Optional.
+ *                       If empty, will return all settings.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the settings from.
+ *                              If empty, it'll return the settings for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
+ *
+ * @return array The settings to retrieve.
+ */
+function gutenberg_get_global_settings( $path = array(), $context = array() ) {
+	if ( ! empty( $context['block_name'] ) ) {
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
+
+	$origin = 'custom';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+		$origin = 'theme';
+	}
+
+	$settings = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_settings();
+
+	return _wp_array_get( $settings, $path, $settings );
 }
 
-if ( ! function_exists( 'wp_get_global_styles' ) ) {
-	/**
-	 * Function to get the styles resulting of merging core, theme, and user data.
-	 *
-	 * @param array $path    Path to the specific style to retrieve. Optional.
-	 *                       If empty, will return all styles.
-	 * @param array $context {
-	 *     Metadata to know where to retrieve the $path from. Optional.
-	 *
-	 *     @type string $block_name Which block to retrieve the styles from.
-	 *                              If empty, it'll return the styles for the global context.
-	 *     @type string $origin     Which origin to take data from.
-	 *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
-	 *                              If empty or unknown, 'all' is used.
-	 * }
-	 *
-	 * @return array The styles to retrieve.
-	 */
-	function wp_get_global_styles( $path = array(), $context = array() ) {
-		if ( ! empty( $context['block_name'] ) ) {
-			$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
-		}
-
-		$origin = 'custom';
-		if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
-			$origin = 'theme';
-		}
-
-		$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
-
-		return _wp_array_get( $styles, $path, $styles );
+/**
+ * Function to get the styles resulting of merging core, theme, and user data.
+ *
+ * @param array $path    Path to the specific style to retrieve. Optional.
+ *                       If empty, will return all styles.
+ * @param array $context {
+ *     Metadata to know where to retrieve the $path from. Optional.
+ *
+ *     @type string $block_name Which block to retrieve the styles from.
+ *                              If empty, it'll return the styles for the global context.
+ *     @type string $origin     Which origin to take data from.
+ *                              Valid values are 'all' (core, theme, and user) or 'base' (core and theme).
+ *                              If empty or unknown, 'all' is used.
+ * }
+ *
+ * @return array The styles to retrieve.
+ */
+function gutenberg_get_global_styles( $path = array(), $context = array() ) {
+	if ( ! empty( $context['block_name'] ) ) {
+		$path = array_merge( array( 'blocks', $context['block_name'] ), $path );
 	}
+
+	$origin = 'custom';
+	if ( isset( $context['origin'] ) && 'base' === $context['origin'] ) {
+		$origin = 'theme';
+	}
+
+	$styles = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( $origin )->get_raw_data()['styles'];
+
+	return _wp_array_get( $styles, $path, $styles );
 }
 
-if ( ! function_exists( 'wp_get_global_stylesheet' ) ) {
-	/**
-	 * Returns the stylesheet resulting of merging core, theme, and user data.
-	 *
-	 * @param array $types Types of styles to load. Optional.
-	 *                     It accepts 'variables', 'styles', 'presets' as values.
-	 *                     If empty, it'll load all for themes with theme.json support
-	 *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
-	 *
-	 * @return string Stylesheet.
-	 */
-	function wp_get_global_stylesheet( $types = array() ) {
-		// Return cached value if it can be used and exists.
-		// It's cached by theme to make sure that theme switching clears the cache.
-		$can_use_cached = (
+/**
+ * Returns the stylesheet resulting of merging core, theme, and user data.
+ *
+ * @param array $types Types of styles to load. Optional.
+ *                     It accepts 'variables', 'styles', 'presets' as values.
+ *                     If empty, it'll load all for themes with theme.json support
+ *                     and only [ 'variables', 'presets' ] for themes without theme.json support.
+ *
+ * @return string Stylesheet.
+ */
+function gutenberg_get_global_stylesheet( $types = array() ) {
+	// Return cached value if it can be used and exists.
+	// It's cached by theme to make sure that theme switching clears the cache.
+	$can_use_cached = (
 		( empty( $types ) ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
 		! is_admin()
-		);
-		$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
-		if ( $can_use_cached ) {
-			$cached = get_transient( $transient_name );
-			if ( $cached ) {
-				return $cached;
-			}
+	);
+	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
+	if ( $can_use_cached ) {
+		$cached = get_transient( $transient_name );
+		if ( $cached ) {
+			return $cached;
 		}
-
-		$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-		$supports_link_color = get_theme_support( 'experimental-link-color' );
-		if ( empty( $types ) && ! $supports_theme_json ) {
-			$types = array( 'variables', 'presets' );
-		} elseif ( empty( $types ) ) {
-			$types = array( 'variables', 'styles', 'presets' );
-		}
-
-		$origins = array( 'default', 'theme', 'custom' );
-		if ( ! $supports_theme_json && ! $supports_link_color ) {
-			// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
-			$origins = array( 'default' );
-		} elseif ( ! $supports_theme_json && $supports_link_color ) {
-			// For the legacy link color feature to work, the CSS Custom Properties
-			// should be in scope (either the core or the theme ones).
-			$origins = array( 'default', 'theme' );
-		}
-
-		$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-		$stylesheet = $tree->get_stylesheet( $types, $origins );
-
-		if ( $can_use_cached ) {
-			// Cache for a minute.
-			// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
-			set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
-		}
-
-		return $stylesheet;
 	}
+
+	$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+	$supports_link_color = get_theme_support( 'experimental-link-color' );
+	if ( empty( $types ) && ! $supports_theme_json ) {
+		$types = array( 'variables', 'presets' );
+	} elseif ( empty( $types ) ) {
+		$types = array( 'variables', 'styles', 'presets' );
+	}
+
+	$origins = array( 'default', 'theme', 'custom' );
+	if ( ! $supports_theme_json && ! $supports_link_color ) {
+		// In this case we only enqueue the core presets (CSS Custom Properties + the classes).
+		$origins = array( 'default' );
+	} elseif ( ! $supports_theme_json && $supports_link_color ) {
+		// For the legacy link color feature to work, the CSS Custom Properties
+		// should be in scope (either the core or the theme ones).
+		$origins = array( 'default', 'theme' );
+	}
+
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$stylesheet = $tree->get_stylesheet( $types, $origins );
+
+	if ( $can_use_cached ) {
+		// Cache for a minute.
+		// This cache doesn't need to be any longer, we only want to avoid spikes on high-traffic sites.
+		set_transient( $transient_name, $stylesheet, MINUTE_IN_SECONDS );
+	}
+
+	return $stylesheet;
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -10,7 +10,7 @@
  * and enqueues the resulting stylesheet.
  */
 function gutenberg_experimental_global_styles_enqueue_assets() {
-	$stylesheet = wp_get_global_stylesheet();
+	$stylesheet = gutenberg_get_global_stylesheet();
 	if ( empty( $stylesheet ) ) {
 		return;
 	}
@@ -52,7 +52,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	if ( 'mobile' === $context && WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-		$settings['__experimentalStyles'] = wp_get_global_styles();
+		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 	}
 
 	if ( 'other' === $context ) {
@@ -83,7 +83,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			),
 		);
 		foreach ( $new_presets as $new_style ) {
-			$style_css = wp_get_global_stylesheet( array( $new_style['css'] ) );
+			$style_css = gutenberg_get_global_stylesheet( array( $new_style['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_style['css']    = $style_css;
 				$new_global_styles[] = $new_style;
@@ -95,7 +95,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			'__unstableType' => 'theme',
 		);
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$style_css = wp_get_global_stylesheet( array( $new_block_classes['css'] ) );
+			$style_css = gutenberg_get_global_stylesheet( array( $new_block_classes['css'] ) );
 			if ( '' !== $style_css ) {
 				$new_block_classes['css'] = $style_css;
 				$new_global_styles[]      = $new_block_classes;
@@ -106,7 +106,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.
-	$settings['__experimentalFeatures'] = wp_get_global_settings();
+	$settings['__experimentalFeatures'] = gutenberg_get_global_settings();
 
 	if ( isset( $settings['__experimentalFeatures']['color']['palette'] ) ) {
 		$colors_by_origin   = $settings['__experimentalFeatures']['color']['palette'];


### PR DESCRIPTION
Reverts https://github.com/WordPress/gutenberg/pull/36907

## What this PR fixes

When the plugin is active in WordPress 5.9, it doesn't override global styles WordPress core public API.

## Context

In https://github.com/WordPress/gutenberg/pull/36907 I renamed the public API of GS from `gutengerg_*`  to `wp_*`), to make backport easier and make the functions available in all the WordPress versions the plugin supports. I hoped that we could introduce some filters at https://github.com/WordPress/gutenberg/pull/36909 to modify their behavior from the plugin. However, we decided against that, and, as a side-effect, we don't have a way to overwrite the WordPress core functions when the plugin runs on WordPress 5.9.

## Follow-ups post 5.9

We'd need to clarify how to best address the following (can be done post-5.9):

- What happens when/if we need to modify the behavior of the public GS API? In principle, we shouldn't update code that lives in `lib/compat/5.9` after WordPress 5.9 has been released.

- What happens if we don't need to modify the behavior of those functions and the plugin minimum version is 5.9 (so the `lib/compat/5.9` is removed? At that point, we can't remove the functions from the plugin as we may still need them to overwrite the core behavior.

Unless I'm missing something, it looks like the code for the public API of GS should not live in `lib/compat`.

