### PR TITLE
Tag Cloud Block: Add outline style

### DIFF
--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -51,5 +51,14 @@ function register_block_core_tag_cloud() {
 			'render_callback' => 'render_block_core_tag_cloud',
 		)
 	);
+
+	register_block_style(
+		'core/tag-cloud',
+		array(
+			'name'         => 'pill',
+			'label'        => __( 'Pill', 'gutenberg' ),
+			'style_handle' => 'pill',
+		)
+	);
 }
 add_action( 'init', 'register_block_core_tag_cloud' );

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -55,9 +55,9 @@ function register_block_core_tag_cloud() {
 	register_block_style(
 		'core/tag-cloud',
 		array(
-			'name'         => 'pill',
-			'label'        => __( 'Pill', 'gutenberg' ),
-			'style_handle' => 'pill',
+			'name'         => 'outline',
+			'label'        => __( 'Outline', 'gutenberg' ),
+			'style_handle' => 'outline',
 		)
 	);
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -21,15 +21,8 @@
 
 	&.is-style-pill a {
 		border: 1px solid var(--wp--preset--color--foreground);
-		border-radius: 5px;
 		font-size: var(--wp--preset--font-size--normal);
 		margin-bottom: 10px;
 		padding: 5px 10px;
-
-		&:active,
-		&:hover {
-			background-color: var(--wp--preset--color--foreground);
-			color: var(--wp--preset--color--background);
-		}
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -26,6 +26,7 @@
 		margin-bottom: 10px;
 		padding: 5px 10px;
 
+		&:active,
 		&:hover {
 			background-color: var(--wp--preset--color--foreground);
 			color: var(--wp--preset--color--background);

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -24,5 +24,6 @@
 		font-size: var(--wp--preset--font-size--normal);
 		margin-bottom: 10px;
 		padding: 5px 10px;
+		text-decoration: none;
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -18,4 +18,12 @@
 		margin-left: 5px;
 		text-decoration: none;
 	}
+
+	&.is-style-pill a {
+		border: 1px solid var(--wp--preset--color--foreground);
+		border-radius: 5px;
+		font-size: var(--wp--preset--font-size--normal);
+		margin-bottom: 10px;
+		padding: 5px 10px;
+	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -25,5 +25,10 @@
 		font-size: var(--wp--preset--font-size--normal);
 		margin-bottom: 10px;
 		padding: 5px 10px;
+
+		&:hover {
+			background-color: var(--wp--preset--color--foreground);
+			color: var(--wp--preset--color--background);
+		}
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -21,9 +21,10 @@
 
 	&.is-style-pill a {
 		border: 1px solid currentColor;
-		font-size: var(--wp--preset--font-size--normal);
-		margin-bottom: 10px;
-		padding: 5px 10px;
-		text-decoration: none;
+		font-size: var(--wp--preset--font-size--normal) !important; // !important Needed to override the inline styles.
+		margin-bottom: 1ch;
+		margin-right: 1ch;
+		padding: 1ch 2ch;
+		text-decoration: none !important; // !important needed to override generic post content link decoration.
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -20,7 +20,7 @@
 	}
 
 	&.is-style-pill a {
-		border: 1px solid var(--wp--preset--color--foreground);
+		border: 1px solid currentColor;
 		font-size: var(--wp--preset--font-size--normal);
 		margin-bottom: 10px;
 		padding: 5px 10px;

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -21,7 +21,7 @@
 
 	&.is-style-pill a {
 		border: 1px solid currentColor;
-		font-size: var(--wp--preset--font-size--medium) !important; // !important Needed to override the inline styles.
+		font-size: unset !important; // !important Needed to override the inline styles.
 		margin-bottom: 1ch;
 		margin-right: 1ch;
 		padding: 1ch 2ch;

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -19,7 +19,7 @@
 		text-decoration: none;
 	}
 
-	&.is-style-pill a {
+	&.is-style-outline a {
 		border: 1px solid currentColor;
 		font-size: unset !important; // !important Needed to override the inline styles.
 		margin-bottom: 1ch;

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -21,7 +21,7 @@
 
 	&.is-style-pill a {
 		border: 1px solid currentColor;
-		font-size: var(--wp--preset--font-size--normal) !important; // !important Needed to override the inline styles.
+		font-size: var(--wp--preset--font-size--medium) !important; // !important Needed to override the inline styles.
 		margin-bottom: 1ch;
 		margin-right: 1ch;
 		padding: 1ch 2ch;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This adds an outline style to the Tag Cloud block. We don't yet have an agreed standard for color names, so it's possible that these presets won't be defined in the theme.

## How has this been tested?
In TT2 and Skatepark

## Screenshots <!-- if applicable -->
<img width="315" alt="Screenshot 2021-12-03 at 10 42 51" src="https://user-images.githubusercontent.com/275961/144589557-3cf116ec-e870-4e01-876b-6f4bc0b8bb66.png">

<img width="818" alt="Screenshot 2021-12-16 at 12 18 02" src="https://user-images.githubusercontent.com/275961/146370721-2cdeaedd-7150-4a7f-ac5a-b6ff76c57004.png">
<img width="812" alt="Screenshot 2021-12-16 at 12 17 44" src="https://user-images.githubusercontent.com/275961/146370727-c0a5d49f-8fa4-483a-8c7a-c9c0535a00e6.png">



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
