### PR TITLE
Site Editor: add customized indicator to plugin templates that have been customized

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -62,7 +62,11 @@ function AddedByPlugin( { slug, isCustomized } ) {
 	return (
 		<HStack alignment="left">
 			<CustomizedTooltip isCustomized={ isCustomized }>
-				<div className="edit-site-list-added-by__icon">
+				<div
+					className={ classnames( 'edit-site-list-added-by__icon', {
+						'is-customized': isCustomized,
+					} ) }
+				>
 					<Icon icon={ pluginIcon } />
 				</div>
 			</CustomizedTooltip>


### PR DESCRIPTION
## Description
When a template or template part has been customized, Gutenberg displays a blue circle on top of the icon to make it clear it's a custom template. However, that style is not currently applied to templates whose origin is a plugin. This PR fixes that.

## How has this been tested?

<details>
<summary>With Twenty Twenty Two and example code</summary>

1. Make sure you have Twenty Twenty Two installed.
2. Copy and paste this code to a PHP file (ie, in a plugin). It will mark the _Page (Large Header)_ as being customized and set its origin to a plugin. Of course, that's only to test this PR:
```PHP
add_filter(
	'get_block_templates',
	function( $query_result, $query, $template_type ) {
		foreach ( $query_result as $result ) {
			if ( 'twentytwentytwo//page-large-header' === $result->id ) {
				$result->source    = 'custom';
				$result->origin    = 'plugin';
				$result->is_custom = true;
			}
		}

		return $query_result;
	},
	10,
	3
);
```
3.  Go to Appearance > Site Editor > Templates and verify _Page (Large Header)_ has a blue dot on top of the plugin icon:

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/146005843-b07dcce7-e667-482a-ad23-e617cb087b31.png) | ![imatge](https://user-images.githubusercontent.com/3616980/146005708-acbc98c6-df68-41d5-b6fe-1a65cf97116b.png) |

</details>

<details>
<summary>With WooCommerce</summary>

You will need to install WooCommerce 6.0 or later and clone [WC Blocks repo](https://github.com/woocommerce/woocommerce-gutenberg-products-block) (and then run `composer i && npm i && npm run build`). Once that's done, these are the testing steps:

1. Go to Appearance > Site Editor > Templates.
2. If you haven't edited any of the WooCommerce templates, edit one and go back to the Templates list.
3. Verify the WooCommerce edited template has the blue dot that indicates it has been edited.

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/145827705-0395ff46-6728-4094-bbc9-e9173dc865d7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/145830094-c67af00a-323b-451a-a163-3075e0e49539.png) |

</details>

## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
