### PR TITLE
Polish unset color indicator.

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -49,12 +49,10 @@
 		height: 24px;
 		width: 24px;
 		padding: 0;
-		background-image:
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-		background-position: 0 0, 25px 25px;
-		background-size: calc(2 * 5px) calc(2 * 5px);
 		border: $border-width solid $gray-300;
+
+		// Show a diagonal line (crossed out) for empty swatches.
+		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	}
 }
 


### PR DESCRIPTION
## Description

Small PR to change the transparency indication in the global styles color picker to look more "unset". Here's before:

<img width="339" alt="Screenshot 2021-11-30 at 12 14 54" src="https://user-images.githubusercontent.com/1204802/144037554-f45cd02e-89f7-4d18-bde0-1c8e71c2ed52.png">

Here's after:

<img width="347" alt="Screenshot 2021-11-30 at 12 09 34" src="https://user-images.githubusercontent.com/1204802/144037571-d3fed9fc-75af-40ce-9bc4-1f83c0ddeac3.png">

This also matches the mockups:

<img width="723" alt="Screenshot 2021-11-30 at 12 05 27" src="https://user-images.githubusercontent.com/1204802/144037598-154279d4-5a93-4d8b-9e68-0f607d0c09d7.png">

## How has this been tested?

Test a theme with some undefined text background or link colors.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
