### PR TITLE
Block Styles: remove duplicate styles

### DIFF
--- a/packages/block-editor/src/components/block-styles/style.scss
+++ b/packages/block-editor/src/components/block-styles/style.scss
@@ -6,13 +6,7 @@
 	display: none;
 	position: absolute;
 	right: $grid-unit-20;
-	top: $grid-unit-20;
-	border: $border-width solid $gray-300;
-	border-radius: $radius-block-ui;
-	background: $white;
-	width: 300px;
 	left: auto;
-	overflow: hidden;
 	// Same layer as the sidebar from which it's triggered.
 	z-index: z-index(".interface-interface-skeleton__sidebar {greater than small}");
 


### PR DESCRIPTION
## Description
This PR removes the duplicate styles, letting the `.block-editor-block-styles_preview-panel` underneath define the border and other common properties.

The most obvious effect of these changes is the vanquishing of the double border.

**Before**
<img width="300" alt="Screen Shot 2021-12-06 at 9 56 34 am" src="https://user-images.githubusercontent.com/6458278/144767302-b0398d10-9e7e-4b4f-80d2-cc5ec4257371.png">

**After**
<img width="300" alt="Screen Shot 2021-12-06 at 9 54 21 am" src="https://user-images.githubusercontent.com/6458278/144767266-ea1d77af-5823-45d7-ba35-2e6213c85584.png">

## Testing

Fire up this branch.
Insert a block that has variations, e.g., Image, Table or Button
Focus/Mouseover the block style button in the sidebar.
Ensure that the preview appear as expected (in the top, right-hand corner of the editor) and that there's a single border.

Props to @shaunandrews for spotting the border

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
