### PR TITLE
Fix: ToggleGroupControl active state

### DIFF
--- a/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
@@ -54,6 +54,9 @@ export const buttonView = css`
 
 export const buttonActive = css`
 	color: ${ COLORS.white };
+	&:active {
+		background: transparent;
+	}
 `;
 
 export const ButtonContentView = styled.div`


### PR DESCRIPTION
This PR is a minor fix for ToggleGroupControl active state. The issue is more noticeable when the control is rendered on a popover with autofocus but can already be noticed by continuously clicking on the button.

## How has this been tested?
I added a group block and went to the background color option.
I continuously pressed between color and gradient buttons and verified the button was always visible (on the trunk, it is not).

## Screenshots <!-- if applicable -->
Before:
![Dec-13-2021 16-23-30](https://user-images.githubusercontent.com/11271197/145849664-dd802c0c-e42f-46bc-a727-a11b7ace1e0b.gif)
After:
![Dec-13-2021 16-24-15](https://user-images.githubusercontent.com/11271197/145849787-229e84a6-00b6-46d3-aa33-f6fb70019277.gif)
