### PR TITLE
Gallery block: enable the new gallery block by default if running in core 

### DIFF
--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -29,11 +29,17 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
  * can be removed when minimum supported WP version >=5.9.
  */
 export function isGalleryV2Enabled() {
-	// We want to fail early here, at least during beta testing phase, to ensure
-	// there aren't instances where undefined values cause false negatives.
-	if ( ! window.wp || typeof window.wp.galleryBlockV2Enabled !== 'boolean' ) {
-		throw 'window.wp.galleryBlockV2Enabled is not defined';
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		// We want to fail early here, at least during beta testing phase, to ensure
+		// there aren't instances where undefined values cause false negatives.
+		if (
+			! window.wp ||
+			typeof window.wp.galleryBlockV2Enabled !== 'boolean'
+		) {
+			throw 'window.wp.galleryBlockV2Enabled is not defined';
+		}
+		return window.wp.galleryBlockV2Enabled;
 	}
 
-	return window.wp.galleryBlockV2Enabled;
+	return true;
 }

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -29,6 +29,8 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
  * can be removed when minimum supported WP version >=5.9.
  */
 export function isGalleryV2Enabled() {
+	// Only run the Gallery version compat check if the plugin is running, otherwise
+	// assume we are in 5.9 core and enable by default.
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		// We want to fail early here, at least during beta testing phase, to ensure
 		// there aren't instances where undefined values cause false negatives.


### PR DESCRIPTION
## Description
Add a check to see if running in plugin in core, and only check Gallery block version compatibility if in plugin, otherwise enable the new version by default

## How has this been tested?
Add a v1 gallery block to a site with use_balanceTags enabled
Check out this PR and make sure the block remains in v1 format and new blocks added are v1
Turn off the use_balanceTags option and check that the v1 blocks migrate to v2 and new blocks are v2 format
