### PR TITLE
PHP Unit Tests: Use global transients 

### DIFF
--- a/lib/class-wp-rest-url-details-controller.php
+++ b/lib/class-wp-rest-url-details-controller.php
@@ -383,7 +383,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 	 * @return mixed The value from the cache.
 	 */
 	private function get_cache( $key ) {
-		return get_transient( $key );
+		return get_site_transient( $key );
 	}
 
 	/**
@@ -406,7 +406,7 @@ class WP_REST_URL_Details_Controller extends WP_REST_Controller {
 		 */
 		$cache_expiration = apply_filters( 'rest_url_details_cache_expiration', $ttl );
 
-		return set_transient( $key, $data, $cache_expiration );
+		return set_site_transient( $key, $data, $cache_expiration );
 	}
 
 	/**

--- a/phpunit/class-wp-rest-url-details-controller-test.php
+++ b/phpunit/class-wp-rest-url-details-controller-test.php
@@ -277,11 +277,11 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 	public function test_will_return_from_cache_if_populated() {
 		$transient_name = 'g_url_details_response_' . md5( static::$url_placeholder );
 
-		remove_filter( "pre_transient_{$transient_name}", '__return_null' );
+		remove_filter( "pre_site_transient_{$transient_name}", '__return_null' );
 
 		// Force cache to return a known value as the remote URL http response body.
 		add_filter(
-			"pre_transient_{$transient_name}",
+			"pre_site_transient_{$transient_name}",
 			function() {
 				return '<html><head><title>This value from cache.</title></head><body></body></html>';
 			}
@@ -301,7 +301,7 @@ class WP_REST_URL_Details_Controller_Test extends WP_Test_REST_Controller_Testca
 		// Data should be that from cache not from mocked network response.
 		$this->assertContains( 'This value from cache', $data['title'] );
 
-		remove_all_filters( "pre_transient_{$transient_name}" );
+		remove_all_filters( "pre_site_transient_{$transient_name}" );
 	}
 
 	public function test_allows_filtering_data_retrieved_for_a_given_url() {


### PR DESCRIPTION
## Description

This PR is a just a test to see whether changing to the `pre_site_transient_filter` fixes the PHP unit tests, reflecting the changes in https://core.trac.wordpress.org/changeset/52311


## How has this been tested?
Silently. Waiting in the dark until the PHP Unit tests pass.

## Screenshots <!-- if applicable -->

<img width="829" alt="Screen Shot 2021-12-04 at 2 57 03 pm" src="https://user-images.githubusercontent.com/6458278/144696031-a5d1958d-ddd5-43fb-804a-ef43a705a0f8.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
