### PR TITLE
fix break point of Media + Text Block

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -102,7 +102,7 @@
 * If the style were set on mobile first, on desktop styles,
 * we would have no way of setting the style again to the inline style.
 */
-@media (max-width: #{ ($break-small) }) {
+@media (max-width: #{ ($break-small - 1) }) {
 	.wp-block-media-text.is-stacked-on-mobile {
 		grid-template-columns: 100% !important;
 		.wp-block-media-text__media {


### PR DESCRIPTION
## Description
The breakpoints for column blocks and gallery blocks are "@media (max-width: 599px)".
On the other hand, only the breakpoint for image and text block is "@media (max-width: 600px)".
This is very inconvenient and has been a problem among the theme developers I know.
I think the value in the scss was wrong.

see issue #37350

## How has this been tested?
I built the CSS, overwrote wp-includes/css/dist/block-editor/style.min.css, and checked it in my local environment.

## Types of changes
Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
