### PR TITLE
Border panel: Update the value of the ColorPicker when color is cleared

### DIFF
--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -78,7 +78,7 @@ export function BorderColorEdit( props ) {
 				customBorderColor
 			)?.color
 		);
-	}, [ borderColor, customBorderColor ] );
+	}, [ borderColor, customBorderColor, availableColors ] );
 
 	const onChangeColor = ( value ) => {
 		setColorValue( value );

--- a/packages/block-editor/src/hooks/border-color.js
+++ b/packages/block-editor/src/hooks/border-color.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -56,14 +56,29 @@ export function BorderColorEdit( props ) {
 		( colors, origin ) => colors.concat( origin.colors ),
 		[]
 	);
+	const { color: customBorderColor } = style?.border || {};
 	const [ colorValue, setColorValue ] = useState(
 		() =>
 			getColorObjectByAttributeValues(
 				availableColors,
 				borderColor,
-				style?.border?.color
+				customBorderColor
 			)?.color
 	);
+
+	// Detect changes in the color attributes and update the colorValue to keep the
+	// UI in sync. This is necessary for situations when border controls interact with
+	// eachother: eg, setting the border width to zero causes the color and style
+	// selections to be cleared.
+	useEffect( () => {
+		setColorValue(
+			getColorObjectByAttributeValues(
+				availableColors,
+				borderColor,
+				customBorderColor
+			)?.color
+		);
+	}, [ borderColor, customBorderColor ] );
 
 	const onChangeColor = ( value ) => {
 		setColorValue( value );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Fixes #37047

## Description
<!-- Please describe what you have changed or added -->
When border width is set to zero, any selections for the color and style controls should be cleared. The attributes are correctly getting cleared, but the Color controls do not visually reflect this -- the color appears to remain selected. This PR just updates the Color controls to detect this change to the attributes.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a block with border color and width support, like Group
2. In the inspector controls, give the block a non-zero width
3. Select a border color (I selected orange)
4. Set the width to zero
5. Verify that not only is the color attribute cleared, but the icon in the palette is deselected.
6. Set the width to a non-zero value
7. Verify that the color attribute is restored and appears selected in the color palette again.

Test with both color presets and a custom border color.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![color-failing-to-clear](https://user-images.githubusercontent.com/63313398/144334304-ae6cb086-988e-4e04-80bd-f8a821a49868.gif) | ![color-clearing-correctly](https://user-images.githubusercontent.com/63313398/144334328-383616b0-086e-42e4-bcfb-b5cb7ab32e19.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
