### PR TITLE
Gradient picker: Small refinement to "Remove Control Point".

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -129,14 +129,16 @@ const ColorPicker = (
 						}
 					/>
 				</HStack>
-				<Spacer margin={ 4 } />
 				{ showInputs && (
-					<ColorInput
-						colorType={ colorType }
-						color={ safeColordColor }
-						onChange={ handleChange }
-						enableAlpha={ enableAlpha }
-					/>
+					<>
+						<Spacer margin={ 4 } />
+						<ColorInput
+							colorType={ colorType }
+							color={ safeColordColor }
+							onChange={ handleChange }
+							enableAlpha={ enableAlpha }
+						/>
+					</>
 				) }
 			</AuxiliaryColorArtefactWrapper>
 		</ColorfulWrapper>

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -10,7 +10,7 @@ import { colord } from 'colord';
 import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { plus } from '@wordpress/icons';
+import { plus, trash } from '@wordpress/icons';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
 
 /**
@@ -228,6 +228,8 @@ function ControlPoints( {
 							{ ! disableRemove && (
 								<Button
 									className="components-custom-gradient-picker__remove-control-point"
+									icon={ trash }
+									label={ __( 'Remove control point' ) }
 									onClick={ () => {
 										onChange(
 											removeControlPoint(
@@ -237,10 +239,7 @@ function ControlPoints( {
 										);
 										onClose();
 									} }
-									variant="link"
-								>
-									{ __( 'Remove Control Point' ) }
-								</Button>
+								/>
 							) }
 						</>
 					) }

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -63,9 +63,11 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 
 .components-custom-gradient-picker__color-picker-popover .components-custom-gradient-picker__remove-control-point {
 	margin-left: auto;
-	margin-right: auto;
+	padding: 0;
+	margin-right: $grid-unit-20;
 	display: block;
-	margin-bottom: $grid-unit-10;
+	min-width: $button-size-small;
+	height: $button-size-small;
 }
 
 .components-custom-gradient-picker__inserter {


### PR DESCRIPTION
## Description

The flow for removing gradient control points is currently a bit challenged:
![before](https://user-images.githubusercontent.com/1204802/145019149-1fc4e2c3-833c-4ee1-9048-6a2c28a16eff.gif)

Specificlally, the "Remove Control Point" button has undue prominence, is a link button, uses titlecase, and doesn't really sit in a well-balanced part of the interface. 

This PR is what I'd consider a very small bandaid to reduce the prominence a little bit, without making big changes. It just makes it a small trash button:

![after](https://user-images.githubusercontent.com/1204802/145019413-068f222c-4a24-42ba-bb2e-871b0d396439.gif)

I don't really like the placement or flow, or the icon. To an extent I would think it plenty sufficient for the Delete key to remove the point, as it's such an edgecase that it really should have little prominence in the UI. But as a temporary holdover, this seems like a small win.

I also noticed by the way that you can endlessly remove control points. It seems like we should show the "remove control point" button only if there are more than two control points, since the gradient isn't actually functional with less than that:

![removing](https://user-images.githubusercontent.com/1204802/145020199-f5e8b4b1-966e-452e-85ec-2b2d79fb1cac.gif)

@ajlende is this something you can help me with?

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
