### PR TITLE
Fix/drag pattern

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -37,9 +37,6 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 					aria-describedby={
 						pattern.description ? descriptionId : undefined
 					}
-					draggable={ draggable }
-					onDragStart={ onDragStart }
-					onDragEnd={ onDragEnd }
 				>
 					<CompositeItem
 						role="option"
@@ -48,10 +45,18 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 						className="block-editor-block-patterns-list__item"
 						onClick={ () => onClick( pattern, blocks ) }
 					>
-						<BlockPreview
-							blocks={ blocks }
-							viewportWidth={ viewportWidth }
-						/>
+						<div
+							className="block-editor-block-patterns-preview__overlay"
+							draggable={ draggable }
+							onDragStart={ onDragStart }
+							onDragEnd={ onDragEnd }
+						></div>
+						<div className="block-editor-block-patterns-pattern__preview">
+							<BlockPreview
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+							/>
+						</div>
 						<div className="block-editor-block-patterns-list__item-title">
 							{ pattern.title }
 						</div>

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -30,9 +30,6 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 					aria-describedby={
 						pattern.description ? descriptionId : undefined
 					}
-					draggable={ draggable }
-					onDragStart={ onDragStart }
-					onDragEnd={ onDragEnd }
 				>
 					<CompositeItem
 						role="option"
@@ -41,10 +38,18 @@ function BlockPattern( { isDraggable, pattern, onClick, composite } ) {
 						className="block-editor-block-patterns-list__item"
 						onClick={ () => onClick( pattern, blocks ) }
 					>
-						<BlockPreview
-							blocks={ blocks }
-							viewportWidth={ viewportWidth }
-						/>
+						<div
+							className="block-editor-block-patterns-preview__overlay"
+							draggable={ draggable }
+							onDragStart={ onDragStart }
+							onDragEnd={ onDragEnd }
+						></div>
+						<div className="block-editor-block-patterns-pattern__preview">
+							<BlockPreview
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+							/>
+						</div>
 						<div className="block-editor-block-patterns-list__item-title">
 							{ pattern.title }
 						</div>

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -74,3 +74,17 @@
 	padding: 4px 2px 8px;
 	font-size: 12px;
 }
+
+.block-editor-block-patterns-preview__overlay {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	z-index: 1;
+}
+
+.block-editor-block-patterns-pattern__preview {
+	width: 100%;
+	height: 100%;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fixes issue: Unable to insert Patterns using Safari by drag and dropping them.

The problem was caused by the positioning of the iFrame that renders the Pattern preview, which was on top of the draggable div element. Most browsers handled it well, but not Safari. To solve this, a new draggable div element was created and placed on top of the iFrame.

Resolves #36523

## How has this been tested?
Using Safari:

1. Go to the Site Editor.
2. Open the block inserter from the top bar.
3. Open the Patterns tab bar.
4. Confirm ability to drag a Pattern into the canvas.

Repeated the steps above with Google Chrome, Firefox and Brave browsers.

<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
