### PR TITLE
Site Editor: Hide the block appender in the Template Part editor

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -124,6 +124,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					<BlockList
 						className="edit-site-block-editor__block-list wp-site-blocks"
 						__experimentalLayout={ LAYOUT }
+						renderAppender={ isTemplatePart ? false : undefined }
 					/>
 				</ResizableEditor>
 


### PR DESCRIPTION
## Description

Closes https://github.com/WordPress/gutenberg/issues/36827.

Just a simple PR that hides the block appender in the Template Part editor.

I confirmed that the background colour of the Template Part editor is taken from Global Styles, so no action is required there.

On tall viewports, the height of the editor is greater than the height of the content which means there's a large bit of whitespace at the bottom. This is tracked separately in https://github.com/WordPress/gutenberg/issues/36141.

## How has this been tested?

1. Open the Site Editor and browse to a Template Part (e.g. using the W menu).
2. There should be no appender at the bottom.
3. Check that there still is an appender at the bottom of the Template Editor.

## Screenshots <!-- if applicable -->

| Before | After |
| - | - |
| <img width="1164" alt="Screen Shot 2021-12-08 at 3 55 43 pm" src="https://user-images.githubusercontent.com/612155/145150549-91cb23f6-15f9-4569-b01b-71826e00f87c.png"> | <img width="1164" alt="Screen Shot 2021-12-08 at 3 55 26 pm" src="https://user-images.githubusercontent.com/612155/145150567-70a90d81-591f-4ba3-a01b-9d03f32a67f8.png"> |

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->