### PR TITLE
Avoids polluting Layout functionality with Query Pagination specific requirements.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -167,12 +167,11 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$id              = uniqid();
 	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
 	$container_class = 'wp-container-' . $id . ' ';
-	$justify_class   = $used_layout['justifyContent'] ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . $container_class . $justify_class,
+		'class="' . $container_class,
 		$block_content,
 		1
 	);

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -18,8 +18,8 @@ function render_block_core_query_pagination( $attributes, $content ) {
 		return '';
 	}
 
-	$justifyContent = $attributes['layout']['justifyContent'];
-	$justify_class  = $justifyContent ? 'wp-justify-' . $justifyContent : '';
+	$justify_content = $attributes['layout']['justifyContent'];
+	$justify_class   = isset( $justify_content ) ? 'wp-justify-' . $justify_content : '';
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -18,9 +18,12 @@ function render_block_core_query_pagination( $attributes, $content ) {
 		return '';
 	}
 
+	$justifyContent = $attributes['layout']['justifyContent'];
+	$justify_class  = $justifyContent ? 'wp-justify-' . $justifyContent : '';
+
 	return sprintf(
 		'<div %1$s>%2$s</div>',
-		get_block_wrapper_attributes(),
+		get_block_wrapper_attributes( array( 'class' => $justify_class ) ),
 		$content
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This characteristic was introduced here by this recently merged PR https://github.com/WordPress/gutenberg/pull/36681 and currently it is only necesary for the Query Pagination.

As @ntsekouras suggested we would need to avoid adding extra logic to the Layout block support.  So I made this litte refactor to move the functionality to the block's code.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
`Wordpress 5.8.2`
`Gutenberg latest trunk version`

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
This is just a refactor and no functionality is changed.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
