### PR TITLE
[RNMobile] Use text-align to center multiline text in inserter

### DIFF
--- a/packages/components/src/mobile/inserter-button/style.native.scss
+++ b/packages/components/src/mobile/inserter-button/style.native.scss
@@ -42,6 +42,7 @@
 	padding-top: 4;
 	padding-bottom: 0;
 	justify-content: center;
+	text-align: center;
 	font-size: 12;
 	color: $gray-dark;
 }

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [*] Give multi-line block names central alignment in inserter [#37185]
 -   [**] [iOS] Fix scroll update when typing in RichText component [#36914]
 -   [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes. [#36883]
 -   [***] Highlight text - enables color customization for specific text within a Pragraph block [#36028]


### PR DESCRIPTION
Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4343

## Description
This PR fixes https://github.com/WordPress/gutenberg/issues/34748, which noted that block titles spanning multiple lines are not centrally aligned in the inserter.

## How has this been tested?
1. Open the block inserter
2. Verify that when the name of a block spans multiple lines the name is centered (You will probably need to add a reusable block with a long name and test this in WPAndroid or WPiOS to verify this).

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/4656348/145050733-a175a7c0-9e44-4b21-ba9e-47e0b4cc0956.png)


## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
