### PR TITLE
Site Editor: Elevate "Editor" menu item

### DIFF
--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -41,28 +41,36 @@ function gutenberg_remove_legacy_pages() {
 	}
 
 	global $submenu;
-	if ( isset( $submenu['themes.php'] ) ) {
-		$indexes_to_remove = array();
-		foreach ( $submenu['themes.php'] as $index => $menu_item ) {
-			if ( false !== strpos( $menu_item[2], 'customize.php' ) && ! gutenberg_site_requires_customizer() ) {
-				$indexes_to_remove[] = $index;
-			}
+	if ( ! isset( $submenu['themes.php'] ) ) {
+		return;
+	}
 
-			if ( false !== strpos( $menu_item[2], 'site-editor.php' ) ) {
-				$indexes_to_remove[] = $index;
-			}
-
-			if ( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ) {
-				$indexes_to_remove[] = $index;
-			}
+	$indexes_to_remove = array();
+	$customize_menu    = null;
+	foreach ( $submenu['themes.php'] as $index => $menu_item ) {
+		if ( false !== strpos( $menu_item[2], 'customize.php' ) ) {
+			$indexes_to_remove[] = $index;
+			$customize_menu      = $menu_item;
 		}
 
-		foreach ( $indexes_to_remove as $index ) {
-			unset( $submenu['themes.php'][ $index ] );
+		if ( false !== strpos( $menu_item[2], 'site-editor.php' ) ) {
+			$indexes_to_remove[] = $index;
+		}
+
+		if ( false !== strpos( $menu_item[2], 'gutenberg-widgets' ) ) {
+			$indexes_to_remove[] = $index;
 		}
 	}
-}
 
+	foreach ( $indexes_to_remove as $index ) {
+		unset( $submenu['themes.php'][ $index ] );
+	}
+
+	// Add Customizer back but with a new sub-menu position when a site requires this feature.
+	if ( gutenberg_site_requires_customizer() && $customize_menu ) {
+		$submenu['themes.php'][20] = $customize_menu;
+	}
+}
 add_action( 'admin_menu', 'gutenberg_remove_legacy_pages' );
 
 /**


### PR DESCRIPTION
## Description
PR updates logic in legacy menu pages and re-adds Customizer page below the Editor when other plugins require this feature.

The WP core already has similar logic in place, so there's no need for backporting this change - https://github.com/WordPress/wordpress-develop/blob/9cc20468ef4803510f24caee93082514224f01f2/src/wp-admin/menu.php#L219-L223.

P.S. I also did minor refactoring of this function to reduce nesting for readability.

Closes #37056.

## How has this been tested?
1. Install and activate the plugin that requires Customizer. e.g., WooCommerce or BuddyPress.
2. Check that the Customizer appears below the "Editor (beta)" menu item.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
