### PR TITLE
Packages: Include `@babel/core` as a dependency where applicable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19721,6 +19721,7 @@
 			"version": "file:packages/scripts",
 			"dev": true,
 			"requires": {
+				"@babel/core": "^7.16.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 				"@svgr/webpack": "^5.5.0",
 				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -49,8 +49,9 @@
 		"requireindex": "^1.2.0"
 	},
 	"peerDependencies": {
-		"eslint": "^8",
-		"typescript": "^4"
+		"@babel/core": ">=7",
+		"eslint": "=>8",
+		"typescript": "=>4"
 	},
 	"peerDependenciesMeta": {
 		"typescript": {

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -38,6 +38,7 @@
 		"enzyme-to-json": "^3.4.4"
 	},
 	"peerDependencies": {
+		"@babel/core": ">=7",
 		"jest": ">=26"
 	},
 	"publishConfig": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -32,6 +32,7 @@
 		"wp-scripts": "./bin/wp-scripts.js"
 	},
 	"dependencies": {
+		"@babel/core": "^7.16.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
 		"@svgr/webpack": "^5.5.0",
 		"@wordpress/babel-preset-default": "file:../babel-preset-default",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Part of #37264.

> Yarn 2 (Cherry) implements Plug'n'Play versus the node_modules node linker. One major issue that I have noticed is many packages inside gutenberg are missing peerDependencies on several libraries. This is frequently react, react-dom, or redux. 

This PR adds missing references for `@babel/core`.

## How has this been tested?

CI checks should still pass.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
