### PR TITLE
Disable Nav block editing for lower perm users

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -584,6 +584,11 @@ function Navigation( {
 							/>
 						</MaybeDisabledComponent>
 					) }
+					{ isPlaceholderShown && ! canUserUseBlock && (
+						<MaybeDisabledComponent>
+							<PlaceholderPreview />
+						</MaybeDisabledComponent>
+					) }
 					{ ! isEntityAvailable && ! isPlaceholderShown && (
 						<MaybeDisabledComponent>
 							<PlaceholderPreview isLoading />

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -13,6 +13,7 @@ import {
 	useRef,
 	useCallback,
 	Platform,
+	Fragment,
 } from '@wordpress/element';
 import {
 	InspectorControls,
@@ -36,6 +37,7 @@ import {
 	ToolbarGroup,
 	ToolbarDropdownMenu,
 	Button,
+	Disabled,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -109,6 +111,8 @@ function Navigation( {
 		showSubmenuIcon,
 		layout: { justifyContent, orientation = 'horizontal' } = {},
 	} = attributes;
+
+	const canUserEdit = false;
 
 	let areaMenu,
 		setAreaMenu = noop;
@@ -370,142 +374,150 @@ function Navigation( {
 		? CustomPlaceholder
 		: Placeholder;
 
+	const MaybeDisabledComponent = canUserEdit ? Fragment : Disabled;
+
 	return (
 		<EntityProvider kind="postType" type="wp_navigation" id={ ref }>
 			<RecursionProvider>
-				<BlockControls>
-					{ ! isDraftNavigationMenu && isEntityAvailable && (
-						<ToolbarGroup>
-							<ToolbarDropdownMenu
-								label={ __( 'Select Menu' ) }
-								text={ __( 'Select Menu' ) }
-								icon={ null }
-							>
-								{ ( { onClose } ) => (
-									<NavigationMenuSelector
-										onSelect={ ( { id } ) => {
-											setRef( id );
-											onClose();
-										} }
-										onCreateNew={ startWithEmptyMenu }
-									/>
-								) }
-							</ToolbarDropdownMenu>
-						</ToolbarGroup>
-					) }
-					<ToolbarGroup>{ listViewToolbarButton }</ToolbarGroup>
-				</BlockControls>
+				{ canUserEdit && (
+					<BlockControls>
+						{ ! isDraftNavigationMenu && isEntityAvailable && (
+							<ToolbarGroup>
+								<ToolbarDropdownMenu
+									label={ __( 'Select Menu' ) }
+									text={ __( 'Select Menu' ) }
+									icon={ null }
+								>
+									{ ( { onClose } ) => (
+										<NavigationMenuSelector
+											onSelect={ ( { id } ) => {
+												setRef( id );
+												onClose();
+											} }
+											onCreateNew={ startWithEmptyMenu }
+										/>
+									) }
+								</ToolbarDropdownMenu>
+							</ToolbarGroup>
+						) }
+						<ToolbarGroup>{ listViewToolbarButton }</ToolbarGroup>
+					</BlockControls>
+				) }
 				{ listViewModal }
-				<InspectorControls>
-					{ hasSubmenuIndicatorSetting && (
-						<PanelBody title={ __( 'Display' ) }>
-							<h3>{ __( 'Overlay Menu' ) }</h3>
-							<ToggleGroupControl
-								label={ __( 'Configure overlay menu' ) }
-								value={ overlayMenu }
-								help={ __(
-									'Collapses the navigation options in a menu icon opening an overlay.'
-								) }
-								onChange={ ( value ) =>
-									setAttributes( { overlayMenu: value } )
-								}
-								isBlock
-								hideLabelFromVision
-							>
-								<ToggleGroupControlOption
-									value="never"
-									label={ __( 'Off' ) }
-								/>
-								<ToggleGroupControlOption
-									value="mobile"
-									label={ __( 'Mobile' ) }
-								/>
-								<ToggleGroupControlOption
-									value="always"
-									label={ __( 'Always' ) }
-								/>
-							</ToggleGroupControl>
-							{ hasSubmenus && (
-								<>
-									<h3>{ __( 'Submenus' ) }</h3>
-									<ToggleControl
-										checked={ openSubmenusOnClick }
-										onChange={ ( value ) => {
-											setAttributes( {
-												openSubmenusOnClick: value,
-												...( value && {
-													showSubmenuIcon: true,
-												} ), // Make sure arrows are shown when we toggle this on.
-											} );
-										} }
-										label={ __( 'Open on click' ) }
+				{ canUserEdit && (
+					<InspectorControls>
+						{ hasSubmenuIndicatorSetting && canUserEdit && (
+							<PanelBody title={ __( 'Display' ) }>
+								<h3>{ __( 'Overlay Menu' ) }</h3>
+								<ToggleGroupControl
+									label={ __( 'Configure overlay menu' ) }
+									value={ overlayMenu }
+									help={ __(
+										'Collapses the navigation options in a menu icon opening an overlay.'
+									) }
+									onChange={ ( value ) =>
+										setAttributes( { overlayMenu: value } )
+									}
+									isBlock
+									hideLabelFromVision
+								>
+									<ToggleGroupControlOption
+										value="never"
+										label={ __( 'Off' ) }
 									/>
+									<ToggleGroupControlOption
+										value="mobile"
+										label={ __( 'Mobile' ) }
+									/>
+									<ToggleGroupControlOption
+										value="always"
+										label={ __( 'Always' ) }
+									/>
+								</ToggleGroupControl>
+								{ hasSubmenus && (
+									<>
+										<h3>{ __( 'Submenus' ) }</h3>
+										<ToggleControl
+											checked={ openSubmenusOnClick }
+											onChange={ ( value ) => {
+												setAttributes( {
+													openSubmenusOnClick: value,
+													...( value && {
+														showSubmenuIcon: true,
+													} ), // Make sure arrows are shown when we toggle this on.
+												} );
+											} }
+											label={ __( 'Open on click' ) }
+										/>
 
-									<ToggleControl
-										checked={ showSubmenuIcon }
-										onChange={ ( value ) => {
-											setAttributes( {
-												showSubmenuIcon: value,
-											} );
-										} }
-										disabled={
-											attributes.openSubmenusOnClick
-										}
-										label={ __( 'Show arrow' ) }
-									/>
-								</>
-							) }
-						</PanelBody>
-					) }
-					{ hasColorSettings && (
-						<PanelColorSettings
-							__experimentalHasMultipleOrigins
-							__experimentalIsRenderedInSidebar
-							title={ __( 'Color' ) }
-							initialOpen={ false }
-							colorSettings={ [
-								{
-									value: textColor.color,
-									onChange: setTextColor,
-									label: __( 'Text' ),
-								},
-								{
-									value: backgroundColor.color,
-									onChange: setBackgroundColor,
-									label: __( 'Background' ),
-								},
-								{
-									value: overlayTextColor.color,
-									onChange: setOverlayTextColor,
-									label: __( 'Submenu & overlay text' ),
-								},
-								{
-									value: overlayBackgroundColor.color,
-									onChange: setOverlayBackgroundColor,
-									label: __( 'Submenu & overlay background' ),
-								},
-							] }
-						>
-							{ enableContrastChecking && (
-								<>
-									<ContrastChecker
-										backgroundColor={
-											detectedBackgroundColor
-										}
-										textColor={ detectedColor }
-									/>
-									<ContrastChecker
-										backgroundColor={
-											detectedOverlayBackgroundColor
-										}
-										textColor={ detectedOverlayColor }
-									/>
-								</>
-							) }
-						</PanelColorSettings>
-					) }
-				</InspectorControls>
-				{ isEntityAvailable && (
+										<ToggleControl
+											checked={ showSubmenuIcon }
+											onChange={ ( value ) => {
+												setAttributes( {
+													showSubmenuIcon: value,
+												} );
+											} }
+											disabled={
+												attributes.openSubmenusOnClick
+											}
+											label={ __( 'Show arrow' ) }
+										/>
+									</>
+								) }
+							</PanelBody>
+						) }
+						{ hasColorSettings && canUserEdit && (
+							<PanelColorSettings
+								__experimentalHasMultipleOrigins
+								__experimentalIsRenderedInSidebar
+								title={ __( 'Color' ) }
+								initialOpen={ false }
+								colorSettings={ [
+									{
+										value: textColor.color,
+										onChange: setTextColor,
+										label: __( 'Text' ),
+									},
+									{
+										value: backgroundColor.color,
+										onChange: setBackgroundColor,
+										label: __( 'Background' ),
+									},
+									{
+										value: overlayTextColor.color,
+										onChange: setOverlayTextColor,
+										label: __( 'Submenu & overlay text' ),
+									},
+									{
+										value: overlayBackgroundColor.color,
+										onChange: setOverlayBackgroundColor,
+										label: __(
+											'Submenu & overlay background'
+										),
+									},
+								] }
+							>
+								{ enableContrastChecking && (
+									<>
+										<ContrastChecker
+											backgroundColor={
+												detectedBackgroundColor
+											}
+											textColor={ detectedColor }
+										/>
+										<ContrastChecker
+											backgroundColor={
+												detectedOverlayBackgroundColor
+											}
+											textColor={ detectedOverlayColor }
+										/>
+									</>
+								) }
+							</PanelColorSettings>
+						) }
+					</InspectorControls>
+				) }
+				{ isEntityAvailable && canUserEdit && (
 					<InspectorControls __experimentalGroup="advanced">
 						<NavigationMenuNameControl />
 						<NavigationMenuDeleteControl
@@ -552,20 +564,27 @@ function Navigation( {
 							styles={ overlayStyles }
 						>
 							{ isEntityAvailable && (
-								<NavigationInnerBlocks
-									isVisible={ ! isPlaceholderShown }
-									clientId={ clientId }
-									appender={ CustomAppender }
-									hasCustomPlaceholder={
-										!! CustomPlaceholder
-									}
-									orientation={ orientation }
-								/>
+								<MaybeDisabledComponent>
+									<NavigationInnerBlocks
+										isVisible={ ! isPlaceholderShown }
+										clientId={ clientId }
+										appender={ CustomAppender }
+										hasCustomPlaceholder={
+											!! CustomPlaceholder
+										}
+										orientation={ orientation }
+									/>
+								</MaybeDisabledComponent>
 							) }
 						</ResponsiveWrapper>
 					) }
 				</nav>
 			</RecursionProvider>
+			{ ! canUserEdit && isSelected && (
+				<Warning>
+					{ __( 'You do not have permission to edit Navigation.' ) }
+				</Warning>
+			) }
 		</EntityProvider>
 	);
 }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -170,10 +170,11 @@ function Navigation( {
 				hasSubmenus: firstSubmenu,
 				innerBlocks: blocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-				canUserCreateNavigation: select( coreStore ).canUser(
-					'create',
-					'navigation'
-				),
+				// canUserCreateNavigation: select( coreStore ).canUser(
+				// 	'publish',
+				// 	'navigation'
+				// ),
+				canUserCreateNavigation: false,
 				canUserEditNavigationEntity: ref
 					? select( coreStore ).canUser( 'edit', 'navigation', ref )
 					: false,
@@ -182,7 +183,8 @@ function Navigation( {
 		[ clientId ]
 	);
 
-	const userCanCreateNewNavigationBlock = ! ref && canUserCreateNavigation;
+	const userCanCreateNewNavigationBlock =
+		! ref && Boolean( canUserCreateNavigation );
 
 	const hasExistingNavItems = !! innerBlocks.length;
 	const {
@@ -563,23 +565,29 @@ function Navigation( {
 				) }
 				<nav { ...blockProps }>
 					{ isPlaceholderShown && canUserUseBlock && (
-						<PlaceholderComponent
-							onFinish={ ( post ) => {
-								setIsPlaceholderShown( false );
-								if ( post ) {
-									setRef( post.id );
+						<MaybeDisabledComponent>
+							<PlaceholderComponent
+								onFinish={ ( post ) => {
+									setIsPlaceholderShown( false );
+									if ( post ) {
+										setRef( post.id );
+									}
+									selectBlock( clientId );
+								} }
+								canSwitchNavigationMenu={
+									canSwitchNavigationMenu
 								}
-								selectBlock( clientId );
-							} }
-							canSwitchNavigationMenu={ canSwitchNavigationMenu }
-							hasResolvedNavigationMenus={
-								hasResolvedNavigationMenus
-							}
-							clientId={ clientId }
-						/>
+								hasResolvedNavigationMenus={
+									hasResolvedNavigationMenus
+								}
+								clientId={ clientId }
+							/>
+						</MaybeDisabledComponent>
 					) }
 					{ ! isEntityAvailable && ! isPlaceholderShown && (
-						<PlaceholderPreview isLoading />
+						<MaybeDisabledComponent>
+							<PlaceholderPreview isLoading />
+						</MaybeDisabledComponent>
 					) }
 					{ ! isPlaceholderShown && (
 						<ResponsiveWrapper

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -221,6 +221,7 @@ function Navigation( {
 				'background-color',
 				backgroundColor?.slug
 			) ]: !! backgroundColor?.slug,
+			'is-disabled': ! canUserEdit,
 		} ),
 		style: {
 			color: ! textColor?.slug && textColor?.color,
@@ -352,9 +353,11 @@ function Navigation( {
 					{ __(
 						'Navigation menu has been deleted or is unavailable. '
 					) }
-					<Button onClick={ startWithEmptyMenu } variant="link">
-						{ __( 'Create a new menu?' ) }
-					</Button>
+					{ canUserEdit && (
+						<Button onClick={ startWithEmptyMenu } variant="link">
+							{ __( 'Create a new menu?' ) }
+						</Button>
+					) }
 				</Warning>
 			</div>
 		);
@@ -534,7 +537,7 @@ function Navigation( {
 					</InspectorControls>
 				) }
 				<nav { ...blockProps }>
-					{ isPlaceholderShown && (
+					{ isPlaceholderShown && canUserEdit && (
 						<PlaceholderComponent
 							onFinish={ ( post ) => {
 								setIsPlaceholderShown( false );

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -20,6 +20,11 @@
 	}
 }
 
+.editor-styles-wrapper .wp-block-navigation.is-disabled,
+.editor-styles-wrapper .wp-block-navigation.is-disabled * {
+	cursor: not-allowed;
+}
+
 // The following rule affects the positioning of the dropdown arrow indicator.
 // On the frontend, this element is inline, which makes it look correct. In the editor,
 // the label is block, which causes the dropdown indicator to wrap onto a new line.

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { navigation as icon } from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -50,3 +51,24 @@ export const settings = {
 	save,
 	deprecated,
 };
+
+function setInserterVisibility( _settings, _name ) {
+	if ( _name !== 'core/navigation' ) {
+		return _settings;
+	}
+
+	// Todo: remove only if user does not have
+	// create permission.
+	_settings.supports = {
+		..._settings.supports,
+		inserter: false,
+	};
+
+	return _settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/navigation-block/setInserterVisibility',
+	setInserterVisibility
+);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/issues/36286 we learnt the Nav block provides a very poor UX for users with lower permissions.

The block should be readable but not writeable/editable. 

This PR seeks to address that by:

- Disabling the entire block UI but allowing it to remain visible.
- Removing all block specific controls
- Adding a warning notice below the block indicating a lack of permissions is why the block isn't editable.

Currently this uses a constant variable to indicate whether the user has suitable permissions. We will need to replace that with a call to `canUser()` and ensure the `wp_navigation` post type is configured with the correct perms.

Addresses part of https://github.com/WordPress/gutenberg/issues/36286

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
