### PR TITLE
E2E Tests: Update Multi Entity Saving test to improve reliability

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+-   Added `getOption` and `setOption` functions to make it easier to set and reset options such as the site title and site tagline ([#37139](https://github.com/WordPress/gutenberg/pull/37139)).
+
 ### Breaking Changes
 
 -   The peer `puppeteer` dependency has been replaced with `puppeteer-core` requiring version `>=11` (see [Breaking Changes](https://github.com/puppeteer/puppeteer/releases/tag/v11.0.0), [#36040](https://github.com/WordPress/gutenberg/pull/36040)).

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -363,6 +363,18 @@ _Returns_
 
 -   `Promise`: Promise resolving with post content markup.
 
+### getOption
+
+Returns a site option, from the options admin page.
+
+_Parameters_
+
+-   _setting_ `string`: The option, used to get the option by id.
+
+_Returns_
+
+-   `string`: The value of the option.
+
 ### getPageError
 
 Returns a promise resolving to one of either a string or null. A string will
@@ -632,6 +644,15 @@ _Parameters_
 -   _$1_ `Object`: Options.
 -   _$1.plainText_ `string`: Plain text to set.
 -   _$1.html_ `string`: HTML to set.
+
+### setOption
+
+Sets a site option, from the options-general admin page.
+
+_Parameters_
+
+-   _setting_ `string`: The option, used to get the option by id.
+-   _value_ `string`: The value to set the option to.
 
 ### setPostContent
 

--- a/packages/e2e-test-utils/src/get-option.js
+++ b/packages/e2e-test-utils/src/get-option.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { switchUserToAdmin } from './switch-user-to-admin';
+import { visitAdminPage } from './visit-admin-page';
+import { switchUserToTest } from './switch-user-to-test';
+
+/**
+ * Returns a site option, from the options admin page.
+ *
+ * @param {string} setting The option, used to get the option by id.
+ * @return {string} The value of the option.
+ */
+export async function getOption( setting ) {
+	await switchUserToAdmin();
+	await visitAdminPage( 'options.php' );
+
+	const value = await page.$eval(
+		`#${ setting }`,
+		( element ) => element.value
+	);
+	await switchUserToTest();
+	return value;
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -38,6 +38,7 @@ export { getEditedPostContent } from './get-edited-post-content';
 export { getCurrentPostContent } from './get-current-post-content';
 export { hasBlockSwitcher } from './has-block-switcher';
 export { getPageError } from './get-page-error';
+export { getOption } from './get-option';
 export {
 	insertBlock,
 	insertPattern,
@@ -74,6 +75,7 @@ export { publishPostWithPrePublishChecksDisabled } from './publish-post-with-pre
 export { saveDraft } from './save-draft';
 export { selectBlockByClientId } from './select-block-by-client-id';
 export { setBrowserViewport } from './set-browser-viewport';
+export { setOption } from './set-option';
 export { setPostContent } from './set-post-content';
 export { switchEditorModeTo } from './switch-editor-mode-to';
 export { switchUserToAdmin } from './switch-user-to-admin';

--- a/packages/e2e-test-utils/src/set-option.js
+++ b/packages/e2e-test-utils/src/set-option.js
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { switchUserToAdmin } from './switch-user-to-admin';
+import { visitAdminPage } from './visit-admin-page';
+import { switchUserToTest } from './switch-user-to-test';
+import { pressKeyWithModifier } from './press-key-with-modifier';
+
+/**
+ * Sets a site option, from the options-general admin page.
+ *
+ * @param {string} setting The option, used to get the option by id.
+ * @param {string} value   The value to set the option to.
+ */
+export async function setOption( setting, value ) {
+	await switchUserToAdmin();
+	await visitAdminPage( 'options-general.php' );
+
+	await page.focus( `#${ setting }` );
+	await pressKeyWithModifier( 'primary', 'a' );
+	await page.type( `#${ setting }`, value );
+
+	await Promise.all( [
+		page.click( '#submit' ),
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+
+	await switchUserToTest();
+}

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -5,41 +5,12 @@ import {
 	createNewPost,
 	createUser,
 	deleteUser,
+	getOption,
 	insertBlock,
 	loginUser,
 	pressKeyWithModifier,
-	switchUserToAdmin,
-	switchUserToTest,
-	visitAdminPage,
+	setOption,
 } from '@wordpress/e2e-test-utils';
-
-async function getOption( setting ) {
-	await switchUserToAdmin();
-	await visitAdminPage( 'options.php' );
-
-	const value = await page.$eval(
-		`#${ setting }`,
-		( element ) => element.value
-	);
-	await switchUserToTest();
-	return value;
-}
-
-async function setOption( setting, value ) {
-	await switchUserToAdmin();
-	await visitAdminPage( 'options-general.php' );
-
-	await page.focus( `#${ setting }` );
-	await pressKeyWithModifier( 'primary', 'a' );
-	await page.type( `#${ setting }`, value );
-
-	await Promise.all( [
-		page.click( '#submit' ),
-		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-	] );
-
-	await switchUserToTest();
-}
 
 const saveEntities = async () => {
 	const savePostSelector = '.editor-post-publish-button__button';

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -53,6 +53,8 @@ describe( 'Multi-entity save flow', () => {
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
 
+		// Get the current Site Title and Site Tagline, so that we can reset
+		// them back to the original values once the test suite has finished.
 		originalSiteTitle = await getOption( 'blogname' );
 		originalBlogDescription = await getOption( 'blogdescription' );
 	} );
@@ -60,6 +62,7 @@ describe( 'Multi-entity save flow', () => {
 	afterAll( async () => {
 		await activateTheme( 'twentytwentyone' );
 
+		// Reset the Site Title and Site Tagline back to their original values.
 		await setOption( 'blogname', originalSiteTitle );
 		await setOption( 'blogdescription', originalBlogDescription );
 	} );

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -4,8 +4,10 @@
 import {
 	createNewPost,
 	disablePrePublishChecks,
+	getOption,
 	insertBlock,
 	publishPost,
+	setOption,
 	trashAllPosts,
 	activateTheme,
 	clickButton,
@@ -44,14 +46,22 @@ describe( 'Multi-entity save flow', () => {
 		}
 	};
 
+	let originalSiteTitle, originalBlogDescription;
+
 	beforeAll( async () => {
 		await activateTheme( 'tt1-blocks' );
 		await trashAllPosts( 'wp_template' );
 		await trashAllPosts( 'wp_template_part' );
+
+		originalSiteTitle = await getOption( 'blogname' );
+		originalBlogDescription = await getOption( 'blogdescription' );
 	} );
 
 	afterAll( async () => {
 		await activateTheme( 'twentytwentyone' );
+
+		await setOption( 'blogname', originalSiteTitle );
+		await setOption( 'blogdescription', originalBlogDescription );
 	} );
 
 	describe( 'Post Editor', () => {
@@ -185,7 +195,9 @@ describe( 'Multi-entity save flow', () => {
 
 			await insertBlock( 'Site Title' );
 			// Ensure title is retrieved before typing.
-			await page.waitForXPath( '//a[contains(text(), "gutenberg")]' );
+			await page.waitForXPath(
+				`//a[contains(text(), "${ originalSiteTitle }")]`
+			);
 			const editableSiteTitleSelector =
 				'.wp-block-site-title a[contenteditable="true"]';
 			await page.waitForSelector( editableSiteTitleSelector );
@@ -211,23 +223,16 @@ describe( 'Multi-entity save flow', () => {
 			await checkboxInputs[ 1 ].click();
 			await page.click( entitiesSaveSelector );
 
+			// Wait for the snackbar notice that the post has been published.
+			await page.waitForSelector( '.components-snackbar' );
+
 			await clickButton( 'Update…' );
 			await page.waitForSelector( savePanelSelector );
-			checkboxInputs = await page.$$( checkboxInputSelector );
-			expect( checkboxInputs ).toHaveLength( 1 );
 
-			// Reset site entity to default value to not affect other tests.
-			await page.evaluate( () => {
-				wp.data
-					.dispatch( 'core' )
-					.editEntityRecord( 'root', 'site', undefined, {
-						title: 'gutenberg',
-						description: 'Just another WordPress site',
-					} );
-				wp.data
-					.dispatch( 'core' )
-					.saveEditedEntityRecord( 'root', 'site', undefined );
-			} );
+			await page.waitForSelector( checkboxInputSelector );
+			checkboxInputs = await page.$$( checkboxInputSelector );
+
+			expect( checkboxInputs ).toHaveLength( 1 );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

I noticed on `trunk` that we sometimes see intermittent failures of the multi entity saving e2e test. A recent example is [this failure](https://github.com/WordPress/gutenberg/runs/4425609298?check_suite_focus=true). The test `Site blocks should save individually` first publishes the post with only one of the site entities selected, and then clicks "Update" to check that the deselected entity appears in the list of checkboxes.

This test appears to fail intermittently due to a race condition where the test is run so quickly, that the Update panel is re-opened before the publish event has finished. This is much faster than real world usage, and means that the test runner sees two checkboxes where it expects to see only one. By running with Headless switched to `false` I could see the issue where two checkboxes are visible for a tiny moment before the publishing concludes:

![Kapture 2021-12-06 at 15 46 11](https://user-images.githubusercontent.com/14988353/144797246-5bdbc38f-eec9-41f1-99fc-49e73146b94b.gif)

This results in the following error message:

![image](https://user-images.githubusercontent.com/14988353/144797352-aa9d0ed7-3ecb-4557-9128-b8b59b305ae5.png)

## The fix

The fix for the above involves the following:

* Before attempting to update the post, wait for the Published snackbar notification.
* Refactor the logic that resets the site title and site tagline so that it occurs before the test is run. I noticed with the existing approach, the reset happens at the end of the test. In a local testing environment, once you've hit a single failure, subsequent runs would fail because the initial site title was incorrect.
* To do the above step, I borrowed the `getOption` and `setOption` functions from the Site Title block test that @ockham introduced, and moved them to the `e2e-test-utils` package, as they're now useful in more than one place.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Locally, after starting up `wp-env` and running `npm run dev`, I ran the following:

```
# Check that the Site Title test still passes
PUPPETEER_HEADLESS="false" npm run test-e2e specs/editor/blocks/site-title.test.js

# Check that the Multi Event Saving tests pass
PUPPETEER_HEADLESS="false" npm run test-e2e specs/site-editor/multi-entity-saving.test.js
```

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
