### PR TITLE
Update template controller unit test now that author support is in WP core

### DIFF
--- a/phpunit/class-gutenberg-rest-template-controller-test.php
+++ b/phpunit/class-gutenberg-rest-template-controller-test.php
@@ -278,7 +278,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'has_theme_file' => false,
 				'is_custom'      => true,
 				'origin'         => null,
-				'author'         => 0,
+				'author'         => self::$admin_id,
 			),
 			$data
 		);
@@ -318,7 +318,7 @@ class Gutenberg_REST_Templates_Controller_Test extends WP_Test_REST_Controller_T
 				'area'           => 'header',
 				'has_theme_file' => false,
 				'origin'         => null,
-				'author'         => 0,
+				'author'         => self::$admin_id,
 			),
 			$data
 		);


### PR DESCRIPTION
## Description
As mentioned in https://github.com/WordPress/gutenberg/pull/36896#issuecomment-981256873 and https://github.com/WordPress/gutenberg/pull/36896#issuecomment-981287616, the templates rest controller is in an unusual situation of using some PHP code from WordPress core and some from Gutenberg. (a situation that I'm looking to fix separately in https://github.com/WordPress/gutenberg/pull/36898).

This resulted in the author feature implemented in #36896 not fully working until the supporting code landed in WordPress core. Now that it has landed there, the unit tests need updating again in Gutenberg since the author is now correctly assigned when saving. 

## How has this been tested?
Unit tests should pass.