### PR TITLE
Do not remove theme presets if defaults are hidden

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1490,7 +1490,15 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * Returns an associative array of slugs per type for the default source.
+	 * Returns the default slugs for all the presets in an associative array
+	 * whose keys are the preset paths and the leafs is the list of slugs.
+	 *
+	 *  array(
+	 *   'color' => array(
+	 *     'palette'   => array( 'slug-1', 'slug-2' ),
+	 *     'gradients' => array( 'slug-3', 'slug-4' ),
+	 *   ),
+	 * )
 	 *
 	 * @param array $data A theme.json like structure.
 	 * @param array $node_path The path to inspect. It's 'settings' by default.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1493,6 +1493,8 @@ class WP_Theme_JSON_Gutenberg {
 	 * Returns the default slugs for all the presets in an associative array
 	 * whose keys are the preset paths and the leafs is the list of slugs.
 	 *
+	 * For example:
+	 *
 	 *  array(
 	 *   'color' => array(
 	 *     'palette'   => array( 'slug-1', 'slug-2' ),

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1426,8 +1426,7 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Replace the presets.
 			foreach ( self::PRESETS_METADATA as $preset ) {
-				$override_preset  = self::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
-				$slugs_for_preset = _wp_array_get( $slugs, $preset['path'], array() );
+				$override_preset = self::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
 
 				foreach ( self::VALID_ORIGINS as $origin ) {
 					$path    = array_merge( $node['path'], $preset['path'], array( $origin ) );
@@ -1442,7 +1441,8 @@ class WP_Theme_JSON_Gutenberg {
 					) {
 						_wp_array_set( $this->theme_json, $path, $content );
 					} else {
-						$content = self::filter_slugs( $content, $slugs_for_preset );
+						$slugs_for_preset = _wp_array_get( $slugs, $preset['path'], array() );
+						$content          = self::filter_slugs( $content, $slugs_for_preset );
 						_wp_array_set( $this->theme_json, $path, $content );
 					}
 				}

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1412,9 +1412,9 @@ class WP_Theme_JSON_Gutenberg {
 		 * we remove it from the theme presets.
 		 */
 		$nodes        = self::get_setting_nodes( $incoming_data );
-		$slugs_global = self::get_slugs_not_to_override( $this->theme_json );
+		$slugs_global = self::get_default_slugs( $this->theme_json, array( 'settings' ) );
 		foreach ( $nodes as $node ) {
-			$slugs_node = self::get_slugs_not_to_override( $this->theme_json, $node['path'] );
+			$slugs_node = self::get_default_slugs( $this->theme_json, $node['path'] );
 			$slugs      = array_merge_recursive( $slugs_global, $slugs_node );
 
 			// Replace the spacing.units.
@@ -1426,6 +1426,9 @@ class WP_Theme_JSON_Gutenberg {
 
 			// Replace the presets.
 			foreach ( self::PRESETS_METADATA as $preset ) {
+				$override_preset  = self::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
+				$slugs_for_preset = _wp_array_get( $slugs, $preset['path'], array() );
+
 				foreach ( self::VALID_ORIGINS as $origin ) {
 					$path    = array_merge( $node['path'], $preset['path'], array( $origin ) );
 					$content = _wp_array_get( $incoming_data, $path, null );
@@ -1433,17 +1436,13 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					$should_override = self::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
-
 					if (
 						( 'theme' !== $origin ) ||
-						( 'theme' === $origin && $should_override )
+						( 'theme' === $origin && $override_preset )
 					) {
 						_wp_array_set( $this->theme_json, $path, $content );
-					}
-
-					if ( 'theme' === $origin && ! $should_override ) {
-						$content = self::filter_slugs( $content, $preset['path'], $slugs );
+					} else {
+						$content = self::filter_slugs( $content, $slugs_for_preset );
 						_wp_array_set( $this->theme_json, $path, $content );
 					}
 				}
@@ -1464,51 +1463,46 @@ class WP_Theme_JSON_Gutenberg {
 			return $override;
 		}
 
+		// The relationship between whether to override the defaults
+		// and whether the defaults are enabled is inverse:
+		//
+		// - If defaults are enabled  => theme presets should not be overriden
+		// - If defaults are disabled => theme presets should be overriden
+		//
+		// For example, a theme sets defaultPalette to false,
+		// making the default palette hidden from the user.
+		// In that case, we want all the theme presets to be present,
+		// so they should override the defaults.
 		if ( is_array( $override ) ) {
-			// The relationship between whether to override the defaults
-			// and whether the defaults are enabled is inverse:
-			//
-			// - If defaults are enabled  => theme presets should not be overriden
-			// - If defaults are disabled => theme presets should be overriden
-			//
-			// For example, a theme sets defaultPalette to false,
-			// making the default palette hidden from the user.
-			// In that case, we want all the theme presets to be present,
-			// so they should override the defaults.
-			return ! _wp_array_get( $theme_json, array_merge( $path, $override ), true );
+			$value = _wp_array_get( $theme_json, array_merge( $path, $override ) );
+			if ( isset( $value ) ) {
+				return ! $value;
+			}
+
+			// Search the top-level key if none was found for this node.
+			$value = _wp_array_get( $theme_json, array_merge( array( 'settings' ), $override ) );
+			if ( isset( $value ) ) {
+				return ! $value;
+			}
+
+			return true;
 		}
 	}
 
 	/**
-	 * Returns the slugs for all the presets that cannot be overriden
-	 * in the given path. It returns an associative array
-	 * whose keys are the preset paths and the leafs is the list of slugs.
+	 * Returns an associative array of slugs per type for the default source.
 	 *
-	 * For example:
-	 *
-	 * array(
-	 *   'color' => array(
-	 *     'palette'   => array( 'slug-1', 'slug-2' ),
-	 *     'gradients' => array( 'slug-3', 'slug-4' ),
-	 *   ),
-	 * )
-	 *
-	 * @param array $data A theme.json like structure to inspect.
+	 * @param array $data A theme.json like structure.
 	 * @param array $node_path The path to inspect. It's 'settings' by default.
 	 *
-	 * @return array An associative array containing the slugs for the given path.
+	 * @return array
 	 */
-	private static function get_slugs_not_to_override( $data, $node_path = array( 'settings' ) ) {
+	private static function get_default_slugs( $data, $node_path ) {
 		$slugs = array();
-		foreach ( self::PRESETS_METADATA as $metadata ) {
-			$override = self::should_override_preset( $data, $node_path, $metadata['override'] );
-			if ( $override ) {
-				continue;
-			}
 
-			$slugs_for_preset = array();
-			$path             = array_merge( $node_path, $metadata['path'], array( 'default' ) );
-			$preset           = _wp_array_get( $data, $path, null );
+		foreach ( self::PRESETS_METADATA as $metadata ) {
+			$path   = array_merge( $node_path, $metadata['path'], array( 'default' ) );
+			$preset = _wp_array_get( $data, $path, null );
 			if ( ! isset( $preset ) ) {
 				continue;
 			}
@@ -1529,20 +1523,18 @@ class WP_Theme_JSON_Gutenberg {
 	 * Removes the preset values whose slug is equal to any of given slugs.
 	 *
 	 * @param array $node The node with the presets to validate.
-	 * @param array $path The path to the preset type to inspect.
 	 * @param array $slugs The slugs that should not be overriden.
 	 *
 	 * @return array The new node
 	 */
-	private static function filter_slugs( $node, $path, $slugs ) {
-		$slugs_for_preset = _wp_array_get( $slugs, $path, array() );
-		if ( empty( $slugs_for_preset ) ) {
+	private static function filter_slugs( $node, $slugs ) {
+		if ( empty( $slugs ) ) {
 			return $node;
 		}
 
 		$new_node = array();
 		foreach ( $node as $value ) {
-			if ( isset( $value['slug'] ) && ! in_array( $value['slug'], $slugs_for_preset, true ) ) {
+			if ( isset( $value['slug'] ) && ! in_array( $value['slug'], $slugs, true ) ) {
 				$new_node[] = $value;
 			}
 		}

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1517,6 +1517,7 @@ class WP_Theme_JSON_Gutenberg {
 				continue;
 			}
 
+			$slugs_for_preset = array();
 			$slugs_for_preset = array_map(
 				function( $value ) {
 					return isset( $value['slug'] ) ? $value['slug'] : null;

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1081,13 +1081,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
-	public function test_merge_incoming_data_removes_theme_presets_with_slugs_as_default_presets() {
+	public function test_merge_incoming_data_color_presets_with_same_slugs_as_default_are_removed() {
 		$defaults = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'color'  => array(
-						'palette' => array(
+						'defaultPalette' => true,
+						'palette'        => array(
 							array(
 								'slug'  => 'red',
 								'color' => 'red',
@@ -1166,7 +1167,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color'  => array(
-					'palette' => array(
+					'palette'        => array(
 						'default' => array(
 							array(
 								'slug'  => 'red',
@@ -1187,6 +1188,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'defaultPalette' => true,
 				),
 				'blocks' => array(
 					'core/paragraph' => array(
@@ -1206,6 +1208,94 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 										'name'  => 'Yellow',
 									),
 								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$defaults->merge( $theme );
+		$actual = $defaults->get_raw_data();
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	public function test_merge_incoming_data_color_presets_with_same_slugs_as_default_are_not_removed_if_defaults_are_disabled() {
+		$defaults = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'defaultPalette' => true, // Emulate the defaults from core theme.json.
+						'palette'        => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+								'name'  => 'Red',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Green',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$theme    = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'color' => array(
+						'defaultPalette' => false,
+						'palette'        => array(
+							array(
+								'slug'  => 'pink',
+								'color' => 'pink',
+								'name'  => 'Pink',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Greenish',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'color' => array(
+					'defaultPalette' => false,
+					'palette'        => array(
+						'default' => array(
+							array(
+								'slug'  => 'red',
+								'color' => 'red',
+								'name'  => 'Red',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Green',
+							),
+						),
+						'theme'   => array(
+							array(
+								'slug'  => 'pink',
+								'color' => 'pink',
+								'name'  => 'Pink',
+							),
+							array(
+								'slug'  => 'green',
+								'color' => 'green',
+								'name'  => 'Greenish',
 							),
 						),
 					),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1226,7 +1226,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'color' => array(
+					'color'  => array(
 						'defaultPalette' => true, // Emulate the defaults from core theme.json.
 						'palette'        => array(
 							array(
@@ -1241,6 +1241,19 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Blue',
+									),
+								),
+							),
+						),
+					),
 				),
 			),
 			'default'
@@ -1249,7 +1262,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'color' => array(
+					'color'  => array(
 						'defaultPalette' => false,
 						'palette'        => array(
 							array(
@@ -1264,6 +1277,29 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'blocks' => array(
+						'core/paragraph' => array(
+							'color' => array(
+								'palette' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Bluish',
+									),
+									array(
+										'slug'  => 'yellow',
+										'color' => 'yellow',
+										'name'  => 'Yellow',
+									),
+									array(
+										'slug'  => 'green',
+										'color' => 'green',
+										'name'  => 'Block Green',
+									),
+								),
+							),
+						),
+					),
 				),
 			)
 		);
@@ -1271,7 +1307,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
-				'color' => array(
+				'color'  => array(
 					'defaultPalette' => false,
 					'palette'        => array(
 						'default' => array(
@@ -1296,6 +1332,38 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								'slug'  => 'green',
 								'color' => 'green',
 								'name'  => 'Greenish',
+							),
+						),
+					),
+				),
+				'blocks' => array(
+					'core/paragraph' => array(
+						'color' => array(
+							'palette' => array(
+								'default' => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Blue',
+									),
+								),
+								'theme'   => array(
+									array(
+										'slug'  => 'blue',
+										'color' => 'blue',
+										'name'  => 'Bluish',
+									),
+									array(
+										'slug'  => 'yellow',
+										'color' => 'yellow',
+										'name'  => 'Yellow',
+									),
+									array(
+										'slug'  => 'green',
+										'color' => 'green',
+										'name'  => 'Block Green',
+									),
+								),
 							),
 						),
 					),


### PR DESCRIPTION
In https://github.com/WordPress/gutenberg/issues/36772 we made it so that theme presets with the same slug as a default preset will be removed.

In doing so, we missed one case that was brought up by @chthonic-ds: when the defaults are disabled by the theme, we still need to show all theme presets, whether or not they have the same slug as a default one.

By doing this, we also make sure that themes with no `theme.json` will see no changes (defaults are disabled for them unless they opt-in), and they'll have the same number of presets values they had before the introduction of default presets.