### PR TITLE
Testing whether we can force the nonce setup to run only once in an E2E test.

### DIFF
--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -95,6 +95,7 @@ export { deleteAllWidgets } from './widgets';
 export {
 	rest as __experimentalRest,
 	batch as __experimentalBatch,
+	setup as __experimentalSetup,
 } from './rest-api';
 export { openListView, closeListView } from './list-view';
 

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -84,14 +84,26 @@ const setNonce = ( async () => {
 /**
  * Call REST API using `apiFetch` to build and clear test states.
  *
- * @param {Object} options `apiFetch` options.
+ * @param {Object}  options `apiFetch` options.
+ * @param {boolean} runSetup Whether to run setup().
  * @return {Promise<any>} The response value.
  */
-async function rest( options = {} ) {
+async function rest( options = {}, runSetup = true ) {
 	// Only need to set them once but before any requests.
-	await Promise.all( [ setAPIRootURL, setNonce ] );
-
+	if ( runSetup ) {
+		await setup();
+	}
 	return await apiFetch( options );
+}
+
+/**
+ * Call `setAPIRootURL()` and `setNonce()`
+ *
+ * @return {Promise<any>} The response value.
+ */
+async function setup() {
+	// Only need to set them once but before any requests.
+	return await Promise.all( [ setAPIRootURL, setNonce ] );
 }
 
 /**
@@ -113,4 +125,4 @@ async function batch( requests ) {
 	} );
 }
 
-export { rest, batch };
+export { rest, batch, setup };

--- a/packages/e2e-tests/specs/widgets/editing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/editing-widgets.test.js
@@ -11,6 +11,7 @@ import {
 	deleteAllWidgets,
 	pressKeyWithModifier,
 	__experimentalRest as rest,
+	__experimentalSetup as setup,
 	openListView,
 	closeListView,
 	openGlobalBlockInserter,
@@ -909,7 +910,10 @@ async function saveWidgets() {
 }
 
 async function getSerializedWidgetAreas() {
-	const widgets = await rest( { path: '/wp/v2/widgets' } );
+	const setupResponse = await setup();
+	// eslint-disable-next-line no-console
+	console.log( 'getSerializedWidgetAreas setup: ', setupResponse );
+	const widgets = await rest( { path: '/wp/v2/widgets' }, false );
 
 	const serializedWidgetAreas = mapValues(
 		groupBy( widgets, 'sidebar' ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
