### PR TITLE
Add: Border indication to global styles colors.

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -46,7 +46,6 @@
 		margin-left: 0;
 		display: block;
 		border-radius: 50%;
-		border: 0;
 		height: 24px;
 		width: 24px;
 		padding: 0;
@@ -55,6 +54,7 @@
 			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
 		background-position: 0 0, 25px 25px;
 		background-size: calc(2 * 5px) calc(2 * 5px);
+		border: $border-width solid $gray-300;
 	}
 }
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/36543

This PR adds a border to the color indications on the global styles panels.
The border allows the white color to be noticeable.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/143875255-07a86cef-2149-4e79-8b4f-f3a7c0e06d5b.png)
