### PR TITLE
Global Styles: add blockDefault icon to navigation button 

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -8,6 +8,7 @@ import {
 	Card,
 	CardDivider,
 } from '@wordpress/components';
+import { blockDefault } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,7 +40,7 @@ function ScreenRoot() {
 							) }
 						</p>
 					</Item>
-					<NavigationButton path="/blocks">
+					<NavigationButton icon={ blockDefault } path="/blocks">
 						{ __( 'Blocks' ) }
 					</NavigationButton>
 				</ItemGroup>


### PR DESCRIPTION

Resolves:
- https://github.com/WordPress/gutenberg/issues/36569

## Description

From https://github.com/WordPress/gutenberg/issues/36569

> In the style section of blocks, there is a text named Blocks but it is clickable and can open block list. But, it's not appearing like button or clickable things. It simply display like text. We can make it even better to make it like button.

👋 What about adding an icon to the blocks navigation button to make it consistent with the navigation buttons in the sidebar, e.g., colors, layout etc?
 
The default blocks icon seems like a decent choice as it as used as the default "block" icon in the [BlockIcon component](https://github.com/WordPress/gutenberg/blob/6b4b8c45b9cfdb1a46869cdc92a2226b9a71ef0d/packages/block-editor/src/components/block-icon/index.js).


## How has this been tested?
Using a blocks-based theme, e.g., TwentyTwentyTwo, open the Site Editor Styles sidebar.

Check that the `blockDefault` icon appears next to the Blocks navigation button.

 
<img width="293" alt="Screen Shot 2021-12-13 at 12 25 08 pm" src="https://user-images.githubusercontent.com/6458278/145738684-255b8e4b-995f-4e31-8348-a281bd3d9ba2.png">


## Types of changes
Adding an icon prop to `NavigationButton`, which already accepts it.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
