### PR TITLE
Storybook: Fix deprecated `disabled` key

### DIFF
--- a/packages/components/src/alignment-matrix-control/stories/index.js
+++ b/packages/components/src/alignment-matrix-control/stories/index.js
@@ -20,7 +20,7 @@ export default {
 	title: 'Components/AlignmentMatrixControl',
 	component: AlignmentMatrixControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/base-control/stories/index.js
+++ b/packages/components/src/base-control/stories/index.js
@@ -13,7 +13,7 @@ export default {
 	title: 'Components/BaseControl',
 	component: BaseControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/button/stories/index.js
+++ b/packages/components/src/button/stories/index.js
@@ -24,7 +24,7 @@ export default {
 	title: 'Components/Button',
 	component: Button,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/card/stories/index.js
+++ b/packages/components/src/card/stories/index.js
@@ -22,7 +22,7 @@ export default {
 	component: Card,
 	title: 'Components/Card',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/checkbox-control/stories/index.js
+++ b/packages/components/src/checkbox-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/CheckboxControl',
 	component: CheckboxControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/color-indicator/stories/index.js
+++ b/packages/components/src/color-indicator/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/ColorIndicator',
 	component: ColorIndicator,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/ColorPalette',
 	component: ColorPalette,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/color-picker/stories/index.js
+++ b/packages/components/src/color-picker/stories/index.js
@@ -20,7 +20,7 @@ export default {
 	component: ColorPicker,
 	title: 'Components/ColorPicker',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -16,7 +16,7 @@ export default {
 	component: ConfirmDialog,
 	title: 'Components (Experimental)/ConfirmDialog',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/DateTimePicker',
 	component: DateTimePicker,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/date-time/stories/time.js
+++ b/packages/components/src/date-time/stories/time.js
@@ -13,7 +13,7 @@ export default {
 	title: 'Components/TimePicker',
 	component: TimePicker,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/dropdown-menu/stories/index.js
+++ b/packages/components/src/dropdown-menu/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/DropdownMenu',
 	component: DropdownMenu,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/elevation/stories/index.js
+++ b/packages/components/src/elevation/stories/index.js
@@ -26,7 +26,7 @@ export default {
 	component: Elevation,
 	title: 'Components (Experimental)/Elevation',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/external-link/stories/index.js
+++ b/packages/components/src/external-link/stories/index.js
@@ -11,7 +11,7 @@ export default {
 	title: 'Components/ExternalLink',
 	component: ExternalLink,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/FontSizePicker',
 	component: FontSizePicker,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/form-token-field/stories/index.js
+++ b/packages/components/src/form-token-field/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/FormTokenField',
 	component: FormTokenField,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/gradient-picker/stories/index.js
+++ b/packages/components/src/gradient-picker/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/GradientPicker',
 	component: GradientPicker,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/grid/stories/index.js
+++ b/packages/components/src/grid/stories/index.js
@@ -13,7 +13,7 @@ export default {
 	component: Grid,
 	title: 'Components (Experimental)/Grid',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/guide/stories/index.js
+++ b/packages/components/src/guide/stories/index.js
@@ -19,7 +19,7 @@ export default {
 	title: 'Components/Guide',
 	component: Guide,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/icon/stories/index.js
+++ b/packages/components/src/icon/stories/index.js
@@ -18,7 +18,7 @@ export default {
 	title: 'Components/Icon',
 	component: Icon,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/input-control/stories/index.js
+++ b/packages/components/src/input-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/InputControl',
 	component: InputControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/item-group/stories/index.js
+++ b/packages/components/src/item-group/stories/index.js
@@ -32,7 +32,7 @@ export default {
 	component: ItemGroup,
 	title: 'Components (Experimental)/ItemGroup',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/modal/stories/index.js
+++ b/packages/components/src/modal/stories/index.js
@@ -20,7 +20,7 @@ export default {
 	title: 'Components/Modal',
 	component: Modal,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/notice/stories/index.js
+++ b/packages/components/src/notice/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/Notice',
 	component: Notice,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/NumberControl',
 	component: NumberControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -19,7 +19,7 @@ export default {
 	title: 'Components/Panel',
 	component: Panel,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/placeholder/stories/index.js
+++ b/packages/components/src/placeholder/stories/index.js
@@ -13,7 +13,7 @@ export default {
 	title: 'Components/Placeholder',
 	component: Placeholder,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/popover/stories/index.js
+++ b/packages/components/src/popover/stories/index.js
@@ -19,7 +19,7 @@ export default {
 	title: 'Components/Popover',
 	component: Popover,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/range-control/stories/index.js
+++ b/packages/components/src/range-control/stories/index.js
@@ -20,7 +20,7 @@ export default {
 	title: 'Components/RangeControl',
 	component: RangeControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/resizable-box/stories/index.js
+++ b/packages/components/src/resizable-box/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/ResizableBox',
 	component: ResizableBox,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/scrollable/stories/index.js
+++ b/packages/components/src/scrollable/stories/index.js
@@ -15,7 +15,7 @@ export default {
 	component: Scrollable,
 	title: 'Components (Experimental)/Scrollable',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/search-control/stories/index.js
+++ b/packages/components/src/search-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/SearchControl',
 	component: SearchControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/select-control/stories/index.js
+++ b/packages/components/src/select-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/SelectControl',
 	component: SelectControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/slot-fill/stories/index.js
+++ b/packages/components/src/slot-fill/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/SlotFill',
 	component: Slot,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/snackbar/stories/index.js
+++ b/packages/components/src/snackbar/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/Snackbar',
 	component: Snackbar,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/spacer/stories/index.js
+++ b/packages/components/src/spacer/stories/index.js
@@ -15,7 +15,7 @@ export default {
 	component: Spacer,
 	title: 'Components (Experimental)/Spacer',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/surface/stories/index.js
+++ b/packages/components/src/surface/stories/index.js
@@ -13,7 +13,7 @@ export default {
 	component: Surface,
 	title: 'Components (Experimental)/Surface',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/tab-panel/stories/index.js
+++ b/packages/components/src/tab-panel/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/TabPanel',
 	component: TabPanel,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/text-control/stories/index.js
+++ b/packages/components/src/text-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/TextControl',
 	component: TextControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/text-highlight/stories/index.js
+++ b/packages/components/src/text-highlight/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/TextHighlight',
 	component: TextHighlight,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/textarea-control/stories/index.js
+++ b/packages/components/src/textarea-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/TextareaControl',
 	component: TextareaControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/tip/stories/index.js
+++ b/packages/components/src/tip/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	title: 'Components/Tip',
 	component: Tip,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/toggle-control/stories/index.js
+++ b/packages/components/src/toggle-control/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/ToggleControl',
 	component: ToggleControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -19,7 +19,7 @@ export default {
 	component: ToggleGroupControl,
 	title: 'Components/ToggleGroupControl',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/toolbar-button/stories/index.js
+++ b/packages/components/src/toolbar-button/stories/index.js
@@ -18,7 +18,7 @@ export default {
 	title: 'Components/ToolbarButton',
 	component: ToolbarButton,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/tooltip/stories/index.js
+++ b/packages/components/src/tooltip/stories/index.js
@@ -18,7 +18,7 @@ export default {
 	title: 'Components/ToolTip',
 	component: Tooltip,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/tree-select/stories/index.js
+++ b/packages/components/src/tree-select/stories/index.js
@@ -17,7 +17,7 @@ export default {
 	title: 'Components/TreeSelect',
 	component: TreeSelect,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/truncate/stories/index.js
+++ b/packages/components/src/truncate/stories/index.js
@@ -12,7 +12,7 @@ export default {
 	component: Truncate,
 	title: 'Components (Experimental)/Truncate',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -19,7 +19,7 @@ export default {
 	title: 'Components/UnitControl',
 	component: UnitControl,
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/packages/components/src/z-stack/stories/index.js
+++ b/packages/components/src/z-stack/stories/index.js
@@ -15,7 +15,7 @@ export default {
 	component: ZStack,
 	title: 'Components (Experimental)/ZStack',
 	parameters: {
-		knobs: { disabled: false },
+		knobs: { disable: false },
 	},
 };
 

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -25,6 +25,6 @@ export const parameters = {
 	knobs: {
 		// Knobs are deprecated, and new stories should use addon-controls.
 		// Will be enabled on a per-story basis until migration is complete.
-		disabled: true,
+		disable: true,
 	},
 };


### PR DESCRIPTION
## Description

Storybook had been showing console warnings in some stories due to a [deprecated config key](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-disabled-parameter):

```
Use 'parameters.key.disable' instead of 'parameters.key.disabled'.
```

In this PR we migrate the deprecated `disabled` keys to the new `disable`.

## How has this been tested?

1. `npm run storybook:dev`
2. Go to http://localhost:50240/?path=/story/components-animate--default
3. DevTools console should not show the deprecated parameter warning.

## Types of changes

Bug fix (Storybook only)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
