### PR TITLE
Fix form-submit styles by adding button classes to the submit-button in post-comments block

### DIFF
--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -31,5 +31,9 @@
 			"link": true
 		}
 	},
-	"style": "wp-block-post-comments"
+	"style": [
+		"wp-block-post-comments",
+		"wp-block-buttons",
+		"wp-block-button"
+	]
 }

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -66,3 +66,20 @@ function register_block_core_post_comments() {
 	);
 }
 add_action( 'init', 'register_block_core_post_comments' );
+
+if ( ! function_exists( 'wp_post_comments_block_form_defaults' ) ) {
+	/**
+	 * Use the button block classes for the form-submit button.
+	 *
+	 * @param array $fields The default comment form arguments.
+	 *
+	 * @return array Returns the modified fields.
+	 */
+	function wp_post_comments_block_form_defaults( $fields ) {
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+
+		return $fields;
+	}
+	add_filter( 'comment_form_defaults', 'wp_post_comments_block_form_defaults' );
+}

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -67,19 +67,17 @@ function register_block_core_post_comments() {
 }
 add_action( 'init', 'register_block_core_post_comments' );
 
-if ( ! function_exists( 'wp_post_comments_block_form_defaults' ) ) {
-	/**
-	 * Use the button block classes for the form-submit button.
-	 *
-	 * @param array $fields The default comment form arguments.
-	 *
-	 * @return array Returns the modified fields.
-	 */
-	function wp_post_comments_block_form_defaults( $fields ) {
-		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
-		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+/**
+ * Use the button block classes for the form-submit button.
+ *
+ * @param array $fields The default comment form arguments.
+ *
+ * @return array Returns the modified fields.
+ */
+function gutenberg_post_comments_block_form_defaults( $fields ) {
+	$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+	$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
 
-		return $fields;
-	}
-	add_filter( 'comment_form_defaults', 'wp_post_comments_block_form_defaults' );
+	return $fields;
 }
+add_filter( 'comment_form_defaults', 'gutenberg_post_comments_block_form_defaults' );


### PR DESCRIPTION
## Description

Fixes the issue reported in https://github.com/WordPress/twentytwentytwo/issues/281
Should be backported to WP5.9.
Since we split the post-comments block this doesn't work as expected because these changes were moved to the post-comments-form block (which is not being backported to WP Core yet). The changes must therefore also exist in the post-comments block for backwards-compatibility purposes with WP 5.9.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
