### PR TITLE
Accessibility improvements for Columns and Column blocks.

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -94,7 +94,7 @@ function ColumnEdit( {
 	);
 
 	const innerBlocksProps = useInnerBlocksProps(
-		{ ...blockProps, 'aria-label': label },
+		{ ...blockProps, 'aria-label': label, role: 'gridcell' },
 		{
 			templateLock,
 			allowedBlocks,

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -94,7 +94,7 @@ function ColumnEdit( {
 	);
 
 	const innerBlocksProps = useInnerBlocksProps(
-		{ ...blockProps, 'aria-label': label, role: 'gridcell' },
+		{ ...blockProps, 'aria-label': label, role: 'gridcell', 'aria-readonly': 'false' },
 		{
 			templateLock,
 			allowedBlocks,

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -81,7 +81,7 @@ function ColumnsEditContainer( {
 	} );
 	const ariaDescribedById = sprintf( '%s-description', clientId );
 	const innerBlocksProps = useInnerBlocksProps(
-		{ ...blockProps, 'aria-describedby': ariaDescribedById, role: 'grid' },
+		{ ...blockProps, 'aria-describedby': ariaDescribedById, role: 'grid', 'aria-readonly': 'false' },
 		{
 			allowedBlocks: ALLOWED_BLOCKS,
 			orientation: 'horizontal',

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -7,12 +7,13 @@ import { dropRight, get, times } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Notice,
 	PanelBody,
 	RangeControl,
 	ToggleControl,
+	VisuallyHidden,
 } from '@wordpress/components';
 
 import {
@@ -78,11 +79,15 @@ function ColumnsEditContainer( {
 	const blockProps = useBlockProps( {
 		className: classes,
 	} );
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		allowedBlocks: ALLOWED_BLOCKS,
-		orientation: 'horizontal',
-		renderAppender: false,
-	} );
+	const ariaDescribedById = sprintf( '%s-description', clientId );
+	const innerBlocksProps = useInnerBlocksProps(
+		{ ...blockProps, 'aria-describedby': ariaDescribedById, role: 'grid' },
+		{
+			allowedBlocks: ALLOWED_BLOCKS,
+			orientation: 'horizontal',
+			renderAppender: false,
+		}
+	);
 
 	return (
 		<>
@@ -120,6 +125,10 @@ function ColumnsEditContainer( {
 				</PanelBody>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />
+			<VisuallyHidden as="span" id={ ariaDescribedById }>
+				Use the Left and Right Arrow keys to navigate through the list
+				of columns.
+			</VisuallyHidden>
 		</>
 	);
 }


### PR DESCRIPTION
## Description

Possible fix for: #30620

Accessibility improvements for Columns and Column blocks.
- Render Columns as grid and Column as gridcell.
- Add note on how to navigate the Columns/Column blocks via aria-describedby.

## How has this been tested?

Tested with NVDA screen reader on Windows 10 in Firefox.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
