### PR TITLE
Docs: Fix code formating for card components

### DIFF
--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -6,7 +6,7 @@
 
 `Card` also provides a convenient set of [sub-components](#sub-components) such as `CardBody`, `CardHeader`, `CardFooter`, and more (see below).
 
-```jsx live
+```jsx
 import {
 	Card,
 	CardHeader,


### PR DESCRIPTION

## Description

The code defintion for the card was usage was malformed.

It contained a space and extra "live" word after the three ticks and language definition.


## How has this been tested?

Confirm after publishing it is corrected.


## Types of changes

Documentation only.
