### PR TITLE
Do not register global styles CPT in WordPress 5.9

### DIFF
--- a/lib/compat/wordpress-5.9/register-global-styles-cpt.php
+++ b/lib/compat/wordpress-5.9/register-global-styles-cpt.php
@@ -21,7 +21,7 @@ if ( ! function_exists( 'wp_get_global_settings' ) ) {
 	function register_global_styles_custom_post_type() {
 		$args = array(
 			'label'        => __( 'Global Styles', 'gutenberg' ),
-			'description'  => 'CPT to store user design tokens',
+			'description'  => 'Global styles to include in themes.',
 			'public'       => false,
 			'show_ui'      => false,
 			'show_in_rest' => false,
@@ -45,15 +45,5 @@ if ( ! function_exists( 'wp_get_global_settings' ) ) {
 		register_post_type( 'wp_global_styles', $args );
 	}
 
-	/**
-	 * Register CPT to store/access user data.
-	 *
-	 * @return void
-	 */
-	function maybe_register_global_styles_custom_post_type() {
-		if ( wp_is_block_theme() ) {
-			register_global_styles_custom_post_type();
-		}
-	}
-	add_action( 'init', 'maybe_register_global_styles_custom_post_type' );
+	add_action( 'init', 'register_global_styles_custom_post_type' );
 }

--- a/lib/compat/wordpress-5.9/register-global-styles-cpt.php
+++ b/lib/compat/wordpress-5.9/register-global-styles-cpt.php
@@ -6,34 +6,54 @@
  * @package gutenberg
  */
 
-/**
- * Registers a Custom Post Type to store the user's origin config.
- *
- * This has been ported to src/wp-includes/post.php
+/*
+ * If wp_get_global_settings is defined, it means the plugin
+ * is running on WordPress 5.9, so don't need to register the CPT
+ * as it was already done by WordPress core.
  */
-function register_global_styles_custom_post_type() {
-	$args = array(
-		'label'        => __( 'Global Styles', 'gutenberg' ),
-		'description'  => 'CPT to store user design tokens',
-		'public'       => false,
-		'show_ui'      => false,
-		'show_in_rest' => false,
-		'rewrite'      => false,
-		'capabilities' => array(
-			'read'                   => 'edit_theme_options',
-			'create_posts'           => 'edit_theme_options',
-			'edit_posts'             => 'edit_theme_options',
-			'edit_published_posts'   => 'edit_theme_options',
-			'delete_published_posts' => 'edit_theme_options',
-			'edit_others_posts'      => 'edit_theme_options',
-			'delete_others_posts'    => 'edit_theme_options',
-		),
-		'map_meta_cap' => true,
-		'supports'     => array(
-			'title',
-			'editor',
-			'revisions',
-		),
-	);
-	register_post_type( 'wp_global_styles', $args );
+if ( ! function_exists( 'wp_get_global_settings' ) ) {
+
+	/**
+	 * Registers a Custom Post Type to store the user's origin config.
+	 *
+	 * This has been ported to src/wp-includes/post.php
+	 */
+	function register_global_styles_custom_post_type() {
+		$args = array(
+			'label'        => __( 'Global Styles', 'gutenberg' ),
+			'description'  => 'CPT to store user design tokens',
+			'public'       => false,
+			'show_ui'      => false,
+			'show_in_rest' => false,
+			'rewrite'      => false,
+			'capabilities' => array(
+				'read'                   => 'edit_theme_options',
+				'create_posts'           => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
+				'edit_published_posts'   => 'edit_theme_options',
+				'delete_published_posts' => 'edit_theme_options',
+				'edit_others_posts'      => 'edit_theme_options',
+				'delete_others_posts'    => 'edit_theme_options',
+			),
+			'map_meta_cap' => true,
+			'supports'     => array(
+				'title',
+				'editor',
+				'revisions',
+			),
+		);
+		register_post_type( 'wp_global_styles', $args );
+	}
+
+	/**
+	 * Register CPT to store/access user data.
+	 *
+	 * @return void
+	 */
+	function maybe_register_global_styles_custom_post_type() {
+		if ( wp_is_block_theme() ) {
+			register_global_styles_custom_post_type();
+		}
+	}
+	add_action( 'init', 'maybe_register_global_styles_custom_post_type' );
 }

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -154,26 +154,6 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 }
 
 /**
- * Whether or not the Site Editor is available.
- *
- * @return boolean
- */
-function gutenberg_experimental_is_site_editor_available() {
-	return wp_is_block_theme();
-}
-
-/**
- * Register CPT to store/access user data.
- *
- * @return void
- */
-function gutenberg_experimental_global_styles_register_user_cpt() {
-	if ( gutenberg_experimental_is_site_editor_available() ) {
-		register_global_styles_custom_post_type();
-	}
-}
-
-/**
  * Sanitizes global styles user content removing unsafe rules.
  *
  * @param string $content Post content to filter.
@@ -293,7 +273,6 @@ if ( function_exists( 'get_block_editor_settings' ) ) {
 	add_filter( 'block_editor_settings', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
 }
 
-add_action( 'init', 'gutenberg_experimental_global_styles_register_user_cpt' );
 add_action( 'wp_enqueue_scripts', 'gutenberg_experimental_global_styles_enqueue_assets' );
 
 // kses actions&filters.

--- a/lib/init.php
+++ b/lib/init.php
@@ -94,7 +94,7 @@ add_action( 'admin_menu', 'gutenberg_menu', 9 );
  * @since 9.4.0
  */
 function gutenberg_site_editor_menu() {
-	if ( gutenberg_experimental_is_site_editor_available() ) {
+	if ( wp_is_block_theme() ) {
 		add_theme_page(
 			__( 'Editor (beta)', 'gutenberg' ),
 			sprintf(


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/36978

This PR makes sure we only register the global styles Custom Post Type in environments other than WordPress 5.9. It moves some more code to `lib/compat/wordpress-5.9`.

## How to test

- Use WordPress 5.8.
- Activate TwentyTwentyTwo or any other theme that uses the site editor.
- Load the site editor, go to the global styles sidebar and do some changes (change color background, font size, etc.)
- Save and publish.
- Go to the front-end and verify that the changes are reflected.

The expected result is that everything worked as expected and there were no errors due to the CPT not being registered.
