### PR TITLE
[@wordpress/data]: Refactor use-select in preparation for adding types

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -820,7 +820,7 @@ function Paste( { children } ) {
 
 _Parameters_
 
--   _\_mapSelect_ `Function|StoreDescriptor|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
+-   _mapSelect_ `Function|StoreDescriptor|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
 -   _deps_ `Array`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -230,7 +230,10 @@ export default function useSelect( mapSelect, deps ) {
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
 			renderQueue.flush( queueContext );
 		};
-	}, [ registry, trapSelect, hasMappingFunction, ...( deps || [] ) ] );
+		// If you're tempted to eliminate the spread dependencies below don't do it!
+		// We're passing these in from the calling function and want to make sure we're
+		// examining every individual value inside the `deps` array.
+	}, [ registry, trapSelect, hasMappingFunction, ...( deps ?? [] ) ] );
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -88,7 +88,7 @@ const renderQueue = createQueue();
  *
  * @return {Function}  A custom react hook.
  */
-export default function useSelect( mapSelect, deps = [] ) {
+export default function useSelect( mapSelect, deps ) {
 	const hasMappingFunction = 'function' === typeof mapSelect;
 
 	// If we're recalling a store by its name or by
@@ -230,7 +230,7 @@ export default function useSelect( mapSelect, deps = [] ) {
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
 			renderQueue.flush( queueContext );
 		};
-	}, [ registry, trapSelect, ...deps, hasMappingFunction ] );
+	}, [ registry, trapSelect, hasMappingFunction, ...( deps || [] ) ] );
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -230,7 +230,7 @@ export default function useSelect( mapSelect, deps = [] ) {
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
 			renderQueue.flush( queueContext );
 		};
-	}, [ registry, trapSelect, deps, hasMappingFunction ] );
+	}, [ registry, trapSelect, ...deps, hasMappingFunction ] );
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -104,7 +104,10 @@ export default function useSelect( mapSelect, deps ) {
 	// for `mapSelect`. we'll create this intermediate variable to
 	// fulfill that need and then reference it with our "real"
 	// `_mapSelect` if we can.
-	const callbackMapper = useCallback( hasMappingFunction ? mapSelect : noop, deps );
+	const callbackMapper = useCallback(
+		hasMappingFunction ? mapSelect : noop,
+		deps
+	);
 	const _mapSelect = hasMappingFunction ? callbackMapper : null;
 
 	const registry = useRegistry();

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -7,7 +7,7 @@ import { useMemoOne } from 'use-memo-one';
  * WordPress dependencies
  */
 import { createQueue } from '@wordpress/priority-queue';
-import { useRef, useCallback, useReducer } from '@wordpress/element';
+import { useRef, useCallback, useMemo, useReducer } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 
@@ -133,6 +133,11 @@ export default function useSelect( mapSelect, deps ) {
 		[ registry ]
 	);
 
+	// Generate a "flag" for used in the effect dependency array.
+	// It's different than just using `mapSelect` since deps could be undefined,
+	// in that case, we would still want to memoize it.
+	const depsChangedFlag = useMemo( () => ( {} ), deps || [] );
+
 	let mapOutput;
 
 	if ( _mapSelect ) {
@@ -234,7 +239,7 @@ export default function useSelect( mapSelect, deps ) {
 		// If you're tempted to eliminate the spread dependencies below don't do it!
 		// We're passing these in from the calling function and want to make sure we're
 		// examining every individual value inside the `deps` array.
-	}, [ registry, trapSelect, hasMappingFunction, ...( deps ?? [] ) ] );
+	}, [ registry, trapSelect, hasMappingFunction, depsChangedFlag ] );
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -17,6 +17,7 @@ import { useIsomorphicLayoutEffect } from '@wordpress/compose';
 import useRegistry from '../registry-provider/use-registry';
 import useAsyncMode from '../async-mode-provider/use-async-mode';
 
+const noop = () => {};
 const renderQueue = createQueue();
 
 /** @typedef {import('../../types').StoreDescriptor} StoreDescriptor */
@@ -103,7 +104,7 @@ export default function useSelect( mapSelect, deps ) {
 	// for `mapSelect`. we'll create this intermediate variable to
 	// fulfill that need and then reference it with our "real"
 	// `_mapSelect` if we can.
-	const callbackMapper = useCallback( mapSelect, deps );
+	const callbackMapper = useCallback( hasMappingFunction ? mapSelect : noop, deps );
 	const _mapSelect = hasMappingFunction ? callbackMapper : null;
 
 	const registry = useRegistry();


### PR DESCRIPTION
## Description

In this patch we're making what should be a few minor changes to `use-select`
as we get ready to add types to the data package. Primarily:

### Inverting double-negatives

Personally I found the logic of `isWithoutMapping` and `if ( ! isWithoutMapping )`
confusing and replaced that with a positive assertion, `hasMappingFunction`, and
the respective logic updates as well.

### Introduce intermediate variable for `useCallback(mapSelect)`

This function accepts either a mapping function or a store reference. When given
a mapping function we want to memoize that function to avoid needless clones
and re-renders. The rule of hooks tells us though that we can't conditionally-call
`useCallback` otherwise React will confuse the other hooks.

While `useCallback` is happy to return a junk value if given something that isn't
a function this style will make it hard to use the returned value when we add types
to this module.

While the existing code isn't _wrong_ or buggy the new code provides an escape
hatch for the type system, making it much easier to detect if we have a mapping
function we can use by measuring directly.

```ts
const _mapSelect = useCallback( mapSelect, deps);

if ( hasMappingFunction ) {  // measures mapSelect
	_mapSelect(); // calls _mapSelect
}
```

```ts
const callbackMapper = useCallback( mapSelect, deps );
const _mapSelect = 'function' === hasMappingFunction ? callbackMapper : null;

if ( _mapSelect ) { // measures _mapSelect
	_mapSelect(); // calls _mapSelect
}
```

The point is simply to more directly measure what we're using and minimize or
push to the edges any opportunity for bugs.

### <del>Replace `useMemo`-based `depsChangedFlag` with actual  deps</del>

**Update**: From [the discussion below](https://github.com/WordPress/gutenberg/pull/37017#discussion_r760873329) I have decided to leave this code in place.

It confused me what role `depsChangedFlag` played and after some investigation
I think it was used because passing `deps` to `useIsomorphicLayoutEffect()` triggers
a render-cycle that React complains about. I believe this is because `deps` is an array
and instead of using the actual dependencies in the effect hook it examines the wrapping
array holding those deps.

By merging `deps` into effect-specific dependencies we get what I think the original
code was after. @kevin940726 I would appreciate any thoughts you have on this, to confirm
my conclusion or point out something I'm overlooking.

### Expose `mapSelect` instead of `_mapSelect`

Exposing `_mapSelect` as the name of the mapping function seems odd to me. Even though
it doesn't force any caller to use that naming, it shows up in documentation and auto-complete
suggestions. I've changed this to `mapSelect` to better conform to our naming conventions
and to remove this little abstraction leak from the API.

### Untangle nesting in `try`/`catch`

The assignment of `mapOutput` happened unconditionally yet was duplicated in each side of
the `try/catch` block. I've moved this assignment out of the block, given names to the condition
under which we run the update, and swapped the inner `if` and `try` to minimize the scope of
where the `try/catch` is in effect. This is in order to focus on the throwable bits of code and
leave everything else alone.

---

There shouldn't be any impact on the behavior of the package.

## How has this been tested?

Spooled up the branch in WordPress and smoke-tested with core blocks.

## Types of changes

Small code refactors to help in legibility of `use-select` and in supporting
work to introduce type safety and type-aided design.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
