### PR TITLE
Docs: Fix link to how to guide template

### DIFF
--- a/docs/contributors/documentation/README.md
+++ b/docs/contributors/documentation/README.md
@@ -38,7 +38,7 @@ The handbook is organized into four sections based on the functional types of do
 
 ### Templates
 
-A [how to guide template](/docs/contributors/documentation/how-to-guide-template.md) is available to provide a common structure to guides. If starting a new how to guide, copy the markdown from the template to get started.
+A [how to guide template](https://raw.githubusercontent.com/WordPress/gutenberg/trunk/docs/contributors/documentation/how-to-guide-template.md) is available to provide a common structure to guides. If starting a new how to guide, copy the markdown from the template to get started.
 
 The template is based on examples from The Good Docs Project, see their [template repository for additional examples](https://github.com/thegooddocsproject/templates) to help you create quality documentation.
 


### PR DESCRIPTION
## Description

The link to the how to template added in #36694 did not work because the template is not in the table of contents so does not get published to the documentation site.

This PR fixes that link to go straight to the GitHub raw file to allow copy and paste from.

## How has this been tested?

Confirm GitHub raw link works properly.


## Types of changes

Documentation, link fix.

