### PR TITLE
Update the `WP_Theme_JSON_Gutenberg` class to be like the core one

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1141,9 +1141,9 @@ class WP_Theme_JSON_Gutenberg {
 	 *       '--wp--nested-property--sub-property': 'value'
 	 *     }
 	 *
-	 * @param array  $tree Input tree to process.
-	 * @param string $prefix Prefix to prepend to each variable. '' by default.
-	 * @param string $token Token to use between levels. '--' by default.
+	 * @param array  $tree   Input tree to process.
+	 * @param string $prefix Optional. Prefix to prepend to each variable. Default empty string.
+	 * @param string $token  Optional. Token to use between levels. Default '--'.
 	 * @return array The flattened tree.
 	 */
 	private static function flatten_tree( $tree, $prefix = '', $token = '--' ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1,14 +1,20 @@
 <?php
 /**
- * Process of structures that adhere to the theme.json schema.
+ * WP_Theme_JSON_Gutenberg class
  *
  * @package gutenberg
  */
 
 /**
- * Class that encapsulates the processing of
- * structures that adhere to the theme.json spec.
+ * Class that encapsulates the processing of structures that adhere to the theme.json spec.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please,
+ * use get_global_settings, get_global_styles, and get_global_stylesheet instead.
+ *
+ * @access private
  */
+
 class WP_Theme_JSON_Gutenberg {
 
 	/**
@@ -28,102 +34,22 @@ class WP_Theme_JSON_Gutenberg {
 	private static $blocks_metadata = null;
 
 	/**
-	 * The CSS selector for the root block.
+	 * The CSS selector for the top-level styles.
 	 *
 	 * @var string
 	 */
 	const ROOT_BLOCK_SELECTOR = 'body';
 
+	/**
+	 * The sources of data this object can represent.
+	 *
+	 * @since 5.8.0
+	 * @var string[]
+	 */
 	const VALID_ORIGINS = array(
 		'default',
 		'theme',
 		'custom',
-	);
-
-	const VALID_TOP_LEVEL_KEYS = array(
-		'customTemplates',
-		'templateParts',
-		'styles',
-		'settings',
-		'version',
-	);
-
-	const VALID_STYLES = array(
-		'border'     => array(
-			'color'  => null,
-			'radius' => null,
-			'style'  => null,
-			'width'  => null,
-		),
-		'color'      => array(
-			'background' => null,
-			'gradient'   => null,
-			'text'       => null,
-		),
-		'filter'     => array(
-			'duotone' => null,
-		),
-		'spacing'    => array(
-			'margin'   => null,
-			'padding'  => null,
-			'blockGap' => null,
-		),
-		'typography' => array(
-			'fontFamily'     => null,
-			'fontSize'       => null,
-			'fontStyle'      => null,
-			'fontWeight'     => null,
-			'letterSpacing'  => null,
-			'lineHeight'     => null,
-			'textDecoration' => null,
-			'textTransform'  => null,
-		),
-	);
-
-	const VALID_SETTINGS = array(
-		'appearanceTools' => null,
-		'border'          => array(
-			'color'  => null,
-			'radius' => null,
-			'style'  => null,
-			'width'  => null,
-		),
-		'color'           => array(
-			'background'       => null,
-			'custom'           => null,
-			'customDuotone'    => null,
-			'customGradient'   => null,
-			'defaultGradients' => null,
-			'defaultPalette'   => null,
-			'duotone'          => null,
-			'gradients'        => null,
-			'link'             => null,
-			'palette'          => null,
-			'text'             => null,
-		),
-		'custom'          => null,
-		'layout'          => array(
-			'contentSize' => null,
-			'wideSize'    => null,
-		),
-		'spacing'         => array(
-			'blockGap' => null,
-			'margin'   => null,
-			'padding'  => null,
-			'units'    => null,
-		),
-		'typography'      => array(
-			'customFontSize' => null,
-			'dropCap'        => null,
-			'fontFamilies'   => null,
-			'fontSizes'      => null,
-			'fontStyle'      => null,
-			'fontWeight'     => null,
-			'letterSpacing'  => null,
-			'lineHeight'     => null,
-			'textDecoration' => null,
-			'textTransform'  => null,
-		),
 	);
 
 	/**
@@ -154,7 +80,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * - value_func => optionally, instead of value_key, a function to generate
 	 *                 the value that takes a preset as an argument
 	 *
-	 * - css_var    => name of the var to generate. The "$slug" substring will be
+	 * - css_vars   => name of the var to generate. The "$slug" substring will be
 	 *                 replaced by the slug of each preset. For example,
 	 *                 given a preset for color with two values whose slugs are "black" and "white",
 	 *                 the string "--wp--preset--color--$slug" will generate two variables:
@@ -170,6 +96,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *                   '.has-$slug-background-color' => 'background-color',
 	 *                   '.has-$slug-border-color'     => 'border-color',
 	 *                 )
+	 *
 	 * - properties => array of CSS properties to be used by kses to
 	 *                 validate the content of each preset
 	 *                 by means of the remove_insecure_properties method.
@@ -274,6 +201,112 @@ class WP_Theme_JSON_Gutenberg {
 		'spacing.blockGap' => array( 'spacing', 'blockGap' ),
 	);
 
+	/**
+	 * The top-level keys a theme.json can have.
+	 *
+	 * @var string[]
+	 */
+	const VALID_TOP_LEVEL_KEYS = array(
+		'customTemplates',
+		'settings',
+		'styles',
+		'templateParts',
+		'version',
+	);
+
+	/**
+	 * The valid properties under the settings key.
+	 *
+	 * @var array
+	 */
+	const VALID_SETTINGS = array(
+		'appearanceTools' => null,
+		'border'          => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+		),
+		'color'           => array(
+			'background'       => null,
+			'custom'           => null,
+			'customDuotone'    => null,
+			'customGradient'   => null,
+			'defaultGradients' => null,
+			'defaultPalette'   => null,
+			'duotone'          => null,
+			'gradients'        => null,
+			'link'             => null,
+			'palette'          => null,
+			'text'             => null,
+		),
+		'custom'          => null,
+		'layout'          => array(
+			'contentSize' => null,
+			'wideSize'    => null,
+		),
+		'spacing'         => array(
+			'blockGap' => null,
+			'margin'   => null,
+			'padding'  => null,
+			'units'    => null,
+		),
+		'typography'      => array(
+			'customFontSize' => null,
+			'dropCap'        => null,
+			'fontFamilies'   => null,
+			'fontSizes'      => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
+
+	/**
+	 * The valid properties under the styles key.
+	 *
+	 * @var array
+	 */
+	const VALID_STYLES = array(
+		'border'     => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+		),
+		'color'      => array(
+			'background' => null,
+			'gradient'   => null,
+			'text'       => null,
+		),
+		'filter'     => array(
+			'duotone' => null,
+		),
+		'spacing'    => array(
+			'margin'   => null,
+			'padding'  => null,
+			'blockGap' => null,
+		),
+		'typography' => array(
+			'fontFamily'     => null,
+			'fontSize'       => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
+
+	/**
+	 * The valid elements that can be found under styles.
+	 *
+	 * @var string[]
+	 */
 	const ELEMENTS = array(
 		'link' => 'a',
 		'h1'   => 'h1',
@@ -284,24 +317,31 @@ class WP_Theme_JSON_Gutenberg {
 		'h6'   => 'h6',
 	);
 
+	/**
+	 * The latest version of the schema in use.
+	 *
+	 * @var int
+	 */
+
 	const LATEST_SCHEMA = 2;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param array  $theme_json A structure that follows the theme.json schema.
-	 * @param string $origin What source of data this object represents. One of default, theme, or custom. Default: theme.
+	 * @param array $theme_json A structure that follows the theme.json schema.
+	 * @param string $origin    Optional. What source of data this object represents.
+	 *                          One of 'default', 'theme', or 'custom'. Default 'theme'.
 	 */
 	public function __construct( $theme_json = array(), $origin = 'theme' ) {
 		if ( ! in_array( $origin, self::VALID_ORIGINS, true ) ) {
 			$origin = 'theme';
 		}
 
-		$theme_json = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json );
+		$this->theme_json    = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json );
 
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
 		$valid_element_names = array_keys( self::ELEMENTS );
-		$theme_json          = self::sanitize( $theme_json, $valid_block_names, $valid_element_names );
+		$theme_json          = self::sanitize( $this->theme_json, $valid_block_names, $valid_element_names );
 		$this->theme_json    = self::maybe_opt_in_into_settings( $theme_json );
 
 		// Internally, presets are keyed by origin.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -410,7 +410,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $input Structure to sanitize.
 	 * @param array $valid_block_names List of valid block names.
 	 * @param array $valid_element_names List of valid element names.
-	 *
 	 * @return array The sanitized output.
 	 */
 	private static function sanitize( $input, $valid_block_names, $valid_element_names ) {
@@ -469,21 +468,25 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * Example:
 	 *
-	 * {
-	 *   'core/paragraph': {
-	 *     'selector': 'p'
-	 *   },
-	 *   'core/heading': {
-	 *     'selector': 'h1'
-	 *   },
-	 *   'core/group': {
-	 *     'selector': '.wp-block-group'
-	 *   },
-	 *   'core/cover': {
-	 *     'selector': '.wp-block-cover',
-	 *     'duotone': '> .wp-block-cover__image-background, > .wp-block-cover__video-background'
-	 *   }
-	 * }
+	 *     {
+	 *       'core/paragraph': {
+	 *         'selector': 'p',
+	 *         'elements': {
+	 *           'link' => 'link selector',
+	 *           'etc'  => 'element selector'
+	 *         }
+	 *       },
+	 *       'core/heading': {
+	 *         'selector': 'h1',
+	 *         'elements': {}
+	 *       },
+	 *       'core/image': {
+	 *         'selector': '.wp-block-image',
+	 *         'duotone': 'img',
+	 *         'elements': {}
+	 *       }
+	 *     }
+	 *
 	 *
 	 * @return array Block metadata.
 	 */
@@ -536,7 +539,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param array $tree Input to process.
 	 * @param array $schema Schema to adhere to.
-	 *
 	 * @return array Returns the modified $tree.
 	 */
 	private static function remove_keys_not_in_schema( $tree, $schema ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -642,7 +642,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_custom_templates() {
 		$custom_templates = array();
-		if ( ! isset( $this->theme_json['customTemplates'] ) ) {
+		if ( ! isset( $this->theme_json['customTemplates'] ) || ! is_array( $this->theme_json['customTemplates'] ) ) {
 			return $custom_templates;
 		}
 
@@ -664,7 +664,7 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	public function get_template_parts() {
 		$template_parts = array();
-		if ( ! isset( $this->theme_json['templateParts'] ) ) {
+		if ( ! isset( $this->theme_json['templateParts'] ) || ! is_array( $this->theme_json['templateParts'] ) ) {
 			return $template_parts;
 		}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -315,7 +315,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @var int
 	 */
-
 	const LATEST_SCHEMA = 2;
 
 	/**
@@ -568,18 +567,18 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * Example:
 	 *
-	 * {
-	 *   'root': {
-	 *     'color': {
-	 *       'custom': true
+	 *     {
+	 *       'root': {
+	 *         'color': {
+	 *           'custom': true
+	 *         }
+	 *       },
+	 *       'core/paragraph': {
+	 *         'spacing': {
+	 *           'customPadding': true
+	 *         }
+	 *       }
 	 *     }
-	 *   },
-	 *   'core/paragraph': {
-	 *     'typography': {
-	 *       'customFontSize': true
-	 *     }
-	 *   }
-	 * }
 	 *
 	 * @return array Settings per block.
 	 */
@@ -599,11 +598,22 @@ class WP_Theme_JSON_Gutenberg {
 	 *                         'variables': only the CSS Custom Properties for presets & custom ones.
 	 *                         'styles': only the styles section in theme.json.
 	 *                         'presets': only the classes for the presets.
-	 * @param array $origins A list of origins to include. By default it includes 'default', 'theme', and 'custom'.
-	 *
+	 * @param array $origins A list of origins to include. By default it includes self::VALID_ORIGINS.
 	 * @return string Stylesheet.
 	 */
 	public function get_stylesheet( $types = array( 'variables', 'styles', 'presets' ), $origins = self::VALID_ORIGINS ) {
+		if ( is_string( $types ) ) {
+			// Dispatch error and map old arguments to new ones.
+			_deprecated_argument( __FUNCTION__, '5.9' );
+			if ( 'block_styles' === $types ) {
+				$types = array( 'styles', 'presets' );
+			} elseif ( 'css_variables' === $types ) {
+				$types = array( 'variables' );
+			} else {
+				$types = array( 'variables', 'styles', 'presets' );
+			}
+		}
+
 		$blocks_metadata = self::get_blocks_metadata();
 		$style_nodes     = self::get_style_nodes( $this->theme_json, $blocks_metadata );
 		$setting_nodes   = self::get_setting_nodes( $this->theme_json, $blocks_metadata );
@@ -682,7 +692,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *   }
 	 *
 	 * @param array $style_nodes Nodes with styles.
-	 *
 	 * @return string The new stylesheet.
 	 */
 	private function get_block_classes( $style_nodes ) {
@@ -756,10 +765,9 @@ class WP_Theme_JSON_Gutenberg {
 	 *   p.has-value-gradient-background {
 	 *     background: value;
 	 *   }
-
+	 *
 	 * @param array $setting_nodes Nodes with settings.
 	 * @param array $origins       List of origins to process presets from.
-	 *
 	 * @return string The new stylesheet.
 	 */
 	private function get_preset_classes( $setting_nodes, $origins ) {
@@ -787,14 +795,13 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * For each section this creates a new ruleset such as:
 	 *
-	 *   block-selector {
-	 *     --wp--preset--category--slug: value;
-	 *     --wp--custom--variable: value;
-	 *   }
+	 *     block-selector {
+	 *       --wp--preset--category--slug: value;
+	 *       --wp--custom--variable: value;
+	 *     }
 	 *
 	 * @param array $nodes Nodes with settings.
 	 * @param array $origins List of origins to process.
-	 *
 	 * @return string The new stylesheet.
 	 */
 	private function get_css_variables( $nodes, $origins ) {
@@ -863,7 +870,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param string $selector Original selector.
 	 * @param string $to_append Selector to append.
-	 *
 	 * @return string
 	 */
 	private static function append_to_selector( $selector, $to_append ) {
@@ -883,7 +889,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array  $settings Settings to process.
 	 * @param string $selector Selector wrapping the classes.
 	 * @param array  $origins  List of origins to process.
-	 *
 	 * @return string The result of processing the presets.
 	 */
 	private static function compute_preset_classes( $settings, $selector, $origins ) {
@@ -978,7 +983,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $settings Settings to process.
 	 * @param array $preset_metadata One of the PRESETS_METADATA values.
 	 * @param array $origins List of origins to process.
-	 *
 	 * @return array Array of presets where each key is a slug and each value is the preset value.
 	 */
 	private static function get_settings_values_by_slug( $settings, $preset_metadata, $origins ) {
@@ -1019,7 +1023,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param array $settings Settings to process.
 	 * @param array $preset_metadata One of the PRESETS_METADATA values.
 	 * @param array $origins List of origins to process.
-	 *
 	 * @return array Array of presets where the key and value are both the slug.
 	 */
 	private static function get_settings_slugs( $settings, $preset_metadata, $origins = self::VALID_ORIGINS ) {
@@ -1045,7 +1048,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @param string $input String to replace.
 	 * @param string $slug The slug value to use to generate the custom property.
-	 *
 	 * @return string The CSS Custom Property. Something along the lines of --wp--preset--color--black.
 	 */
 	private static function replace_slug_in_string( $input, $slug ) {
@@ -1057,16 +1059,14 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the presets and adds them to the $declarations array
 	 * following the format:
 	 *
-	 * ```php
-	 * array(
-	 *   'name'  => 'property_name',
-	 *   'value' => 'property_value,
-	 * )
-	 * ```
+	 *     array(
+	 *       'name'  => 'property_name',
+	 *       'value' => 'property_value,
+	 *     )
+	 *
 	 *
 	 * @param array $settings Settings to process.
 	 * @param array $origins  List of origins to process.
-	 *
 	 * @return array Returns the modified $declarations.
 	 */
 	private static function compute_preset_vars( $settings, $origins ) {
@@ -1089,15 +1089,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the custom values and adds them to the $declarations
 	 * array following the format:
 	 *
-	 * ```php
-	 * array(
-	 *   'name'  => 'property_name',
-	 *   'value' => 'property_value,
-	 * )
-	 * ```
+	 *     array(
+	 *       'name'  => 'property_name',
+	 *       'value' => 'property_value,
+	 *     )
 	 *
 	 * @param array $settings Settings to process.
-	 *
 	 * @return array Returns the modified $declarations.
 	 */
 	private static function compute_theme_vars( $settings ) {
@@ -1130,24 +1127,23 @@ class WP_Theme_JSON_Gutenberg {
 	 * For example, assuming the given prefix is '--wp'
 	 * and the token is '--', for this input tree:
 	 *
-	 * {
-	 *   'some/property': 'value',
-	 *   'nestedProperty': {
-	 *     'sub-property': 'value'
-	 *   }
-	 * }
+	 *     {
+	 *       'some/property': 'value',
+	 *       'nestedProperty': {
+	 *         'sub-property': 'value'
+	 *       }
+	 *     }
 	 *
 	 * it'll return this output:
 	 *
-	 * {
-	 *   '--wp--some-property': 'value',
-	 *   '--wp--nested-property--sub-property': 'value'
-	 * }
+	 *     {
+	 *       '--wp--some-property': 'value',
+	 *       '--wp--nested-property--sub-property': 'value'
+	 *     }
 	 *
 	 * @param array  $tree Input tree to process.
 	 * @param string $prefix Prefix to prepend to each variable. '' by default.
 	 * @param string $token Token to use between levels. '--' by default.
-	 *
 	 * @return array The flattened tree.
 	 */
 	private static function flatten_tree( $tree, $prefix = '', $token = '--' ) {
@@ -1176,17 +1172,14 @@ class WP_Theme_JSON_Gutenberg {
 	 * Given a styles array, it extracts the style properties
 	 * and adds them to the $declarations array following the format:
 	 *
-	 * ```php
-	 * array(
-	 *   'name'  => 'property_name',
-	 *   'value' => 'property_value,
-	 * )
-	 * ```
+	 *     array(
+	 *       'name'  => 'property_name',
+	 *       'value' => 'property_value,
+	 *     )
 	 *
 	 * @param array $styles Styles to process.
 	 * @param array $settings Theme settings.
 	 * @param array $properties Properties metadata.
-	 *
 	 * @return array Returns the modified $declarations.
 	 */
 	private static function compute_style_properties( $styles, $settings = array(), $properties = self::PROPERTIES_METADATA ) {
@@ -1233,8 +1226,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * "--wp--preset--color--secondary".
 	 *
 	 * @param array $styles Styles subtree.
-	 * @param array $path Which property to process.
-	 *
+	 * @param array $path   Which property to process.
 	 * @return string Style property value.
 	 */
 	private static function get_property_value( $styles, $path ) {
@@ -1263,20 +1255,19 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Builds metadata for the setting nodes, which returns in the form of:
 	 *
-	 * [
-	 *   [
-	 *     'path'     => ['path', 'to', 'some', 'node' ],
-	 *     'selector' => 'CSS selector for some node'
-	 *   ],
-	 *   [
-	 *     'path'     => [ 'path', 'to', 'other', 'node' ],
-	 *     'selector' => 'CSS selector for other node'
-	 *   ],
-	 * ]
+	 *     [
+	 *       [
+	 *         'path'     => ['path', 'to', 'some', 'node' ],
+	 *         'selector' => 'CSS selector for some node'
+	 *       ],
+	 *       [
+	 *         'path'     => [ 'path', 'to', 'other', 'node' ],
+	 *         'selector' => 'CSS selector for other node'
+	 *       ],
+	 *     ]
 	 *
 	 * @param array $theme_json The tree to extract setting nodes from.
-	 * @param array $selectors List of selectors per block.
-	 *
+	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
 	private static function get_setting_nodes( $theme_json, $selectors = array() ) {
@@ -1314,22 +1305,21 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Builds metadata for the style nodes, which returns in the form of:
 	 *
-	 * [
-	 *   [
-	 *     'path'     => [ 'path', 'to', 'some', 'node' ],
-	 *     'selector' => 'CSS selector for some node',
-	 *     'duotone'  => 'CSS selector for duotone for some node'
-	 *   ],
-	 *   [
-	 *     'path'     => ['path', 'to', 'other', 'node' ],
-	 *     'selector' => 'CSS selector for other node',
-	 *     'duotone'  => null
-	 *   ],
-	 * ]
+	 *     [
+	 *       [
+	 *         'path'     => [ 'path', 'to', 'some', 'node' ],
+	 *         'selector' => 'CSS selector for some node',
+	 *         'duotone'  => 'CSS selector for duotone for some node'
+	 *       ],
+	 *       [
+	 *         'path'     => ['path', 'to', 'other', 'node' ],
+	 *         'selector' => 'CSS selector for other node',
+	 *         'duotone'  => null
+	 *       ],
+	 *     ]
 	 *
 	 * @param array $theme_json The tree to extract style nodes from.
-	 * @param array $selectors List of selectors per block.
-	 *
+	 * @param array $selectors  List of selectors per block.
 	 * @return array
 	 */
 	private static function get_style_nodes( $theme_json, $selectors = array() ) {
@@ -1455,7 +1445,6 @@ class WP_Theme_JSON_Gutenberg {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -1532,7 +1521,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * Removes insecure data from theme.json.
 	 *
 	 * @param array $theme_json Structure to sanitize.
-	 *
 	 * @return array Sanitized structure.
 	 */
 	public static function remove_insecure_properties( $theme_json ) {
@@ -1591,7 +1579,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * without the insecure settings.
 	 *
 	 * @param array $input Node to process.
-	 *
 	 * @return array
 	 */
 	private static function remove_insecure_settings( $input ) {
@@ -1647,7 +1634,6 @@ class WP_Theme_JSON_Gutenberg {
 	 * without the insecure styles.
 	 *
 	 * @param array $input Node to process.
-	 *
 	 * @return array
 	 */
 	private static function remove_insecure_styles( $input ) {
@@ -1691,13 +1677,11 @@ class WP_Theme_JSON_Gutenberg {
 		return $this->theme_json;
 	}
 
-		/**
-	 *
+	/**
 	 * Transforms the given editor settings according the
 	 * add_theme_support format to the theme.json format.
 	 *
 	 * @param array $settings Existing editor settings.
-	 *
 	 * @return array Config that adheres to the theme.json schema.
 	 */
 	public static function get_from_editor_settings( $settings ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -76,11 +76,10 @@ class WP_Theme_JSON_Gutenberg {
 	 * - value_key  => the key that represents the value
 	 * - value_func => optionally, instead of value_key, a function to generate
 	 *                 the value that takes a preset as an argument
-	 * - css_vars   => name of the var to generate. The "$slug" substring will be
-	 *                 replaced by the slug of each preset. For example,
-	 *                 given a preset for color with two values whose slugs are "black" and "white",
-	 *                 the string "--wp--preset--color--$slug" will generate two variables:
-	 *                 "--wp--preset--color--black" and "--wp--preset--color--white".
+	 *                 (either value_key or value_func should be present)
+	 * - css_vars   => template string to use in generating the CSS Custom Property.
+	 *                 Example output: "--wp--preset--duotone--blue: <value>" will generate as many CSS Custom Properties as presets defined
+	 *                 substituting the $slug for the slug's value for each preset value.
 	 * - classes    => array containing a structure with the classes to
 	 *                 generate for the presets, where for each array item
 	 *                 the key is the class name and the value the property name.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -14,7 +14,6 @@
  *
  * @access private
  */
-
 class WP_Theme_JSON_Gutenberg {
 
 	/**
@@ -320,9 +319,9 @@ class WP_Theme_JSON_Gutenberg {
 	/**
 	 * Constructor.
 	 *
-	 * @param array $theme_json A structure that follows the theme.json schema.
-	 * @param string $origin    Optional. What source of data this object represents.
-	 *                          One of 'default', 'theme', or 'custom'. Default 'theme'.
+	 * @param array  $theme_json A structure that follows the theme.json schema.
+	 * @param string $origin     Optional. What source of data this object represents.
+	 *                           One of 'default', 'theme', or 'custom'. Default 'theme'.
 	 */
 	public function __construct( $theme_json = array(), $origin = 'theme' ) {
 		if ( ! in_array( $origin, self::VALID_ORIGINS, true ) ) {
@@ -330,7 +329,6 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		$this->theme_json    = WP_Theme_JSON_Schema_Gutenberg::migrate( $theme_json );
-
 		$valid_block_names   = array_keys( self::get_blocks_metadata() );
 		$valid_element_names = array_keys( self::ELEMENTS );
 		$theme_json          = self::sanitize( $this->theme_json, $valid_block_names, $valid_element_names );
@@ -485,7 +483,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *         'elements': {}
 	 *       }
 	 *     }
-	 *
 	 *
 	 * @return array Block metadata.
 	 */
@@ -1059,11 +1056,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the presets and adds them to the $declarations array
 	 * following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
-	 *
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @param array $settings Settings to process.
 	 * @param array $origins  List of origins to process.
@@ -1089,10 +1087,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * for the custom values and adds them to the $declarations
 	 * array following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @param array $settings Settings to process.
 	 * @return array Returns the modified $declarations.
@@ -1172,10 +1172,12 @@ class WP_Theme_JSON_Gutenberg {
 	 * Given a styles array, it extracts the style properties
 	 * and adds them to the $declarations array following the format:
 	 *
-	 *     array(
-	 *       'name'  => 'property_name',
-	 *       'value' => 'property_value,
-	 *     )
+	 * ```php
+	 * array(
+	 *   'name'  => 'property_name',
+	 *   'value' => 'property_value,
+	 * )
+	 * ```
 	 *
 	 * @param array $styles Styles to process.
 	 * @param array $settings Theme settings.

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -71,21 +71,16 @@ class WP_Theme_JSON_Gutenberg {
 	 * This contains the necessary metadata to process them:
 	 *
 	 * - path       => where to find the preset within the settings section
-	 *
 	 * - override   => whether a theme preset with the same slug as a default preset
 	 *                 can override it
-	 *
 	 * - value_key  => the key that represents the value
-	 *
 	 * - value_func => optionally, instead of value_key, a function to generate
 	 *                 the value that takes a preset as an argument
-	 *
 	 * - css_vars   => name of the var to generate. The "$slug" substring will be
 	 *                 replaced by the slug of each preset. For example,
 	 *                 given a preset for color with two values whose slugs are "black" and "white",
 	 *                 the string "--wp--preset--color--$slug" will generate two variables:
 	 *                 "--wp--preset--color--black" and "--wp--preset--color--white".
-	 *
 	 * - classes    => array containing a structure with the classes to
 	 *                 generate for the presets, where for each array item
 	 *                 the key is the class name and the value the property name.
@@ -96,7 +91,6 @@ class WP_Theme_JSON_Gutenberg {
 	 *                   '.has-$slug-background-color' => 'background-color',
 	 *                   '.has-$slug-border-color'     => 'border-color',
 	 *                 )
-	 *
 	 * - properties => array of CSS properties to be used by kses to
 	 *                 validate the content of each preset
 	 *                 by means of the remove_insecure_properties method.


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/1967

This PR makes sure that the order of constants, methods, etc. as well as the PHPDoc comments are the same between the Gutenberg's `lib/class-wp-theme-json-gutenberg.php` and WordPress core `wp-includes/class-wp-theme-json.php`.

This way the backports are way easier and require minimal manual intervention.
