### PR TITLE
[Block Library - Navigation]: Fix vertical layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -96,6 +96,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style .= "flex-wrap: $flex_wrap;";
 		if ( 'horizontal' === $layout_orientation ) {
 			$style .= 'align-items: center;';
+			if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
+				$style .= '--layout-direction: row;';
+			}
 			/**
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
@@ -106,7 +109,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
 					// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
 					$style .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
-					$style .= '--layout-direction: row;';
 					$style .= "--layout-wrap: $flex_wrap;";
 					$style .= "--layout-justify: {$justify_content_options[ $layout['justifyContent'] ]};";
 					$style .= '--layout-align: center;';
@@ -114,12 +116,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			}
 		} else {
 			$style .= 'flex-direction: column;';
+			if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
+				$style .= '--layout-direction: column;';
+			}
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$style .= "align-items: {$justify_content_options[ $layout['justifyContent'] ]};";
 				if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
 					// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
 					$style .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
-					$style .= '--layout-direction: column;';
 					$style .= '--layout-justify: initial;';
 					$style .= "--layout-align: {$justify_content_options[ $layout['justifyContent'] ]};";
 				}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36902

This PR fixes a regression introduced here: https://github.com/WordPress/gutenberg/pull/36292.

## Testing instructions
1. In a page/post add a `Navigation` block and add a couple of items
2. Change the `layout` orientation to `vertical` (**do not change content justification**)
3. Save
4. View the frontend and observe that the Navigation is `vertical` now

In general I think [something like this](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/social-links/edit.js#L66) should be used to get the `default` block layout in `edit` function. Now in Navigation block we provide some layout defaults which seems that it shouldn't - I haven't checked in depth yet as the block itself is really convoluted.

The specific problem was that we needed the `--layout-direction` attribute which wasn't added if `layout.justifyContent` was empty.

The logic about `setCascadingProperties` needs more looking. I noticed the 'spread' of items in vertical orientation (Search in Navigation, Social Links) and I believe there must be similar css rules like this fix.

https://user-images.githubusercontent.com/16275880/144107848-e434f58b-03a5-490a-867f-6544f8e07bc1.mov



