### PR TITLE
Remove template parts from post content inserter an __unstable filter

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1679,7 +1679,7 @@ export const getInserterItems = createSelector(
 			...sortedBlockTypes,
 			...reusableBlockInserterItems,
 		];
-		const hookName = 'blockEditor.getInserterItems';
+		const hookName = 'blockEditor.__unstableGetInserterItems';
 		return applyFilters( hookName, computedBlockTypes, rootClientId, {
 			// Pass bound selectors of the current registry. If we're in a nested
 			// context, the data will differ from the one selected from the root

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -30,6 +30,7 @@ import {
 	parse,
 } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { symbol } from '@wordpress/icons';
 
 /**
@@ -826,6 +827,7 @@ export const isAncestorMultiSelected = createSelector(
 		state.selection.selectionEnd.clientId,
 	]
 );
+
 /**
  * Returns the client ID of the block which begins the multi-selection set, or
  * null if there is no multi-selection.
@@ -1513,7 +1515,9 @@ const buildBlockTypeItem = ( state, { buildScope = 'inserter' } ) => (
 		isDisabled,
 		frecency: calculateFrecency( time, count ),
 	};
-	if ( buildScope === 'transform' ) return blockItemBase;
+	if ( buildScope === 'transform' ) {
+		return blockItemBase;
+	}
 
 	const inserterVariations = getBlockVariations( blockType.name, 'inserter' );
 	return {
@@ -1673,7 +1677,18 @@ export const getInserterItems = createSelector(
 			noncore: nonCoreItems,
 		} = items.reduce( groupByType, { core: [], noncore: [] } );
 		const sortedBlockTypes = [ ...coreItems, ...nonCoreItems ];
-		return [ ...sortedBlockTypes, ...reusableBlockInserterItems ];
+		const computedBlockTypes = [
+			...sortedBlockTypes,
+			...reusableBlockInserterItems,
+		];
+		const hookName = 'blockEditor.getInserterItems';
+		return applyFilters( hookName, computedBlockTypes, rootClientId, {
+			getBlock: getBlock.bind( null, state ),
+			getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
+				null,
+				state
+			),
+		} );
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],
@@ -1950,7 +1965,9 @@ export const __experimentalGetAllowedPatterns = createSelector(
  */
 export const __experimentalGetPatternsByBlockTypes = createSelector(
 	( state, blockNames, rootClientId = null ) => {
-		if ( ! blockNames ) return EMPTY_ARRAY;
+		if ( ! blockNames ) {
+			return EMPTY_ARRAY;
+		}
 		const patterns = __experimentalGetAllowedPatterns(
 			state,
 			rootClientId
@@ -1991,7 +2008,9 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
  */
 export const __experimentalGetPatternTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
-		if ( ! blocks ) return EMPTY_ARRAY;
+		if ( ! blocks ) {
+			return EMPTY_ARRAY;
+		}
 		/**
 		 * For now we only handle blocks without InnerBlocks and take into account
 		 * the `__experimentalRole` property of blocks' attributes for the transformation.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1261,15 +1261,30 @@ const canInsertBlockTypeUnmemoized = (
 		parentName
 	);
 
-	if ( hasParentAllowedBlock !== null && hasBlockAllowedParent !== null ) {
-		return hasParentAllowedBlock || hasBlockAllowedParent;
-	} else if ( hasParentAllowedBlock !== null ) {
-		return hasParentAllowedBlock;
-	} else if ( hasBlockAllowedParent !== null ) {
-		return hasBlockAllowedParent;
+	if (
+		hasParentAllowedBlock !== null &&
+		hasBlockAllowedParent !== null &&
+		! hasParentAllowedBlock &&
+		! hasBlockAllowedParent
+	) {
+		return false;
+	} else if ( hasParentAllowedBlock !== null && ! hasParentAllowedBlock ) {
+		return false;
+	} else if ( hasBlockAllowedParent !== null && ! hasBlockAllowedParent ) {
+		return false;
 	}
 
-	return true;
+	const hookName = 'blockEditor.__unstableCanInsertBlockType';
+	return applyFilters( hookName, true, blockType, rootClientId, {
+		// Pass bound selectors of the current registry. If we're in a nested
+		// context, the data will differ from the one selected from the root
+		// registry.
+		getBlock: getBlock.bind( null, state ),
+		getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
+			null,
+			state
+		),
+	} );
 };
 
 /**
@@ -1675,21 +1690,7 @@ export const getInserterItems = createSelector(
 			noncore: nonCoreItems,
 		} = items.reduce( groupByType, { core: [], noncore: [] } );
 		const sortedBlockTypes = [ ...coreItems, ...nonCoreItems ];
-		const computedBlockTypes = [
-			...sortedBlockTypes,
-			...reusableBlockInserterItems,
-		];
-		const hookName = 'blockEditor.__unstableGetInserterItems';
-		return applyFilters( hookName, computedBlockTypes, rootClientId, {
-			// Pass bound selectors of the current registry. If we're in a nested
-			// context, the data will differ from the one selected from the root
-			// registry.
-			getBlock: getBlock.bind( null, state ),
-			getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
-				null,
-				state
-			),
-		} );
+		return [ ...sortedBlockTypes, ...reusableBlockInserterItems ];
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1515,9 +1515,7 @@ const buildBlockTypeItem = ( state, { buildScope = 'inserter' } ) => (
 		isDisabled,
 		frecency: calculateFrecency( time, count ),
 	};
-	if ( buildScope === 'transform' ) {
-		return blockItemBase;
-	}
+	if ( buildScope === 'transform' ) return blockItemBase;
 
 	const inserterVariations = getBlockVariations( blockType.name, 'inserter' );
 	return {
@@ -1965,9 +1963,7 @@ export const __experimentalGetAllowedPatterns = createSelector(
  */
 export const __experimentalGetPatternsByBlockTypes = createSelector(
 	( state, blockNames, rootClientId = null ) => {
-		if ( ! blockNames ) {
-			return EMPTY_ARRAY;
-		}
+		if ( ! blockNames ) return EMPTY_ARRAY;
 		const patterns = __experimentalGetAllowedPatterns(
 			state,
 			rootClientId
@@ -2008,9 +2004,7 @@ export const __experimentalGetPatternsByBlockTypes = createSelector(
  */
 export const __experimentalGetPatternTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
-		if ( ! blocks ) {
-			return EMPTY_ARRAY;
-		}
+		if ( ! blocks ) return EMPTY_ARRAY;
 		/**
 		 * For now we only handle blocks without InnerBlocks and take into account
 		 * the `__experimentalRole` property of blocks' attributes for the transformation.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1261,17 +1261,13 @@ const canInsertBlockTypeUnmemoized = (
 		parentName
 	);
 
-	if (
-		hasParentAllowedBlock !== null &&
-		hasBlockAllowedParent !== null &&
-		! hasParentAllowedBlock &&
-		! hasBlockAllowedParent
-	) {
-		return false;
-	} else if ( hasParentAllowedBlock !== null && ! hasParentAllowedBlock ) {
-		return false;
-	} else if ( hasBlockAllowedParent !== null && ! hasBlockAllowedParent ) {
-		return false;
+	const canInsert =
+		( hasParentAllowedBlock === null && hasBlockAllowedParent === null ) ||
+		hasParentAllowedBlock === true ||
+		hasBlockAllowedParent === true;
+
+	if ( ! canInsert ) {
+		return canInsert;
 	}
 
 	/**
@@ -1288,7 +1284,7 @@ const canInsertBlockTypeUnmemoized = (
 	 */
 	return applyFilters(
 		'blockEditor.__unstableCanInsertBlockType',
-		true,
+		canInsert,
 		blockType,
 		rootClientId,
 		{

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1274,17 +1274,23 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
-	const hookName = 'blockEditor.__unstableCanInsertBlockType';
-	return applyFilters( hookName, true, blockType, rootClientId, {
-		// Pass bound selectors of the current registry. If we're in a nested
-		// context, the data will differ from the one selected from the root
-		// registry.
-		getBlock: getBlock.bind( null, state ),
-		getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
-			null,
-			state
-		),
-	} );
+	// Filter to give other packages a chance to affect the outcome.
+	return applyFilters(
+		'blockEditor.__unstableCanInsertBlockType',
+		true,
+		blockType,
+		rootClientId,
+		{
+			// Pass bound selectors of the current registry. If we're in a nested
+			// context, the data will differ from the one selected from the root
+			// registry.
+			getBlock: getBlock.bind( null, state ),
+			getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
+				null,
+				state
+			),
+		}
+	);
 };
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1274,7 +1274,18 @@ const canInsertBlockTypeUnmemoized = (
 		return false;
 	}
 
-	// Filter to give other packages a chance to affect the outcome.
+	/**
+	 * This filter is an ad-hoc solution to prevent adding template parts inside post content.
+	 * Conceptually, having a filter inside a selector is bad pattern so this code will be
+	 * replaced by a declarative API that doesn't the following drawbacks:
+	 *
+	 * Filters are not reactive: Upon switching between "template mode" and non "template mode",
+	 * the filter and selector won't necessarily be executed again. For now, it doesn't matter much
+	 * because you can't switch between the two modes while the inserter stays open.
+	 *
+	 * Filters are global: Once they're defined, they will affect all editor instances and all registries.
+	 * An ideal API would only affect specific editor instances.
+	 */
 	return applyFilters(
 		'blockEditor.__unstableCanInsertBlockType',
 		true,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1681,6 +1681,9 @@ export const getInserterItems = createSelector(
 		];
 		const hookName = 'blockEditor.getInserterItems';
 		return applyFilters( hookName, computedBlockTypes, rootClientId, {
+			// Pass bound selectors of the current registry. If we're in a nested
+			// context, the data will differ from the one selected from the root
+			// registry.
 			getBlock: getBlock.bind( null, state ),
 			getBlockParentsByBlockName: getBlockParentsByBlockName.bind(
 				null,

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -52,6 +52,7 @@ addFilter(
 );
 
 // Prevent adding template parts inside post templates.
+const DISALLOWED_PARENTS = [ 'core/post-template', 'core/post-content' ];
 addFilter(
 	'blockEditor.__unstableCanInsertBlockType',
 	'removeTemplatePartsFromPostTemplates',
@@ -65,10 +66,15 @@ addFilter(
 			return can;
 		}
 
-		const hasDisallowedParent =
-			getBlock( rootClientId )?.name === 'core/post-template' ||
-			getBlockParentsByBlockName( rootClientId, 'core/post-template' )
-				.length;
-		return ! hasDisallowedParent;
+		for ( const disallowedParentType of DISALLOWED_PARENTS ) {
+			const hasDisallowedParent =
+				getBlock( rootClientId )?.name === disallowedParentType ||
+				getBlockParentsByBlockName( rootClientId, disallowedParentType )
+					.length;
+			if ( hasDisallowedParent ) {
+				return false;
+			}
+		}
+		return true;
 	}
 );

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -55,18 +55,19 @@ addFilter(
 	'blockEditor.getInserterItems',
 	'test',
 	( types, rootClientId, { getBlock, getBlockParentsByBlockName } ) => {
-		const templateParts = types.filter( ( { id } ) =>
-			id.startsWith( 'core/template-part' )
+		const templateParts = types.filter(
+			( type ) => type.name === 'core/template-part'
 		);
 		if ( ! templateParts.length ) {
 			return types;
 		}
 
-		const hasParent =
+		const hasDisallowedParent =
 			getBlock( rootClientId )?.name === 'core/post-template' ||
 			getBlockParentsByBlockName( rootClientId, 'core/post-template' )
 				.length;
-		if ( hasParent ) {
+		if ( hasDisallowedParent ) {
+			// Remove all template part-like blocks
 			for ( let i = templateParts.length - 1; i >= 0; i-- ) {
 				types.splice( types.indexOf( templateParts[ i ] ), 1 );
 			}

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -52,8 +52,8 @@ addFilter(
 );
 
 addFilter(
-	'blockEditor.getInserterItems',
-	'test',
+	'blockEditor.__unstableGetInserterItems',
+	'removeTemplatePartsFromPostTemplates',
 	( types, rootClientId, { getBlock, getBlockParentsByBlockName } ) => {
 		const templateParts = types.filter(
 			( type ) => type.name === 'core/template-part'

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -51,6 +51,7 @@ addFilter(
 	enhanceTemplatePartVariations
 );
 
+// Prevent adding template parts inside post templates.
 addFilter(
 	'blockEditor.__unstableCanInsertBlockType',
 	'removeTemplatePartsFromPostTemplates',

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -50,3 +50,28 @@ addFilter(
 	'core/template-part',
 	enhanceTemplatePartVariations
 );
+
+addFilter(
+	'blockEditor.getInserterItems',
+	'test',
+	( types, rootClientId, { getBlock, getBlockParentsByBlockName } ) => {
+		const templateParts = types.filter( ( { id } ) =>
+			id.startsWith( 'core/template-part' )
+		);
+		if ( ! templateParts.length ) {
+			return types;
+		}
+
+		const hasParent =
+			getBlock( rootClientId )?.name === 'core/post-template' ||
+			getBlockParentsByBlockName( rootClientId, 'core/post-template' )
+				.length;
+		if ( hasParent ) {
+			for ( let i = templateParts.length - 1; i >= 0; i-- ) {
+				types.splice( types.indexOf( templateParts[ i ] ), 1 );
+			}
+		}
+
+		return types;
+	}
+);

--- a/packages/block-library/src/template-part/index.js
+++ b/packages/block-library/src/template-part/index.js
@@ -52,27 +52,22 @@ addFilter(
 );
 
 addFilter(
-	'blockEditor.__unstableGetInserterItems',
+	'blockEditor.__unstableCanInsertBlockType',
 	'removeTemplatePartsFromPostTemplates',
-	( types, rootClientId, { getBlock, getBlockParentsByBlockName } ) => {
-		const templateParts = types.filter(
-			( type ) => type.name === 'core/template-part'
-		);
-		if ( ! templateParts.length ) {
-			return types;
+	(
+		can,
+		blockType,
+		rootClientId,
+		{ getBlock, getBlockParentsByBlockName }
+	) => {
+		if ( blockType.name !== 'core/template-part' ) {
+			return can;
 		}
 
 		const hasDisallowedParent =
 			getBlock( rootClientId )?.name === 'core/post-template' ||
 			getBlockParentsByBlockName( rootClientId, 'core/post-template' )
 				.length;
-		if ( hasDisallowedParent ) {
-			// Remove all template part-like blocks
-			for ( let i = templateParts.length - 1; i >= 0; i-- ) {
-				types.splice( types.indexOf( templateParts[ i ] ), 1 );
-			}
-		}
-
-		return types;
+		return ! hasDisallowedParent;
 	}
 );

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -97,8 +97,8 @@ describe( 'Multi-entity save flow', () => {
 			expect( multiSaveButton ).toBeNull();
 		};
 
-		it( 'Save flow should work as expected.', async () => {
-			await createNewPost();
+		// Template parts can't be used in posts, so this test needs to be rebuilt using perhaps reusable blocks.
+		it.skip( 'Save flow should work as expected.', async () => {
 			// Edit the page some.
 			await page.click( '.editor-post-title' );
 			await page.keyboard.type( 'Test Post...' );

--- a/packages/e2e-tests/specs/site-editor/template-part.test.js
+++ b/packages/e2e-tests/specs/site-editor/template-part.test.js
@@ -280,7 +280,8 @@ describe( 'Template Part', () => {
 		const confirmTitleButtonSelector =
 			'.wp-block-template-part__placeholder-create-new__title-form .components-button.is-primary';
 
-		it( 'Should insert new template part on creation', async () => {
+		// Template parts can't be used in posts, so this test needs to be rebuilt for the template editor.
+		it.skip( 'Should insert new template part on creation', async () => {
 			await createNewPost();
 			await disablePrePublishChecks();
 			// Create new template part.

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -7,7 +7,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -17,6 +17,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import './hooks';
 import './plugins';
 import Editor from './editor';
+import { store as editPostStore } from './store';
 
 /**
  * Reinitializes the editor after the user chooses to reboot the editor after
@@ -85,7 +86,10 @@ export function initializeEditor(
 		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromInserter',
 		( can, blockType ) => {
-			if ( blockType.name === 'core/template-part' ) {
+			if (
+				! select( editPostStore ).isEditingTemplate() &&
+				blockType.name === 'core/template-part'
+			) {
 				return false;
 			}
 			return can;

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -81,10 +81,14 @@ export function initializeEditor(
 ) {
 	// Only add the filter when the post editor is initialized, not imported.
 	addFilter(
-		'blockEditor.__unstableGetInserterItems',
+		'blockEditor.__unstableCanInsertBlockType',
 		'removeTemplatePartsFromInserter',
-		( types ) =>
-			types.filter( ( type ) => type.name !== 'core/template-part' )
+		( can, blockType ) => {
+			if ( blockType.name === 'core/template-part' ) {
+				return false;
+			}
+			return can;
+		}
 	);
 
 	const target = document.getElementById( id );

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -79,6 +79,7 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
+	// Prevent adding template part in the post editor.
 	// Only add the filter when the post editor is initialized, not imported.
 	addFilter(
 		'blockEditor.__unstableCanInsertBlockType',

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -8,6 +8,7 @@ import {
 } from '@wordpress/block-library';
 import { render, unmountComponentAtNode } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
+import { addFilter } from '@wordpress/hooks';
 import { store as interfaceStore } from '@wordpress/interface';
 
 /**
@@ -78,6 +79,14 @@ export function initializeEditor(
 	settings,
 	initialEdits
 ) {
+	// Only add the filter when the post editor is initialized, not imported.
+	addFilter(
+		'blockEditor.__unstableGetInserterItems',
+		'removeTemplatePartsFromInserter',
+		( types ) =>
+			types.filter( ( type ) => type.name !== 'core/template-part' )
+	);
+
 	const target = document.getElementById( id );
 	const reboot = reinitializeEditor.bind(
 		null,


### PR DESCRIPTION
## Description
Solves #30668

Following up on the [discussion](https://github.com/WordPress/gutenberg/pull/37109#issuecomment-986506146) in https://github.com/WordPress/gutenberg/pull/37109, this PR proposes a workaround to remove template parts from the post content editor without adding new stable APIs. The time is short and we are also past the feature freeze, so let's leave new, contexttual APIs for 6.0

The idea behind this PR is to filter the return value of `canInsertBlockType` using a globally-registered hook.

The nice thing is that it prevents adding template parts using other means such as copying, pasting, and manually editing the code. 

## Test plan

* Go to the site editor, confirm you can't add a `template-part` block inside `post-template` or `post-content`, but that you can add it in other places.
* Go to the post editor, confirm you can't add a `template-part` block at all.
* Go to the template editor, confirm you can add a `template-part` block, except inside `post-template` or `post-content`.

cc @youknowriad @ntsekouras @gziolo 