### PR TITLE
`Card`: support the `extraSmall` option for the `size` prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Updated readme to include default value introduced in fix for unexpected movements in the `ColorPicker` ([#35670](https://github.com/WordPress/gutenberg/pull/35670)).
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 -   Fixed empty `ToolsPanel` height by correcting menu button line-height ([#36895](https://github.com/WordPress/gutenberg/pull/36895)).
+-   Added support for the legacy `extraSmall` value for the `size` prop in the `Card` component ([#37097](https://github.com/WordPress/gutenberg/pull/37097)).
 
 ### Experimental
 

--- a/packages/components/src/card/styles.js
+++ b/packages/components/src/card/styles.js
@@ -88,6 +88,10 @@ export const rounded = css`
 	border-radius: ${ CONFIG.cardBorderRadius };
 `;
 
+const xSmallCardPadding = css`
+	padding: ${ CONFIG.cardPaddingXSmall };
+`;
+
 export const cardPaddings = {
 	large: css`
 		padding: ${ CONFIG.cardPaddingLarge };
@@ -98,9 +102,10 @@ export const cardPaddings = {
 	small: css`
 		padding: ${ CONFIG.cardPaddingSmall };
 	`,
-	xSmall: css`
-		padding: ${ CONFIG.cardPaddingXSmall };
-	`,
+	xSmall: xSmallCardPadding,
+	// The `extraSmall` size is not officially documented, but the following styles
+	// are kept for legacy reasons to support older values of the `size` prop.
+	extraSmall: xSmallCardPadding,
 };
 
 export const shady = css`

--- a/packages/components/src/card/test/__snapshots__/index.js.snap
+++ b/packages/components/src/card/test/__snapshots__/index.js.snap
@@ -141,7 +141,7 @@ Snapshot Diff:
         </div>
         <div
 -         class="components-flex components-card__footer components-card-footer css-c7cteg-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-large-borderless em57xhy0"
-+         class="components-flex components-card__footer components-card-footer css-1mzdgj0-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-xSmall em57xhy0"
++         class="components-flex components-card__footer components-card-footer css-1t7s584-View-Flex-sx-Base-sx-Items-ItemsRow-Footer-borderRadius-borderColor-xSmallCardPadding em57xhy0"
           data-wp-c16t="true"
           data-wp-component="CardFooter"
         >
@@ -782,6 +782,11 @@ Snapshot Diff:
       data-wp-component="Elevation"
     />
   </div>
+`;
+
+exports[`Card Card component should support the legacy extraSmall value for the size prop as an alias for the xSmall value 1`] = `
+Snapshot Diff:
+Compared values have no visual difference.
 `;
 
 exports[`Card Card component should warn when the isElevated prop is passed 1`] = `

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -152,7 +152,7 @@ describe( 'Card', () => {
 				</Card>
 			);
 			const { container: containerExtraSmall } = render(
-				<Card isBorderless={ false } size="extraSmall">
+				<Card size="extraSmall">
 					<CardHeader>Header</CardHeader>
 					<CardBody>Body</CardBody>
 					<CardFooter>Footer</CardFooter>

--- a/packages/components/src/card/test/index.js
+++ b/packages/components/src/card/test/index.js
@@ -143,6 +143,26 @@ describe( 'Card', () => {
 			expect( withoutBorder ).toMatchDiffSnapshot( withBorder );
 		} );
 
+		it( 'should support the legacy extraSmall value for the size prop as an alias for the xSmall value', () => {
+			const { container: containerXSmall } = render(
+				<Card size="xSmall">
+					<CardHeader>Header</CardHeader>
+					<CardBody>Body</CardBody>
+					<CardFooter>Footer</CardFooter>
+				</Card>
+			);
+			const { container: containerExtraSmall } = render(
+				<Card isBorderless={ false } size="extraSmall">
+					<CardHeader>Header</CardHeader>
+					<CardBody>Body</CardBody>
+					<CardFooter>Footer</CardFooter>
+				</Card>
+			);
+			expect( containerXSmall ).toMatchDiffSnapshot(
+				containerExtraSmall
+			);
+		} );
+
 		describe( 'CardHeader', () => {
 			it( 'should render with a darker background color when isShady is true', () => {
 				const { container } = render( <CardHeader>Header</CardHeader> );

--- a/packages/components/src/card/types.ts
+++ b/packages/components/src/card/types.ts
@@ -9,6 +9,7 @@ import type { CSSProperties } from 'react';
  */
 import type { Props as SurfaceProps } from '../surface/types';
 
+type DeprecatedSizeOptions = 'extraSmall';
 export type SizeOptions = 'xSmall' | 'small' | 'medium' | 'large';
 
 type SizeableProps = {
@@ -17,7 +18,7 @@ type SizeableProps = {
 	 *
 	 * @default 'medium'
 	 */
-	size?: SizeOptions;
+	size?: SizeOptions | DeprecatedSizeOptions;
 };
 
 export type Props = SurfaceProps &


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

As reported in https://github.com/WordPress/gutenberg/pull/32566#issuecomment-985132091 , when the `Card` component was last updated, a change was introduced to the list of values accepted by the `size` prop.

In particular, prior to that PR, the `Card` component was able to accept the `extraSmall` value, while since that PR, it now accepts the `xSmall` value instead.

This PR introduces support for the legacy `extraSmall` value, avoiding a breaking change for the consumers of the component that are still using the older value.

Note: the older `extraSmall` value is not mentioned in the README on purpose, in order to encourage folks to use the newer `xSmall` value.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Storybook (you can edit the Card story and add `extraSmall` as a potential value for `size`
- Unit tests

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
