### PR TITLE
[@wordpress/data] Add types to the useSelect function

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -387,7 +387,7 @@ _Parameters_
 
 _Returns_
 
--   `WPDataRegistry`: Data registry.
+-   `DataRegistry`: Data registry.
 
 ### createRegistryControl
 
@@ -820,8 +820,8 @@ function Paste( { children } ) {
 
 _Parameters_
 
--   _mapSelect_ `Function|StoreDescriptor|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
--   _deps_ `Array`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
+-   _mapSelect_ `SelectChooser`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
+-   _deps_ `unknown[]`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 

--- a/packages/data/src/components/registry-provider/use-registry.ts
+++ b/packages/data/src/components/registry-provider/use-registry.ts
@@ -45,7 +45,7 @@ import { Context } from './context';
  * };
  * ```
  *
- * @return {Function}  A custom react hook exposing the registry context value.
+ * @return A custom react hook exposing the registry context value.
  */
 export default function useRegistry() {
 	return useContext( Context );

--- a/packages/data/src/components/registry-provider/use-registry.ts
+++ b/packages/data/src/components/registry-provider/use-registry.ts
@@ -45,7 +45,7 @@ import { Context } from './context';
  * };
  * ```
  *
- * @return A custom react hook exposing the registry context value.
+ * @return {Function} A custom react hook exposing the registry context value.
  */
 export default function useRegistry() {
 	return useContext( Context );

--- a/packages/data/src/components/use-select/index.ts
+++ b/packages/data/src/components/use-select/index.ts
@@ -109,7 +109,7 @@ export default function useSelect(
 	// `_mapSelect` if we can.
 	const callbackMapper = useCallback(
 		hasMappingFunction ? mapSelect : noop,
-		deps ?? []
+		deps as unknown[]
 	);
 	const _mapSelect = hasMappingFunction ? callbackMapper : null;
 

--- a/packages/data/src/components/use-select/index.ts
+++ b/packages/data/src/components/use-select/index.ts
@@ -87,7 +87,7 @@ const renderQueue = createQueue();
  * }
  * ```
  *
- * @return A custom react hook.
+ * @return {Function} A custom react hook.
  */
 export default function useSelect(
 	mapSelect: SelectChooser,

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -16,26 +16,7 @@ import coreDataStore from './store';
 import { createEmitter } from './utils/emitter';
 
 /** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
-
-/**
- * @typedef {Object} WPDataRegistry An isolated orchestrator of store registrations.
- *
- * @property {Function} registerGenericStore Given a namespace key and settings
- *                                           object, registers a new generic
- *                                           store.
- * @property {Function} registerStore        Given a namespace key and settings
- *                                           object, registers a new namespace
- *                                           store.
- * @property {Function} subscribe            Given a function callback, invokes
- *                                           the callback on any change to state
- *                                           within any registered store.
- * @property {Function} select               Given a namespace key, returns an
- *                                           object of the  store's registered
- *                                           selectors.
- * @property {Function} dispatch             Given a namespace key, returns an
- *                                           object of the store's registered
- *                                           action dispatchers.
- */
+/** @typedef {import('./types').DataRegistry} DataRegistry */
 
 /**
  * @typedef {Object} WPDataPlugin An object of registry function overrides.
@@ -50,7 +31,7 @@ import { createEmitter } from './utils/emitter';
  * @param {Object}  storeConfigs Initial store configurations.
  * @param {Object?} parent       Parent registry.
  *
- * @return {WPDataRegistry} Data registry.
+ * @return {DataRegistry} Data registry.
  */
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -1,10 +1,25 @@
-type MapOf< T > = { [ name: string ]: T };
+/**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { MutableRefObject } from 'react';
+
+export type MapOf< T > = { [ name: string ]: T };
 
 export type ActionCreator = Function | Generator;
 export type Resolver = Function | Generator;
 export type Selector = Function;
 
 export type AnyConfig = ReduxStoreConfig< any, any, any >;
+
+export interface SelectMapper {
+	(
+		select: ( reference: StoreReference ) => MapOf< Function >,
+		registry: DataRegistry
+	): unknown;
+}
+export type SelectChooser = SelectMapper | StoreReference;
+export type StoreReference = StoreDescriptor< any > | string;
 
 export interface StoreInstance< Config extends AnyConfig > {
 	getSelectors: () => SelectorsOf< Config >;
@@ -38,7 +53,17 @@ export interface ReduxStoreConfig<
 }
 
 export interface DataRegistry {
+	__experimentalMarkListeningStores: (
+		callback: ( this: DataRegistry ) => unknown,
+		listeningStores: MutableRefObject< unknown >
+	) => unknown;
+	__experimentalSubscribeStore: (
+		storeName: string,
+		listener: () => void
+	) => ReturnType< DataEmitter[ 'subscribe' ] >;
+
 	register: ( store: StoreDescriptor< any > ) => void;
+	select: ( chooser: SelectChooser, deps?: unknown[] ) => any;
 }
 
 export interface DataEmitter {

--- a/packages/is-shallow-equal/src/index.js
+++ b/packages/is-shallow-equal/src/index.js
@@ -15,8 +15,8 @@ export { default as isShallowEqualArrays } from './arrays';
  * Returns true if the two arrays or objects are shallow equal, or false
  * otherwise.
  *
- * @param {any[]|ComparableObject} a First object or array to compare.
- * @param {any[]|ComparableObject} b Second object or array to compare.
+ * @param {unknown[]|ComparableObject|any} a First object or array to compare.
+ * @param {unknown[]|ComparableObject|any} b Second object or array to compare.
  *
  * @return {boolean} Whether the two values are shallow equal.
  */


### PR DESCRIPTION
## Description

Adds primitive TypeScript types to `useSelect`. In this PR we're adding
enough type information to `useSelect` to make it (a) internally consistent,
and (b) marginally useful to callers.

**Internal consistency** is mostly about introducing types without violations
so that TypeScript can compile the code successfully. While we have introduced
a few type casts in this patch they are either benign or replicate existing risk,
such as in asserting that an `error` in a `catch` clause does in fact extend the
`Error` class/prototype.

**Marginally useful** is about providing information to callers that ensures type
safety and introduces information to aid in development. In order to keep this PR
small the goals are low here. We don't provide any information about the return
value from calling `useSelect` other than to indicate that it could be a map of
functions or it could be anything (if provided a mapping function). It does, however,
provide a hint for the mapping function and what arguments it expects.

![useSelectMarginalUtility mov](https://user-images.githubusercontent.com/5431237/145307901-49690750-7795-4f5b-9c9d-6504caca599d.gif)

There is much more we should be able to do to let our types flow through the
system and to provide hints on what functions are available after calling `select(store)`
but for now this makes one small step towards that goal while hopefully not
taking any steps backward away from it.

## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes

Adds types to `useSelect` with minimal changes to actual code.
There should be no functional or behavioral changes in this PR,
apart from a couple of small fixes as forced by TypeScript, for
example, in supplying a default value for `deps` to `useCallback`
when not supplied by the caller.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
