### PR TITLE
`Navigator`: add basic history support, enable advanced focus restoration

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1044,6 +1044,18 @@
 		"parent": "components"
 	},
 	{
+		"title": "NavigatorBackLink",
+		"slug": "navigator-back-link",
+		"markdown_source": "../packages/components/src/navigator/navigator-back-link/README.md",
+		"parent": "components"
+	},
+	{
+		"title": "NavigatorLink",
+		"slug": "navigator-link",
+		"markdown_source": "../packages/components/src/navigator/navigator-link/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "NavigatorProvider",
 		"slug": "navigator-provider",
 		"markdown_source": "../packages/components/src/navigator/navigator-provider/README.md",

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -100,6 +100,8 @@ export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
 	NavigatorProvider as __experimentalNavigatorProvider,
 	NavigatorScreen as __experimentalNavigatorScreen,
+	NavigatorLink as __experimentalNavigatorLink,
+	NavigatorBackLink as __experimentalNavigatorBackLink,
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
 export { default as Notice } from './notice';

--- a/packages/components/src/navigator/context.ts
+++ b/packages/components/src/navigator/context.ts
@@ -8,5 +8,9 @@ import { createContext } from '@wordpress/element';
  */
 import type { NavigatorContext as NavigatorContextType } from './types';
 
-const initialContextValue: NavigatorContextType = [ {}, () => {} ];
+const initialContextValue: NavigatorContextType = {
+	location: {},
+	push: () => {},
+	pop: () => {},
+};
 export const NavigatorContext = createContext( initialContextValue );

--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,3 +1,5 @@
 export { default as NavigatorProvider } from './navigator-provider';
 export { default as NavigatorScreen } from './navigator-screen';
+export { default as NavigatorLink } from './navigator-link';
+export { default as NavigatorBackLink } from './navigator-back-link';
 export { default as useNavigator } from './use-navigator';

--- a/packages/components/src/navigator/navigator-back-link/README.md
+++ b/packages/components/src/navigator/navigator-back-link/README.md
@@ -1,0 +1,19 @@
+# `NavigatorBackLink`
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
+**TODO**
+
+The `Navigator*` family of components is _not_ opinionated in terms of UI, and can be composed with any UI components to navigate between the nested screens.
+
+## Usage
+
+**TODO**
+
+## Props
+
+The component accepts the following props:
+
+**TODO**

--- a/packages/components/src/navigator/navigator-back-link/component.tsx
+++ b/packages/components/src/navigator/navigator-back-link/component.tsx
@@ -5,53 +5,20 @@
 import type { Ref } from 'react';
 
 /**
- * WordPress dependencies
- */
-import { useCallback } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
-import {
-	contextConnect,
-	useContextSystem,
-	WordPressComponentProps,
-} from '../../ui/context';
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { View } from '../../view';
-import useNavigator from '../use-navigator';
+import { useNavigatorBackLink } from './hook';
 import type { NavigatorBackLinkProps } from '../types';
 
 function NavigatorBackLink(
 	props: WordPressComponentProps< NavigatorBackLinkProps, 'button' >,
 	forwardedRef: Ref< any >
 ) {
-	const {
-		children,
-		onClick,
-		as = 'button',
-		...otherProps
-	} = useContextSystem( props, 'NavigatorBackLink' );
+	const navigatorBackLinkProps = useNavigatorBackLink( props );
 
-	const { pop } = useNavigator();
-	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
-		( e ) => {
-			e.preventDefault();
-			pop();
-			onClick?.( e );
-		},
-		[ pop, onClick ]
-	);
-
-	return (
-		<View
-			as={ as }
-			ref={ forwardedRef }
-			onClick={ handleClick }
-			{ ...otherProps }
-		>
-			{ children }
-		</View>
-	);
+	return <View ref={ forwardedRef } { ...navigatorBackLinkProps } />;
 }
 
 /**

--- a/packages/components/src/navigator/navigator-back-link/component.tsx
+++ b/packages/components/src/navigator/navigator-back-link/component.tsx
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { Ref } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	contextConnect,
+	useContextSystem,
+	WordPressComponentProps,
+} from '../../ui/context';
+import { View } from '../../view';
+import useNavigator from '../use-navigator';
+import type { NavigatorBackLinkProps } from '../types';
+
+function NavigatorBackLink(
+	props: WordPressComponentProps< NavigatorBackLinkProps, 'button' >,
+	forwardedRef: Ref< any >
+) {
+	const {
+		children,
+		onClick,
+		as = 'button',
+		...otherProps
+	} = useContextSystem( props, 'NavigatorBackLink' );
+
+	const { pop } = useNavigator();
+	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
+		( e ) => {
+			e.preventDefault();
+			pop();
+			onClick?.( e );
+		},
+		[ pop, onClick ]
+	);
+
+	return (
+		<View
+			as={ as }
+			ref={ forwardedRef }
+			onClick={ handleClick }
+			{ ...otherProps }
+		>
+			{ children }
+		</View>
+	);
+}
+
+/**
+ * TODO: add example
+ */
+const ConnectedNavigatorBackLink = contextConnect(
+	NavigatorBackLink,
+	'NavigatorBackLink'
+);
+
+export default ConnectedNavigatorBackLink;

--- a/packages/components/src/navigator/navigator-back-link/hook.ts
+++ b/packages/components/src/navigator/navigator-back-link/hook.ts
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import useNavigator from '../use-navigator';
+import type { NavigatorBackLinkProps } from '../types';
+
+export function useNavigatorBackLink(
+	props: WordPressComponentProps< NavigatorBackLinkProps, 'button' >
+) {
+	const { onClick, as = 'button', ...otherProps } = useContextSystem(
+		props,
+		'NavigatorBackLink'
+	);
+
+	const { pop } = useNavigator();
+	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
+		( e ) => {
+			e.preventDefault();
+			pop();
+			onClick?.( e );
+		},
+		[ pop, onClick ]
+	);
+
+	return {
+		as,
+		onClick: handleClick,
+		...otherProps,
+	};
+}

