### PR TITLE
Template Part: Fix 'isMissing' condition check

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -99,7 +104,7 @@ export default function TemplatePartEdit( {
 			return {
 				innerBlocks: getBlocks( clientId ),
 				isResolved: hasResolvedEntity,
-				isMissing: hasResolvedEntity && ! entityRecord,
+				isMissing: hasResolvedEntity && isEmpty( entityRecord ),
 				defaultWrapper: defaultWrapperElement || 'div',
 				area: _area,
 				enableSelection: _enableSelection,


### PR DESCRIPTION
## Description
PR fixes incorrect `isMissing` condition check. The `getEditedEntityRecord` will return an empty object when the entity isn't available.

Fixes #36510.

## How has this been tested?

1. Add a paragraph with some text in the site editor
2. Make a template part using the 'Make template part' option in the block settings menu, give it a name, and create it.
3. Save all the changes
4. Navigate to Site Editor > Template Parts (using navigation sidebar) and delete the template part you just created
5. Go back to the site editor
6. Observe that the template part made in step 2 is now empty. Blocks can be added to it, but they can't be saved.

_Adapted from #36510._

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-14 at 17 24 28](https://user-images.githubusercontent.com/240569/146006816-ca0d691c-5012-47e4-bd26-c813bcda1cdb.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
