### PR TITLE
Fix array key warning in block supports layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -167,7 +167,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$id              = uniqid();
 	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
 	$container_class = 'wp-container-' . $id . ' ';
-	$justify_class   = $used_layout['justifyContent'] ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
+	$justify_class   = isset( $used_layout['justifyContent'] ) ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(


### PR DESCRIPTION

## Description

During testing I noticed the following warning in PHP logs:

```
PHP Warning:  Undefined array key "justifyContent" in /home/mkaz/src/wp/gutenberg/lib/block-supports/layout.php on line 170, referer: http://localhost:8003/wp-admin/themes.php?page=gutenberg-edit-site&postId=twentytwentytwo%2F%2Fhome&postType=wp_template
```

This PR adds an isset() check for the justifyContent value to suppress the warning.

## How has this been tested?

1. Using twentytwentytwo with no changes
2. Enable debug logging / at least warning level
3. Open site in site editor and confirm warning
4. Apply patch, confirm warning goes away
5. Modfiy a block using justifyContent confirm works


## Types of changes

Switches a array check to `isset()`

