### PR TITLE
Comments Query Loop: Improve context handling in inner blocks

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -64,6 +64,7 @@ function gutenberg_reregister_core_block_types() {
 				'comment-edit-link.php'           => 'core/comment-edit-link',
 				'comment-reply-link.php'          => 'core/comment-reply-link',
 				'comment-template.php'            => 'core/comment-template',
+				'comments-pagination.php'         => 'core/comments-pagination',
 				'comments-pagination-numbers.php' => 'core/comments-pagination-numbers',
 				'file.php'                        => 'core/file',
 				'home-link.php'                   => 'core/home-link',

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Temporary compatibility shims for features present in Gutenberg.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
+	/**
+	 * Helper function that constructs a comment query vars array from the passed block properties.
+	 *
+	 * It's used with the Comment Query Loop inner blocks.
+	 *
+	 * @param WP_Block $block Block instance.
+	 *
+	 * @return array Returns the comment query parameters to use with the WP_Comment_Query constructor.
+	 */
+	function build_comment_query_vars_from_block( $block ) {
+		$comment_args = array(
+			'orderby'                   => 'comment_date_gmt',
+			'order'                     => 'ASC',
+			'status'                    => 'approve',
+			'no_found_rows'             => false,
+			'update_comment_meta_cache' => false, // We lazy-load comment meta for performance.
+		);
+
+		if ( ! empty( $block->context['postId'] ) ) {
+			$comment_args['post_id'] = (int) $block->context['postId'];
+		}
+
+		if ( get_option( 'thread_comments' ) ) {
+			$comment_args['hierarchical'] = 'threaded';
+		} else {
+			$comment_args['hierarchical'] = false;
+		}
+
+		$per_page = ! empty( $block->context['comments/perPage'] ) ? (int) $block->context['comments/perPage'] : 0;
+		if ( 0 === $per_page && get_option( 'page_comments' ) ) {
+			$per_page = (int) get_query_var( 'comments_per_page' );
+			if ( 0 === $per_page ) {
+				$per_page = (int) get_option( 'comments_per_page' );
+			}
+		}
+		if ( $per_page > 0 ) {
+			$comment_args['number'] = $per_page;
+			$page                   = (int) get_query_var( 'cpage' );
+
+			if ( $page ) {
+				$comment_args['offset'] = ( $page - 1 ) * $per_page;
+			} elseif ( 'oldest' === get_option( 'default_comments_page' ) ) {
+				$comment_args['offset'] = 0;
+			}
+		}
+
+		return $comment_args;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -117,6 +117,7 @@ require __DIR__ . '/compat/wordpress-5.9/default-theme-supports.php';
 require __DIR__ . '/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php';
 require __DIR__ . '/compat/wordpress-5.9/rest-active-global-styles.php';
 require __DIR__ . '/compat/wordpress-5.9/move-theme-editor-menu-item.php';
+require __DIR__ . '/compat/experimental/blocks.php';
 
 require __DIR__ . '/blocks.php';
 require __DIR__ . '/block-patterns.php';

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -7,7 +7,7 @@
 	"parent": [ "core/comments-query-loop" ],
 	"description": "Contains the block elements used to render a comment, like the title, date, author, avatar and more.",
 	"textdomain": "default",
-	"usesContext": [ "queryId", "queryPerPage", "postId" ],
+	"usesContext": [ "comments/perPage", "postId" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -114,7 +114,7 @@ const CommentsList = ( {
 
 export default function CommentTemplateEdit( {
 	clientId,
-	context: { postId, queryPerPage },
+	context: { postId, 'comments/perPage': perPage },
 } ) {
 	const blockProps = useBlockProps();
 
@@ -138,13 +138,16 @@ export default function CommentTemplateEdit( {
 		[ postId, clientId ]
 	);
 
+	// TODO: Replicate the logic used on the server.
+	perPage = perPage || 50;
+
 	// We convert the flat list of comments to tree.
-	// Then, we show only a maximum of `queryPerPage` number of comments.
+	// Then, we show only a maximum of `perPage` number of comments.
 	// This is because passing `per_page` to `getEntityRecords()` does not
 	// take into account nested comments.
 	const comments = useMemo(
-		() => convertToTree( rawComments ).slice( 0, queryPerPage ),
-		[ rawComments, queryPerPage ]
+		() => convertToTree( rawComments ).slice( 0, perPage ),
+		[ rawComments, perPage ]
 	);
 
 	if ( ! rawComments ) {

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -53,25 +53,17 @@ function block_core_comment_template_render_comments( $comments, $block ) {
  * defined by the block's inner blocks.
  */
 function render_block_core_comment_template( $attributes, $content, $block ) {
-
-	$post_id = $block->context['postId'];
-
 	// Bail out early if the post ID is not set for some reason.
-	if ( ! isset( $post_id ) ) {
+	if ( empty( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	$number = $block->context['queryPerPage'];
-
-	// Get an array of comments for the current post.
-	$comments = get_approved_comments(
-		$post_id,
-		array(
-			'number'       => $number,
-			'hierarchical' => 'threaded',
-		)
+	$comment_query = new WP_Comment_Query(
+		build_comment_query_vars_from_block( $block )
 	);
 
+	// Get an array of comments for the current post.
+	$comments = $comment_query->get_comments();
 	if ( count( $comments ) === 0 ) {
 		return '';
 	}

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -3,11 +3,11 @@
 	"apiVersion": 2,
 	"name": "core/comments-pagination-numbers",
 	"title": "Comments Pagination Numbers",
-  "category": "theme",
+	"category": "theme",
 	"parent": [ "core/comments-pagination" ],
 	"description": "Displays a list of page numbers for comments pagination.",
 	"textdomain": "default",
-	"usesContext": [ "queryId", "queryPerPage", "postId" ],
+	"usesContext": [ "comments/perPage", "postId" ],
 	"supports": {
 		"reusable": false,
 		"html": false

--- a/packages/block-library/src/comments-pagination-numbers/index.php
+++ b/packages/block-library/src/comments-pagination-numbers/index.php
@@ -15,31 +15,21 @@
  * @return string Returns the pagination numbers for the comments.
  */
 function render_block_core_comments_pagination_numbers( $attributes, $content, $block ) {
-	// Get the post ID from which comments should be retrieved.
-	$post_id = isset( $block->context['postId'] )
-		? $block->context['postId']
-		: get_the_id();
-
-	if ( ! $post_id ) {
+	// Bail out early if the post ID is not set for some reason.
+	if ( empty( $block->context['postId'] ) ) {
 		return '';
 	}
 
-	// Get the 'comments per page' setting.
-	$per_page = isset( $block->context['queryPerPage'] )
-		? $block->context['queryPerPage']
-		: get_option( 'comments_per_page' );
-
-	// Get the total number of pages.
-	$comments = get_approved_comments( $post_id );
-	$total    = get_comment_pages_count( $comments, $per_page );
-
-	// Get the number of the default page.
-	$default_page = 'newest' === get_option( 'default_comments_page' ) ? $total : 1;
+	$comments_query = new WP_Comment_Query(
+		build_comment_query_vars_from_block( $block )
+	);
+	$total          = $comments_query->max_num_pages;
 
 	// Get the current comment page from the URL.
 	$current = get_query_var( 'cpage' );
 	if ( ! $current ) {
-		$current = $default_page;
+		// Get the number of the default page.
+		$current = 'newest' === get_option( 'default_comments_page' ) ? $total : 1;
 	}
 
 	// Render links.

--- a/packages/block-library/src/comments-query-loop/block.json
+++ b/packages/block-library/src/comments-query-loop/block.json
@@ -7,12 +7,9 @@
 	"description": "An advanced block that allows displaying post comments based on different query parameters and visual configurations.",
 	"textdomain": "default",
 	"attributes": {
-		"queryId": {
-			"type": "number"
-		},
-		"queryPerPage": {
+		"perPage": {
 			"type": "number",
-			"default": 50
+			"default": null
 		},
 		"tagName": {
 			"type": "string",
@@ -20,8 +17,7 @@
 		}
 	},
 	"providesContext": {
-		"queryId": "queryId",
-		"queryPerPage": "queryPerPage"
+		"comments/perPage": "perPage"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/comments-query-loop/edit.js
+++ b/packages/block-library/src/comments-query-loop/edit.js
@@ -18,7 +18,7 @@ import QueryToolbar from './toolbar';
 const TEMPLATE = [ [ 'core/comment-template' ] ];
 
 export default function CommentsQueryLoopEdit( { attributes, setAttributes } ) {
-	const { queryPerPage, tagName: TagName } = attributes;
+	const { perPage, tagName: TagName } = attributes;
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -28,10 +28,7 @@ export default function CommentsQueryLoopEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<BlockControls>
-				<QueryToolbar
-					queryPerPage={ queryPerPage }
-					setQuery={ setAttributes }
-				/>
+				<QueryToolbar perPage={ perPage } setQuery={ setAttributes } />
 			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl

--- a/packages/block-library/src/comments-query-loop/toolbar.js
+++ b/packages/block-library/src/comments-query-loop/toolbar.js
@@ -11,7 +11,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { settings } from '@wordpress/icons';
 
-export default function CommentsQueryLoopToolbar( { queryPerPage, setQuery } ) {
+export default function CommentsQueryLoopToolbar( { perPage, setQuery } ) {
 	return (
 		<ToolbarGroup>
 			<Dropdown
@@ -41,11 +41,11 @@ export default function CommentsQueryLoopToolbar( { queryPerPage, setQuery } ) {
 										return;
 									}
 									setQuery( {
-										queryPerPage: num,
+										perPage: num,
 									} );
 								} }
 								step="1"
-								value={ queryPerPage }
+								value={ perPage }
 								isDragEnabled={ false }
 							/>
 						</BaseControl>

--- a/test/integration/fixtures/blocks/core__comments-query-loop.json
+++ b/test/integration/fixtures/blocks/core__comments-query-loop.json
@@ -4,7 +4,7 @@
 		"name": "core/comments-query-loop",
 		"isValid": true,
 		"attributes": {
-			"queryPerPage": 50,
+			"perPage": null,
 			"tagName": "div"
 		},
 		"innerBlocks": [],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

It might replace #36623. I still don't know. I'm exploring the minimal set of block context values to use to make pagination work. I'm also using this branch to document issues discovered while testing.

At the moment only the following site settings are respected:

<img width="842" alt="Screenshot 2021-12-09 at 00 04 33" src="https://user-images.githubusercontent.com/699132/145305341-5ec54371-1c96-4b66-8b8b-0bcc2c9ca35d.png">

We still need to add better support for:

<img width="524" alt="Screenshot 2021-12-09 at 00 05 19" src="https://user-images.githubusercontent.com/699132/145305382-9bc898a3-1833-4bd2-b81d-190578d80a02.png">
<img width="607" alt="Screenshot 2021-12-09 at 00 05 22" src="https://user-images.githubusercontent.com/699132/145305384-f5ae7258-3921-4faf-a21e-e7d00f3ee46d.png">

I propose we:
- Remove the `queryId` attribute from the Comments Query Loop block and from the block context for now since it is not used. We can add it back once we have a clear vision for multiple queries on a single page discussed in #36642.
- Rename the `queryPerPage` attribute in the Comments Query Loop to `perPage` and expose it in the block context as `comments/perPage`. It should help to clarify that the context is coming from the parent block and aligns more closely with the documentation that promotes namespaces: https://github.com/WordPress/gutenberg/blob/trunk/docs/reference-guides/block-api/block-context.md#defining-block-context.
- Introduce a new PHP helper function `build_comment_query_vars_from_block` to have a unified way to query comments and all related characteristics. It should work both for pages that define a currently selected post id and all other pages where users might want to show a custom list of comments.

The implementation is based on the functionality present in WordPress core in the [`comments_template`](https://developer.wordpress.org/reference/functions/comments_template/) function.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
