### PR TITLE
Search Block: Fix application of border color class in the editor

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -128,7 +128,6 @@ export default function SearchEdit( {
 	const getBlockClassNames = () => {
 		return classnames(
 			className,
-			! isButtonPositionInside ? borderProps.className : undefined,
 			isButtonPositionInside
 				? 'wp-block-search__button-inside'
 				: undefined,


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/34061
- https://github.com/WordPress/gutenberg/pull/31783

## Description

Now that border support classes apply default border styles etc the superfluous addition of border classes to the search block wrapper in the editor displays an extra border.

## How has this been tested?

1. Create a post, add a Search block, and select it
2. Toggle on the border color control from the inspector controls sidebar and choose a color
3. Notice the extra border regardless of where the button is positioned in the block
4. Apply the changes in this PR and repeat the steps above. There should be no extra border.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![SearchBorderIssue](https://user-images.githubusercontent.com/60436221/145314562-61025087-e785-4e8f-b114-6c6140962988.gif) | ![SearchBorderIssueFix](https://user-images.githubusercontent.com/60436221/145314574-af9fb34b-f427-4c63-a401-710754ab3d7b.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