--- a/packages/components/src/navigator/navigator-back-link/hook.ts
+++ b/packages/components/src/navigator/navigator-back-link/hook.ts
@@ -7,13 +7,14 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import Button from '../../button';
 import useNavigator from '../use-navigator';
 import type { NavigatorBackLinkProps } from '../types';
 
 export function useNavigatorBackLink(
 	props: WordPressComponentProps< NavigatorBackLinkProps, 'button' >
 ) {
-	const { onClick, as = 'button', ...otherProps } = useContextSystem(
+	const { onClick, as = Button, ...otherProps } = useContextSystem(
 		props,
 		'NavigatorBackLink'
 	);

--- a/packages/components/src/navigator/navigator-back-link/index.ts
+++ b/packages/components/src/navigator/navigator-back-link/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/packages/components/src/navigator/navigator-link/README.md
+++ b/packages/components/src/navigator/navigator-link/README.md
@@ -1,0 +1,19 @@
+# `NavigatorLink`
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
+**TODO**
+
+The `Navigator*` family of components is _not_ opinionated in terms of UI, and can be composed with any UI components to navigate between the nested screens.
+
+## Usage
+
+**TODO**
+
+## Props
+
+The component accepts the following props:
+
+**TODO**

--- a/packages/components/src/navigator/navigator-link/component.tsx
+++ b/packages/components/src/navigator/navigator-link/component.tsx
@@ -21,7 +21,7 @@ import { View } from '../../view';
 import useNavigator from '../use-navigator';
 import type { NavigatorLinkProps } from '../types';
 
-const defaultAttributeName = 'data-navigator-focusable-id';
+const defaultAttributeName = 'id';
 const defaultSelectorFactory = ( attrName: string, attrValue: string ) =>
 	`[${ attrName }="${ attrValue }"]`;
 

--- a/packages/components/src/navigator/navigator-link/component.tsx
+++ b/packages/components/src/navigator/navigator-link/component.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { Ref } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	contextConnect,
+	useContextSystem,
+	WordPressComponentProps,
+} from '../../ui/context';
+import { View } from '../../view';
+import useNavigator from '../use-navigator';
+import type { NavigatorLinkProps } from '../types';
+
+const defaultAttributeName = 'data-navigator-focusable-id';
+const defaultSelectorFactory = ( attrName: string, attrValue: string ) =>
+	`[${ attrName }="${ attrValue }"]`;
+
+function NavigatorLink(
+	props: WordPressComponentProps< NavigatorLinkProps, 'a' >,
+	forwardedRef: Ref< any >
+) {
+	const {
+		path,
+		children,
+		onClick,
+		as = 'button',
+		attributeName = defaultAttributeName,
+		selectorFactory = defaultSelectorFactory,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorLink' );
+
+	const { push } = useNavigator();
+	const focusTargetSelector = selectorFactory( attributeName, path );
+	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
+		( e ) => {
+			e.preventDefault();
+			push( path, { focusTargetSelector } );
+			onClick?.( e );
+		},
+		[ push, selectorFactory, onClick ]
+	);
+
+	const linkProps = { [ attributeName ]: path, path, ...otherProps };
+
+	return (
+		<View
+			as={ as }
+			ref={ forwardedRef }
+			onClick={ handleClick }
+			{ ...linkProps }
+		>
+			{ children }
+		</View>
+	);
+}
+
+/**
+ * TODO: add example
+ */
+const ConnectedNavigatorLink = contextConnect( NavigatorLink, 'NavigatorLink' );
+
+export default ConnectedNavigatorLink;

--- a/packages/components/src/navigator/navigator-link/component.tsx
+++ b/packages/components/src/navigator/navigator-link/component.tsx
@@ -5,63 +5,20 @@
 import type { Ref } from 'react';
 
 /**
- * WordPress dependencies
- */
-import { useCallback } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
-import {
-	contextConnect,
-	useContextSystem,
-	WordPressComponentProps,
-} from '../../ui/context';
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { View } from '../../view';
-import useNavigator from '../use-navigator';
+import { useNavigatorLink } from './hook';
 import type { NavigatorLinkProps } from '../types';
 
-const defaultAttributeName = 'id';
-const defaultSelectorFactory = ( attrName: string, attrValue: string ) =>
-	`[${ attrName }="${ attrValue }"]`;
-
 function NavigatorLink(
-	props: WordPressComponentProps< NavigatorLinkProps, 'a' >,
+	props: WordPressComponentProps< NavigatorLinkProps, 'button' >,
 	forwardedRef: Ref< any >
 ) {
-	const {
-		path,
-		children,
-		onClick,
-		as = 'button',
-		attributeName = defaultAttributeName,
-		selectorFactory = defaultSelectorFactory,
-		...otherProps
-	} = useContextSystem( props, 'NavigatorLink' );
+	const navigatorLinkProps = useNavigatorLink( props );
 
-	const { push } = useNavigator();
-	const focusTargetSelector = selectorFactory( attributeName, path );
-	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
-		( e ) => {
-			e.preventDefault();
-			push( path, { focusTargetSelector } );
-			onClick?.( e );
-		},
-		[ push, selectorFactory, onClick ]
-	);
-
-	const linkProps = { [ attributeName ]: path, path, ...otherProps };
-
-	return (
-		<View
-			as={ as }
-			ref={ forwardedRef }
-			onClick={ handleClick }
-			{ ...linkProps }
-		>
-			{ children }
-		</View>
-	);
+	return <View ref={ forwardedRef } { ...navigatorLinkProps } />;
 }
 
 /**

--- a/packages/components/src/navigator/navigator-link/hook.ts
+++ b/packages/components/src/navigator/navigator-link/hook.ts
@@ -7,6 +7,7 @@ import { useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import Button from '../../button';
 import useNavigator from '../use-navigator';
 import type { NavigatorLinkProps } from '../types';
 
@@ -19,7 +20,7 @@ export function useNavigatorLink(
 	const {
 		path,
 		onClick,
-		as = 'button',
+		as = Button,
 		attributeName = 'id',
 		...otherProps
 	} = useContextSystem( props, 'NavigatorLink' );

--- a/packages/components/src/navigator/navigator-link/hook.ts
+++ b/packages/components/src/navigator/navigator-link/hook.ts
@@ -21,19 +21,22 @@ export function useNavigatorLink(
 		onClick,
 		as = 'button',
 		attributeName = 'id',
-		selectorFactory = cssSelectorForAttribute,
 		...otherProps
 	} = useContextSystem( props, 'NavigatorLink' );
 
 	const { push } = useNavigator();
-	const focusTargetSelector = selectorFactory( attributeName, path );
 	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
 		( e ) => {
 			e.preventDefault();
-			push( path, { focusTargetSelector } );
+			push( path, {
+				focusTargetSelector: cssSelectorForAttribute(
+					attributeName,
+					path
+				),
+			} );
 			onClick?.( e );
 		},
-		[ push, selectorFactory, onClick ]
+		[ push, onClick ]
 	);
 
 	return {

--- a/packages/components/src/navigator/navigator-link/hook.ts
+++ b/packages/components/src/navigator/navigator-link/hook.ts
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import useNavigator from '../use-navigator';
+import type { NavigatorLinkProps } from '../types';
+
+const cssSelectorForAttribute = ( attrName: string, attrValue: string ) =>
+	`[${ attrName }="${ attrValue }"]`;
+
+export function useNavigatorLink(
+	props: WordPressComponentProps< NavigatorLinkProps, 'button' >
+) {
+	const {
+		path,
+		onClick,
+		as = 'button',
+		attributeName = 'id',
+		selectorFactory = cssSelectorForAttribute,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorLink' );
+
+	const { push } = useNavigator();
+	const focusTargetSelector = selectorFactory( attributeName, path );
+	const handleClick: React.MouseEventHandler< HTMLElement > = useCallback(
+		( e ) => {
+			e.preventDefault();
+			push( path, { focusTargetSelector } );
+			onClick?.( e );
+		},
+		[ push, selectorFactory, onClick ]
+	);
+
+	return {
+		as,
+		onClick: handleClick,
+		path,
+		...otherProps,
+		[ attributeName ]: path,
+	};
+}

--- a/packages/components/src/navigator/navigator-link/index.ts
+++ b/packages/components/src/navigator/navigator-link/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -43,18 +43,29 @@ function NavigatorProvider(
 	>( [
 		{
 			path: initialPath,
+			isBack: false,
 		},
 	] );
 
 	const navigatorContextValue: NavigatorContextType = {
 		location: locationHistory[ locationHistory.length - 1 ],
 		push: ( path, options ) => {
+			const { navigationTriggerElement, ...restOptions } = options;
+
+			// The `navigationTriggerElement` needs to be applied on the current
+			// location, while the remaining options need to be applied on the
+			// incoming location
 			setLocationHistory( [
-				...locationHistory,
+				...locationHistory.slice( 0, -1 ),
+				// Force the `isBack` flag to `true` when navigating back.
+				{
+					...locationHistory[ locationHistory.length - 1 ],
+					navigationTriggerElement,
+				},
 				{
 					path,
 					isBack: false,
-					navigationTriggerElement: options?.navigationTriggerElement,
+					...restOptions,
 				},
 			] );
 		},

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -57,7 +57,6 @@ function NavigatorProvider(
 			// incoming location
 			setLocationHistory( [
 				...locationHistory.slice( 0, -1 ),
-				// Force the `isBack` flag to `true` when navigating back.
 				{
 					...locationHistory[ locationHistory.length - 1 ],
 					focusRestorationSelector,

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -50,9 +50,9 @@ function NavigatorProvider(
 	const navigatorContextValue: NavigatorContextType = {
 		location: locationHistory[ locationHistory.length - 1 ],
 		push: ( path, options ) => {
-			const { navigationTriggerElement, ...restOptions } = options;
+			const { focusRestorationSelector, ...restOptions } = options;
 
-			// The `navigationTriggerElement` needs to be applied on the current
+			// The `focusRestorationSelector` needs to be applied on the current
 			// location, while the remaining options need to be applied on the
 			// incoming location
 			setLocationHistory( [
@@ -60,7 +60,7 @@ function NavigatorProvider(
 				// Force the `isBack` flag to `true` when navigating back.
 				{
 					...locationHistory[ locationHistory.length - 1 ],
-					navigationTriggerElement,
+					focusRestorationSelector,
 				},
 				{
 					path,

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -50,9 +50,9 @@ function NavigatorProvider(
 
 	const push = useCallback(
 		( path, options ) => {
-			const { focusRestorationSelector, ...restOptions } = options;
+			const { focusTargetSelector, ...restOptions } = options;
 
-			// The `focusRestorationSelector` needs to be applied on the current
+			// The `focusTargetSelector` needs to be applied on the current
 			// location, while the remaining options need to be applied on the
 			// incoming location
 			setLocationHistory( [
@@ -60,7 +60,7 @@ function NavigatorProvider(
 				{
 					...locationHistory[ locationHistory.length - 1 ],
 					isBack: false,
-					focusRestorationSelector,
+					focusTargetSelector,
 				},
 				{
 					path,

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -8,7 +8,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useMemo, useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -48,9 +48,8 @@ function NavigatorProvider(
 		},
 	] );
 
-	const navigatorContextValue: NavigatorContextType = {
-		location: locationHistory[ locationHistory.length - 1 ],
-		push: ( path, options ) => {
+	const push = useCallback(
+		( path, options ) => {
 			const { focusRestorationSelector, ...restOptions } = options;
 
 			// The `focusRestorationSelector` needs to be applied on the current
@@ -71,18 +70,26 @@ function NavigatorProvider(
 				},
 			] );
 		},
-		pop: () => {
-			if ( locationHistory.length > 1 ) {
-				setLocationHistory( [
-					...locationHistory.slice( 0, -2 ),
-					// Force the `isBack` flag to `true` when navigating back.
-					{
-						...locationHistory[ locationHistory.length - 2 ],
-						isBack: true,
-					},
-				] );
-			}
-		},
+		[ locationHistory ]
+	);
+
+	const pop = useCallback( () => {
+		if ( locationHistory.length > 1 ) {
+			setLocationHistory( [
+				...locationHistory.slice( 0, -2 ),
+				// Force the `isBack` flag to `true` when navigating back.
+				{
+					...locationHistory[ locationHistory.length - 2 ],
+					isBack: true,
+				},
+			] );
+		}
+	}, [ locationHistory ] );
+
+	const navigatorContextValue: NavigatorContextType = {
+		location: locationHistory[ locationHistory.length - 1 ],
+		push,
+		pop,
 	};
 
 	const cx = useCx();

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -48,7 +48,7 @@ function NavigatorProvider(
 		},
 	] );
 
-	const push = useCallback(
+	const push: NavigatorContextType[ 'push' ] = useCallback(
 		( path, options ) => {
 			const { focusTargetSelector, ...restOptions } = options;
 
@@ -63,17 +63,17 @@ function NavigatorProvider(
 					focusTargetSelector,
 				},
 				{
+					...restOptions,
 					path,
 					isBack: false,
 					isInitial: false,
-					...restOptions,
 				},
 			] );
 		},
 		[ locationHistory ]
 	);
 
-	const pop = useCallback( () => {
+	const pop: NavigatorContextType[ 'pop' ] = useCallback( () => {
 		if ( locationHistory.length > 1 ) {
 			setLocationHistory( [
 				...locationHistory.slice( 0, -2 ),

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -44,6 +44,7 @@ function NavigatorProvider(
 		{
 			path: initialPath,
 			isBack: false,
+			isInitial: true,
 		},
 	] );
 
@@ -59,11 +60,13 @@ function NavigatorProvider(
 				...locationHistory.slice( 0, -1 ),
 				{
 					...locationHistory[ locationHistory.length - 1 ],
+					isBack: false,
 					focusRestorationSelector,
 				},
 				{
 					path,
 					isBack: false,
+					isInitial: false,
 					...restOptions,
 				},
 			] );

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -46,8 +46,8 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	);
 
 	const prefersReducedMotion = useReducedMotion();
-	const [ currentPath ] = useContext( NavigatorContext );
-	const isMatch = currentPath.path === path;
+	const { location } = useContext( NavigatorContext );
+	const isMatch = location.path === path;
 	const ref = useFocusOnMount();
 
 	const cx = useCx();
@@ -96,8 +96,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	const initial = {
 		opacity: 0,
 		x:
-			( isRTL() && currentPath.isBack ) ||
-			( ! isRTL() && ! currentPath.isBack )
+			( isRTL() && location.isBack ) || ( ! isRTL() && ! location.isBack )
 				? 50
 				: -50,
 	};
@@ -105,8 +104,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 		delay: animationExitDelay,
 		opacity: 0,
 		x:
-			( ! isRTL() && currentPath.isBack ) ||
-			( isRTL() && ! currentPath.isBack )
+			( ! isRTL() && location.isBack ) || ( isRTL() && ! location.isBack )
 				? 50
 				: -50,
 		transition: {

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -82,9 +82,9 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 
 		// When navigating back, if a selector is provided, use it to look for the
 		// target element (assumed to be a node inside the current NavigatorScreen)
-		if ( location.isBack && location.focusRestorationSelector ) {
+		if ( location.isBack && location.focusTargetSelector ) {
 			elementToFocus = wrapperRef.current.querySelector(
-				location.focusRestorationSelector
+				location.focusTargetSelector
 			);
 		}
 

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -11,13 +11,7 @@ import { css } from '@emotion/react';
  * WordPress dependencies
  */
 import { focus } from '@wordpress/dom';
