### PR TITLE
Site Editor: Display a notice if export fails

### DIFF
--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -1,21 +1,13 @@
 /**
- * External dependencies
- */
-import downloadjs from 'downloadjs';
-
-/**
  * WordPress dependencies
  */
-import { MenuItem } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import apiFetch from '@wordpress/api-fetch';
-import { download } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import ToolsMoreMenuGroup from '../components/header/tools-more-menu-group';
+import SiteExport from './site-export';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
 
 registerPlugin( 'edit-site', {
@@ -23,29 +15,7 @@ registerPlugin( 'edit-site', {
 		return (
 			<>
 				<ToolsMoreMenuGroup>
-					<MenuItem
-						role="menuitem"
-						icon={ download }
-						onClick={ () =>
-							apiFetch( {
-								path: '/wp-block-editor/v1/export',
-								parse: false,
-							} )
-								.then( ( res ) => res.blob() )
-								.then( ( blob ) =>
-									downloadjs(
-										blob,
-										'edit-site-export.zip',
-										'application/zip'
-									)
-								)
-						}
-						info={ __(
-							'Download your templates and template parts.'
-						) }
-					>
-						{ __( 'Export' ) }
-					</MenuItem>
+					<SiteExport />
 					<WelcomeGuideMenuItem />
 				</ToolsMoreMenuGroup>
 			</>

--- a/packages/edit-site/src/plugins/site-export.js
+++ b/packages/edit-site/src/plugins/site-export.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import downloadjs from 'downloadjs';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { MenuItem } from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { download } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
+
+export default function SiteExport() {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	async function handleExport() {
+		try {
+			const response = await apiFetch( {
+				path: '/wp-block-editor/v1/export',
+				parse: false,
+			} );
+			const blob = await response.blob();
+
+			downloadjs( blob, 'edit-site-export.zip', 'application/zip' );
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the site export.' );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	}
+
+	return (
+		<MenuItem
+			role="menuitem"
+			icon={ download }
+			onClick={ handleExport }
+			info={ __( 'Download your templates and template parts.' ) }
+		>
+			{ __( 'Export' ) }
+		</MenuItem>
+	);
+}


### PR DESCRIPTION
## Description
PR adds error handling for Site Editor export functionality.

P.S. I've also extracted the Export menu item into a separate component for convenience 

## How has this been tested?
1. Go to the Site Editor.
2. Emulate offline mode using DevTools.
3. Open the "More tools and options" dropdown and trigger export.
4. A snackbar notice should be displayed with an error message.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-05 at 15 56 52](https://user-images.githubusercontent.com/240569/144745644-ffbb6c7e-b369-4d16-9415-9a56d3f814cb.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
