### PR TITLE
make sure justifyContent exists before using it

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -167,7 +167,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	$id              = uniqid();
 	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
 	$container_class = 'wp-container-' . $id . ' ';
-	$justify_class   = $used_layout['justifyContent'] ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
+	$justify_class   = ! empty( $used_layout['justifyContent'] ) ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(


### PR DESCRIPTION
## Description
I started getting PHP errors in my installation today (WP trunk, Gutenberg trunk):
`PHP Notice:  Undefined index: justifyContent in /var/www/src/wp-content/plugins/gutenberg/lib/block-supports/layout.php on line 170`

This PR simply checks that `justifyContent` exists before using it, in order to avoid undefined-index errors.

## How has this been tested?
After the patch I no longer get errors.

## Types of changes

Added an `empty()` check.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
