### PR TITLE
Fix usage of useSetting('color.palette')

### DIFF
--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -36,8 +36,6 @@ const withCustomColorPalette = ( colorsArray ) =>
 		'withCustomColorPalette'
 	);
 
-const EMPTY_OBJECT = {};
-
 /**
  * Higher order component factory for injecting the editor colors as the
  * `colors` prop in the `withColors` HOC.
@@ -50,15 +48,12 @@ const withEditorColorPalette = () =>
 			// Some color settings have a special handling for deprecated flags in `useSetting`,
 			// so we can't unwrap them by doing const { ... } = useSetting('color')
 			// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
-			const colorPerOrigin =
-				useSetting( 'color.palette' ) || EMPTY_OBJECT;
+			const userPalette = useSetting( 'color.palette.custom' );
+			const themePalette = useSetting( 'color.palette.theme' );
+			const defaultPalette = useSetting( 'color.palette.default' );
 			const allColors = useMemo(
-				() => [
-					...( colorPerOrigin?.custom || [] ),
-					...( colorPerOrigin?.theme || [] ),
-					...( colorPerOrigin?.default || [] ),
-				],
-				[ colorPerOrigin ]
+				() => [ ...userPalette, ...themePalette, ...defaultPalette ],
+				[ userPalette, themePalette, defaultPalette ]
 			);
 			return <WrappedComponent { ...props } colors={ allColors } />;
 		},

--- a/packages/block-editor/src/components/colors/with-colors.js
+++ b/packages/block-editor/src/components/colors/with-colors.js
@@ -52,7 +52,11 @@ const withEditorColorPalette = () =>
 			const themePalette = useSetting( 'color.palette.theme' );
 			const defaultPalette = useSetting( 'color.palette.default' );
 			const allColors = useMemo(
-				() => [ ...userPalette, ...themePalette, ...defaultPalette ],
+				() => [
+					...( userPalette || [] ),
+					...( themePalette || [] ),
+					...( defaultPalette || [] ),
+				],
 				[ userPalette, themePalette, defaultPalette ]
 			);
 			return <WrappedComponent { ...props } colors={ allColors } />;

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -221,7 +221,13 @@ export function ColorEdit( props ) {
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
 	// so we can't unwrap them by doing const { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
-	const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
+	const userPalette = useSetting( 'color.palette.custom' );
+	const themePalette = useSetting( 'color.palette.theme' );
+	const defaultPalette = useSetting( 'color.palette.default' );
+	const allSolids = useMemo(
+		() => [ ...userPalette, ...themePalette, ...defaultPalette ],
+		[ userPalette, themePalette, defaultPalette ]
+	);
 	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
 	const areCustomSolidsEnabled = useSetting( 'color.custom' );
 	const areCustomGradientsEnabled = useSetting( 'color.customGradient' );
@@ -230,23 +236,12 @@ export function ColorEdit( props ) {
 	const isTextEnabled = useSetting( 'color.text' );
 
 	const solidsEnabled =
-		areCustomSolidsEnabled ||
-		! solidsPerOrigin?.theme ||
-		solidsPerOrigin?.theme?.length > 0;
+		areCustomSolidsEnabled || ! themePalette || themePalette?.length > 0;
 
 	const gradientsEnabled =
 		areCustomGradientsEnabled ||
 		! gradientsPerOrigin?.theme ||
 		gradientsPerOrigin?.theme?.length > 0;
-
-	const allSolids = useMemo(
-		() => [
-			...( solidsPerOrigin?.custom || [] ),
-			...( solidsPerOrigin?.theme || [] ),
-			...( solidsPerOrigin?.default || [] ),
-		],
-		[ solidsPerOrigin ]
-	);
 
 	const allGradients = useMemo(
 		() => [
@@ -444,19 +439,13 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 	( BlockListBlock ) => ( props ) => {
 		const { name, attributes } = props;
 		const { backgroundColor, textColor } = attributes;
-		const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
-		const colors = useMemo(
-			() => [
-				...( solidsPerOrigin?.custom || [] ),
-				...( solidsPerOrigin?.theme || [] ),
-				...( solidsPerOrigin?.default || [] ),
-			],
-			[ solidsPerOrigin ]
-		);
+		const userPalette = useSetting( 'color.palette.custom' ) || [];
+		const themePalette = useSetting( 'color.palette.theme' ) || [];
+		const defaultPalette = useSetting( 'color.palette.default' ) || [];
+		const colors = [ ...userPalette, ...themePalette, ...defaultPalette ];
 		if ( ! hasColorSupport( name ) || shouldSkipSerialization( name ) ) {
 			return <BlockListBlock { ...props } />;
 		}
-
 		const extraStyles = {};
 
 		if ( textColor ) {

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -225,7 +225,11 @@ export function ColorEdit( props ) {
 	const themePalette = useSetting( 'color.palette.theme' );
 	const defaultPalette = useSetting( 'color.palette.default' );
 	const allSolids = useMemo(
-		() => [ ...userPalette, ...themePalette, ...defaultPalette ],
+		() => [
+			...( userPalette || [] ),
+			...( themePalette || [] ),
+			...( defaultPalette || [] ),
+		],
 		[ userPalette, themePalette, defaultPalette ]
 	);
 	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
@@ -442,7 +446,14 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 		const userPalette = useSetting( 'color.palette.custom' ) || [];
 		const themePalette = useSetting( 'color.palette.theme' ) || [];
 		const defaultPalette = useSetting( 'color.palette.default' ) || [];
-		const colors = [ ...userPalette, ...themePalette, ...defaultPalette ];
+		const colors = useMemo(
+			() => [
+				...( userPalette || [] ),
+				...( themePalette || [] ),
+				...( defaultPalette || [] ),
+			],
+			[ userPalette, themePalette, defaultPalette ]
+		);
 		if ( ! hasColorSupport( name ) || shouldSkipSerialization( name ) ) {
 			return <BlockListBlock { ...props } />;
 		}

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -92,17 +92,11 @@ export function useColorProps( attributes ) {
 	// Some color settings have a special handling for deprecated flags in `useSetting`,
 	// so we can't unwrap them by doing const { ... } = useSetting('color')
 	// until https://github.com/WordPress/gutenberg/issues/37094 is fixed.
-	const solidsPerOrigin = useSetting( 'color.palette' ) || EMPTY_OBJECT;
+	const userPalette = useSetting( 'color.palette.custom' ) || [];
+	const themePalette = useSetting( 'color.palette.theme' ) || [];
+	const defaultPalette = useSetting( 'color.palette.default' ) || [];
 	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
-
-	const colors = useMemo(
-		() => [
-			...( solidsPerOrigin?.custom || [] ),
-			...( solidsPerOrigin?.theme || [] ),
-			...( solidsPerOrigin?.default || [] ),
-		],
-		[ solidsPerOrigin ]
-	);
+	const colors = [ ...userPalette, ...themePalette, ...defaultPalette ];
 	const gradients = useMemo(
 		() => [
 			...( gradientsPerOrigin?.custom || [] ),

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -96,7 +96,14 @@ export function useColorProps( attributes ) {
 	const themePalette = useSetting( 'color.palette.theme' ) || [];
 	const defaultPalette = useSetting( 'color.palette.default' ) || [];
 	const gradientsPerOrigin = useSetting( 'color.gradients' ) || EMPTY_OBJECT;
-	const colors = [ ...userPalette, ...themePalette, ...defaultPalette ];
+	const colors = useMemo(
+		() => [
+			...( userPalette || [] ),
+			...( themePalette || [] ),
+			...( defaultPalette || [] ),
+		],
+		[ userPalette, themePalette, defaultPalette ]
+	);
 	const gradients = useMemo(
 		() => [
 			...( gradientsPerOrigin?.custom || [] ),


### PR DESCRIPTION
Two recent PRs changing how we consume color palette settings conflicted and resulted in broken unit test (and broken behavior as well)

 - The first one moved from `useSetting( 'color.palette' )` to useSetting( 'color') in order to consume all subways (theme, default, custom): this is not great since useSetting( 'color' ) doesn't handle backward compatibility properly and shouldn't be used (ideally should be deprecated in favor of leaf keys. #36841 
 - The second one reverted that behavior but without accounting of the fact that the result of `useSetting('color.palette')` is different than `useSetting('color').palette` resulting in some breakage. #37051 

The unstable php tests (from core) didn't help identify that the test failures were actually valid.
 
This one tries to reconcile both.