### PR TITLE
[Block Library]: Rename Query Pagination blocks

### DIFF
--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-next",
-	"title": "Pagination Next",
+	"title": "Next Page",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the next posts page link.",

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-next",
-	"title": "Query Pagination Next",
+	"title": "Pagination Next",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the next posts page link.",

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-numbers",
-	"title": "Pagination Numbers",
+	"title": "Page Numbers",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays a list of page numbers for pagination",

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-numbers",
-	"title": "Query Pagination Numbers",
+	"title": "Pagination Numbers",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays a list of page numbers for pagination",

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-previous",
-	"title": "Query Pagination Previous",
+	"title": "Pagination Previous",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the previous posts page link.",

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination-previous",
-	"title": "Pagination Previous",
+	"title": "Previous Page",
 	"category": "design",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the previous posts page link.",

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/query-pagination",
-	"title": "Query Pagination",
+	"title": "Pagination",
 	"category": "design",
 	"parent": [ "core/query" ],
 	"description": "Displays a paginated navigation to next/previous set of posts, when applicable.",


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/37079

> The Query Loop block's inner blocks all include the Query prefix in their names, making them sound more complex than they actually are.

This PR just renames these blocks to be more user-friendly, like Pagination Numbers instead of Query pagination numbers, as they are only surfaced within a Query Loop context.

I updated only the title of the blocks, making everything else work as before.