### PR TITLE
Site Editor: list view needs `enqueue_block_editor_assets`

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -123,6 +123,8 @@ function gutenberg_edit_site_list_init( $settings ) {
 			wp_json_encode( $settings )
 		)
 	);
+
+	do_action( 'enqueue_block_editor_assets' );
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The list view introduced in #36379 does not fire the `enqueue_block_editor_assets` action. It is possible that this oversight was intentional so as to keep that pageload faster, but it breaks any editor customization that depends on it. All of our other specialized editor instances (widgets, nav menus) have used it, and this should too.

For instance, on WordPress.com, we use `apiFetch.setFetchHandler` to rewrite REST API requests to our centralized `public-api.wordpress.com` URL. All of the loading code for this is hooked to `enqueue_block_editor_assets`, the correct place to add assets to the editor.

## How has this been tested?
Load the list view page, expected code hooked to `enqueue_block_editor_assets` is loaded.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- I've deleted the rest of the checklist as it was inapplicable.