### PR TITLE
Block Styles: check for existence of scroll container

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -35,6 +35,11 @@ function BlockStylesPreviewPanelFill( { children, scope, ...props } ) {
 	);
 }
 
+// Top position (in px) of the Block Styles container
+// relative to the editor pane.
+// The value is the equivalent of the container's right position.
+const DEFAULT_POSITION_TOP = 16;
+
 // Block Styles component for the Settings Sidebar.
 function BlockStyles( {
 	clientId,
@@ -61,8 +66,7 @@ function BlockStyles( {
 			'.interface-interface-skeleton__content'
 		);
 		const scrollTop = scrollContainer?.scrollTop || 0;
-		// Add the hardcoded equivalent of the container's right position.
-		setContainerScrollTop( scrollTop + 16 );
+		setContainerScrollTop( scrollTop + DEFAULT_POSITION_TOP );
 	}, [ hoveredStyle ] );
 
 	if ( ! stylesToRender || stylesToRender.length === 0 ) {

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -60,7 +60,9 @@ function BlockStyles( {
 		const scrollContainer = document.querySelector(
 			'.interface-interface-skeleton__content'
 		);
-		setContainerScrollTop( scrollContainer.scrollTop + 16 );
+		const scrollTop = scrollContainer?.scrollTop || 0;
+		// Add the hardcoded equivalent of the container's right position.
+		setContainerScrollTop( scrollTop + 16 );
 	}, [ hoveredStyle ] );
 
 	if ( ! stylesToRender || stylesToRender.length === 0 ) {


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/36999

## Description

Where a block has block styles, the Block Styles component throws an error when adding it as a widget in the Customizer. 

To avoid this, let's check if the scrollContainer can be found before trying to use its property `scrollTop`.

## Testing

First checkout the latest version of trunk.

I'm using TwentyTwenty theme to test.

1. Head over to the Customizer: `/wp-admin/customize.php?return=%2Fwp-admin%2Fthemes.php`
2. Then, from the sidebar menu, select **Widgets**, then a widget area, for example `Footer #1`
3. Insert an Image Block, add an image and save.
4. Refresh the page. Navigate back to the same widget area and select your Image Block.
5. You should see an error.

<img width="352" alt="Screen Shot 2021-12-01 at 7 27 39 am" src="https://user-images.githubusercontent.com/6458278/144123650-031a3482-abaf-44a4-8e06-e27beeb1e69e.png">
<img width="757" alt="Screen Shot 2021-12-01 at 7 27 35 am" src="https://user-images.githubusercontent.com/6458278/144123659-d680f2c6-3bea-4252-8420-01b1046f1f48.png">


Repeat the same as above using this branch.

The error should not be thrown.

Props to @alshakero for documenting it.


## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