-import {
-	useContext,
-	useEffect,
-	useMemo,
-	useState,
-	useRef,
-} from '@wordpress/element';
+import { useContext, useEffect, useMemo, useRef } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 
@@ -73,14 +67,14 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 	);
 
 	// Focus restoration
-	const [ isFirstRender, setIsFirstRender ] = useState( true );
+	const isInitialLocation = location.isInitial && ! location.isBack;
+
 	useEffect( () => {
 		// Only attempt to restore focus:
-		// - after the first render (to avoid moving focus on page load)
+		// - if the current location is not the initial one (to avoid moving focus on page load)
 		// - when the screen becomes visible
-		// - the wrapper ref has been assigned
-		if ( isFirstRender || ! isMatch || ! wrapperRef.current ) {
-			setIsFirstRender( false );
+		// - if the wrapper ref has been assigned
+		if ( isInitialLocation || ! isMatch || ! wrapperRef.current ) {
 			return;
 		}
 
@@ -105,7 +99,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 		}
 
 		elementToFocus.focus();
-	}, [ isFirstRender, isMatch ] );
+	}, [ isInitialLocation, isMatch ] );
 
 	if ( ! isMatch ) {
 		return null;

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -20,12 +20,12 @@ export default {
 
 function NavigatorButton( { path, isBack = false, ...props } ) {
 	const navigator = useNavigator();
+
+	const handleOnClick = () =>
+		isBack ? navigator.pop() : navigator.push( path );
+
 	return (
-		<Button
-			variant="secondary"
-			onClick={ () => navigator.push( path, { isBack } ) }
-			{ ...props }
-		/>
+		<Button variant="secondary" onClick={ handleOnClick } { ...props } />
 	);
 }
 

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -18,15 +18,32 @@ export default {
 	component: NavigatorProvider,
 };
 
-function NavigatorButton( { path, isBack = false, ...props } ) {
-	const navigator = useNavigator();
+function NavigatorButton( { path, ...props } ) {
+	const { push } = useNavigator();
+	const dataAttrName = 'data-navigator-focusable-id';
+	const dataAttrValue = path;
 
-	const handleOnClick = () =>
-		isBack ? navigator.pop() : navigator.push( path );
+	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
+
+	const buttonProps = {
+		...props,
+		[ dataAttrName ]: dataAttrValue,
+	};
 
 	return (
-		<Button variant="secondary" onClick={ handleOnClick } { ...props } />
+		<Button
+			variant="secondary"
+			onClick={ () =>
+				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+			}
+			{ ...buttonProps }
+		/>
 	);
+}
+
+function NavigatorBackButton( { ...props } ) {
+	const { pop } = useNavigator();
+	return <Button variant="secondary" onClick={ pop } { ...props } />;
 }
 
 const MyNavigation = () => {
@@ -74,9 +91,7 @@ const MyNavigation = () => {
 				<Card>
 					<CardBody>
 						<p>This is the child screen.</p>
-						<NavigatorButton path="/" isBack>
-							Go back
-						</NavigatorButton>
+						<NavigatorBackButton>Go back</NavigatorBackButton>
 					</CardBody>
 				</Card>
 			</NavigatorScreen>
@@ -84,9 +99,7 @@ const MyNavigation = () => {
 			<NavigatorScreen path="/overflow-child">
 				<Card>
 					<CardBody>
-						<NavigatorButton path="/" isBack>
-							Go back
-						</NavigatorButton>
+						<NavigatorBackButton>Go back</NavigatorBackButton>
 						<div
 							className={ cx(
 								css( `
@@ -114,9 +127,7 @@ const MyNavigation = () => {
 			<NavigatorScreen path="/stickies">
 				<Card>
 					<Sticky as={ CardHeader } z="2">
-						<NavigatorButton path="/" isBack>
-							Go back
-						</NavigatorButton>
+						<NavigatorBackButton>Go back</NavigatorBackButton>
 					</Sticky>
 					<CardBody>
 						<Sticky top="69px" colors="papayawhip/peachpuff">

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -34,7 +34,7 @@ function NavigatorButton( { path, ...props } ) {
 		<Button
 			variant="secondary"
 			onClick={ () =>
-				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+				push( path, { focusTargetSelector: dataAttrCssSelector } )
 			}
 			{ ...buttonProps }
 		/>

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -11,39 +11,24 @@ import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { HStack } from '../../h-stack';
 import { Flyout } from '../../flyout';
 import { useCx } from '../../utils/hooks/use-cx';
-import { NavigatorProvider, NavigatorScreen, useNavigator } from '../';
+import {
+	NavigatorProvider,
+	NavigatorScreen,
+	NavigatorLink,
+	NavigatorBackLink,
+} from '../';
 
 export default {
 	title: 'Components (Experimental)/Navigator',
 	component: NavigatorProvider,
 };
 
-function NavigatorButton( { path, ...props } ) {
-	const { push } = useNavigator();
-	const dataAttrName = 'data-navigator-focusable-id';
-	const dataAttrValue = path;
-
-	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
-
-	const buttonProps = {
-		...props,
-		[ dataAttrName ]: dataAttrValue,
-	};
-
-	return (
-		<Button
-			variant="secondary"
-			onClick={ () =>
-				push( path, { focusTargetSelector: dataAttrCssSelector } )
-			}
-			{ ...buttonProps }
-		/>
-	);
+function NavigatorButton( props ) {
+	return <NavigatorLink as={ Button } variant="secondary" { ...props } />;
 }
 
-function NavigatorBackButton( { ...props } ) {
-	const { pop } = useNavigator();
-	return <Button variant="secondary" onClick={ pop } { ...props } />;
+function NavigatorBackButton( props ) {
+	return <NavigatorBackLink as={ Button } variant="secondary" { ...props } />;
 }
 
 const MyNavigation = () => {

--- a/packages/components/src/navigator/stories/index.js
+++ b/packages/components/src/navigator/stories/index.js
@@ -23,14 +23,6 @@ export default {
 	component: NavigatorProvider,
 };
 
-function NavigatorButton( props ) {
-	return <NavigatorLink as={ Button } variant="secondary" { ...props } />;
-}
-
-function NavigatorBackButton( props ) {
-	return <NavigatorBackLink as={ Button } variant="secondary" { ...props } />;
-}
-
 const MyNavigation = () => {
 	const cx = useCx();
 	return (
@@ -44,17 +36,20 @@ const MyNavigation = () => {
 						<p>This is the home screen.</p>
 
 						<HStack justify="flex-start" wrap>
-							<NavigatorButton path="/child">
+							<NavigatorLink variant="secondary" path="/child">
 								Navigate to child screen.
-							</NavigatorButton>
+							</NavigatorLink>
 
-							<NavigatorButton path="/overflow-child">
+							<NavigatorLink
+								variant="secondary"
+								path="/overflow-child"
+							>
 								Navigate to screen with horizontal overflow.
-							</NavigatorButton>
+							</NavigatorLink>
 
-							<NavigatorButton path="/stickies">
+							<NavigatorLink variant="secondary" path="/stickies">
 								Navigate to screen with sticky content.
-							</NavigatorButton>
+							</NavigatorLink>
 
 							<Flyout
 								trigger={
@@ -76,7 +71,9 @@ const MyNavigation = () => {
 				<Card>
 					<CardBody>
 						<p>This is the child screen.</p>
-						<NavigatorBackButton>Go back</NavigatorBackButton>
+						<NavigatorBackLink variant="secondary">
+							Go back
+						</NavigatorBackLink>
 					</CardBody>
 				</Card>
 			</NavigatorScreen>
@@ -84,7 +81,9 @@ const MyNavigation = () => {
 			<NavigatorScreen path="/overflow-child">
 				<Card>
 					<CardBody>
-						<NavigatorBackButton>Go back</NavigatorBackButton>
+						<NavigatorBackLink variant="secondary">
+							Go back
+						</NavigatorBackLink>
 						<div
 							className={ cx(
 								css( `
@@ -112,7 +111,9 @@ const MyNavigation = () => {
 			<NavigatorScreen path="/stickies">
 				<Card>
 					<Sticky as={ CardHeader } z="2">
-						<NavigatorBackButton>Go back</NavigatorBackButton>
+						<NavigatorBackLink variant="secondary">
+							Go back
+						</NavigatorBackLink>
 					</Sticky>
 					<CardBody>
 						<Sticky top="69px" colors="papayawhip/peachpuff">

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -5,13 +5,12 @@
 import type { ReactNode } from 'react';
 
 type NavigateOptions = {
-	navigationTriggerElement?: unknown;
+	focusRestorationSelector?: string;
 };
 
-export type NavigatorLocation = {
+export type NavigatorLocation = NavigateOptions & {
 	isBack?: boolean;
 	path?: string;
-	navigationTriggerElement?: unknown;
 };
 
 export type NavigatorContext = {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -4,23 +4,24 @@
 // eslint-disable-next-line no-restricted-imports
 import type { ReactNode } from 'react';
 
-type NavigatorPathOptions = {
+type NavigateOptions = {
+	navigationTriggerElement?: unknown;
+};
+
+export type NavigatorLocation = {
 	isBack?: boolean;
-};
-
-export type NavigatorPath = NavigatorPathOptions & {
 	path?: string;
+	navigationTriggerElement?: unknown;
 };
 
-export type NavigatorContext = [
-	NavigatorPath,
-	( path: NavigatorPath ) => void
-];
+export type NavigatorContext = {
+	location: NavigatorLocation;
+	push: ( path: string, options: NavigateOptions ) => void;
+	pop: () => void;
+};
 
 // Returned by the `useNavigator` hook
-export type Navigator = {
-	push: ( path: string, options: NavigatorPathOptions ) => void;
-};
+export type Navigator = NavigatorContext;
 
 export type NavigatorProviderProps = {
 	/**

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -44,3 +44,38 @@ export type NavigatorScreenProps = {
 	 */
 	children: ReactNode;
 };
+
+export type NavigatorBackLinkProps = {
+	/**
+	 * The children elements.
+	 */
+	children: ReactNode;
+	/**
+	 * The callback called in response to a `click` event.
+	 */
+	onClick?: React.MouseEventHandler< HTMLElement >;
+};
+
+export type NavigatorLinkProps = NavigatorBackLinkProps & {
+	/**
+	 * The path to navigate to.
+	 */
+	path: string;
+	/**
+	 * The HTML attribute used to identify the `NavigatorLink`, which is used
+	 * by `Navigator` to restore focus.
+	 *
+	 * @default 'data-navigator-focusable-id'
+	 */
+	attributeName?: string;
+	/**
+	 * A function that generates the CSS selector used ny `Navigator` when
+	 * restoring focus.
+	 *
+	 * @default ( attrName, attrValue ) => `[${ attrName }="${ attrValue }"]`;
+	 */
+	selectorFactory?: (
+		attributeName: string,
+		attributeValue: string
+	) => string;
+};

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -9,6 +9,7 @@ type NavigateOptions = {
 };
 
 export type NavigatorLocation = NavigateOptions & {
+	isInitial?: boolean;
 	isBack?: boolean;
 	path?: string;
 };

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -5,7 +5,7 @@
 import type { ReactNode } from 'react';
 
 type NavigateOptions = {
-	focusRestorationSelector?: string;
+	focusTargetSelector?: string;
 };
 
 export type NavigatorLocation = NavigateOptions & {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -65,7 +65,7 @@ export type NavigatorLinkProps = NavigatorBackLinkProps & {
 	 * The HTML attribute used to identify the `NavigatorLink`, which is used
 	 * by `Navigator` to restore focus.
 	 *
-	 * @default 'data-navigator-focusable-id'
+	 * @default 'id'
 	 */
 	attributeName?: string;
 	/**

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -68,14 +68,4 @@ export type NavigatorLinkProps = NavigatorBackLinkProps & {
 	 * @default 'id'
 	 */
 	attributeName?: string;
-	/**
-	 * A function that generates the CSS selector used ny `Navigator` when
-	 * restoring focus.
-	 *
-	 * @default ( attrName, attrValue ) => `[${ attrName }="${ attrValue }"]`;
-	 */
-	selectorFactory?: (
-		attributeName: string,
-		attributeValue: string
-	) => string;
 };

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -13,12 +13,12 @@ import type { Navigator } from './types';
  * Retrieves a `navigator` instance.
  */
 function useNavigator(): Navigator {
-	const [ , setPath ] = useContext( NavigatorContext );
+	const { location, push, pop } = useContext( NavigatorContext );
 
 	return {
-		push( path, options ) {
-			setPath( { path, ...options } );
-		},
+		location,
+		push,
+		pop,
 	};
 }
 

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -55,19 +55,14 @@ import BlockManager from '../block-manager';
 const MODAL_NAME = 'edit-post/preferences';
 const PREFERENCES_MENU = 'preferences-menu';
 
-function NavigationButton( {
-	as: Tag = Button,
-	path,
-	isBack = false,
-	...props
-} ) {
-	const navigator = useNavigator();
-	return (
-		<Tag
-			onClick={ () => navigator.push( path, { isBack } ) }
-			{ ...props }
-		/>
-	);
+function NavigationButton( { as: Tag = Button, path, ...props } ) {
+	const { push } = useNavigator();
+	return <Tag onClick={ () => push( path ) } { ...props } />;
+}
+
+function NavigationBackButton( { as: Tag = Button, ...props } ) {
+	const { pop } = useNavigator();
+	return <Tag onClick={ pop } { ...props } />;
 }
 
 export default function PreferencesModal() {
@@ -376,12 +371,10 @@ export default function PreferencesModal() {
 									size="small"
 									gap="6"
 								>
-									<NavigationButton
-										path="/"
+									<NavigationBackButton
 										icon={
 											isRTL() ? chevronRight : chevronLeft
 										}
-										isBack
 										aria-label={ __(
 											'Navigate to the previous view'
 										) }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -57,7 +57,25 @@ const PREFERENCES_MENU = 'preferences-menu';
 
 function NavigationButton( { as: Tag = Button, path, ...props } ) {
 	const { push } = useNavigator();
-	return <Tag onClick={ () => push( path ) } { ...props } />;
+
+	const dataAttrName = 'data-navigator-focusable-id';
+	const dataAttrValue = path;
+
+	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
+
+	const tagProps = {
+		...props,
+		[ dataAttrName ]: dataAttrValue,
+	};
+
+	return (
+		<Tag
+			onClick={ () =>
+				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+			}
+			{ ...tagProps }
+		/>
+	);
 }
 
 function NavigationBackButton( { as: Tag = Button, ...props } ) {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -71,7 +71,7 @@ function NavigationButton( { as: Tag = Button, path, ...props } ) {
 	return (
 		<Tag
 			onClick={ () =>
-				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+				push( path, { focusTargetSelector: dataAttrCssSelector } )
 			}
 			{ ...tagProps }
 		/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -9,7 +9,8 @@ import { get } from 'lodash';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
-	__experimentalUseNavigator as useNavigator,
+	__experimentalNavigatorLink as NavigatorLink,
+	__experimentalNavigatorBackLink as NavigatorBackLink,
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 	__experimentalHStack as HStack,
@@ -55,33 +56,33 @@ import BlockManager from '../block-manager';
 const MODAL_NAME = 'edit-post/preferences';
 const PREFERENCES_MENU = 'preferences-menu';
 
-function NavigationButton( { as: Tag = Button, path, ...props } ) {
-	const { push } = useNavigator();
+// function NavigationButton( { as: Tag = Button, path, ...props } ) {
+// 	const { push } = useNavigator();
 
-	const dataAttrName = 'data-navigator-focusable-id';
-	const dataAttrValue = path;
+// 	const dataAttrName = 'data-navigator-focusable-id';
+// 	const dataAttrValue = path;
 
-	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
+// 	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
 
-	const tagProps = {
-		...props,
-		[ dataAttrName ]: dataAttrValue,
-	};
+// 	const tagProps = {
+// 		...props,
+// 		[ dataAttrName ]: dataAttrValue,
+// 	};
 
-	return (
-		<Tag
-			onClick={ () =>
-				push( path, { focusTargetSelector: dataAttrCssSelector } )
-			}
-			{ ...tagProps }
-		/>
-	);
-}
+// 	return (
+// 		<Tag
+// 			onClick={ () =>
+// 				push( path, { focusTargetSelector: dataAttrCssSelector } )
+// 			}
+// 			{ ...tagProps }
+// 		/>
+// 	);
+// }
 
-function NavigationBackButton( { as: Tag = Button, ...props } ) {
-	const { pop } = useNavigator();
-	return <Tag onClick={ pop } { ...props } />;
-}
+// function NavigationBackButton( { as: Tag = Button, ...props } ) {
+// 	const { pop } = useNavigator();
+// 	return <Tag onClick={ pop } { ...props } />;
+// }
 
 export default function PreferencesModal() {
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -347,7 +348,7 @@ export default function PreferencesModal() {
 							<ItemGroup>
 								{ tabs.map( ( tab ) => {
 									return (
-										<NavigationButton
+										<NavigatorLink
 											key={ tab.name }
 											path={ tab.name }
 											as={ Item }
@@ -369,7 +370,7 @@ export default function PreferencesModal() {
 													/>
 												</FlexItem>
 											</HStack>
-										</NavigationButton>
+										</NavigatorLink>
 									);
 								} ) }
 							</ItemGroup>
@@ -389,7 +390,8 @@ export default function PreferencesModal() {
 									size="small"
 									gap="6"
 								>
-									<NavigationBackButton
+									<NavigatorBackLink
+										as={ Button }
 										icon={
 											isRTL() ? chevronRight : chevronLeft
 										}

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -19,7 +19,6 @@ import {
 	FlexItem,
 	Modal,
 	TabPanel,
-	Button,
 	Card,
 	CardHeader,
 	CardBody,
@@ -55,34 +54,6 @@ import BlockManager from '../block-manager';
 
 const MODAL_NAME = 'edit-post/preferences';
 const PREFERENCES_MENU = 'preferences-menu';
-
-// function NavigationButton( { as: Tag = Button, path, ...props } ) {
-// 	const { push } = useNavigator();
-
-// 	const dataAttrName = 'data-navigator-focusable-id';
-// 	const dataAttrValue = path;
-
-// 	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
-
-// 	const tagProps = {
-// 		...props,
-// 		[ dataAttrName ]: dataAttrValue,
-// 	};
-
-// 	return (
-// 		<Tag
-// 			onClick={ () =>
-// 				push( path, { focusTargetSelector: dataAttrCssSelector } )
-// 			}
-// 			{ ...tagProps }
-// 		/>
-// 	);
-// }
-
-// function NavigationBackButton( { as: Tag = Button, ...props } ) {
-// 	const { pop } = useNavigator();
-// 	return <Tag onClick={ pop } { ...props } />;
-// }
 
 export default function PreferencesModal() {
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -391,7 +362,6 @@ export default function PreferencesModal() {
 									gap="6"
 								>
 									<NavigatorBackLink
-										as={ Button }
 										icon={
 											isRTL() ? chevronRight : chevronLeft
 										}

--- a/packages/edit-site/src/components/global-styles/context-menu.js
+++ b/packages/edit-site/src/components/global-styles/context-menu.js
@@ -12,7 +12,7 @@ import { useHasBorderPanel } from './border-panel';
 import { useHasColorPanel } from './color-utils';
 import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 
 function ContextMenu( { name, parentMenu = '' } ) {
 	const hasTypographyPanel = useHasTypographyPanel( name );

--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -14,15 +14,14 @@ import { chevronRight, chevronLeft, Icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import NavigationButton from './navigation-button';
+import { NavigationBackButton } from './navigation-button';
 
-function ScreenHeader( { back, title, description } ) {
+function ScreenHeader( { title, description } ) {
 	return (
 		<VStack spacing={ 2 }>
 			<HStack spacing={ 2 }>
 				<View>
-					<NavigationButton
-						path={ back }
+					<NavigationBackButton
 						icon={
 							<Icon
 								icon={ isRTL() ? chevronRight : chevronLeft }
@@ -30,7 +29,6 @@ function ScreenHeader( { back, title, description } ) {
 							/>
 						}
 						size="small"
-						isBack
 						aria-label={ __( 'Navigate to the previous view' ) }
 					/>
 				</View>

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -27,8 +27,24 @@ function GenericNavigationButton( { icon, children, ...props } ) {
 
 function NavigationButton( { path, ...props } ) {
 	const { push } = useNavigator();
+
+	const dataAttrName = 'data-navigator-focusable-id';
+	const dataAttrValue = path;
+
+	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
+
+	const buttonProps = {
+		...props,
+		[ dataAttrName ]: dataAttrValue,
+	};
+
 	return (
-		<GenericNavigationButton onClick={ () => push( path ) } { ...props } />
+		<GenericNavigationButton
+			onClick={ () =>
+				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+			}
+			{ ...buttonProps }
+		/>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -9,16 +9,9 @@ import {
 } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 
-function NavigationButton( {
-	path,
-	icon,
-	children,
-	isBack = false,
-	...props
-} ) {
-	const navigator = useNavigator();
+function GenericNavigationButton( { icon, children, ...props } ) {
 	return (
-		<Item onClick={ () => navigator.push( path, { isBack } ) } { ...props }>
+		<Item { ...props }>
 			{ icon && (
 				<HStack justify="flex-start">
 					<FlexItem>
@@ -32,4 +25,16 @@ function NavigationButton( {
 	);
 }
 
-export default NavigationButton;
+function NavigationButton( { path, ...props } ) {
+	const { push } = useNavigator();
+	return (
+		<GenericNavigationButton onClick={ () => push( path ) } { ...props } />
+	);
+}
+
+function NavigationBackButton( { ...props } ) {
+	const { pop } = useNavigator();
+	return <GenericNavigationButton onClick={ pop } { ...props } />;
+}
+
+export { NavigationButton, NavigationBackButton };

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -41,7 +41,7 @@ function NavigationButton( { path, ...props } ) {
 	return (
 		<GenericNavigationButton
 			onClick={ () =>
-				push( path, { focusRestorationSelector: dataAttrCssSelector } )
+				push( path, { focusTargetSelector: dataAttrCssSelector } )
 			}
 			{ ...buttonProps }
 		/>

--- a/packages/edit-site/src/components/global-styles/navigation-button.js
+++ b/packages/edit-site/src/components/global-styles/navigation-button.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import {
-	__experimentalUseNavigator as useNavigator,
+	__experimentalNavigatorLink as NavigatorLink,
+	__experimentalNavigatorBackLink as NavigatorBackLink,
 	__experimentalItem as Item,
 	FlexItem,
 	__experimentalHStack as HStack,
@@ -25,32 +26,12 @@ function GenericNavigationButton( { icon, children, ...props } ) {
 	);
 }
 
-function NavigationButton( { path, ...props } ) {
-	const { push } = useNavigator();
-
-	const dataAttrName = 'data-navigator-focusable-id';
-	const dataAttrValue = path;
-
-	const dataAttrCssSelector = `[${ dataAttrName }="${ dataAttrValue }"]`;
-
-	const buttonProps = {
-		...props,
-		[ dataAttrName ]: dataAttrValue,
-	};
-
-	return (
-		<GenericNavigationButton
-			onClick={ () =>
-				push( path, { focusTargetSelector: dataAttrCssSelector } )
-			}
-			{ ...buttonProps }
-		/>
-	);
+function NavigationButton( props ) {
+	return <NavigatorLink as={ GenericNavigationButton } { ...props } />;
 }
 
-function NavigationBackButton( { ...props } ) {
-	const { pop } = useNavigator();
-	return <GenericNavigationButton onClick={ pop } { ...props } />;
+function NavigationBackButton( props ) {
+	return <NavigatorBackLink as={ GenericNavigationButton } { ...props } />;
 }
 
 export { NavigationButton, NavigationBackButton };

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -17,7 +17,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import Subtitle from './subtitle';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 import { useSetting } from './hooks';
 
 const EMPTY_COLORS = [];

--- a/packages/edit-site/src/components/global-styles/screen-background-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-background-color.js
@@ -17,7 +17,6 @@ import {
 } from './hooks';
 
 function ScreenBackgroundColor( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ gradients ] = useSetting( 'color.gradients', name );
@@ -86,7 +85,6 @@ function ScreenBackgroundColor( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu + '/colors' }
 				title={ __( 'Background' ) }
 				description={ __(
 					'Set a background color or gradient for the whole site.'

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -17,7 +17,7 @@ import { useHasColorPanel } from './color-utils';
 import { useHasDimensionsPanel } from './dimensions-panel';
 import { useHasTypographyPanel } from './typography-panel';
 import ScreenHeader from './header';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 
 function BlockMenuItem( { block } ) {
 	const hasTypographyPanel = useHasTypographyPanel( block.name );
@@ -48,7 +48,6 @@ function ScreenBlockList() {
 	return (
 		<>
 			<ScreenHeader
-				back="/"
 				title={ __( 'Blocks' ) }
 				description={ __(
 					'Customize the appearance of specific blocks and for the whole site.'

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -14,7 +14,7 @@ function ScreenBlock( { name } ) {
 
 	return (
 		<>
-			<ScreenHeader back="/blocks" title={ blockType.title } />
+			<ScreenHeader title={ blockType.title } />
 			<ContextMenu parentMenu={ '/blocks/' + name } name={ name } />
 		</>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-color-palette.js
+++ b/packages/edit-site/src/components/global-styles/screen-color-palette.js
@@ -17,12 +17,10 @@ import ScreenHeader from './header';
 
 function ScreenColorPalette( { name } ) {
 	const [ currentTab, setCurrentTab ] = useState( 'solid' );
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu + '/colors' }
 				title={ __( 'Palette' ) }
 				description={ __(
 					'Palettes are used to provide default color options for blocks and various design tools. Here you can edit the colors with their labels.'

--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -15,7 +15,7 @@ import {
  */
 import ScreenHeader from './header';
 import Palette from './palette';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 import { getSupportedGlobalStylesPanels, useStyle } from './hooks';
 import Subtitle from './subtitle';
 
@@ -93,7 +93,6 @@ function ScreenColors( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu ? parentMenu : '/' }
 				title={ __( 'Colors' ) }
 				description={ __(
 					'Manage palettes and the default color of different global elements on the site.'

--- a/packages/edit-site/src/components/global-styles/screen-layout.js
+++ b/packages/edit-site/src/components/global-styles/screen-layout.js
@@ -11,16 +11,12 @@ import DimensionsPanel, { useHasDimensionsPanel } from './dimensions-panel';
 import ScreenHeader from './header';
 
 function ScreenLayout( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 	const hasBorderPanel = useHasBorderPanel( name );
 	const hasDimensionsPanel = useHasDimensionsPanel( name );
 
 	return (
 		<>
-			<ScreenHeader
-				back={ parentMenu ? parentMenu : '/' }
-				title={ __( 'Layout' ) }
-			/>
+			<ScreenHeader title={ __( 'Layout' ) } />
 			{ hasDimensionsPanel && <DimensionsPanel name={ name } /> }
 			{ hasBorderPanel && <BorderPanel name={ name } /> }
 		</>

--- a/packages/edit-site/src/components/global-styles/screen-link-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-link-color.js
@@ -16,7 +16,6 @@ import {
 } from './hooks';
 
 function ScreenLinkColor( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
@@ -47,7 +46,6 @@ function ScreenLinkColor( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu + '/colors' }
 				title={ __( 'Links' ) }
 				description={ __(
 					'Set the default color used for links across the site.'

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -17,7 +17,7 @@ import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import StylesPreview from './preview';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 import ContextMenu from './context-menu';
 
 function ScreenRoot() {

--- a/packages/edit-site/src/components/global-styles/screen-text-color.js
+++ b/packages/edit-site/src/components/global-styles/screen-text-color.js
@@ -16,7 +16,6 @@ import {
 } from './hooks';
 
 function ScreenTextColor( { name } ) {
-	const parentMenu = name === undefined ? '' : '/blocks/' + name;
 	const supports = getSupportedGlobalStylesPanels( name );
 	const [ solids ] = useSetting( 'color.palette', name );
 	const [ areCustomSolidsEnabled ] = useSetting( 'color.custom', name );
@@ -39,7 +38,6 @@ function ScreenTextColor( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu + '/colors' }
 				title={ __( 'Text' ) }
 				description={ __(
 					'Set the default color used for text across the site.'

--- a/packages/edit-site/src/components/global-styles/screen-typography-element.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography-element.js
@@ -21,13 +21,9 @@ const elements = {
 };
 
 function ScreenTypographyElement( { name, element } ) {
-	const parentMenu =
-		name === undefined ? '/typography' : '/blocks/' + name + '/typography';
-
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu }
 				title={ elements[ element ].title }
 				description={ elements[ element ].description }
 			/>

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -13,7 +13,7 @@ import {
  * Internal dependencies
  */
 import ScreenHeader from './header';
-import NavigationButton from './navigation-button';
+import { NavigationButton } from './navigation-button';
 import { useStyle } from './hooks';
 import Subtitle from './subtitle';
 import TypographyPanel from './typography-panel';
@@ -72,7 +72,6 @@ function ScreenTypography( { name } ) {
 	return (
 		<>
 			<ScreenHeader
-				back={ parentMenu ? parentMenu : '/' }
 				title={ __( 'Typography' ) }
 				description={ __(
 					'Manage the typography settings for different elements.'

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -100,7 +100,7 @@ function ScreenTypography( { name } ) {
 				</div>
 			) }
 
-			{ /* no typogrpahy elements support yet for blocks */ }
+			{ /* no typography elements support yet for blocks */ }
 			{ !! name && <TypographyPanel name={ name } element="text" /> }
 		</>
 	);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following the conversation in #37063, this PR is an exploration into enabling focus restoration when navigating back

Changes:
- added basic location history stack (necessary for implementing focus restoration):
  - refactored the `Navigator` component, especially the shape of the context object: it now exposes `location` (the current location), `push` (used to navigate to a new location), and `pop` (used to navigate to the previous location)
  - refactored usages across gutenberg
- enhanced focus restoration:
  - prior to this PR, each `NavigatorScreen` would focus its first tabbable element when mounted
  - this PR adds logic to attempt to restore focus on a specific element when navigating back (with a fallback on the first tabbable element, as it already happens)
  - updated Storybook example to take advantage of that
  - note that, as of now, the element that will receive focus is targeted via `querySelector`, and it is the responsibility of the developer to make sure that each link can be correctly `selected` by providing a working selector.


TODO:
- edit Storybook example to add a standard `NavigatorLink`
- add/update `Navigator`'s unit tests
- update `Navigator` README and JSDocs (including the `@example`s)
- add CHANGELOG entry

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- [TODO] Unit tests
- Check that the Storybook example works as expected (both focus restoration and back/forward navigation)
- Check that the Global Styles Sidebar in the site editor works as expected (both focus restoration and back/forward navigation)
- Check that the Preferences Modal in the post editor (on mobile screens) works as expected (both focus restoration and back/forward navigation)

## Screenshots <!-- if applicable -->

### Storybook

https://user-images.githubusercontent.com/1083581/145439161-fa003973-0c73-4f5d-95bd-8f8160f09ba8.mp4

### Preferences Modal

https://user-images.githubusercontent.com/1083581/145445546-c91306cf-be68-436c-b0e8-56243b5e481f.mp4

### Global Styles Sidebar

https://user-images.githubusercontent.com/1083581/145446524-aefcdd02-1294-4627-a43d-661bdf582bdb.mp4


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature (technically not breaking, since the component is experimental)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
