### PR TITLE
Navigation: Remove blobs that look like a loading state (alternate version)

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -6,24 +6,18 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Icon, search } from '@wordpress/icons';
+import { Icon, navigation } from '@wordpress/icons';
 
 const PlaceholderPreview = ( { isLoading } ) => {
 	return (
-		<ul
+		<div
 			className={ classnames(
 				'wp-block-navigation-placeholder__preview',
-				'wp-block-navigation__container',
 				{ 'is-loading': isLoading }
 			) }
 		>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-item">&#8203;</li>
-			<li className="wp-block-navigation-placeholder__preview-search-icon">
-				<Icon icon={ search } />
-			</li>
-		</ul>
+			<Icon icon={ navigation } />
+		</div>
 	);
 };
 

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -3,21 +3,20 @@
  */
 import classnames from 'classnames';
 
-/**
- * WordPress dependencies
- */
-import { Icon, navigation } from '@wordpress/icons';
-
 const PlaceholderPreview = ( { isLoading } ) => {
 	return (
-		<div
+		<ul
 			className={ classnames(
 				'wp-block-navigation-placeholder__preview',
 				{ 'is-loading': isLoading }
 			) }
 		>
-			<Icon icon={ navigation } />
-		</div>
+			<li>&#8203;</li>
+			<li>&#8203;</li>
+			<li>&#8203;</li>
+			<li>&#8203;</li>
+			<li>&#8203;</li>
+		</ul>
 	);
 };
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -239,8 +239,9 @@ $color-control-label-height: 20px;
 	align-items: center;
 	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
 	padding: $grid-unit-05 $grid-unit-10 $grid-unit-05 $grid-unit-15;
+	min-width: $grid-unit-10 * 12;
 
-	.is-selected & {
+	.wp-block-navigation.is-selected & {
 		display: none;
 	}
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -191,10 +191,23 @@ $color-control-label-height: 20px;
 	justify-content: flex-start;
 }
 
+
 /**
  * Setup state
  */
 
+// Loading state.
+@keyframes loadingpulse {
+	0% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+	100% {
+		opacity: 1;
+	}
+}
 // Unstyle some inherited placeholder component styles.
 .components-placeholder.wp-block-navigation-placeholder {
 	outline: none;
@@ -220,115 +233,66 @@ $color-control-label-height: 20px;
 	}
 }
 
-// Spinner.
-.wp-block-navigation-placeholder .components-spinner {
-	margin-top: -4px;
-	margin-left: 4px;
-	vertical-align: middle;
-	margin-right: 7px;
-}
-
-@keyframes loadingpulse {
-	0% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.5;
-	}
-	100% {
-		opacity: 1;
-	}
-}
-
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
 	display: flex;
-	flex-direction: row;
 	align-items: center;
-	flex-wrap: nowrap;
-	width: 100%;
-	overflow: hidden;
+	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
+	padding: $grid-unit-05 $grid-unit-10 $grid-unit-05 $grid-unit-15;
 
