### PR TITLE
Fix returning empty array in getEntityRecords for unknown entities

### DIFF
--- a/packages/core-data/CHANGELOG.md
+++ b/packages/core-data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `getEntityRecords` no longer returns an empty array for unknown entities but returns `null` instead. `hasEntityRecords` now also returns `false` when the entity configuration is unknown. ([#36984](https://github.com/WordPress/gutenberg/pull/36984))
+
 ## 4.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -29,17 +29,6 @@ import { getNormalizedCommaSeparable, isRawAttribute } from './utils';
 const EMPTY_OBJECT = {};
 
 /**
- * Shared reference to an empty array for cases where it is important to avoid
- * returning a new array reference on every invocation, as in a connected or
- * other pure component which performs `shouldComponentUpdate` check on props.
- * This should be used as a last resort, since the normalized data should be
- * maintained by the reducer result in state.
- *
- * @type {Array}
- */
-const EMPTY_ARRAY = [];
-
-/**
  * Returns true if a request is in progress for embed preview data, or false
  * otherwise.
  *
@@ -304,16 +293,14 @@ export function hasEntityRecords( state, kind, name, query ) {
  */
 export function getEntityRecords( state, kind, name, query ) {
 	// Queried data state is prepopulated for all known entities. If this is not
-	// assigned for the given parameters, then it is known to not exist. Thus, a
-	// return value of an empty array is used instead of `null` (where `null` is
-	// otherwise used to represent an unknown state).
+	// assigned for the given parameters, then it is known to not exist.
 	const queriedState = get( state.entities.data, [
 		kind,
 		name,
 		'queriedData',
 	] );
 	if ( ! queriedState ) {
-		return EMPTY_ARRAY;
+		return null;
 	}
 	return getQueriedItems( queriedState, query );
 }

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -160,14 +160,14 @@ describe( 'hasEntityRecords', () => {
 		expect( hasEntityRecords( state, 'root', 'postType' ) ).toBe( false );
 	} );
 
-	it( 'returns true if the entity configuration is not known', () => {
+	it( 'returns false if the entity configuration is not known', () => {
 		const state = deepFreeze( {
 			entities: {
 				data: {},
 			},
 		} );
 
-		expect( hasEntityRecords( state, 'root', 'postType' ) ).toBe( true );
+		expect( hasEntityRecords( state, 'root', 'postType' ) ).toBe( false );
 	} );
 
 	it( 'returns true if entity records have been received', () => {
@@ -295,14 +295,14 @@ describe( 'getEntityRecords', () => {
 		expect( getEntityRecords( state, 'root', 'postType' ) ).toBe( null );
 	} );
 
-	it( 'should return an empty array for an unknown entity configuration', () => {
+	it( 'should return null for an unknown entity configuration', () => {
 		const state = deepFreeze( {
 			entities: {
 				data: {},
 			},
 		} );
 
-		expect( getEntityRecords( state, 'root', 'postType' ) ).toEqual( [] );
+		expect( getEntityRecords( state, 'root', 'postType' ) ).toBe( null );
 	} );
 
 	it( 'should return all the records', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
`getEntityRecords` currently will return an empty array if the entity is unknown (not fetched), but it will also later return `null` when the entity is loaded (via `getQueriedItems`), until finally return the list of records when the data is fully fetched.

This behavior doesn't make sense to me, I think we should also return `null` if the entity is unknown, to align with the `null` value when the data is still fetching. By returning `null` for the initial request, the end developers can also better distinguish between a loaded empty list and a loading state.

There are some former discussion about this: https://github.com/WordPress/gutenberg/pull/19498#discussion_r462630069, https://github.com/WordPress/gutenberg/pull/21630#issuecomment-614881500. I believe the consensus was to always return `null`.

This shouldn't be a breaking change since it already returns `null` in other cases, and we could treat the original behavior as a bug.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Unit tests should pass.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
