### PR TITLE
LineHeightControl: Migrate internals to `NumberControl` (Part 2: Behavior)

### DIFF
--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { UP, DOWN } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import LineHeightControl from '../';
+import { BASE_DEFAULT_VALUE, STEP } from '../utils';
+
+const ControlledLineHeightControl = () => {
+	const [ value, setValue ] = useState();
+	return <LineHeightControl value={ value } onChange={ setValue } />;
+};
+
+describe( 'LineHeightControl', () => {
+	it( 'should immediately step up from the default value if up-arrowed from an unset state', () => {
+		render( <ControlledLineHeightControl /> );
+		const input = screen.getByRole( 'spinbutton' );
+		input.focus();
+		fireEvent.keyDown( input, { keyCode: UP } );
+		expect( input ).toHaveValue( BASE_DEFAULT_VALUE + STEP );
+	} );
+
+	it( 'should immediately step down from the default value if down-arrowed from an unset state', () => {
+		render( <ControlledLineHeightControl /> );
+		const input = screen.getByRole( 'spinbutton' );
+		input.focus();
+		fireEvent.keyDown( input, { keyCode: DOWN } );
+		expect( input ).toHaveValue( BASE_DEFAULT_VALUE - STEP );
+	} );
+
+	it( 'should immediately step up from the default value if spin button up was clicked from an unset state', () => {
+		render( <ControlledLineHeightControl /> );
+		const input = screen.getByRole( 'spinbutton' );
+		input.focus();
+		fireEvent.change( input, { target: { value: 0.1 } } ); // simulates click on spin button up
+		expect( input ).toHaveValue( BASE_DEFAULT_VALUE + STEP );
+	} );
+
+	it( 'should immediately step down from the default value if spin button down was clicked from an unset state', () => {
+		render( <ControlledLineHeightControl /> );
+		const input = screen.getByRole( 'spinbutton' );
+		input.focus();
+		fireEvent.change( input, { target: { value: 0 } } ); // simulates click on spin button down
+		expect( input ).toHaveValue( BASE_DEFAULT_VALUE - STEP );
+	} );
+} );

--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -17,7 +17,13 @@ import { BASE_DEFAULT_VALUE, STEP } from '../utils';
 
 const ControlledLineHeightControl = () => {
 	const [ value, setValue ] = useState();
-	return <LineHeightControl value={ value } onChange={ setValue } />;
+	return (
+		<LineHeightControl
+			value={ value }
+			onChange={ setValue }
+			__nextHasNoMarginBottom={ true }
+		/>
+	);
 };
 
 describe( 'LineHeightControl', () => {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -50,6 +50,9 @@ export const composeStateReducers = (
 ): StateReducer => {
 	return ( ...args ) => {
 		return fns.reduceRight( ( state, fn ) => {
+			// TODO: Assess whether this can be replaced with a more standard `compose` implementation
+			// like wp.data.compose() (aka lodash flowRight) or Redux compose().
+			// The current implementation only works by functions mutating the original state object.
 			const fnState = fn( ...args );
 			return isEmpty( fnState ) ? state : { ...state, ...fnState };
 		}, {} as InputState );


### PR DESCRIPTION
Will merge into #37160 (changelog will be updated there)
Prerequisite for #36196

## Description

As part of changing the underlying component from `TextControl` to `NumberControl`, we need to port some existing, line-height-specific logic. The logic handles what happens on the *first interaction from an unset state*.

| Interaction | Desired behavior | Default `NumberControl` |
|--------|-------|-------|
|Click on spin button|<img src="https://user-images.githubusercontent.com/555336/144906377-38deaac8-2619-4eca-a21f-f7c632ed9cfb.gif" alt="A click on the up spin button will set the value to 1.6" width="100">|<img src="https://user-images.githubusercontent.com/555336/144907608-84c8ea3e-96d9-4a51-a493-fbd7bd115842.gif" alt="A click on the up spin button will set the value to 0.1" width="100">|
|Hit up/down arrow key|<img src="https://user-images.githubusercontent.com/555336/144906736-a992e936-8cbd-4b42-85bb-89f012911260.gif" alt="Hitting the arrow up key will set the value to 1.6" width="100">|<img src="https://user-images.githubusercontent.com/555336/144907734-5a5b39ad-de6e-4615-94d7-c52aa6896ea3.gif" alt="Hitting the arrow up key will set the value to 0.1" width="100">|

Special handling is added for entering `0`, because browser event-wise this can look very similar to a click on the down spin button:

| Interaction | Desired behavior | Naive implementation |
|--------|-------|-------|
|Enter `0`|<img src="https://user-images.githubusercontent.com/555336/144907238-dc6459ea-4837-4ff6-a303-59e9b864c602.gif" alt="Entering zero will set the value to 0" width="100">|<img src="https://user-images.githubusercontent.com/555336/144908182-5f783fd6-836e-4554-bac1-558f2358d3cb.gif" alt="Entering zero will set the value to 1.4" width="100">|

All this logic was ported from the original (event-based, direct state manipulation) to fit the composed state reducer model of `InputControl`.

## How has this been tested?

1. `npm run storybook:dev`
2. Go to the Block Editor ▸ LineHeightControl ▸ Temporary Test story.
3. The Migrated behavior should match the Legacy behavior in Chrome/Firefox/Safari, especially in regards to the special handling described above. (Note there is a spin button hover bug in Safari #37127)

UI tests have been added for the stepping behavior. Unfortunately I don't think we can test the "Enter `0`" case in jsdom, as the logic relies on some deeper event behavior. (These number input events differ a bit even across browsers, so it would require Playwright E2E for reliable testing. Probably not worth it here.)

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
