### PR TITLE
Color Picker: Improve border, padding, and box shadow styles.

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -135,6 +135,7 @@ export default function ColorPalette( {
 		<VStack spacing={ 3 } className={ className }>
 			{ ! disableCustomColors && (
 				<Dropdown
+					contentClassName="components-color-palette__custom-color-dropdown-content"
 					renderContent={ renderCustomColorPicker }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<button

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -16,3 +16,12 @@
 	color: $white;
 	cursor: pointer;
 }
+
+.components-dropdown__content.components-color-palette__custom-color-dropdown-content .components-popover__content {
+	overflow: visible;
+	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.05);
+	border: none;
+	& > div {
+		padding: 0;
+	}
+}

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -26,6 +26,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
 
 exports[`ColorPalette Dropdown should render it correctly 1`] = `
 <Dropdown
+  contentClassName="components-color-palette__custom-color-dropdown-content"
   key=".0"
   renderContent={[Function]}
   renderToggle={[Function]}
@@ -177,6 +178,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
         data-wp-component="VStack"
       >
         <Dropdown
+          contentClassName="components-color-palette__custom-color-dropdown-content"
           key=".0"
           renderContent={[Function]}
           renderToggle={[Function]}


### PR DESCRIPTION
This PR removes the padding and fixes the border and box-shadow styles of the custom color picker popover. These change makes the "look and feel" closer to the mockups.

Part of: https://github.com/WordPress/gutenberg/issues/36542

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/143893571-fba0a84c-4c04-457c-9559-d3cc96802c55.png)
