### PR TITLE
Fix HTML drop issues with the Windows browsers

### DIFF
--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -259,6 +259,10 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 		const files = getFilesFromDataTransfer( event.dataTransfer );
 		const html = event.dataTransfer.getData( 'text/html' );
 
+		/**
+		 * From Windows Chrome 96, the `event.dataTransfer` returns both file object and HTML.
+		 * The order of the checks is important to recognise the HTML drop.
+		 */
 		if ( html ) {
 			_onHTMLDrop( html );
 		} else if ( files.length ) {

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -259,10 +259,10 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 		const files = getFilesFromDataTransfer( event.dataTransfer );
 		const html = event.dataTransfer.getData( 'text/html' );
 
-		if ( files.length ) {
-			_onFilesDrop( files );
-		} else if ( html ) {
+		if ( html ) {
 			_onHTMLDrop( html );
+		} else if ( files.length ) {
+			_onFilesDrop( files );
 		} else {
 			_onDrop( event );
 		}

--- a/packages/components/src/drop-zone/index.js
+++ b/packages/components/src/drop-zone/index.js
@@ -39,10 +39,14 @@ export default function DropZoneComponent( {
 			const files = getFilesFromDataTransfer( event.dataTransfer );
 			const html = event.dataTransfer.getData( 'text/html' );
 
-			if ( files.length && onFilesDrop ) {
-				onFilesDrop( files );
-			} else if ( html && onHTMLDrop ) {
+			/**
+			 * From Windows Chrome 96, the `event.dataTransfer` returns both file object and HTML.
+			 * The order of the checks is important to recognise the HTML drop.
+			 */
+			if ( html && onHTMLDrop ) {
 				onHTMLDrop( html );
+			} else if ( files.length && onFilesDrop ) {
+				onFilesDrop( files );
 			} else if ( onDrop ) {
 				onDrop( event );
 			}
@@ -52,15 +56,19 @@ export default function DropZoneComponent( {
 
 			let _type = 'default';
 
-			if (
+			/**
+			 * From Windows Chrome 96, the `event.dataTransfer` returns both file object and HTML.
+			 * The order of the checks is important to recognise the HTML drop.
+			 */
+			if ( includes( event.dataTransfer.types, 'text/html' ) ) {
+				_type = 'html';
+			} else if (
 				// Check for the types because sometimes the files themselves
 				// are only available on drop.
 				includes( event.dataTransfer.types, 'Files' ) ||
 				getFilesFromDataTransfer( event.dataTransfer ).length > 0
 			) {
 				_type = 'file';
-			} else if ( includes( event.dataTransfer.types, 'text/html' ) ) {
-				_type = 'html';
 			}
 
 			setType( _type );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The File drops intercept HTML drops, and it takes precedence with the recent Windows chrome version. It causes the plugins relying on the HTML drop to stop working. Changing the order of the checks fixes the problem — Fixes #36824.

## How has this been tested?
The steps to test has been documented in issue #36824. 

## Screenshots <!-- if applicable -->

## Types of changes
Changing the order of the checks fixes the problem.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
