### PR TITLE
Block Editor: Handle the absence of href attrib in links

### DIFF
--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -45,7 +45,7 @@ export default function LinkPreview( {
 	const displayTitle = richData?.title || value?.title || displayURL;
 
 	// url can be undefined if the href attribute is unset
-	const isEmptyURL = ! value.url?.length;
+	const isEmptyURL = ! value?.url?.length;
 
 	let icon;
 

--- a/packages/block-editor/src/components/link-control/link-preview.js
+++ b/packages/block-editor/src/components/link-control/link-preview.js
@@ -44,7 +44,8 @@ export default function LinkPreview( {
 
 	const displayTitle = richData?.title || value?.title || displayURL;
 
-	const isEmptyURL = ! value.url.length;
+	// url can be undefined if the href attribute is unset
+	const isEmptyURL = ! value.url?.length;
 
 	let icon;
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
When the href attribute is absent in anchors, the entire block containing such anchors crashes. Due to this [line](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/link-control/link-preview.js#L47). This tiny PR fixes the issue.

This is the only place in the codebase where we access a prop of `url` (as in `value.url.length`), so everywhere else handles `null` and `undefined` well.

## How has this been tested?
I tested before and after the change. The issue is resolved. To reproduce:

1. Add a paragraph with a few words. 
2. From the block menu, select “Edit HTML”.
3. Wrap some word with an anchor without href, like `<a>hello</a> world`.
4. Back to “Edit visually”.
5. Click the newly created link to generate a preview. The block will crash.

Apply this patch, and test again. All should work.

## Types of changes
Bugfix. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
