### PR TITLE
Fix theme requirement validation with WP 5.8

### DIFF
--- a/lib/compat/wordpress-5.9/theme.php
+++ b/lib/compat/wordpress-5.9/theme.php
@@ -16,3 +16,13 @@ if ( ! function_exists( 'wp_is_block_theme' ) ) {
 			is_readable( get_theme_file_path( '/templates/index.html' ) );
 	}
 }
+
+/**
+ * Note: We have to maintain this function for backward compatibility with WP 5.8.
+ * Only remove once 5.9 is the minimum supported WordPress version for the Gutenberg plugin.
+ *
+ * @return boolean Whether the current theme is a block theme or not.
+ */
+function gutenberg_is_fse_theme() {
+	return wp_is_block_theme();
+}

--- a/lib/compat/wordpress-5.9/theme.php
+++ b/lib/compat/wordpress-5.9/theme.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'wp_is_block_theme' ) ) {
 
 /**
  * Note: We have to maintain this function for backward compatibility with WP 5.8.
- * Only remove once 5.9 is the minimum supported WordPress version for the Gutenberg plugin.
+ * The `validate_theme_requirements` method is using `gutenberg_is_fse_theme` in older versions of WP.
  *
  * @return boolean Whether the current theme is a block theme or not.
  */

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -105,3 +105,13 @@ function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_e
 		: $is_block_editor_screen;
 }
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_site_editor_load_block_editor_scripts_and_styles' );
+
+/**
+ * Note: We have to maintain this function for backward compatibility with WP 5.8.
+ * Only remove once 5.9 is the minimum supported WordPress version for the Gutenberg plugin.
+ *
+ * @return boolean Whether the current theme is a block theme or not.
+ */
+function gutenberg_is_fse_theme() {
+	return wp_is_block_theme();
+}

--- a/lib/full-site-editing/full-site-editing.php
+++ b/lib/full-site-editing/full-site-editing.php
@@ -105,13 +105,3 @@ function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_e
 		: $is_block_editor_screen;
 }
 add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_site_editor_load_block_editor_scripts_and_styles' );
-
-/**
- * Note: We have to maintain this function for backward compatibility with WP 5.8.
- * Only remove once 5.9 is the minimum supported WordPress version for the Gutenberg plugin.
- *
- * @return boolean Whether the current theme is a block theme or not.
- */
-function gutenberg_is_fse_theme() {
-	return wp_is_block_theme();
-}


### PR DESCRIPTION
## Description
Fixes regression when it wasn't possible to activate block theme with WP 5.8. The `validate_theme_requirements` method is using `gutenberg_is_fse_theme` in older versions of WP.

Introduced in #37218.

## How has this been tested?
Try activating block theme with WP 5.8

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-08 at 19 37 25](https://user-images.githubusercontent.com/240569/145237015-e9ec6c58-155e-4dc0-836d-a60221daddcc.png)


## Types of changes
Bugfix/Regression

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