-	&.is-loading {
-		animation: loadingpulse 1s linear infinite;
-		animation-delay: 0.5s; // avoid animating for fast network responses
+	.is-selected & {
+		display: none;
 	}
 
-	// Style skeleton elements to mostly match the metrics of actual menu items.
-	// Needs specificity.
-	.wp-block-navigation-item.wp-block-navigation-item {
-		position: relative;
-		min-width: 72px;
+	// Draw the dashed outline.
+	// By setting the dashed border to currentColor, we ensure it's visible
+	// against any background color.
+	color: currentColor;
+	background: transparent;
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		border: $border-width dashed currentColor;
+		opacity: 0.4;
+		pointer-events: none;
 
-		&::before {
-			display: block;
-			content: "";
-			border-radius: $radius-block-ui;
-			background: currentColor;
-			height: $grid-unit-20;
-			width: 100%;
-		}
+		// Inherit border radius from style variations.
+		border-radius: inherit;
 	}
 
-	.wp-block-navigation-placeholder__preview-search-icon {
-		height: $icon-size;
-		svg {
-			fill: currentColor;
-		}
-	}
-
-	.wp-block-navigation-item.wp-block-navigation-item,
-	.wp-block-navigation-placeholder__preview-search-icon {
-		opacity: 0.3;
-	}
-
-	&:not(.is-loading) {
-		// Don't show the preview boxes for an empty nav block,
-		// but be technically present to help size the empty state.
-		.wp-block-navigation.is-selected & {
-			display: flex;
-			opacity: 0;
-			width: 0;
-			overflow: hidden;
-			flex-wrap: nowrap;
-			flex: 0;
-		}
-
-		// Hide entirely when vertical.
-		.wp-block-navigation.is-selected .is-small &,
-		.wp-block-navigation.is-selected .is-medium & {
-			display: none;
-		}
+	> svg {
+		opacity: 0.4;
 	}
 }
 
 // Selected state.
 .wp-block-navigation-placeholder__controls {
-	padding: $grid-unit-10;
+	padding: $grid-unit-05 $grid-unit-10;
 	border-radius: $radius-block-ui;
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
+	display: none;
 	flex-direction: row;
 	align-items: center;
-	display: none;
 	position: relative;
 	z-index: 1;
 
-	// Adjust padding for when shown horizontally.
-	.is-large & {
-		padding: $grid-unit-05 $grid-unit-10;
+	// Show when selected.
+	.wp-block-navigation.is-selected & {
+		display: flex;
 	}
+
 
 	// If an ancestor has a text-decoration property applied, it is inherited regardless of
 	// the specificity of a child element. Only pulling the child out of the flow fixes it.
 	// See also https://www.w3.org/TR/CSS21/text.html#propdef-text-decoration.
 	float: left;
 	width: 100%;
-
-	// Show when selected.
-	.wp-block-navigation.is-selected & {
-		display: flex;
-	}
 
 	// Show stacked for the vertical navigation, or small placeholders.
 	.is-small &,

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -266,6 +266,7 @@ $color-control-label-height: 20px;
 	}
 
 	> svg {
+		fill: currentColor;
 		opacity: 0.4;
 	}
 }

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -217,8 +217,10 @@ $color-control-label-height: 20px;
 	min-height: 0;
 
 	// Needed for the preview menu items to match actual menu items.
+	gap: inherit;
 	.components-placeholder__fieldset {
 		font-size: inherit;
+		gap: inherit;
 	}
 
 	.components-placeholder__fieldset .components-button {
@@ -237,15 +239,18 @@ $color-control-label-height: 20px;
 .wp-block-navigation-placeholder__preview {
 	display: flex;
 	align-items: center;
-	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
 	padding: $grid-unit-05 $grid-unit-10 $grid-unit-05 $grid-unit-15;
 	min-width: $grid-unit-10 * 12;
 
+	// Make it at least as high as the smallest placeholder.
+	min-height: $button-size + $grid-unit-05 + $grid-unit-05;
+
+	// Hide when selected.
 	.wp-block-navigation.is-selected & {
 		display: none;
 	}
 
-	// Draw the dashed outline.
+	/*// Draw the dashed outline.
 	// By setting the dashed border to currentColor, we ensure it's visible
 	// against any background color.
 	color: currentColor;
@@ -264,11 +269,17 @@ $color-control-label-height: 20px;
 
 		// Inherit border radius from style variations.
 		border-radius: inherit;
-	}
+	}*/
 
-	> svg {
-		fill: currentColor;
-		opacity: 0.4;
+	// Draw navigation placeholder indicators.
+	gap: inherit;
+
+	li {
+		border: $border-width dashed currentColor;
+		opacity: 0.45;
+		height: 1em;
+		width: 4em;
+		border-radius: $radius-block-ui;
 	}
 }
 

--- a/packages/block-library/src/post-featured-image/editor.scss
+++ b/packages/block-library/src/post-featured-image/editor.scss
@@ -48,7 +48,7 @@
 			bottom: 0;
 			left: 0;
 			border: $border-width dashed currentColor;
-			opacity: 0.4;
+			opacity: 0.45;
 			pointer-events: none;
 
 			// Inherit border radius from style variations.
@@ -93,7 +93,7 @@
 			height: 100%;
 			stroke: currentColor;
 			stroke-dasharray: 3;
-			opacity: 0.4;
+			opacity: 0.45;
 		}
 
 		// Show default placeholder height when not resized.

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -110,7 +110,7 @@
 			bottom: 0;
 			left: 0;
 			border: $border-width dashed currentColor;
-			opacity: 0.4;
+			opacity: 0.45;
 			pointer-events: none;
 
 			// Inherit border radius from style variations.
@@ -155,7 +155,7 @@
 			height: 100%;
 			stroke: currentColor;
 			stroke-dasharray: 3;
-			opacity: 0.4;
+			opacity: 0.45;
 		}
 	}
 


### PR DESCRIPTION
## Description

Alternative to #36858 which removes the blobs entirely, and to #37099 which has a more generic looking setup state.

As outlined on those other PRs, the gray blobs are problematic in that they look like a loading state, meaning people assume no further action is needed on the navigation block. While there may be opportunities in the future to retire a setup state entirely, that needs some further thought, and in the near term, the balance to find is that of:

- Making the item look like it needs further manual setup (i.e. select and configure)
- Passing the squint test in its default state, for themes that just insert an empty navigation block
- It should avoid looking like a loading state

In contrast to #37099, this one looks like a row of menu items:

![nav](https://user-images.githubusercontent.com/1204802/144833385-8c258187-9a10-4eff-a331-663c4ef00122.gif)

I personally don't really think either of these solutions are ideal, so I consider all three options to be temporary.

## How has this been tested?

Please insert an empty navigation block and observe the setup state.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
