### PR TITLE
Remove Navigation Menus from WP Admin sidebar

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -39,7 +39,7 @@ function gutenberg_register_navigation_post_type() {
 		'has_archive'           => false,
 		// We should disable UI for non-FSE themes.
 		'show_ui'               => gutenberg_is_fse_theme(),
-		'show_in_menu'          => 'themes.php',
+		'show_in_menu'          => false,
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,
 		'map_meta_cap'          => true,

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -5,6 +5,7 @@ import { MenuGroup, MenuItem, MenuItemsChoice } from '@wordpress/components';
 import { useEntityId } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -44,6 +45,13 @@ export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
 			<MenuGroup>
 				<MenuItem onClick={ onCreateNew }>
 					{ __( 'Create new menu' ) }
+				</MenuItem>
+				<MenuItem
+					href={ addQueryArgs( 'edit.php', {
+						post_type: 'wp_navigation',
+					} ) }
+				>
+					{ __( 'Manage menus' ) }
 				</MenuItem>
 			</MenuGroup>
 		</>


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/36589.

Removes the 'Navigation Menus' link from the WP Admin sidebar. Instead,
a 'Manage menus' link is added to the dropdown menu in the Navigation
block.

## How has this been tested?

1. Go to the site editor.
2. Select or insert a Navigation block.
3. Click _Select Menu_.
4. Click _Manage menus_.

Also confirm that there is no _Appearance → Navigation Menus_ link.

## Screenshots 

<img width="1475" alt="Screen Shot 2021-12-08 at 3 32 44 pm" src="https://user-images.githubusercontent.com/612155/145148662-f9aa121b-a4ca-499f-99eb-4829835cdef8.png">
<img width="1475" alt="Screen Shot 2021-12-08 at 3 33 07 pm" src="https://user-images.githubusercontent.com/612155/145148676-8b576815-016a-4fd8-90cf-47fb1f336932.png">

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->