### PR TITLE
Site Editor: Update save panel's cancel button from icon to visible text

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -13,7 +13,6 @@ import { useState, useCallback, useRef } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { __experimentalUseDialog as useDialog } from '@wordpress/compose';
-import { close as closeIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -223,10 +222,12 @@ export default function EntitiesSavedStates( { close } ) {
 					{ __( 'Save' ) }
 				</Button>
 				<Button
-					icon={ closeIcon }
+					className="editor-entities-saved-states__cancel-button"
 					onClick={ dismissPanel }
-					label={ __( 'Close panel' ) }
-				/>
+					variant="secondary"
+				>
+					{ __( 'Cancel' ) }
+				</Button>
 			</div>
 
 			<div className="entities-saved-states__text-prompt">

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -6,7 +6,7 @@ import { some, groupBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Flex, FlexItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useState, useCallback, useRef } from '@wordpress/element';
@@ -207,8 +207,10 @@ export default function EntitiesSavedStates( { close } ) {
 			{ ...saveDialogProps }
 			className="entities-saved-states__panel"
 		>
-			<div className="entities-saved-states__panel-header">
-				<Button
+			<Flex className="entities-saved-states__panel-header" gap={ 2 }>
+				<FlexItem
+					isBlock
+					as={ Button }
 					ref={ saveButtonRef }
 					variant="primary"
 					disabled={
@@ -220,15 +222,17 @@ export default function EntitiesSavedStates( { close } ) {
 					className="editor-entities-saved-states__save-button"
 				>
 					{ __( 'Save' ) }
-				</Button>
-				<Button
-					className="editor-entities-saved-states__cancel-button"
-					onClick={ dismissPanel }
+				</FlexItem>
+				<FlexItem
+					isBlock
+					as={ Button }
 					variant="secondary"
+					onClick={ dismissPanel }
+					className="editor-entities-saved-states__cancel-button"
 				>
 					{ __( 'Cancel' ) }
-				</Button>
-			</div>
+				</FlexItem>
+			</Flex>
 
 			<div className="entities-saved-states__text-prompt">
 				<strong>{ __( 'Are you ready to save?' ) }</strong>

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -228,7 +228,6 @@ export default function EntitiesSavedStates( { close } ) {
 					as={ Button }
 					variant="secondary"
 					onClick={ dismissPanel }
-					className="editor-entities-saved-states__cancel-button"
 				>
 					{ __( 'Cancel' ) }
 				</FlexItem>

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -45,13 +45,18 @@
 		align-items: center;
 		align-content: space-between;
 
-		.editor-entities-saved-states__save-button {
+		.components-button {
+			flex-grow: 1;
+			justify-content: center;
 			margin: auto;
 		}
 
-		.components-button.has-icon {
-			position: absolute;
-			right: $grid-unit-10;
+		.editor-entities-saved-states__cancel-button {
+			margin-left: 4px;
+		}
+
+		.editor-entities-saved-states__save-button {
+			margin-right: 4px;
 		}
 	}
 

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -41,23 +41,6 @@
 		padding-right: $grid-unit-10;
 		height: $header-height + $border-width;
 		border-bottom: $border-width solid $gray-300;
-		display: flex;
-		align-items: center;
-		align-content: space-between;
-
-		.components-button {
-			flex-grow: 1;
-			justify-content: center;
-			margin: auto;
-		}
-
-		.editor-entities-saved-states__cancel-button {
-			margin-left: 4px;
-		}
-
-		.editor-entities-saved-states__save-button {
-			margin-right: 4px;
-		}
 	}
 
 	.entities-saved-states__text-prompt {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Resolves #29886

The current save panel for site editor uses an X icon to close the panel. This is inconsistent with the post editor's cancel button. This PR updates the save panel's cancel button of site editor from the X icon to the cancel button with text, similar to post editor's button.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Open up site editor
2. Make any changes to the page
3. Click on the "Save" button to open up the save panel
4. The save and cancel buttons should be consistent with the design of the post editor panel's buttons

## Screenshots <!-- if applicable -->
| Before| After|
| ----------- | ----------- |
| ![image](https://user-images.githubusercontent.com/47470981/145699146-2c68f576-6216-468e-9f68-f75ed3edc3d2.png)      | ![image](https://user-images.githubusercontent.com/47470981/145699383-ed892dc3-9b51-4188-b906-097bf730a289.png)      |


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
