### PR TITLE
Remove gutenberg_ prefix from @wordpress/block-library

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -54,7 +54,7 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  *
  * @return array Returns the modified fields.
  */
-function comments_form_block_form_defaults( $fields ) {
+function post_comments_form_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
 		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
@@ -62,4 +62,4 @@ function comments_form_block_form_defaults( $fields ) {
 
 	return $fields;
 }
-add_filter( 'comment_form_defaults', 'comments_form_block_form_defaults' );
+add_filter( 'comment_form_defaults', 'post_comments_form_block_form_defaults' );

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -54,7 +54,7 @@ add_action( 'init', 'register_block_core_post_comments_form' );
  *
  * @return array Returns the modified fields.
  */
-function gutenberg_comment_form_block_form_defaults( $fields ) {
+function comments_form_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
 		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
@@ -62,4 +62,4 @@ function gutenberg_comment_form_block_form_defaults( $fields ) {
 
 	return $fields;
 }
-add_filter( 'comment_form_defaults', 'gutenberg_comment_form_block_form_defaults' );
+add_filter( 'comment_form_defaults', 'comments_form_block_form_defaults' );

--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -74,7 +74,7 @@ add_action( 'init', 'register_block_core_post_comments' );
  *
  * @return array Returns the modified fields.
  */
-function gutenberg_post_comments_block_form_defaults( $fields ) {
+function post_comments_block_form_defaults( $fields ) {
 	if ( wp_is_block_theme() ) {
 		$fields['submit_button'] = '<input name="%1$s" type="submit" id="%2$s" class="%3$s wp-block-button__link" value="%4$s" />';
 		$fields['submit_field']  = '<p class="form-submit wp-block-button">%1$s %2$s</p>';
@@ -82,4 +82,4 @@ function gutenberg_post_comments_block_form_defaults( $fields ) {
 
 	return $fields;
 }
-add_filter( 'comment_form_defaults', 'gutenberg_post_comments_block_form_defaults' );
+add_filter( 'comment_form_defaults', 'post_comments_block_form_defaults' );


### PR DESCRIPTION
## Description

Removes two instances of the `gutenberg_` prefix appearing in `@wordpress/block-library`.

This code is copied to Core as-is so it shouldn't reference Gutenberg.

We really ought to add a lint rule for this... one day!

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
