### PR TITLE
Show a UI warning when user does not have permission to update/edit an existing Navigation block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -359,22 +359,6 @@ function Navigation( {
 		);
 	}
 
-	if (
-		ref &&
-		hasResolvedcanUserUpdateNavigationEntity &&
-		! canUserUpdateNavigationEntity
-	) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __(
-						'You do not have permission to edit this Navigation.'
-					) }
-				</Warning>
-			</div>
-		);
-	}
-
 	if ( ref && isNavigationMenuMissing ) {
 		// Show a warning if the selected menu is no longer available.
 		// TODO - the user should be able to select a new one?
@@ -601,6 +585,15 @@ function Navigation( {
 						</ResponsiveWrapper>
 					) }
 				</nav>
+				{ ref &&
+					hasResolvedcanUserUpdateNavigationEntity &&
+					! canUserUpdateNavigationEntity && (
+						<Warning>
+							{ __(
+								'You do not have permission to edit this Navigation. Any edits made will not be saved.'
+							) }
+						</Warning>
+					) }
 			</RecursionProvider>
 		</EntityProvider>
 	);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -586,6 +586,7 @@ function Navigation( {
 					) }
 				</nav>
 				{ ref &&
+					isEntityAvailable &&
 					hasResolvedcanUserUpdateNavigationEntity &&
 					! canUserUpdateNavigationEntity && (
 						<Warning>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -348,7 +348,7 @@ function Navigation( {
 
 			createWarningNotice(
 				__(
-					'You do not have permission to edit this Navigation. Any edits made will not be saved.'
+					'You do not have permission to edit this Menu. Any changes made will not be saved.'
 				),
 				{
 					id: noticeRef.current,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -152,7 +152,9 @@ function Navigation( {
 
 	const {
 		canUserUpdateNavigationEntity,
-		hasResolvedcanUserUpdateNavigationEntity,
+		hasResolvedCanUserUpdateNavigationEntity,
+		canUserDeleteNavigationEntity,
+		hasResolvedCanUserDeleteNavigationEntity,
 		innerBlocks,
 		isInnerBlockSelected,
 		hasSubmenus,
@@ -175,9 +177,16 @@ function Navigation( {
 				canUserUpdateNavigationEntity: ref
 					? canUser( 'update', 'navigation', ref )
 					: undefined,
-				hasResolvedcanUserUpdateNavigationEntity: hasFinishedResolution(
+				hasResolvedCanUserUpdateNavigationEntity: hasFinishedResolution(
 					'canUser',
 					[ 'update', 'navigation', ref ]
+				),
+				canUserDeleteNavigationEntity: ref
+					? canUser( 'delete', 'navigation', ref )
+					: undefined,
+				hasResolvedCanUserDeleteNavigationEntity: hasFinishedResolution(
+					'canUser',
+					[ 'delete', 'navigation', ref ]
 				),
 			};
 		},
@@ -360,7 +369,7 @@ function Navigation( {
 
 		if (
 			( isSelected || isInnerBlockSelected ) &&
-			hasResolvedcanUserUpdateNavigationEntity &&
+			hasResolvedCanUserUpdateNavigationEntity &&
 			! canUserUpdateNavigationEntity
 		) {
 			setPermissionsNotice();
@@ -368,7 +377,7 @@ function Navigation( {
 	}, [
 		ref,
 		isEntityAvailable,
-		hasResolvedcanUserUpdateNavigationEntity,
+		hasResolvedCanUserUpdateNavigationEntity,
 		canUserUpdateNavigationEntity,
 		isSelected,
 		isInnerBlockSelected,
@@ -578,18 +587,24 @@ function Navigation( {
 				</InspectorControls>
 				{ isEntityAvailable && (
 					<InspectorControls __experimentalGroup="advanced">
-						<NavigationMenuNameControl />
-						<NavigationMenuDeleteControl
-							onDelete={ () => {
-								if ( navigationArea ) {
-									setAreaMenu( 0 );
-								}
-								setAttributes( {
-									ref: undefined,
-								} );
-								setIsPlaceholderShown( true );
-							} }
-						/>
+						{ hasResolvedCanUserUpdateNavigationEntity &&
+							canUserUpdateNavigationEntity && (
+								<NavigationMenuNameControl />
+							) }
+						{ hasResolvedCanUserDeleteNavigationEntity &&
+							canUserDeleteNavigationEntity && (
+								<NavigationMenuDeleteControl
+									onDelete={ () => {
+										if ( navigationArea ) {
+											setAreaMenu( 0 );
+										}
+										setAttributes( {
+											ref: undefined,
+										} );
+										setIsPlaceholderShown( true );
+									} }
+								/>
+							) }
 					</InspectorControls>
 				) }
 				<nav { ...blockProps }>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -359,9 +359,9 @@ function Navigation( {
 		);
 	}
 
+	// Show a warning if the selected menu is no longer available.
+	// TODO - the user should be able to select a new one?
 	if ( ref && isNavigationMenuMissing ) {
-		// Show a warning if the selected menu is no longer available.
-		// TODO - the user should be able to select a new one?
 		return (
 			<div { ...blockProps }>
 				<Warning>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -351,6 +351,7 @@ function Navigation( {
 				),
 				{
 					id: noticeRef.current,
+					type: 'snackbar',
 				}
 			);
 		};

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { noop, uniqueId } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -343,7 +343,8 @@ function Navigation( {
 				return;
 			}
 
-			noticeRef.current = uniqueId( 'navBlockNoEditPermissions' );
+			noticeRef.current =
+				'block-library/core/navigation/permissions/update';
 
 			createWarningNotice(
 				__(

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -178,7 +178,7 @@ function Navigation( {
 				),
 			};
 		},
-		[ clientId ]
+		[ clientId, ref ]
 	);
 	const hasExistingNavItems = !! innerBlocks.length;
 	const {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -162,7 +162,7 @@ function Navigation( {
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};
 		},
-		[ clientId, ref ]
+		[ clientId ]
 	);
 	const hasExistingNavItems = !! innerBlocks.length;
 	const {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -26,11 +26,7 @@ import {
 	getColorClassName,
 	Warning,
 } from '@wordpress/block-editor';
-import {
-	EntityProvider,
-	useEntityProp,
-	store as coreStore,
-} from '@wordpress/core-data';
+import { EntityProvider, useEntityProp } from '@wordpress/core-data';
 
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -150,15 +146,7 @@ function Navigation( {
 		`navigationMenu/${ ref }`
 	);
 
-	const {
-		canUserUpdateNavigationEntity,
-		hasResolvedCanUserUpdateNavigationEntity,
-		canUserDeleteNavigationEntity,
-		hasResolvedCanUserDeleteNavigationEntity,
-		innerBlocks,
-		isInnerBlockSelected,
-		hasSubmenus,
-	} = useSelect(
+	const { innerBlocks, isInnerBlockSelected, hasSubmenus } = useSelect(
 		( select ) => {
 			const { getBlocks, hasSelectedInnerBlock } = select(
 				blockEditorStore
@@ -168,26 +156,10 @@ function Navigation( {
 				( block ) => block.name === 'core/navigation-submenu'
 			);
 
-			const { canUser, hasFinishedResolution } = select( coreStore );
-
 			return {
 				hasSubmenus: firstSubmenu,
 				innerBlocks: blocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-				canUserUpdateNavigationEntity: ref
-					? canUser( 'update', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserUpdateNavigationEntity: hasFinishedResolution(
-					'canUser',
-					[ 'update', 'navigation', ref ]
-				),
-				canUserDeleteNavigationEntity: ref
-					? canUser( 'delete', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserDeleteNavigationEntity: hasFinishedResolution(
-					'canUser',
-					[ 'delete', 'navigation', ref ]
-				),
 			};
 		},
 		[ clientId, ref ]
@@ -223,6 +195,10 @@ function Navigation( {
 		hasResolvedNavigationMenus,
 		navigationMenus,
 		navigationMenu,
+		canUserUpdateNavigationEntity,
+		hasResolvedCanUserUpdateNavigationEntity,
+		canUserDeleteNavigationEntity,
+		hasResolvedCanUserDeleteNavigationEntity,
 	} = useNavigationMenu( ref );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -12,6 +12,7 @@ export default function useNavigationMenu( ref ) {
 				getEditedEntityRecord,
 				getEntityRecords,
 				hasFinishedResolution,
+				canUser,
 			} = select( coreStore );
 
 			const navigationMenuSingleArgs = [
@@ -64,6 +65,20 @@ export default function useNavigationMenu( ref ) {
 				),
 				navigationMenu,
 				navigationMenus,
+				canUserUpdateNavigationEntity: ref
+					? canUser( 'update', 'navigation', ref )
+					: undefined,
+				hasResolvedCanUserUpdateNavigationEntity: hasFinishedResolution(
+					'canUser',
+					[ 'update', 'navigation', ref ]
+				),
+				canUserDeleteNavigationEntity: ref
+					? canUser( 'delete', 'navigation', ref )
+					: undefined,
+				hasResolvedCanUserDeleteNavigationEntity: hasFinishedResolution(
+					'canUser',
+					[ 'delete', 'navigation', ref ]
+				),
 			};
 		},
 		[ ref ]

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -207,6 +207,17 @@ async function getNavigationMenuRawContent() {
 // Disable reason - these tests are to be re-written.
 // eslint-disable-next-line jest/no-disabled-tests
 describe( 'Navigation', () => {
+	let username;
+	let contribUserPassword;
+
+	beforeAll( async () => {
+		username = 'contributoruser';
+
+		contribUserPassword = await createUser( username, {
+			role: 'contributor',
+		} );
+	} );
+
 	beforeEach( async () => {
 		await deleteAll( [
 			POSTS_ENDPOINT,
@@ -227,6 +238,8 @@ describe( 'Navigation', () => {
 			NAVIGATION_MENUS_ENDPOINT,
 		] );
 		await deleteAllClassicMenus();
+
+		await deleteUser( username );
 	} );
 
 	describe( 'placeholder', () => {
@@ -787,12 +800,6 @@ describe( 'Navigation', () => {
 			// The Post itself is irrelevant.
 			await publishPost();
 
-			const username = 'contributoruser';
-
-			const contribUserPassword = await createUser( username, {
-				role: 'contributor',
-			} );
-
 			// Switch to a Contributor role user - they should not have
 			// permission to update Navigations.
 			await loginUser( username, contribUserPassword );
@@ -815,9 +822,6 @@ describe( 'Navigation', () => {
 			await page.waitForXPath(
 				`//*[contains(@class, 'components-snackbar__content')][ text()="You do not have permission to edit this Menu. Any changes made will not be saved." ]`
 			);
-
-			// Tidy up after ourselves.
-			await deleteUser( username );
 
 			// Expect a console 403 for request to Navigation Areas for lower permisison users.
 			// This is because reading requires the `edit_theme_options` capability

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -819,7 +819,10 @@ describe( 'Navigation', () => {
 			// Tidy up after ourselves.
 			await deleteUser( username );
 
-			// Expect a console 403 for request to Navigation Areas.
+			// Expect a console 403 for request to Navigation Areas for lower permisison users.
+			// This is because reading requires the `edit_theme_options` capability
+			// which the Contributor level user does not have.
+			// See: https://github.com/WordPress/gutenberg/blob/4cedaf0c4abb0aeac4bfd4289d63e9889efe9733/lib/class-wp-rest-block-navigation-areas-controller.php#L81-L91.
 			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
 			expect( console ).toHaveErrored();
 		} );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -813,7 +813,7 @@ describe( 'Navigation', () => {
 
 			// Make sure the snackbar error shows up
 			await page.waitForXPath(
-				`//*[contains(@class, 'components-snackbar__content')][ text()="You do not have permission to edit this Navigation. Any edits made will not be saved." ]`
+				`//*[contains(@class, 'components-snackbar__content')][ text()="You do not have permission to edit this Menu. Any changes made will not be saved." ]`
 			);
 
 			// Tidy up after ourselves.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -17,6 +17,9 @@ import {
 	ensureSidebarOpened,
 	__experimentalRest as rest,
 	publishPost,
+	createUser,
+	loginUser,
+	deleteUser,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -111,6 +114,7 @@ const PLACEHOLDER_ACTIONS_CLASS = 'wp-block-navigation-placeholder__actions';
 const PLACEHOLDER_ACTIONS_XPATH = `//*[contains(@class, '${ PLACEHOLDER_ACTIONS_CLASS }')]`;
 const START_EMPTY_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Start empty']`;
 const ADD_ALL_PAGES_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Add all pages']`;
+const SELECT_MENU_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Select menu']`;
 
 async function turnResponsivenessOn() {
 	const blocks = await getAllBlocks();
@@ -764,6 +768,60 @@ describe( 'Navigation', () => {
 
 			await page.waitForXPath( NAV_ENTITY_SELECTOR );
 			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'Permission based restrictions', () => {
+		it( 'shows a warning if user does not have permission to edit / update Navigations', async () => {
+			await createNewPost();
+			await insertBlock( 'Navigation' );
+
+			const startEmptyButton = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+
+			// This creates an empty Navigation post type entity.
+			await startEmptyButton.click();
+
+			// Publishing the Post ensures the Navigation entity is saved.
+			// The Post itself is irrelevant.
+			await publishPost();
+
+			const username = 'contributoruser';
+
+			const contribUserPassword = await createUser( username, {
+				role: 'contributor',
+			} );
+
+			// Switch to a Contributor role user - they should not have
+			// permission to update Navigations.
+			await loginUser( username, contribUserPassword );
+
+			await createNewPost();
+
+			await insertBlock( 'Navigation' );
+
+			// Select the Navigation post created by the Admin early
+			// in the test.
+			const navigationPostCreatedByAdminName = 'Navigation';
+			const dropdown = await page.waitForXPath( SELECT_MENU_XPATH );
+			await dropdown.click();
+			const theOption = await page.waitForXPath(
+				`//*[contains(@class, 'components-menu-item__item')][ text()="${ navigationPostCreatedByAdminName }" ]`
+			);
+			await theOption.click();
+
+			// Make sure the snackbar error shows up
+			await page.waitForXPath(
+				`//*[contains(@class, 'components-snackbar__content')][ text()="You do not have permission to edit this Navigation. Any edits made will not be saved." ]`
+			);
+
+			// Tidy up after ourselves.
+			await deleteUser( username );
+
+			// Expect a console 403 for request to Navigation Areas.
+			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
+			expect( console ).toHaveErrored();
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -772,7 +772,7 @@ describe( 'Navigation', () => {
 	} );
 
 	describe( 'Permission based restrictions', () => {
-		it( 'shows a warning if user does not have permission to edit / update Navigations', async () => {
+		it( 'shows a warning if user does not have permission to edit or update navigation menus', async () => {
 			await createNewPost();
 			await insertBlock( 'Navigation' );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Explores part of https://github.com/WordPress/gutenberg/issues/36286#issuecomment-990845661 to display a warning to the user if they have insufficient permissions to _**edit/update**_ the given Navigation block.

This also disallows renaming or deleting the Navigation via the Inspector controls sidebar.

Note this does not cover the creation of brand new Navigations, but rather the scenario whereby another user has created the Navigation and a lower permission user is attempting to edit it.

## ⚠️ String changes post string freeze in WP 5.9 Beta 3

Having spoken with release leads, as requested I have raised [this Trac ticket](https://core.trac.wordpress.org/ticket/54643#ticket). 

## How has this been tested?

- Install a Plugin such as User Switching to afford easy switching between Users.
- Create a Admin and Contributor level user.
- As the Contributor, create a Post.
- As the Admin go to that post and add a Navigation block and add some items and save.
- As the Contributor, go back to the Post. You should see a notice warning that you have insufficient permission to edit.
- As the Admin go to that post and check you can still edit the Navigation as before. You should see no notices.

Also check you cannot delete or rename the Navigation using the Inspector controls under "Advanced".

Note you are not stopped from attempting to update. It might be possible to somewhat disable the component but that will be handled in a follow up.

## Screenshots <!-- if applicable -->

<img width="1510" alt="Screen Shot 2021-12-14 at 15 18 47" src="https://user-images.githubusercontent.com/444434/146026372-1b5084bf-0ac0-4c39-a192-171485bab76c.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
