### PR TITLE
Link Control: Fix scroll bar on long links

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -192,6 +192,7 @@ $preview-image-height: 140px;
 		flex-direction: row;
 		align-items: flex-start;
 		margin-right: $grid-unit-10;
+		min-width: 0;
 
 		// Force text to wrap to improve UX when encountering long lines
 		// of text, particular those with no spaces.
@@ -222,6 +223,10 @@ $preview-image-height: 140px;
 		img {
 			width: 16px; // favicons often have a source of 32px
 		}
+	}
+
+	.block-editor-link-control__search-item-details {
+		min-width: 0;
 	}
 
 	&.is-error .block-editor-link-control__search-item-icon {
@@ -269,6 +274,7 @@ $preview-image-height: 140px;
 		color: $gray-700;
 		font-size: 0.9em;
 		line-height: 1.3;
+		white-space: nowrap;
 	}
 
 	.block-editor-link-control__search-item-error-notice {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
If you add a very long URL via the Link UI then it causes a horiztonal scroll bar to appear. Make sure the URL is truncated.

Fixes #36961

## How has this been tested?
1. Added a new Post
1. Added link to a very long URL https://wordpress.slack.com/archives/C02QB2JS7/p1637762376489200.
1. Clicked on Link to show preview.
1. Confirmed that there is no scroll bar.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/1415747/143954365-60c291bc-1981-429e-b5d9-36dbca9ecf0d.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
