### PR TITLE
Add suspense support to the data module

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -662,6 +662,20 @@ _Parameters_
 
 -   _listener_ `Function`: Callback function.
 
+### suspendSelect
+
+Given the name of a registered store, returns an object containing the store's
+selectors pre-bound to state so that you only need to supply additional arguments,
+and modified so that they throw promises in case the selector is not resolved yet.
+
+_Parameters_
+
+-   _storeNameOrDescriptor_ `string|StoreDescriptor`: Unique namespace identifier for the store or the store descriptor.
+
+_Returns_
+
+-   `Object`: Object containing the store's suspense-wrapped selectors.
+
 ### use
 
 Extends a registry to inherit functionality provided by a given plugin. A
@@ -826,6 +840,20 @@ _Parameters_
 _Returns_
 
 -   `Function`: A custom react hook.
+
+### useSuspenseSelect
+
+A variant of the `useSelect` hook that has the same API, but will throw a
+suspense Promise if any of the called selectors is in an unresolved state.
+
+_Parameters_
+
+-   _mapSelect_ `Function`: Function called on every state change. The returned value is exposed to the component using this hook. The function receives the `registry.suspendSelect` method as the first argument and the `registry` as the second one.
+-   _deps_ `Array`: A dependency array used to memoize the `mapSelect` so that the same `mapSelect` is invoked on every state change unless the dependencies change.
+
+_Returns_
+
+-   `Object`: Data object returned by the `mapSelect` function.
 
 ### withDispatch
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -262,75 +262,68 @@ export function useSuspenseSelect( mapSelect, deps ) {
 
 	const registry = useRegistry();
 	const isAsync = useAsyncMode();
-	// React can sometimes clear the `useMemo` cache.
-	// We use the cache-stable `useMemoOne` to avoid
-	// losing queues.
-	const queueContext = useMemoOne( () => ( { queue: true } ), [ registry ] );
-	const [ , forceRender ] = useReducer( ( s ) => s + 1, 0 );
 
+	const latestRegistry = useRef( registry );
 	const latestMapSelect = useRef();
 	const latestIsAsync = useRef( isAsync );
 	const latestMapOutput = useRef();
 	const latestMapOutputError = useRef();
-	const isMountedAndNotUnsubscribing = useRef();
 
 	// Keep track of the stores being selected in the `mapSelect` function,
 	// and only subscribe to those stores later.
 	const listeningStores = useRef( [] );
-	const trapSelect = useCallback(
+	const wrapSelect = useCallback(
 		( callback ) =>
-			registry.__experimentalMarkListeningStores(
+			registry.__unstableMarkListeningStores(
 				() => callback( registry.suspendSelect, registry ),
 				listeningStores
 			),
 		[ registry ]
 	);
 
+	// Generate a "flag" for used in the effect dependency array.
+	// It's different than just using `mapSelect` since deps could be undefined,
+	// in that case, we would still want to memoize it.
+	const depsChangedFlag = useMemo( () => ( {} ), deps || [] );
+
 	let mapOutput = latestMapOutput.current;
 	let mapOutputError = latestMapOutputError.current;
 
-	if ( latestMapSelect.current !== _mapSelect ) {
+	const hasReplacedRegistry = latestRegistry.current !== registry;
+	const hasReplacedMapSelect = latestMapSelect.current !== _mapSelect;
+	const hasLeftAsyncMode = latestIsAsync.current && ! isAsync;
+
+	if ( hasReplacedRegistry || hasReplacedMapSelect || hasLeftAsyncMode ) {
 		try {
-			mapOutput = trapSelect( _mapSelect );
+			mapOutput = wrapSelect( _mapSelect );
 		} catch ( error ) {
 			mapOutputError = error;
 		}
 	}
 
 	useIsomorphicLayoutEffect( () => {
+		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
+		latestIsAsync.current = isAsync;
 		latestMapOutput.current = mapOutput;
 		latestMapOutputError.current = mapOutputError;
-		isMountedAndNotUnsubscribing.current = true;
-
-		// This has to run after the other ref updates
-		// to avoid using stale values in the flushed
-		// callbacks or potentially overwriting a
-		// changed `latestMapOutput.current`.
-		if ( latestIsAsync.current !== isAsync ) {
-			latestIsAsync.current = isAsync;
-			renderQueue.flush( queueContext );
-		}
 	} );
 
-	// Generate a "flag" for used in the effect dependency array.
-	// It's different than just using `mapSelect` since deps could be undefined,
-	// in that case, we would still want to memoize it.
-	const depsChangedFlag = useMemo( () => ( {} ), deps || [] );
+	// React can sometimes clear the `useMemo` cache.
+	// We use the cache-stable `useMemoOne` to avoid
+	// losing queues.
+	const queueContext = useMemoOne( () => ( { queue: true } ), [ registry ] );
+	const [ , forceRender ] = useReducer( ( s ) => s + 1, 0 );
+	const isMounted = useRef( false );
 
 	useIsomorphicLayoutEffect( () => {
 		const onStoreChange = () => {
-			if ( ! isMountedAndNotUnsubscribing.current ) {
-				return;
-			}
-
 			try {
-				const newMapOutput = trapSelect( latestMapSelect.current );
+				const newMapOutput = wrapSelect( latestMapSelect.current );
 
 				if ( isShallowEqual( latestMapOutput.current, newMapOutput ) ) {
 					return;
 				}
-
 				latestMapOutput.current = newMapOutput;
 			} catch ( error ) {
 				latestMapOutputError.current = error;
@@ -340,6 +333,10 @@ export function useSuspenseSelect( mapSelect, deps ) {
 		};
 
 		const onChange = () => {
+			if ( ! isMounted.current ) {
+				return;
+			}
+
 			if ( latestIsAsync.current ) {
 				renderQueue.add( queueContext, onStoreChange );
 			} else {
@@ -349,19 +346,21 @@ export function useSuspenseSelect( mapSelect, deps ) {
 
 		// catch any possible state changes during mount before the subscription
 		// could be set.
-		onChange();
+		onStoreChange();
 
 		const unsubscribers = listeningStores.current.map( ( storeName ) =>
-			registry.__experimentalSubscribeStore( storeName, onChange )
+			registry.__unstableSubscribeStore( storeName, onChange )
 		);
 
+		isMounted.current = true;
+
 		return () => {
-			isMountedAndNotUnsubscribing.current = false;
 			// The return value of the subscribe function could be undefined if the store is a custom generic store.
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
-			renderQueue.flush( queueContext );
+			renderQueue.cancel( queueContext );
+			isMounted.current = false;
 		};
-	}, [ registry, trapSelect, depsChangedFlag ] );
+	}, [ registry, wrapSelect, depsChangedFlag ] );
 
 	if ( mapOutputError ) {
 		throw mapOutputError;

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -241,3 +241,131 @@ export default function useSelect( mapSelect, deps ) {
 
 	return hasMappingFunction ? mapOutput : registry.select( mapSelect );
 }
+
+/**
+ * A variant of the `useSelect` hook that has the same API, but will throw a
+ * suspense Promise if any of the called selectors is in an unresolved state.
+ *
+ * @param {Function} mapSelect Function called on every state change. The
+ *                             returned value is exposed to the component
+ *                             using this hook. The function receives the
+ *                             `registry.suspendSelect` method as the first
+ *                             argument and the `registry` as the second one.
+ * @param {Array}    deps      A dependency array used to memoize the `mapSelect`
+ *                             so that the same `mapSelect` is invoked on every
+ *                             state change unless the dependencies change.
+ *
+ * @return {Object} Data object returned by the `mapSelect` function.
+ */
+export function useSuspenseSelect( mapSelect, deps ) {
+	const _mapSelect = useCallback( mapSelect, deps );
+
+	const registry = useRegistry();
+	const isAsync = useAsyncMode();
+	// React can sometimes clear the `useMemo` cache.
+	// We use the cache-stable `useMemoOne` to avoid
+	// losing queues.
+	const queueContext = useMemoOne( () => ( { queue: true } ), [ registry ] );
+	const [ , forceRender ] = useReducer( ( s ) => s + 1, 0 );
+
+	const latestMapSelect = useRef();
+	const latestIsAsync = useRef( isAsync );
+	const latestMapOutput = useRef();
+	const latestMapOutputError = useRef();
+	const isMountedAndNotUnsubscribing = useRef();
+
+	// Keep track of the stores being selected in the `mapSelect` function,
+	// and only subscribe to those stores later.
+	const listeningStores = useRef( [] );
+	const trapSelect = useCallback(
+		( callback ) =>
+			registry.__experimentalMarkListeningStores(
+				() => callback( registry.suspendSelect, registry ),
+				listeningStores
+			),
+		[ registry ]
+	);
+
+	let mapOutput = latestMapOutput.current;
+	let mapOutputError = latestMapOutputError.current;
+
+	if ( latestMapSelect.current !== _mapSelect ) {
+		try {
+			mapOutput = trapSelect( _mapSelect );
+		} catch ( error ) {
+			mapOutputError = error;
+		}
+	}
+
+	useIsomorphicLayoutEffect( () => {
+		latestMapSelect.current = _mapSelect;
+		latestMapOutput.current = mapOutput;
+		latestMapOutputError.current = mapOutputError;
+		isMountedAndNotUnsubscribing.current = true;
+
+		// This has to run after the other ref updates
+		// to avoid using stale values in the flushed
+		// callbacks or potentially overwriting a
+		// changed `latestMapOutput.current`.
+		if ( latestIsAsync.current !== isAsync ) {
+			latestIsAsync.current = isAsync;
+			renderQueue.flush( queueContext );
+		}
+	} );
+
+	// Generate a "flag" for used in the effect dependency array.
+	// It's different than just using `mapSelect` since deps could be undefined,
+	// in that case, we would still want to memoize it.
+	const depsChangedFlag = useMemo( () => ( {} ), deps || [] );
+
+	useIsomorphicLayoutEffect( () => {
+		const onStoreChange = () => {
+			if ( ! isMountedAndNotUnsubscribing.current ) {
+				return;
+			}
+
+			try {
+				const newMapOutput = trapSelect( latestMapSelect.current );
+
+				if ( isShallowEqual( latestMapOutput.current, newMapOutput ) ) {
+					return;
+				}
+
+				latestMapOutput.current = newMapOutput;
+			} catch ( error ) {
+				latestMapOutputError.current = error;
+			}
+
+			forceRender();
+		};
+
+		const onChange = () => {
+			if ( latestIsAsync.current ) {
+				renderQueue.add( queueContext, onStoreChange );
+			} else {
+				onStoreChange();
+			}
+		};
+
+		// catch any possible state changes during mount before the subscription
+		// could be set.
+		onChange();
+
+		const unsubscribers = listeningStores.current.map( ( storeName ) =>
+			registry.__experimentalSubscribeStore( storeName, onChange )
+		);
+
+		return () => {
+			isMountedAndNotUnsubscribing.current = false;
+			// The return value of the subscribe function could be undefined if the store is a custom generic store.
+			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
+			renderQueue.flush( queueContext );
+		};
+	}, [ registry, trapSelect, depsChangedFlag ] );
+
+	if ( mapOutputError ) {
+		throw mapOutputError;
+	}
+
+	return mapOutput;
+}

--- a/packages/data/src/components/use-select/test/suspense.js
+++ b/packages/data/src/components/use-select/test/suspense.js
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import { render, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createRegistry,
+	createReduxStore,
+	useSuspenseSelect,
+	RegistryProvider,
+} from '@wordpress/data';
+import { Component, Suspense } from '@wordpress/element';
+
+jest.useRealTimers();
+
+function createRegistryWithStore() {
+	const initialState = {
+		prefix: 'pre-',
+		token: null,
+		data: null,
+		fails: true,
+	};
+
+	const reducer = ( state = initialState, action ) => {
+		switch ( action.type ) {
+			case 'RECEIVE_TOKEN':
+				return { ...state, token: action.token };
+			case 'RECEIVE_DATA':
+				return { ...state, data: action.data };
+			default:
+				return state;
+		}
+	};
+
+	const selectors = {
+		getPrefix: ( state ) => state.prefix,
+		getToken: ( state ) => state.token,
+		getData: ( state, token ) => {
+			if ( ! token ) {
+				throw 'missing token in selector';
+			}
+			return state.data;
+		},
+		getThatFails: ( state ) => state.fails,
+	};
+
+	const sleep = ( ms ) => new Promise( ( r ) => setTimeout( () => r(), ms ) );
+
+	const resolvers = {
+		getToken: () => async ( { dispatch } ) => {
+			await sleep( 10 );
+			dispatch( { type: 'RECEIVE_TOKEN', token: 'token' } );
+		},
+		getData: ( token ) => async ( { dispatch } ) => {
+			await sleep( 10 );
+			if ( ! token ) {
+				throw 'missing token in resolver';
+			}
+			dispatch( { type: 'RECEIVE_DATA', data: 'therealdata' } );
+		},
+		getThatFails: () => async () => {
+			await sleep( 10 );
+			throw 'resolution failed';
+		},
+	};
+
+	const store = createReduxStore( 'test', {
+		reducer,
+		selectors,
+		resolvers,
+	} );
+
+	const registry = createRegistry();
+	registry.register( store );
+
+	return { registry, store };
+}
+
+describe( 'useSuspenseSelect', () => {
+	it( 'renders after suspending a few times', async () => {
+		const { registry, store } = createRegistryWithStore();
+		let attempts = 0;
+		let renders = 0;
+
+		const UI = () => {
+			attempts++;
+			const { result } = useSuspenseSelect( ( select ) => {
+				const prefix = select( store ).getPrefix();
+				const token = select( store ).getToken();
+				const data = select( store ).getData( token );
+				return { result: prefix + data };
+			}, [] );
+			renders++;
+			return <div aria-label="loaded">{ result }</div>;
+		};
+
+		const App = () => (
+			<RegistryProvider value={ registry }>
+				<Suspense fallback="loading">
+					<UI />
+				</Suspense>
+			</RegistryProvider>
+		);
+
+		const rendered = render( <App /> );
+		await waitFor( () => rendered.getByLabelText( 'loaded' ) );
+
+		// Verify there were 3 attempts to render. Suspended twice because of
+		// `getToken` and `getData` selectors not being resolved, and then finally
+		// rendered after all data got loaded.
+		expect( attempts ).toBe( 3 );
+		expect( renders ).toBe( 1 );
+	} );
+
+	it( 'shows error when resolution fails', async () => {
+		const { registry, store } = createRegistryWithStore();
+
+		const UI = () => {
+			const { token } = useSuspenseSelect( ( select ) => {
+				// Call a selector whose resolution fails. The `useSuspenseSelect`
+				// is then supposed to throw the resolution error.
+				return { token: select( store ).getThatFails() };
+			}, [] );
+			return <div aria-label="loaded">{ token }</div>;
+		};
+
+		class Error extends Component {
+			state = { error: null };
+
+			static getDerivedStateFromError( error ) {
+				return { error };
+			}
+
+			render() {
+				if ( this.state.error ) {
+					return <div aria-label="error">{ this.state.error }</div>;
+				}
+				return this.props.children;
+			}
+		}
+
+		const App = () => (
+			<RegistryProvider value={ registry }>
+				<Error>
+					<Suspense fallback="loading">
+						<UI />
+					</Suspense>
+				</Error>
+			</RegistryProvider>
+		);
+
+		const rendered = render( <App /> );
+		const label = await waitFor( () => rendered.getByLabelText( 'error' ) );
+		expect( label.textContent ).toBe( 'resolution failed' );
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -19,7 +19,10 @@ export {
 	RegistryConsumer,
 	useRegistry,
 } from './components/registry-provider';
-export { default as useSelect } from './components/use-select';
+export {
+	default as useSelect,
+	useSuspenseSelect,
+} from './components/use-select';
 export { useDispatch } from './components/use-dispatch';
 export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';
@@ -114,6 +117,18 @@ export const select = defaultRegistry.select;
  * @return {Object} Object containing the store's promise-wrapped selectors.
  */
 export const resolveSelect = defaultRegistry.resolveSelect;
+
+/**
+ * Given the name of a registered store, returns an object containing the store's
+ * selectors pre-bound to state so that you only need to supply additional arguments,
+ * and modified so that they throw promises in case the selector is not resolved yet.
+ *
+ * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
+ *                                                       or the store descriptor.
+ *
+ * @return {Object} Object containing the store's suspense-wrapped selectors.
+ */
+export const suspendSelect = defaultRegistry.suspendSelect;
 
 /**
  * Given the name of a registered store, returns an object of the store's action creators.

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -398,6 +398,10 @@ function mapSuspendSelectors( selectors, store ) {
 			const result = selector.apply( null, args );
 
 			if ( selectors.hasFinishedResolution( selectorName, args ) ) {
+				if ( selectors.hasResolutionFailed( selectorName, args ) ) {
+					throw selectors.getResolutionError( selectorName, args );
+				}
+
 				return result;
 			}
 

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -143,7 +143,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		const storeName = isObject( storeNameOrDescriptor )
 			? storeNameOrDescriptor.name
 			: storeNameOrDescriptor;
-		__experimentalListeningStores.add( storeName );
+		listeningStores.add( storeName );
 		const store = stores[ storeName ];
 		if ( store ) {
 			return store.getSuspendSelectors();

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -93,14 +93,16 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 			return store.getSelectors();
 		}
 
-		return parent && parent.select( storeName );
+		return parent?.select( storeName );
 	}
 
 	function __unstableMarkListeningStores( callback, ref ) {
 		listeningStores.clear();
-		const result = callback.call( this );
-		ref.current = Array.from( listeningStores );
-		return result;
+		try {
+			return callback.call( this );
+		} finally {
+			ref.current = Array.from( listeningStores );
+		}
 	}
 
 	/**
@@ -125,6 +127,29 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		}
 
 		return parent && parent.resolveSelect( storeName );
+	}
+
+	/**
+	 * Given the name of a registered store, returns an object containing the store's
+	 * selectors pre-bound to state so that you only need to supply additional arguments,
+	 * and modified so that they throw promises in case the selector is not resolved yet.
+	 *
+	 * @param {string|StoreDescriptor} storeNameOrDescriptor Unique namespace identifier for the store
+	 *                                                       or the store descriptor.
+	 *
+	 * @return {Object} Object containing the store's suspense-wrapped selectors.
+	 */
+	function suspendSelect( storeNameOrDescriptor ) {
+		const storeName = isObject( storeNameOrDescriptor )
+			? storeNameOrDescriptor.name
+			: storeNameOrDescriptor;
+		__experimentalListeningStores.add( storeName );
+		const store = stores[ storeName ];
+		if ( store ) {
+			return store.getSuspendSelectors();
+		}
+
+		return parent && parent.suspendSelect( storeName );
 	}
 
 	/**
@@ -276,6 +301,7 @@ export function createRegistry( storeConfigs = {}, parent = null ) {
 		subscribe,
 		select,
 		resolveSelect,
+		suspendSelect,
 		dispatch,
 		use,
 		register,


### PR DESCRIPTION
Be prepared for some ugly code, bug ugly code for pocs is always the best kind of code.

Anyway, the idea here is simple, instead of doing `useSelect`, we should be able to do `useSuspenseSelect` in order to have the exact same result but for any thing that is async (in our case, it means for anything that has a resolver), suspend the rendering and tell react that it's not ready yet.

In other words, add Suspense support to the data module.

**What this allows us to do?**

Right now, when loading the editor (or more visibility in the site editor), there's a waterfall effect, the template is loaded and then rendered with a bunch of spinners and then the template parts get loaded and then site logo shows a spinner, same for query loops... until everything is loaded.

With suspense we can declaratively say, show this fallback loading state until everything is ready pretty easily. You can try the site editor in this PR to see how it compared to trunk.

There are still some glitches right now that I haven't been able to pinpoint yet. Basically when the template parts loads, there's a very small delay of some milliseconds that pass before the site logo block get rendered suspending the rendering once more, this ends up with a glitch showing the loading state twice separated with a very small delay where the actual components in their temporary state are rendered. I think this should be solvable but we need to figure out where the asyncness is happening to be able to do that.

**Open questions**

 - This implements suspense support in the data module using the experimental APIs that are present in React 17 (throwing promises) but I'm not clear yet whether React 18 will make changes there so I'm not sure yet if we should proceed there before the React 18 upgrade.