### PR TITLE
[Global Styles]: Make Blocks section more distinguishable

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -4,11 +4,14 @@
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
+	__experimentalHStack as HStack,
+	FlexItem,
 	CardBody,
 	Card,
 	CardDivider,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -33,14 +36,21 @@ function ScreenRoot() {
 			<CardBody>
 				<ItemGroup>
 					<Item>
-						<p>
-							{ __(
-								'Customize the appearance of specific blocks for the whole site.'
-							) }
-						</p>
+						{ __(
+							'Customize the appearance of specific blocks for the whole site.'
+						) }
 					</Item>
 					<NavigationButton path="/blocks">
-						{ __( 'Blocks' ) }
+						<HStack justify="space-between">
+							<FlexItem>{ __( 'Blocks' ) }</FlexItem>
+							<FlexItem>
+								<Icon
+									icon={
+										isRTL() ? chevronLeft : chevronRight
+									}
+								/>
+							</FlexItem>
+						</HStack>
 					</NavigationButton>
 				</ItemGroup>
 			</CardBody>


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/36569

This PR adds the arrow to blocks sections in Global Styles sidebar based on @mtias [comment](https://github.com/WordPress/gutenberg/issues/36569#issuecomment-989648889)

<img width="940" alt="Screenshot 2021-12-10 at 6 31 05 PM" src="https://user-images.githubusercontent.com/16275880/145608152-301ae95a-158c-4589-8c1c-690d5b3d1067.png">


## Notes

Do we want to add the arrow like here to the single blocks list? 
