### PR TITLE
CustomSelectControl: Update to use a Popover component for rendering the internals

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Bug Fix
 
+-   CustomSelectControl: Update to use a Popover component for rendering the menu ([#37272](https://github.com/WordPress/gutenberg/pull/37272)).
 -   Fixed spacing between `BaseControl` fields and help text within the `ToolsPanel` ([#36334](https://github.com/WordPress/gutenberg/pull/36334))
 -   Replaced hardcoded blue in `ColorPicker` with UI theme color ([#36153](https://github.com/WordPress/gutenberg/pull/36153)).
 -   Fixed empty `ToolsPanel` height by correcting menu button line-height ([#36895](https://github.com/WordPress/gutenberg/pull/36895)).

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -14,16 +14,12 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { Button, Popover, VisuallyHidden } from '../';
 
-const OptionList = ( { anchorRect, isOpen, children } ) => {
+const OptionList = ( { isOpen, children } ) => {
 	if ( ! isOpen ) {
 		return children;
 	}
 
-	return (
-		<Popover anchorRect={ anchorRect } position={ 'bottom left' }>
-			{ children }
-		</Popover>
-	);
+	return <Popover position={ 'bottom left' }>{ children }</Popover>;
 };
 
 const itemToString = ( item ) => item?.name;

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -12,7 +12,19 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, VisuallyHidden } from '../';
+import { Button, Popover, VisuallyHidden } from '../';
+
+const OptionList = ( { anchorRect, isOpen, children } ) => {
+	if ( ! isOpen ) {
+		return children;
+	}
+
+	return (
+		<Popover anchorRect={ anchorRect } position={ 'bottom left' }>
+			{ children }
+		</Popover>
+	);
+};
 
 const itemToString = ( item ) => item?.name;
 // This is needed so that in Windows, where
@@ -104,6 +116,7 @@ export default function CustomSelectControl( {
 	) {
 		delete menuProps[ 'aria-activedescendant' ];
 	}
+
 	return (
 		<div
 			className={ classnames(
@@ -125,58 +138,62 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<Button
-				{ ...getToggleButtonProps( {
-					// This is needed because some speech recognition software don't support `aria-labelledby`.
-					'aria-label': label,
-					'aria-labelledby': undefined,
-					className: 'components-custom-select-control__button',
-					isSmall: true,
-					describedBy: getDescribedBy(),
-				} ) }
-			>
-				{ itemToString( selectedItem ) }
-				<Icon
-					icon={ chevronDown }
-					className="components-custom-select-control__button-icon"
-				/>
-			</Button>
-			<ul { ...menuProps }>
-				{ isOpen &&
-					items.map( ( item, index ) => (
-						// eslint-disable-next-line react/jsx-key
-						<li
-							{ ...getItemProps( {
-								item,
-								index,
-								key: item.key,
-								className: classnames(
-									item.className,
-									'components-custom-select-control__item',
-									{
-										'is-highlighted':
-											index === highlightedIndex,
-										'has-hint': !! item.__experimentalHint,
-									}
-								),
-								style: item.style,
-							} ) }
-						>
-							{ item.name }
-							{ item.__experimentalHint && (
-								<span className="components-custom-select-control__item-hint">
-									{ item.__experimentalHint }
-								</span>
-							) }
-							{ item === selectedItem && (
-								<Icon
-									icon={ check }
-									className="components-custom-select-control__item-icon"
-								/>
-							) }
-						</li>
-					) ) }
-			</ul>
+			<div className="components-custom-select-control__inner">
+				<Button
+					{ ...getToggleButtonProps( {
+						// This is needed because some speech recognition software don't support `aria-labelledby`.
+						'aria-label': label,
+						'aria-labelledby': undefined,
+						className: 'components-custom-select-control__button',
+						isSmall: true,
+						describedBy: getDescribedBy(),
+					} ) }
+				>
+					{ itemToString( selectedItem ) }
+					<Icon
+						icon={ chevronDown }
+						className="components-custom-select-control__button-icon"
+					/>
+				</Button>
+				<OptionList isOpen={ isOpen }>
+					<ul { ...menuProps }>
+						{ isOpen &&
+							items.map( ( item, index ) => (
+								// eslint-disable-next-line react/jsx-key
+								<li
+									{ ...getItemProps( {
+										item,
+										index,
+										key: item.key,
+										className: classnames(
+											item.className,
+											'components-custom-select-control__item',
+											{
+												'is-highlighted':
+													index === highlightedIndex,
+												'has-hint': !! item.__experimentalHint,
+											}
+										),
+										style: item.style,
+									} ) }
+								>
+									{ item.name }
+									{ item.__experimentalHint && (
+										<span className="components-custom-select-control__item-hint">
+											{ item.__experimentalHint }
+										</span>
+									) }
+									{ item === selectedItem && (
+										<Icon
+											icon={ check }
+											className="components-custom-select-control__item-icon"
+										/>
+									) }
+								</li>
+							) ) }
+					</ul>
+				</OptionList>
+			</div>
 		</div>
 	);
 }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -104,14 +104,10 @@ export default function CustomSelectControl( {
 	const anchorRef = useRef();
 
 	// Calculate Popover width based on the size of the component's container.
-	// The width will be set for the content of the menu, so factor in the
-	// Popover's border to ensure that the menu lines up with the toggle button.
 	const [
 		containerResizeListener,
 		{ width: containerWidth },
 	] = useResizeObserver();
-	const widthMinusBorder =
-		containerWidth >= 2 ? containerWidth - 2 : containerWidth;
 
 	function getDescribedBy() {
 		if ( describedBy ) {
@@ -130,7 +126,7 @@ export default function CustomSelectControl( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
 		style: {
-			minWidth: widthMinusBorder,
+			width: containerWidth,
 		},
 	} );
 

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -155,64 +155,62 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<div className="components-custom-select-control__inner">
-				<Button
-					ref={ anchorRef }
-					{ ...getToggleButtonProps( {
-						// This is needed because some speech recognition software don't support `aria-labelledby`.
-						'aria-label': label,
-						'aria-labelledby': undefined,
-						className: 'components-custom-select-control__button',
-						isSmall: true,
-						describedBy: getDescribedBy(),
-					} ) }
-				>
-					{ buttonResizeListener }
-					{ itemToString( selectedItem ) }
-					<Icon
-						icon={ chevronDown }
-						className="components-custom-select-control__button-icon"
-					/>
-				</Button>
-				<OptionList isOpen={ isOpen } anchorRef={ anchorRef }>
-					<ul { ...menuProps }>
-						{ isOpen &&
-							items.map( ( item, index ) => (
-								// eslint-disable-next-line react/jsx-key
-								<li
-									{ ...getItemProps( {
-										item,
-										index,
-										key: item.key,
-										className: classnames(
-											item.className,
-											'components-custom-select-control__item',
-											{
-												'is-highlighted':
-													index === highlightedIndex,
-												'has-hint': !! item.__experimentalHint,
-											}
-										),
-										style: item.style,
-									} ) }
-								>
-									{ item.name }
-									{ item.__experimentalHint && (
-										<span className="components-custom-select-control__item-hint">
-											{ item.__experimentalHint }
-										</span>
-									) }
-									{ item === selectedItem && (
-										<Icon
-											icon={ check }
-											className="components-custom-select-control__item-icon"
-										/>
-									) }
-								</li>
-							) ) }
-					</ul>
-				</OptionList>
-			</div>
+			<Button
+				ref={ anchorRef }
+				{ ...getToggleButtonProps( {
+					// This is needed because some speech recognition software don't support `aria-labelledby`.
+					'aria-label': label,
+					'aria-labelledby': undefined,
+					className: 'components-custom-select-control__button',
+					isSmall: true,
+					describedBy: getDescribedBy(),
+				} ) }
+			>
+				{ buttonResizeListener }
+				{ itemToString( selectedItem ) }
+				<Icon
+					icon={ chevronDown }
+					className="components-custom-select-control__button-icon"
+				/>
+			</Button>
+			<OptionList isOpen={ isOpen } anchorRef={ anchorRef }>
+				<ul { ...menuProps }>
+					{ isOpen &&
+						items.map( ( item, index ) => (
+							// eslint-disable-next-line react/jsx-key
+							<li
+								{ ...getItemProps( {
+									item,
+									index,
+									key: item.key,
+									className: classnames(
+										item.className,
+										'components-custom-select-control__item',
+										{
+											'is-highlighted':
+												index === highlightedIndex,
+											'has-hint': !! item.__experimentalHint,
+										}
+									),
+									style: item.style,
+								} ) }
+							>
+								{ item.name }
+								{ item.__experimentalHint && (
+									<span className="components-custom-select-control__item-hint">
+										{ item.__experimentalHint }
+									</span>
+								) }
+								{ item === selectedItem && (
+									<Icon
+										icon={ check }
+										className="components-custom-select-control__item-icon"
+									/>
+								) }
+							</li>
+						) ) }
+				</ul>
+			</OptionList>
 		</div>
 	);
 }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useSelect } from 'downshift';
 import classnames from 'classnames';
 
 /**
@@ -12,83 +11,25 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, Popover, VisuallyHidden } from '../';
-
-const OptionList = ( { isOpen, children } ) => {
-	if ( ! isOpen ) {
-		return children;
-	}
-
-	return <Popover position={ 'bottom left' }>{ children }</Popover>;
-};
+import { DropdownMenu, MenuGroup, MenuItem, VisuallyHidden } from '../';
 
 const itemToString = ( item ) => item?.name;
-// This is needed so that in Windows, where
-// the menu does not necessarily open on
-// key up/down, you can still switch between
-// options with the menu closed.
-const stateReducer = (
-	{ selectedItem },
-	{ type, changes, props: { items } }
-) => {
-	switch ( type ) {
-		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowDown:
-			// If we already have a selected item, try to select the next one,
-			// without circular navigation. Otherwise, select the first item.
-			return {
-				selectedItem:
-					items[
-						selectedItem
-							? Math.min(
-									items.indexOf( selectedItem ) + 1,
-									items.length - 1
-							  )
-							: 0
-					],
-			};
-		case useSelect.stateChangeTypes.ToggleButtonKeyDownArrowUp:
-			// If we already have a selected item, try to select the previous one,
-			// without circular navigation. Otherwise, select the last item.
-			return {
-				selectedItem:
-					items[
-						selectedItem
-							? Math.max( items.indexOf( selectedItem ) - 1, 0 )
-							: items.length - 1
-					],
-			};
-		default:
-			return changes;
-	}
+
+const POPOVER_PROPS = {
+	className: 'block-editor-block-settings-menu__popover',
+	position: 'bottom right',
+	isAlternate: true,
 };
-export default function CustomSelectControl( {
+
+export default function CustomSelectControlWithDropdownMenu( {
 	className,
 	hideLabelFromVision,
 	label,
 	describedBy,
 	options: items,
 	onChange: onSelectedItemChange,
-	value: _selectedItem,
+	value: selectedItem,
 } ) {
-	const {
-		getLabelProps,
-		getToggleButtonProps,
-		getMenuProps,
-		getItemProps,
-		isOpen,
-		highlightedIndex,
-		selectedItem,
-	} = useSelect( {
-		initialSelectedItem: items[ 0 ],
-		items,
-		itemToString,
-		onSelectedItemChange,
-		...( typeof _selectedItem !== 'undefined' && _selectedItem !== null
-			? { selectedItem: _selectedItem }
-			: undefined ),
-		stateReducer,
-	} );
-
 	function getDescribedBy() {
 		if ( describedBy ) {
 			return describedBy;
@@ -102,16 +43,23 @@ export default function CustomSelectControl( {
 		return sprintf( __( 'Currently selected: %s' ), selectedItem.name );
 	}
 
-	const menuProps = getMenuProps( {
-		className: 'components-custom-select-control__menu',
-		'aria-hidden': ! isOpen,
-	} );
-	// We need this here, because the null active descendant is not fully ARIA compliant.
-	if (
-		menuProps[ 'aria-activedescendant' ]?.startsWith( 'downshift-null' )
-	) {
-		delete menuProps[ 'aria-activedescendant' ];
-	}
+	const toggleProps = {
+		// This is needed because some speech recognition software don't support `aria-labelledby`.
+		'aria-label': label,
+		'aria-labelledby': undefined,
+		className: 'components-custom-select-control__button',
+		isSmall: true,
+		describedBy: getDescribedBy(),
+		children: (
+			<>
+				{ itemToString( selectedItem ) }
+				<Icon
+					icon={ chevronDown }
+					className="components-custom-select-control__button-icon"
+				/>
+			</>
+		),
+	};
 
 	return (
 		<div
@@ -121,57 +69,54 @@ export default function CustomSelectControl( {
 			) }
 		>
 			{ hideLabelFromVision ? (
-				<VisuallyHidden as="label" { ...getLabelProps() }>
-					{ label }
-				</VisuallyHidden>
+				<VisuallyHidden as="label">{ label }</VisuallyHidden>
 			) : (
 				/* eslint-disable-next-line jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */
 				<label
-					{ ...getLabelProps( {
+					{ ...{
 						className: 'components-custom-select-control__label',
-					} ) }
+					} }
 				>
 					{ label }
 				</label>
 			) }
-			<div className="components-custom-select-control__inner">
-				<Button
-					{ ...getToggleButtonProps( {
-						// This is needed because some speech recognition software don't support `aria-labelledby`.
-						'aria-label': label,
-						'aria-labelledby': undefined,
-						className: 'components-custom-select-control__button',
-						isSmall: true,
-						describedBy: getDescribedBy(),
-					} ) }
-				>
-					{ itemToString( selectedItem ) }
-					<Icon
-						icon={ chevronDown }
-						className="components-custom-select-control__button-icon"
-					/>
-				</Button>
-				<OptionList isOpen={ isOpen }>
-					<ul { ...menuProps }>
-						{ isOpen &&
-							items.map( ( item, index ) => (
-								// eslint-disable-next-line react/jsx-key
-								<li
-									{ ...getItemProps( {
-										item,
-										index,
-										key: item.key,
+			<DropdownMenu
+				className={ classnames(
+					'components-custom-select-control__inner',
+					className
+				) }
+				popoverProps={ POPOVER_PROPS }
+				toggleProps={ toggleProps }
+				icon={ null }
+				noIcons={ true }
+			>
+				{ ( { isOpen, onClose } ) =>
+					isOpen && (
+						<MenuGroup>
+							{ items.map( ( item, index ) => (
+								<MenuItem
+									key={ index }
+									{ ...{
 										className: classnames(
 											item.className,
 											'components-custom-select-control__item',
 											{
 												'is-highlighted':
-													index === highlightedIndex,
+													item === selectedItem,
 												'has-hint': !! item.__experimentalHint,
+												'has-check':
+													item === selectedItem,
 											}
 										),
 										style: item.style,
-									} ) }
+									} }
+									onClick={ () => {
+										onSelectedItemChange( {
+											selectedItem: item,
+										} );
+										onClose();
+									} }
+									icon={ item === selectedItem && check }
 								>
 									{ item.name }
 									{ item.__experimentalHint && (
@@ -179,17 +124,12 @@ export default function CustomSelectControl( {
 											{ item.__experimentalHint }
 										</span>
 									) }
-									{ item === selectedItem && (
-										<Icon
-											icon={ check }
-											className="components-custom-select-control__item-icon"
-										/>
-									) }
-								</li>
+								</MenuItem>
 							) ) }
-					</ul>
-				</OptionList>
-			</div>
+						</MenuGroup>
+					)
+				}
+			</DropdownMenu>
 		</div>
 	);
 }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useMergeRefs, useResizeObserver } from '@wordpress/compose';
+import { useResizeObserver } from '@wordpress/compose';
 import { useRef } from '@wordpress/element';
 import { Icon, check, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
@@ -103,10 +103,15 @@ export default function CustomSelectControl( {
 
 	const anchorRef = useRef();
 
+	// Calculate Popover width based on the size of the component's container.
+	// The width will be set for the content of the menu, so factor in the
+	// Popover's border to ensure that the menu lines up with the toggle button.
 	const [
-		buttonResizeListener,
-		{ width: buttonWidth },
+		containerResizeListener,
+		{ width: containerWidth },
 	] = useResizeObserver();
+	const widthMinusBorder =
+		containerWidth >= 2 ? containerWidth - 2 : containerWidth;
 
 	function getDescribedBy() {
 		if ( describedBy ) {
@@ -125,9 +130,10 @@ export default function CustomSelectControl( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
 		style: {
-			minWidth: buttonWidth,
+			minWidth: widthMinusBorder,
 		},
 	} );
+
 	// We need this here, because the null active descendant is not fully ARIA compliant.
 	if (
 		menuProps[ 'aria-activedescendant' ]?.startsWith( 'downshift-null' )
@@ -144,17 +150,15 @@ export default function CustomSelectControl( {
 		describedBy: getDescribedBy(),
 	} );
 
-	// Merge the toggle button's ref and the anchorRef so that the anchorRef can be
-	// used for calculating the Popover position based on the size of the button.
-	const buttonRef = useMergeRefs( [ toggleButtonProps.ref, anchorRef ] );
-
 	return (
 		<div
 			className={ classnames(
 				'components-custom-select-control',
 				className
 			) }
+			ref={ anchorRef }
 		>
+			{ containerResizeListener }
 			{ hideLabelFromVision ? (
 				<VisuallyHidden as="label" { ...getLabelProps() }>
 					{ label }
@@ -169,8 +173,7 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<Button { ...toggleButtonProps } ref={ buttonRef }>
-				{ buttonResizeListener }
+			<Button { ...toggleButtonProps }>
 				{ itemToString( selectedItem ) }
 				<Icon
 					icon={ chevronDown }

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -11,7 +11,7 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { DropdownMenu, MenuGroup, MenuItem, VisuallyHidden } from '../';
+import { DropdownMenu, MenuItem, VisuallyHidden } from '../';
 
 const itemToString = ( item ) => item?.name;
 
@@ -61,6 +61,10 @@ export default function CustomSelectControlWithDropdownMenu( {
 		),
 	};
 
+	const menuProps = {
+		role: 'select',
+	};
+
 	return (
 		<div
 			className={ classnames(
@@ -85,6 +89,7 @@ export default function CustomSelectControlWithDropdownMenu( {
 					'components-custom-select-control__inner',
 					className
 				) }
+				menuProps={ menuProps }
 				popoverProps={ POPOVER_PROPS }
 				toggleProps={ toggleProps }
 				icon={ null }
@@ -92,10 +97,11 @@ export default function CustomSelectControlWithDropdownMenu( {
 			>
 				{ ( { isOpen, onClose } ) =>
 					isOpen && (
-						<MenuGroup>
+						<>
 							{ items.map( ( item, index ) => (
 								<MenuItem
 									key={ index }
+									role="option"
 									{ ...{
 										className: classnames(
 											item.className,
@@ -126,7 +132,7 @@ export default function CustomSelectControlWithDropdownMenu( {
 									) }
 								</MenuItem>
 							) ) }
-						</MenuGroup>
+						</>
 					)
 				}
 			</DropdownMenu>

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useResizeObserver } from '@wordpress/compose';
+import { useMergeRefs, useResizeObserver } from '@wordpress/compose';
 import { useRef } from '@wordpress/element';
 import { Icon, check, chevronDown } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
@@ -27,6 +27,7 @@ const OptionList = ( { anchorRef, isOpen, children } ) => {
 			className="components-custom-select-control__popover"
 			isAlternate={ true }
 			position={ 'bottom center' }
+			shouldAnchorIncludePadding
 		>
 			{ children }
 		</Popover>
@@ -124,7 +125,7 @@ export default function CustomSelectControl( {
 		className: 'components-custom-select-control__menu',
 		'aria-hidden': ! isOpen,
 		style: {
-			width: buttonWidth,
+			minWidth: buttonWidth,
 		},
 	} );
 	// We need this here, because the null active descendant is not fully ARIA compliant.
@@ -133,6 +134,19 @@ export default function CustomSelectControl( {
 	) {
 		delete menuProps[ 'aria-activedescendant' ];
 	}
+
+	const toggleButtonProps = getToggleButtonProps( {
+		// This is needed because some speech recognition software don't support `aria-labelledby`.
+		'aria-label': label,
+		'aria-labelledby': undefined,
+		className: 'components-custom-select-control__button',
+		isSmall: true,
+		describedBy: getDescribedBy(),
+	} );
+
+	// Merge the toggle button's ref and the anchorRef so that the anchorRef can be
+	// used for calculating the Popover position based on the size of the button.
+	const buttonRef = useMergeRefs( [ toggleButtonProps.ref, anchorRef ] );
 
 	return (
 		<div
@@ -155,17 +169,7 @@ export default function CustomSelectControl( {
 					{ label }
 				</label>
 			) }
-			<Button
-				ref={ anchorRef }
-				{ ...getToggleButtonProps( {
-					// This is needed because some speech recognition software don't support `aria-labelledby`.
-					'aria-label': label,
-					'aria-labelledby': undefined,
-					className: 'components-custom-select-control__button',
-					isSmall: true,
-					describedBy: getDescribedBy(),
-				} ) }
-			>
+			<Button { ...toggleButtonProps } ref={ buttonRef }>
 				{ buttonResizeListener }
 				{ itemToString( selectedItem ) }
 				<Icon

--- a/packages/components/src/custom-select-control/index.js
+++ b/packages/components/src/custom-select-control/index.js
@@ -62,7 +62,7 @@ export default function CustomSelectControlWithDropdownMenu( {
 	};
 
 	const menuProps = {
-		role: 'select',
+		role: 'listbox',
 	};
 
 	return (

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -2,6 +2,10 @@
 	position: relative;
 }
 
+.components-custom-select-control__inner {
+	display: inline-block;
+}
+
 .components-custom-select-control__label {
 	display: block;
 	margin-bottom: $grid-unit-10;
@@ -52,7 +56,7 @@
 	min-width: 100%;
 	overflow: auto;
 	padding: 0;
-	position: absolute;
+	margin: 0;
 	z-index: z-index(".components-popover");
 }
 

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -61,17 +61,10 @@
 }
 
 .components-custom-select-control__item {
-	align-items: center;
-	display: grid;
-	grid-template-columns: auto auto;
-	list-style-type: none;
 	padding: $grid-unit-10;
 	cursor: default;
 	line-height: $icon-size + $grid-unit-05;
 
-	&.has-hint {
-		grid-template-columns: auto auto 30px;
-	}
 	&.is-highlighted {
 		background: $gray-300;
 	}
@@ -79,8 +72,6 @@
 		color: $gray-700;
 		text-align: right;
 		padding-right: $grid-unit-05;
-	}
-	.components-custom-select-control__item-icon {
 		margin-left: auto;
 	}
 

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -2,10 +2,6 @@
 	position: relative;
 }
 
-.components-custom-select-control__inner {
-	display: inline-block;
-}
-
 .components-custom-select-control__label {
 	display: block;
 	margin-bottom: $grid-unit-10;
@@ -45,15 +41,10 @@
 		display: none;
 	}
 
-	// Block UI appearance.
-	border: $border-width solid $gray-900;
-	background-color: $white;
-	border-radius: $radius-block-ui;
 	outline: none;
 	transition: none;
-
 	max-height: 400px;
-	min-width: 100%;
+	min-width: 130px;
 	overflow: auto;
 	padding: 0;
 	margin: 0;
@@ -61,10 +52,17 @@
 }
 
 .components-custom-select-control__item {
+	align-items: center;
+	display: grid;
+	grid-template-columns: auto auto;
+	list-style-type: none;
 	padding: $grid-unit-10;
 	cursor: default;
 	line-height: $icon-size + $grid-unit-05;
 
+	&.has-hint {
+		grid-template-columns: auto auto 30px;
+	}
 	&.is-highlighted {
 		background: $gray-300;
 	}
@@ -72,6 +70,8 @@
 		color: $gray-700;
 		text-align: right;
 		padding-right: $grid-unit-05;
+	}
+	.components-custom-select-control__item-icon {
 		margin-left: auto;
 	}
 

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -46,7 +46,7 @@
 	max-height: 400px;
 	overflow: auto;
 	padding: 0;
-	margin: 0 -$border-width; // Allow width value to include the Popover border width.
+	margin: 0 (-$border-width); // Allow width value to include the Popover border width.
 	z-index: z-index(".components-popover");
 }
 
@@ -76,5 +76,15 @@
 
 	&:last-child {
 		margin-bottom: 0;
+	}
+}
+
+.components-custom-select-control__popover {
+	&.components-popover {
+		.components-popover__content {
+			// Prevent the Popover scrollbars so that
+			// the scrollbars are only handled by the Menu.
+			overflow: hidden;
+		}
 	}
 }

--- a/packages/components/src/custom-select-control/style.scss
+++ b/packages/components/src/custom-select-control/style.scss
@@ -44,10 +44,9 @@
 	outline: none;
 	transition: none;
 	max-height: 400px;
-	min-width: 130px;
 	overflow: auto;
 	padding: 0;
-	margin: 0;
+	margin: 0 -$border-width; // Allow width value to include the Popover border width.
 	z-index: z-index(".components-popover");
 }
 

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -134,7 +134,7 @@ function DropdownMenu( dropdownMenuProps ) {
 				);
 
 				return (
-					<NavigableMenu role="menu" { ...mergedMenuProps }>
+					<NavigableMenu { ...mergedMenuProps } role="menu">
 						{ isFunction( children ) ? children( props ) : null }
 						{ flatMap( controlSets, ( controlSet, indexOfSet ) =>
 							controlSet.map( ( control, indexOfControl ) => (

--- a/packages/components/src/dropdown-menu/index.js
+++ b/packages/components/src/dropdown-menu/index.js
@@ -134,7 +134,7 @@ function DropdownMenu( dropdownMenuProps ) {
 				);
 
 				return (
-					<NavigableMenu { ...mergedMenuProps } role="menu">
+					<NavigableMenu role="menu" { ...mergedMenuProps }>
 						{ isFunction( children ) ? children( props ) : null }
 						{ flatMap( controlSets, ( controlSet, indexOfSet ) =>
 							controlSet.map( ( control, indexOfControl ) => (


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Raised in https://github.com/WordPress/gutenberg/issues/36545#issuecomment-976447915, the `CustomSelectControl` component gets cut off when used in certain areas, such as in the global styles sidebar.

This PR explores using a Popover component for rendering the drop down items. The goal is to ensure that the dropdown items do not get cut off, and that we preserve accessibility and backwards compatibility of the component.

Kudos @aaronrobertshaw for the approach in this PR.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Open up the site editor and go to the global styles tab. Select block styles, and go to a block that opts in to Typography controls (e.g. the Heading block). Select from the font size dropdown and before this PR, you should see that the dropdown gets cut off visually. After this PR, the Popover component should try to ensure that the dropdown options are always visible, or at least can be scrolled to.

Check to ensure that keyboard navigation is unaffected.

You can also test in Storybook by running `npm run storybook:dev` and then navigate to: http://localhost:50240/?path=/story/components-customselectcontrol--long-labels

## To-do

* [x] Update styling to ensure the correct width is set for the dropdown
* [x] Update the position of where the Popover opens from, so that it's correctly aligned
* [x] Update the border of the Popover as it looks like it adds an extra grey border
* [x] ~Try using the `DropdownMenu` component instead of the `Popover` component~ (Reverted attempt to use `DropdownMenu` component due to accessibility issues)
* [x] Render popover position relative to the Container position and size 
* [ ] Place the Popover behaviour before an experimental prop (e.g. `__experimentalPopover`) so that we don't break backwards compatibility? Update: since we've managed to pretty well preserve the styling of the menu, I'm not sure this is worth it. Let me know if anyone thinks it's necessary, though!

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/145519299-fc3dc08f-ae05-4e5b-8b4a-cbcc4d6e2f84.png) | ![Kapture 2021-12-10 at 15 27 28](https://user-images.githubusercontent.com/14988353/146133099-7e87e3dd-681f-4941-8db2-7c8baa958319.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
