### PR TITLE
Gallery: remove placeholder border

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -45,20 +45,6 @@ figure.wp-block-gallery {
 	}
 	.block-editor-media-placeholder {
 		margin: 0;
-
-		&::before {
-			box-shadow: 0 0 0 $border-width $white inset, 0 0 0 3px var(--wp-admin-theme-color) inset;
-			content: "";
-			// Shown in Windows 10 high contrast mode.
-			outline: 2px solid transparent;
-			position: absolute;
-			top: 0;
-			right: 0;
-			bottom: 0;
-			left: 0;
-			z-index: 1;
-			pointer-events: none;
-		}
 		.components-placeholder__label {
 			display: flex;
 		}


### PR DESCRIPTION

## Description

Now that we have Image Blocks in Galleries, there's the possibility that Image Block placeholders will also turn up.

To make focus behaviour consistent with the Image Block, this small PR removes the persistent border from the Image Block placeholder in the Gallery Block.

<img width="800" alt="Screen Shot 2021-12-02 at 11 57 03 am" src="https://user-images.githubusercontent.com/6458278/144342803-b795378d-3384-4074-923b-2a2de1d53c4e.png">

The Image Block placeholder won't appear very often in the Gallery Block, but it might if we delete an image from the media library. I first came across this while trying deal with [deleted images in the Image Block ](https://github.com/WordPress/gutenberg/pull/35973)

The blue border for [selected blocks is taken care of by default](https://github.com/WordPress/gutenberg/blob/c2d0c8c4a9aba52366f927d5885c18141967dbd7/packages/block-editor/src/components/block-list/style.scss#L159).

## Testing

Create a new post
Insert the following gallery code:

```html

<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="https://s.w.org/images/home/sotw-2021-draw-logo.png?1" alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image {"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img alt=""/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->

```

Check that the extra border on the placeholder does not appear.

Example:

![Kapture 2021-12-02 at 12 15 52](https://user-images.githubusercontent.com/6458278/144342568-4151ac80-d1e7-4797-892b-7c543818aba8.gif)

I've tested with v1 galleries as well to make sure. Seeing as Image Blocks do not appear in v1 galleries anyway, I think it's pretty safe.

<img width="733" alt="Screen Shot 2021-12-02 at 12 40 23 pm" src="https://user-images.githubusercontent.com/6458278/144342581-58c6c7ee-114d-4b54-99d4-f8f44bd43183.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
