### PR TITLE
Block Templates: Fix PHP notices on WP 5.8

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -506,11 +506,13 @@ if ( ! function_exists( '_build_block_template_result_from_file' ) ) {
 		$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
 		$template->slug           = $template_file['slug'];
 		$template->source         = 'theme';
+		$template->origin         = null;
 		$template->type           = $template_type;
 		$template->title          = ! empty( $template_file['title'] ) ? $template_file['title'] : $template_file['slug'];
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
 		$template->is_custom      = true;
+		$template->author         = 0;
 
 		if ( 'wp_template' === $template_type && isset( $default_template_types[ $template_file['slug'] ] ) ) {
 			$template->description = $default_template_types[ $template_file['slug'] ]['description'];


### PR DESCRIPTION
## Description
When the plugin runs on WP 5.8.x, it will use the `WP_Block_Template` class from the core, which doesn't have new properties. To avoid PHP notices, we've to use dynamic properties when building templates from the file.

Note: The issue doesn't affect WP 5.9.

## How has this been tested?
1. Clone this branch.
2. Open Site Editor with `WP_DEBUG_LOG` enabled.
3. The `debug.log` shouldn't contain notices.

## Log
```log
PHP Notice:  Undefined property: WP_Block_Template::$origin in ~/Projects/gutenberg/wp-content/plugins/gutenberg/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php on line 467
PHP Notice:  Undefined property: WP_Block_Template::$author in ~/Projects/gutenberg/wp-content/plugins/gutenberg/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php on line 477
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
