### PR TITLE
Add: Missing margin to the color picker clear button

### DIFF
--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -9,6 +9,7 @@ $color-palette-circle-spacing: 12px;
 	.components-circular-option-picker__custom-clear-wrapper {
 		display: flex;
 		justify-content: flex-end;
+		margin-top: $grid-unit-15;
 	}
 
 	.components-circular-option-picker__swatches {


### PR DESCRIPTION
This PR adds a missing margin to the custom color picker clear button.


## How has this been tested?
![image](https://user-images.githubusercontent.com/11271197/144143399-e705380c-0f6f-4210-a2f4-cd6201c2d9ab.png)
