### PR TITLE
Fix how `appearanceTools` works

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -396,7 +396,9 @@ class WP_Theme_JSON_Gutenberg {
 		);
 
 		foreach ( $to_opt_in as $path ) {
-			if ( null === _wp_array_get( $context, $path, null ) ) {
+			// Use "unset prop" as a marker instead of "null" because
+			// "null" can be a valid value for some props (e.g. blockGap).
+			if ( "unset prop" === _wp_array_get( $context, $path, "unset prop" ) ) {
 				_wp_array_set( $context, $path, true );
 			}
 		}

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -359,13 +359,16 @@ class WP_Theme_JSON_Gutenberg {
 	private static function maybe_opt_in_into_settings( $theme_json ) {
 		$new_theme_json = $theme_json;
 
-		if ( isset( $new_theme_json['settings']['appearanceTools'] ) ) {
+		if (
+			isset( $new_theme_json['settings']['appearanceTools'] ) &&
+			true === $new_theme_json['settings']['appearanceTools']
+		) {
 			self::do_opt_in_into_settings( $new_theme_json['settings'] );
 		}
 
 		if ( isset( $new_theme_json['settings']['blocks'] ) && is_array( $new_theme_json['settings']['blocks'] ) ) {
 			foreach ( $new_theme_json['settings']['blocks'] as &$block ) {
-				if ( isset( $block['appearanceTools'] ) ) {
+				if ( isset( $block['appearanceTools'] ) && ( true === $block['appearanceTools'] ) ) {
 					self::do_opt_in_into_settings( $block );
 				}
 			}

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -398,7 +398,7 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $to_opt_in as $path ) {
 			// Use "unset prop" as a marker instead of "null" because
 			// "null" can be a valid value for some props (e.g. blockGap).
-			if ( "unset prop" === _wp_array_get( $context, $path, "unset prop" ) ) {
+			if ( 'unset prop' === _wp_array_get( $context, $path, 'unset prop' ) ) {
 				_wp_array_set( $context, $path, true );
 			}
 		}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -208,6 +208,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							'typography'      => array(
 								'lineHeight' => false, // This should override appearanceTools.
 							),
+							'spacing'         => array(
+								'blockGap' => null,
+							),
 						),
 					),
 				),
@@ -250,7 +253,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'link' => true,
 					),
 					'spacing'    => array(
-						'blockGap' => true,
+						'blockGap' => false,
 						'margin'   => true,
 						'padding'  => true,
 					),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -188,12 +188,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected_no_origin, $actual_no_origin );
 	}
 
-	function test_get_settings_using_opt_in_key() {
+	function test_get_settings_appearance_true_opts_in() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'appearanceTools' => true,
+					'spacing'         => array(
+						'blockGap' => false, // This should override appearanceTools.
+					),
 					'blocks'          => array(
 						'core/paragraph' => array(
 							'typography' => array(
@@ -223,7 +226,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'link' => true,
 			),
 			'spacing'    => array(
-				'blockGap' => true,
+				'blockGap' => false,
 				'margin'   => true,
 				'padding'  => true,
 			),
@@ -251,6 +254,54 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						'margin'   => true,
 						'padding'  => true,
 					),
+					'typography' => array(
+						'lineHeight' => false,
+					),
+				),
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
+	function test_get_settings_appearance_false_does_not_opt_in() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'appearanceTools' => false,
+					'border'          => array(
+						'width' => true,
+					),
+					'blocks'          => array(
+						'core/paragraph' => array(
+							'typography' => array(
+								'lineHeight' => false,
+							),
+						),
+						'core/group'     => array(
+							'typography'      => array(
+								'lineHeight' => false,
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$actual   = $theme_json->get_settings();
+		$expected = array(
+			'appearanceTools' => false,
+			'border'          => array(
+				'width'  => true,
+			),
+			'blocks'          => array(
+				'core/paragraph' => array(
+					'typography' => array(
+						'lineHeight' => false,
+					),
+				),
+				'core/group'     => array(
 					'typography' => array(
 						'lineHeight' => false,
 					),

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -280,7 +280,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 						'core/group'     => array(
-							'typography'      => array(
+							'typography' => array(
 								'lineHeight' => false,
 							),
 						),
@@ -293,7 +293,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected = array(
 			'appearanceTools' => false,
 			'border'          => array(
-				'width'  => true,
+				'width' => true,
 			),
 			'blocks'          => array(
 				'core/paragraph' => array(


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37232
Follow-up to https://github.com/WordPress/gutenberg/pull/36646

This PR fixes two things:

- It looks like the mere presence of the `appearanceTools` flag was activating the others, while it should only be the case if `appearanceTools` was `true`.
- There are some flags (such as `blockGap`) for which the `null` value is actually valid, so we need to detect whether they are set/unset using a different marker.

## How to test

- Activate TwentyTwentyTwo theme.
- Add a post with a group and a few paragraphs within. Publish.

Verify that without `appearanceTools` things work as expected:

- Remove or set to `false` the flag `appearanceTools` in the `theme.json` of TwentyTwentyTwo.
- Load the published post in the front-end and verify that the block gap classes are not present (see https://github.com/WordPress/gutenberg/issues/37232 for details).

Verity that with `appearanceTools` active blockGap can be disabled:

- Set to `true` the flag `appearanceTools` in the `theme.json` of TwentyTwentyTwo.
- Set `settings.spacing.blockGap` to `null`.
- Load the published post in the front-end and verify that the block gap classes are not present (see https://github.com/WordPress/gutenberg/issues/37232 for details).
