### PR TITLE
Add alt toolbar for image crop mode

### DIFF
--- a/packages/block-editor/src/components/block-controls/groups.js
+++ b/packages/block-editor/src/components/block-controls/groups.js
@@ -8,6 +8,7 @@ const BlockControlsBlock = createSlotFill( 'BlockControlsBlock' );
 const BlockControlsInline = createSlotFill( 'BlockFormatControls' );
 const BlockControlsOther = createSlotFill( 'BlockControlsOther' );
 const BlockControlsParent = createSlotFill( 'BlockControlsParent' );
+const BlockControlsAlt = createSlotFill( 'BlockControlsParent' );
 
 const groups = {
 	default: BlockControlsDefault,
@@ -15,6 +16,7 @@ const groups = {
 	inline: BlockControlsInline,
 	other: BlockControlsOther,
 	parent: BlockControlsParent,
+	alt: BlockControlsAlt,
 };
 
 export default groups;

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -32,6 +32,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		hasReducedUI,
 		isValid,
 		isVisual,
+		isAltMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -60,6 +61,9 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			),
 			isVisual: selectedBlockClientIds.every(
 				( id ) => getBlockMode( id ) === 'visual'
+			),
+			isAltMode: selectedBlockClientIds.every(
+				( id ) => getBlockMode( id ) === 'alt'
 			),
 		};
 	}, [] );
@@ -104,6 +108,17 @@ export default function BlockToolbar( { hideDragHandle } ) {
 		'block-editor-block-toolbar',
 		shouldShowMovers && 'is-showing-movers'
 	);
+
+	if ( isAltMode ) {
+		return (
+			<div className={ classes }>
+				<BlockControls.Slot
+					group="alt"
+					className="block-editor-block-toolbar__slot"
+				/>
+			</div>
+		);
+	}
 
 	return (
 		<div className={ classes }>

--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import { Icon, crop } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,6 +34,9 @@ export default function ImageEditor( {
 				naturalWidth={ naturalWidth }
 			/>
 			<BlockControls group="alt">
+				<div className="image-editor__crop-toolbar-icon">
+					<Icon icon={ crop } label={ __( 'Crop' ) } />
+				</div>
 				<ToolbarGroup>
 					<ZoomDropdown />
 					<ToolbarItem>

--- a/packages/block-editor/src/components/image-editor/index.js
+++ b/packages/block-editor/src/components/image-editor/index.js
@@ -31,7 +31,7 @@ export default function ImageEditor( {
 				naturalHeight={ naturalHeight }
 				naturalWidth={ naturalWidth }
 			/>
-			<BlockControls>
+			<BlockControls group="alt">
 				<ToolbarGroup>
 					<ZoomDropdown />
 					<ToolbarItem>

--- a/packages/block-editor/src/components/image-editor/style.scss
+++ b/packages/block-editor/src/components/image-editor/style.scss
@@ -1,0 +1,11 @@
+.image-editor__crop-toolbar-icon {
+    display: flex;
+    align-items: center;
+    padding: 6px 12px;
+	background-color: $gray-900;
+	color: $white;
+
+    svg {
+        fill: currentColor;
+    }
+}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -897,6 +897,22 @@ export function toggleBlockMode( clientId ) {
 }
 
 /**
+ * Returns an action object used to set alternate editing modes.
+ *
+ * @param {string} clientId Block client ID.
+ * @param {string} mode     Block editing mode.
+ *
+ * @return {Object} Action object.
+ */
+export function setBlockMode( clientId, mode ) {
+	return {
+		type: 'SET_BLOCK_MODE',
+		clientId,
+		mode,
+	};
+}
+
+/**
  * Returns an action object used in signalling that the user has begun to type.
  *
  * @return {Object} Action object.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1390,15 +1390,22 @@ export function initialPosition( state = null, action ) {
 }
 
 export function blocksMode( state = {}, action ) {
-	if ( action.type === 'TOGGLE_BLOCK_MODE' ) {
-		const { clientId } = action;
-		return {
-			...state,
-			[ clientId ]:
-				state[ clientId ] && state[ clientId ] === 'html'
-					? 'visual'
-					: 'html',
-		};
+	const { clientId } = action;
+
+	switch ( action.type ) {
+		case 'TOGGLE_BLOCK_MODE':
+			return {
+				...state,
+				[ clientId ]:
+					state[ clientId ] && state[ clientId ] === 'html'
+						? 'visual'
+						: 'html',
+			};
+		case 'SET_BLOCK_MODE':
+			return {
+				...state,
+				[ clientId ]: action.mode,
+			};
 	}
 
 	return state;

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -32,6 +32,7 @@
 @import "./components/default-block-appender/style.scss";
 @import "./components/duotone-control/style.scss";
 @import "./components/font-appearance-control/style.scss";
+@import "./components/image-editor/style.scss";
 @import "./components/image-size-control/style.scss";
 @import "./components/inner-blocks/style.scss";
 @import "./components/inserter-list-item/style.scss";

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -50,6 +50,8 @@ import { isExternalImage } from './edit';
  */
 import { MIN_SIZE, ALLOWED_MEDIA_TYPES } from './constants';
 
+const IMAGE_EDITING_BLOCK_MODE = 'alt';
+
 export default function Image( {
 	temporaryURL,
 	attributes: {
@@ -110,12 +112,14 @@ export default function Image( {
 		imageSizes,
 		maxWidth,
 		mediaUpload,
+		isEditingImage,
 	} = useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
 				getSettings,
 				canInsertBlockType,
+				getBlockMode,
 			} = select( blockEditorStore );
 
 			const rootClientId = getBlockRootClientId( clientId );
@@ -132,11 +136,15 @@ export default function Image( {
 					'core/cover',
 					rootClientId
 				),
+				isEditingImage:
+					getBlockMode( clientId ) === IMAGE_EDITING_BLOCK_MODE,
 			};
 		},
 		[ clientId ]
 	);
-	const { replaceBlocks, toggleSelection } = useDispatch( blockEditorStore );
+	const { replaceBlocks, toggleSelection, setBlockMode } = useDispatch(
+		blockEditorStore
+	);
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		noticesStore
 	);
@@ -146,7 +154,6 @@ export default function Image( {
 		{ loadedNaturalWidth, loadedNaturalHeight },
 		setLoadedNaturalSize,
 	] = useState( {} );
-	const [ isEditingImage, setIsEditingImage ] = useState( false );
 	const [ externalBlob, setExternalBlob ] = useState();
 	const clientWidth = useClientWidth( containerRef, [ align ] );
 	const isResizable = allowResize && ! ( isWideAligned && isLargeViewport );
@@ -156,6 +163,11 @@ export default function Image( {
 		),
 		( { name, slug } ) => ( { value: slug, label: name } )
 	);
+	const setIsEditingImage = ( isEditing ) =>
+		setBlockMode(
+			clientId,
+			isEditing ? IMAGE_EDITING_BLOCK_MODE : 'visual'
+		);
 
 	// If an image is externally hosted, try to fetch the image data. This may
 	// fail if the image host doesn't allow CORS with the domain. If it works,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

First part in fixing #23721

Replace the entire toolbar when opening the image editor.

The toolbar is replaced by adding a new `alt` mode for the block in addition to `visual` and `html` and a new `alt` slot for the toolbar.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

In the image block, 

## Screenshots <!-- if applicable -->

![Screen Shot 2021-12-13 at 12 39 04](https://user-images.githubusercontent.com/5129775/145869318-bfef4a8e-40b6-4bca-b654-477802afb3bd.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
