### PR TITLE
Template Editor Mode: Hide editor mode switcher

### DIFF
--- a/packages/edit-post/src/components/header/mode-switcher/index.js
+++ b/packages/edit-post/src/components/header/mode-switcher/index.js
@@ -33,6 +33,7 @@ function ModeSwitcher() {
 		shortcut,
 		isRichEditingEnabled,
 		isCodeEditingEnabled,
+		isEditingTemplate,
 		mode,
 	} = useSelect(
 		( select ) => ( {
@@ -43,11 +44,16 @@ function ModeSwitcher() {
 				.richEditingEnabled,
 			isCodeEditingEnabled: select( editorStore ).getEditorSettings()
 				.codeEditingEnabled,
+			isEditingTemplate: select( editPostStore ).isEditingTemplate(),
 			mode: select( editPostStore ).getEditorMode(),
 		} ),
 		[]
 	);
 	const { switchEditorMode } = useDispatch( editPostStore );
+
+	if ( isEditingTemplate ) {
+		return null;
+	}
 
 	if ( ! isRichEditingEnabled || ! isCodeEditingEnabled ) {
 		return null;


### PR DESCRIPTION
## Description
Resolves #37320.

Code Editor isn't supported in Site Editor nor correctly works in the Template Editing Mode. PR hides editor mode switcher. We should enable this feature back once Code Editor mode is fully supported - #22528.

## How has this been tested?
1. Create a post/page.
2. Create a template for the post using the Template panel.
3. Switch to Template Editing Mode.
4. The "Editor" menu group shouldn't be visible in the "Options" dropdown.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-14 at 13 19 10](https://user-images.githubusercontent.com/240569/145970109-aa896fb7-cbb2-4f77-a441-3e782b3329b7.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
