### PR TITLE
[Components - ToggleGroupControl]: Fix extra update on incoming change

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Added `__experimentalHideHeader` prop to `Modal` component ([#36831](https://github.com/WordPress/gutenberg/pull/36831)).
 -   Added experimental `ConfirmDialog` component ([#34153](https://github.com/WordPress/gutenberg/pull/34153)).
 -   Divider: improve support for vertical orientation and RTL styles, use start/end logical props instead of top/bottom, change border-color to `currentColor` ([#36579](https://github.com/WordPress/gutenberg/pull/36579)).
+-   ToggleGroupControl: Avoid calling `onChange` if radio state changed from an incoming value ([#37224](https://github.com/WordPress/gutenberg/pull/37224/)).
 
 ### Bug Fix
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -12,7 +12,7 @@ import useResizeAware from 'react-resize-aware';
  */
 import { __ } from '@wordpress/i18n';
 import { useRef, useMemo } from '@wordpress/element';
-import { useMergeRefs, useInstanceId } from '@wordpress/compose';
+import { useMergeRefs, useInstanceId, usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -59,10 +59,15 @@ function ToggleGroupControl(
 		baseId,
 		state: value,
 	} );
+	const previousValue = usePrevious( value );
 
 	// Propagate radio.state change
 	useUpdateEffect( () => {
-		onChange( radio.state );
+		// Avoid calling onChange if radio state changed
+		// from incoming value.
+		if ( previousValue !== radio.state ) {
+			onChange( radio.state );
+		}
 	}, [ radio.state ] );
 
 	// Sync incoming value with radio.state


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37172

There was a bug in `ToggleGroupControl` component where it would call the passed `onChange` function during rendering an extra time where the value was the result of an incoming change (redo/undo). That would cause an extra level in history which was the same with the previous one, due to internal logic of handling history steps.

## Testing instructions (from the issue 😄 )

1. Navigate to the post editor
2. Add text to a paragraph block
3. In the paragraph block's block settings menu, update line height
4. Update font size
5. Undo until the text and typography updates are gone
6. Redo until you return to the current revision
7. Verify that font-size isn't restored

** noting that to reproduce the bug we have to also have at least one more typography setting which is handled by `style` object property. This is needed because it has to do with internals detection of `marking` history steps.




### Before

https://user-images.githubusercontent.com/16275880/145225987-58eda2e7-5bed-4c1c-b872-75cf5373371d.mov




### After

https://user-images.githubusercontent.com/16275880/145225999-11fd44f7-1e22-4615-8481-79f9267d625e.mov


