### PR TITLE
[WIP] Widget Editor: hide secondary sidebar in mobile

### DIFF
--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -87,7 +87,7 @@ function Interface( { blockEditorSettings } ) {
 		<InterfaceSkeleton
 			labels={ interfaceLabels }
 			header={ <Header /> }
-			secondarySidebar={ <SecondarySidebar /> }
+			secondarySidebar={ ! isMobileViewport && <SecondarySidebar /> }
 			sidebar={
 				hasSidebarEnabled && (
 					<ComplementaryArea.Slot scope="core/edit-widgets" />


### PR DESCRIPTION
🚧 *WIP - in progress!!**

## Description

Hi! A PR to test out whether we can hide the SecondarySidebar in smaller viewports.

When working in the Widgets Editor I noticed that the secondary sidebar was hiding the workspace in narrow widths

![widget-sidebar](https://user-images.githubusercontent.com/6458278/144132717-424ca2bd-6744-4162-8a49-92c18f9624f3.gif)

## How has this been tested?

I was using TwentyTwenty and TwentyNineteen to test.

Open the Widgets Editor `/wp-admin/widgets.php`.

Reduce the width of the viewport.

You should still be able to see the workspace and editor.

You should still be able to toggle the sidebar.

You should be able to toggle the inserter.


## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
