### PR TITLE
Update the `WP_Theme_JSON_Resolver_Gutenberg` class to be like the core one

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -1,14 +1,19 @@
 <?php
 /**
- * Process the different data sources for site-level
- * config and offers and API to work with them.
+ * WP_Theme_JSON_Resolver_Gutenberg class
  *
  * @package gutenberg
  */
 
 /**
- * Class that abstracts the processing
- * of the different data sources.
+ * Class that abstracts the processing of the different data sources
+ * for site-level config and offers an API to work with them.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please,
+ * use get_global_settings, get_global_styles, and get_global_stylesheet instead.
+ *
+ * @access private
  */
 class WP_Theme_JSON_Resolver_Gutenberg {
 
@@ -29,7 +34,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Whether or not the theme supports theme.json.
 	 *
-	 * @var boolean
+	 * @var bool
 	 */
 	private static $theme_has_support = null;
 
@@ -51,7 +56,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Container to keep loaded i18n schema for `theme.json`.
 	 *
-	 * @var Array
+	 * @var array
 	 */
 	private static $i18n_schema = null;
 
@@ -61,7 +66,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * or a void array if none found.
 	 *
 	 * @param string $file_path Path to file. Empty if no file.
-	 *
 	 * @return array Contents that adhere to the theme.json schema.
 	 */
 	private static function read_json_file( $file_path ) {
@@ -78,6 +82,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Returns a data structure used in theme.json translation.
 	 *
+	 * @deprecated
 	 * @return array An array of theme.json fields that are translatable and the keys that are translatable
 	 */
 	public static function get_fields_to_translate() {
@@ -91,9 +96,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * according to the language set by the user.
 	 *
 	 * @param array  $theme_json The theme.json to translate.
-	 * @param string $domain    Optional. Text domain. Unique identifier for retrieving translated strings.
-	 *                          Default 'default'.
-	 *
+	 * @param string $domain     Optional. Text domain. Unique identifier for retrieving translated strings.
+	 *                           Default 'default'.
 	 * @return array Returns the modified $theme_json_structure.
 	 */
 	private static function translate( $theme_json, $domain = 'default' ) {
@@ -132,7 +136,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
-	public static function get_theme_data() {
+	public static function get_theme_data( $deprecated = array() ) {
+		if ( ! empty( $deprecated ) ) {
+			_deprecated_argument( __METHOD__, '5.9' );
+		}
 		if ( null === self::$theme ) {
 			$theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = self::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
@@ -190,18 +197,19 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Returns the CPT that contains the user's origin config
-	 * for the current theme or a void array if none found.
+	 * Returns the custom post type that contains the user's origin config
+	 * for the current theme or a void array if none are found.
 	 *
-	 * It can also create and return a new draft CPT.
+	 * This can also create and return a new draft custom post type.
 	 *
-	 * @param WP_Theme $theme             The theme object.
-	 *                                    If empty, it defaults to the current theme.
-	 * @param bool     $should_create_cpt Whether a new CPT should be created if no one was found.
-	 *                                    False by default.
-	 * @param array    $post_status_filter Filter CPT by post status.
-	 *                                    ['publish'] by default, so it only fetches published posts.
-	 *
+	 * @param WP_Theme $theme              The theme object.  If empty, it
+	 *                                     defaults to the current theme.
+	 * @param bool     $should_create_cpt  Optional. Whether a new custom post
+	 *                                     type should be created if none are
+	 *                                     found.  False by default.
+	 * @param array    $post_status_filter Filter Optional. custom post type by
+	 *                                     post status.  ['publish'] by default,
+	 *                                     so it only fetches published posts.
 	 * @return array Custom Post Type for the user's origin config.
 	 */
 	public static function get_user_data_from_custom_post_type( $theme, $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
@@ -274,6 +282,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$config   = array();
 		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme() );
+
 		if ( array_key_exists( 'post_content', $user_cpt ) ) {
 			$decoded_data = json_decode( $user_cpt['post_content'], true );
 
@@ -315,13 +324,16 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * for the paragraph block, and the theme has done it as well,
 	 * the user preference wins.
 	 *
-	 * @param string $origin To what level should we merge data.
+	 * @param string $origin Optional. To what level should we merge data.
 	 *                       Valid values are 'theme' or 'custom'.
 	 *                       Default is 'custom'.
-	 *
 	 * @return WP_Theme_JSON_Gutenberg
 	 */
 	public static function get_merged_data( $origin = 'custom' ) {
+		if ( is_array( $origin ) ) {
+			_deprecated_argument( __FUNCTION__, '5.9' );
+		}
+
 		$result = new WP_Theme_JSON_Gutenberg();
 		$result->merge( self::get_core_data() );
 		$result->merge( self::get_theme_data() );
@@ -334,40 +346,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Registers a Custom Post Type to store the user's origin config.
-	 */
-	public static function register_user_custom_post_type() {
-		$args = array(
-			'label'        => __( 'Global Styles', 'gutenberg' ),
-			'description'  => 'CPT to store user design tokens',
-			'public'       => false,
-			'show_ui'      => false,
-			'show_in_rest' => false,
-			'rewrite'      => false,
-			'capabilities' => array(
-				'read'                   => 'edit_theme_options',
-				'create_posts'           => 'edit_theme_options',
-				'edit_posts'             => 'edit_theme_options',
-				'edit_published_posts'   => 'edit_theme_options',
-				'delete_published_posts' => 'edit_theme_options',
-				'edit_others_posts'      => 'edit_theme_options',
-				'delete_others_posts'    => 'edit_theme_options',
-			),
-			'map_meta_cap' => true,
-			'supports'     => array(
-				'title',
-				'editor',
-				'revisions',
-			),
-		);
-		register_post_type( 'wp_global_styles', $args );
-	}
-
-	/**
 	 * Returns the ID of the custom post type
 	 * that stores user data.
 	 *
-	 * @return integer
+	 * @return integer|null
 	 */
 	public static function get_user_custom_post_type_id() {
 		if ( null !== self::$user_custom_post_type_id ) {
@@ -375,6 +357,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme(), true );
+
 		if ( array_key_exists( 'ID', $user_cpt ) ) {
 			self::$user_custom_post_type_id = $user_cpt['ID'];
 		}
@@ -385,7 +368,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Whether the current theme has a theme.json file.
 	 *
-	 * @return boolean
+	 * @return bool
 	 */
 	public static function theme_has_support() {
 		if ( ! isset( self::$theme_has_support ) ) {
@@ -399,14 +382,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Builds the path to the given file
-	 * and checks that it is readable.
+	 * Builds the path to the given file and checks that it is readable.
 	 *
-	 * If it isn't, returns an empty string,
-	 * otherwise returns the whole file path.
+	 * If it isn't, returns an empty string, otherwise returns the whole file path.
 	 *
 	 * @param string $file_name Name of the file.
-	 * @param bool   $template  Use template theme directroy. Default: false.
+	 * @param bool   $template  Optional. Use template theme directory. Default false.
 	 * @return string The whole file path or empty if the file doesn't exist.
 	 */
 	private static function get_file_path_from_theme( $file_name, $template = false ) {

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -134,6 +134,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * is present in theme.json and in theme supports,
 	 * the theme.json takes precendence.
 	 *
+	 * @param array $deprecated Deprecated argument.
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
 	public static function get_theme_data( $deprecated = array() ) {

--- a/lib/compat/wordpress-5.9/register-global-styles-cpt.php
+++ b/lib/compat/wordpress-5.9/register-global-styles-cpt.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Function to register the Custom Post Type
+ * to be used to store user's config.
+ *
+ * @package gutenberg
+ */
 
 /**
  * Registers a Custom Post Type to store the user's origin config.

--- a/lib/compat/wordpress-5.9/register-global-styles-cpt.php
+++ b/lib/compat/wordpress-5.9/register-global-styles-cpt.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Registers a Custom Post Type to store the user's origin config.
+ *
+ * This has been ported to src/wp-includes/post.php
+ */
+function register_global_styles_custom_post_type() {
+	$args = array(
+		'label'        => __( 'Global Styles', 'gutenberg' ),
+		'description'  => 'CPT to store user design tokens',
+		'public'       => false,
+		'show_ui'      => false,
+		'show_in_rest' => false,
+		'rewrite'      => false,
+		'capabilities' => array(
+			'read'                   => 'edit_theme_options',
+			'create_posts'           => 'edit_theme_options',
+			'edit_posts'             => 'edit_theme_options',
+			'edit_published_posts'   => 'edit_theme_options',
+			'delete_published_posts' => 'edit_theme_options',
+			'edit_others_posts'      => 'edit_theme_options',
+			'delete_others_posts'    => 'edit_theme_options',
+		),
+		'map_meta_cap' => true,
+		'supports'     => array(
+			'title',
+			'editor',
+			'revisions',
+		),
+	);
+	register_post_type( 'wp_global_styles', $args );
+}

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -181,7 +181,7 @@ function gutenberg_experimental_is_site_editor_available() {
  */
 function gutenberg_experimental_global_styles_register_user_cpt() {
 	if ( gutenberg_experimental_is_site_editor_available() ) {
-		WP_Theme_JSON_Resolver_Gutenberg::register_user_custom_post_type();
+		register_global_styles_custom_post_type();
 	}
 }
 

--- a/lib/load.php
+++ b/lib/load.php
@@ -94,6 +94,7 @@ require __DIR__ . '/compat/wordpress-5.8.1/index.php';
 require __DIR__ . '/compat/wordpress-5.9/blocks.php';
 require __DIR__ . '/compat/wordpress-5.9/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-5.9/default-editor-styles.php';
+require __DIR__ . '/compat/wordpress-5.9/register-global-styles-cpt.php';
 require __DIR__ . '/compat/wordpress-5.9/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-5.9/json-file-decode.php';
 require __DIR__ . '/compat/wordpress-5.9/translate-settings-using-i18n-schema.php';


### PR DESCRIPTION
Related https://github.com/WordPress/wordpress-develop/pull/1967

This PR makes sure that the contents of the Gutenberg's `lib/class-wp-theme-json-resolver-gutenberg.php` and WordPress core `wp-includes/class-wp-theme-json-resolver.php` are the same, so it's easier to compare them and the backports require minimal manual intervention.
