### PR TITLE
Fix WP 5.9 check for conditionally running code

### DIFF
--- a/lib/compat/wordpress-5.9/template-parts.php
+++ b/lib/compat/wordpress-5.9/template-parts.php
@@ -12,8 +12,8 @@
  */
 
 // Only run any of the code in this file if the version is less than 5.9.
-// wp_is_block_theme was introduced in 5.9.
-if ( ! function_exists( 'wp_is_block_theme' ) ) {
+// wp_list_users was introduced in 5.9.
+if ( ! function_exists( 'wp_list_users' ) ) {
 	/**
 	 * Registers block editor 'wp_template_part' post type.
 	 */

--- a/lib/compat/wordpress-5.9/templates.php
+++ b/lib/compat/wordpress-5.9/templates.php
@@ -12,8 +12,8 @@
  */
 
 // Only run any of the code in this file if the version is less than 5.9.
-// wp_is_block_theme was introduced in 5.9.
-if ( ! function_exists( 'wp_is_block_theme' ) ) {
+// wp_list_users was introduced in 5.9.
+if ( ! function_exists( 'wp_list_users' ) ) {
 	/**
 	 * Registers block editor 'wp_template' post type.
 	 */


### PR DESCRIPTION
## Description
Use a different function to check if the plugin runs on an older WP version. The `wp_is_block_theme` got ported back to the plugin (#37218). PR update conditional check to use a function that's WP core specific and was [introduced in 5.9](https://core.trac.wordpress.org/changeset/52064) - `wp_list_users`

The current logic only works because the `compat/wordpress-5.9/theme.php` file is included later in `load.php`.

## How has this been tested?
1. Make sure you're running WordPress 5.9
2. Change something related to one of the post types in the Gutenberg codebase (i.e., one of the labels)
3. Load the relevant part of the UI and notice the change is not displayed because this code isn't active.

~~Borrowed~~ Copied from #36898.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
