### PR TITLE
Remove some labels from the experiments sections of the changelog

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -62,13 +62,6 @@ const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
  * @type {Record<string,string>}
  */
 const LABEL_TYPE_MAPPING = {
-	'[Block] Navigation': 'Experiments',
-	'[Block] Post Comments Count': 'Experiments',
-	'[Block] Post Comments Form': 'Experiments',
-	'[Block] Post Comments': 'Experiments',
-	'[Block] Post Hierarchical Terms': 'Experiments',
-	'[Feature] Full Site Editing': 'Experiments',
-	'Global Styles': 'Experiments',
 	'[Feature] Navigation Screen': 'Experiments',
 	'[Package] Dependency Extraction Webpack Plugin': 'Tools',
 	'[Package] Jest Puppeteer aXe': 'Tools',

--- a/bin/plugin/commands/test/__snapshots__/changelog.js.snap
+++ b/bin/plugin/commands/test/__snapshots__/changelog.js.snap
@@ -45,6 +45,7 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 #### Block Library
 - Fix justification for button block when selected. ([33739](https://github.com/WordPress/gutenberg/pull/33739))
 - Fix navigation block appender invalid html. ([33964](https://github.com/WordPress/gutenberg/pull/33964))
+- Fix navigation margin collapsing. ([33021](https://github.com/WordPress/gutenberg/pull/33021))
 - Image Block: Fix issue with canInsertCover not being set to false for empty arrays. ([33863](https://github.com/WordPress/gutenberg/pull/33863))
 - [Query Pagination Numbers]: Fix first page's link. ([33629](https://github.com/WordPress/gutenberg/pull/33629))
 
@@ -113,18 +114,6 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 - Refactor the HierarchicalTermSelector so that it does not cause unnecessary loading of terms. ([33418](https://github.com/WordPress/gutenberg/pull/33418))
 
 
-### Experiments
-
-#### Full Site Editing
-- Site Editor: Implement a settings object filter. ([33737](https://github.com/WordPress/gutenberg/pull/33737))
-- Template Part placeholder - Add title step to creation flow. ([33703](https://github.com/WordPress/gutenberg/pull/33703))
-- Template part selection popover - minor style updates for visiblity. ([33733](https://github.com/WordPress/gutenberg/pull/33733))
-
-#### Block Library
-- Enable ability to remove a link from the Nav Link block in the Nav Block. ([33777](https://github.com/WordPress/gutenberg/pull/33777))
-- Fix navigation margin collapsing. ([33021](https://github.com/WordPress/gutenberg/pull/33021))
-
-
 ### Documentation
 
 - Add documentation to disable remote calls for block patterns. ([33930](https://github.com/WordPress/gutenberg/pull/33930))
@@ -186,8 +175,14 @@ exports[`formatChangelog verify that the changelog is properly formatted 1`] = `
 - Tune appender margin. ([33866](https://github.com/WordPress/gutenberg/pull/33866))
 
 #### Block Library
+- Enable ability to remove a link from the Nav Link block in the Nav Block. ([33777](https://github.com/WordPress/gutenberg/pull/33777))
 - Search Block: Removed components class from icon button and polished css. ([33961](https://github.com/WordPress/gutenberg/pull/33961))
 - [Button Block]: Add padding block support. ([31774](https://github.com/WordPress/gutenberg/pull/31774))
+
+#### Full Site Editing
+- Site Editor: Implement a settings object filter. ([33737](https://github.com/WordPress/gutenberg/pull/33737))
+- Template Part placeholder - Add title step to creation flow. ([33703](https://github.com/WordPress/gutenberg/pull/33703))
+- Template part selection popover - minor style updates for visiblity. ([33733](https://github.com/WordPress/gutenberg/pull/33733))
 
 #### Widgets Editor
 - Try to fix flaky customizer inspector test 2nd try. ([33965](https://github.com/WordPress/gutenberg/pull/33965))


### PR DESCRIPTION
The Changelog command automatically marks some labels as "experiments" but the list was outdated, this removes the features that are now stable.