### PR TITLE
Navigation: Try removing absorb toolbar prop.

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -510,7 +510,7 @@ export default function NavigationSubmenuEdit( {
 			__experimentalDirectInsert: true,
 
 			// Ensure block toolbar is not too far removed from item
-			// being edited when in vertical mode.
+			// being edited.
 			// see: https://github.com/WordPress/gutenberg/pull/34615.
 			__experimentalCaptureToolbars: true,
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -508,6 +508,12 @@ export default function NavigationSubmenuEdit( {
 			allowedBlocks: ALLOWED_BLOCKS,
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: true,
+
+			// Ensure block toolbar is not too far removed from item
+			// being edited when in vertical mode.
+			// see: https://github.com/WordPress/gutenberg/pull/34615.
+			__experimentalCaptureToolbars: true,
+
 			renderAppender:
 				isSelected ||
 				( isImmediateParentOfSelectedBlock &&

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -110,11 +110,6 @@ export default function NavigationInnerBlocks( {
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,
 			renderAppender: CustomAppender || appender,
-
-			// Ensure block toolbar is not too far removed from item
-			// being edited when in vertical mode.
-			// see: https://github.com/WordPress/gutenberg/pull/34615.
-			__experimentalCaptureToolbars: orientation !== 'vertical',
 			// Template lock set to false here so that the Nav
 			// Block on the experimental menus screen does not
 			// inherit templateLock={ 'all' }.


### PR DESCRIPTION
## Description

Fixes #36538, mitigates #36977 and #36701. But the primary reason for creating this PR was #36701. Props to @getdave for [pointing me in the right direction](https://github.com/WordPress/gutenberg/issues/36977#issuecomment-982426491).

The absorb toolbar prop exists for the parent block to absorb the block toolbar of children. This is useful for some blocks that feature very compact or intricate child blocks, or for some use cases such as a sketching block where child blocks are blocks you insert and rotate inside as innerblocks. 

It was created for the older version of the navigation block, where the block UI was much heavier to the point that borders were overlaying and creating confusion on their own. With the simpler handling of borders on focus, this is less of a concern with the navigation block than it was at the time, and on the flipside, the change comes with its own tradeoffs:

- Absorbing toolbar keeps the block toolbar from covering content such as preceding submenu items, and it keeps the mover control still as you move items around. But it can also be spatially far removed from the menu item you're actually editing.
- Not absorbing the toolbar can cover preceding content, and the mover control moves with the block. But it is in spatially in perfect context of the menu item.

Due to the balance tipping, I'm currently leaning back towards not absorbing the toolbar, in part also because of the two important bugs that the change mitigates. I also think we could keep a semblance of the absorb behavior, for example absorb the toolbar only for submenu blocks. 

Before:

![before](https://user-images.githubusercontent.com/1204802/144022177-3800b7eb-b632-48bc-8deb-bfbf1dee3ec5.gif)

After:

![after](https://user-images.githubusercontent.com/1204802/144022198-cbc32f0a-0cb8-46da-9356-ab4e8b7cbd1a.gif)

## How has this been tested?

Insert a navigation block and observe the toolbar being in spatial context of the child block selected. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
