### PR TITLE
Group, Columns: Lower specificity of padding rules further.

### DIFF
--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -10,10 +10,6 @@
 		flex-wrap: nowrap;
 	}
 
-	&:where(.has-background) {
-		padding: $block-bg-padding--v $block-bg-padding--h;
-	}
-
 	/**
 	* All Columns Alignment
 	*/
@@ -85,8 +81,8 @@
 		> .wp-block-column {
 			// Available space should be divided equally amongst columns.
 			flex-basis: 0;
-			flex-grow: 1;
 
+			flex-grow: 1;
 			// Columns with an explicitly-assigned width should maintain their
 			// `flex-basis` width and not grow.
 			&[style*="flex-basis"] {
@@ -100,6 +96,13 @@
 		}
 	}
 }
+
+// Add low specificity default padding to columns blocks with backgrounds.
+:where(.wp-block-columns.has-background) {
+	// Matches paragraph block padding.
+	padding: $block-bg-padding--v $block-bg-padding--h;
+}
+
 
 .wp-block-column {
 	flex-grow: 1;

--- a/packages/block-library/src/group/theme.scss
+++ b/packages/block-library/src/group/theme.scss
@@ -1,6 +1,5 @@
-.wp-block-group {
-	&:where(.has-background) {
-		// Matches paragraph Block padding
-		padding: $block-bg-padding--v $block-bg-padding--h;
-	}
+// Add low specificity default padding to groups with backgrounds.
+:where(.wp-block-group.has-background) {
+	// Matches paragraph block padding.
+	padding: $block-bg-padding--v $block-bg-padding--h;
 }


### PR DESCRIPTION
## Description

Followup to #34854, and inspired by https://github.com/WordPress/twentytwentytwo/commit/395e093967679957b4423029b32140798ed20f9d#r61847726.

The group and columns blocks both add a default padding when a background is applied. Using `:where` it already had pretty low specificity. But it can be lower still, and this PR does so. By wrapping both the block and the background class to the where selector, the specificity is now low enough that the 60px margin wins out in the following example, despite the default padding rule being after the 60px rule:

```
.has-background {
	padding: 60px;
}

:where(.wp-block-group.has-background) {
	padding: 10px;
}
```

## How has this been tested?

Test group and columns blocks with and without a background applied. Verify no visual changes otherwise. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
