### PR TITLE
Add margin support to group block

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -26,6 +26,7 @@
 			"link": true
 		},
 		"spacing": {
+			"margin": true,
 			"padding": true,
 			"__experimentalDefaultControls": {
 				"padding": true


### PR DESCRIPTION
The group block currently supports padding, but not margin. This adds it in. The general reasoning for this is to bring the Group block on par with the spacing controls that used to exist for the Template Part block. 

Here's a specific use case though: In Twenty Twenty-Two, we used to have some margin applied to the bottom of the header template part. This was necessary to ensure consistent content/title spacing across pages. When support for Margin was removed from the Template Part block in https://github.com/WordPress/gutenberg/pull/36571, we had to [move those settings over to a Group block instead](https://github.com/WordPress/twentytwentytwo/pull/262). This worked fine, but the margin control [does not appear in the editor](https://github.com/WordPress/twentytwentytwo/issues/272) since the block does not "officially" support margin. That looks like a bug, and it prevents users from clearing that margin if they'd like to. 

Before|After
---|---
<img width="1198" alt="Screen Shot 2021-12-03 at 10 50 40 AM" src="https://user-images.githubusercontent.com/1202812/144632776-eb046238-b184-4a1b-86d3-6b3b865711c4.png">|<img width="1199" alt="Screen Shot 2021-12-03 at 10 49 57 AM" src="https://user-images.githubusercontent.com/1202812/144632778-1ce29358-ab61-4848-bb26-6274c729d4bb.png">

