### PR TITLE
Navigation: Fix vertical alignment of page list in modal.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -427,6 +427,7 @@ button.wp-block-navigation-item__content {
 
 			// Always align the contents of the menu to the top.
 			&,
+			.wp-block-page-list,
 			.wp-block-navigation__container {
 				justify-content: flex-start;
 			}


### PR DESCRIPTION
## Description

Followup to #36991. That PR fixed the contents of the modal overlay menu to always be top aligned, despite what might have been inherited. 

But the page list can still be aligned wrongly. Here's a justified-right menu, which should justify the contents of the modal right, but still keep it towards the top:
<img width="1392" alt="before, menu" src="https://user-images.githubusercontent.com/1204802/145798001-c43d666f-0e1e-4877-8b99-8c728eef366c.png">

Here's the page list showing the bug, being bottom justified:

<img width="1392" alt="before, page list" src="https://user-images.githubusercontent.com/1204802/145798036-51445440-d321-4754-8ea2-f2c47795e382.png">

Here's the bug, fixed:

<img width="1392" alt="after, page list" src="https://user-images.githubusercontent.com/1204802/145798051-f556e94e-c1ed-41bb-9bb1-9cc1eaf03c0f.png">

## How has this been tested?

Insert a navigation menu that's set to always be responsive, have a page list inside, justify it right. The contents of the modal should still be top aligned.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
