### PR TITLE
Backport JSON schemas for WP 5.8

### DIFF
--- a/schemas/CHANGELOG.md
+++ b/schemas/CHANGELOG.md
@@ -1,0 +1,5 @@
+<!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
+
+## Unreleased
+
+Initial release.

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,0 +1,26 @@
+# Schemas
+
+The collection of schemas used in WordPress, including the `theme.json` schema, and `block.json` schemas.
+
+## Usage
+
+JSON schemas are used by code editors to offer tooltips, autocomplete, and validation. To use in your JSON file, add the `$schema` property to the top of the file with the value of the schema URL.
+
+For example, in your `block.json` file you would add:
+
+```json
+{
+	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
+}
+```
+
+## SchemaStore.org
+
+[SchemaStore.org](https://schemastore.org) is an open collection of schemas, including the WordPress `theme.json` and `block.json` schemas. Any changes to schemas in this package should be mirror there.
+
+To update on SchemaStore, create a PR at their repository [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore/). The files can be found in their reposiory at:
+
+-   block.json: `src/schemas/json/block.json`
+-   theme.json: `src/schemas/json/theme-v1.json`
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -6,7 +6,9 @@ JSON schemas are used by code editors to offer tooltips, autocomplete, and valid
 
 ## JSON schema usage
 
-Many popular editors recognize the `$schema` property in JSON files. For example, update your `block.json` to include:
+Many editors recognize the `$schema` property in JSON files.
+
+Update your `block.json` to include:
 
 ```json
 {
@@ -30,6 +32,6 @@ For a specific version of the schema, replace `trunk` with `wp/X.X`:
 }
 ```
 
-Some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations.html#editors) have lists of editors known to have support if your current editor is unsupported.
+Visual Studio Code and PhpStorm are two popular editors that work out of the box. However, some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations.html#editors) have lists of editors known to have support if your current editor is unsupported.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,17 +1,35 @@
 # Schemas
 
-The collection of schemas used in WordPress, including the `theme.json` schema, and `block.json` schemas.
+The collection of schemas used in WordPress, including the `theme.json` and `block.json` schemas.
 
-## Usage
+JSON schemas are used by code editors to offer tooltips, autocomplete, and validation.
 
-JSON schemas are used by code editors to offer tooltips, autocomplete, and validation. To use in your JSON file, add the `$schema` property to the top of the file with the value of the schema URL.
+## JSON schema usage
 
-For example, in your `block.json` file you would add:
+Many popular editors recognize the `$schema` property in JSON files. For example, update your `block.json` to include:
 
 ```json
 {
-	"$schema": "https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json"
+	"$schema": "https://schemas.wp.org/trunk/block.json"
 }
 ```
+
+Or in your `theme.json`:
+
+```json
+{
+	"$schema": "https://schemas.wp.org/trunk/theme.json"
+}
+```
+
+For a specific version of the schema, replace `trunk` with `wp/X.X`:
+
+```json
+{
+	"$schema": "https://schemas.wp.org/wp/5.8/block.json"
+}
+```
+
+Some editors require a plugin installed, and not all editors recognize the `$schema` property. Check your editor's documentation for details. Additionally, [SchemaStore.org](https://www.schemastore.org/) and [JSON Schema](https://json-schema.org/implementations.html#editors) have lists of editors known to have support if your current editor is unsupported.
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -14,13 +14,4 @@ For example, in your `block.json` file you would add:
 }
 ```
 
-## SchemaStore.org
-
-[SchemaStore.org](https://schemastore.org) is an open collection of schemas, including the WordPress `theme.json` and `block.json` schemas. Any changes to schemas in this package should be mirror there.
-
-To update on SchemaStore, create a PR at their repository [SchemaStore/schemastore](https://github.com/SchemaStore/schemastore/). The files can be found in their reposiory at:
-
--   block.json: `src/schemas/json/block.json`
--   theme.json: `src/schemas/json/theme-v1.json`
-
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -1,0 +1,437 @@
+{
+	"title": "JSON schema for WordPress blocks",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"definitions": {
+		"//": {
+			"reference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/",
+			"attributesReference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/",
+			"contextReference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/",
+			"supportsReference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/",
+			"registerReference": "https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#example-optional"
+		}
+	},
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"type": "string"
+		},
+		"apiVersion": {
+			"type": "integer",
+			"description": "The version of the Block API used by the block. The most recent version is 2 and it was introduced in WordPress 5.6.\n\n See the the API versions documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/ for more details.",
+			"default": 1,
+			"enum": [ 1, 2 ]
+		},
+		"name": {
+			"type": "string",
+			"pattern": "^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$",
+			"description": "The name for a block is a unique string that identifies a block. Names have to be structured as `namespace/block-name`, where namespace is the name of your plugin or theme."
+		},
+		"title": {
+			"type": "string",
+			"description": "This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name."
+		},
+		"category": {
+			"description": "Blocks are grouped into categories to help users browse and discover them.\n Core provided categories are: text, media, design, widgets, theme, embed\n\nPlugins and Themes can also register custom block categories.\n\nhttps://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#managing-block-categories",
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"enum": [
+						"text",
+						"media",
+						"design",
+						"widgets",
+						"theme",
+						"embed"
+					]
+				}
+			]
+		},
+		"parent": {
+			"type": "array",
+			"description": "Setting parent lets a block require that it is only available when nested within the specified blocks. For example, you might want to allow an ‘Add to Cart’ block to only be available within a ‘Product’ block.",
+			"items": {
+				"type": "string"
+			}
+		},
+		"icon": {
+			"type": "string",
+			"description": "An icon property should be specified to make it easier to identify a block. These can be any of WordPress’ Dashicons (slug serving also as a fallback in non-js contexts)."
+		},
+		"description": {
+			"type": "string",
+			"description": "This is a short description for your block, which can be translated with our translation functions. This will be shown in the block inspector."
+		},
+		"keywords": {
+			"type": "array",
+			"description": "Sometimes a block could have aliases that help users discover it while searching. For example, an image block could also want to be discovered by photo. You can do so by providing an array of unlimited terms (which are translated).",
+			"items": {
+				"type": "string"
+			}
+		},
+		"textdomain": {
+			"type": "string",
+			"description": "The gettext text domain of the plugin/block. More information can be found in the Text Domain section of the How to Internationalize your Plugin page.\n\nhttps://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/"
+		},
+		"attributes": {
+			"type": "object",
+			"description": "Attributes provide the structured data needs of a block. They can exist in different forms when they are serialized, but they are declared together under a common interface.\n\nSee the attributes documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/ for more details.",
+			"patternProperties": {
+				"[a-zA-Z]": {
+					"type": "object",
+					"properties": {
+						"type": {
+							"description": "The type indicates the type of data that is stored by the attribute. It does not indicate where the data is stored, which is defined by the source field.\n\nA type is required, unless an enum is provided. A type can be used with an enum.\n\nNote that the validity of an object is determined by your source. For an example, see the query details below.",
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": [
+										"null",
+										"boolean",
+										"object",
+										"array",
+										"string",
+										"integer",
+										"number"
+									]
+								},
+								{
+									"type": "array",
+									"uniqueItems": true,
+									"items": {
+										"type": "string",
+										"enum": [
+											"null",
+											"boolean",
+											"object",
+											"array",
+											"string",
+											"integer",
+											"number"
+										]
+									}
+								}
+							]
+						},
+						"enum": {
+							"type": "array",
+							"description": "An attribute can be defined as one of a fixed set of values. This is specified by an enum, which contains an array of allowed values:",
+							"items": {
+								"oneOf": [
+									{
+										"type": "boolean"
+									},
+									{
+										"type": "number"
+									},
+									{
+										"type": "string"
+									}
+								]
+							}
+						},
+						"source": {
+							"type": "string",
+							"description": "Attribute sources are used to define how the attribute values are extracted from saved post content. They provide a mechanism to map from the saved markup to a JavaScript representation of a block.",
+							"enum": [
+								"attribute",
+								"text",
+								"html",
+								"query",
+								"meta"
+							]
+						},
+						"selector": {
+							"type": "string",
+							"description": "The selector can be an HTML tag, or anything queryable with querySelector, such as a class or id attribute. Examples are given below.\n\nFor example, a selector of img will match an img element, and img.class will match an img element that has a class of class."
+						},
+						"attribute": {
+							"type": "string",
+							"description": "Use an attribute source to extract the value from an attribute in the markup. The attribute is specified by the attribute field, which must be supplied.\n\nExample: Extract the src attribute from an image found in the block’s markup."
+						},
+						"multiline": {
+							"type": "string",
+							"description": "Use the multiline property to extract the inner HTML of matching tag names for the use in RichText with the multiline prop."
+						},
+						"query": {
+							"type": "object",
+							"description": "Use query to extract an array of values from markup. Entries of the array are determined by the selector argument, where each matched element within the block will have an entry structured corresponding to the second argument, an object of attribute sources."
+						},
+						"meta": {
+							"type": "string",
+							"description": "Although attributes may be obtained from a post’s meta, meta attribute sources are considered deprecated; EntityProvider and related hook APIs should be used instead, as shown in the Create Meta Block how-to here:\n\nhttps://developer.wordpress.org/block-editor/how-to-guides/metabox/meta-block-3-add/"
+						},
+						"default": {
+							"description": "TA block attribute can contain a default value, which will be used if the type and source do not match anything within the block content.\n\nThe value is provided by the default field, and the value should match the expected format of the attribute."
+						}
+					},
+					"required": [ "type" ]
+				}
+			},
+			"additionalProperties": false
+		},
+		"providesContext": {
+			"type": "object",
+			"description": "Context provided for available access by descendants of blocks of this type, in the form of an object which maps a context name to one of the block’s own attribute.\n\nSee the block context documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/ for more details.",
+			"patternProperties": {
+				"[a-zA-Z]": {
+					"type": "string"
+				}
+			}
+		},
+		"usesContext": {
+			"type": "array",
+			"description": "Array of the names of context values to inherit from an ancestor provider.\n\nSee the block context documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-context/ for more details.",
+			"items": {
+				"type": "string"
+			}
+		},
+		"supports": {
+			"type": "object",
+			"description": "It contains as set of options to control features used in the editor. See the the supports documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/ for more details.",
+			"properties": {
+				"anchor": {
+					"type": "boolean",
+					"description": "Anchors let you link directly to a specific block on a page. This property adds a field to define an id for the block and a button to copy the direct link.",
+					"default": false
+				},
+				"align": {
+					"default": false,
+					"description": "This property adds block controls which allow to change block’s alignment.",
+					"oneOf": [
+						{
+							"type": "boolean"
+						},
+						{
+							"type": "array",
+							"items": {
+								"type": "string",
+								"enum": [
+									"wide",
+									"full",
+									"left",
+									"center",
+									"right"
+								]
+							}
+						}
+					]
+				},
+				"alignWide": {
+					"type": "boolean",
+					"description": "This property allows to enable wide alignment for your theme. To disable this behavior for a single block, set this flag to false.",
+					"default": true
+				},
+				"className": {
+					"type": "boolean",
+					"description": "By default, the class .wp-block-your-block-name is added to the root element of your saved markup. This helps having a consistent mechanism for styling blocks that themes and plugins can rely on. If, for whatever reason, a class is not desired on the markup, this functionality can be disabled.",
+					"default": true
+				},
+				"color": {
+					"type": "object",
+					"description": "This value signals that a block supports some of the properties related to color. When it does, the block editor will show UI controls for the user to set their values.\n\nNote that the background and text keys have a default value of true, so if the color property is present they’ll also be considered enabled",
+					"properties": {
+						"background": {
+							"type": "boolean",
+							"description": "This property adds UI controls which allow the user to apply a solid background color to a block.\n\nWhen color support is declared, this property is enabled by default (along with text), so simply setting color will enable background color.\n\nTo disable background support while keeping other color supports enabled, set to false.\n\nWhen the block declares support for color.background, the attributes definition is extended to include two new attributes: backgroundColor and style",
+							"default": true
+						},
+						"gradients": {
+							"type": "boolean",
+							"description": "This property adds UI controls which allow the user to apply a gradient background to a block.\n\nGradient presets are sourced from editor-gradient-presets theme support.\n\nWhen the block declares support for color.gradient, the attributes definition is extended to include two new attributes: gradient and style",
+							"default": false
+						},
+						"link": {
+							"type": "boolean",
+							"description": "This property adds block controls which allow the user to set link color in a block, link color is disabled by default.\n\nLink color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.link, the attributes definition is extended to include two new attributes: linkColor and style",
+							"default": false
+						},
+						"text": {
+							"type": "boolean",
+							"description": "This property adds block controls which allow the user to set text color in a block.\n\nWhen color support is declared, this property is enabled by default (along with background), so simply setting color will enable text color.\n\nText color presets are sourced from the editor-color-palette theme support.\n\nWhen the block declares support for color.text, the attributes definition is extended to include two new attributes: textColor and style",
+							"default": true
+						}
+					}
+				},
+				"customClassName": {
+					"type": "boolean",
+					"description": "This property adds a field to define a custom className for the block’s wrapper.",
+					"default": true
+				},
+				"defaultStylePicker": {
+					"type": "boolean",
+					"description": "When the style picker is shown, a dropdown is displayed so the user can select a default style for this block type. If you prefer not to show the dropdown, set this property to false.",
+					"default": true
+				},
+				"fontSize": {
+					"type": "boolean",
+					"description": "This value signals that a block supports the font-size CSS style property. When it does, the block editor will show an UI control for the user to set its value.\n\nThe values shown in this control are the ones declared by the theme via the editor-font-sizes theme support, or the default ones if none is provided.\n\nWhen the block declares support for fontSize, the attributes definition is extended to include two new attributes: fontSize and style",
+					"default": false
+				},
+				"html": {
+					"type": "boolean",
+					"description": "By default, a block’s markup can be edited individually. To disable this behavior, set html to false.",
+					"default": true
+				},
+				"inserter": {
+					"type": "boolean",
+					"description": "By default, all blocks will appear in the inserter. To hide a block so that it can only be inserted programmatically, set inserter to false.",
+					"default": true
+				},
+				"lineHeight": {
+					"type": "boolean",
+					"description": "This value signals that a block supports the line-height CSS style property. When it does, the block editor will show an UI control for the user to set its value if the theme declares support.\n\nWhen the block declares support for lineHeight, the attributes definition is extended to include a new attribute style of object type with no default assigned. It stores the custom value set by the user. The block can apply a default style by specifying its own style attribute with a default",
+					"default": false
+				},
+				"multiple": {
+					"type": "boolean",
+					"description": "A non-multiple block can be inserted into each post, one time only. For example, the built-in ‘More’ block cannot be inserted again if it already exists in the post being edited. A non-multiple block’s icon is automatically dimmed (unclickable) to prevent multiple instances.",
+					"default": true
+				},
+				"reusable": {
+					"type": "boolean",
+					"description": "A block may want to disable the ability of being converted into a reusable block. By default all blocks can be converted to a reusable block. If supports reusable is set to false, the option to convert the block into a reusable block will not appear.",
+					"default": true
+				},
+				"spacing": {
+					"type": "object",
+					"description": "This value signals that a block supports some of the CSS style properties related to spacing. When it does, the block editor will show UI controls for the user to set their values, if the theme declares support.\n\nWhen the block declares support for a specific spacing property, the attributes definition is extended to include the style attribute.",
+					"properties": {
+						"margin": {
+							"oneOf": [
+								{
+									"type": "boolean"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [
+											"top",
+											"right",
+											"left",
+											"bottom"
+										]
+									}
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [ "vertical", "horizontal" ]
+									}
+								}
+							]
+						},
+						"padding": {
+							"oneOf": [
+								{
+									"type": "boolean"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [
+											"top",
+											"right",
+											"left",
+											"bottom"
+										]
+									}
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": [ "vertical", "horizontal" ]
+									}
+								}
+							]
+						}
+					}
+				}
+			},
+			"additionalProperties": true
+		},
+		"styles": {
+			"type": "array",
+			"description": "Block styles can be used to provide alternative styles to block. It works by adding a class name to the block’s wrapper. Using CSS, a theme developer can target the class name for the block style if it is selected.\n\nPlugins and Themes can also register custom block style for existing blocks.\n\nhttps://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#block-styles",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"type": "string"
+					},
+					"label": {
+						"type": "string"
+					},
+					"isDefault": {
+						"type": "boolean",
+						"default": false
+					}
+				},
+				"required": [ "name", "label" ],
+				"additionalProperties": false
+			}
+		},
+		"example": {
+			"type": "object",
+			"description": "It provides structured example data for the block. This data is used to construct a preview for the block to be shown in the Inspector Help Panel when the user mouses over the block.\n\nSee the the example documentation at https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/#example-optional for more details.",
+			"properties": {
+				"viewportWidth": {
+					"type": "number",
+					"description": "The viewportWidth controls the width of the iFrame container in which the block preview will get rendered",
+					"default": 1200
+				},
+				"attributes": {
+					"type": "object",
+					"description": "Set the attribues for the block example"
+				},
+				"innerBlocks": {
+					"type": "array",
+					"description": "Set the inner blocks that should be used within the block example. The blocks should be defined as a nested array like this: \n\n [ [ 'core/heading', { content: 'This is an Example' }, [] ] ]\n\n Where each block itself is an array that contains the block name, the block attributes, and the blocks inner blocks."
+				}
+			}
+		},
+		"editorScript": {
+			"type": "string",
+			"description": "Block type editor script definition. It will only be enqueued in the context of the editor."
+		},
+		"script": {
+			"type": "string",
+			"description": "Block type frontend and editor script definition. It will be enqueued both in the editor and when viewing the content on the front of the site."
+		},
+		"editorStyle": {
+			"description": "Block type editor style definition. It will only be enqueued in the context of the editor.",
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
+		},
+		"style": {
+			"description": "Block type frontend style definition. It will be enqueued both in the editor and when viewing the content on the front of the site.",
+			"oneOf": [
+				{
+					"type": "string"
+				},
+				{
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
+			]
+		}
+	},
+	"required": [ "name", "title" ],
+	"additionalProperties": false
+}

--- a/schemas/json/block.json
+++ b/schemas/json/block.json
@@ -70,6 +70,10 @@
 				"type": "string"
 			}
 		},
+		"version": {
+			"type": "string",
+			"description": "The current version number of the block, such as 1.0 or 1.0.3. It’s similar to how plugins are versioned. This field might be used with block assets to control cache invalidation, and when the block author omits it, then the installed version of WordPress is used instead."
+		},
 		"textdomain": {
 			"type": "string",
 			"description": "The gettext text domain of the plugin/block. More information can be found in the Text Domain section of the How to Internationalize your Plugin page.\n\nhttps://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -1,0 +1,1097 @@
+{
+	"title": "JSON schema for WordPress block theme global settings and styles",
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"definitions": {
+		"//": {
+			"explainer": "https://developer.wordpress.org/themes/advanced-topics/theme-json/",
+			"createTheme": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
+			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
+		},
+		"settingsProperties": {
+			"properties": {
+				"border": {
+					"description": "Settings related to borders.",
+					"type": "object",
+					"properties": {
+						"customColor": {
+							"description": "Allow users to set custom border colors.",
+							"type": "boolean",
+							"default": false
+						},
+						"customRadius": {
+							"description": "Allow users to set custom border radius.",
+							"type": "boolean",
+							"default": false
+						},
+						"customStyle": {
+							"description": "Allow users to set custom border styles.",
+							"type": "boolean",
+							"default": false
+						},
+						"customWidth": {
+							"description": "Allow users to set custom border widths.",
+							"type": "boolean",
+							"default": false
+						}
+					},
+					"additionalProperties": false
+				},
+				"color": {
+					"description": "Settings related to colors.",
+					"type": "object",
+					"properties": {
+						"background": {
+							"description": "Allow users to set background colors.",
+							"type": "boolean",
+							"default": true
+						},
+						"custom": {
+							"description": "Allow users to select custom colors.",
+							"type": "boolean",
+							"default": true
+						},
+						"customDuotone": {
+							"description": "Allow users to create custom duotone filters.",
+							"type": "boolean",
+							"default": true
+						},
+						"customGradient": {
+							"description": "Allow users to create custom gradients.",
+							"type": "boolean",
+							"default": true
+						},
+						"duotone": {
+							"description": "Duotone presets for the duotone picker.\nDoesn't generate classes or properties.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the duotone preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the duotone preset.",
+										"type": "string"
+									},
+									"colors": {
+										"description": "List of colors from dark to light.",
+										"type": "array",
+										"items": {
+											"description": "CSS hex or rgb string.",
+											"type": "string"
+										}
+									}
+								},
+								"required": [ "name", "slug", "colors" ],
+								"additionalProperties": false
+							}
+						},
+						"gradients": {
+							"description": "Gradient presets for the gradient picker.\nGenerates a single class (`.has-{slug}-background`) and custom property (`--wp--preset--gradient--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the gradient preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the gradient preset.",
+										"type": "string"
+									},
+									"gradient": {
+										"description": "CSS gradient string.",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "gradient" ],
+								"additionalProperties": false
+							}
+						},
+						"link": {
+							"description": "Allow users to set link colors.",
+							"type": "boolean",
+							"default": false
+						},
+						"palette": {
+							"description": "Color palette presets for the color picker.\nGenerates three classes (`.has-{slug}-color`, `.has-{slug}-background-color`, and `.has-{slug}-border-color`) and a single custom property (`--wp--preset--color--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the color preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the color preset.",
+										"type": "string"
+									},
+									"color": {
+										"description": "CSS hex or rgb(a) string.",
+										"type": "string"
+									}
+								},
+								"required": [ "name", "slug", "color" ],
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				},
+				"layout": {
+					"description": "Settings related to layout.",
+					"type": "object",
+					"properties": {
+						"contentSize": {
+							"description": "Sets the max-width of the content.",
+							"type": "string"
+						},
+						"wideSize": {
+							"description": "Sets the max-width of wide (`.alignwide`) content.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
+				"spacing": {
+					"description": "Settings related to spacing.",
+					"type": "object",
+					"properties": {
+						"customMargin": {
+							"description": "Allow users to set a custom margin.",
+							"type": "boolean",
+							"default": false
+						},
+						"customPadding": {
+							"description": "Allow users to set a custom padding.",
+							"type": "boolean",
+							"default": false
+						},
+						"units": {
+							"description": "List of units the user can use for spacing values.",
+							"type": "array",
+							"items": {
+								"type": "string"
+							},
+							"default": [ "px", "em", "rem", "vh", "vw", "%" ]
+						}
+					},
+					"additionalProperties": false
+				},
+				"typography": {
+					"description": "Settings related to typography.",
+					"type": "object",
+					"properties": {
+						"customFontSize": {
+							"description": "Allow users to set custom font sizes.",
+							"type": "boolean",
+							"default": true
+						},
+						"customFontStyle": {
+							"description": "Allow users to set custom font styles.",
+							"type": "boolean",
+							"default": true
+						},
+						"customFontWeight": {
+							"description": "Allow users to set custom font weights.",
+							"type": "boolean",
+							"default": true
+						},
+						"customLineHeight": {
+							"description": "Allow users to set custom line height.",
+							"type": "boolean",
+							"default": false
+						},
+						"customTextDecoration": {
+							"description": "Allow users to set custom text decorations.",
+							"type": "boolean",
+							"default": true
+						},
+						"customTextTransform": {
+							"description": "Allow users to set custom text transforms.",
+							"type": "boolean",
+							"default": true
+						},
+						"dropCap": {
+							"description": "Enable drop cap.",
+							"type": "boolean",
+							"default": true
+						},
+						"fontSizes": {
+							"description": "Font size presets for the font size selector.\nGenerates a single class (`.has-{slug}-color`) and custom property (`--wp--preset--font-size--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the font size preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the font size preset.",
+										"type": "string"
+									},
+									"size": {
+										"description": "CSS font-size value, including units.",
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						},
+						"fontFamilies": {
+							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"name": {
+										"description": "Name of the font family preset, translatable.",
+										"type": "string"
+									},
+									"slug": {
+										"description": "Kebab-case unique identifier for the font family preset.",
+										"type": "string"
+									},
+									"fontFamily": {
+										"description": "CSS font-family value.",
+										"type": "string"
+									}
+								},
+								"additionalProperties": false
+							}
+						}
+					},
+					"additionalProperties": false
+				},
+				"custom": {
+					"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.",
+					"$ref": "#/definitions/settingsCustomAdditionalProperties"
+				}
+			}
+		},
+		"settingsPropertiesComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"layout": {},
+						"spacing": {},
+						"typography": {},
+						"custom": {}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"settingsBlocksPropertiesComplete": {
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/table-of-contents": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"settingsCustomAdditionalProperties": {
+			"type": "object",
+			"additionalProperties": {
+				"oneOf": [
+					{
+						"type": "string"
+					},
+					{
+						"type": "number"
+					},
+					{
+						"$ref": "#/definitions/settingsCustomAdditionalProperties"
+					}
+				]
+			}
+		},
+		"stylesProperties": {
+			"properties": {
+				"border": {
+					"description": "Border styles.",
+					"type": "object",
+					"properties": {
+						"color": {
+							"description": "Sets the `border-color` CSS property.",
+							"type": "string"
+						},
+						"radius": {
+							"description": "Sets the `border-radius` CSS property.",
+							"type": "string"
+						},
+						"style": {
+							"description": "Sets the `border-style` CSS property.",
+							"type": "string"
+						},
+						"width": {
+							"description": "Sets the `border-width` CSS property.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
+				"color": {
+					"description": "Color styles.",
+					"type": "object",
+					"properties": {
+						"background": {
+							"description": "Sets the `background-color` CSS property.",
+							"type": "string"
+						},
+						"gradient": {
+							"description": "Sets the `background` CSS property.",
+							"type": "string"
+						},
+						"text": {
+							"description": "Sets the `color` CSS property.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				},
+				"spacing": {
+					"description": "Spacing styles.",
+					"type": "object",
+					"properties": {
+						"blockGap": {
+							"description": "Sets the `--wp--style--block-gap` CSS custom property when settings.spacing.blockGap is true.",
+							"type": "string"
+						},
+						"margin": {
+							"description": "Margin styles.",
+							"type": "object",
+							"properties": {
+								"top": {
+									"description": "Sets the `margin-top` CSS property.",
+									"type": "string"
+								},
+								"right": {
+									"description": "Sets the `margin-right` CSS property.",
+									"type": "string"
+								},
+								"bottom": {
+									"description": "Sets the `margin-bottom` CSS property.",
+									"type": "string"
+								},
+								"left": {
+									"description": "Sets the `margin-left` CSS property.",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						},
+						"padding": {
+							"description": "Padding styles.",
+							"type": "object",
+							"properties": {
+								"top": {
+									"description": "Sets the `padding-top` CSS property.",
+									"type": "string"
+								},
+								"right": {
+									"description": "Sets the `padding-right` CSS property.",
+									"type": "string"
+								},
+								"bottom": {
+									"description": "Sets the `padding-bottom` CSS property.",
+									"type": "string"
+								},
+								"left": {
+									"description": "Sets the `padding-left` CSS property.",
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						}
+					},
+					"additionalProperties": false
+				},
+				"typography": {
+					"description": "Typography styles.",
+					"type": "object",
+					"properties": {
+						"fontFamily": {
+							"description": "Sets the `font-family` CSS property.",
+							"type": "string"
+						},
+						"fontSize": {
+							"description": "Sets the `font-size` CSS property.",
+							"type": "string"
+						},
+						"fontStyle": {
+							"description": "Sets the `font-style` CSS property.",
+							"type": "string"
+						},
+						"fontWeight": {
+							"description": "Sets the `font-weight` CSS property.",
+							"type": "string"
+						},
+						"lineHeight": {
+							"description": "Sets the `line-height` CSS property.",
+							"type": "string"
+						},
+						"textDecoration": {
+							"description": "Sets the `text-decoration` CSS property.",
+							"type": "string"
+						},
+						"textTransform": {
+							"description": "Sets the `text-transform` CSS property.",
+							"type": "string"
+						}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"stylesPropertiesComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"spacing": {},
+						"typography": {}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"stylesElementsPropertiesComplete": {
+			"type": "object",
+			"properties": {
+				"link": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h1": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h2": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h3": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h4": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h5": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				},
+				"h6": {
+					"$ref": "#/definitions/stylesPropertiesComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesBlocksPropertiesComplete": {
+			"type": "object",
+			"properties": {
+				"core/archives": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/audio": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/block": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/button": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/buttons": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/calendar": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/categories": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/code": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/column": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/columns": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/cover": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/embed": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/file": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/freeform": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/gallery": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/group": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/heading": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/home-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/html": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/image": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/latest-comments": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/latest-posts": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/list": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/loginout": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/media-text": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/missing": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/more": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/navigation": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/navigation-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/nextpage": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/page-list": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/paragraph": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-author": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-count": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-form": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-comments-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-content": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-date": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-excerpt": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-featured-image": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-navigation-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-template": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-terms": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/post-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/preformatted": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/pullquote": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-next": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-numbers": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-pagination-previous": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/quote": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/rss": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/search": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/separator": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/shortcode": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-logo": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-tagline": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/site-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/social-link": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/social-links": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/spacer": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/table": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/table-of-contents": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/tag-cloud": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/template-part": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/term-description": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/text-columns": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/verse": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/video": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/widget-area": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/legacy-widget": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/widget-group": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				}
+			},
+			"patternProperties": {
+				"^[a-z][a-z0-9-]*/[a-z][a-z0-9-]*$": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				}
+			},
+			"additionalProperties": false
+		},
+		"stylesPropertiesAndElementsComplete": {
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"spacing": {},
+						"typography": {},
+						"elements": {
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		}
+	},
+	"type": "object",
+	"properties": {
+		"$schema": {
+			"description": "JSON schema URI for theme.json.",
+			"type": "string"
+		},
+		"version": {
+			"description": "Version of theme.json to use.",
+			"type": "integer",
+			"enum": [ 1 ]
+		},
+		"settings": {
+			"description": "Settings for the block editor and individual blocks. These include things like:\n- Which customization options should be available to the user. \n- The default colors, font sizes... available to the user. \n- CSS custom properties and class names used in styles.\n- And the default layout of the editor (widths and available alignments).",
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/settingsProperties"
+				},
+				{
+					"properties": {
+						"color": {},
+						"layout": {},
+						"spacing": {},
+						"typography": {},
+						"border": {},
+						"custom": {},
+						"blocks": {
+							"description": "Settings defined on a per-block basis.",
+							"$ref": "#/definitions/settingsBlocksPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"styles": {
+			"description": "Organized way to set CSS properties. Styles in the top-level will be added in the `body` selector.",
+			"type": "object",
+			"allOf": [
+				{
+					"$ref": "#/definitions/stylesProperties"
+				},
+				{
+					"properties": {
+						"border": {},
+						"color": {},
+						"spacing": {},
+						"typography": {},
+						"elements": {
+							"description": "Styles defined on a per-element basis using the element's selector.",
+							"$ref": "#/definitions/stylesElementsPropertiesComplete"
+						},
+						"blocks": {
+							"description": "Styles defined on a per-block basis using the block's selector.",
+							"$ref": "#/definitions/stylesBlocksPropertiesComplete"
+						}
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+		"customTemplates": {
+			"description": "Additional metadata for custom templates defined in the templates folder.",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Filename, without extension, of the template in the templates folder.",
+						"type": "string"
+					},
+					"title": {
+						"description": "Title of the template, translatable.",
+						"type": "string"
+					},
+					"postTypes": {
+						"description": "List of post types that can use this custom template.",
+						"type": "array",
+						"items": {
+							"type": "string"
+						},
+						"default": [ "page" ]
+					}
+				},
+				"required": [ "name", "title" ],
+				"additionalProperties": false
+			}
+		},
+		"templateParts": {
+			"description": "Additional metadata for template parts defined in the parts folder.",
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"name": {
+						"description": "Filename, without extension, of the template in the parts folder.",
+						"type": "string"
+					},
+					"area": {
+						"description": "The area the template part is used for. Block variations for `header` and `footer` values exist and will be used when the area is set to one of those.",
+						"type": "string",
+						"default": "uncategorized"
+					}
+				},
+				"required": [ "name" ],
+				"additionalProperties": false
+			}
+		}
+	},
+	"required": [ "version" ],
+	"additionalProperties": false
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This adds the JSON schemas for folks on WP 5.8. Merging this branch should automatically link up `https://schemas.wp.org/wp/5.8/theme.json` since the handler for that route is just a redirect to `https://raw.githubusercontent.com/WordPress/gutenberg/wp/5.8/schemas/json/theme.json`.

Note that the schemas added here differ somewhat from the schemas on SchemaStore.

### theme-v1.json

The properties that were only available via the Gutenberg plugin in theme-v1.json have been removed here and the distinction between 5.8 and plugin-only in the descriptions has been removed as well.

There were some discrepancies between properties that were labelled as plugin-only and what I found in the 5.8 source, so all properties that I found referenced in the source should be included here.

### block.json

~~The `version` property is not included. I didn't see any reference to it in any of the core blocks or in the source.~~

See https://github.com/WordPress/gutenberg/pull/37269#issuecomment-991043953

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Please read through the properties (especially the ones that were renamed in 5.9) to ensure that we have all of the proper properties for 5.8.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Backport to 5.8

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
