### PR TITLE
Only apply default margin from global styles if root body does not have margin set in theme.json

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -724,7 +724,11 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
-				$block_rules .= 'body { margin: 0; }';
+				// If the root body node has margin set in its spacing property
+				// then avoid setting a default margin.
+				if ( ! isset( $node['spacing']['margin'] ) ) {
+					$block_rules .= 'body { margin: 0; }';
+				}
 				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
 				$block_rules .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 				$block_rules .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Note there is now also an alternative approach to this in https://github.com/WordPress/gutenberg/pull/36960.

In https://github.com/WordPress/gutenberg/issues/36147 we learn that the Theme JSON class automatically applies a `margin: 0` to the `body` element. Unfortunately it does so in a way that means if you use `theme.json` to define a margin on the body element, the default `margin: 0` will still take precedence.

For example applying this to `theme.json` will still leave you with the _default_ `margin: 0` on the `body`, rather than the _expected_ value of `margin: 0 5rem`:

```
{
	"styles": {
		"spacing": {
			"margin": "0 5rem",
			"padding": "0"
		},
	}
}
```

This PR fixes this by only applying the default `margin: 0` if the root spacing does not have a margin declaration.

Closes https://github.com/WordPress/gutenberg/issues/36147

## Question

Need to consider what happens how to handle things if the `spacing -> margin` is only set on a single axis (e.g. `margin-left` or `margin-bottom`.

An alternative implementation might be to simply allow the `margin: 0` to be set but to ensure that any margin declarations coming from `theme.json` are applied _afterwards_ rather than before as they are currently. This would allow the `theme.json` declarations to take precedence.

**Update**: I have this approach as a PR in https://github.com/WordPress/gutenberg/pull/36960.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

⚠️ ⚠️ ⚠️ ⚠️ ~You cannot currently test this because the `class-wp-theme-json-gutenberg.php` file is not loaded when WP 5.9 is active. Rather the Core version of the class is used. This PR now includes changes from https://github.com/WordPress/gutenberg/pull/36957 which allow you to test this PR. They will be removed prior to merge~ You will need to use WordPress **5.8** (that is five point **EIGHT** _not_ NINE) to test this PR. See https://github.com/WordPress/gutenberg/pull/36957#issuecomment-981759580 for reasons. ⚠️ ⚠️ ⚠️ 

@oandregal is working on a fix for this at which point you will be able to follow the testing instructions below:

0. Make sure you are running WP 5.8!
1. Install and activate TT1 blocks (or block Theme or your choice). You should make this theme local in order that you can edit the `theme.json` of the Theme.
2. Load the front of the site. Inspect the `body` element and notice the `margin: 0` applied to the `body` element.
3. Now edit `theme.json` and add the following under the `styles` section:
```
{
	"spacing": {
		"margin": "0 5rem",
		"padding": "0"
	},
}
```
4. Reload the front of the site and inspect the `body`. Notice how the `margin: 0` is no longer applied and instead the applied style of the `body` is `margin: 0 5rem`.

⚠️  **Watch out**: [TT1 blocks applies `margin: 0` to `body` in its `style.css` file](https://github.com/WordPress/theme-experiments/blob/dff7d86e56f3657b492fdeae3e7e6765a00f22c0/tt1-blocks/style.css#L24-L26). Don't get confused when verifying the results of this PR which have nothing to do with the manually created `style.css` file.




## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
