### PR TITLE
Port global styles code to `lib/compat/wordpress-5.9`: css custom properties

### DIFF
--- a/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
+++ b/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
@@ -1,0 +1,15 @@
+<?php
+
+// This has been ported as part of default-filters.php
+if ( ! function_exists( 'wp_enqueue_global_styles_css_custom_properties' ) ) {
+	/**
+	 * Function to enqueue the CSS Custom Properties
+	 * coming from theme.json.
+	 */
+	function wp_enqueue_global_styles_css_custom_properties() {
+		wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
+		wp_add_inline_style( 'global-styles-css-custom-properties', wp_get_global_stylesheet( array( 'variables' ) ) );
+		wp_enqueue_style( 'global-styles-css-custom-properties' );
+	}
+	add_filter( 'enqueue_block_editor_assets', 'wp_enqueue_global_styles_css_custom_properties' );
+}

--- a/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
+++ b/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Loads the CSS Custom Properties in use by Global Styles.
+ * @package Gutenberg
+ */
 
 // This has been ported as part of default-filters.php
 if ( ! function_exists( 'wp_enqueue_global_styles_css_custom_properties' ) ) {

--- a/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
+++ b/lib/compat/wordpress-5.9/global-styles-css-custom-properties.php
@@ -1,10 +1,11 @@
 <?php
 /**
  * Loads the CSS Custom Properties in use by Global Styles.
+ *
  * @package Gutenberg
  */
 
-// This has been ported as part of default-filters.php
+// This has been ported as part of default-filters.php.
 if ( ! function_exists( 'wp_enqueue_global_styles_css_custom_properties' ) ) {
 	/**
 	 * Function to enqueue the CSS Custom Properties

--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -264,16 +264,6 @@ function gutenberg_global_styles_include_support_for_wp_variables( $allow_css, $
 	return ! ! preg_match( '/^var\(--wp-[a-zA-Z0-9\-]+\)$/', trim( $parts[1] ) );
 }
 
-/**
- * Function to enqueue the CSS Custom Properties
- * coming from theme.json.
- */
-function gutenberg_load_css_custom_properties() {
-	wp_register_style( 'global-styles-css-custom-properties', false, array(), true, true );
-	wp_add_inline_style( 'global-styles-css-custom-properties', wp_get_global_stylesheet( array( 'variables' ) ) );
-	wp_enqueue_style( 'global-styles-css-custom-properties' );
-}
-
 // The else clause can be removed when plugin support requires WordPress 5.8.0+.
 if ( function_exists( 'get_block_editor_settings' ) ) {
 	add_filter( 'block_editor_settings_all', 'gutenberg_experimental_global_styles_settings', PHP_INT_MAX );
@@ -289,5 +279,3 @@ add_action( 'set_current_user', 'gutenberg_global_styles_kses_init' );
 add_filter( 'force_filtered_html_on_import', 'gutenberg_global_styles_force_filtered_html_on_import_filter', 999 );
 add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_global_styles_include_support_for_wp_variables', 10, 2 );
 // This filter needs to be executed last.
-
-add_filter( 'enqueue_block_editor_assets', 'gutenberg_load_css_custom_properties' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -100,6 +100,7 @@ require __DIR__ . '/compat/wordpress-5.9/register-global-styles-cpt.php';
 require __DIR__ . '/compat/wordpress-5.9/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-5.9/json-file-decode.php';
 require __DIR__ . '/compat/wordpress-5.9/translate-settings-using-i18n-schema.php';
+require __DIR__ . '/compat/wordpress-5.9/global-styles-css-custom-properties.php';
 require __DIR__ . '/compat/wordpress-5.9/class-gutenberg-block-template.php';
 require __DIR__ . '/compat/wordpress-5.9/templates.php';
 require __DIR__ . '/compat/wordpress-5.9/template-parts.php';


### PR DESCRIPTION
This PR continues porting global styles code into `lib/compat/wordpress-5.9` folder. See related core PR where this is being backported https://github.com/WordPress/wordpress-develop/pull/2048#issuecomment-992671727

## How to test

- Activate the TwentyTwentyTwo theme.
- Load the site editor.
- Go to the editor palette in the global styles sidebar and click the gradients tab.

The expected result is that gradients are visualized properly:

![Captura de ecrã de 2021-12-13 17-52-26](https://user-images.githubusercontent.com/583546/145858787-048091e0-36fe-4f0a-b7b0-52641098d0c9.png)
