### PR TITLE
Mobile Release v1.68.0

### DIFF
--- a/packages/react-native-aztec/package.json
+++ b/packages/react-native-aztec/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-aztec",
-	"version": "1.67.0",
+	"version": "1.68.0",
 	"description": "Aztec view for react-native.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-bridge/package.json
+++ b/packages/react-native-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-bridge",
-	"version": "1.67.0",
+	"version": "1.68.0",
 	"description": "Native bridge library used to integrate the block editor into a native App.",
 	"private": true,
 	"author": "The WordPress Contributors",

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,9 +10,13 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+
+## 1.68.0
+-   [**] Fix undo/redo functionality in links when applying text format [#36861]
 -   [**] [iOS] Fix scroll update when typing in RichText component [#36914]
--   [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes. [#36883]
--   [***] Highlight text - enables color customization for specific text within a Pragraph block [#36028]
+-   [*] [Preformatted block] Fix an issue where the background color is not showing up for standard themes [#36883]
+-   [**] Update Gallery Block to default to the new format and auto-convert old galleries to the new format [#36191]
+-   [***] Highlight text - enables color customization for specific text within a Paragraph block [#36028]
 
 ## 1.67.0
 -   [**] Adds Clipboard Link Suggestion to Image block and Button block [#35972]

--- a/packages/react-native-editor/ios/Podfile.lock
+++ b/packages/react-native-editor/ios/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
     - React-jsi (= 0.64.0)
     - ReactCommon/turbomodule/core (= 0.64.0)
   - glog (0.3.5)
-  - Gutenberg (1.67.0):
+  - Gutenberg (1.68.0):
     - React-Core (= 0.64.0)
     - React-CoreModules (= 0.64.0)
     - React-RCTImage (= 0.64.0)
@@ -303,7 +303,7 @@ PODS:
     - React-Core
   - RNSVG (9.13.7-wp-1):
     - React-Core
-  - RNTAztecView (1.67.0):
+  - RNTAztecView (1.68.0):
     - React-Core
     - WordPress-Aztec-iOS (~> 1.19.6)
   - WordPress-Aztec-iOS (1.19.6)
@@ -457,9 +457,9 @@ SPEC CHECKSUMS:
   BVLinearGradient: 1e5474c982efcfcaed47f368a61431bb38a4faf8
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 49cbe4b43e445b06bf29199b6ad2057649e4c8f5
-  FBReactNativeSpec: 80e9cf1155002ee4720084d8813326d913815e2f
+  FBReactNativeSpec: 483e4a3c2982c1ce57d08e90fea6be852dd5f691
   glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
-  Gutenberg: cb22fce31133194d87ce74b3f3d45ebf91b585cf
+  Gutenberg: c60e4e43b9cba783fd2e65aad912d1b6cf2f0098
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: 2f8cb5b7533219bf4218a045f92768129cf7050a
   RCTTypeSafety: 512728b73549e72ad7330b92f3d42936f2a4de5b
@@ -496,7 +496,7 @@ SPEC CHECKSUMS:
   RNReanimated: 39a9478eb635667c9a4da08ac906add9901b145e
   RNScreens: 185dcb481fab2f3dc77413f62b43dc3df826029c
   RNSVG: 9c0db12736608e32841e90fe9773db70ea40de20
-  RNTAztecView: 28dd2b1cdb74cb8161d76a7c1defbda1ad2f737a
+  RNTAztecView: bdcd4b1b309ed88241779868bfbba05ca8432795
   WordPress-Aztec-iOS: 129276e7d1391acb08157641a54394668bb0d7f8
   Yoga: 8c8436d4171c87504c648ae23b1d81242bdf3bbf
 

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/react-native-editor",
-	"version": "1.67.0",
+	"version": "1.68.0",
 	"description": "Mobile WordPress gutenberg editor.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Description
Release 1.68.0 of the react-native-editor and Gutenberg-Mobile.

For more information about this release and testing instructions, please see the related Gutenberg-Mobile PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4362

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->