### PR TITLE
Block Styles: add preview pane to widget editor

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -115,7 +115,7 @@ const BlockInspectorSingleBlock = ( {
 				<div>
 					<PanelBody title={ __( 'Styles' ) }>
 						<BlockStyles
-							scope="core/edit-post"
+							scope="core/block-inspector"
 							clientId={ clientId }
 						/>
 						{ hasBlockSupport(

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -239,7 +239,7 @@ function Layout( { styles } ) {
 						{ isMobileViewport && sidebarIsOpened && (
 							<ScrollLock />
 						) }
-						<BlockStyles.Slot scope="core/edit-post" />
+						<BlockStyles.Slot scope="core/block-inspector" />
 					</>
 				}
 				footer={

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useViewportMatch } from '@wordpress/compose';
-import { BlockBreadcrumb } from '@wordpress/block-editor';
+import { BlockBreadcrumb, BlockStyles } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -94,9 +94,12 @@ function Interface( { blockEditorSettings } ) {
 				)
 			}
 			content={
-				<WidgetAreasBlockEditorContent
-					blockEditorSettings={ blockEditorSettings }
-				/>
+				<>
+					<WidgetAreasBlockEditorContent
+						blockEditorSettings={ blockEditorSettings }
+					/>
+					<BlockStyles.Slot scope="core/block-inspector" />
+				</>
 			}
 			footer={
 				hasBlockBreadCrumbsEnabled &&


### PR DESCRIPTION
## Description

¡Hola! y Guten BergTag!

We added block style previews to the Block Editor in https://github.com/WordPress/gutenberg/pull/34522

Now it's time to spread the warm and gooey joy of block style previews to the widget editor.

This PR does a couple of things:

- adds the block styles slot to the widget editor so we can preview block styles in the Widget Edtior : `/wp-admin/widgets.php`
- sets `block-inspector` as the context for the block styles slot since that's where the fill originates from (and so it can work across editors)

<img width="1127" alt="Screen Shot 2021-12-01 at 8 09 51 am" src="https://user-images.githubusercontent.com/6458278/144128517-3e272cfb-70c2-4b32-83c3-761e9be07271.png">

## Testing

You can follow the test instructions over at https://github.com/WordPress/gutenberg/pull/34522

But the gist of it is:

1. Fire up this branch, and head to the Widgets Editor (`/wp-admin/widgets.php`)
2. Insert an Image Block (or any block that has block style variations depending on your theme, e.g., table, button) I'm using TwentyTwenty and TwentyNineteen to test
3. Select your block and interact with the preview buttons (onMouseEnter, onFocus)
4. The preview should work as it does in the editor.
Props to @stacimc for nudging us on this one! 🙇 


## Types of changes
Enhancement. Adding existing feature to the Widgets Editor.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
