### PR TITLE
[WIP] E2E tests: Add a retry to the nonce login api call to try and fix flakey e2e

### DIFF
--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -42,10 +42,10 @@ const fetchRetry = async ( url, options = {}, retries ) => {
 		return response;
 	}
 	if ( retries > 0 ) {
-		return fetchRetry( url, options, retries - 1 );
+		return setTimeout( fetchRetry( url, options, retries - 1 ), 200 );
 	}
 	throw new Error(
-		`Fetch api call failed for ${ url }: ${ JSON.stringify( response ) }`
+		`Fetch api call failed for ${ url }: ${ response.status }`
 	);
 };
 
@@ -84,7 +84,7 @@ const setNonce = ( async () => {
 		{
 			headers: { cookie },
 		},
-		2
+		3
 	);
 	const nonce = await res.text();
 

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -38,7 +38,7 @@ Link header: ${ links }` );
 const fetchRetry = async ( url, options = {}, retries ) => {
 	const response = await fetch( url, options );
 
-	if ( response.status === 302 ) {
+	if ( response.ok || response.status === 302 || response.status === 200 ) {
 		return response;
 	}
 	if ( retries > 0 ) {

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -42,7 +42,7 @@ const fetchRetry = async ( url, options = {}, retries ) => {
 		return response;
 	}
 	if ( retries > 0 ) {
-		return setTimeout( fetchRetry( url, options, retries - 1 ), 200 );
+		fetchRetry( url, options, retries - 1 );
 	}
 	throw new Error(
 		`Fetch api call failed for ${ url }: ${ response.status }`

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -37,7 +37,7 @@ Link header: ${ links }` );
 
 const fetchRetry = async ( url, options = {}, retries ) => {
 	const response = await fetch( url, options );
-
+	console.log( 'url: ', url, 'status: ', response.status );
 	if ( response.ok || response.status === 302 || response.status === 200 ) {
 		return response;
 	}

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -44,7 +44,9 @@ const fetchRetry = async ( url, options = {}, retries ) => {
 	if ( retries > 0 ) {
 		return fetchRetry( url, options, retries - 1 );
 	}
-	throw new Error( `Login to get nonce failed: ${ response.status }` );
+	throw new Error(
+		`Fetch api call failed for ${ url }: ${ response.status }`
+	);
 };
 
 const setNonce = ( async () => {
@@ -77,9 +79,13 @@ const setNonce = ( async () => {
 	);
 
 	// Get the initial nonce.
-	const res = await fetch( apiFetch.nonceEndpoint, {
-		headers: { cookie },
-	} );
+	const res = await fetchRetry(
+		apiFetch.nonceEndpoint,
+		{
+			headers: { cookie },
+		},
+		2
+	);
 	const nonce = await res.text();
 
 	// Register the nonce middleware.

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -45,7 +45,7 @@ const fetchRetry = async ( url, options = {}, retries ) => {
 		return fetchRetry( url, options, retries - 1 );
 	}
 	throw new Error(
-		`Fetch api call failed for ${ url }: ${ response.status }`
+		`Fetch api call failed for ${ url }: ${ JSON.stringify( response ) }`
 	);
 };
 

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -44,7 +44,7 @@ const fetchRetry = async ( url, options = {}, retries ) => {
 	if ( retries > 0 ) {
 		return fetchRetry( url, options, retries - 1 );
 	}
-	throw new Error( response.status );
+	throw new Error( `Login to get nonce failed: ${ response.status }` );
 };
 
 const setNonce = ( async () => {


### PR DESCRIPTION
## Description
The e2e tests are regularly failing with a 400 error for a call to `wp-admin/admin-ajax.php?action=rest-nonce`. It seems that in some instances on CI the initial login call just before this may be failing so a valid cookie is not received. 

This PR adds a retry to the initial login call to try and make this part of the trust less likely to fail.

## How has this been tested?
Rerunning tests in CI and checking for failures
