### PR TITLE
Heading and Text Components are experimental

### DIFF
--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -12,7 +12,7 @@ import {
 	CardHeader,
 	CardBody,
 	CardFooter,
-	Text,
+	__experimentalText as Text,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 

--- a/packages/components/src/card/card/README.md
+++ b/packages/components/src/card/card/README.md
@@ -13,7 +13,7 @@ import {
 	CardBody,
 	CardFooter,
 	Text,
-	Heading,
+	__experimentalHeading as Heading,
 } from '@wordpress/components';
 
 function Example() {


### PR DESCRIPTION
As of 12.0.2 Heading is still experimental, check it out 👉🏽 https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/index.js#L79

**Update** 
It appear that `Text` it is also experimental