### PR TITLE
Move WP 5.9 wp-admin menus compatibility code to lib/compat folder

### DIFF
--- a/lib/compat/wordpress-5.9/admin-menu.php
+++ b/lib/compat/wordpress-5.9/admin-menu.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Full Site Editing Utils
+ * WP Admin Menus changes to match WordPress 5.9
  *
  * @package gutenberg
  */
@@ -92,16 +92,3 @@ function gutenberg_site_requires_customizer() {
 
 	return false;
 }
-
-/**
- * Tells the script loader to load the scripts and styles of custom block on site editor screen.
- *
- * @param bool $is_block_editor_screen Current decision about loading block assets.
- * @return bool Filtered decision about loading block assets.
- */
-function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
-	return ( is_callable( 'get_current_screen' ) && get_current_screen() && 'appearance_page_gutenberg-edit-site' === get_current_screen()->base )
-		? true
-		: $is_block_editor_screen;
-}
-add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_site_editor_load_block_editor_scripts_and_styles' );

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -225,3 +225,16 @@ function register_site_editor_homepage_settings() {
 	);
 }
 add_action( 'init', 'register_site_editor_homepage_settings', 10 );
+
+/**
+ * Tells the script loader to load the scripts and styles of custom block on site editor screen.
+ *
+ * @param bool $is_block_editor_screen Current decision about loading block assets.
+ * @return bool Filtered decision about loading block assets.
+ */
+function gutenberg_site_editor_load_block_editor_scripts_and_styles( $is_block_editor_screen ) {
+	return ( is_callable( 'get_current_screen' ) && get_current_screen() && 'appearance_page_gutenberg-edit-site' === get_current_screen()->base )
+		? true
+		: $is_block_editor_screen;
+}
+add_filter( 'should_load_block_editor_scripts_and_styles', 'gutenberg_site_editor_load_block_editor_scripts_and_styles' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -109,7 +109,7 @@ require __DIR__ . '/compat/wordpress-5.9/class-wp-theme-json-schema-gutenberg.ph
 require __DIR__ . '/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php';
 require __DIR__ . '/compat/wordpress-5.9/theme.php';
-require __DIR__ . '/full-site-editing/full-site-editing.php';
+require __DIR__ . '/compat/wordpress-5.9/admin-menu.php';
 require __DIR__ . '/full-site-editing/edit-site-page.php';
 require __DIR__ . '/compat/wordpress-5.9/block-template.php';
 require __DIR__ . '/compat/wordpress-5.9/wp-theme-get-post-templates.php';


### PR DESCRIPTION
Just continues the code quality work that is similar to #37141 