### PR TITLE
Revert "Site Editor: Set the <title> on the list page to be same as the CPT name"

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -225,18 +225,3 @@ function register_site_editor_homepage_settings() {
 	);
 }
 add_action( 'init', 'register_site_editor_homepage_settings', 10 );
-
-/**
- * Sets the HTML <title> in the Site Editor list page to be the title of the CPT
- * being edited, e.g. 'Templates'.
- */
-function gutenberg_set_site_editor_list_page_title() {
-	global $title;
-	if ( gutenberg_is_edit_site_list_page() ) {
-		$post_type = get_post_type_object( $_GET['postType'] );
-		if ( $post_type ) {
-			$title = $post_type->labels->name;
-		}
-	}
-}
-add_action( 'load-appearance_page_gutenberg-edit-site', 'gutenberg_set_site_editor_list_page_title' );


### PR DESCRIPTION
Reverts WordPress/gutenberg#36805

As @youknowriad notes in https://github.com/WordPress/gutenberg/pull/36805#issuecomment-989872468, this isn't necessary now that this screen uses client side routing.

To test:

1. Open the site editor.
2. Open the W menu.
3. Browse to Templates or Template Parts.
4. Notice that the window title is _Templates_ or _Template Parts_.