### PR TITLE
Ensure the overlay menu works when inserting navigation block patterns and that inner blocks are retained

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -423,6 +423,11 @@ function Navigation( {
 							hasSavedUnsavedInnerBlocks
 						}
 						onSave={ ( post ) => {
+							// replaceInnerBlocks is required to ensure the block editor store is sync'd
+							// to be aware that there are now no inner blocks (as blocks moved to entity).
+							// This should probably happen automatically with useBlockSync
+							// but there appears to be a bug.
+							replaceInnerBlocks( clientId, [] );
 							setHasSavedUnsavedInnerBlocks( true );
 							// Switch to using the wp_navigation entity.
 							setRef( post.id );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -423,12 +423,13 @@ function Navigation( {
 							hasSavedUnsavedInnerBlocks
 						}
 						onSave={ ( post ) => {
+							// Set some state used as a guard to prevent the creation of multiple posts.
+							setHasSavedUnsavedInnerBlocks( true );
 							// replaceInnerBlocks is required to ensure the block editor store is sync'd
 							// to be aware that there are now no inner blocks (as blocks moved to entity).
 							// This should probably happen automatically with useBlockSync
 							// but there appears to be a bug.
 							replaceInnerBlocks( clientId, [] );
-							setHasSavedUnsavedInnerBlocks( true );
 							// Switch to using the wp_navigation entity.
 							setRef( post.id );
 						} }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -381,19 +381,33 @@ function Navigation( {
 		hasExistingNavItems && ! isEntityAvailable && ! isWithinUnassignedArea;
 	if ( hasUnsavedBlocks ) {
 		return (
-			<UnsavedInnerBlocks
-				blockProps={ blockProps }
-				blocks={ innerBlocks }
-				clientId={ clientId }
-				navigationMenus={ navigationMenus }
-				hasSelection={ isSelected || isInnerBlockSelected }
-				hasSavedUnsavedInnerBlocks={ hasSavedUnsavedInnerBlocks }
-				onSave={ ( post ) => {
-					setHasSavedUnsavedInnerBlocks( true );
-					// Switch to using the wp_navigation entity.
-					setRef( post.id );
-				} }
-			/>
+			<nav { ...blockProps }>
+				<ResponsiveWrapper
+					id={ clientId }
+					onToggle={ setResponsiveMenuVisibility }
+					isOpen={ isResponsiveMenuOpen }
+					isResponsive={ 'never' !== overlayMenu }
+					isHiddenByDefault={ 'always' === overlayMenu }
+					classNames={ overlayClassnames }
+					styles={ overlayStyles }
+				>
+					<UnsavedInnerBlocks
+						blockProps={ blockProps }
+						blocks={ innerBlocks }
+						clientId={ clientId }
+						navigationMenus={ navigationMenus }
+						hasSelection={ isSelected || isInnerBlockSelected }
+						hasSavedUnsavedInnerBlocks={
+							hasSavedUnsavedInnerBlocks
+						}
+						onSave={ ( post ) => {
+							setHasSavedUnsavedInnerBlocks( true );
+							// Switch to using the wp_navigation entity.
+							setRef( post.id );
+						} }
+					/>
+				</ResponsiveWrapper>
+			</nav>
 		);
 	}
 

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -125,22 +125,18 @@ export default function UnsavedInnerBlocks( {
 	] );
 
 	return (
-		<>
-			<nav { ...blockProps }>
-				<div className="wp-block-navigation__unsaved-changes">
-					<Disabled
-						className={ classnames(
-							'wp-block-navigation__unsaved-changes-overlay',
-							{
-								'is-saving': hasSelection,
-							}
-						) }
-					>
-						<div { ...innerBlocksProps } />
-					</Disabled>
-					{ hasSelection && <Spinner /> }
-				</div>
-			</nav>
-		</>
+		<div className="wp-block-navigation__unsaved-changes">
+			<Disabled
+				className={ classnames(
+					'wp-block-navigation__unsaved-changes-overlay',
+					{
+						'is-saving': hasSelection,
+					}
+				) }
+			>
+				<div { ...innerBlocksProps } />
+			</Disabled>
+			{ hasSelection && <Spinner /> }
+		</div>
 	);
 }

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -23,15 +23,9 @@ export default function useNavigationMenu( ref ) {
 			const rawNavigationMenu = ref
 				? getEntityRecord( ...navigationMenuSingleArgs )
 				: null;
-			let navigationMenu = ref
+			const navigationMenu = ref
 				? getEditedEntityRecord( ...navigationMenuSingleArgs )
 				: null;
-
-			// getEditedEntityRecord will return the post regardless of status.
-			// Therefore if the found post is not published then we should ignore it.
-			if ( navigationMenu?.status !== 'publish' ) {
-				navigationMenu = null;
-			}
 
 			const hasResolvedNavigationMenu = ref
 				? hasFinishedResolution(

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -23,9 +23,15 @@ export default function useNavigationMenu( ref ) {
 			const rawNavigationMenu = ref
 				? getEntityRecord( ...navigationMenuSingleArgs )
 				: null;
-			const navigationMenu = ref
+			let navigationMenu = ref
 				? getEditedEntityRecord( ...navigationMenuSingleArgs )
 				: null;
+
+			// getEditedEntityRecord will return the post regardless of status.
+			// Therefore if the found post is not published then we should ignore it.
+			if ( navigationMenu?.status !== 'publish' ) {
+				navigationMenu = null;
+			}
 
 			const hasResolvedNavigationMenu = ref
 				? hasFinishedResolution(

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -43,3 +43,5 @@ exports[`Navigation placeholder allows a navigation block to be created from exi
 exports[`Navigation placeholder allows a navigation block to be created using existing pages 1`] = `"<!-- wp:page-list /-->"`;
 
 exports[`Navigation placeholder creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
+
+exports[`Navigation supports navigation blocks that have inner blocks within their markup and converts them to wp_navigation posts 1`] = `"<!-- wp:page-list /-->"`;

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -616,6 +616,9 @@ describe( 'Navigation', () => {
 	} );
 
 	describe( 'Creating and restarting', () => {
+		const NAV_ENTITY_SELECTOR =
+			'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
+
 		async function populateNavWithOneItem() {
 			// Add a Link block first.
 			const appender = await page.waitForSelector(
@@ -641,6 +644,44 @@ describe( 'Navigation', () => {
 			newMenuButton.click();
 		}
 
+		it( 'does not retain uncontrolled inner blocks when creating a new entity', async () => {
+			await createNewPost();
+			await clickOnMoreMenuItem( 'Code editor' );
+			const codeEditorInput = await page.waitForSelector(
+				'.editor-post-text-editor'
+			);
+			await codeEditorInput.click();
+			const markup =
+				'<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->';
+			await page.keyboard.type( markup );
+			await clickButton( 'Exit code editor' );
+			const navBlock = await page.waitForSelector(
+				'nav[aria-label="Block: Navigation"]'
+			);
+
+			// Select the block to convert to a wp_navigation and publish.
+			// The select menu button shows up when saving is complete.
+			await navBlock.click();
+			await page.waitForSelector( 'button[aria-label="Select Menu"]' );
+
+			// Reset the nav block to create a new entity.
+			await resetNavBlockToInitialState();
+			const startEmptyButton = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+			await startEmptyButton.click();
+			await populateNavWithOneItem();
+
+			// Confirm that only the last menu entity was updated.
+			const publishPanelButton2 = await page.waitForSelector(
+				'.editor-post-publish-button__button:not([aria-disabled="true"])'
+			);
+			await publishPanelButton2.click();
+
+			await page.waitForXPath( NAV_ENTITY_SELECTOR );
+			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+		} );
+
 		it( 'only update a single entity currently linked with the block', async () => {
 			await createNewPost();
 			await insertBlock( 'Navigation' );
@@ -657,8 +698,6 @@ describe( 'Navigation', () => {
 			);
 			await publishPanelButton.click();
 
-			const NAV_ENTITY_SELECTOR =
-				'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
 			await page.waitForXPath( NAV_ENTITY_SELECTOR );
 			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -68,7 +68,10 @@ async function updateActiveNavigationLink( { url, label, type } ) {
 	};
 
 	if ( url ) {
-		await page.type( 'input[placeholder="Search or type url"]', url );
+		const input = await page.waitForSelector(
+			'input[placeholder="Search or type url"]'
+		);
+		await input.type( url );
 
 		const suggestionPath = `//button[contains(@class, 'block-editor-link-control__search-item') and contains(@class, '${ typeClasses[ type ] }')]/span/span[@class='block-editor-link-control__search-item-title']/mark[text()="${ url }"]`;
 
@@ -612,6 +615,87 @@ describe( 'Navigation', () => {
 		expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 	} );
 
+	describe( 'Creating and restarting', () => {
+		async function populateNavWithOneItem() {
+			// Add a Link block first.
+			const appender = await page.waitForSelector(
+				'.wp-block-navigation .block-list-appender'
+			);
+			await appender.click();
+			// Add a link to the Link block.
+			await updateActiveNavigationLink( {
+				url: 'https://wordpress.org',
+				label: 'WP',
+				type: 'url',
+			} );
+		}
+
+		async function resetNavBlockToInitialState() {
+			const selectMenuDropdown = await page.waitForSelector(
+				'[aria-label="Select Menu"]'
+			);
+			await selectMenuDropdown.click();
+			const newMenuButton = await page.waitForXPath(
+				'//span[text()="Create new menu"]'
+			);
+			newMenuButton.click();
+		}
+
+		it( 'only update a single entity currently linked with the block', async () => {
+			await createNewPost();
+			await insertBlock( 'Navigation' );
+
+			const startEmptyButton = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+			await startEmptyButton.click();
+			await populateNavWithOneItem();
+
+			// Confirm that the menu entity was updated.
+			const publishPanelButton = await page.waitForSelector(
+				'.editor-post-publish-panel__toggle:not([aria-disabled="true"])'
+			);
+			await publishPanelButton.click();
+
+			const NAV_ENTITY_SELECTOR =
+				'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
+			await page.waitForXPath( NAV_ENTITY_SELECTOR );
+			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+
+			// Publish the post
+			const entitySaveButton = await page.waitForSelector(
+				'.editor-entities-saved-states__save-button'
+			);
+			await entitySaveButton.click();
+			const publishButton = await page.waitForSelector(
+				'.editor-post-publish-button:not([aria-disabled="true"])'
+			);
+			await publishButton.click();
+
+			// A success notice should show up.
+			await page.waitForSelector( '.components-snackbar' );
+
+			// Now try inserting another Link block via the quick inserter.
+			await page.click( 'nav[aria-label="Block: Navigation"]' );
+
+			await resetNavBlockToInitialState();
+			const startEmptyButton2 = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+			await startEmptyButton2.click();
+			await populateNavWithOneItem();
+
+			// Confirm that only the last menu entity was updated.
+			const publishPanelButton2 = await page.waitForSelector(
+				'.editor-post-publish-button__button:not([aria-disabled="true"])'
+			);
+			await publishPanelButton2.click();
+
+			await page.waitForXPath( NAV_ENTITY_SELECTOR );
+			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
+		} );
+	} );
+
 	// The following tests are unstable, roughly around when https://github.com/WordPress/wordpress-develop/pull/1412
 	// landed. The block manually tests well, so let's skip to unblock other PRs and immediately follow up. cc @vcanales
 	it.skip( 'loads frontend code only if the block is present', async () => {
@@ -722,97 +806,6 @@ describe( 'Navigation', () => {
 		);
 
 		expect( isScriptLoaded ).toBe( true );
-	} );
-
-	describe.skip( 'Creating and restarting', () => {
-		async function populateNavWithOneItem() {
-			// Add a Link block first.
-			await page.waitForSelector(
-				'.wp-block-navigation .block-list-appender'
-			);
-			await page.click( '.wp-block-navigation .block-list-appender' );
-			// Add a link to the Link block.
-			await updateActiveNavigationLink( {
-				url: 'https://wordpress.org',
-				label: 'WP',
-				type: 'url',
-			} );
-		}
-
-		async function resetNavBlockToInitialState() {
-			await page.waitForSelector( '[aria-label="Select Menu"]' );
-			await page.click( '[aria-label="Select Menu"]' );
-
-			await page.waitForXPath( '//span[text()="Create new menu"]' );
-			const newMenuButton = await page.$x(
-				'//span[text()="Create new menu"]'
-			);
-			newMenuButton[ 0 ].click();
-		}
-
-		it( 'only update a single entity currently linked with the block', async () => {
-			// Mock the response from the Pages endpoint. This is done so that the pages returned are always
-			// consistent and to test the feature more rigorously than the single default sample page.
-			// await mockPagesResponse( [
-			// 	{
-			// 		title: 'Home',
-			// 		slug: 'home',
-			// 	},
-			// 	{
-			// 		title: 'About',
-			// 		slug: 'about',
-			// 	},
-			// 	{
-			// 		title: 'Contact Us',
-			// 		slug: 'contact',
-			// 	},
-			// ] );
-
-			await insertBlock( 'Navigation' );
-			const startEmptyButton = await page.waitForXPath(
-				START_EMPTY_XPATH
-			);
-			await startEmptyButton.click();
-			await populateNavWithOneItem();
-
-			// Let's confirm that the menu entity was updated.
-			await page.waitForSelector(
-				'.editor-post-publish-panel__toggle:not([aria-disabled="true"])'
-			);
-			await page.click( '.editor-post-publish-panel__toggle' );
-
-			const NAV_ENTITY_SELECTOR =
-				'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
-			await page.waitForXPath( NAV_ENTITY_SELECTOR );
-			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
-
-			// Publish the post
-			await page.click( '.editor-entities-saved-states__save-button' );
-			await page.waitForSelector( '.editor-post-publish-button' );
-			await page.click( '.editor-post-publish-button' );
-
-			// A success notice should show up
-			await page.waitForSelector( '.components-snackbar' );
-
-			// Now try inserting another Link block via the quick inserter.
-			await page.focus( '.wp-block-navigation' );
-
-			await resetNavBlockToInitialState();
-			const startEmptyButton2 = await page.waitForXPath(
-				START_EMPTY_XPATH
-			);
-			await startEmptyButton2.click();
-			await populateNavWithOneItem();
-
-			// Let's confirm that only the last menu entity was updated.
-			await page.waitForSelector(
-				'.editor-post-publish-button__button:not([aria-disabled="true"])'
-			);
-			await page.click( '.editor-post-publish-button__button' );
-
-			await page.waitForXPath( NAV_ENTITY_SELECTOR );
-			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
-		} );
 	} );
 
 	describe( 'Permission based restrictions', () => {


### PR DESCRIPTION
## Description
Fixes #36670
Fixes #37354

This fixes the two issues mentioned above. When testing the first one, I noticed the second one was no longer working.

The first issue is that the `UnsavedInnerBlocks` component that's shown when the block has standard uncontrolled inner blocks (this is hard to describe without using technical terms) didn't use the `ResponsiveWrapper` component that's used for showing the overlay menu. That was a pretty simple fix.

The second issue was introduced when another fix went in recently (https://github.com/WordPress/gutenberg/pull/36880). It's understandable as the `UnsavedInnerBlocks` behavior there isn't all that easy to follow, it exists to support an edge case, and also there are no end to end tests.

## How has this been tested?
1. Open the post editor
2. Switch to code editor mode
3. Paste in the following markup:
```html
<!-- wp:navigation {"overlayMenu":"always"} -->
<!-- wp:navigation-link {"label":"Hello world!","type":"post","id":1,"url":"http://localhost:8888/?p=1","kind":"post-type","isTopLevelLink":true} /-->
<!-- wp:navigation-link {"label":"Sample Page","type":"page","id":2,"url":"http://localhost:8888/?page_id=2","kind":"post-type","isTopLevelLink":true} /-->
<!-- /wp:navigation -->
```
4. Confirm that the overlay menu shows correctly and that the inner blocks are not lost.

Also test that the fix in #36880 continues to work.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
