### PR TITLE
Remove all blocks - Dev Option

### DIFF
--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -326,10 +326,8 @@ class NativeEditorProvider extends Component {
 	}
 
 	removeAllBlocks() {
-		console.log('***** REMOVE ALL BLOCKS');
-		console.log(this.props)
-		const test = this.props.getAllBlocksWithoutInnerBlocks();
-		console.log(test)
+		const allClientIds = this.props.blocks.map( block => block.clientId );
+		this.props.removeBlocks( allClientIds );
 	}
 
 	updateCapabilitiesAction( capabilities ) {
@@ -380,7 +378,6 @@ export default compose( [
 			getSelectedBlockClientId,
 			getGlobalBlockCount,
 			getSettings: getBlockEditorSettings,
-			__unstableGetBlockWithoutInnerBlocks: getAllBlocksWithoutInnerBlocks,
 		} = select( blockEditorStore );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
@@ -391,7 +388,6 @@ export default compose( [
 			title: getEditedPostAttribute( 'title' ),
 			getEditedPostContent,
 			getBlockEditorSettings,
-			getAllBlocksWithoutInnerBlocks,
 			selectedBlockIndex: getBlockIndex( selectedBlockClientId ),
 			blockCount: getGlobalBlockCount(),
 			paragraphCount: getGlobalBlockCount( 'core/paragraph' ),
@@ -404,6 +400,7 @@ export default compose( [
 			clearSelectedBlock,
 			insertBlock,
 			replaceBlock,
+			removeBlocks,
 		} = dispatch( blockEditorStore );
 		const { switchEditorMode } = dispatch( 'core/edit-post' );
 		const { addEntities, receiveEntityRecords } = dispatch( 'core' );
@@ -428,6 +425,7 @@ export default compose( [
 				switchEditorMode( mode );
 			},
 			replaceBlock,
+			removeBlocks,
 		};
 	} ),
 ] )( NativeEditorProvider );

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -11,6 +11,7 @@ import RNReactNativeGutenbergBridge, {
 	setBlockTypeImpressions,
 	subscribeParentGetHtml,
 	subscribeParentToggleHTMLMode,
+	subscribeParentRemoveAllBlocks,
 	subscribeUpdateHtml,
 	subscribeSetTitle,
 	subscribeMediaAppend,
@@ -111,6 +112,12 @@ class NativeEditorProvider extends Component {
 		this.subscriptionParentToggleHTMLMode = subscribeParentToggleHTMLMode(
 			() => {
 				this.toggleMode();
+			}
+		);
+
+		this.subscriptionRemoveAllBlocks = subscribeParentRemoveAllBlocks(
+			() => {
+				this.removeAllBlocks();
 			}
 		);
 
@@ -318,6 +325,13 @@ class NativeEditorProvider extends Component {
 		switchMode( mode === 'visual' ? 'text' : 'visual' );
 	}
 
+	removeAllBlocks() {
+		console.log('***** REMOVE ALL BLOCKS');
+		console.log(this.props)
+		const test = this.props.getAllBlocksWithoutInnerBlocks();
+		console.log(test)
+	}
+
 	updateCapabilitiesAction( capabilities ) {
 		this.props.updateSettings( capabilities );
 	}
@@ -366,6 +380,7 @@ export default compose( [
 			getSelectedBlockClientId,
 			getGlobalBlockCount,
 			getSettings: getBlockEditorSettings,
+			__unstableGetBlockWithoutInnerBlocks: getAllBlocksWithoutInnerBlocks,
 		} = select( blockEditorStore );
 
 		const selectedBlockClientId = getSelectedBlockClientId();
@@ -376,6 +391,7 @@ export default compose( [
 			title: getEditedPostAttribute( 'title' ),
 			getEditedPostContent,
 			getBlockEditorSettings,
+			getAllBlocksWithoutInnerBlocks,
 			selectedBlockIndex: getBlockIndex( selectedBlockClientId ),
 			blockCount: getGlobalBlockCount(),
 			paragraphCount: getGlobalBlockCount( 'core/paragraph' ),

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -326,7 +326,9 @@ class NativeEditorProvider extends Component {
 	}
 
 	removeAllBlocks() {
-		const allClientIds = this.props.blocks.map( block => block.clientId );
+		const allClientIds = this.props.blocks.map(
+			( block ) => block.clientId
+		);
 		this.props.removeBlocks( allClientIds );
 	}
 

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -42,6 +42,7 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     private static final String EVENT_NAME_FOCUS_TITLE = "setFocusOnTitle";
     private static final String EVENT_NAME_MEDIA_APPEND = "mediaAppend";
     private static final String EVENT_NAME_TOGGLE_HTML_MODE = "toggleHTMLMode";
+    private static final String EVENT_NAME_REMOVE_ALL_BLOCKS = "removeAllBlocks";
     private static final String EVENT_NAME_NOTIFY_MODAL_CLOSED = "notifyModalClosed";
     private static final String EVENT_NAME_PREFERRED_COLOR_SCHEME = "preferredColorScheme";
     private static final String EVENT_NAME_MEDIA_REPLACE_BLOCK = "replaceBlock";
@@ -399,6 +400,10 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
 
     public void toggleEditorMode() {
         emitToJS(EVENT_NAME_TOGGLE_HTML_MODE, null);
+    }
+
+    public void removeAllBlocks() {
+        emitToJS(EVENT_NAME_REMOVE_ALL_BLOCKS, null);
     }
 
     public void notifyModalClosed() {

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -50,6 +50,10 @@ export function subscribeParentToggleHTMLMode( callback ) {
 	return gutenbergBridgeEvents.addListener( 'toggleHTMLMode', callback );
 }
 
+export function subscribeParentRemoveAllBlocks( callback ) {
+	return gutenbergBridgeEvents.addListener( 'removeAllBlocks', callback );
+}
+
 export function subscribeSetFocusOnTitle( callback ) {
 	return gutenbergBridgeEvents.addListener( 'setFocusOnTitle', callback );
 }

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -109,6 +109,10 @@ public class Gutenberg: NSObject {
         sendEvent(.toggleHTMLMode)
     }
 
+    public func removeAllBlocks() {
+        sendEvent(.removeAllBlocks)
+    }
+
     public func setTitle(_ title: String) {
         sendEvent(.setTitle, body: ["title": title])
     }

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -418,6 +418,7 @@ extension RNReactNativeGutenbergBridge {
         case showNotice
         case mediaSave
         case showEditorHelp
+        case removeAllBlocks
     }
 
     public override func supportedEvents() -> [String]! {

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainApplication.java
@@ -353,6 +353,13 @@ public class MainApplication extends Application implements ReactApplication, Gu
             }
         });
 
+        devSupportManager.addCustomDevOption("Remove all blocks", new DevOptionHandler() {
+            @Override
+            public void onOptionSelected() {
+                mRnReactNativeGutenbergBridgePackage.getRNReactNativeGutenbergBridgeModule().removeAllBlocks();
+            }
+        });
+
         devSupportManager.addCustomDevOption("Help", new DevOptionHandler() {
             @Override
             public void onOptionSelected() {

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -380,6 +380,7 @@ extension GutenbergViewController {
         }
         let cancelAction = UIAlertAction(title: "Keep Editing", style: .cancel)
         alert.addAction(toggleHTMLModeAction)
+        alert.addAction(removeAllBlocksAction)
         alert.addAction(updateHtmlAction)
         alert.addAction(unsupportedBlockUIAction)
         alert.addAction(showEditorHelpAction)
@@ -394,6 +395,15 @@ extension GutenbergViewController {
             style: .default,
             handler: { [unowned self] action in
                 self.toggleHTMLMode(action)
+        })
+    }
+
+    var removeAllBlocksAction: UIAlertAction {
+        return UIAlertAction(
+            title: "Remove All Blocks",
+            style: .default,
+            handler: { [unowned self] action in
+                self.removeAllBlocks()
         })
     }
     
@@ -450,6 +460,10 @@ extension GutenbergViewController {
     func toggleHTMLMode(_ action: UIAlertAction) {
         htmlMode = !htmlMode
         gutenberg.toggleHTMLMode()
+    }
+
+    func removeAllBlocks() {
+        gutenberg.removeAllBlocks()
     }
     
     func showEditorHelp() {

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -457,7 +457,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: 1e5474c982efcfcaed47f368a61431bb38a4faf8
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: f677cf7e2020cc453422757457ee2554984e0935
+  FBReactNativeSpec: 576cdc0b18dc6371ce9033ceda15ad7e8cb6d5e6
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Gutenberg: 0dc62f9914304edd96818b94cd45b23ad64397db
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -457,7 +457,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: 1e5474c982efcfcaed47f368a61431bb38a4faf8
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 576cdc0b18dc6371ce9033ceda15ad7e8cb6d5e6
+  FBReactNativeSpec: f677cf7e2020cc453422757457ee2554984e0935
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   Gutenberg: 0dc62f9914304edd96818b94cd45b23ad64397db
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c


### PR DESCRIPTION
## Description
Adds remove all blocks option to dev menu for demo app.

### Screenshots

https://user-images.githubusercontent.com/13263478/145090107-ee6c192b-a3ce-4bd7-a3f6-a1284e28f553.mp4

https://user-images.githubusercontent.com/13263478/145090053-08886835-8f0b-409e-8bcd-fa6685724d3a.mp4

## How has this been tested?
* Load Android demo app
* Ensure that there are blocks with and without inner blocks
* Open dev menu
* Choose "Remove all blocks"
* See that all blocks are gone
* Repeat for iOS

## Types of changes
* This is a new feature for the demo app only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
