### PR TITLE
Only use block markup for comment form button when using a block theme

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -55,8 +55,10 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  * @return array Returns the modified fields.
  */
 function gutenberg_comment_form_block_form_defaults( $fields ) {
-	$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
-	$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+	if ( wp_is_block_theme() ) {
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+	}
 
 	return $fields;
 }

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -75,8 +75,10 @@ add_action( 'init', 'register_block_core_post_comments' );
  * @return array Returns the modified fields.
  */
 function gutenberg_post_comments_block_form_defaults( $fields ) {
-	$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
-	$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+	if ( wp_is_block_theme() ) {
+		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
+		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
+	}
 
 	return $fields;
 }


### PR DESCRIPTION
## Description

Follows https://github.com/WordPress/gutenberg/pull/37245.

Fixes a small bug I noticed thanks to a failing test in https://github.com/WordPress/wordpress-develop/pull/2048.

Steps to reproduce the bug:

1. Activate an older theme e.g. Twenty Ten.
2. Go to a post on the frontend.
3. Look at the "Post Comment" button.

It looks weird because we're erroneously changing the markup to be a Gutenberg button. We should only do that if the current theme is a block theme.

## How has this been tested?

As above.

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->