### PR TITLE
Fix blank site editor when theme name contains a period

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -27,7 +27,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// List themes global styles.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/themes/(?P<stylesheet>[^.\/]+(?:\/[^.\/]+)?)',
+			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -46,7 +46,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// Lists/updates a single global style variation based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\d]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -109,11 +109,6 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
-		// Request ID is theme name for some instances, causing it to fail.
-		// Should this look up based on theme name if not numeric?
-		if ( ! is_numeric( $request['id'] ) ) {
-			return [];
-		};
 		$post = get_post( $request['id'] );
 		if ( ! $post || 'wp_global_styles' !== $post->post_type ) {
 			return new WP_Error( 'rest_global_styles_not_found', __( 'No global styles config exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -46,7 +46,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// Lists/updates a single global style variation based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -109,6 +109,11 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
+		// Request ID is theme name for some instances, causing it to fail.
+		// Should this look up based on theme name if not numeric?
+		if ( ! is_numeric( $request['id'] ) ) {
+			return [];
+		};
 		$post = get_post( $request['id'] );
 		if ( ! $post || 'wp_global_styles' !== $post->post_type ) {
 			return new WP_Error( 'rest_global_styles_not_found', __( 'No global styles config exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -46,7 +46,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// Lists/updates a single global style variation based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\d]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -27,7 +27,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// List themes global styles.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\w\.-]+)',
+			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -54,8 +54,8 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
 						'id' => array(
-							'description' => __( 'The id of the global style variation', 'gutenberg' ),
-							'type'        => 'string',
+							'description'       => __( 'The id of the global style variation', 'gutenberg' ),
+							'type'              => 'string',
 							'sanitize_callback' => array( $this, '_sanitize_global_styles_callback' ),
 						),
 					),

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php
@@ -27,7 +27,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// List themes global styles.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\/\w\.-]+)',
+			'/' . $this->rest_base . '/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -46,7 +46,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 		// Lists/updates a single global style variation based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\s%\w\.\(\)\[\]\@_\-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -56,6 +56,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 						'id' => array(
 							'description' => __( 'The id of the global style variation', 'gutenberg' ),
 							'type'        => 'string',
+							'sanitize_callback' => array( $this, '_sanitize_global_styles_callback' ),
 						),
 					),
 				),
@@ -68,6 +69,20 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Controller {
 				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
+	}
+
+	/**
+	 * Sanitize the global styles ID or stylesheet to decode endpoint.
+	 * For example, `wp/v2/global-styles/templatetwentytwo%200.4.0`
+	 * would be decoded to `templatetwentytwo 0.4.0`.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $id_or_stylesheet Global styles ID or stylesheet.
+	 * @return string Sanitized global styles ID or stylesheet.
+	 */
+	public function _sanitize_global_styles_callback( $id_or_stylesheet ) {
+		return urldecode( $id_or_stylesheet );
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -59,7 +59,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		// Lists/updates a single template based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -59,7 +59,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		// Lists/updates a single template based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[.*\/]?[\/\w\.-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -59,7 +59,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		// Lists/updates a single template based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
+			'/' . $this->rest_base . '/(?P<id>[.*\/]?[\/\w\.-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -59,7 +59,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		// Lists/updates a single template based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\w\.-]+)',
+			'/' . $this->rest_base . '/(?P<id>[\/\s%\w\.\(\)\[\]\@_\-]+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
@@ -131,7 +131,10 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	 * @return string Sanitized template ID.
 	 */
 	public function _sanitize_template_id( $id ) {
+		// Decode empty space.
 		$last_slash_pos = strrpos( $id, '/' );
+		$id = urldecode( $id );
+
 		if ( false === $last_slash_pos ) {
 			return $id;
 		}

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -133,7 +133,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	public function _sanitize_template_id( $id ) {
 		// Decode empty space.
 		$last_slash_pos = strrpos( $id, '/' );
-		$id = urldecode( $id );
+		$id             = urldecode( $id );
 
 		if ( false === $last_slash_pos ) {
 			return $id;

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -56,7 +56,16 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
-		$this->assertArrayHasKey( '/wp/v2/global-styles/(?P<id>[\/\w-]+)', $routes );
+		$this->assertArrayHasKey(
+			'/wp/v2/global-styles/(?P<id>[\/\s%\w\.\(\)\[\]\@_\-]+)',
+			$routes,
+			'Single global style based on the given ID route does not exist'
+		);
+		$this->assertArrayHasKey(
+			'/wp/v2/global-styles/themes/(?P<stylesheet>[\/\s%\w\.\(\)\[\]\@_\-]+)',
+			$routes,
+			'Theme global styles route does not exist'
+		);
 	}
 
 	public function test_context_param() {


### PR DESCRIPTION
## Description

The rest routes do not include a period in the regex so if the theme name includes a period the API requests will fail.

There is still an issue when the route matches and the callback `get_item()` is passed the theme name as the id. The `get_item()` method attempts look up global styles using this id but as a string it fails.

@oandregal ~How should that look up work? Checking for numeric seems to work but feels like it is skipping an important part.~ I think I figured out the lookup, it got oversimplied but I think the regex might of been from template routes, and didn't need to be as complicated.

I've confirmed via test instructions below and this now seems to work with no errors.

Fixes #37156


## How has this been tested?

1. Rename a block theme to include a period, for example twentytwentytwo -> twentytwentytwo-1.0
2. Activate block theme with period in the name.
3. Load site editor confirm error in console.log (404 route not found)
4. Apply patch.
5. Confirm site editor loads and global style changes are saved.


