### PR TITLE
Link Control: Hide Transforms when no options are available

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -286,6 +286,10 @@ function navStripHTML( html ) {
  */
 
 function LinkControlTransforms( { block, transforms, replace } ) {
+	if ( ! transforms?.length ) {
+		return null;
+	}
+
 	return (
 		<div className="link-control-transform">
 			<h3 className="link-control-transform__subheading">


### PR DESCRIPTION
## Description
Hides Link Control "Transforms" component when no options are available.

## How has this been tested?
1. Add menu to a post.
2. Add submenu.
3. Link Control shouldn't display the "Transforms" control when adding a link to a submenu.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2021-12-10 at 17 19 02](https://user-images.githubusercontent.com/240569/145580459-f98fa9fa-4112-4041-a4fc-1fc72810be69.png)|![CleanShot 2021-12-10 at 17 13 04](https://user-images.githubusercontent.com/240569/145580452-ef3fbb1d-39e9-49b1-9f40-015cd83a36de.png)|

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
