### PR TITLE
Docs: Add closing ticks for blockGap code example

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -1110,3 +1110,4 @@ The default value is 2em.
 		}
 	}
 }
+```


### PR DESCRIPTION

## Description

Published formating here https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#what-is-blockgap-and-how-can-i-use-it is incorrect due to missing closing ticks on JSON code example.


## How has this been tested?

Confirm ticks match.


## Types of changes

Documentation.
