### PR TITLE
Use dropdown menus for nested color controls

### DIFF
--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -9,7 +9,6 @@ import { __ } from '@wordpress/i18n';
  */
 import PanelColorGradientSettings from '../components/colors-gradients/panel-color-gradient-settings';
 import ContrastChecker from '../components/contrast-checker';
-import InspectorControls from '../components/inspector-controls';
 import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
 
 function getComputedStyle( node ) {
@@ -20,7 +19,6 @@ export default function ColorPanel( {
 	settings,
 	clientId,
 	enableContrastChecking = true,
-	showTitle = true,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -54,22 +52,19 @@ export default function ColorPanel( {
 	} );
 
 	return (
-		<InspectorControls>
-			<PanelColorGradientSettings
-				title={ __( 'Color' ) }
-				initialOpen={ false }
-				settings={ settings }
-				showTitle={ showTitle }
-				__experimentalHasMultipleOrigins
-				__experimentalIsRenderedInSidebar
-			>
-				{ enableContrastChecking && (
-					<ContrastChecker
-						backgroundColor={ detectedBackgroundColor }
-						textColor={ detectedColor }
-					/>
-				) }
-			</PanelColorGradientSettings>
-		</InspectorControls>
+		<PanelColorGradientSettings
+			title={ __( 'Color' ) }
+			settings={ settings }
+			showTitle={ false }
+			__experimentalHasMultipleOrigins
+			__experimentalIsRenderedInSidebar
+		>
+			{ enableContrastChecking && (
+				<ContrastChecker
+					backgroundColor={ detectedBackgroundColor }
+					textColor={ detectedColor }
+				/>
+			) }
+		</PanelColorGradientSettings>
 	);
 }

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -2,27 +2,31 @@
  * WordPress dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import PanelColorGradientSettings from '../components/colors-gradients/panel-color-gradient-settings';
 import ContrastChecker from '../components/contrast-checker';
 import { __unstableUseBlockRef as useBlockRef } from '../components/block-list/use-block-props/use-block-refs';
+import ColorGradientControl from '../components/colors-gradients/control';
+import useCommonSingleMultipleSelects from '../components/colors-gradients/use-common-single-multiple-selects';
+import useSetting from '../components/use-setting';
 
 function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
 export default function ColorPanel( {
-	settings,
+	setting,
 	clientId,
 	enableContrastChecking = true,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 	const ref = useBlockRef( clientId );
+	const colorGradientSettings = useCommonSingleMultipleSelects();
+	colorGradientSettings.colors = useSetting( 'color.palette' );
+	colorGradientSettings.gradients = useSetting( 'color.gradients' );
 
 	useEffect( () => {
 		if ( ! enableContrastChecking ) {
@@ -52,19 +56,18 @@ export default function ColorPanel( {
 	} );
 
 	return (
-		<PanelColorGradientSettings
-			title={ __( 'Color' ) }
-			settings={ settings }
-			showTitle={ false }
-			__experimentalHasMultipleOrigins
-			__experimentalIsRenderedInSidebar
-		>
+		<div className="block-editor-panel-color-gradient-settings">
+			<ColorGradientControl
+				showTitle={ false }
+				{ ...colorGradientSettings }
+				{ ...setting }
+			/>
 			{ enableContrastChecking && (
 				<ContrastChecker
 					backgroundColor={ detectedBackgroundColor }
 					textColor={ detectedColor }
 				/>
 			) }
-		</PanelColorGradientSettings>
+		</div>
 	);
 }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -9,25 +9,18 @@ import { isObject, setWith, clone } from 'lodash';
  */
 import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport } from '@wordpress/blocks';
-import { __, isRTL } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useRef, useEffect, useMemo, Platform } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import {
-	__experimentalNavigatorProvider as NavigatorProvider,
-	__experimentalNavigatorScreen as NavigatorScreen,
-	__experimentalUseNavigator as useNavigator,
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
-	__experimentalView as View,
 	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	__experimentalSpacer as Spacer,
-	__experimentalHeading as Heading,
 	FlexItem,
 	ColorIndicator,
 	PanelBody,
+	Dropdown,
 } from '@wordpress/components';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -224,55 +217,6 @@ function immutableSet( object, path, value ) {
 	return setWith( object ? clone( object ) : {}, path, value, clone );
 }
 
-function NavigationButton( {
-	path,
-	icon,
-	children,
-	isBack = false,
-	...props
-} ) {
-	const navigator = useNavigator();
-	return (
-		<Item onClick={ () => navigator.push( path, { isBack } ) } { ...props }>
-			{ icon && (
-				<HStack justify="flex-start">
-					<FlexItem>
-						<Icon icon={ icon } size={ 24 } />
-					</FlexItem>
-					<FlexItem>{ children }</FlexItem>
-				</HStack>
-			) }
-			{ ! icon && children }
-		</Item>
-	);
-}
-
-function ScreenHeader( { back, title } ) {
-	return (
-		<VStack spacing={ 2 }>
-			<HStack spacing={ 2 }>
-				<View>
-					<NavigationButton
-						path={ back }
-						icon={
-							<Icon
-								icon={ isRTL() ? chevronRight : chevronLeft }
-								variant="muted"
-							/>
-						}
-						size="small"
-						isBack
-						aria-label={ __( 'Navigate to the previous view' ) }
-					/>
-				</View>
-				<Spacer>
-					<Heading level={ 5 }>{ title }</Heading>
-				</Spacer>
-			</HStack>
-		</VStack>
-	);
-}
-
 /**
  * Inspector control panel containing the color related configuration
  *
@@ -460,69 +404,39 @@ export function ColorEdit( props ) {
 				title={ __( 'Colors' ) }
 				className="block-editor__hooks-colors-panel"
 			>
-				<NavigatorProvider initialPath="/">
-					<NavigatorScreen path="/">
-						<ItemGroup isBordered isSeparated>
-							{ ( hasBackgroundColor || hasGradientColor ) && (
-								<NavigationButton path="/background">
-									<HStack justify="flex-start">
-										<FlexItem>
-											<ColorIndicator
-												colorValue={
-													gradientValue ??
-													backgroundValue
-												}
-											/>
-										</FlexItem>
-										<FlexItem>
-											{ __( 'Background' ) }
-										</FlexItem>
-									</HStack>
-								</NavigationButton>
-							) }
-							{ hasTextColor && (
-								<NavigationButton path="/text">
-									<HStack justify="flex-start">
-										<FlexItem>
-											<ColorIndicator
-												colorValue={ textColorValue }
-											/>
-										</FlexItem>
-										<FlexItem>{ __( 'Text' ) }</FlexItem>
-									</HStack>
-								</NavigationButton>
-							) }
-							{ hasLinkColor && (
-								<NavigationButton path="/link">
-									<HStack justify="flex-start">
-										<FlexItem>
-											<ColorIndicator
-												colorValue={ linkColorValue }
-											/>
-										</FlexItem>
-										<FlexItem>{ __( 'Links' ) }</FlexItem>
-									</HStack>
-								</NavigationButton>
-							) }
-						</ItemGroup>
-					</NavigatorScreen>
-
+				<ItemGroup isBordered isSeparated>
 					{ ( hasBackgroundColor || hasGradientColor ) && (
-						<NavigatorScreen path="/background">
-							<ScreenHeader
-								back="/"
-								title={ __( 'Background' ) }
-							/>
-							<ColorPanel
-								enableContrastChecking={
-									// Turn on contrast checker for web only since it's not supported on mobile yet.
-									Platform.OS === 'web' &&
-									! gradient &&
-									! style?.color?.gradient
-								}
-								clientId={ props.clientId }
-								settings={ [
-									{
+						<Dropdown
+							position="middle left"
+							renderToggle={ ( { onToggle } ) => {
+								return (
+									<Item onClick={ onToggle }>
+										<HStack justify="flex-start">
+											<FlexItem>
+												<ColorIndicator
+													colorValue={
+														gradientValue ??
+														backgroundValue
+													}
+												/>
+											</FlexItem>
+											<FlexItem>
+												{ __( 'Background' ) }
+											</FlexItem>
+										</HStack>
+									</Item>
+								);
+							} }
+							renderContent={ () => (
+								<ColorPanel
+									enableContrastChecking={
+										// Turn on contrast checker for web only since it's not supported on mobile yet.
+										Platform.OS === 'web' &&
+										! gradient &&
+										! style?.color?.gradient
+									}
+									clientId={ props.clientId }
+									setting={ {
 										label: __( 'Background color' ),
 										onColorChange: hasBackgroundColor
 											? onChangeColor( 'background' )
@@ -532,47 +446,69 @@ export function ColorEdit( props ) {
 										onGradientChange: hasGradientColor
 											? onChangeGradient
 											: undefined,
-									},
-								] }
-							/>
-						</NavigatorScreen>
+									} }
+								/>
+							) }
+						/>
 					) }
-
 					{ hasTextColor && (
-						<NavigatorScreen path="/text">
-							<ScreenHeader back="/" title={ __( 'Text' ) } />
-							<ColorPanel
-								enableContrastChecking={
-									// Turn on contrast checker for web only since it's not supported on mobile yet.
-									Platform.OS === 'web' &&
-									! gradient &&
-									! style?.color?.gradient
-								}
-								clientId={ props.clientId }
-								settings={ [
-									{
+						<Dropdown
+							position="middle left"
+							renderToggle={ ( { onToggle } ) => (
+								<Item onClick={ onToggle }>
+									<HStack justify="flex-start">
+										<FlexItem>
+											<ColorIndicator
+												colorValue={ textColorValue }
+											/>
+										</FlexItem>
+										<FlexItem>{ __( 'Text' ) }</FlexItem>
+									</HStack>
+								</Item>
+							) }
+							renderContent={ () => (
+								<ColorPanel
+									enableContrastChecking={
+										// Turn on contrast checker for web only since it's not supported on mobile yet.
+										Platform.OS === 'web' &&
+										! gradient &&
+										! style?.color?.gradient
+									}
+									clientId={ props.clientId }
+									setting={ {
 										label: __( 'Text color' ),
 										onColorChange: onChangeColor( 'text' ),
 										colorValue: textColorValue,
-									},
-								] }
-							/>
-						</NavigatorScreen>
+									} }
+								/>
+							) }
+						/>
 					) }
-
 					{ hasLinkColor && (
-						<NavigatorScreen path="/link">
-							<ScreenHeader back="/" title={ __( 'Link' ) } />
-							<ColorPanel
-								enableContrastChecking={
-									// Turn on contrast checker for web only since it's not supported on mobile yet.
-									Platform.OS === 'web' &&
-									! gradient &&
-									! style?.color?.gradient
-								}
-								clientId={ props.clientId }
-								settings={ [
-									{
+						<Dropdown
+							position="middle left"
+							renderToggle={ ( { onToggle } ) => (
+								<Item onClick={ onToggle }>
+									<HStack justify="flex-start">
+										<FlexItem>
+											<ColorIndicator
+												colorValue={ linkColorValue }
+											/>
+										</FlexItem>
+										<FlexItem>{ __( 'Links' ) }</FlexItem>
+									</HStack>
+								</Item>
+							) }
+							renderContent={ () => (
+								<ColorPanel
+									enableContrastChecking={
+										// Turn on contrast checker for web only since it's not supported on mobile yet.
+										Platform.OS === 'web' &&
+										! gradient &&
+										! style?.color?.gradient
+									}
+									clientId={ props.clientId }
+									setting={ {
 										label: __( 'Link Color' ),
 										onColorChange: onChangeLinkColor,
 										colorValue: getLinkColorFromAttributeValue(
@@ -581,12 +517,12 @@ export function ColorEdit( props ) {
 										),
 										clearable: !! style?.elements?.link
 											?.color?.text,
-									},
-								] }
-							/>
-						</NavigatorScreen>
+									} }
+								/>
+							) }
+						/>
 					) }
-				</NavigatorProvider>
+				</ItemGroup>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -407,7 +407,7 @@ export function ColorEdit( props ) {
 				<ItemGroup isBordered isSeparated>
 					{ ( hasBackgroundColor || hasGradientColor ) && (
 						<Dropdown
-							position="middle left"
+							contentClassName="block-editor__hooks-colors-panel__dropdown"
 							renderToggle={ ( { onToggle } ) => {
 								return (
 									<Item onClick={ onToggle }>
@@ -453,7 +453,7 @@ export function ColorEdit( props ) {
 					) }
 					{ hasTextColor && (
 						<Dropdown
-							position="middle left"
+							contentClassName="block-editor__hooks-colors-panel__dropdown"
 							renderToggle={ ( { onToggle } ) => (
 								<Item onClick={ onToggle }>
 									<HStack justify="flex-start">
@@ -486,7 +486,7 @@ export function ColorEdit( props ) {
 					) }
 					{ hasLinkColor && (
 						<Dropdown
-							position="middle left"
+							contentClassName="block-editor__hooks-colors-panel__dropdown"
 							renderToggle={ ( { onToggle } ) => (
 								<Item onClick={ onToggle }>
 									<HStack justify="flex-start">

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,5 +1,9 @@
 .block-editor__hooks-colors-panel {
 
+	.components-dropdown {
+		display: block;
+	}
+
 	// Allow horizontal overflow so the size-increasing color indicators don't cause a scrollbar.
 	.components-navigator-screen {
 		overflow-x: visible;

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,14 +1,23 @@
-.block-editor__hooks-colors-panel .component-color-indicator {
-	margin-left: 0;
-	display: block;
-	border-radius: 50%;
-	border: 0;
-	height: 24px;
-	width: 24px;
-	padding: 0;
-	background-image:
-		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
-		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
-	background-position: 0 0, 25px 25px;
-	background-size: calc(2 * 5px) calc(2 * 5px);
+.block-editor__hooks-colors-panel {
+
+	// Allow horizontal overflow so the size-increasing color indicators don't cause a scrollbar.
+	.components-navigator-screen {
+		overflow-x: visible;
+	}
+
+	// @todo: this can be removed when https://github.com/WordPress/gutenberg/pull/37028 lands.
+	.component-color-indicator {
+		margin-left: 0;
+		display: block;
+		border-radius: 50%;
+		border: 0;
+		height: 24px;
+		width: 24px;
+		padding: 0;
+		background-image:
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+		background-position: 0 0, 25px 25px;
+		background-size: calc(2 * 5px) calc(2 * 5px);
+	}
 }

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,0 +1,14 @@
+.block-editor__hooks-colors-panel .component-color-indicator {
+	margin-left: 0;
+	display: block;
+	border-radius: 50%;
+	border: 0;
+	height: 24px;
+	width: 24px;
+	padding: 0;
+	background-image:
+		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),
+		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
+	background-position: 0 0, 25px 25px;
+	background-size: calc(2 * 5px) calc(2 * 5px);
+}

--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,5 +1,4 @@
 .block-editor__hooks-colors-panel {
-
 	.components-dropdown {
 		display: block;
 	}
@@ -23,5 +22,12 @@
 			repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200);
 		background-position: 0 0, 25px 25px;
 		background-size: calc(2 * 5px) calc(2 * 5px);
+	}
+}
+
+@include break-medium() {
+	.block-editor__hooks-colors-panel__dropdown .components-popover__content {
+		margin-right: #{ math.div($sidebar-width, 2) + $grid-unit-20 } !important;
+		margin-top: #{ -($grid-unit-60 + $grid-unit-15) } !important;
 	}
 }

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -57,6 +57,7 @@
 @import "./hooks/border.scss";
 @import "./hooks/dimensions.scss";
 @import "./hooks/typography.scss";
+@import "./hooks/color.scss";
 
 @import "./components/block-toolbar/style.scss";
 @import "./components/inserter/style.scss";

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -28,6 +28,11 @@
 	&.is-opened {
 		padding: $grid-unit-20;
 	}
+
+	// Don't cascade the padding into nested panels.
+	.components-panel__body {
+		padding: 0;
+	}
 }
 
 .components-panel__header {


### PR DESCRIPTION
This is an alternative to #36952 

The idea is to simplify/clarify the colors UI in block inspectors using the ItemGroup approach used in Global Styles. The current PR doesn't use navigation but uses Dropdown components instead.

It does surface the double popover issue when clicking the custom color selector but for some reason it doesn't bother me much.

We can definitely take this approach a bit further by introducing navigation inside the popover to go to the custom color selector, the issue there is that the components for editing colors grew organically over time and are not in a very good state, there are special cases and components everywhere and I don't want to introduce another special case or another component there.