### PR TITLE
E2E Tests: Increase delay in image block e2e test to fix intermittent failure when clearing url field

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -344,8 +344,7 @@ describe( 'Image', () => {
 
 		// Clear the input field. Delay added to account for typing delays.
 		const inputField = await page.$( '.block-editor-url-input__input' );
-		await inputField.click( { clickCount: 3, delay: 100 } );
-		await page.keyboard.press( 'Backspace', { delay: 100 } );
+		await inputField.click( { clickCount: 3, delay: 200 } );
 
 		// Replace the url. Delay added to account for typing delays.
 		await page.focus( '.block-editor-url-input__input' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR implements the suggestion from @aaronrobertshaw in https://github.com/WordPress/gutenberg/pull/36982#discussion_r758972413 to increase the delay when clearing the input field in the Image block's e2e test. While testing locally, we noticed intermittent test failures in the clearing of the URL field, and slightly increasing the delay appears to improve the reliability without adding too much time to the test.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Locally, before checking out this PR, and after starting up `wp-env` and running `npm run dev`, run the following:

```
npm run test-e2e specs/editor/blocks/image.test.js
```

Before this PR, the tests pass for me _most_ of the time. However, after running the above command 5 or 6 times, it starts to fail with the error shown in the screenshot below.

With this PR applied, the tests appear to pass consistently in my local environment.

## Screenshots <!-- if applicable -->

This is the intermittent error message I would sometimes get prior to this PR. Note that in the "received" string, the UUID-based filename still appears in the URL and has not been cleared, so the target url has been appended to that string. In the expected string, the UUID filename is replaced with `/wp-includes/images/w-logo-blue.png`.

![image](https://user-images.githubusercontent.com/14988353/144780509-09ae7785-558f-4c37-9bd4-5b8d293cb16c.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code quality / test reliability.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
