### PR TITLE
Don't request the deprecated navigation areas endpoint outside of the Gutenberg plugin

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import noop from 'lodash';
 
 /**
  * WordPress dependencies
@@ -109,7 +110,8 @@ function Navigation( {
 		layout: { justifyContent, orientation = 'horizontal' } = {},
 	} = attributes;
 
-	let areaMenu, setAreaMenu;
+	let areaMenu,
+		setAreaMenu = noop;
 	// Navigation areas are deprecated and on their way out. Let's not perform
 	// the request unless we're in an environment where the endpoint exists.
 	if ( process.env.GUTENBERG_PHASE === 2 ) {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -109,12 +109,18 @@ function Navigation( {
 		layout: { justifyContent, orientation = 'horizontal' } = {},
 	} = attributes;
 
-	const [ areaMenu, setAreaMenu ] = useEntityProp(
-		'root',
-		'navigationArea',
-		'navigation',
-		navigationArea
-	);
+	let areaMenu, setAreaMenu;
+	// Navigation areas are deprecated and on their way out. Let's not perform
+	// the request unless we're in an environment where the endpoint exists.
+	if ( process.env.GUTENBERG_PHASE === 2 ) {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		[ areaMenu, setAreaMenu ] = useEntityProp(
+			'root',
+			'navigationArea',
+			'navigation',
+			navigationArea
+		);
+	}
 
 	const navigationAreaMenu = areaMenu === 0 ? undefined : areaMenu;
 


### PR DESCRIPTION
## Description

Solves https://github.com/WordPress/gutenberg/issues/37138

The navigation areas endpoint is not shipped with core, yet the `useEntityProp` endpoint causes a HTTP request. This PR restricts that HTTP exchange to when the Gutenberg plugin is active by guarding the call to `useEntityProp` with a check for `process.env.GUTENBERG_PHASE === 2`. Normally guarding react hooks is a big no-no, but this should be okay since the variable is fixed.

## How has this been tested?

- Go to any editor
- Add a navigation block
- Confirm it showed up and there were no requests to `/wp/v2/block-navigation-areas`
