### PR TITLE
Shortcuts: don't fire keydown handlers outside block editor content area

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -66,7 +66,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		return (
 			<div className="block-editor-block-inspector">
 				<MultiSelectionInspector />
-				<InspectorControls.Slot />
+				<InspectorControls.Slot bubblesVirtually={ false } />
 			</div>
 		);
 	}

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -21,20 +21,6 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import { usePopoverScroll } from './use-popover-scroll';
 
 /**
- * Returns true if the container contains the document active element.
- *
- * @param {HTMLElement} container An HTML element.
- *
- * @return {boolean} Whether the container contains the currently active element in the document.
- */
-const hasFocusWithin = ( container ) => {
-	return (
-		!! container &&
-		!! container?.contains( container?.ownerDocument?.activeElement )
-	);
-};
-
-/**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
@@ -68,13 +54,6 @@ export default function BlockTools( {
 	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
-		if (
-			__unstableContentRef?.current &&
-			! hasFocusWithin( __unstableContentRef?.current )
-		) {
-			return;
-		}
-
 		if ( isMatch( 'core/block-editor/move-up', event ) ) {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -28,7 +28,10 @@ import { usePopoverScroll } from './use-popover-scroll';
  * @return {boolean} Whether the container contains the currently active element in the document.
  */
 const hasFocusWithin = ( container ) => {
-	return !! container?.contains( container?.ownerDocument?.activeElement );
+	return (
+		!! container &&
+		!! container?.contains( container?.ownerDocument?.activeElement )
+	);
 };
 
 /**

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -21,6 +21,17 @@ import BlockContextualToolbar from './block-contextual-toolbar';
 import { usePopoverScroll } from './use-popover-scroll';
 
 /**
+ * Returns true if the container contains the document active element.
+ *
+ * @param {HTMLElement} container An HTML element.
+ *
+ * @return {boolean} Whether the container contains the currently document active element.
+ */
+const hasFocusWithin = ( container ) => {
+	return !! container?.contains( container?.ownerDocument?.activeElement );
+};
+
+/**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
  * insertion point and a slot for the inline rich text toolbar). Must be wrapped
  * around the block content and editor styles wrapper or iframe.
@@ -54,6 +65,10 @@ export default function BlockTools( {
 	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
+		if ( ! hasFocusWithin( __unstableContentRef?.current ) ) {
+			return;
+		}
+
 		if ( isMatch( 'core/block-editor/move-up', event ) ) {
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length ) {

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -25,7 +25,7 @@ import { usePopoverScroll } from './use-popover-scroll';
  *
  * @param {HTMLElement} container An HTML element.
  *
- * @return {boolean} Whether the container contains the currently document active element.
+ * @return {boolean} Whether the container contains the currently active element in the document.
  */
 const hasFocusWithin = ( container ) => {
 	return !! container?.contains( container?.ownerDocument?.activeElement );

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -65,7 +65,10 @@ export default function BlockTools( {
 	} = useDispatch( blockEditorStore );
 
 	function onKeyDown( event ) {
-		if ( ! hasFocusWithin( __unstableContentRef?.current ) ) {
+		if (
+			__unstableContentRef?.current &&
+			! hasFocusWithin( __unstableContentRef?.current )
+		) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/inspector-controls/block-support-slot-container.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-slot-container.js
@@ -4,9 +4,17 @@
 import { __experimentalToolsPanelContext as ToolsPanelContext } from '@wordpress/components';
 import { useContext } from '@wordpress/element';
 
-export default function BlockSupportSlotContainer( { Slot, ...props } ) {
+export default function BlockSupportSlotContainer( {
+	Slot,
+	bubblesVirtually,
+	...props
+} ) {
 	const toolsPanelContext = useContext( ToolsPanelContext );
 	return (
-		<Slot { ...props } fillProps={ toolsPanelContext } bubblesVirtually />
+		<Slot
+			{ ...props }
+			fillProps={ toolsPanelContext }
+			bubblesVirtually={ bubblesVirtually }
+		/>
 	);
 }

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -14,6 +14,7 @@ import groups from './groups';
 export default function InspectorControlsSlot( {
 	__experimentalGroup: group = 'default',
 	label,
+	bubblesVirtually = true,
 	...props
 } ) {
 	const Slot = groups[ group ]?.Slot;
@@ -31,10 +32,14 @@ export default function InspectorControlsSlot( {
 	if ( label ) {
 		return (
 			<BlockSupportToolsPanel group={ group } label={ label }>
-				<BlockSupportSlotContainer { ...props } Slot={ Slot } />
+				<BlockSupportSlotContainer
+					{ ...props }
+					Slot={ Slot }
+					bubblesVirtually={ bubblesVirtually }
+				/>
 			</BlockSupportToolsPanel>
 		);
 	}
 
-	return <Slot { ...props } bubblesVirtually />;
+	return <Slot { ...props } bubblesVirtually={ bubblesVirtually } />;
 }


### PR DESCRIPTION
Let's see if this PR resolves:
- https://github.com/WordPress/gutenberg/issues/37316


## Description

Just an experiment. Don't take it too seriously... unless it works that is :trollface: 

Prevent block editor keyboard shortcuts where the block editor itself does not have focus.

The concept rides on the claim that we shouldn't fire editor-specific callbacks where the editor area, or its children, are not focussed.


## How has this been tested?

When writing/editing in the block editor, you should be able to use all the [Block Tool keyboard shortcuts](https://github.com/WordPress/gutenberg/blob/5864da50b5b1e3e13af49d061a119303be2d3ad9/packages/block-editor/src/components/block-tools/index.js):

<img width="471" alt="Screen Shot 2021-12-14 at 2 32 30 pm" src="https://user-images.githubusercontent.com/6458278/145928293-53d6b187-e2e1-4a38-ae88-92f90b700aa1.png">

Check that deleting control values in the Block Inspector does not affect the Block Editor:

1. Add a few paragraph blocks.
2. Multi-select your new blocks and click on the color selector. 
3. Show the detailed input and delete the content. 
4. Your selected blocks should not disappear.

## Screenshots <!-- if applicable -->

| Before | After |
| ------------- | ------------- |
| ![before](https://user-images.githubusercontent.com/6458278/145807527-a7940066-03db-4023-88d9-50ea5dbfe505.gif) | ![after](https://user-images.githubusercontent.com/6458278/145807541-7d5fd6a3-e384-45f4-8a1e-92b1c92fde8a.gif)  |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
