### PR TITLE
Site Editor: Use server definition for the Template Areas

### DIFF
--- a/packages/edit-site/src/components/sidebar/template-card/template-areas.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-areas.js
@@ -6,7 +6,7 @@ import {
 	Button,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
-import { getTemplatePartIcon } from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -14,19 +14,36 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
-import { TEMPLATE_PART_AREA_TO_NAME } from '../../../store/constants';
 
 function TemplateAreaItem( { area, clientId } ) {
 	const { selectBlock, toggleBlockHighlight } = useDispatch(
 		blockEditorStore
 	);
+	const { icon, label } = useSelect(
+		( select ) => {
+			const defaultAreas = select(
+				editorStore
+			).__experimentalGetDefaultTemplatePartAreas();
+
+			const matchedArea = defaultAreas.find(
+				( defaultArea ) => defaultArea.area === area
+			);
+
+			return {
+				icon: matchedArea?.icon,
+				label: matchedArea?.label,
+			};
+		},
+		[ area ]
+	);
+
 	const highlightBlock = () => toggleBlockHighlight( clientId, true );
 	const cancelHighlightBlock = () => toggleBlockHighlight( clientId, false );
 
 	return (
 		<Button
 			className="edit-site-template-card__template-areas-item"
-			icon={ getTemplatePartIcon( area ) }
+			icon={ icon }
 			onMouseOver={ highlightBlock }
 			onMouseLeave={ cancelHighlightBlock }
 			onFocus={ highlightBlock }
@@ -35,7 +52,7 @@ function TemplateAreaItem( { area, clientId } ) {
 				selectBlock( clientId );
 			} }
 		>
-			{ TEMPLATE_PART_AREA_TO_NAME[ area ] }
+			{ label }
 		</Button>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/template-card/template-areas.js
+++ b/packages/edit-site/src/components/sidebar/template-card/template-areas.js
@@ -19,20 +19,15 @@ function TemplateAreaItem( { area, clientId } ) {
 	const { selectBlock, toggleBlockHighlight } = useDispatch(
 		blockEditorStore
 	);
-	const { icon, label } = useSelect(
+	const templatePartArea = useSelect(
 		( select ) => {
 			const defaultAreas = select(
 				editorStore
 			).__experimentalGetDefaultTemplatePartAreas();
 
-			const matchedArea = defaultAreas.find(
+			return defaultAreas.find(
 				( defaultArea ) => defaultArea.area === area
 			);
-
-			return {
-				icon: matchedArea?.icon,
-				label: matchedArea?.label,
-			};
 		},
 		[ area ]
 	);
@@ -43,7 +38,7 @@ function TemplateAreaItem( { area, clientId } ) {
 	return (
 		<Button
 			className="edit-site-template-card__template-areas-item"
-			icon={ icon }
+			icon={ templatePartArea?.icon }
 			onMouseOver={ highlightBlock }
 			onMouseLeave={ cancelHighlightBlock }
 			onFocus={ highlightBlock }
@@ -52,7 +47,7 @@ function TemplateAreaItem( { area, clientId } ) {
 				selectBlock( clientId );
 			} }
 		>
-			{ label }
+			{ templatePartArea?.label }
 		</Button>
 	);
 }

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -4,7 +4,7 @@
 import { sprintf, __ } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { getTemplatePartIcon } from '@wordpress/editor';
+import { store as editorStore } from '@wordpress/editor';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { moreVertical } from '@wordpress/icons';
 
@@ -12,7 +12,6 @@ import { moreVertical } from '@wordpress/icons';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../store';
-import { TEMPLATE_PART_AREA_TO_NAME } from '../../store/constants';
 import isTemplateRevertable from '../../utils/is-template-revertable';
 
 function TemplatePartItemMore( {
@@ -67,6 +66,23 @@ function TemplatePartItem( {
 	const { selectBlock, toggleBlockHighlight } = useDispatch(
 		blockEditorStore
 	);
+	const { icon, label } = useSelect(
+		( select ) => {
+			const defaultAreas = select(
+				editorStore
+			).__experimentalGetDefaultTemplatePartAreas();
+
+			const matchedArea = defaultAreas.find(
+				( defaultArea ) => defaultArea.area === templatePart.area
+			);
+
+			return {
+				icon: matchedArea?.icon,
+				label: matchedArea?.label,
+			};
+		},
+		[ templatePart.area ]
+	);
 	const highlightBlock = () => toggleBlockHighlight( clientId, true );
 	const cancelHighlightBlock = () => toggleBlockHighlight( clientId, false );
 
@@ -77,7 +93,7 @@ function TemplatePartItem( {
 		>
 			<MenuItem
 				role="button"
-				icon={ getTemplatePartIcon( templatePart.area ) }
+				icon={ icon }
 				iconPosition="left"
 				onClick={ () => {
 					selectBlock( clientId );
@@ -87,7 +103,7 @@ function TemplatePartItem( {
 				onFocus={ highlightBlock }
 				onBlur={ cancelHighlightBlock }
 			>
-				{ TEMPLATE_PART_AREA_TO_NAME[ templatePart.area ] }
+				{ label }
 			</MenuItem>
 
 			<DropdownMenu

--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -66,20 +66,15 @@ function TemplatePartItem( {
 	const { selectBlock, toggleBlockHighlight } = useDispatch(
 		blockEditorStore
 	);
-	const { icon, label } = useSelect(
+	const templatePartArea = useSelect(
 		( select ) => {
 			const defaultAreas = select(
 				editorStore
 			).__experimentalGetDefaultTemplatePartAreas();
 
-			const matchedArea = defaultAreas.find(
+			return defaultAreas.find(
 				( defaultArea ) => defaultArea.area === templatePart.area
 			);
-
-			return {
-				icon: matchedArea?.icon,
-				label: matchedArea?.label,
-			};
 		},
 		[ templatePart.area ]
 	);
@@ -93,7 +88,7 @@ function TemplatePartItem( {
 		>
 			<MenuItem
 				role="button"
-				icon={ icon }
+				icon={ templatePartArea?.icon }
 				iconPosition="left"
 				onClick={ () => {
 					selectBlock( clientId );
@@ -103,7 +98,7 @@ function TemplatePartItem( {
 				onFocus={ highlightBlock }
 				onBlur={ cancelHighlightBlock }
 			>
-				{ label }
+				{ templatePartArea?.label }
 			</MenuItem>
 
 			<DropdownMenu

--- a/packages/edit-site/src/store/constants.js
+++ b/packages/edit-site/src/store/constants.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * The identifier for the data store.
  *
  * @type {string}
@@ -14,10 +9,3 @@ export const TEMPLATE_PART_AREA_HEADER = 'header';
 export const TEMPLATE_PART_AREA_FOOTER = 'footer';
 export const TEMPLATE_PART_AREA_SIDEBAR = 'sidebar';
 export const TEMPLATE_PART_AREA_GENERAL = 'uncategorized';
-
-export const TEMPLATE_PART_AREA_TO_NAME = {
-	[ TEMPLATE_PART_AREA_HEADER ]: __( 'Header' ),
-	[ TEMPLATE_PART_AREA_FOOTER ]: __( 'Footer' ),
-	[ TEMPLATE_PART_AREA_SIDEBAR ]: __( 'Sidebar' ),
-	[ TEMPLATE_PART_AREA_GENERAL ]: __( 'General' ),
-};


### PR DESCRIPTION
## Description
Closes #36955.

Updates template details components to use server-side definitions for the Template Areas. In addition, it will allow correctly displaying custom areas registered by themes. If the custom area isn't registered, it will fall back to the "General" area.

## How has this been tested?
1. Create a new template part and add it to the [template parts](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#templateparts) in theme.json.
2. Use `nav` in the area field.
3. Use the snippet below to register the new default template part area.
4. In the site editor, add the new template part we just defined.
5. Template details should correctly display labels for this new area (as seen on screenshot).

```php
add_filter( 'default_wp_template_part_areas', function( $areas ) {
	$areas[] = array(
		'area'        => 'nav',
		'label'       => __( 'Navigation', 'gutenberg' ),
		'description' => '',
		'icon'        => 'layout',
		'area_tag'    => 'div',
	);

	return $areas;
} );
```

For testing, you can also use the [Wowmall](https://wordpress.org/themes/wowmall/) theme.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-08 at 12 43 49](https://user-images.githubusercontent.com/240569/145179526-be71c206-7e8b-44d9-9eca-6e364c3e5efe.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
