### PR TITLE
Fix docs and function naming for gallery block registration in PHP

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Server-side rendering of the `core/image` block.
+ * Server-side rendering of the `core/gallery` block.
  *
  * @package WordPress
  */
@@ -13,9 +13,8 @@
  * we add a custom `data-id` attribute before rendering the gallery
  * so that the Image Block can pick it up in its render_callback.
  *
- * @param  array $parsed_block A single parsed block object.
- *
- * @return array               The migrated block object.
+ * @param array $parsed_block The block being rendered.
+ * @return array The migrated block object.
  */
 function render_block_core_gallery_data( $parsed_block ) {
 	if ( 'core/gallery' === $parsed_block['blockName'] ) {

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -16,7 +16,7 @@
  * @param array $parsed_block The block being rendered.
  * @return array The migrated block object.
  */
-function render_block_core_gallery_data( $parsed_block ) {
+function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
 	if ( 'core/gallery' === $parsed_block['blockName'] ) {
 		foreach ( $parsed_block['innerBlocks'] as $key => $inner_block ) {
 			if ( 'core/image' === $inner_block['blockName'] ) {
@@ -30,7 +30,7 @@ function render_block_core_gallery_data( $parsed_block ) {
 	return $parsed_block;
 }
 
-add_filter( 'render_block_data', 'render_block_core_gallery_data' );
+add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
 
 /**
  * Registers the `core/gallery` block on server.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -38,7 +38,7 @@ add_filter( 'render_block_data', 'render_block_core_gallery_data' );
  * This render callback needs to be here
  * so that the gallery styles are loaded in block-based themes.
  */
-function gutenberg_register_block_core_gallery() {
+function register_block_core_gallery() {
 	register_block_type_from_metadata(
 		__DIR__ . '/gallery',
 		array(
@@ -49,4 +49,4 @@ function gutenberg_register_block_core_gallery() {
 	);
 }
 
-add_action( 'init', 'gutenberg_register_block_core_gallery', 20 );
+add_action( 'init', 'register_block_core_gallery', 20 );

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -11,7 +11,7 @@
  *
  * @param  array $attributes The block attributes.
  * @param  array $content    The block content.
- * @return string            Returns the block content with the data-id attribute added.
+ * @return string Returns the block content with the data-id attribute added.
  */
 function render_block_core_image( $attributes, $content ) {
 	if ( isset( $attributes['data-id'] ) ) {


### PR DESCRIPTION
## Description
This PRs removes the `gutenberg_` prefix for `gutenberg_register_block_core_gallery()` so it can be merged to WordPress core. It also improves the naming for `render_block_core_gallery_data()` to be less generic. And some minor doc changes.

I noticed these issue because I was trying to test the new gallery block in the current WordPress 5.9 beta but that didn't work since it's not enabled which may be an oversee. See also https://github.com/WordPress/gutenberg/pull/36508#issuecomment-986248683.

This change is required for https://github.com/WordPress/wordpress-develop/pull/2009

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
