### PR TITLE
Site Editor: Sync Export API error codes

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -907,7 +907,7 @@ if ( ! function_exists( 'wp_generate_block_templates_export_file' ) ) {
 	 */
 	function wp_generate_block_templates_export_file() {
 		if ( ! class_exists( 'ZipArchive' ) ) {
-			return new WP_Error( __( 'Zip Export not supported.', 'gutenberg' ) );
+			return new WP_Error( 'missing_zip_package', __( 'Zip Export not supported.', 'gutenberg' ) );
 		}
 
 		$obscura  = wp_generate_password( 12, false, false );
@@ -915,7 +915,7 @@ if ( ! function_exists( 'wp_generate_block_templates_export_file' ) ) {
 
 		$zip = new ZipArchive();
 		if ( true !== $zip->open( $filename, ZipArchive::CREATE ) ) {
-			return new WP_Error( __( 'Unable to open export file (archive) for writing.', 'gutenberg' ) );
+			return new WP_Error( 'unable_to_create_zip', __( 'Unable to open export file (archive) for writing.', 'gutenberg' ) );
 		}
 
 		$zip->addEmptyDir( 'theme' );

--- a/lib/compat/wordpress-5.9/class-wp-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-5.9/class-wp-rest-edit-site-export-controller.php
@@ -52,7 +52,7 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 		}
 
 		return new WP_Error(
-			'rest_cannot_view_url_details',
+			'rest_cannot_export_templates',
 			__( 'Sorry, you are not allowed to export templates and template parts.', 'gutenberg' ),
 			array( 'status' => rest_authorization_required_code() )
 		);

--- a/lib/compat/wordpress-5.9/class-wp-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-5.9/class-wp-rest-edit-site-export-controller.php
@@ -69,6 +69,8 @@ class WP_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 		$filename = wp_generate_block_templates_export_file();
 
 		if ( is_wp_error( $filename ) ) {
+			$filename->add_data( array( 'status' => 500 ) );
+
 			return $filename;
 		}
 


### PR DESCRIPTION
## Description
PR sync Export API error codes from the core.

* https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-edit-site-export-controller.php#L58
* https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-template-utils.php#L916-L924

## How has this been tested?
All checks are green. This is a non-breaking change.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
