### PR TITLE
Add plugins styles customization support

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 12.0.1 =
+
+### Enhancements
+
+#### Global Styles
+- Add caching to `WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type()`. ([36584](https://github.com/WordPress/gutenberg/pull/36584))
+
+
 = 12.0.0 =
 
 ### Features

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,6 @@
 == Changelog ==
 
-= 12.0.0-rc.1 =
-
-
+= 12.0.0 =
 
 ### Features
 
@@ -13,35 +11,34 @@
 
 #### Block Library
 - Move WP_REST_Block_Navigation_Areas_Controller from Gutenberg to Core. ([36374](https://github.com/WordPress/gutenberg/pull/36374))
-- Try: Let Featured Image block inherit dimensions, look like a placeholder. ([36517](https://github.com/WordPress/gutenberg/pull/36517))
+- Let Featured Image block inherit dimensions, look like a placeholder. ([36517](https://github.com/WordPress/gutenberg/pull/36517))
 - Change all the uses of "website" to "site". ([36220](https://github.com/WordPress/gutenberg/pull/36220))
 - Enable Previews for Navigation Link Blocks. ([36412](https://github.com/WordPress/gutenberg/pull/36412))
 
 #### Site Editor
-- FSE: Add welcome guide. ([36172](https://github.com/WordPress/gutenberg/pull/36172))
+- Add  welcome guide. ([36172](https://github.com/WordPress/gutenberg/pull/36172))
 - Update back button URL. ([36313](https://github.com/WordPress/gutenberg/pull/36313))
 - Improve compatiblity with menu endpoints WordPress 5.9. ([36372](https://github.com/WordPress/gutenberg/pull/36372))
 - React to any errors coming up in gutenberg_migrate_menu_to_navigation_post. ([36461](https://github.com/WordPress/gutenberg/pull/36461))
 
 #### Block API
-- Blocks: Update schema to require either a type or an enum. ([36267](https://github.com/WordPress/gutenberg/pull/36267))
-- Schema: Allow block.json attribute type to be an array. ([36295](https://github.com/WordPress/gutenberg/pull/36295))
+- Update schema to require either a type or an enum. ([36267](https://github.com/WordPress/gutenberg/pull/36267))
 - Add `_wp_array_set` and `_wp_to_kebab_case` to 5.8 compat. ([36399](https://github.com/WordPress/gutenberg/pull/36399))
 
 #### Design Tools
 - Paragraph: Merge text settings into typography panel. ([36334](https://github.com/WordPress/gutenberg/pull/36334))
 
 #### Build Tooling
-- Scripts: Add TypeScript for builds and tests. ([36260](https://github.com/WordPress/gutenberg/pull/36260))
+- Add TypeScript for builds and tests. ([36260](https://github.com/WordPress/gutenberg/pull/36260))
 - stylelint-config: Widen the acceptable version range for the 'stylelint' peerDependency. ([36518](https://github.com/WordPress/gutenberg/pull/36518))
-- Babel Preset: Update Babel packages to 7.16 version. ([36244](https://github.com/WordPress/gutenberg/pull/36244))
+- Update Babel packages to 7.16 version. ([36244](https://github.com/WordPress/gutenberg/pull/36244))
 
 #### Style Variations
 - Block Styles: Show style preview when hovered or focused. ([34522](https://github.com/WordPress/gutenberg/pull/34522))
 
 #### Schema
-- Schemas: Update schema URL to wp.org domain. ([36316](https://github.com/WordPress/gutenberg/pull/36316))
-
+- Update schema URL to wp.org domain. ([36316](https://github.com/WordPress/gutenberg/pull/36316))
+- Allow block.json attribute type to be an array. ([36295](https://github.com/WordPress/gutenberg/pull/36295))
 
 ### Bug Fixes
 
@@ -49,7 +46,7 @@
 - DEWP: Fix deprecation warning. ([36285](https://github.com/WordPress/gutenberg/pull/36285))
 - Fix mobile horizontal scrollbar. ([36567](https://github.com/WordPress/gutenberg/pull/36567))
 - Fix schema to allow for custom blocks in theme.json. ([36341](https://github.com/WordPress/gutenberg/pull/36341))
-- Fix: Theme switch on the global styles rest api unit test. ([36277](https://github.com/WordPress/gutenberg/pull/36277))
+- Theme switch on the global styles rest api unit test. ([36277](https://github.com/WordPress/gutenberg/pull/36277))
 - Polish metabox container. ([36297](https://github.com/WordPress/gutenberg/pull/36297))
 
 #### Block Library
@@ -84,7 +81,7 @@
 - Site Editor - prevent loading state from showing the admin menu. ([36455](https://github.com/WordPress/gutenberg/pull/36455))
 
 #### Themes
-- Fix: Add ability to opt out of Core color palette V2. ([36492](https://github.com/WordPress/gutenberg/pull/36492))
+- Add the ability to opt-out of Core color palette V2. ([36492](https://github.com/WordPress/gutenberg/pull/36492))
 
 #### Build Tooling
 - Fix not transforming logical assignments for packages. ([36484](https://github.com/WordPress/gutenberg/pull/36484))
@@ -105,7 +102,7 @@
 #### Global Styles
 - Chore: Add comment to Remove filter to allow WP variables after min version is 5.8. ([36281](https://github.com/WordPress/gutenberg/pull/36281))
 - Chore: Update: Centralize safe_style_css usages. ([36280](https://github.com/WordPress/gutenberg/pull/36280))
-- [Global Styles]: Add block icon next to blocks list. ([36520](https://github.com/WordPress/gutenberg/pull/36520))
+- Add block icon next to blocks list. ([36520](https://github.com/WordPress/gutenberg/pull/36520))
 - theme.json: Adds a setting property that enables some other ones. ([36246](https://github.com/WordPress/gutenberg/pull/36246))
 
 #### Block Library
@@ -115,15 +112,15 @@
 - Return wp error from wp_insert_post. ([36483](https://github.com/WordPress/gutenberg/pull/36483))
 
 #### Full Site Editing
-- FSE: Add template_type guards. ([36318](https://github.com/WordPress/gutenberg/pull/36318))
+- Add template_type guards. ([36318](https://github.com/WordPress/gutenberg/pull/36318))
 
 
 ### Documentation
 
 - "npm install" suggestion provides a better learning experience. ([36217](https://github.com/WordPress/gutenberg/pull/36217))
 - Added specific links to agenda and notes posts related to core editor meetings. ([36199](https://github.com/WordPress/gutenberg/pull/36199))
-- Docs: Schemastore - $schema is VS Code-specific. ([36179](https://github.com/WordPress/gutenberg/pull/36179))
-- Docs: Update GIF image in documentation with wp.org schema URL. ([36456](https://github.com/WordPress/gutenberg/pull/36456))
+- Schemastore - $schema is VS Code-specific. ([36179](https://github.com/WordPress/gutenberg/pull/36179))
+- Update GIF image in documentation with wp.org schema URL. ([36456](https://github.com/WordPress/gutenberg/pull/36456))
 - Update Versions in WordPress to include 5.9. ([36156](https://github.com/WordPress/gutenberg/pull/36156))
 - Update combobox-control component readme. ([36413](https://github.com/WordPress/gutenberg/pull/36413))
 - Update theme.json schema to refer to wp.org URL. ([36332](https://github.com/WordPress/gutenberg/pull/36332))
@@ -150,7 +147,7 @@
 - E2E: Add more Cover block tests. ([36321](https://github.com/WordPress/gutenberg/pull/36321))
 - Fix Performance CI tests and make them always use the latest major as base branch. ([36463](https://github.com/WordPress/gutenberg/pull/36463))
 - Fix failing tests and compatibility with 5.9. ([36368](https://github.com/WordPress/gutenberg/pull/36368))
-- Tests: Add integration tests with core blocks schema validation. ([36351](https://github.com/WordPress/gutenberg/pull/36351))
+- Add integration tests with core blocks schema validation. ([36351](https://github.com/WordPress/gutenberg/pull/36351))
 - Skip flaky image block test. ([36446](https://github.com/WordPress/gutenberg/pull/36446))
 
 #### Icons
@@ -179,9 +176,6 @@
 
 #### Template Editor
 - Change edit links for templates and template parts. ([36294](https://github.com/WordPress/gutenberg/pull/36294))
-
-
-
 
 
 = 11.9.1 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,189 @@
 == Changelog ==
 
+= 12.0.0-rc.1 =
+
+
+
+### Features
+
+- Disable BottomSheet swipe gesture to navigate backwards. ([36271](https://github.com/WordPress/gutenberg/pull/36271))
+
+
+### Enhancements
+
+#### Block Library
+- Move WP_REST_Block_Navigation_Areas_Controller from Gutenberg to Core. ([36374](https://github.com/WordPress/gutenberg/pull/36374))
+- Try: Let Featured Image block inherit dimensions, look like a placeholder. ([36517](https://github.com/WordPress/gutenberg/pull/36517))
+- Change all the uses of "website" to "site". ([36220](https://github.com/WordPress/gutenberg/pull/36220))
+- Enable Previews for Navigation Link Blocks. ([36412](https://github.com/WordPress/gutenberg/pull/36412))
+
+#### Site Editor
+- FSE: Add welcome guide. ([36172](https://github.com/WordPress/gutenberg/pull/36172))
+- Update back button URL. ([36313](https://github.com/WordPress/gutenberg/pull/36313))
+- Improve compatiblity with menu endpoints WordPress 5.9. ([36372](https://github.com/WordPress/gutenberg/pull/36372))
+- React to any errors coming up in gutenberg_migrate_menu_to_navigation_post. ([36461](https://github.com/WordPress/gutenberg/pull/36461))
+
+#### Block API
+- Blocks: Update schema to require either a type or an enum. ([36267](https://github.com/WordPress/gutenberg/pull/36267))
+- Schema: Allow block.json attribute type to be an array. ([36295](https://github.com/WordPress/gutenberg/pull/36295))
+- Add `_wp_array_set` and `_wp_to_kebab_case` to 5.8 compat. ([36399](https://github.com/WordPress/gutenberg/pull/36399))
+
+#### Design Tools
+- Paragraph: Merge text settings into typography panel. ([36334](https://github.com/WordPress/gutenberg/pull/36334))
+
+#### Build Tooling
+- Scripts: Add TypeScript for builds and tests. ([36260](https://github.com/WordPress/gutenberg/pull/36260))
+- stylelint-config: Widen the acceptable version range for the 'stylelint' peerDependency. ([36518](https://github.com/WordPress/gutenberg/pull/36518))
+- Babel Preset: Update Babel packages to 7.16 version. ([36244](https://github.com/WordPress/gutenberg/pull/36244))
+
+#### Style Variations
+- Block Styles: Show style preview when hovered or focused. ([34522](https://github.com/WordPress/gutenberg/pull/34522))
+
+#### Schema
+- Schemas: Update schema URL to wp.org domain. ([36316](https://github.com/WordPress/gutenberg/pull/36316))
+
+
+### Bug Fixes
+
+- Chore: Fix small typos on the rest endpoints. ([36272](https://github.com/WordPress/gutenberg/pull/36272))
+- DEWP: Fix deprecation warning. ([36285](https://github.com/WordPress/gutenberg/pull/36285))
+- Fix mobile horizontal scrollbar. ([36567](https://github.com/WordPress/gutenberg/pull/36567))
+- Fix schema to allow for custom blocks in theme.json. ([36341](https://github.com/WordPress/gutenberg/pull/36341))
+- Fix: Theme switch on the global styles rest api unit test. ([36277](https://github.com/WordPress/gutenberg/pull/36277))
+- Polish metabox container. ([36297](https://github.com/WordPress/gutenberg/pull/36297))
+
+#### Block Library
+- Fix background colours in nested submenus. ([36476](https://github.com/WordPress/gutenberg/pull/36476))
+- Fix colour rendering in Navigation overlay. ([36479](https://github.com/WordPress/gutenberg/pull/36479))
+- Fix duplicate custom classnames in navigation submenu block. ([36478](https://github.com/WordPress/gutenberg/pull/36478))
+- Fix submenu justification and spacer orientation. ([36340](https://github.com/WordPress/gutenberg/pull/36340))
+- Group - Fix overzealous regex when restoring inner containers. ([36221](https://github.com/WordPress/gutenberg/pull/36221))
+- Hide visilibility and status for navigation posts. ([36363](https://github.com/WordPress/gutenberg/pull/36363))
+- Nav block menu switcher - decode HTML entities and utilise accessible markup pattern. ([36397](https://github.com/WordPress/gutenberg/pull/36397))
+- Navigation: Fix click-button size, submenu directions, scrollbars. ([36215](https://github.com/WordPress/gutenberg/pull/36215))
+- Page List block: Fix space before `href` attribute. ([36505](https://github.com/WordPress/gutenberg/pull/36505))
+- Page List: Use core entities instead of direct apiFetch. ([36531](https://github.com/WordPress/gutenberg/pull/36531))
+- Post Comments Form: Ensure typography styles are applied to child elements. ([36425](https://github.com/WordPress/gutenberg/pull/36425))
+- Post title block default CSS: Add a break-word rule by default. ([35703](https://github.com/WordPress/gutenberg/pull/35703))
+
+#### Block API
+- Use firstChild and lastChild when parsing lists from MS Word. ([36019](https://github.com/WordPress/gutenberg/pull/36019))
+
+#### Mobile
+- [Android] Synchronize content retrieval over the bridge. ([36072](https://github.com/WordPress/gutenberg/pull/36072))
+
+#### Full Site Editing
+- Fix layout shift in `core/post-featured-image` block with `isLink` enabled. ([36552](https://github.com/WordPress/gutenberg/pull/36552))
+- Template Part Block: Add some guards. ([36324](https://github.com/WordPress/gutenberg/pull/36324))
+- Chore: Add rewrite false to global styles CPT. ([36273](https://github.com/WordPress/gutenberg/pull/36273))
+- Revert "theme.json: Adds a setting property that enables some other ones". ([36477](https://github.com/WordPress/gutenberg/pull/36477))
+-  Update more references to __experimental menu endpoints to make them stable. ([36386](https://github.com/WordPress/gutenberg/pull/36386))
+
+#### Site Editor
+- Fix site editor reset styles in WP 5.9. ([36390](https://github.com/WordPress/gutenberg/pull/36390))
+- Site Editor - prevent loading state from showing the admin menu. ([36455](https://github.com/WordPress/gutenberg/pull/36455))
+
+#### Themes
+- Fix: Add ability to opt out of Core color palette V2. ([36492](https://github.com/WordPress/gutenberg/pull/36492))
+
+#### Build Tooling
+- Fix not transforming logical assignments for packages. ([36484](https://github.com/WordPress/gutenberg/pull/36484))
+
+#### Global Styles
+- Replace get_theme_file_path in theme_has_support. ([36398](https://github.com/WordPress/gutenberg/pull/36398))
+
+#### Block Editor
+- Strip meta tags from pasted links in Chromium. ([36356](https://github.com/WordPress/gutenberg/pull/36356))
+- Add `webp` extension in `filePasteHandler` and `getPasteEventData`. ([36361](https://github.com/WordPress/gutenberg/pull/36361))
+
+#### CSS & Styling
+- Update theme styles for the code block. ([36282](https://github.com/WordPress/gutenberg/pull/36282))
+
+
+### Experiments
+
+#### Global Styles
+- Chore: Add comment to Remove filter to allow WP variables after min version is 5.8. ([36281](https://github.com/WordPress/gutenberg/pull/36281))
+- Chore: Update: Centralize safe_style_css usages. ([36280](https://github.com/WordPress/gutenberg/pull/36280))
+- [Global Styles]: Add block icon next to blocks list. ([36520](https://github.com/WordPress/gutenberg/pull/36520))
+- theme.json: Adds a setting property that enables some other ones. ([36246](https://github.com/WordPress/gutenberg/pull/36246))
+
+#### Block Library
+- Apply i18n functions to Nav block menu drops when selecting existing Menu. ([36301](https://github.com/WordPress/gutenberg/pull/36301))
+- Navigation: Refactor and simplify setup state. ([36375](https://github.com/WordPress/gutenberg/pull/36375))
+- Rename fse_navigation_area to wp_navigation_area. ([36460](https://github.com/WordPress/gutenberg/pull/36460))
+- Return wp error from wp_insert_post. ([36483](https://github.com/WordPress/gutenberg/pull/36483))
+
+#### Full Site Editing
+- FSE: Add template_type guards. ([36318](https://github.com/WordPress/gutenberg/pull/36318))
+
+
+### Documentation
+
+- "npm install" suggestion provides a better learning experience. ([36217](https://github.com/WordPress/gutenberg/pull/36217))
+- Added specific links to agenda and notes posts related to core editor meetings. ([36199](https://github.com/WordPress/gutenberg/pull/36199))
+- Docs: Schemastore - $schema is VS Code-specific. ([36179](https://github.com/WordPress/gutenberg/pull/36179))
+- Docs: Update GIF image in documentation with wp.org schema URL. ([36456](https://github.com/WordPress/gutenberg/pull/36456))
+- Update Versions in WordPress to include 5.9. ([36156](https://github.com/WordPress/gutenberg/pull/36156))
+- Update combobox-control component readme. ([36413](https://github.com/WordPress/gutenberg/pull/36413))
+- Update theme.json schema to refer to wp.org URL. ([36332](https://github.com/WordPress/gutenberg/pull/36332))
+
+#### Components
+- Update `@wordpress/components` changelog. ([36448](https://github.com/WordPress/gutenberg/pull/36448))
+
+
+### Code Quality
+
+- Change @package to WordPress in block-library. ([36494](https://github.com/WordPress/gutenberg/pull/36494))
+- postcss-themes: Fix PostCSS 8 deprecation warning. ([36284](https://github.com/WordPress/gutenberg/pull/36284))
+
+#### Navigation Screen
+- Prepare navigation php code for core patch. ([36336](https://github.com/WordPress/gutenberg/pull/36336))
+
+#### Block Library
+- Add block.json schema defintion to core blocks. ([35900](https://github.com/WordPress/gutenberg/pull/35900))
+
+
+### Tools
+
+#### Testing
+- E2E: Add more Cover block tests. ([36321](https://github.com/WordPress/gutenberg/pull/36321))
+- Fix Performance CI tests and make them always use the latest major as base branch. ([36463](https://github.com/WordPress/gutenberg/pull/36463))
+- Fix failing tests and compatibility with 5.9. ([36368](https://github.com/WordPress/gutenberg/pull/36368))
+- Tests: Add integration tests with core blocks schema validation. ([36351](https://github.com/WordPress/gutenberg/pull/36351))
+- Skip flaky image block test. ([36446](https://github.com/WordPress/gutenberg/pull/36446))
+
+#### Icons
+- Add the missing comment edit link icon. ([36565](https://github.com/WordPress/gutenberg/pull/36565))
+- Remove hard coded color from query pagination icons. ([35837](https://github.com/WordPress/gutenberg/pull/35837))
+- Remove hard-coded values on icons. ([36564](https://github.com/WordPress/gutenberg/pull/36564))
+
+#### Components
+- ToolsPanel: Allow additional props on ToolsPanel. ([36428](https://github.com/WordPress/gutenberg/pull/36428))
+- Typography Panel: Make letter spacing jsDoc and prop use consistent. ([36367](https://github.com/WordPress/gutenberg/pull/36367))
+
+#### Block Library
+- Remove textdomain from calendar block. ([36500](https://github.com/WordPress/gutenberg/pull/36500))
+
+#### Site Editor
+- Update site editor title truncation. ([36436](https://github.com/WordPress/gutenberg/pull/36436))
+
+#### Design Tools
+- Letter spacing: Update label copy. ([36385](https://github.com/WordPress/gutenberg/pull/36385))
+
+#### Block API
+- Add pattern to `name` key in block.json Schema. ([36343](https://github.com/WordPress/gutenberg/pull/36343))
+
+#### Data Layer
+- Data: Clean up registerGenericStore param names. ([36300](https://github.com/WordPress/gutenberg/pull/36300))
+
+#### Template Editor
+- Change edit links for templates and template parts. ([36294](https://github.com/WordPress/gutenberg/pull/36294))
+
+
+
+
+
 = 11.9.1 =
 
 ### Bug Fixes

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.7
  * Requires PHP: 5.6
- * Version: 11.9.1
+ * Version: 12.0.0-rc.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.7
  * Requires PHP: 5.6
- * Version: 12.0.0
+ * Version: 12.0.1
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.7
  * Requires PHP: 5.6
- * Version: 12.0.0-rc.1
+ * Version: 12.0.0
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/gutenberg.php
+++ b/gutenberg.php
@@ -5,7 +5,7 @@
  * Description: Printing since 1440. This is the development plugin for the new block editor in core.
  * Requires at least: 5.7
  * Requires PHP: 5.6
- * Version: 12.0.1
+ * Version: 12.0.2
  * Author: Gutenberg Team
  * Text Domain: gutenberg
  *

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -170,33 +170,49 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * It can also create and return a new draft CPT.
 	 *
-	 * @param bool  $should_create_cpt Whether a new CPT should be created if no one was found.
-	 *                                 False by default.
-	 * @param array $post_status_filter Filter CPT by post status.
-	 *                                  ['publish'] by default, so it only fetches published posts.
+	 * @param WP_Theme $theme             The theme object.
+	 *                                    If empty, it defaults to the current theme.
+	 * @param bool     $should_create_cpt Whether a new CPT should be created if no one was found.
+	 *                                    False by default.
+	 * @param array    $post_status_filter Filter CPT by post status.
+	 *                                    ['publish'] by default, so it only fetches published posts.
 	 *
 	 * @return array Custom Post Type for the user's origin config.
 	 */
-	private static function get_user_data_from_custom_post_type( $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
+	public static function get_user_data_from_custom_post_type( $theme, $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
+		if ( ! $theme instanceof WP_Theme ) {
+			$theme = wp_get_theme();
+		}
 		$user_cpt         = array();
 		$post_type_filter = 'wp_global_styles';
-		$recent_posts     = wp_get_recent_posts(
-			array(
-				'numberposts' => 1,
-				'orderby'     => 'date',
-				'order'       => 'desc',
-				'post_type'   => $post_type_filter,
-				'post_status' => $post_status_filter,
-				'tax_query'   => array(
-					array(
-						'taxonomy' => 'wp_theme',
-						'field'    => 'name',
-						'terms'    => wp_get_theme()->get_stylesheet(),
-					),
+		$args             = array(
+			'numberposts' => 1,
+			'orderby'     => 'date',
+			'order'       => 'desc',
+			'post_type'   => $post_type_filter,
+			'post_status' => $post_status_filter,
+			'tax_query'   => array(
+				array(
+					'taxonomy' => 'wp_theme',
+					'field'    => 'name',
+					'terms'    => $theme->get_stylesheet(),
 				),
-			)
+			),
 		);
 
+		$cache_key = sprintf( 'wp_global_styles_%s', md5( serialize( $args ) ) );
+		$post_id   = wp_cache_get( $cache_key );
+
+		if ( (int) $post_id > 0 ) {
+			return get_post( $post_id, ARRAY_A );
+		}
+
+		// Special case: '-1' is a results not found.
+		if ( -1 === $post_id && ! $should_create_cpt ) {
+			return $user_cpt;
+		}
+
+		$recent_posts = wp_get_recent_posts( $args );
 		if ( is_array( $recent_posts ) && ( count( $recent_posts ) === 1 ) ) {
 			$user_cpt = $recent_posts[0];
 		} elseif ( $should_create_cpt ) {
@@ -215,6 +231,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			);
 			$user_cpt    = get_post( $cpt_post_id, ARRAY_A );
 		}
+		$cache_expiration = $user_cpt ? DAY_IN_SECONDS : HOUR_IN_SECONDS;
+		wp_cache_set( $cache_key, $user_cpt ? $user_cpt['ID'] : -1, '', $cache_expiration );
 
 		return $user_cpt;
 	}
@@ -230,7 +248,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$config   = array();
-		$user_cpt = self::get_user_data_from_custom_post_type();
+		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme() );
 		if ( array_key_exists( 'post_content', $user_cpt ) ) {
 			$decoded_data = json_decode( $user_cpt['post_content'], true );
 
@@ -331,7 +349,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return self::$user_custom_post_type_id;
 		}
 
-		$user_cpt = self::get_user_data_from_custom_post_type( true );
+		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme(), true );
 		if ( array_key_exists( 'ID', $user_cpt ) ) {
 			self::$user_custom_post_type_id = $user_cpt['ID'];
 		}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -72,7 +72,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				$config = $decoded_file;
 			}
 		}
-		return $config;
+		return apply_filters( 'gutenberg_read_json_file', $config, $decoded_file, $file_path );
 	}
 
 	/**
@@ -231,6 +231,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			);
 			$user_cpt    = get_post( $cpt_post_id, ARRAY_A );
 		}
+		$user_cpt         = apply_filters( 'gutenberg_wp_global_styles', $user_cpt );
 		$cache_expiration = $user_cpt ? DAY_IN_SECONDS : HOUR_IN_SECONDS;
 		wp_cache_set( $cache_key, $user_cpt ? $user_cpt['ID'] : -1, '', $cache_expiration );
 
@@ -387,8 +388,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	private static function get_file_path_from_theme( $file_name, $template = false ) {
 		$path      = $template ? get_template_directory() : get_stylesheet_directory();
 		$candidate = $path . '/' . $file_name;
+		$file_path = is_readable( $candidate ) ? $candidate : '';
 
-		return is_readable( $candidate ) ? $candidate : '';
+		return apply_filters( 'gutenberg_file_path_from_theme', $file_path, $file_name, $template );
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/rest-active-global-styles.php
+++ b/lib/compat/wordpress-5.9/rest-active-global-styles.php
@@ -16,22 +16,8 @@ function gutenberg_add_active_global_styles_link( $response, $theme ) {
 		// This creates a record for the current theme if not existent.
 		$id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
 	} else {
-		$wp_query_args       = array(
-			'post_status'    => 'publish',
-			'post_type'      => 'wp_global_styles',
-			'posts_per_page' => 1,
-			'no_found_rows'  => true,
-			'fields'         => 'ids',
-			'tax_query'      => array(
-				array(
-					'taxonomy' => 'wp_theme',
-					'field'    => 'name',
-					'terms'    => $theme->get_stylesheet(),
-				),
-			),
-		);
-		$global_styles_query = new WP_Query( $wp_query_args );
-		$id                  = ! empty( $global_styles_query->posts ) ? array_shift( $global_styles_query->posts ) : null;
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( $theme );
+		$id       = isset( $user_cpt['ID'] ) ? $user_cpt['ID'] : null;
 	}
 
 	if ( $id ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "11.9.1",
+	"version": "12.0.0-rc.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.0",
+	"version": "12.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.0-rc.1",
+	"version": "12.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.1",
+	"version": "12.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.0",
+	"version": "12.0.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "11.9.1",
+	"version": "12.0.0-rc.1",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.0-rc.1",
+	"version": "12.0.0",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gutenberg",
-	"version": "12.0.1",
+	"version": "12.0.2",
 	"private": true,
 	"description": "A new WordPress editor experience.",
 	"author": "The WordPress Contributors",

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -35,6 +35,11 @@ function BlockStylesPreviewPanelFill( { children, scope, ...props } ) {
 	);
 }
 
+// Top position (in px) of the Block Styles container
+// relative to the editor pane.
+// The value is the equivalent of the container's right position.
+const DEFAULT_POSITION_TOP = 16;
+
 // Block Styles component for the Settings Sidebar.
 function BlockStyles( {
 	clientId,
@@ -60,7 +65,8 @@ function BlockStyles( {
 		const scrollContainer = document.querySelector(
 			'.interface-interface-skeleton__content'
 		);
-		setContainerScrollTop( scrollContainer.scrollTop + 16 );
+		const scrollTop = scrollContainer?.scrollTop || 0;
+		setContainerScrollTop( scrollTop + DEFAULT_POSITION_TOP );
 	}, [ hoveredStyle ] );
 
 	if ( ! stylesToRender || stylesToRender.length === 0 ) {

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -20,6 +20,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
 		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
 		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+		$this->queries = array();
 		// Clear caches.
 		wp_clean_themes_cache();
 		unset( $GLOBALS['wp_themes'] );
@@ -38,6 +39,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 	function filter_set_locale_to_polish() {
 		return 'pl_PL';
+	}
+
+	function filter_db_query( $query ) {
+		if ( preg_match( '#post_type = \'wp_global_styles\'#', $query ) ) {
+			$this->queries[] = $query;
+		}
+		return $query;
 	}
 
 	function test_translations_are_applied() {
@@ -258,5 +266,31 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			)
 		);
+	}
+
+	function test_get_user_data_from_custom_post_type_does_not_use_uncached_queries() {
+		add_filter( 'query', array( $this, 'filter_db_query' ) );
+		$query_count = count( $this->queries );
+		for ( $i = 0; $i < 3; $i++ ) {
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+		$query_count = count( $this->queries ) - $query_count;
+		$this->assertEquals( 1, $query_count, 'Only one SQL query should be peformed for multiple invocations of WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type()' );
+
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+		$this->assertEmpty( $user_cpt );
+
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme(), true );
+		$this->assertNotEmpty( $user_cpt );
+
+		$query_count = count( $this->queries );
+		for ( $i = 0; $i < 3; $i++ ) {
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
+		}
+		$query_count = count( $this->queries ) - $query_count;
+		$this->assertEquals( 0, $query_count, 'Unexpected SQL queries detected for the wp_global_style post type' );
+		remove_filter( 'query', array( $this, 'filter_db_query' ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 11.9.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v11.9.1">release page</a>.
+To read the changelog for Gutenberg 12.0.0-rc.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.0-rc.1">release page</a>.

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 12.0.0, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.0">release page</a>.
+To read the changelog for Gutenberg 12.0.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.1">release page</a>.

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 12.0.0-rc.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.0-rc.1">release page</a>.
+To read the changelog for Gutenberg 12.0.0, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.0">release page</a>.

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 12.0.1, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.1">release page</a>.
+To read the changelog for Gutenberg 12.0.2, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.0.2">release page</a>.


### PR DESCRIPTION
## Description
This pull request adds three filters that allow plugins to customize Global Styles and theme.json files.

It solves #37206

## How has this been tested?
Just added filters, so my tests were just loading everything, pretty straightforward.

## Types of changes
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
