### PR TITLE
Reset focus after route navigation in Site Editor

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -1,66 +1,56 @@
 /**
  * WordPress dependencies
  */
-import { SlotFillProvider } from '@wordpress/components';
-import { UnsavedChangesWarning } from '@wordpress/editor';
-import { store as noticesStore } from '@wordpress/notices';
-import { useDispatch } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
-import { PluginArea } from '@wordpress/plugins';
+import { useSelect } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
-import { Routes } from '../routes';
+import { store as editSiteStore } from '../../store';
+import { useLocation } from '../routes';
 import Editor from '../editor';
 import List from '../list';
-import NavigationSidebar from '../navigation-sidebar';
 import getIsListPage from '../../utils/get-is-list-page';
 
 export default function EditSiteApp( { reboot } ) {
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { params } = useLocation();
+	const {
+		isInserterOpen,
+		isListViewOpen,
+		sidebarIsOpened,
+		postType,
+	} = useSelect(
+		( select ) => {
+			const { isInserterOpened, isListViewOpened } = select(
+				editSiteStore
+			);
 
-	function onPluginAreaError( name ) {
-		createErrorNotice(
-			sprintf(
-				/* translators: %s: plugin name */
-				__(
-					'The "%s" plugin has encountered an error and cannot be rendered.'
-				),
-				name
-			)
-		);
-	}
-
-	return (
-		<SlotFillProvider>
-			<UnsavedChangesWarning />
-
-			<Routes>
-				{ ( { params } ) => {
-					const isListPage = getIsListPage( params );
-
-					return (
-						<>
-							{ isListPage ? (
-								<List />
-							) : (
-								<Editor onError={ reboot } />
-							) }
-							<PluginArea onError={ onPluginAreaError } />
-							{ /* Keep the instance of the sidebar to ensure focus will not be lost
-							 * when navigating to other pages. */ }
-							<NavigationSidebar
-								// Open the navigation sidebar by default when in the list page.
-								isDefaultOpen={ !! isListPage }
-								activeTemplateType={
-									isListPage ? params.postType : undefined
-								}
-							/>
-						</>
-					);
-				} }
-			</Routes>
-		</SlotFillProvider>
+			// The currently selected entity to display. Typically template or template part.
+			return {
+				isInserterOpen: isInserterOpened(),
+				isListViewOpen: isListViewOpened(),
+				sidebarIsOpened: !! select(
+					interfaceStore
+				).getActiveComplementaryArea( editSiteStore.name ),
+				postType: select( coreStore ).getPostType( params.postType ),
+			};
+		},
+		[ params.postType ]
 	);
+
+	const isListPage = getIsListPage( params );
+
+	return isListPage
+		? List.renderLayout( {
+				postType,
+				activeTemplateType: params.postType,
+		  } )
+		: Editor.renderLayout( {
+				isInserterOpen,
+				isListViewOpen,
+				sidebarIsOpened,
+				reboot,
+		  } );
 }

--- a/packages/edit-site/src/components/editor/actions.js
+++ b/packages/edit-site/src/components/editor/actions.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { EntitiesSavedStates } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function EditorActions() {
+	const isEntitiesSavedStatesOpen = useSelect(
+		( select ) => select( editSiteStore ).getIsEntitiesSavedStatesOpen(),
+		[]
+	);
+	const { setIsEntitiesSavedStatesOpen } = useDispatch( editSiteStore );
+	const openEntitiesSavedStates = useCallback(
+		() => setIsEntitiesSavedStatesOpen( true ),
+		[ setIsEntitiesSavedStatesOpen ]
+	);
+	const closeEntitiesSavedStates = useCallback(
+		() => setIsEntitiesSavedStatesOpen( false ),
+		[ setIsEntitiesSavedStatesOpen ]
+	);
+
+	return isEntitiesSavedStatesOpen ? (
+		<EntitiesSavedStates close={ closeEntitiesSavedStates } />
+	) : (
+		<div className="edit-site-editor__toggle-save-panel">
+			<Button
+				variant="secondary"
+				className="edit-site-editor__toggle-save-panel-button"
+				onClick={ openEntitiesSavedStates }
+				aria-expanded={ false }
+			>
+				{ __( 'Open save panel' ) }
+			</Button>
+		</div>
+	);
+}

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -1,37 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Popover, Button, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
 import {
-	InterfaceSkeleton,
 	ComplementaryArea,
 	store as interfaceStore,
 } from '@wordpress/interface';
-import {
-	EditorNotices,
-	EditorSnackbars,
-	EntitiesSavedStates,
-} from '@wordpress/editor';
+import { EditorNotices } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
-import {
-	ShortcutProvider,
-	store as keyboardShortcutsStore,
-} from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
  */
 import Header from '../header';
 import { SidebarComplementaryAreaFills } from '../sidebar';
-import NavigationSidebar from '../navigation-sidebar';
 import BlockEditor from '../block-editor';
 import CodeEditor from '../code-editor';
 import KeyboardShortcuts from '../keyboard-shortcuts';
-import URLQueryController from '../url-query-controller';
+import useURLQueryController from './use-url-query-controller';
 import InserterSidebar from '../secondary-sidebar/inserter-sidebar';
 import ListViewSidebar from '../secondary-sidebar/list-view-sidebar';
 import ErrorBoundary from '../error-boundary';
@@ -40,36 +30,28 @@ import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from './global-styles-renderer';
 import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import useTitle from '../routes/use-title';
+import Layout from '../layout';
+import EditorActions from './actions';
 
 const interfaceLabels = {
 	secondarySidebar: __( 'Block Library' ),
 	drawer: __( 'Navigation Sidebar' ),
 };
-
 function Editor( { onError } ) {
 	const {
-		isInserterOpen,
-		isListViewOpen,
-		sidebarIsOpened,
 		settings,
 		entityId,
 		templateType,
 		page,
 		template,
 		templateResolved,
-		isNavigationOpen,
-		previousShortcut,
-		nextShortcut,
 		editorMode,
 	} = useSelect( ( select ) => {
 		const {
-			isInserterOpened,
-			isListViewOpened,
 			getSettings,
 			getEditedPostType,
 			getEditedPostId,
 			getPage,
-			isNavigationOpened,
 			getEditorMode,
 		} = select( editSiteStore );
 		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
@@ -78,11 +60,6 @@ function Editor( { onError } ) {
 
 		// The currently selected entity to display. Typically template or template part.
 		return {
-			isInserterOpen: isInserterOpened(),
-			isListViewOpen: isListViewOpened(),
-			sidebarIsOpened: !! select(
-				interfaceStore
-			).getActiveComplementaryArea( editSiteStore.name ),
 			settings: getSettings(),
 			templateType: postType,
 			page: getPage(),
@@ -97,30 +74,11 @@ function Editor( { onError } ) {
 				  ] )
 				: false,
 			entityId: postId,
-			isNavigationOpen: isNavigationOpened(),
-			previousShortcut: select(
-				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-site/previous-region' ),
-			nextShortcut: select(
-				keyboardShortcutsStore
-			).getAllShortcutKeyCombinations( 'core/edit-site/next-region' ),
 			editorMode: getEditorMode(),
 		};
 	}, [] );
 	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-
-	const [
-		isEntitiesSavedStatesOpen,
-		setIsEntitiesSavedStatesOpen,
-	] = useState( false );
-	const openEntitiesSavedStates = useCallback(
-		() => setIsEntitiesSavedStatesOpen( true ),
-		[]
-	);
-	const closeEntitiesSavedStates = useCallback( () => {
-		setIsEntitiesSavedStatesOpen( false );
-	}, [] );
 
 	const blockContext = useMemo(
 		() => ( {
@@ -143,14 +101,6 @@ function Editor( { onError } ) {
 		[ page?.context ]
 	);
 
-	useEffect( () => {
-		if ( isNavigationOpen ) {
-			document.body.classList.add( 'is-navigation-sidebar-open' );
-		} else {
-			document.body.classList.remove( 'is-navigation-sidebar-open' );
-		}
-	}, [ isNavigationOpen ] );
-
 	useEffect(
 		function openGlobalStylesOnLoad() {
 			const searchParams = new URLSearchParams( window.location.search );
@@ -170,143 +120,90 @@ function Editor( { onError } ) {
 		templateType !== undefined &&
 		entityId !== undefined;
 
-	const secondarySidebar = () => {
-		if ( isInserterOpen ) {
-			return <InserterSidebar />;
-		}
-		if ( isListViewOpen ) {
-			return <ListViewSidebar />;
-		}
-		return null;
-	};
-
 	// Only announce the title once the editor is ready to prevent "Replace"
-	// action in <URlQueryController> from double-announcing.
+	// action in useURlQueryController from double-announcing.
 	useTitle( isReady && __( 'Editor (beta)' ) );
 
+	useURLQueryController();
+
+	if ( ! isReady ) {
+		return null;
+	}
+
 	return (
-		<>
-			<URLQueryController />
-			{ isReady && (
-				<ShortcutProvider>
-					<EntityProvider kind="root" type="site">
-						<EntityProvider
-							kind="postType"
-							type={ templateType }
-							id={ entityId }
-						>
-							<GlobalStylesProvider>
-								<BlockContextProvider value={ blockContext }>
-									<GlobalStylesRenderer />
-									<ErrorBoundary onError={ onError }>
-										<KeyboardShortcuts.Register />
-										<SidebarComplementaryAreaFills />
-										<InterfaceSkeleton
-											labels={ interfaceLabels }
-											secondarySidebar={ secondarySidebar() }
-											sidebar={
-												sidebarIsOpened && (
-													<ComplementaryArea.Slot scope="core/edit-site" />
-												)
-											}
-											drawer={
-												<NavigationSidebar.Slot />
-											}
-											header={
-												<Header
-													openEntitiesSavedStates={
-														openEntitiesSavedStates
-													}
-												/>
-											}
-											notices={ <EditorSnackbars /> }
-											content={
-												<>
-													<EditorNotices />
-													{ editorMode === 'visual' &&
-														template && (
-															<BlockEditor
-																setIsInserterOpen={
-																	setIsInserterOpened
-																}
-															/>
-														) }
-													{ editorMode === 'text' &&
-														template && (
-															<CodeEditor />
-														) }
-													{ templateResolved &&
-														! template &&
-														settings?.siteUrl &&
-														entityId && (
-															<Notice
-																status="warning"
-																isDismissible={
-																	false
-																}
-															>
-																{ __(
-																	"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-																) }
-															</Notice>
-														) }
-													<KeyboardShortcuts
-														openEntitiesSavedStates={
-															openEntitiesSavedStates
-														}
-													/>
-												</>
-											}
-											actions={
-												<>
-													{ isEntitiesSavedStatesOpen ? (
-														<EntitiesSavedStates
-															close={
-																closeEntitiesSavedStates
-															}
-														/>
-													) : (
-														<div className="edit-site-editor__toggle-save-panel">
-															<Button
-																variant="secondary"
-																className="edit-site-editor__toggle-save-panel-button"
-																onClick={
-																	openEntitiesSavedStates
-																}
-																aria-expanded={
-																	false
-																}
-															>
-																{ __(
-																	'Open save panel'
-																) }
-															</Button>
-														</div>
-													) }
-												</>
-											}
-											footer={
-												<BlockBreadcrumb
-													rootLabelText={ __(
-														'Template'
-													) }
-												/>
-											}
-											shortcuts={ {
-												previous: previousShortcut,
-												next: nextShortcut,
-											} }
-										/>
-										<WelcomeGuide />
-										<Popover.Slot />
-									</ErrorBoundary>
-								</BlockContextProvider>
-							</GlobalStylesProvider>
-						</EntityProvider>
-					</EntityProvider>
-				</ShortcutProvider>
-			) }
-		</>
+		<EntityProvider kind="root" type="site">
+			<EntityProvider
+				kind="postType"
+				type={ templateType }
+				id={ entityId }
+			>
+				<GlobalStylesProvider>
+					<BlockContextProvider value={ blockContext }>
+						<GlobalStylesRenderer />
+						<ErrorBoundary onError={ onError }>
+							<KeyboardShortcuts.Register />
+							<SidebarComplementaryAreaFills />
+							<EditorNotices />
+							{ editorMode === 'visual' && template && (
+								<BlockEditor
+									setIsInserterOpen={ setIsInserterOpened }
+								/>
+							) }
+							{ editorMode === 'text' && template && (
+								<CodeEditor />
+							) }
+							{ templateResolved &&
+								! template &&
+								settings?.siteUrl &&
+								entityId && (
+									<Notice
+										status="warning"
+										isDismissible={ false }
+									>
+										{ __(
+											"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+										) }
+									</Notice>
+								) }
+							<KeyboardShortcuts />
+						</ErrorBoundary>
+					</BlockContextProvider>
+				</GlobalStylesProvider>
+			</EntityProvider>
+		</EntityProvider>
 	);
 }
+
+Editor.renderLayout = function renderEditorLayout( {
+	sidebarIsOpened,
+	isInserterOpen,
+	isListViewOpen,
+	reboot,
+} ) {
+	let secondarySidebar = null;
+	if ( isInserterOpen ) {
+		secondarySidebar = <InserterSidebar />;
+	} else if ( isListViewOpen ) {
+		secondarySidebar = <ListViewSidebar />;
+	}
+
+	return (
+		<Layout
+			labels={ interfaceLabels }
+			sidebar={
+				sidebarIsOpened && (
+					<ComplementaryArea.Slot scope="core/edit-site" />
+				)
+			}
+			secondarySidebar={ secondarySidebar }
+			header={ <Header /> }
+			content={ <Editor onError={ reboot } /> }
+			actions={ <EditorActions /> }
+			footer={ <BlockBreadcrumb rootLabelText={ __( 'Template' ) } /> }
+		>
+			<WelcomeGuide />
+		</Layout>
+	);
+};
+
 export default Editor;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -28,7 +28,6 @@ import ErrorBoundary from '../error-boundary';
 import WelcomeGuide from '../welcome-guide';
 import { store as editSiteStore } from '../../store';
 import { GlobalStylesRenderer } from './global-styles-renderer';
-import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import useTitle from '../routes/use-title';
 import Layout from '../layout';
 import EditorActions from './actions';
@@ -137,38 +136,34 @@ function Editor( { onError } ) {
 				type={ templateType }
 				id={ entityId }
 			>
-				<GlobalStylesProvider>
-					<BlockContextProvider value={ blockContext }>
-						<GlobalStylesRenderer />
-						<ErrorBoundary onError={ onError }>
-							<KeyboardShortcuts.Register />
-							<SidebarComplementaryAreaFills />
-							<EditorNotices />
-							{ editorMode === 'visual' && template && (
-								<BlockEditor
-									setIsInserterOpen={ setIsInserterOpened }
-								/>
+				<BlockContextProvider value={ blockContext }>
+					<GlobalStylesRenderer />
+					<ErrorBoundary onError={ onError }>
+						<KeyboardShortcuts.Register />
+						<SidebarComplementaryAreaFills />
+						<EditorNotices />
+						{ editorMode === 'visual' && template && (
+							<BlockEditor
+								setIsInserterOpen={ setIsInserterOpened }
+							/>
+						) }
+						{ editorMode === 'text' && template && <CodeEditor /> }
+						{ templateResolved &&
+							! template &&
+							settings?.siteUrl &&
+							entityId && (
+								<Notice
+									status="warning"
+									isDismissible={ false }
+								>
+									{ __(
+										"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
+									) }
+								</Notice>
 							) }
-							{ editorMode === 'text' && template && (
-								<CodeEditor />
-							) }
-							{ templateResolved &&
-								! template &&
-								settings?.siteUrl &&
-								entityId && (
-									<Notice
-										status="warning"
-										isDismissible={ false }
-									>
-										{ __(
-											"You attempted to edit an item that doesn't exist. Perhaps it was deleted?"
-										) }
-									</Notice>
-								) }
-							<KeyboardShortcuts />
-						</ErrorBoundary>
-					</BlockContextProvider>
-				</GlobalStylesProvider>
+						<KeyboardShortcuts />
+					</ErrorBoundary>
+				</BlockContextProvider>
 			</EntityProvider>
 		</EntityProvider>
 	);

--- a/packages/edit-site/src/components/editor/use-url-query-controller.js
+++ b/packages/edit-site/src/components/editor/use-url-query-controller.js
@@ -10,7 +10,7 @@ import { useDispatch } from '@wordpress/data';
 import { useLocation } from '../routes';
 import { store as editSiteStore } from '../../store';
 
-export default function URLQueryController() {
+export default function useURLQueryController() {
 	const { setTemplate, setTemplatePart, setPage } = useDispatch(
 		editSiteStore
 	);

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -31,10 +31,7 @@ const preventDefault = ( event ) => {
 	event.preventDefault();
 };
 
-export default function Header( {
-	openEntitiesSavedStates,
-	isEntitiesSavedStatesOpen,
-} ) {
+export default function Header() {
 	const inserterButton = useRef();
 	const {
 		deviceType,
@@ -173,10 +170,7 @@ export default function Header( {
 							setDeviceType={ setPreviewDeviceType }
 						/>
 					) }
-					<SaveButton
-						openEntitiesSavedStates={ openEntitiesSavedStates }
-						isEntitiesSavedStatesOpen={ isEntitiesSavedStatesOpen }
-					/>
+					<SaveButton />
 					<PinnedItems.Slot scope="core/edit-site" />
 					<MoreMenu />
 				</div>

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -18,7 +18,7 @@ import { store as editSiteStore } from '../../store';
 import { SIDEBAR_BLOCK } from '../sidebar/constants';
 import { STORE_NAME } from '../../store/constants';
 
-function KeyboardShortcuts( { openEntitiesSavedStates } ) {
+function KeyboardShortcuts() {
 	const {
 		__experimentalGetDirtyEntityRecords,
 		isSavingEntityRecord,
@@ -36,9 +36,11 @@ function KeyboardShortcuts( { openEntitiesSavedStates } ) {
 		[]
 	);
 	const { redo, undo } = useDispatch( coreStore );
-	const { setIsListViewOpened, switchEditorMode } = useDispatch(
-		editSiteStore
-	);
+	const {
+		setIsListViewOpened,
+		switchEditorMode,
+		setIsEntitiesSavesStateOpen,
+	} = useDispatch( editSiteStore );
 	const { enableComplementaryArea, disableComplementaryArea } = useDispatch(
 		interfaceStore
 	);
@@ -53,7 +55,7 @@ function KeyboardShortcuts( { openEntitiesSavedStates } ) {
 		);
 
 		if ( ! isSaving && isDirty ) {
-			openEntitiesSavedStates();
+			setIsEntitiesSavesStateOpen( true );
 		}
 	} );
 

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -19,6 +19,7 @@ import { PluginArea } from '@wordpress/plugins';
  * Internal dependencies
  */
 import NavigationSidebar from '../navigation-sidebar';
+import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import { store as editSiteStore } from '../../store';
 
 function Layout( {
@@ -73,24 +74,26 @@ function Layout( {
 		<ShortcutProvider>
 			<SlotFillProvider>
 				<EntityProvider kind="root" type="site">
-					<UnsavedChangesWarning />
-					<InterfaceSkeleton
-						drawer={
-							<NavigationSidebar
-								isDefaultOpen={ isNavigationDefaultOpen }
-								activeTemplateType={ activeTemplateType }
-							/>
-						}
-						notices={ <EditorSnackbars /> }
-						shortcuts={ {
-							previous: previousShortcut,
-							next: nextShortcut,
-						} }
-						{ ...props }
-					/>
-					<Popover.Slot />
-					<PluginArea onError={ onPluginAreaError } />
-					{ children }
+					<GlobalStylesProvider>
+						<UnsavedChangesWarning />
+						<InterfaceSkeleton
+							drawer={
+								<NavigationSidebar
+									isDefaultOpen={ isNavigationDefaultOpen }
+									activeTemplateType={ activeTemplateType }
+								/>
+							}
+							notices={ <EditorSnackbars /> }
+							shortcuts={ {
+								previous: previousShortcut,
+								next: nextShortcut,
+							} }
+							{ ...props }
+						/>
+						<Popover.Slot />
+						<PluginArea onError={ onPluginAreaError } />
+						{ children }
+					</GlobalStylesProvider>
 				</EntityProvider>
 			</SlotFillProvider>
 		</ShortcutProvider>

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { SlotFillProvider, Popover } from '@wordpress/components';
+import { EntityProvider } from '@wordpress/core-data';
+import { InterfaceSkeleton } from '@wordpress/interface';
+import { EditorSnackbars, UnsavedChangesWarning } from '@wordpress/editor';
+import {
+	ShortcutProvider,
+	store as keyboardShortcutsStore,
+} from '@wordpress/keyboard-shortcuts';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { PluginArea } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import NavigationSidebar from '../navigation-sidebar';
+import { store as editSiteStore } from '../../store';
+
+function Layout( {
+	children,
+	isNavigationDefaultOpen,
+	activeTemplateType,
+	...props
+} ) {
+	const { isNavigationOpen, previousShortcut, nextShortcut } = useSelect(
+		( select ) => {
+			const { isNavigationOpened } = select( editSiteStore );
+			const { getAllShortcutKeyCombinations } = select(
+				keyboardShortcutsStore
+			);
+
+			// The currently selected entity to display. Typically template or template part.
+			return {
+				isNavigationOpen: isNavigationOpened(),
+				previousShortcut: getAllShortcutKeyCombinations(
+					'core/edit-site/previous-region'
+				),
+				nextShortcut: getAllShortcutKeyCombinations(
+					'core/edit-site/next-region'
+				),
+			};
+		},
+		[]
+	);
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	useEffect( () => {
+		if ( isNavigationOpen ) {
+			document.body.classList.add( 'is-navigation-sidebar-open' );
+		} else {
+			document.body.classList.remove( 'is-navigation-sidebar-open' );
+		}
+	}, [ isNavigationOpen ] );
+
+	function onPluginAreaError( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
+
+	return (
+		<ShortcutProvider>
+			<SlotFillProvider>
+				<EntityProvider kind="root" type="site">
+					<UnsavedChangesWarning />
+					<InterfaceSkeleton
+						drawer={
+							<NavigationSidebar
+								isDefaultOpen={ isNavigationDefaultOpen }
+								activeTemplateType={ activeTemplateType }
+							/>
+						}
+						notices={ <EditorSnackbars /> }
+						shortcuts={ {
+							previous: previousShortcut,
+							next: nextShortcut,
+						} }
+						{ ...props }
+					/>
+					<Popover.Slot />
+					<PluginArea onError={ onPluginAreaError } />
+					{ children }
+				</EntityProvider>
+			</SlotFillProvider>
+		</ShortcutProvider>
+	);
+}
+
+export default Layout;

--- a/packages/edit-site/src/components/list/header.js
+++ b/packages/edit-site/src/components/list/header.js
@@ -9,8 +9,12 @@ import { __experimentalHeading as Heading } from '@wordpress/components';
  * Internal dependencies
  */
 import AddNewTemplate from '../add-new-template';
+import { useLocation } from '../routes';
 
-export default function Header( { templateType } ) {
+export default function Header() {
+	const {
+		params: { postType: templateType },
+	} = useLocation();
 	const postType = useSelect(
 		( select ) => select( coreStore ).getPostType( templateType ),
 		[ templateType ]

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -1,60 +1,23 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-import { InterfaceSkeleton } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
-import { EditorSnackbars } from '@wordpress/editor';
 
 /**
  * Internal dependencies
  */
-import useRegisterShortcuts from './use-register-shortcuts';
 import Header from './header';
-import NavigationSidebar from '../navigation-sidebar';
 import Table from './table';
-import { store as editSiteStore } from '../../store';
-import { useLocation } from '../routes';
-import useTitle from '../routes/use-title';
+import Layout from '../layout';
 
-export default function List() {
-	const {
-		params: { postType: templateType },
-	} = useLocation();
+function List() {
+	return <Table />;
+}
 
-	useRegisterShortcuts();
-
-	const { previousShortcut, nextShortcut, isNavigationOpen } = useSelect(
-		( select ) => {
-			return {
-				previousShortcut: select(
-					keyboardShortcutsStore
-				).getAllShortcutKeyCombinations(
-					'core/edit-site/previous-region'
-				),
-				nextShortcut: select(
-					keyboardShortcutsStore
-				).getAllShortcutKeyCombinations( 'core/edit-site/next-region' ),
-				isNavigationOpen: select( editSiteStore ).isNavigationOpened(),
-			};
-		},
-		[]
-	);
-
-	const postType = useSelect(
-		( select ) => select( coreStore ).getPostType( templateType ),
-		[ templateType ]
-	);
-
-	useTitle( postType?.labels?.name );
-
+List.renderLayout = function renderListLayout( {
+	postType,
+	activeTemplateType,
+} ) {
 	// `postType` could load in asynchronously. Only provide the detailed region labels if
 	// the postType has loaded, otherwise `InterfaceSkeleton` will fallback to the defaults.
 	const itemsListLabel = postType?.labels?.items_list;
@@ -74,22 +37,18 @@ export default function List() {
 		: undefined;
 
 	return (
-		<InterfaceSkeleton
-			className={ classnames( 'edit-site-list', {
-				'is-navigation-open': isNavigationOpen,
-			} ) }
+		<Layout
+			isNavigationDefaultOpen
+			activeTemplateType={ activeTemplateType }
+			className="edit-site-list"
 			labels={ {
 				drawer: __( 'Navigation Sidebar' ),
 				...detailedRegionLabels,
 			} }
-			header={ <Header templateType={ templateType } /> }
-			drawer={ <NavigationSidebar.Slot /> }
-			notices={ <EditorSnackbars /> }
-			content={ <Table templateType={ templateType } /> }
-			shortcuts={ {
-				previous: previousShortcut,
-				next: nextShortcut,
-			} }
+			header={ <Header /> }
+			content={ <List /> }
 		/>
 	);
-}
+};
+
+export default List;

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -9,8 +9,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import Header from './header';
 import Table from './table';
 import Layout from '../layout';
+import useRegisterShortcuts from './use-register-shortcuts';
 
 function List() {
+	useRegisterShortcuts();
+
 	return <Table />;
 }
 

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -118,7 +118,7 @@
 	}
 }
 
-.edit-site-list.is-navigation-open .components-snackbar-list {
+body.is-navigation-sidebar-open .edit-site-list .components-snackbar-list {
 	@include break-medium() {
 		margin-left: $nav-sidebar-width;
 	}

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -13,11 +13,15 @@ import { decodeEntities } from '@wordpress/html-entities';
 /**
  * Internal dependencies
  */
+import { useLocation } from '../routes';
 import Link from '../routes/link';
 import Actions from './actions';
 import AddedBy from './added-by';
 
-export default function Table( { templateType } ) {
+export default function Table() {
+	const {
+		params: { postType: templateType },
+	} = useLocation();
 	const { templates, isLoading, postType } = useSelect(
 		( select ) => {
 			const {

--- a/packages/edit-site/src/components/navigation-sidebar/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/index.js
@@ -18,11 +18,6 @@ export const {
 	Slot: NavigationPanelPreviewSlot,
 } = createSlotFill( 'EditSiteNavigationPanelPreview' );
 
-const {
-	Fill: NavigationSidebarFill,
-	Slot: NavigationSidebarSlot,
-} = createSlotFill( 'EditSiteNavigationSidebar' );
-
 function NavigationSidebar( { isDefaultOpen = false, activeTemplateType } ) {
 	const isDesktopViewport = useViewportMatch( 'medium' );
 	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
@@ -35,14 +30,12 @@ function NavigationSidebar( { isDefaultOpen = false, activeTemplateType } ) {
 	);
 
 	return (
-		<NavigationSidebarFill>
+		<>
 			<NavigationToggle />
 			<NavigationPanel activeItem={ activeTemplateType } />
 			<NavigationPanelPreviewSlot />
-		</NavigationSidebarFill>
+		</>
 	);
 }
-
-NavigationSidebar.Slot = NavigationSidebarSlot;
 
 export default NavigationSidebar;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -104,6 +104,7 @@ function NavigationToggle( { icon } ) {
 				aria-pressed={ isNavigationOpen }
 				onClick={ toggleNavigationPanel }
 				showTooltip
+				data-route-change-focus-target=""
 			>
 				{ buttonIcon }
 			</Button>

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import { useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
 import {
 	Button,
 	Icon,
@@ -47,16 +46,6 @@ function NavigationToggle( { icon } ) {
 	const { setIsNavigationPanelOpened } = useDispatch( editSiteStore );
 
 	const disableMotion = useReducedMotion();
-
-	const navigationToggleRef = useRef();
-
-	useEffect( () => {
-		// TODO: Remove this effect when alternative solution is merged.
-		// See: https://github.com/WordPress/gutenberg/pull/37314
-		if ( ! isNavigationOpen ) {
-			navigationToggleRef.current.focus();
-		}
-	}, [ isNavigationOpen ] );
 
 	const toggleNavigationPanel = () =>
 		setIsNavigationPanelOpened( ! isNavigationOpen );
@@ -104,7 +93,6 @@ function NavigationToggle( { icon } ) {
 			<Button
 				className={ classes }
 				label={ __( 'Toggle navigation' ) }
-				ref={ navigationToggleRef }
 				// isPressed will add unwanted styles.
 				aria-pressed={ isNavigationOpen }
 				onClick={ toggleNavigationPanel }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import {
@@ -22,6 +23,7 @@ import { useReducedMotion } from '@wordpress/compose';
  * Internal dependencies
  */
 import { store as editSiteStore } from '../../../store';
+import useResetFocusOnRouteChange from '../../routes/use-reset-focus-on-route-change';
 
 function NavigationToggle( { icon } ) {
 	const { isNavigationOpen, isRequestingSiteIcon, siteIconUrl } = useSelect(
@@ -88,6 +90,9 @@ function NavigationToggle( { icon } ) {
 		'has-icon': siteIconUrl,
 	} );
 
+	const buttonRef = useRef();
+	useResetFocusOnRouteChange( buttonRef );
+
 	return (
 		<motion.div
 			className={
@@ -104,7 +109,7 @@ function NavigationToggle( { icon } ) {
 				aria-pressed={ isNavigationOpen }
 				onClick={ toggleNavigationPanel }
 				showTooltip
-				data-route-change-focus-target=""
+				ref={ buttonRef }
 			>
 				{ buttonIcon }
 			</Button>

--- a/packages/edit-site/src/components/routes/index.js
+++ b/packages/edit-site/src/components/routes/index.js
@@ -46,7 +46,7 @@ export function Routes( { children } ) {
 	return (
 		<HistoryContext.Provider value={ history }>
 			<RoutesContext.Provider value={ location }>
-				{ children( location ) }
+				{ children }
 			</RoutesContext.Provider>
 		</HistoryContext.Provider>
 	);

--- a/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
+++ b/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { Action } from 'history';
+
+/**
  * WordPress dependencies
  */
 import { useRef, useEffect } from '@wordpress/element';
@@ -6,19 +11,30 @@ import { useRef, useEffect } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useLocation } from './index';
+import { useLocation, useHistory } from './index';
 
 export default function useResetFocusOnRouteChange( targetRef ) {
+	const history = useHistory();
 	const location = useLocation();
 	const isInitialPageLoadRef = useRef( true );
+	const expectRedirectionRef = useRef( false );
 
 	useEffect( () => {
 		// Don't focus for initial page load.
 		if ( isInitialPageLoadRef.current ) {
 			isInitialPageLoadRef.current = false;
+			expectRedirectionRef.current = true;
 			return;
+		}
+		// Don't focus for the initial page redirection.
+		// TODO: This can be removed once #36873 is resolved.
+		if ( expectRedirectionRef.current ) {
+			expectRedirectionRef.current = false;
+			if ( history.action === Action.Replace ) {
+				return;
+			}
 		}
 
 		targetRef.current?.focus();
-	}, [ location, targetRef ] );
+	}, [ location, targetRef, history ] );
 }

--- a/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
+++ b/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useLocation } from './index';
+
+export default function useResetFocusOnRouteChange( targetRef ) {
+	const location = useLocation();
+	const isInitialPageLoadRef = useRef( true );
+
+	useEffect( () => {
+		// Don't focus for initial page load.
+		if ( isInitialPageLoadRef.current ) {
+			isInitialPageLoadRef.current = false;
+			return;
+		}
+
+		targetRef.current?.focus();
+	}, [ location, targetRef ] );
+}

--- a/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
+++ b/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js
@@ -35,6 +35,11 @@ export default function useResetFocusOnRouteChange( targetRef ) {
 			}
 		}
 
-		targetRef.current?.focus();
+		const activeElement = targetRef.current?.ownerDocument.activeElement;
+
+		// Don't refocus if the activeElement is still on the page (like NavLink).
+		if ( ! activeElement || activeElement === document.body ) {
+			targetRef.current?.focus();
+		}
 	}, [ location, targetRef, history ] );
 }

--- a/packages/edit-site/src/components/save-button/index.js
+++ b/packages/edit-site/src/components/save-button/index.js
@@ -6,28 +6,37 @@ import { some } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 
-export default function SaveButton( {
-	openEntitiesSavedStates,
-	isEntitiesSavedStatesOpen,
-} ) {
-	const { isDirty, isSaving } = useSelect( ( select ) => {
-		const {
-			__experimentalGetDirtyEntityRecords,
-			isSavingEntityRecord,
-		} = select( coreStore );
-		const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
-		return {
-			isDirty: dirtyEntityRecords.length > 0,
-			isSaving: some( dirtyEntityRecords, ( record ) =>
-				isSavingEntityRecord( record.kind, record.name, record.key )
-			),
-		};
-	}, [] );
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
+
+export default function SaveButton() {
+	const { isDirty, isSaving, isEntitiesSavedStatesOpen } = useSelect(
+		( select ) => {
+			const {
+				__experimentalGetDirtyEntityRecords,
+				isSavingEntityRecord,
+			} = select( coreStore );
+			const dirtyEntityRecords = __experimentalGetDirtyEntityRecords();
+			return {
+				isDirty: dirtyEntityRecords.length > 0,
+				isSaving: some( dirtyEntityRecords, ( record ) =>
+					isSavingEntityRecord( record.kind, record.name, record.key )
+				),
+				isEntitiesSavedStatesOpen: select(
+					editSiteStore
+				).getIsEntitiesSavedStatesOpen(),
+			};
+		},
+		[]
+	);
+	const { setIsEntitiesSavedStatesOpen } = useDispatch( editSiteStore );
 
 	const disabled = ! isDirty || isSaving;
 
@@ -40,7 +49,11 @@ export default function SaveButton( {
 				aria-expanded={ isEntitiesSavedStatesOpen }
 				disabled={ disabled }
 				isBusy={ isSaving }
-				onClick={ disabled ? undefined : openEntitiesSavedStates }
+				onClick={
+					disabled
+						? undefined
+						: () => setIsEntitiesSavedStatesOpen( true )
+				}
 			>
 				{ __( 'Save' ) }
 			</Button>

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -22,6 +22,7 @@ import { getQueryArgs } from '@wordpress/url';
  */
 import './hooks';
 import { store as editSiteStore } from './store';
+import { Routes } from './components/routes';
 import EditSiteApp from './components/app';
 import getIsListPage from './utils/get-is-list-page';
 import redirectToHomepage from './components/routes/redirect-to-homepage';
@@ -87,7 +88,12 @@ export async function reinitializeEditor( target, settings ) {
 		}
 	}
 
-	render( <EditSiteApp reboot={ reboot } />, target );
+	render(
+		<Routes>
+			<EditSiteApp reboot={ reboot } />
+		</Routes>,
+		target
+	);
 }
 
 /**

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -463,3 +463,10 @@ export const switchEditorMode = ( mode ) => ( { dispatch, registry } ) => {
 		speak( __( 'Mosaic view selected' ), 'assertive' );
 	}
 };
+
+export function setIsEntitiesSavedStatesOpen( isOpen ) {
+	return {
+		type: 'SET_IS_ENTITIES_SAVED_STATES_OPEN',
+		isOpen,
+	};
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -212,6 +212,15 @@ export function listViewPanel( state = false, action ) {
 	return state;
 }
 
+export function isEntitiesSavedStatesOpen( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_IS_ENTITIES_SAVED_STATES_OPEN':
+			return action.isOpen;
+		default:
+			return state;
+	}
+}
+
 export default combineReducers( {
 	preferences,
 	deviceType,
@@ -221,4 +230,5 @@ export default combineReducers( {
 	navigationPanel,
 	blockInserterPanel,
 	listViewPanel,
+	isEntitiesSavedStatesOpen,
 } );

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -341,3 +341,12 @@ export const getCurrentTemplateTemplateParts = createRegistrySelector(
 export function getEditorMode( state ) {
 	return state.preferences.editorMode || 'visual';
 }
+
+/**
+ * Returns if the entities saves states is open.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} Is entities saved states open.
+ */
+export const getIsEntitiesSavedStatesOpen = ( state ) =>
+	state.isEntitiesSavedStatesOpen;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Part of https://github.com/WordPress/gutenberg/issues/36597. Alternative to https://github.com/WordPress/gutenberg/pull/37265.

Continue from #36488, this PR refactors a large part of the original PR to optimize the render times needed when switching to another route.

This PR will reset the focus to the navigation toggle button on route change. In order to prevent it from focusing on the button on initial page load, we create a flag `isInitialPageLoadRef` and set it to false after the first render.

https://github.com/WordPress/gutenberg/blob/bdb289a158a6f4dd41c20bcc1a8f5eeec5e5963c/packages/edit-site/src/components/routes/use-reset-focus-on-route-change.js#L13-L20

However, the button will remount whenever we switch from list page to the editor or the other way around. It causes `isInitialPageLoadRef` to be reset to `true` after remount, thus skipping the focus.

We could do some weird hack to make it work with minimal efforts, but a more robust fix will be to prevent the button from remounting in the first place. The button only remounts because we change the "parent" of it after switching to a different route. For instance, switching 
from `<List><NavigationToggle /></List>` to `<Editor><NavigationToggle /></Editor>`.

It's called ["Reparenting"](https://github.com/facebook/react/issues/3965) in React, changing the parent of an element will inevitably remount itself. There are only a few options we could do to bypass that. The basic ideas are the same though, **don't re-parent the element**.

The approach this PR takes is to use a `renderLayout` function to render the route layout rather than using yet another component. The advantage of render function here is that it doesn't count as a _parent_, since there's no component being rendered. The disadvantage is that we can't use hooks inside the render function, so we'll have to pass the state from its parent.

First, we define the `renderLayout` function on the Route entry component:

https://github.com/WordPress/gutenberg/blob/bdb289a158a6f4dd41c20bcc1a8f5eeec5e5963c/packages/edit-site/src/components/list/index.js#L20-L55

Then, we just have to call the render function with all the required states in the parent (`<App>`):

https://github.com/WordPress/gutenberg/blob/bdb289a158a6f4dd41c20bcc1a8f5eeec5e5963c/packages/edit-site/src/components/app/index.js#L46-L49

Since that `<Layout>` will never re-parent, neither will `<InterfaceSkeleton>` and `<NavigationToggle>` underneath it, they will not remount on route change anymore. The fix for focus reset then become trivial and predictable.

Note that this refactor doesn't just benefit this focus fix, but also improves the overall performance of the editor, since that it doesn't have to do unnecessary remounts anymore.

This is a big change though, so if we can't get enough testing, I agree to postpone it after 5.9. We can fix focus management in another smaller PR (like #37265).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate `tt1-blocks` theme or any other block-based theme
2. Visit Appearance -> Editor
3. On initial page load, the focus shouldn't focus on the navigation toggle button (should it?)
4. Toggle the navigation button to open the sidebar
5. Visit the "Templates" or "Template Parts" link
6. After the navigation, the focus should reset to the navigation toggle button
7. Select any item in the list page to go to the editor
8. After the navigation, the focus should reset to the navigation toggle button

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
