### PR TITLE
Paragraph: Support paragraph placeholder in block editor settings

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -562,6 +562,7 @@ _Properties_
 -   _focusMode_ `boolean`: Whether the focus mode is enabled or not
 -   _styles_ `Array`: Editor Styles
 -   _keepCaretInsideBlock_ `boolean`: Whether caret should move between blocks in edit mode
+-   _paragraphPlaceholder_ `string`: Empty paragraph placeholder
 -   _bodyPlaceholder_ `string`: Empty post placeholder
 -   _titlePlaceholder_ `string`: Empty title placeholder
 -   _codeEditingEnabled_ `boolean`: Whether or not the user can switch to the code editor

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -21,6 +21,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {boolean}       focusMode                              Whether the focus mode is enabled or not
  * @property {Array}         styles                                 Editor Styles
  * @property {boolean}       keepCaretInsideBlock                   Whether caret should move between blocks in edit mode
+ * @property {string}        paragraphPlaceholder                   Empty paragraph placeholder
  * @property {string}        bodyPlaceholder                        Empty post placeholder
  * @property {string}        titlePlaceholder                       Empty title placeholder
  * @property {boolean}       codeEditingEnabled                     Whether or not the user can switch to the code editor

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -19,8 +19,10 @@ import {
 	RichText,
 	useBlockProps,
 	useSetting,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 import { formatLtr } from '@wordpress/icons';
 
 const name = 'core/paragraph';
@@ -63,6 +65,11 @@ function ParagraphBlock( {
 		} ),
 		style: { direction },
 	} );
+
+	const paragraphPlaceholder = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().paragraphPlaceholder;
+	}, [] );
 
 	return (
 		<>
@@ -145,7 +152,11 @@ function ParagraphBlock( {
 						  )
 				}
 				data-empty={ content ? false : true }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				placeholder={
+					placeholder ||
+					paragraphPlaceholder ||
+					__( 'Type / to choose a block' )
+				}
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -37,6 +37,11 @@ function ParagraphBlock( {
 		...style,
 	};
 
+	const paragraphPlaceholder = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().paragraphPlaceholder;
+	}, [] );
+
 	const onAlignmentChange = useCallback( ( nextAlign ) => {
 		setAttributes( { align: nextAlign } );
 	}, [] );
@@ -81,7 +86,11 @@ function ParagraphBlock( {
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
-				placeholder={ placeholder || __( 'Start writing…' ) }
+				placeholder={
+					placeholder ||
+					paragraphPlaceholder ||
+					__( 'Start writing…' )
+				}
 				textAlign={ align }
 				__unstableEmbedURLOnPaste
 			/>

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -121,6 +121,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'keepCaretInsideBlock',
 				'maxWidth',
 				'onUpdateDefaultBlockStyles',
+				'paragraphPlaceholder',
 				'styles',
 				'template',
 				'templateLock',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

As developer can control the placeholder of the content before focusing on it via the `bodyPlaceholder` of the block settings. I think it's good to apply this config to the paragraph placeholder because some of the developers might also want the placeholder to keep consistent before/after focusing on the content. However, some of the developers might also want the placeholder to show the different text. So, add new settings for the paragraph placeholder to let the developers decide the text should be the same as the body placeholder or not. Also, they can apply the different text for paragraph placeholder if they want

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Add `paragraphPlaceholder` to the default settings in `packages/block-editor/src/store/defaults.js`
   ```js
   export const SETTINGS_DEFAULTS = {
     ...,
     paragraphPlaceholder: 'Hello',
   }
   ```

2. Go to /wp-admin/
3. Create a new post
4. Focus on the content and check the placeholder is what you set above.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/13596067/145335812-ccb8092e-7978-4ff8-85c8-0038b3a43348.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
