### PR TITLE
Navigation: Remove blobs that look like a loading state

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -6,24 +6,18 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Icon, search } from '@wordpress/icons';
+import { Icon, navigation } from '@wordpress/icons';
 
 const PlaceholderPreview = ( { isLoading } ) => {
 	return (
-		<ul
+		<div
 			className={ classnames(
 				'wp-block-navigation-placeholder__preview',
-				'wp-block-navigation__container',
 				{ 'is-loading': isLoading }
 			) }
 		>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-placeholder__preview-search-icon">
-				<Icon icon={ search } />
-			</li>
-		</ul>
+			<Icon icon={ navigation } />
+		</div>
 	);
 };
 

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Icon, navigation } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 const PlaceholderPreview = ( { isLoading } ) => {
 	return (
@@ -16,7 +17,10 @@ const PlaceholderPreview = ( { isLoading } ) => {
 				{ 'is-loading': isLoading }
 			) }
 		>
-			<Icon icon={ navigation } />
+			<div className="wp-block-navigation-placeholder__actions__indicator">
+				<Icon icon={ navigation } />
+				{ __( 'Navigation' ) }
+			</div>
 		</div>
 	);
 };

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -342,6 +342,7 @@ $color-control-label-height: 20px;
 
 	svg {
 		margin-right: $grid-unit-05;
+		fill: currentColor;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -228,7 +228,7 @@ $color-control-label-height: 20px;
 	// For the placeholder indicators to colorize correctly, colors need to be inherited unless selected.
 	color: inherit;
 
-	.is-selected & {
+	.wp-block-navigation.is-selected & {
 		color: $gray-900;
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -237,9 +237,9 @@ $color-control-label-height: 20px;
 .wp-block-navigation-placeholder__preview {
 	display: flex;
 	align-items: center;
-	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
-	padding: $grid-unit-05 $grid-unit-10 $grid-unit-05 $grid-unit-15;
 	min-width: $grid-unit-10 * 12;
+	font-size: $default-font-size;
+	font-family: $default-font;
 
 	.wp-block-navigation.is-selected & {
 		display: none;
@@ -273,14 +273,18 @@ $color-control-label-height: 20px;
 }
 
 // Selected state.
+.wp-block-navigation-placeholder__preview,
 .wp-block-navigation-placeholder__controls {
-	padding: $grid-unit-05 $grid-unit-10;
+	padding: ($grid-unit-15 * 0.5) $grid-unit-10;
+	flex-direction: row;
+	align-items: center;
+}
+
+.wp-block-navigation-placeholder__controls {
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	display: none;
-	flex-direction: row;
-	align-items: center;
 	position: relative;
 	z-index: 1;
 
@@ -288,7 +292,6 @@ $color-control-label-height: 20px;
 	.wp-block-navigation.is-selected & {
 		display: flex;
 	}
-
 
 	// If an ancestor has a text-decoration property applied, it is inherited regardless of
 	// the specificity of a child element. Only pulling the child out of the flow fixes it.
@@ -323,22 +326,22 @@ $color-control-label-height: 20px;
 		margin-right: $grid-unit-15;
 		height: $button-size; // Prevents jumpiness.
 	}
+}
 
-	// Block title
-	.wp-block-navigation-placeholder__actions__indicator {
-		display: flex;
-		padding: 0 ($grid-unit-15 * 0.5) 0 0;
-		align-items: center;
-		justify-content: flex-start;
-		line-height: 0;
-		min-height: $button-size;
+// Block title
+.wp-block-navigation-placeholder__actions__indicator {
+	display: flex;
+	padding: 0 ($grid-unit-15 * 0.5) 0 0;
+	align-items: center;
+	justify-content: flex-start;
+	line-height: 0;
+	min-height: $button-size;
 
-		// Line up with the icon in the toolbar.
-		margin-left: $grid-unit-05;
+	// Line up with the icon in the toolbar.
+	margin-left: $grid-unit-05;
 
-		svg {
-			margin-right: $grid-unit-05;
-		}
+	svg {
+		margin-right: $grid-unit-05;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -191,10 +191,23 @@ $color-control-label-height: 20px;
 	justify-content: flex-start;
 }
 
+
 /**
  * Setup state
  */
 
+// Loading state.
+@keyframes loadingpulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
 // Unstyle some inherited placeholder component styles.
 .components-placeholder.wp-block-navigation-placeholder {
 	outline: none;
@@ -220,99 +233,62 @@ $color-control-label-height: 20px;
 	}
 }
 
-// Spinner.
-.wp-block-navigation-placeholder .components-spinner {
-	margin-top: -4px;
-	margin-left: 4px;
-	vertical-align: middle;
-	margin-right: 7px;
-}
-
-@keyframes loadingpulse {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
 	display: flex;
-	flex-direction: row;
 	align-items: center;
-	flex-wrap: nowrap;
-	width: 100%;
-	overflow: hidden;
+	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
+	padding: $grid-unit-05 $grid-unit-10 $grid-unit-05 $grid-unit-15;
+	min-width: $grid-unit-10 * 12;
 
-	&.is-loading {
-		animation: loadingpulse 1s linear infinite;
-		animation-delay: 0.5s; // avoid animating for fast network responses
+	.wp-block-navigation.is-selected & {
+		display: none;
 	}
 
-	// Style skeleton elements to mostly match the metrics of actual menu items.
-	// Needs specificity.
-	.wp-block-navigation-item.wp-block-navigation-item {
-		position: relative;
-		min-width: 72px;
+	// Draw the dashed outline.
+	// By setting the dashed border to currentColor, we ensure it's visible
+	// against any background color.
+	color: currentColor;
+	background: transparent;
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border: $border-width dashed currentColor;
+		opacity: 0.4;
+		pointer-events: none;
 
-		&::before {
-			display: block;
-			content: "";
-			border-radius: $radius-block-ui;
-			background: currentColor;
-			height: $grid-unit-20;
-			width: 100%;
-		}
+		// Inherit border radius from style variations.
+		border-radius: inherit;
 	}
 
-	.wp-block-navigation-placeholder__preview-search-icon {
-		height: $icon-size;
-		svg {
-			fill: currentColor;
-		}
-	}
-
-	.wp-block-navigation-item.wp-block-navigation-item,
-	.wp-block-navigation-placeholder__preview-search-icon {
-		opacity: 0.3;
-	}
-
-	&:not(.is-loading) {
-		// Don't show the preview boxes for an empty nav block,
-		// but be technically present to help size the empty state.
-		.wp-block-navigation.is-selected & {
-			display: flex;
-			opacity: 0;
-			width: 0;
-			overflow: hidden;
-			flex-wrap: nowrap;
-			flex: 0;
-		}
-
-		// Hide entirely when vertical.
-		.wp-block-navigation.is-selected .is-small &,
-		.wp-block-navigation.is-selected .is-medium & {
-			display: none;
-		}
+	> svg {
+		fill: currentColor;
+		opacity: 0.4;
 	}
 }
 
 // Selected state.
 .wp-block-navigation-placeholder__controls {
+	padding: $grid-unit-05 $grid-unit-10;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
+	display: none;
 	flex-direction: row;
 	align-items: center;
-	display: none;
 	position: relative;
 	z-index: 1;
-	padding: $grid-unit-05 $grid-unit-10;
+
+	// Show when selected.
+	.wp-block-navigation.is-selected & {
+		display: flex;
+	}
+
 
 	// If an ancestor has a text-decoration property applied, it is inherited regardless of
 	// the specificity of a child element. Only pulling the child out of the flow fixes it.
@@ -320,13 +296,8 @@ $color-control-label-height: 20px;
 	float: left;
 	width: 100%;
 
-	// Show when selected.
-	.wp-block-navigation.is-selected & {
-		display: flex;
-	}
-
-	// Hide a few elements in medium size placeholders.
-	// @todo: part of the code here will be irrelevant if https://github.com/WordPress/gutenberg/pull/36775 lands.
+	// Show stacked for the vertical navigation, or small placeholders.
+	.is-small &,
 	.is-medium & {
 		.wp-block-navigation-placeholder__actions__indicator,
 		.wp-block-navigation-placeholder__actions__indicator + hr,


### PR DESCRIPTION
## Description

Alternative to #36858 and #37144. Redesigns the navigation block setup state to not show fake menu item skeleton indicators.

The primary problem to solve is to make the navigation block look _unconfigured_, but still in this state blend a little bit into the theme to provide a better initial experience. The problem with the gray skeleton indicators was that they looked like a loading state, making people think the no further action was taken. A secondary issue was that the previous setup state caused layout shifts on selection. Some additional context from the original issue:

> The initial idea was to let themes preinsert a navigation block at an appropriate place in the theme, but leave it otherwise unconfigured. With that goal in mind, the gray blobs were meant to help the placeholder state pass the "squint test", to look at least a little bit like the end result at least when the block was unselected.
> 
> Feedback suggested this didn't quite work as intended, though: the blobs looked like a "skeleton loading state", that they would be replaced with the real menu once loading had completed.
> 
> There's persistence in the navigation block now, with contents saved separately, and options for providing defaults and fallbacks. Depending on where that lands, we might be able to provide better first run experiences. In any case, it changes the equation from before, where an empty and unconfigured navigation block was more likely to appear in themes.

This PR takes a different direction, leaning into the "generic placeholder" look we recently employed for Site Logo and Featured Image:

![navigation](https://user-images.githubusercontent.com/1204802/151158231-80714024-d3ed-4b6e-b1b4-19b1b7aa16ff.gif)

Let me know your thoughts!

## How has this been tested?

Insert a fresh navigation block, select and deselect it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
