### PR TITLE
Fix content loss when ungrouping template parts or reusable blocks

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -369,9 +369,14 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 					...omit(
 						newState.tree,
 						action.replacedClientIds.concat(
-							action.replacedClientIds.map(
-								( clientId ) => 'controlled||' + clientId
-							)
+							// controlled inner blocks are only removed
+							// if the block don't move to another position
+							// otherwise their content will be lost.
+							action.replacedClientIds
+								.filter( ( clientId ) => ! subTree[ clientId ] )
+								.map(
+									( clientId ) => 'controlled||' + clientId
+								)
 						)
 					),
 					...subTree,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -369,8 +369,8 @@ const withBlockTree = ( reducer ) => ( state = {}, action ) => {
 					...omit(
 						newState.tree,
 						action.replacedClientIds.concat(
-							// controlled inner blocks are only removed
-							// if the block don't move to another position
+							// Controlled inner blocks are only removed
+							// if the block doesn't move to another position
 							// otherwise their content will be lost.
 							action.replacedClientIds
 								.filter( ( clientId ) => ! subTree[ clientId ] )

--- a/packages/e2e-tests/specs/editor/various/block-grouping.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-grouping.test.js
@@ -110,6 +110,52 @@ describe( 'Block Grouping', () => {
 			);
 			expect( ungroupButtons ).toHaveLength( 0 );
 		} );
+		it( 'should group and ungroup a controlled block properly', async () => {
+			const getParagraphText = async () => {
+				const paragraphInReusableSelector =
+					'.block-editor-block-list__block[data-type="core/block"] p';
+				await page.waitForSelector( paragraphInReusableSelector );
+				return page.$eval(
+					paragraphInReusableSelector,
+					( element ) => element.innerText
+				);
+			};
+
+			const paragraphText = 'hi';
+			const reusableBlockNameInputSelector =
+				'.reusable-blocks-menu-items__convert-modal .components-text-control__input';
+			await insertBlock( 'Paragraph' );
+			await page.keyboard.type( paragraphText );
+
+			await clickBlockToolbarButton( 'Options' );
+			await clickMenuItem( 'Add to Reusable blocks' );
+			const nameInput = await page.waitForSelector(
+				reusableBlockNameInputSelector
+			);
+			await nameInput.click();
+			await page.keyboard.type( 'Block' );
+			await page.keyboard.press( 'Enter' );
+
+			// Wait for creation to finish
+			await page.waitForXPath(
+				'//*[contains(@class, "components-snackbar")]/*[text()="Reusable block created."]'
+			);
+			// Group
+			await clickBlockToolbarButton( 'Options' );
+			await clickMenuItem( 'Group' );
+
+			let group = await page.$$( '[data-type="core/group"]' );
+			expect( group ).toHaveLength( 1 );
+			// Make sure the paragraph in reusable block exists.
+			expect( await getParagraphText() ).toMatch( paragraphText );
+
+			await clickBlockToolbarButton( 'Options' );
+			await clickMenuItem( 'Ungroup' );
+			group = await page.$$( '[data-type="core/group"]' );
+			expect( group ).toHaveLength( 0 );
+			// Make sure the paragraph in reusable block exists.
+			expect( await getParagraphText() ).toEqual( paragraphText );
+		} );
 	} );
 
 	describe( 'Grouping Block availability', () => {


### PR DESCRIPTION
Closes #36788 
Alternative to #37274 

There are two low level bugs that create this issue:

 - When the template part or reusable block remounts, the `onChange` handler from `useBlockSync` is called. Ideally it shouldn't be because that component will be unmounted a few milliseconds later. This is hard to solve because the store subscriptions run from the deepest component to the top level ones. Basically, it's another kind of redux zombie bug. I'm not sure we can solve that part of the bug.
 - The other part is that `blocks` shouldn't be emptied in the first place when "moving" the block to another position, this happens because controlled blocks are supposed to retrieve their block again from the "core" store when they remount again but since onChange is called (first bug above) the value in "core" store is wrong (empty blocks). I'm fixing this part of the bug in this PR: I'm making sure if a controlled block moves to a new position, it retains its inner blocks from the previous position.

 