### PR TITLE
Fix wordbreak for URLs

### DIFF
--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -197,7 +197,7 @@ $preview-image-height: 140px;
 		// of text, particular those with no spaces.
 		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
 		white-space: pre-wrap;
-		word-wrap: break-word;
+		overflow-wrap: break-word;
 		word-break: break-all;
 	}
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -197,12 +197,14 @@ $preview-image-height: 140px;
 		// of text, particular those with no spaces.
 		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
 		white-space: pre-wrap;
+		overflow-wrap: break-word;
 		word-wrap: break-word;
+		word-break: break-word;
 	}
 
 	&.is-preview .block-editor-link-control__search-item-header {
 		display: flex;
-		flex: 1; // fill available space.
+		flex: 1; // Fill available space.
 	}
 
 	&.is-error .block-editor-link-control__search-item-header {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -197,7 +197,6 @@ $preview-image-height: 140px;
 		// of text, particular those with no spaces.
 		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
 		white-space: pre-wrap;
-		overflow-wrap: break-word;
 		word-wrap: break-word;
 		word-break: break-all;
 	}

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -198,7 +198,10 @@ $preview-image-height: 140px;
 		// See: https://github.com/WordPress/gutenberg/issues/33586#issuecomment-888921188
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
-		word-break: break-all;
+
+		.block-editor-link-control__search-item-info {
+			word-break: break-all;
+		}
 	}
 
 	&.is-preview .block-editor-link-control__search-item-header {

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -199,7 +199,7 @@ $preview-image-height: 140px;
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 		word-wrap: break-word;
-		word-break: break-word;
+		word-break: break-all;
 	}
 
 	&.is-preview .block-editor-link-control__search-item-header {


### PR DESCRIPTION
## Description

Fixes #36961. URLs didn't wrap:

<img width="787" alt="before" src="https://user-images.githubusercontent.com/1204802/144026109-7ad1d374-88a6-4ac2-8fb7-2f23c6abdc17.png">

They do after this PR:

<img width="715" alt="Screenshot 2021-11-30 at 10 58 46" src="https://user-images.githubusercontent.com/1204802/144026145-342862ff-c8a9-4106-9a19-96d6140993c4.png">

For what it's worth, I don't personally think it's that valuable to see the full URL like this, especially when it gets clipped in editing it after the fact:

<img width="672" alt="Screenshot 2021-11-30 at 10 58 53" src="https://user-images.githubusercontent.com/1204802/144026244-d6a97841-fb14-454f-8cdf-ada0a76e37fb.png">

But that's a not at all a strong opinion, so I've kept the behavior as is, given the CSS comment pointed to a particular issue.

## How has this been tested?

Add a very long URL that does not include hyphens, and observe that it still gets broken up.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
