### PR TITLE
Site editor: remove extra border radius.

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -19,16 +19,12 @@
 	align-items: center;
 
 	&.is-focus-mode {
-		padding: 48px;
+		padding: $grid-unit-60;
 
 		.edit-site-visual-editor__editor-canvas {
-			border-radius: 2px;
+			border-radius: $radius-block-ui;
 		}
 	}
-}
-
-.edit-site-visual-editor__editor-canvas {
-	border-radius: 2px 2px 0 0;
 }
 
 .edit-site-visual-editor__back-button {


### PR DESCRIPTION
## Description

If you look closely at the top left and right corners of the site editor, you can spot a dark gray background peeking through a tiny 2px border radius:

<img width="240" alt="Screenshot 2021-12-01 at 09 31 09" src="https://user-images.githubusercontent.com/1204802/144201461-898e7119-342e-4b77-99b1-a77458dd8712.png">

As best I can tell, the rule was introduced in #34732 to apply the correct 2px border radius for when the editing canvas is scaled down, surrounded by the dark frame. However it doesn't seem like this particular rule is needed anymore, as a separate 2px border radius is already applied conditionaly when the frame is applied. 

So this PR removes it:

<img width="380" alt="Screenshot 2021-12-01 at 09 56 05" src="https://user-images.githubusercontent.com/1204802/144203069-cef17437-b607-4448-a9d6-d5ff3612f941.png">

Am I missing a use case where the border needs to be applied?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
