### PR TITLE
Gradient: Fix clearing a custom gradient from throwing a React warning

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -462,7 +462,6 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 				textColor
 			)?.color;
 		}
-
 		if ( backgroundColor ) {
 			extraStyles.backgroundColor = getColorObjectByAttributeValues(
 				colors,

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -454,15 +454,21 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 			return <BlockListBlock { ...props } />;
 		}
 
-		const extraStyles = {
-			color: textColor
-				? getColorObjectByAttributeValues( colors, textColor )?.color
-				: undefined,
-			backgroundColor: backgroundColor
-				? getColorObjectByAttributeValues( colors, backgroundColor )
-						?.color
-				: undefined,
-		};
+		const extraStyles = {};
+
+		if ( textColor ) {
+			extraStyles.color = getColorObjectByAttributeValues(
+				colors,
+				textColor
+			)?.color;
+		}
+
+		if ( backgroundColor ) {
+			extraStyles.backgroundColor = getColorObjectByAttributeValues(
+				colors,
+				backgroundColor
+			)?.color;
+		}
 
 		let wrapperProps = props.wrapperProps;
 		wrapperProps = {

--- a/packages/block-editor/src/hooks/test/color.js
+++ b/packages/block-editor/src/hooks/test/color.js
@@ -1,12 +1,121 @@
 /**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
+import BlockEditorProvider from '../../components/provider';
 import { cleanEmptyObject } from '../utils';
+import { withColorPaletteStyles } from '../color';
 
 describe( 'cleanEmptyObject', () => {
 	it( 'should remove nested keys', () => {
 		expect( cleanEmptyObject( { color: { text: undefined } } ) ).toEqual(
 			undefined
 		);
+	} );
+} );
+
+describe( 'withColorPaletteStyles', () => {
+	const settings = {
+		__experimentalFeatures: {
+			color: {
+				palette: {
+					default: [
+						{
+							name: 'Pale pink',
+							slug: 'pale-pink',
+							color: '#f78da7',
+						},
+						{
+							name: 'Vivid green cyan',
+							slug: 'vivid-green-cyan',
+							color: '#00d084',
+						},
+					],
+				},
+			},
+		},
+	};
+
+	const EnhancedComponent = withColorPaletteStyles(
+		( { getStyleObj, wrapperProps } ) => (
+			<div>{ getStyleObj( wrapperProps.style ) }</div>
+		)
+	);
+
+	beforeAll( () => {
+		registerBlockType( 'core/test-block', {
+			save: () => undefined,
+			edit: () => undefined,
+			category: 'text',
+			title: 'test block',
+			supports: {
+				color: {
+					text: true,
+					background: true,
+				},
+			},
+		} );
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( 'core/test-block' );
+	} );
+
+	it( 'should add color styles from attributes', () => {
+		const getStyleObj = jest.fn();
+
+		render(
+			<BlockEditorProvider settings={ settings } value={ [] }>
+				<EnhancedComponent
+					attributes={ {
+						backgroundColor: 'vivid-green-cyan',
+						textColor: 'pale-pink',
+					} }
+					name="core/test-block"
+					getStyleObj={ getStyleObj }
+				/>
+			</BlockEditorProvider>
+		);
+
+		expect( getStyleObj ).toHaveBeenLastCalledWith( {
+			color: '#f78da7',
+			backgroundColor: '#00d084',
+		} );
+	} );
+
+	it( 'should not add undefined style values', () => {
+		// This test ensures that undefined `color` and `backgroundColor` styles
+		// are not added to the styles object. An undefined `backgroundColor`
+		// style causes a React warning when gradients are used, as the gradient
+		// style currently uses the `background` shorthand syntax.
+		// See: https://github.com/WordPress/gutenberg/issues/36899.
+		const getStyleObj = jest.fn();
+
+		render(
+			<BlockEditorProvider settings={ settings } value={ [] }>
+				<EnhancedComponent
+					attributes={ {
+						backgroundColor: undefined,
+						textColor: undefined,
+					} }
+					name="core/test-block"
+					getStyleObj={ getStyleObj }
+				/>
+			</BlockEditorProvider>
+		);
+		// Check explictly for the object used in the call, because
+		// `toHaveBeenCalledWith` does not check for empty keys.
+		expect(
+			getStyleObj.mock.calls[ getStyleObj.mock.calls.length - 1 ][ 0 ]
+		).toStrictEqual( {} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #36899

This PR updates the `withColorPaletteStyles` function in the Color block support to not return empty `color` and `backgroundColor` keys. This fixes a React warning that gets thrown when clearing a custom gradient used on a block's background color. To provide extra context:

The color gradient gets stored using the `background` shorthand. When we clear a gradient, the `background` style gets cleared, however in `withColorPaletteStyles` the `backgroundColor` is _also_ being set to `undefined`. Unfortunately for us, React treats this undefined value as us updating the style for the component, even though it has no visual effect. We receive the following warning in the console:

![image](https://user-images.githubusercontent.com/14988353/144360091-d870be3a-9b6c-44d4-ad32-2ce159ef2df5.png)

By explicitly ensuring that we don't set the `backgroundColor` property, we avoid throwing the React warning. Note: this fix is preferable to updating how we store the gradient value, so that we don't have to change how the gradient is saved in post content.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add a custom gradient to a block (e.g. the Group block) — a custom gradient is one that you select from the gradient slider, rather than the circular gradient preset buttons.
2. Before applying this PR, with your browser console window open, click the Clear button on the gradient
3. Notice the React warning in the console
4. With this PR applied, there should be no warning

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![Kapture 2021-12-02 at 15 51 27](https://user-images.githubusercontent.com/14988353/144359978-193a6741-8d5c-4fc3-ad53-f9ecbe97ea9a.gif) | ![Kapture 2021-12-02 at 15 49 54](https://user-images.githubusercontent.com/14988353/144359785-42eb67da-5cc4-468d-8d52-29f4670da1ea.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
