### PR TITLE
ToolsPanel: Allow items to register when panelId is null

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   Normalized label line-height and spacing within the `ToolsPanel` ([36387](https://github.com/WordPress/gutenberg/pull/36387))
 -   Remove unused `reakit-utils` from peer dependencies ([#37369](https://github.com/WordPress/gutenberg/pull/37369)).
 -   Update all Emotion dependencies to the latest version to ensure they work correctly with React types ([#37365](https://github.com/WordPress/gutenberg/pull/37365)).
+-   Allowed `ToolsPanel` to register items when `panelId` is `null` due to multiple block selection ([37216](https://github.com/WordPress/gutenberg/pull/37216)).
 
 ### Enhancements
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -41,10 +41,13 @@ export function useToolsPanelItem(
 	const hasValueCallback = useCallback( hasValue, [ panelId ] );
 	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
 
+	const hasMatchingPanel =
+		currentPanelId === panelId || currentPanelId === null;
+
 	// Registering the panel item allows the panel to include it in its
 	// automatically generated menu and determine its initial checked status.
 	useEffect( () => {
-		if ( currentPanelId === panelId ) {
+		if ( hasMatchingPanel ) {
 			registerPanelItem( {
 				hasValue: hasValueCallback,
 				isShownByDefault,
@@ -55,13 +58,12 @@ export function useToolsPanelItem(
 		}
 
 		return () => {
-			if ( currentPanelId === panelId ) {
+			if ( hasMatchingPanel ) {
 				deregisterPanelItem( label );
 			}
 		};
 	}, [
-		currentPanelId,
-		panelId,
+		hasMatchingPanel,
 		isShownByDefault,
 		label,
 		hasValueCallback,
@@ -88,7 +90,7 @@ export function useToolsPanelItem(
 	// Determine if the panel item's corresponding menu is being toggled and
 	// trigger appropriate callback if it is.
 	useEffect( () => {
-		if ( isResetting || currentPanelId !== panelId ) {
+		if ( isResetting || ! hasMatchingPanel ) {
 			return;
 		}
 
@@ -100,11 +102,10 @@ export function useToolsPanelItem(
 			onDeselect?.();
 		}
 	}, [
-		currentPanelId,
+		hasMatchingPanel,
 		isMenuItemChecked,
 		isResetting,
 		isValueSet,
-		panelId,
 		wasMenuItemChecked,
 	] );
 

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -40,6 +40,7 @@ export function useToolsPanelItem(
 
 	const hasValueCallback = useCallback( hasValue, [ panelId ] );
 	const resetAllFilterCallback = useCallback( resetAllFilter, [ panelId ] );
+	const previousPanelId = usePrevious( currentPanelId );
 
 	const hasMatchingPanel =
 		currentPanelId === panelId || currentPanelId === null;
@@ -47,7 +48,7 @@ export function useToolsPanelItem(
 	// Registering the panel item allows the panel to include it in its
 	// automatically generated menu and determine its initial checked status.
 	useEffect( () => {
-		if ( hasMatchingPanel ) {
+		if ( hasMatchingPanel && previousPanelId !== null ) {
 			registerPanelItem( {
 				hasValue: hasValueCallback,
 				isShownByDefault,
@@ -58,15 +59,21 @@ export function useToolsPanelItem(
 		}
 
 		return () => {
-			if ( hasMatchingPanel ) {
+			if (
+				( previousPanelId === null && !! currentPanelId ) ||
+				currentPanelId === panelId
+			) {
 				deregisterPanelItem( label );
 			}
 		};
 	}, [
+		currentPanelId,
 		hasMatchingPanel,
 		isShownByDefault,
 		label,
 		hasValueCallback,
+		panelId,
+		previousPanelId,
 		resetAllFilterCallback,
 	] );
 

--- a/packages/components/src/tools-panel/tools-panel/README.md
+++ b/packages/components/src/tools-panel/tools-panel/README.md
@@ -93,8 +93,9 @@ panel's dropdown menu.
 ### `panelId`: `string`
 
 If a `panelId` is set, it is passed through the `ToolsPanelContext` and used
-to restrict panel items. Only items with a matching `panelId` will be able
-to register themselves with this panel.
+to restrict panel items. When a `panelId` is set, items can only register
+themselves if the `panelId` is explicitly `null` or the item's `panelId` matches
+exactly.
 
 - Required: No
 


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/issues/37188
- https://github.com/WordPress/gutenberg/pull/37216

## Description

When multiple blocks are selected the `panelId` applied to the `ToolsPanel` is `null`. This PR updates the checks restricting panel item registration to allow them to register in this scenario. 

#### Changes include: 
- Updated the `ToolsPanelItem` hook
- Updated docs
- Added new unit test
- Added changelog


## How has this been tested?

- Run `npm run test-unit packages/components/src/tools-panel/test`
- Test component still functions correctly within the Storybook
- Test Post Featured Image block's conditionally rendered scale control works
- Test that injected controls do not persist between block selections e.g. switching selection between Group and Cover blocks (cover block injects min-height control which should be removed when selecting a Group block).
- Tested multiple block selection within block editor via [37216](https://github.com/WordPress/gutenberg/pull/37216)

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
