### PR TITLE
Multi-Entity Saving: Decode HTML entities in item titles

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -7,6 +7,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -77,7 +78,10 @@ export default function EntityRecordItem( {
 		<PanelRow>
 			<CheckboxControl
 				label={
-					<strong>{ entityRecordTitle || __( 'Untitled' ) }</strong>
+					<strong>
+						{ decodeEntities( entityRecordTitle ) ||
+							__( 'Untitled' ) }
+					</strong>
 				}
 				checked={ checked }
 				onChange={ onChange }


### PR DESCRIPTION
## Description
PR decodes HTML entities in item titles for multi-entity saving flow.

## How has this been tested?
1. Create navigation menu that contains HTML entity - "Blocks & Patterns"
2. Add it to a post.
3. Add new navigation items and Save.
4. HTML entities should be correctly decoded.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2021-12-14 at 11 26 31](https://user-images.githubusercontent.com/240569/145952689-f7b2fb2b-14e0-4937-a191-6157d9dbf042.png)|![CleanShot 2021-12-14 at 11 23 58](https://user-images.githubusercontent.com/240569/145952681-c0f0e581-a917-4f45-b0a5-24e1a1f22025.png)|

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
