### PR TITLE
Fix styles for previews and patterns

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -72,19 +72,27 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 
 		$new_global_styles = array();
 
-		$style_css = wp_get_global_stylesheet( array( 'presets' ) );
-		if ( '' !== $style_css ) {
+		$css_variables = wp_get_global_stylesheet( array( 'variables' ) );
+		if ( '' !== $css_variables ) {
 			$new_global_styles[] = array(
-				'css'            => $style_css,
+				'css'            => $css_variables,
+				'__unstableType' => 'presets',
+			);
+		}
+
+		$css_presets = wp_get_global_stylesheet( array( 'presets' ) );
+		if ( '' !== $css_presets ) {
+			$new_global_styles[] = array(
+				'css'            => $css_presets,
 				'__unstableType' => 'presets',
 			);
 		}
 
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$style_css = wp_get_global_stylesheet( array( 'styles' ) );
-			if ( '' !== $style_css ) {
+			$css_blocks = wp_get_global_stylesheet( array( 'styles' ) );
+			if ( '' !== $css_blocks ) {
 				$new_global_styles[] = array(
-					'css'            => $style_css,
+					'css'            => $css_blocks,
 					'__unstableType' => 'theme',
 				);
 			}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37292

https://github.com/WordPress/gutenberg/pull/36851/ introduced a change to how Gutenberg loads some styles: the CSS Custom Properties for the presets. We removed them from the editor settings' `style` and added them via the `enqueue_block_editor_assets` filter so that they were in the scope of both the content and the sidebar.

While this change fixed the issue we had gradients, it introduced a regression described at https://github.com/WordPress/gutenberg/issues/37292 by which some styles were missing for the previews and patterns. The reason for this appears to be that they load through iframe the styles in editor settings, hence, the CSS Custom Properties were defined in the iframes.

This PR adds back the CSS vars in the editor settings. 

## How to test

See https://github.com/WordPress/gutenberg/issues/37292
