### PR TITLE
Navigation: Fix navigation justifications.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -426,7 +426,10 @@ button.wp-block-navigation-item__content {
 			align-items: var(--layout-justification-setting, inherit);
 
 			// Always align the contents of the menu to the top.
-			justify-content: flex-start;
+			&,
+			.wp-block-navigation__container {
+				justify-content: flex-start;
+			}
 
 			// Allow menu to scroll.
 			overflow: auto;


### PR DESCRIPTION
## Description

The justification of content inside the overlay modal regressed with justifications. It seems as a result of an additional inner container added. The content should always be top aligned, but started inheriting instead:

![justifications](https://user-images.githubusercontent.com/1204802/144024777-bd4e02e9-a2e0-45ce-8288-48ee40fb7c71.gif)

This PR fixes it by also targetting the container:


![after](https://user-images.githubusercontent.com/1204802/144024799-0830303c-7117-40e0-86ee-cc2ed7f35bed.gif)


## How has this been tested?

Insert a navigation block and set it to open as overlay. Verify that in both editor and frontend, content inside the modal is always top aligned.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
