### PR TITLE
Polish color indicator and itemgroup.

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -5,13 +5,13 @@
 }
 
 .block-editor-panel-color-gradient-settings {
-	.component-color-indicator {
-		vertical-align: text-bottom;
-	}
+	.block-editor-panel-color-gradient-settings__panel-title {
+		display: flex;
 
-	&__panel-title {
 		.component-color-indicator {
-			display: inline-block;
+			width: $grid-unit-15;
+			height: $grid-unit-15;
+			align-self: center;
 		}
 	}
 

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -7,6 +7,7 @@
 .block-editor-panel-color-gradient-settings {
 	.block-editor-panel-color-gradient-settings__panel-title {
 		display: flex;
+		gap: $grid-unit-15;
 
 		.component-color-indicator {
 			width: $grid-unit-15;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 ### Enhancements
 
 -   Wrapped `Modal` in a `forwardRef` call ([#36831](https://github.com/WordPress/gutenberg/pull/36831)).
+-   Unify styles for `ColorIndicator` with how they appear in Global Styles ([#37028](https://github.com/WordPress/gutenberg/pull/37028))
 
 ## 19.1.0
 

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -1,11 +1,8 @@
 .component-color-indicator {
-	width: 25px;
-	height: 16px;
-	margin-left: 0.8rem;
-	border: 1px solid #dadada;
+	width: $grid-unit-50 * 0.5;
+	height: $grid-unit-50 * 0.5;
+	border-radius: 50%;
+	border: $border-width solid $gray-300;
 	display: inline-block;
-
-	& + & {
-		margin-left: 0.5rem;
-	}
+	padding: 0;
 }

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -5,4 +5,5 @@
 	border: $border-width solid $gray-300;
 	display: inline-block;
 	padding: 0;
+	margin-left: $grid-unit-15;
 }

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -5,5 +5,4 @@
 	border: $border-width solid $gray-300;
 	display: inline-block;
 	padding: 0;
-	margin-left: $grid-unit-15;
 }

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -10,7 +10,7 @@ import { CONFIG, COLORS } from '../utils';
 
 export const unstyledButton = css`
 	appearance: none;
-	border: 1px solid transparent;
+	border: 0;
 	cursor: pointer;
 	background: none;
 	text-align: left;

--- a/packages/components/src/item-group/styles.ts
+++ b/packages/components/src/item-group/styles.ts
@@ -10,7 +10,7 @@ import { CONFIG, COLORS } from '../utils';
 
 export const unstyledButton = css`
 	appearance: none;
-	border: 0;
+	border: 1px solid transparent;
 	cursor: pointer;
 	background: none;
 	text-align: left;

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -4,15 +4,6 @@
 	justify-content: center;
 	min-height: 152px;
 	line-height: 1;
-
-	.component-color-indicator {
-		border-radius: 50%;
-		border: 0;
-		height: 36px;
-		width: 36px;
-		margin-left: 0;
-		padding: 0;
-	}
 }
 
 .edit-site-typography-panel__preview {
@@ -43,14 +34,6 @@
 	margin: $grid-unit-20;
 
 	.component-color-indicator {
-		margin-left: 0;
-		display: block;
-		border-radius: 50%;
-		height: 24px;
-		width: 24px;
-		padding: 0;
-		border: $border-width solid $gray-300;
-
 		// Show a diagonal line (crossed out) for empty swatches.
 		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -34,6 +34,8 @@
 	margin: $grid-unit-20;
 
 	.component-color-indicator {
+		margin-left: 0;
+
 		// Show a diagonal line (crossed out) for empty swatches.
 		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -34,8 +34,6 @@
 	margin: $grid-unit-20;
 
 	.component-color-indicator {
-		margin-left: 0;
-
 		// Show a diagonal line (crossed out) for empty swatches.
 		background: linear-gradient(-45deg, transparent 48%, $gray-300 48%, $gray-300 52%, transparent 52%);
 	}


### PR DESCRIPTION
## Description

This PR tweaks some of the metrics of the color swatch indicator to match those of the Global Styles design (#34574), which look like this in trunk:
<img width="296" alt="Screenshot 2021-12-01 at 11 31 49" src="https://user-images.githubusercontent.com/1204802/144223383-ff64502e-87b1-4439-a096-150a7b79893f.png">

The circle is a bit big, 24px, should be 20, and each row in the itemgroup is a bit big. This PR polishes a bit to this:

<img width="279" alt="Screenshot 2021-12-01 at 12 00 33" src="https://user-images.githubusercontent.com/1204802/144223450-dd511180-a482-4b28-8d1f-72890e83363c.png">

20x20px circles, about 40px height itemgroup rows. Note also how the gray border at the bottom goes edge to edge. There used to be a barely perceptible diagonal in the corners:

<img width="1197" alt="Screenshot 2021-12-01 at 11 49 31" src="https://user-images.githubusercontent.com/1204802/144223673-e8ad2d6e-b838-4259-b3cc-1e624ed1f466.png">

This was due to a transparent 1px border, adding the joint in the corner.

Note that there's some padding math in the itemgroup component that appears there to adhere to a component size system, so I didn't touch it. This actually makes the itemgroup rows still e a bit too tall (42.38px rather than 40px). I'm curious if there's a better way to solve this:

<img width="313" alt="Screenshot 2021-12-01 at 12 06 25" src="https://user-images.githubusercontent.com/1204802/144224003-09cec7cf-e1d6-467a-8324-ab1f17515229.png">

Also note that this PR completely moves the color indicator styles from global styles into the color circle component itself. As far as I can tell that component is used in the native code, and in global styles. But in both cases it should arguably be identical. I'd appreciate if someone familiar with the RN stuff could give this a quick sanity check.

## How has this been tested?

Test the color pickers in global styles. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
