### PR TITLE
[Try] remove template part from the post editor but not the site editor

### DIFF
--- a/packages/block-editor/src/components/block-env/README.md
+++ b/packages/block-editor/src/components/block-env/README.md
@@ -1,0 +1,56 @@
+# Block Context
+
+Block Context is a React implementation of WordPress's block context. Block context, much like [React's context](https://reactjs.org/docs/context.html), is a method for passing and inheriting values deeply through a hierarchy of blocks. Because of the similarities with React's context, the client-side implementation here is quite minimal. It is complemented by equivalent behaviors in the server-side rendering of a block.
+
+Note that the implementation of Block Context is distinct from [the `BlockEdit` context](../block-edit). While it is true that both provide context relevant for the editing of a block, Block Context is implemented separately so as to prioritize it as most identifiable amongst the machinery of block context, and not amongst other client-side editing context of a block.
+
+## Usage
+
+Currently, only the [Provider component](https://reactjs.org/docs/context.html#contextprovider) is made available on the public interface of the `@wordpress/block-editor` module. This can be used to add or override context which can then be consumed by blocks rendered within that context in the block editor.
+
+```js
+import { BlockContextProvider } from '@wordpress/block-editor';
+
+function MyCustomPostEditor() {
+	return (
+		<BlockContextProvider value={ { postId: 1, postType: 'post' } }>
+			<BlockEditorProvider { /* ... */ } />
+		</BlockContextProvider>
+	);
+}
+```
+
+Internal to the `@wordpress/block-editor` module, a component can access the [full Context object](https://reactjs.org/docs/context.html#api), typically for use in combination with [`useContext`](https://reactjs.org/docs/hooks-reference.html#usecontext).
+
+```js
+import { useContext } from '@wordpress/element';
+
+// Only available internally within `@wordpress/block-editor`!
+import BlockContext from '../block-context';
+
+function MyBlockComponent() {
+	const { postId } = useContext( BlockContext );
+
+	return 'The current post ID is: ' + postId;
+}
+```
+
+The reason `BlockContext` is only internally available within the `@wordpress/block-editor` module is to reinforce the expectation that external consumption of values from block context should be declared on the block registration using the `context` property.
+
+## Props
+
+`BlockContextProvider` behaves like a standard [`Context.Provider` component](https://reactjs.org/docs/context.html#contextprovider). It receives `value` and `children` props. The `value` is merged with the current block context value.
+
+### `value`
+
+-   Type: `Record<string,*>`
+-   Required: Yes
+
+Context value to merge with current value.
+
+### `children`
+
+-   Type: `ReactNode`
+-   Required: Yes
+
+Component children.

--- a/packages/block-editor/src/components/block-env/index.js
+++ b/packages/block-editor/src/components/block-env/index.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext, useMemo } from '@wordpress/element';
+
+/** @typedef {import('react').ReactNode} ReactNode */
+
+/**
+ * @typedef BlockContextProviderProps
+ *
+ * @property {Record<string,*>} value    Context value to merge with current
+ *                                       value.
+ * @property {ReactNode}        children Component children.
+ */
+
+/** @type {import('react').Context<Record<string,*>>} */
+export const EnvContext = createContext( 'root' );
+
+/**
+ * Component which merges passed value with current consumed block context.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-context/README.md
+ *
+ * @param {BlockContextProviderProps} props
+ */
+export function BlockEnvProvider( { name, children } ) {
+	const nextValue = useMemo( () => name, [ name ] );
+
+	return <EnvContext.Provider value={ nextValue } children={ children } />;
+}
+
+export default EnvContext;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -16,6 +16,7 @@ export { default as __experimentalBlockAlignmentMatrixControl } from './block-al
 export { default as BlockBreadcrumb } from './block-breadcrumb';
 export { default as __experimentalBlockContentOverlay } from './block-content-overlay';
 export { BlockContextProvider } from './block-context';
+export { BlockEnvProvider } from './block-env';
 export {
 	default as BlockControls,
 	BlockFormatControls,

--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -13,6 +13,8 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
+import { useContext } from '@wordpress/element';
+import { EnvContext } from '../../block-env';
 
 /**
  * Retrieves the block types inserter state.
@@ -22,6 +24,7 @@ import { store as blockEditorStore } from '../../../store';
  * @return {Array} Returns the block types state. (block types, categories, collections, onSelect handler)
  */
 const useBlockTypesState = ( rootClientId, onInsert ) => {
+	const env = useContext( EnvContext );
 	const { categories, collections, items } = useSelect(
 		( select ) => {
 			const { getInserterItems } = select( blockEditorStore );
@@ -30,7 +33,7 @@ const useBlockTypesState = ( rootClientId, onInsert ) => {
 			return {
 				categories: getCategories(),
 				collections: getCollections(),
-				items: getInserterItems( rootClientId ),
+				items: getInserterItems( rootClientId, env ),
 			};
 		},
 		[ rootClientId ]

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1410,10 +1410,24 @@ function getInsertUsage( state, id ) {
  * @param {Object}  blockType    BlockType
  * @param {?string} rootClientId Optional root client ID of block list.
  *
+ * @param           envs
+ * @param           env
  * @return {boolean} Whether the given block type is allowed to be shown in the inserter.
  */
-const canIncludeBlockTypeInInserter = ( state, blockType, rootClientId ) => {
+const canIncludeBlockTypeInInserter = (
+	state,
+	blockType,
+	rootClientId,
+	env
+) => {
 	if ( ! hasBlockSupport( blockType, 'inserter', true ) ) {
+		return false;
+	}
+
+	if (
+		blockType.supports?.inserterEnv &&
+		env !== blockType.supports.inserterEnv
+	) {
 		return false;
 	}
 
@@ -1558,7 +1572,7 @@ const buildBlockTypeItem = ( state, { buildScope = 'inserter' } ) => (
  * @property {number}   frecency          Heuristic that combines frequency and recency.
  */
 export const getInserterItems = createSelector(
-	( state, rootClientId = null ) => {
+	( state, rootClientId = null, envs = [] ) => {
 		const buildBlockTypeInserterItem = buildBlockTypeItem( state, {
 			buildScope: 'inserter',
 		} );
@@ -1631,7 +1645,12 @@ export const getInserterItems = createSelector(
 
 		const blockTypeInserterItems = getBlockTypes()
 			.filter( ( blockType ) =>
-				canIncludeBlockTypeInInserter( state, blockType, rootClientId )
+				canIncludeBlockTypeInInserter(
+					state,
+					blockType,
+					rootClientId,
+					envs
+				)
 			)
 			.map( buildBlockTypeInserterItem );
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -8,6 +8,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	useSetting,
+	BlockEnvProvider,
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
 	store as blockEditorStore,
 	Warning,
@@ -113,12 +114,14 @@ export default function PostContentEdit( { context, attributes } ) {
 	}
 
 	return (
-		<RecursionProvider>
-			{ contextPostId && contextPostType ? (
-				<Content context={ context } layout={ layout } />
-			) : (
-				<Placeholder />
-			) }
-		</RecursionProvider>
+		<BlockEnvProvider name="post">
+			<RecursionProvider>
+				{ contextPostId && contextPostType ? (
+					<Content context={ context } layout={ layout } />
+				) : (
+					<Placeholder />
+				) }
+			</RecursionProvider>
+		</BlockEnvProvider>
 	);
 }

--- a/packages/block-library/src/template-part/block.json
+++ b/packages/block-library/src/template-part/block.json
@@ -23,7 +23,8 @@
 	"supports": {
 		"align": true,
 		"html": false,
-		"reusable": false
+	  	"reusable": false,
+	  	"inserterEnv": "site"
 	},
 	"editorStyle": "wp-block-template-part-editor"
 }

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -15,6 +15,7 @@ import {
 	__experimentalLinkControl,
 	BlockInspector,
 	BlockTools,
+	BlockEnvProvider,
 	__unstableBlockSettingsMenuFirstItem,
 	__unstableUseTypingObserver as useTypingObserver,
 	store as blockEditorStore,
@@ -121,10 +122,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					settings={ settings }
 					contentRef={ mergedRefs }
 				>
-					<BlockList
-						className="edit-site-block-editor__block-list wp-site-blocks"
-						__experimentalLayout={ LAYOUT }
-					/>
+					<BlockEnvProvider name="site">
+						<BlockList
+							className="edit-site-block-editor__block-list wp-site-blocks"
+							__experimentalLayout={ LAYOUT }
+						/>
+					</BlockEnvProvider>
 				</ResizableEditor>
 
 				<__unstableBlockSettingsMenuFirstItem>


### PR DESCRIPTION
Solves #30668

This is an alternative to https://github.com/WordPress/gutenberg/pull/37065. As @ntsekouras mentioned:

> While we are in post editor we can edit the template and there (outside the PostContent block) the Template Part block should be available.

This means that it's not so much about the editor, as it is about the context.

This PR explores having a contextual label I called `env` for now (Let's absolutely find a better name for that). It is provided be specific blocks, overriding any parent setting like this:

```js
<BlockEnvProvider name="site">
	<BlockList
		className="edit-site-block-editor__block-list wp-site-blocks"
		__experimentalLayout={ LAYOUT }
	/>
</BlockEnvProvider>
```

The PostContent block would also define that label:

```js
<BlockEnvProvider name="post">
	<RecursionProvider>
		{ contextPostId && contextPostType ? (
			<Content context={ context } layout={ layout } />
		) : (
			<Placeholder />
		) }
	</RecursionProvider>
</BlockEnvProvider>
```

Then, the `TemplatePart` block would declare a support for specific env only, e.g. like `supports.inserterEnv = "site"`.

Finally, any inserter triggered inside that BlockList will then filter the blocks like:

```
if (
	blockType.supports?.inserterEnv &&
	env !== blockType.supports.inserterEnv
) {
	return false;
}
```

For now, this PR is just an exploration, a proof of concept. It has the following shortcomings:

* The global inserter cannot access the "env" and thus remove the unwanted blocks
* It is confusing to have both `inserter: true/false` and `inserterEnv: string` settings
* It doesn't support complex logic such as distinguishing between block variations, supporting a few different envs etc.

To that last point, @ntsekouras listed the following use cases:

> It seems that our current API inserter:true|false isn't enough. We have use cases that we would like to hide/show source blocks in the main inserter but being discoverable in the slash inserter, for example we want to hide Query Loop from the main inserter but show it's variations, and at the slash inserter to show the Query Loop block.

Perhaps adding `supports.inserter = "callback"` with a callback defined in `block/index.js` would be better suited here than a declarative `supports` entry?

cc @gziolo @youknowriad @talldan @priethor 