### PR TITLE
Remove the semicolons from the JSON examples

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -14,7 +14,7 @@ Anchors let you link directly to a specific block on a page. This property adds 
 ```js
 // Declare support for anchor links.
 supports: {
-	anchor: true;
+	anchor: true
 }
 ```
 
@@ -30,14 +30,14 @@ supports: {
 	// Declare support for block's alignment.
 	// This adds support for all the options:
 	// left, center, right, wide, and full.
-	align: true;
+	align: true
 }
 ```
 
 ```js
 supports: {
 	// Declare support for specific alignment options.
-	align: [ 'left', 'right', 'full' ];
+	align: [ 'left', 'right', 'full' ]
 }
 ```
 
@@ -62,7 +62,7 @@ This property allows to enable [wide alignment](/docs/how-to-guides/themes/theme
 ```js
 supports: {
 	// Remove the support for wide alignment.
-	alignWide: false;
+	alignWide: false
 }
 ```
 
@@ -76,7 +76,7 @@ By default, the class `.wp-block-your-block-name` is added to the root element o
 ```js
 supports: {
 	// Remove the support for the generated className.
-	className: false;
+	className: false
 }
 ```
 
@@ -99,7 +99,7 @@ Note that the `background` and `text` keys have a default value of `true`, so if
 supports: {
 	color: {
 		// This also enables text and background UI controls.
-		gradients: true; // Enable gradients UI control.
+		gradients: true // Enable gradients UI control.
 	}
 }
 ```
@@ -406,7 +406,7 @@ This property adds a field to define a custom className for the block's wrapper.
 ```js
 supports: {
 	// Remove the support for the custom className.
-	customClassName: false;
+	customClassName: false
 }
 ```
 
@@ -420,7 +420,7 @@ When the style picker is shown, the user can set a default style for a block typ
 ```js
 supports: {
 	// Remove the Default Style picker.
-	defaultStylePicker: false;
+	defaultStylePicker: false
 }
 ```
 
@@ -434,7 +434,7 @@ By default, a block's markup can be edited individually. To disable this behavio
 ```js
 supports: {
 	// Remove support for an HTML mode.
-	html: false;
+	html: false
 }
 ```
 
@@ -448,7 +448,7 @@ By default, all blocks will appear in the inserter. To hide a block so that it c
 ```js
 supports: {
 	// Hide this block from the inserter.
-	inserter: false;
+	inserter: false
 }
 ```
 
@@ -462,7 +462,7 @@ A non-multiple block can be inserted into each post, one time only. For example,
 ```js
 supports: {
 	// Use the block just once per post
-	multiple: false;
+	multiple: false
 }
 ```
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
I was working through the "Supports" documentation and realised there are some semicolons in the JSON examples. It's best if we remove these so if people are copy and pasting anything into their JSON files it'll work as expected and they don't need to remove the semicolons manually to get webpack to build assets successfully.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
I've copied and pasted these into my `block.json` file and webpack has compiled them successfully.
<!-- Include details of your testing environment, tests ran to see how -->
I was running [Chassis](http://chassis.io/) locally with `npm run start` so that webpack would build my assets.
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
This simply updates the documentation in the Developer Handbook for the "Supports" section in the Block API Reference section.
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
