### PR TITLE
E2E: Retry login again after a bad nonce request to prevent intermittent test failures 

### DIFF
--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -65,14 +65,14 @@ async function login() {
 		headers: { cookie },
 	} );
 
-	if ( response.ok || response.status === 302 || response.status === 200 ) {
+	if ( response.status === 200 ) {
 		return {
 			response,
 			cookie,
 		};
 	}
 
-	login();
+	await login();
 
 	throw new Error(
 		`Fetch api call failed for ${ apiFetch.nonceEndpoint }: ${ response.status }`

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -35,7 +35,7 @@ Link header: ${ links }` );
 	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
 } )();
 
-async function login() {
+async function login( retries = 3 ) {
 	const formData = new FormData();
 	formData.append( 'log', 'admin' );
 	formData.append( 'pwd', 'password' );
@@ -71,8 +71,10 @@ async function login() {
 			cookie,
 		};
 	}
-
-	await login();
+	if ( retries > 0 ) {
+		return login( retries - 1 );
+	}
+	
 
 	throw new Error(
 		`Fetch api call failed for ${ apiFetch.nonceEndpoint }: ${ response.status }`

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -71,10 +71,12 @@ async function login( retries = 3 ) {
 			cookie,
 		};
 	}
+
+	// Sometimes the nonce call will fail if a test has forced a new login
+	// and invalidated the cookie, so retry the login in these instances.
 	if ( retries > 0 ) {
 		return login( retries - 1 );
 	}
-	
 
 	throw new Error(
 		`Fetch api call failed for ${ apiFetch.nonceEndpoint }: ${ response.status }`
@@ -83,9 +85,9 @@ async function login( retries = 3 ) {
 
 const setNonce = ( async () => {
 	// Get the initial nonce.
-	const res = await login();
+	const loginRequest = await login();
 
-	const nonce = await res.response.text();
+	const nonce = await loginRequest.response.text();
 
 	// Register the nonce middleware.
 	apiFetch.use( apiFetch.createNonceMiddleware( nonce ) );
@@ -96,7 +98,7 @@ const setNonce = ( async () => {
 			...request,
 			headers: {
 				...request.headers,
-				cookie: res.cookie,
+				cookie: loginRequest.cookie,
 			},
 		} );
 	} );


### PR DESCRIPTION
## Description
The e2e tests intermittently fail due to some sort of race condition which causes the rest-api nonce to fail with a 400 error. This PR adds a login retry  in these instances in order to make the test runs more resilient. 

## How has this been tested?
The e2e tests on this PR have be rerun multiple times

Props to @glendaviesnz @andrewserong @kevin940726 