### PR TITLE
[Block Library - Site Title, Site Tagline]: Add delay to content changes

### DIFF
--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -15,6 +15,7 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useDebounce } from '@wordpress/compose';
 
 export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 	const { textAlign } = attributes;
@@ -23,6 +24,7 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 		'site',
 		'description'
 	);
+	const debouncedOnChange = useDebounce( setSiteTagline, 500 );
 	const { canUserEdit, readOnlySiteTagLine } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord } = select( coreStore );
 		const siteData = getEntityRecord( 'root', '__unstableBase' );
@@ -41,7 +43,7 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 	const siteTaglineContent = canUserEdit ? (
 		<RichText
 			allowedFormats={ [] }
-			onChange={ setSiteTagline }
+			onChange={ debouncedOnChange }
 			aria-label={ __( 'Site tagline text' ) }
 			placeholder={ __( 'Write site tagline…' ) }
 			tagName="p"

--- a/packages/block-library/src/site-title/edit/index.js
+++ b/packages/block-library/src/site-title/edit/index.js
@@ -19,6 +19,7 @@ import {
 import { ToggleControl, PanelBody } from '@wordpress/components';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { useDebounce } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -32,6 +33,7 @@ export default function SiteTitleEdit( {
 } ) {
 	const { level, textAlign, isLink, linkTarget } = attributes;
 	const [ title, setTitle ] = useEntityProp( 'root', 'site', 'title' );
+	const debouncedOnChange = useDebounce( setTitle, 500 );
 	const { canUserEdit, readOnlyTitle } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord } = select( coreStore );
 		const siteData = getEntityRecord( 'root', '__unstableBase' );
@@ -56,7 +58,7 @@ export default function SiteTitleEdit( {
 				aria-label={ __( 'Site title text' ) }
 				placeholder={ __( 'Write site title…' ) }
 				value={ title }
-				onChange={ setTitle }
+				onChange={ debouncedOnChange }
 				allowedFormats={ [] }
 				disableLineBreaks
 				__unstableOnSplitAtEnd={ () =>

--- a/packages/e2e-tests/specs/editor/blocks/site-title.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/site-title.test.js
@@ -53,6 +53,10 @@ describe( 'Site Title block', () => {
 		await pressKeyWithModifier( 'primary', 'a' );
 
 		await page.keyboard.type( 'New Site Title' );
+		// Wait a bit as the Site Title's onChange is debounced.
+		await page.waitForSelector(
+			'.editor-post-publish-button__button.has-changes-dot'
+		);
 
 		await saveEntities();
 

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -218,6 +218,11 @@ describe( 'Multi-entity save flow', () => {
 			await page.focus( editableSiteTagLineSelector );
 			await page.keyboard.type( '...' );
 
+			// Wait a bit as the Site Title's and Site Tagline's `onChange` are debounced,
+			// and we can't know when these changes took effect with a selector.
+			// eslint-disable-next-line no-restricted-syntax
+			await page.waitForTimeout( 1000 );
+
 			await clickButton( 'Publish' );
 			await page.waitForSelector( savePanelSelector );
 			let checkboxInputs = await page.$$( checkboxInputSelector );


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/37171

Currently undoing a site tagline or site title block change, reverts the text one character at a time, instead of in larger "chunks" like in the paragraph block. 

This is happening because we have a specific handling for quick changes in the same block attribute [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/reducer.js#L533). 

For now this PR just adds a little delay before applying these two blocks' changes.

Should we handle this in a similar way for `EDIT_ENTITY_RECORD` action? IMO it might not worth it a new API for `entities` to handle specific fields, as I feel like there will not be many other cases besides these two site `settings`. What do you think?