### PR TITLE
Block Support Panels - Make block support tools panels compatible with multi-selection

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -67,6 +67,18 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
 				<InspectorControls.Slot />
+				<InspectorControls.Slot
+					__experimentalGroup="typography"
+					label={ __( 'Typography' ) }
+				/>
+				<InspectorControls.Slot
+					__experimentalGroup="border"
+					label={ __( 'Border' ) }
+				/>
+				<InspectorControls.Slot
+					__experimentalGroup="dimensions"
+					label={ __( 'Dimensions' ) }
+				/>
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -72,12 +72,12 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 					label={ __( 'Typography' ) }
 				/>
 				<InspectorControls.Slot
-					__experimentalGroup="border"
-					label={ __( 'Border' ) }
-				/>
-				<InspectorControls.Slot
 					__experimentalGroup="dimensions"
 					label={ __( 'Dimensions' ) }
+				/>
+				<InspectorControls.Slot
+					__experimentalGroup="border"
+					label={ __( 'Border' ) }
 				/>
 			</div>
 		);
@@ -144,12 +144,12 @@ const BlockInspectorSingleBlock = ( {
 				label={ __( 'Typography' ) }
 			/>
 			<InspectorControls.Slot
-				__experimentalGroup="border"
-				label={ __( 'Border' ) }
-			/>
-			<InspectorControls.Slot
 				__experimentalGroup="dimensions"
 				label={ __( 'Dimensions' ) }
+			/>
+			<InspectorControls.Slot
+				__experimentalGroup="border"
+				label={ __( 'Border' ) }
 			/>
 			<div>
 				<AdvancedControls />

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -19,8 +19,10 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			hasMultiSelection,
 		} = select( blockEditorStore );
 
-		// This is `null` if multi-selection and used in `clientId` checks
-		// to still allow panel items to register themselves.
+		// When we currently have a multi-selection, the value returned from
+		// `getSelectedBlockClientId()` is `null`. When a `null` value is used
+		// for the `panelId`, a `ToolsPanel` will still allow panel items to
+		// register themselves despite their panelIds not matching.
 		const selectedBlockClientId = getSelectedBlockClientId();
 
 		if ( hasMultiSelection() ) {


### PR DESCRIPTION
Fixes: 
- https://github.com/WordPress/gutenberg/issues/37188

Depends on: 
- https://github.com/WordPress/gutenberg/pull/37273

## Description

The recent switch to [using grouped inspector controls for the typography](https://github.com/WordPress/gutenberg/pull/33744/files#diff-068538657061c47f0a58cfc331259bbeabe11bcc0c576a0cc496d262e5b0038cR132-R136) block support panel meant the typography controls were no longer included within the normal `InspectorControls` slot. As such, they didn't display when multi-block selections were made.

This PR adds the new grouped inspector controls slots into the block inspector for multi-selections. It also updates the `BlockSupportToolsPanel` to be compatible with multiple selected blocks. 

## How has this been tested?

1. Create a new post and add multiple paragraph blocks
2. Select a single paragraph block and adjust its typography ensuring that still functions
3. Now select multiple paragraph blocks together
4. The typography controls should still be present in the sidebar (they will display the options as per the first block selected in order of position on the page)
5. Adjust the typography settings and ensure all selected blocks update accordingly
6. Save the post and check blocks on the frontend
7. Test resetting individual controls as well as the "reset all" option.

## Screenshots <!-- if applicable -->

![MultiSelectTypography](https://user-images.githubusercontent.com/60436221/145533379-3b15d791-42ab-4cc1-bc41-fcb8b1f06732.gif)


## Types of changes
Bug fix.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
