### PR TITLE
Site Editor: Fix edit template part link in header dropdown

### DIFF
--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -13,6 +13,7 @@ import { moreVertical } from '@wordpress/icons';
  */
 import { store as editSiteStore } from '../../store';
 import isTemplateRevertable from '../../utils/is-template-revertable';
+import { useLocation } from '../routes';
 import { useLink } from '../routes/link';
 
 function TemplatePartItemMore( {
@@ -21,10 +22,16 @@ function TemplatePartItemMore( {
 	closeTemplateDetailsDropdown,
 } ) {
 	const { revertTemplate } = useDispatch( editSiteStore );
-	const editLinkProps = useLink( {
-		postId: templatePart.id,
-		postType: templatePart.type,
-	} );
+	const { params } = useLocation();
+	const editLinkProps = useLink(
+		{
+			postId: templatePart.id,
+			postType: templatePart.type,
+		},
+		{
+			fromTemplateId: params.postId,
+		}
+	);
 
 	function editTemplatePart( event ) {
 		editLinkProps.onClick( event );


### PR DESCRIPTION
## Description
Adds missing `fromTemplateId` to the edit template part link in the header dropdown. The lack of this state parameter prevents displaying the "Back" button.

## How has this been tested?
1. Access template part editing focus mode via the dropdown menu.
2. Make sure the "Back" button is displayed.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-09 at 12 21 51](https://user-images.githubusercontent.com/240569/145361596-694f0a4e-ba24-4279-9068-4c324ea2c7f7.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
