### PR TITLE
Move the root body margin reset into the Core theme.json

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -724,7 +724,6 @@ class WP_Theme_JSON_Gutenberg {
 			}
 
 			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
-				$block_rules .= 'body { margin: 0; }';
 				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
 				$block_rules .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 				$block_rules .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -245,7 +245,12 @@
 	},
 	"styles": {
 		"spacing": {
-			"margin": "0",
+			"margin": {
+				"top": "0",
+				"right": "0",
+				"bottom": "0",
+				"left": "0"
+			},
 			"blockGap": "24px"
 		}
 	}

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -244,6 +244,9 @@
 		}
 	},
 	"styles": {
-		"spacing": { "blockGap": "24px" }
+		"spacing": {
+			"margin": "0",
+			"blockGap": "24px"
+		}
 	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

By [popular request](https://github.com/WordPress/gutenberg/pull/36958#issuecomment-982528107) this PR explores an alternative fix for #36147 which moves the CSS reset into the root `theme.json` file in Core.

As I see it this is inferior to my preferred solution in https://github.com/WordPress/gutenberg/pull/36960 for the following reasons:

### Riad's reason

See https://github.com/WordPress/gutenberg/pull/36996#issuecomment-983383201.

### root `margin` value will be overwritten
the root `margin` value will be overwritten in its entirety by anything provided by the Theme's `theme.json`. For example try setting this in your `theme.json`:
```json
{
    "styles": {
        "spacing": {
            "margin": {
                "left": "0",
                "top": "100px"
            },
            "padding": "0"
        }
    }
}
```

This will result in the following CSS being generated which causes us to _lose_ the `0` margin on the `bottom` and `right` sides:

<img width="498" alt="Screen Shot 2021-11-30 at 11 48 08" src="https://user-images.githubusercontent.com/444434/144042002-45302643-0f07-4c10-bea1-b7b62a6fd440.png">

### Reduced clarity of intent

The reason for including `body { margin: 0; }` is as a CSS reset for browser defaults. That's why it has a specific `if()` conditional in the code. By moving this to the Core `theme.json` we risk this seeming like just another default value provided by Core when in fact it has a very specific intent. I believe the intent will be lost especially when we consider you cannot add comments to `.json` files.

### Potential backwards compatiblity issues

Theme have come to expect `body { margin: 0 }`. As explained above if we include this in Core `theme.json` then if the user provides any margin value in _their_ `theme.json` then this risks the `margin: 0` being lost. That could cause many themes to suffer visual regressions. Granted this is simple to solve but we want to avoid these kind of rippling changes, especially this close to 5.9.

Closes #36147


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Follow same instructions as https://github.com/WordPress/gutenberg/pull/36958.

Please ensure you test both the string and object based `margin` properties in your `theme.json` as they will produce different results.



## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
