### PR TITLE
Move the block page templates hook into compat/5.9 folder

### DIFF
--- a/lib/compat/wordpress-5.9/wp-theme-get-post-templates.php
+++ b/lib/compat/wordpress-5.9/wp-theme-get-post-templates.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Support for page templates.
+ * Support for custom block-based page templates.
  *
  * @package gutenberg
  */

--- a/lib/load.php
+++ b/lib/load.php
@@ -115,9 +115,9 @@ require __DIR__ . '/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.
 require __DIR__ . '/full-site-editing/full-site-editing.php';
 require __DIR__ . '/full-site-editing/block-templates.php';
 require __DIR__ . '/full-site-editing/default-template-types.php';
-require __DIR__ . '/full-site-editing/page-templates.php';
 require __DIR__ . '/full-site-editing/template-loader.php';
 require __DIR__ . '/full-site-editing/edit-site-page.php';
+require __DIR__ . '/compat/wordpress-5.9/wp-theme-get-post-templates.php';
 require __DIR__ . '/compat/wordpress-5.9/default-theme-supports.php';
 require __DIR__ . '/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php';
 require __DIR__ . '/compat/wordpress-5.9/rest-active-global-styles.php';


### PR DESCRIPTION
See #37141 for the reasoning about this kind of PR.