### PR TITLE
Add: Corners to custom color picker popover

### DIFF
--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -21,8 +21,13 @@
 	overflow: visible;
 	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.05);
 	border: none;
+	border-radius: $radius-block-ui;
 	& > div {
 		padding: 0;
+	}
+	.react-colorful__saturation {
+		border-top-right-radius: $radius-block-ui;
+		border-top-left-radius: $radius-block-ui;
 	}
 }
 


### PR DESCRIPTION
This PR adds the corners to the custom color picker popover.

cc: @pablohoneyhoney, @mtias in case there are further improvements we could do.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/144141991-cbfd0129-604a-43d3-9003-d8b063c721e1.png)

