### PR TITLE
Site Editor: Add the dark frame

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -70,6 +70,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	const isTemplatePart = templateType === 'wp_template_part';
+	const isTemplate = templateType === 'wp_template';
 
 	return (
 		<BlockEditorProvider
@@ -98,7 +99,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 			</SidebarInspectorFill>
 			<BlockTools
 				className={ classnames( 'edit-site-visual-editor', {
-					'is-focus-mode': isTemplatePart,
+					'is-focus-mode': isTemplatePart || isTemplate,
 				} ) }
 				__unstableContentRef={ contentRef }
 				onClick={ ( event ) => {

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -115,7 +115,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					// Reinitialize the editor and reset the states when the template changes.
 					key={ templateId }
 					enableResizing={
-						isTemplatePart &&
+						isTemplatePart || isTemplate &&
 						// Disable resizing in mobile viewport.
 						! isMobileViewport
 					}

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -20,6 +20,7 @@
 
 	&.is-focus-mode {
 		padding: 48px;
+		padding-bottom: 0;
 
 		.edit-site-visual-editor__editor-canvas {
 			border-radius: 2px;

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -100,7 +100,7 @@ export default function Header( {
 		[ setIsListViewOpened, isListViewOpen ]
 	);
 
-	const isFocusMode = templateType === 'wp_template_part';
+	const isFocusMode = templateType === 'wp_template_part' || 'wp_template';
 
 	return (
 		<div className="edit-site-header">


### PR DESCRIPTION
In a couple of issues, the idea of adding the "frame" that appears when editing a template part (or a template in the post editor) has arisen: https://github.com/WordPress/gutenberg/issues/36535 https://github.com/WordPress/gutenberg/issues/36977

To summarise: The frame provides an empty clickable area that makes it easier to deselect blocks. It also creates space for block toolbars that appear close to the top of the canvas.

There is undoubtedly a much better way to do things on the code side, but we can fix that later. This PR is mostly just to get an idea of how things feel with the frame in place so that we can make a better decision around whether or not to add it.

<img width="1637" alt="Screenshot 2021-11-30 at 11 38 39" src="https://user-images.githubusercontent.com/846565/144040730-cbd1e029-5921-4b50-a66f-d8a46ea6770e.png">
