### PR TITLE
Navigation: Enable even more compact setup state.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -292,7 +292,6 @@ $color-control-label-height: 20px;
 
 // Selected state.
 .wp-block-navigation-placeholder__controls {
-	padding: $grid-unit-10;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
@@ -301,11 +300,7 @@ $color-control-label-height: 20px;
 	display: none;
 	position: relative;
 	z-index: 1;
-
-	// Adjust padding for when shown horizontally.
-	.is-large & {
-		padding: $grid-unit-05 $grid-unit-10;
-	}
+	padding: $grid-unit-05 $grid-unit-10;
 
 	// If an ancestor has a text-decoration property applied, it is inherited regardless of
 	// the specificity of a child element. Only pulling the child out of the flow fixes it.
@@ -318,9 +313,19 @@ $color-control-label-height: 20px;
 		display: flex;
 	}
 
-	// Show stacked for the vertical navigation, or small placeholders.
-	.is-small &,
+	// Hide a few elements in medium size placeholders.
+	// @todo: part of the code here will be irrelevant if https://github.com/WordPress/gutenberg/pull/36775 lands.
 	.is-medium & {
+		.wp-block-navigation-placeholder__actions__indicator,
+		.wp-block-navigation-placeholder__actions__indicator + hr,
+		.wp-block-navigation-placeholder__actions > :nth-last-child(3), // Add all pages.
+		.wp-block-navigation-placeholder__actions > :nth-last-child(2) { // hr separator after it.
+			display: none;
+		}
+	}
+
+	// Show stacked for the vertical navigation, or small placeholders.
+	.is-small & {
 		.wp-block-navigation-placeholder__actions {
 			flex-direction: column;
 		}
@@ -352,6 +357,11 @@ $color-control-label-height: 20px;
 			margin-right: $grid-unit-05;
 		}
 	}
+}
+
+// Keep as row for medium.
+.wp-block-navigation .components-placeholder.is-medium .components-placeholder__fieldset {
+	flex-direction: row !important;
 }
 
 .wp-block-navigation-placeholder__actions {


### PR DESCRIPTION
## Description

Fixes #37077.

This PR enables an even more compact setup state for when the block is used in very very narrow contexts. Shown in this GIF, a navigation block inside a 50% width column showing fewer buttons than the one outside:

![nav](https://user-images.githubusercontent.com/1204802/144569998-15c4dfb4-68cc-4fbb-98f0-99256658f6ec.gif)

Note that the code is a not as nice as it could be if we landed #36775. #36778 is also what I consider to be a more long term solution that both avoids layout shifts when selected, but also indicates the block could be used in a more preconfigured state. 

## How has this been tested?

Insert a navigation block in a thin column, and outside. Select it. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
