### PR TITLE
Disable Navigation block inserter support in all editors apart from the Site Editor

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -78,7 +78,7 @@
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false,
-		"inserter": true,
+		"inserter": false,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -200,6 +200,19 @@ async function getNavigationMenuRawContent() {
 	return stripPageIds( response.content.raw );
 }
 
+/**
+ * Enables the navigation block in the post editor.
+ */
+async function enableNavigationBlockInPostEditor() {
+	await page.evaluate( () => {
+		const navBlockType = wp.data
+			.select( 'core/blocks' )
+			.getBlockType( 'core/navigation' );
+		navBlockType.supports.inserter = true;
+		wp.data.dispatch( 'core/blocks' ).addBlockTypes( navBlockType );
+	} );
+}
+
 // Disable reason - these tests are to be re-written.
 // eslint-disable-next-line jest/no-disabled-tests
 describe( 'Navigation', () => {
@@ -243,8 +256,8 @@ describe( 'Navigation', () => {
 			] );
 
 			await createNewPost();
+			await enableNavigationBlockInPostEditor();
 
-			// Add the navigation block.
 			await insertBlock( 'Navigation' );
 			const allPagesButton = await page.waitForXPath(
 				ADD_ALL_PAGES_XPATH
@@ -265,6 +278,7 @@ describe( 'Navigation', () => {
 			);
 
 			await createNewPost();
+			await enableNavigationBlockInPostEditor();
 			await insertBlock( 'Navigation' );
 			await selectClassicMenu( 'Test Menu 2' );
 
@@ -276,6 +290,7 @@ describe( 'Navigation', () => {
 		it( 'creates an empty navigation block when the selected existing menu is also empty', async () => {
 			await createClassicMenu( { name: 'Test Menu 1' } );
 			await createNewPost();
+			await enableNavigationBlockInPostEditor();
 			await insertBlock( 'Navigation' );
 			await selectClassicMenu( 'Test Menu 1' );
 
@@ -288,6 +303,7 @@ describe( 'Navigation', () => {
 
 		it( 'does not display the options to create from pages or menus if there are none', async () => {
 			await createNewPost();
+			await enableNavigationBlockInPostEditor();
 
 			await insertBlock( 'Navigation' );
 			await page.waitForXPath( START_EMPTY_XPATH );
@@ -304,6 +320,8 @@ describe( 'Navigation', () => {
 
 	it( 'allows an empty navigation block to be created and manually populated using a mixture of internal and external links', async () => {
 		await createNewPost();
+		await enableNavigationBlockInPostEditor();
+
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
 		await startEmptyButton.click();
@@ -374,6 +392,8 @@ describe( 'Navigation', () => {
 
 	it( 'encodes URL when create block if needed', async () => {
 		await createNewPost();
+		await enableNavigationBlockInPostEditor();
+
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
 		await startEmptyButton.click();
@@ -489,6 +509,8 @@ describe( 'Navigation', () => {
 	it( 'renders buttons for the submenu opener elements when the block is set to open on click instead of hover', async () => {
 		await createClassicMenu( { name: 'Test Menu 2' }, menuItemsFixture );
 		await createNewPost();
+		await enableNavigationBlockInPostEditor();
+
 		await insertBlock( 'Navigation' );
 		await selectClassicMenu( 'Test Menu 2' );
 
@@ -529,6 +551,8 @@ describe( 'Navigation', () => {
 
 	it( 'Shows the quick inserter when the block contains non-navigation specific blocks', async () => {
 		await createNewPost();
+		await enableNavigationBlockInPostEditor();
+
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
 		await startEmptyButton.click();

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -15,6 +15,7 @@ import {
 import { store as editorStore } from '@wordpress/editor';
 import { store as viewportStore } from '@wordpress/viewport';
 import { getQueryArgs } from '@wordpress/url';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -81,8 +82,17 @@ export function initializeEditor( id, settings ) {
 
 	const target = document.getElementById( id );
 
+	addFilter(
+		'blocks.registerBlockType',
+		'core/edit-site/block-register',
+		addInsertersupportForNavigationBlock
+	);
+
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
 	registerCoreBlocks();
+
+	removeFilter( 'blocks.registerBlockType', 'core/edit-site/block-register' );
+
 	if ( process.env.GUTENBERG_PHASE === 2 ) {
 		__experimentalRegisterExperimentalCoreBlocks( {
 			enableFSEBlocks: true,
@@ -90,6 +100,19 @@ export function initializeEditor( id, settings ) {
 	}
 
 	reinitializeEditor( target, settings );
+}
+
+function addInsertersupportForNavigationBlock( definition ) {
+	if ( definition.name === 'core/navigation' ) {
+		return {
+			...definition,
+			supports: {
+				...definition.supports,
+				inserter: true,
+			},
+		};
+	}
+	return definition;
 }
 
 export { default as __experimentalMainDashboardButton } from './components/main-dashboard-button';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## DO NOT MERGE 

This requires more discussion prior to merging.

## Description
As discussed in https://github.com/WordPress/gutenberg/issues/36286 this PR experiments with hiding the Navigation block from the inserter in every editor apart from the Site Editor.

Why? Because the block is not currently well suited to usage by users with lower permissions. Whilst in the longer term we will seek to find better solutions, in the short term the most expedient solution is likely to be to hide the block in all editors except the Site Editor. This has the result of _effectively_ meaning the lower permission users will never encounter the block.

Why not simply unregister the block for lower permission users? Well...as users may encounter Posts which contain the Navigation block (e.g. Posts created prior to the introduction of this change, or Reusable blocks created in the Site Editor) we cannot unregister the block entirely as this would cause errors. Better to simply hide it.

Note this may mean we need to implement some basic safe guards or UI to illustrate to users with insufficient permissions that the block is not suitable for them. This is being explored separately in https://github.com/WordPress/gutenberg/pull/37286 and https://github.com/WordPress/gutenberg/pull/37289.

This PR shamelessly builds on work by @adamziel in https://github.com/WordPress/gutenberg/pull/37065 as well as my own work in https://github.com/WordPress/gutenberg/pull/37029/commits/f1d71446085e03067796fc87e1b886dace364356.

Fixes part of https://github.com/WordPress/gutenberg/issues/36286

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

* Open any editor that is not the Site Editor.
* Search for Navigation block. You should not be able to see it.
* Open the Site Editor. 
* Search for Navigation block. You _should_ be able to see it.

## Screenshots <!-- if applicable -->

#### Post Editor
<img width="1278" alt="Screen Shot 2021-12-10 at 16 22 51" src="https://user-images.githubusercontent.com/444434/145607016-458ac29e-0eae-4d08-91b0-55f7eab48933.png">

#### Site Editor
<img width="1273" alt="Screen Shot 2021-12-10 at 16 22 21" src="https://user-images.githubusercontent.com/444434/145607019-8c1db73b-0cd7-4035-93dc-21ef9ab00d04.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
