### PR TITLE
Add margin support to paragraph blocks.

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -36,6 +36,12 @@
 		"color": {
 			"link": true
 		},
+		"spacing": {
+			"margin": [ "top", "bottom" ],
+			"__experimentalDefaultControls": {
+				"margin": true
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes #37299

As noted in the linked issue, paragraph blocks are fundamental to the design of any website. As we move closer towards Full Site Editing, the need for full control over paragraph margins has become increasingly apparent. In fact, theme developers (myself included) are resorting to "magic classes" to zero out, or modify, margins on blocks. Allowing themes to opt-in to paragraph margin support will provide greater flexibility and decrease the reliance on custom CSS in the theme's stylesheet and/or crude "hacks".

As a side benefit, margin support works in tandem with `blockGap`. With `blockGap` enabled, `margin-top` is added to every block. While this is great 90% of the time, there are instances where you would want to remove/modify this margin. Margin support for paragraphs enables this functionality. Again, no need for "magic classes" or alternative solutions.

_I have chosen to focus solely on the paragraph block in this PR, but separate PRs will be created for other block types that equally need greater dimensions support._

## How has this been tested?

1. Activate the latest version of the Twenty Twenty-Two theme. 
2. Make sure that `"appearanceTools": true` is set in theme.json
3. Add a new page and add a paragraph block. 
4. Check that the Dimensions panel is visible and you can modify top and bottom margin on the paragraph.
5. Add a custom margin and make sure it is reflected in the Editor and on the Frontend. 
6. Go back to the theme.json and add `settings.blocks.core/paragraph.spacing.margin.false`.
7. Navigate to a paragraph block in the Editor and the Dimensions panel should be gone.

## Screenshots

![image](https://user-images.githubusercontent.com/4832319/145637298-1e66d90d-4eab-48e6-9109-662e7b9fac8b.png)

## Types of changes
New Feature

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
