### PR TITLE
Image: Fix resizer controls being hidden in Safari when switching between alignments

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -30,7 +30,7 @@ import {
 	__experimentalImageEditor as ImageEditor,
 	__experimentalImageEditingProvider as ImageEditingProvider,
 } from '@wordpress/block-editor';
-import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import { createBlock, switchToBlockType } from '@wordpress/blocks';
@@ -187,18 +187,10 @@ export default function Image( {
 	// width and height. This resolves an issue in Safari where the loaded natural
 	// witdth and height is otherwise lost when switching between alignments.
 	// See: https://github.com/WordPress/gutenberg/pull/37210.
-	const { naturalWidth, naturalHeight } = useMemo( () => {
-		return {
-			naturalWidth:
-				imageRef.current?.naturalWidth ||
-				loadedNaturalWidth ||
-				undefined,
-			naturalHeight:
-				imageRef.current?.naturalHeight ||
-				loadedNaturalHeight ||
-				undefined,
-		};
-	}, [ loadedNaturalWidth, loadedNaturalHeight, imageRef.current ] );
+	const naturalWidth =
+		imageRef.current?.naturalWidth || loadedNaturalWidth || undefined;
+	const naturalHeight =
+		imageRef.current?.nautralHeight || loadedNaturalHeight || undefined;
 
 	function onResizeStart() {
 		toggleSelection( false );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #24587 

In Safari, when switching the Image block between not aligned and an alignment, the component appears to re-render however the `img` element's `onload` callback is never fired, resulting in `naturalWidth` and `naturalHeight` being `undefined`. This means that the conditional [on this line](https://github.com/wordpress/gutenberg/blob/fffa06392bb584c1190948525a8767b78d9d9369/packages/block-library/src/image/image.js#L447) is reached, which means that the resizer isn't rendered.

The fix is to update `naturalWidth` and `naturalHeight` to pull from an image ref (so that the values are always available) and fall back to local component state when not available. This should 🤞 give us the best of both worlds — the real current value is available for Safari, and the fallback local component state value is available when cropping and editing images so that the saving state doesn't unexpectedly fail due to `undefined` natural width/height.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. In Safari, before applying this PR, insert an image block.
2. Switch the image block from no alignment to any alignment (e.g. Left alignment)
3. Observe that the resizer controls are no longer visible.
4. Apply this PR.
5. Repeat the above steps, and the resizer should always be available.

Test in other browsers, and also test cropping / image editing to be sure this doesn't introduce any regressions.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![Kapture 2021-12-08 at 12 31 31](https://user-images.githubusercontent.com/14988353/145132409-b038f63b-b345-432c-9f51-c6eec1790770.gif) | ![Kapture 2021-12-08 at 12 29 20](https://user-images.githubusercontent.com/14988353/145132257-b61de180-e18f-4f90-a2c1-c420ba064218.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
