### PR TITLE
Remove the deprecated navigation area block from the inserter

### DIFF
--- a/packages/block-library/src/navigation-area/block.json
+++ b/packages/block-library/src/navigation-area/block.json
@@ -18,6 +18,6 @@
 	},
 	"supports": {
 		"html": false,
-		"inserter": true
+		"inserter": false
 	}
 }


### PR DESCRIPTION
**Description**

Hides the deprecated navigation area block from the inserter, as discussed in https://github.com/WordPress/gutenberg/issues/37023. The block is being phased out, let's not encourage users to keep using it.

**Test plan**
* Confirm the nav area block is not in the inserter anymore
