### PR TITLE
Block Editor: Avoid wiping out inner block controller content when ungrouping

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -4,7 +4,7 @@
 import { MenuItem } from '@wordpress/components';
 import { _x } from '@wordpress/i18n';
 import { switchToBlockType } from '@wordpress/blocks';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,6 +21,10 @@ function ConvertToGroupButton( {
 	onClose = () => {},
 } ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { areInnerBlocksControlled, getBlocks } = useSelect(
+		blockEditorStore
+	);
+
 	const onConvertToGroup = () => {
 		// Activate the `transform` on the Grouping Block which does the conversion
 		const newBlocks = switchToBlockType(
@@ -37,7 +41,17 @@ function ConvertToGroupButton( {
 		if ( ! innerBlocks.length ) {
 			return;
 		}
-		replaceBlocks( clientIds, innerBlocks );
+
+		// The blocks in block selection don't include inner blocks for the inner block controller.
+		// We've to add them manually to avoid data loss.
+		const newBlocks = innerBlocks.map( ( block ) => {
+			if ( areInnerBlocksControlled( block.clientId ) ) {
+				block.innerBlocks = getBlocks( block.clientId );
+			}
+
+			return block;
+		} );
+		replaceBlocks( clientIds, newBlocks );
 	};
 
 	if ( ! isGroupable && ! isUngroupable ) {


### PR DESCRIPTION
## Description
See #36788.

When grouping and ungrouping inner block controller blocks (Template Parts, Reusable Blocks), their content is wiped out.

## Why
* Group/Ungroup uses `getBlocksByClientId` for block(s) data, which calls the `getBlock` internally.
* The `getBlock` [won't return inner blocks](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/store/selectors.js#L122-L137) when another entity controls them, aka "Controlled Inner Blocks."
* So when ungrouping happens, we only have an empty array instead of an actual `innerBlocks.`

I thought I could manually set inner blocks for controlled entities (see current code), but this method only works halfway. The controlled inner blocks still get deleted after saving the post.

My best guess is that this has something to do with how the `useBlockSync` works.

@noahtallen, @youknowriad I would appreciate any feedback you can provide for this issue 🙇 

## How has this been tested?
1. Create a Reusable Block.
2. Create a new group with this reusable block.
3. Ungroup it.
4. Reusable Block's content shouldn't be lost.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
