### PR TITLE
Allow uploading and setting attachment via Link UI

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -23,6 +23,7 @@ import LinkPreview from './link-preview';
 import useCreatePage from './use-create-page';
 import { ViewerFill } from './viewer-slot';
 import { DEFAULT_LINK_SETTINGS } from './constants';
+import { MediaPlaceholder } from '../';
 
 /**
  * Default properties associated with a link control value.
@@ -356,6 +357,25 @@ function LinkControl( {
 					/>
 				</div>
 			) }
+
+			<MediaPlaceholder
+				onSelect={ ( el ) => {
+					if ( ! el?.url?.includes( 'blob:' ) ) {
+						onChange( {
+							type: 'attachment',
+							url: el?.url,
+							id: el?.id,
+							title: internalTextValue || el?.title,
+							image: el?.url,
+						} );
+					}
+				} }
+				multiple={ false }
+				labels={ {
+					title: 'Link to a file',
+				} }
+			/>
+
 			{ renderControlBottom && renderControlBottom() }
 		</div>
 	);

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -24,6 +24,27 @@ $preview-image-height: 140px;
 	}
 }
 
+.block-editor-link-control .block-editor-media-placeholder {
+	border: 1px dashed #333;
+	background-color: #e7e7e7;
+	box-shadow: none;
+	margin: 10px;
+	min-height: auto;
+	width: auto;
+
+	.components-form-file-upload {
+		margin-right: 10px;
+	}
+
+	.components-placeholder__fieldset {
+		flex-direction: row;
+	}
+
+	.block-editor-media-placeholder__button {
+		margin-bottom: 0;
+	}
+}
+
 // Provides positioning context for reset button. Without this then when an
 // error notice is displayed the input's reset button is incorrectly positioned.
 .block-editor-link-control__search-input-wrapper {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently it isn't easily possible to link directly to a attachement (uploaded file). As described in https://github.com/WordPress/gutenberg/issues/8322 there is a rather involved process to work around this but it's not ideal.

I appreciate this is very frustrating for users and thus I want to resolve it.

This PR _explores_ adding a media upload area to the Link UI.

It is very much _experimental_ and a WIP. It rather exposes some of the weakness of the `<LinkControl>` in handling asynchronicity and also the inflexibility of some of it's handling.

After WP 5.9 ships I intend to try and find time to explore this. I'd value assistance from design folks (cc @jasmussen). 

Tries to address https://github.com/WordPress/gutenberg/issues/8322

### Todo

- [ ] Design - it's a prototype 🤷‍♂️ 
- [ ] Add dropzone.
- [ ] Handle feedback whilst uploaded.
- [ ] Error handling.
- [ ] Hide the Media upload if we've already uploaded
- [ ] Fix close on upload (this is unrelated - it's a "feature" of the Link UI).


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/145444171-5442acd9-e1ea-4263-af61-f7353d255721.mov








## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
