### PR TITLE
Block Styles: add a separating margin to the default picker

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -122,7 +122,6 @@ const BlockInspectorSingleBlock = ( {
 						<BlockStyles
 							scope="core/edit-post"
 							clientId={ clientId }
-							className="block-inspector__block-styles"
 						/>
 						{ hasBlockSupport(
 							blockName,

--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -1,3 +1,7 @@
+.block-editor-block-styles + .default-style-picker__default-switcher {
+	margin-top: $grid-unit-20;
+}
+
 .block-editor-block-styles__preview-panel {
 	display: none;
 	position: absolute;

--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -57,12 +57,14 @@ export default function DefaultStylePicker( { blockName } ) {
 
 	return (
 		onUpdatePreferredStyleVariations && (
-			<SelectControl
-				options={ selectOptions }
-				value={ preferredStyle || '' }
-				label={ __( 'Default Style' ) }
-				onChange={ selectOnChange }
-			/>
+			<div className="default-style-picker__default-switcher">
+				<SelectControl
+					options={ selectOptions }
+					value={ preferredStyle || '' }
+					label={ __( 'Default Style' ) }
+					onChange={ selectOnChange }
+				/>
+			</div>
 		)
 	);
 }

--- a/packages/block-editor/src/components/default-style-picker/style.scss
+++ b/packages/block-editor/src/components/default-style-picker/style.scss
@@ -1,3 +1,0 @@
-.default-style-picker__default-switcher {
-	text-align: center;
-}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -30,7 +30,6 @@
 @import "./components/colors-gradients/style.scss";
 @import "./components/contrast-checker/style.scss";
 @import "./components/default-block-appender/style.scss";
-@import "./components/default-style-picker/style.scss";
 @import "./components/duotone-control/style.scss";
 @import "./components/font-appearance-control/style.scss";
 @import "./components/image-size-control/style.scss";


### PR DESCRIPTION
## Description

In https://github.com/WordPress/gutenberg/pull/34522 we introduced Block Style previews.

This PR fixes a regression whereby the spacing between the default picker and the style variation button container vanished. Props to @apeatling for spotting.

We're doing this by adding a wrapper around the default picker select control so that we can target the component container. 

Why? We can specifically target the default picker _only when it appears after the block styles component_ – a safeguard, just in case folks decide to insert the component elsewhere.

We're also removing some unused styles/classNames. Give and take.



| Before 😱  | After ☮️  |
| ------------- | ------------- |
| <img width="285" alt="Screen Shot 2021-11-30 at 8 15 27 am" src="https://user-images.githubusercontent.com/6458278/143945167-4f38345d-4ea4-461c-a62e-8cccc8617ec2.png">l  | <img width="284" alt="Screen Shot 2021-11-30 at 8 15 19 am" src="https://user-images.githubusercontent.com/6458278/143945177-0875d967-cd1a-4333-b571-e2559e396680.png"> |


## How has this been tested?

Since https://github.com/WordPress/gutenberg/pull/34522, the default style picker will only show if you've already set a preferred style.

A quick way to test is to comment out [the condition](https://github.com/WordPress/gutenberg/blob/ed231cf6d797f683e2c3cb017a23341b738fbbe9/packages/block-editor/src/components/default-style-picker/index.js#L54) that controls this behaviour.

Here's a patch to apply if you like.

<details>
  <summary>Patch to always show default picker</summary>

 ```diff
diff --git a/packages/block-editor/src/components/default-style-picker/index.js b/packages/block-editor/src/components/default-style-picker/index.js
index a897e18837..c8a8c98b2c 100644
--- a/packages/block-editor/src/components/default-style-picker/index.js
+++ b/packages/block-editor/src/components/default-style-picker/index.js
@@ -51,9 +51,9 @@ export default function DefaultStylePicker( { blockName } ) {
 
 	// Until the functionality is migrated to global styles,
 	// only show the default style picker if a non-default style has already been selected.
-	if ( ! preferredStyle || preferredStyle === defaultStyleName ) {
-		return null;
-	}
+	// if ( ! preferredStyle || preferredStyle === defaultStyleName ) {
+	// 	return null;
+	// }
 
 	return (
 		onUpdatePreferredStyleVariations && (

```

</details>

1. Running this branch, insert a new Image Block, or Table Block or other block that has style variations. I'm using TwentyTwentyOne as my theme.
2. Select the block and make sure you see a margin between the block style variation buttons and the default picker dropdown.
3. There should be no other regressions.
4. Thank you.

## Types of changes
Bug fix and janitorial.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
