### PR TITLE
[Block Library - Query Pagination] Simplify pagination blocks

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -17,63 +17,65 @@
 function render_block_core_query_pagination_next( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes        = get_block_wrapper_attributes();
-	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
-	$default_label             = __( 'Next Page' );
-	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow          = get_query_pagination_arrow( $block, true );
-	$content                   = '';
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$default_label      = __( 'Next Page' );
+	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow   = get_query_pagination_arrow( $block, true );
+	$content            = '';
 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
 
+	// TODO: udpate below comment..
+	// If we are in query's first page, render a hidden placeholder for...(design) purposes??
+	$placholder_attributes = get_block_wrapper_attributes(
+		array(
+			'aria-hidden' => 'true',
+			'style'       => 'visibility:hidden;',
+		)
+	);
+	$placeholder           = sprintf(
+		'<span %1$s>%2$s</span>',
+		$placholder_attributes,
+		$label
+	);
+
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		global $wp_query;
-		// Take into account if we have set a bigger `max page`
-		// than what the query has.
-		$max_page               = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 		add_filter( 'next_posts_link_attributes', $filter_link_attributes );
-
-		// If there are pages to paginate.
-		if ( 1 < $max_page ) {
-			if ( (int) $max_page !== $paged ) { // If we are NOT in the last one.
-				$content = get_next_posts_link( $label, $max_page );
-			} else { // If we are in the last one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
+		// Take into account if we have set a bigger `max page`
+		// than what the query has.
+		global $wp_query;
+		if ( $max_page > $wp_query->max_num_pages ) {
+			$max_page = $wp_query->max_num_pages;
+		}
+		$content = get_next_posts_link( $label, $max_page );
+		if ( empty( $content ) ) {
+			// Return the placeholder content as we are in query's last page.
+			$content = $placeholder;
 		}
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
-	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_num_pages = $custom_query->max_num_pages ? $custom_query->max_num_pages : 1;
-		// If there are pages to paginate.
-		if ( 1 < $max_num_pages ) {
-			if ( (int) $max_num_pages !== $page ) { // If we are NOT in the last one.
-				$content = sprintf(
-					'<a href="%1$s" %2$s>%3$s</a>',
-					esc_url( add_query_arg( $page_key, $page + 1 ) ),
-					$wrapper_attributes,
-					$label
-				);
-			} else { // If we are in the last one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
+		return $content;
+	}
+	// We have a custom query here.
+	if ( ! $max_page || $max_page > $page ) {
+		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		if ( (int) $custom_query->max_num_pages !== $page ) {
+			$content = sprintf(
+				'<a href="%1$s" %2$s>%3$s</a>',
+				esc_url( add_query_arg( $page_key, $page + 1 ) ),
+				$wrapper_attributes,
+				$label
+			);
+		} else {
+			// Return the placeholder content as we are in query's last page.
+			$content = $placeholder;
 		}
 		wp_reset_postdata(); // Restore original Post Data.
 	}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -23,19 +23,23 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$pagination_arrow   = get_query_pagination_arrow( $block, false );
 
+	if ( $pagination_arrow ) {
+		$label = $pagination_arrow . $label;
+	}
 	// TODO: udpate below comment..
-	// Also we don't probably care about the arrow addition in $label below, do we?
-	// If we are in query's first page, render a hidden placeholder for...(design, accessibility) purposes??
-	$placholder_attributes = get_block_wrapper_attributes( array( 'style' => 'visibility:hidden;' ) );
+	// If we are in query's first page, render a hidden placeholder for...(design) purposes??
+	$placholder_attributes = get_block_wrapper_attributes(
+		array(
+			'aria-hidden' => 'true',
+			'style'       => 'visibility:hidden;',
+		)
+	);
 	$placeholder           = sprintf(
 		'<span %1$s>%2$s</span>',
 		$placholder_attributes,
 		$label
 	);
 
-	if ( $pagination_arrow ) {
-		$label = $pagination_arrow . $label;
-	}
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -17,15 +17,21 @@
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes        = get_block_wrapper_attributes();
-	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
-	$default_label             = __( 'Previous Page' );
-	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow          = get_query_pagination_arrow( $block, false );
-	$content                   = '';
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$default_label      = __( 'Previous Page' );
+	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow   = get_query_pagination_arrow( $block, false );
+
+	// TODO: udpate below comment..
+	// Also we don't probably care about the arrow addition in $label below, do we?
+	// If we are in query's first page, render a hidden placeholder for...(design, accessibility) purposes??
+	$placholder_attributes = get_block_wrapper_attributes( array( 'style' => 'visibility:hidden;' ) );
+	$placeholder           = sprintf(
+		'<span %1$s>%2$s</span>',
+		$placholder_attributes,
+		$label
+	);
 
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
@@ -33,49 +39,30 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		global $wp_query;
-		$max_page               = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-
-		// If there are pages to paginate...
-		if ( 1 < $max_page ) {
-			if ( 1 !== $paged ) { // ... and we are NOT in the first one.
-				$content = get_previous_posts_link( $label );
-			} else { // ... and we are in the first one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
+		$content = get_previous_posts_link( $label );
+		if ( empty( $content ) ) {
+			// Return the placeholder content as we are in query's first page.
+			$content = $placeholder;
 		}
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_num_pages = $custom_query->max_num_pages ? $custom_query->max_num_pages : 1;
-		// If there are pages to paginate...
-		if ( 1 < $max_num_pages ) {
-			if ( 1 !== $page ) { // ... and we are NOT in the first one.
-				$content = sprintf(
-					'<a href="%1$s" %2$s>%3$s</a>',
-					esc_url( add_query_arg( $page_key, $page - 1 ) ),
-					$wrapper_attributes,
-					$label
-				);
-			} else {  // ... and we are in the first one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
-		}
+		return $content;
 	}
-	return $content;
+	// We have a custom query here.
+	if ( 1 !== $page ) {
+		return sprintf(
+			'<a href="%1$s" %2$s>%3$s</a>',
+			esc_url( add_query_arg( $page_key, $page - 1 ) ),
+			$wrapper_attributes,
+			$label
+		);
+	}
+	// Return the placeholder content as we are in query's first page.
+	return $placeholder;
 }
 
 /**

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -31,11 +31,8 @@ $pagination-margin: 0.5em;
 			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
 		}
 	}
-
-	// Non-clickeable previous and next elements are not visible
-	>span.wp-block-query-pagination-next,
-	>span.wp-block-query-pagination-previous {
-		visibility: hidden;
+	&.aligncenter {
+		justify-content: center;
 	}
 
 	&.wp-justify-left,


### PR DESCRIPTION
Recently in this PR: https://github.com/WordPress/gutenberg/pull/36681, there were some changes to Query Pagination blocks which aimed to render a hidden placeholder element for design purposes, if I understand correctly for now.

I'm not sure if the problem could be solved with another `layout` (other than the currently used `flex`) but for now we  should at least try to simplify the code to achieve this.

There are some things that need to be investigated:
- [x] center align regression
- [ ] leaked specific block logic to the `layout` abstraction
- [ ] logic inside the `next/previous` pagination blocks

The PR's description will be updated as I'm looking through the needed changes. 


--cc @MaggieCabrera @scruffian  @matiasbenedetto 