### PR TITLE
Mobile - Cover block - Fixes color settings and placeholder visibility

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.native.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.native.js
@@ -21,6 +21,7 @@ export default function PanelColorGradientSettings( { settings, title } ) {
 		return settings.map(
 			( {
 				onColorChange,
+				onColorCleared,
 				colorValue,
 				onGradientChange,
 				gradientValue,
@@ -33,6 +34,7 @@ export default function PanelColorGradientSettings( { settings, title } ) {
 							colorValue: gradientValue || colorValue,
 							gradientValue,
 							onGradientChange,
+							onColorCleared,
 							label,
 						} );
 					} }

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -166,7 +166,7 @@ const Cover = ( {
 		gradientValue
 	);
 
-	const hasOnlyColorBackground = ! url && hasBackground;
+	const hasOnlyColorBackground = ! url && ( hasBackground || hasInnerBlocks );
 
 	const [
 		isCustomColorPickerShowing,

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -40,8 +40,9 @@ import {
 	MediaPlaceholder,
 	MediaUpload,
 	MediaUploadProgress,
-	withColors,
-	__experimentalUseGradient,
+	getColorObjectByColorValue,
+	getColorObjectByAttributeValues,
+	getGradientValueBySlug,
 	useSetting,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -83,13 +84,13 @@ const Cover = ( {
 	getStylesFromColorScheme,
 	isParentSelected,
 	onFocus,
-	overlayColor,
 	setAttributes,
 	openGeneralSidebar,
 	closeSettingsBottomSheet,
 	isSelected,
 	selectBlock,
 	blockWidth,
+	hasInnerBlocks,
 } ) => {
 	const {
 		backgroundType,
@@ -103,6 +104,9 @@ const Cover = ( {
 		minHeightUnit = 'px',
 		allowedBlocks,
 		templateLock,
+		customGradient,
+		gradient,
+		overlayColor,
 	} = attributes;
 	const [ isScreenReaderEnabled, setIsScreenReaderEnabled ] = useState(
 		false
@@ -145,14 +149,20 @@ const Cover = ( {
 	const coverDefaultPalette = {
 		colors: colorsDefault.slice( 0, THEME_COLORS_COUNT ),
 	};
-
-	const { gradientValue } = __experimentalUseGradient();
+	const gradients = useSetting( 'color.gradients' ) || [];
+	const gradientValue =
+		customGradient || getGradientValueBySlug( gradients, gradient );
+	const overlayColorValue = getColorObjectByAttributeValues(
+		colorsDefault,
+		overlayColor
+	);
 
 	const hasBackground = !! (
 		url ||
 		( style && style.color && style.color.background ) ||
 		attributes.overlayColor ||
-		overlayColor.color ||
+		overlayColorValue.color ||
+		customOverlayColor ||
 		gradientValue
 	);
 
@@ -225,10 +235,12 @@ const Cover = ( {
 	}, [ closeSettingsBottomSheet ] );
 
 	function setColor( color ) {
+		const colorValue = getColorObjectByColorValue( colorsDefault, color );
+
 		setAttributes( {
 			// clear all related attributes (only one should be set)
-			overlayColor: undefined,
-			customOverlayColor: color,
+			overlayColor: colorValue?.slug ?? undefined,
+			customOverlayColor: ( ! colorValue?.slug && color ) ?? undefined,
 			gradient: undefined,
 			customGradient: undefined,
 		} );
@@ -251,12 +263,12 @@ const Cover = ( {
 		! gradientValue && {
 			backgroundColor:
 				customOverlayColor ||
-				overlayColor?.color ||
+				overlayColorValue?.color ||
 				style?.color?.background ||
 				styles.overlay?.color,
 		},
 		// While we don't support theme colors we add a default bg color
-		! overlayColor.color && ! url ? backgroundColor : {},
+		! overlayColorValue.color && ! url ? backgroundColor : {},
 		isImage &&
 			isParentSelected &&
 			! isUploadInProgress &&
@@ -432,7 +444,10 @@ const Cover = ( {
 		</TouchableWithoutFeedback>
 	);
 
-	if ( ! hasBackground || isCustomColorPickerShowing ) {
+	if (
+		( ! hasBackground && ! hasInnerBlocks ) ||
+		isCustomColorPickerShowing
+	) {
 		return (
 			<View>
 				{ isCustomColorPickerShowing && colorPickerControls }
@@ -575,17 +590,21 @@ const Cover = ( {
 };
 
 export default compose( [
-	withColors( { overlayColor: 'background-color' } ),
 	withSelect( ( select, { clientId } ) => {
-		const { getSelectedBlockClientId } = select( blockEditorStore );
+		const { getSelectedBlockClientId, getBlock } = select(
+			blockEditorStore
+		);
 
 		const selectedBlockClientId = getSelectedBlockClientId();
 
 		const { getSettings } = select( blockEditorStore );
 
+		const hasInnerBlocks = getBlock( clientId )?.innerBlocks.length > 0;
+
 		return {
 			settings: getSettings(),
 			isParentSelected: selectedBlockClientId === clientId,
+			hasInnerBlocks,
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId } ) => {

--- a/packages/block-library/src/cover/overlay-color-settings.native.js
+++ b/packages/block-library/src/cover/overlay-color-settings.native.js
@@ -74,6 +74,15 @@ function OverlayColorSettings( {
 			}
 		};
 
+		const onColorCleared = () => {
+			setAttributes( {
+				overlayColor: undefined,
+				customOverlayColor: undefined,
+				gradient: undefined,
+				customGradient: undefined,
+			} );
+		};
+
 		return [
 			{
 				label: __( 'Color' ),
@@ -81,6 +90,7 @@ function OverlayColorSettings( {
 				colorValue,
 				gradientValue,
 				onGradientChange,
+				onColorCleared,
 			},
 		];
 	}, [ colorValue, gradientValue, colors, gradients ] );

--- a/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
@@ -23,3 +23,11 @@ exports[`color settings sets a gradient overlay background when a solid backgrou
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->"
 `;
+
+exports[`color settings toggles between solid colors and gradients 1`] = `
+"<!-- wp:cover {\\"gradient\\":\\"light-green-cyan-to-vivid-green-cyan\\"} -->
+<div class=\\"wp-block-cover\\"><span aria-hidden=\\"true\\" class=\\"has-background-dim-100 wp-block-cover__gradient-background has-light-green-cyan-to-vivid-green-cyan-gradient-background has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
+<p class=\\"has-text-align-center\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;

--- a/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/cover/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`color settings clears the selected overlay color and mantains the inner blocks 1`] = `
+"<!-- wp:cover -->
+<div class=\\"wp-block-cover\\"><span aria-hidden=\\"true\\" class=\\"has-background-dim-100 wp-block-cover__gradient-background has-background-dim\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
+<p class=\\"has-text-align-center\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`color settings sets a color for the overlay background when the placeholder is visible 1`] = `
+"<!-- wp:cover {\\"overlayColor\\":\\"vivid-red\\"} -->
+<div class=\\"wp-block-cover\\"><span aria-hidden=\\"true\\" class=\\"has-vivid-red-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
+<p class=\\"has-text-align-center\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;
+
+exports[`color settings sets a gradient overlay background when a solid background was already selected 1`] = `
+"<!-- wp:cover {\\"gradient\\":\\"light-green-cyan-to-vivid-green-cyan\\"} -->
+<div class=\\"wp-block-cover\\"><span aria-hidden=\\"true\\" class=\\"has-background-dim-100 wp-block-cover__gradient-background has-light-green-cyan-to-vivid-green-cyan-gradient-background has-background-dim has-background-gradient has-light-green-cyan-to-vivid-green-cyan-gradient-background\\"></span><div class=\\"wp-block-cover__inner-container\\"><!-- wp:paragraph {\\"align\\":\\"center\\",\\"placeholder\\":\\"Write title…\\"} -->
+<p class=\\"has-text-align-center\\"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->"
+`;

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -400,6 +400,95 @@ describe( 'color settings', () => {
 		expect( newGradientButton ).toBeDefined();
 		fireEvent.press( newGradientButton );
 
+		// Dismiss the Block Settings modal
+		fireEvent( blockSettingsModal, 'backdropPress' );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'toggles between solid colors and gradients', async () => {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
+		} );
+
+		const block = await waitFor( () =>
+			getByA11yLabel( 'Cover block. Empty' )
+		);
+		expect( block ).toBeDefined();
+
+		// Select a color from the placeholder palette
+		const colorPalette = await waitFor( () =>
+			getByTestId( 'color-palette' )
+		);
+		const colorButton = within( colorPalette ).getByTestId( COLOR_PINK );
+
+		expect( colorButton ).toBeDefined();
+		fireEvent.press( colorButton );
+
+		// Wait for the block to be created
+		const coverBlockWithOverlay = await waitFor( () =>
+			getByA11yLabel( /Cover Block\. Row 1/ )
+		);
+		fireEvent.press( coverBlockWithOverlay );
+
+		// Open Block Settings
+		const settingsButton = await waitFor( () =>
+			getByA11yLabel( 'Open Settings' )
+		);
+		fireEvent.press( settingsButton );
+
+		// Wait for Block Settings to be visible
+		const blockSettingsModal = getByTestId( 'block-settings-modal' );
+		await waitFor( () => blockSettingsModal.props.isVisible );
+
+		// Open the overlay color settings
+		const colorOverlay = await waitFor( () =>
+			getByA11yLabel( 'Color. Empty' )
+		);
+		expect( colorOverlay ).toBeDefined();
+		fireEvent.press( colorOverlay );
+
+		// Find the selected color
+		const colorPaletteButton = await waitFor( () =>
+			getByTestId( COLOR_PINK )
+		);
+		expect( colorPaletteButton ).toBeDefined();
+
+		// Select another color
+		const newColorButton = await waitFor( () => getByTestId( COLOR_RED ) );
+		fireEvent.press( newColorButton );
+
+		// Open the gradients
+		const gradientsButton = await waitFor( () =>
+			getByA11yLabel( 'Gradient' )
+		);
+		expect( gradientsButton ).toBeDefined();
+
+		fireEvent( gradientsButton, 'layout', {
+			nativeEvent: { layout: { width: 80, height: 26 } },
+		} );
+		fireEvent.press( gradientsButton );
+
+		// Find the gradient color
+		const newGradientButton = await waitFor( () =>
+			getByTestId( GRADIENT_GREEN )
+		);
+		expect( newGradientButton ).toBeDefined();
+		fireEvent.press( newGradientButton );
+
+		// Go back to the settings list
+		fireEvent.press( await waitFor( () => getByA11yLabel( 'Go back' ) ) );
+
+		// Find the color setting
+		const colorSetting = await waitFor( () =>
+			getByA11yLabel( 'Color. Empty' )
+		);
+		expect( colorSetting ).toBeDefined();
+		fireEvent.press( colorSetting );
+
+		// Dismiss the Block Settings modal
+		fireEvent( blockSettingsModal, 'backdropPress' );
+
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -1,15 +1,22 @@
 /**
  * External dependencies
  */
-import { Image } from 'react-native';
-import { render, fireEvent, waitFor } from 'test/helpers';
+import { AccessibilityInfo, Image } from 'react-native';
+import {
+	getEditorHtml,
+	initializeEditor,
+	render,
+	fireEvent,
+	waitFor,
+	within,
+} from 'test/helpers';
 
 /**
  * WordPress dependencies
  */
 import { BottomSheetSettings, BlockEdit } from '@wordpress/block-editor';
 import { SlotFillProvider } from '@wordpress/components';
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { setDefaultBlockName, unregisterBlockType } from '@wordpress/blocks';
 import {
 	requestMediaPicker,
 	requestMediaEditor,
@@ -19,7 +26,9 @@ import {
  * Internal dependencies
  */
 import { IMAGE_BACKGROUND_TYPE } from '../shared';
-import { metadata, settings, name } from '../index';
+import * as paragraph from '../../paragraph';
+import * as cover from '..';
+import { registerBlock } from '../..';
 
 // Avoid errors due to mocked stylesheet files missing required selectors
 jest.mock( '@wordpress/compose', () => ( {
@@ -33,10 +42,25 @@ jest.mock( '@wordpress/compose', () => ( {
 	) ),
 } ) );
 
+const COVER_BLOCK_PLACEHOLDER_HTML = `<!-- wp:cover -->
+<div class="wp-block-cover"><span aria-hidden="true" class="has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"></div></div>
+<!-- /wp:cover -->`;
+const COVER_BLOCK_SOLID_COLOR_HTML = `<!-- wp:cover {"overlayColor":"cyan-bluish-gray"} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="has-cyan-bluish-gray-background-color has-background-dim-100 wp-block-cover__gradient-background has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…"} -->
+<p class="has-text-align-center"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->`;
+
+const COLOR_PINK = '#f78da7';
+const COLOR_RED = '#cf2e2e';
+const COLOR_GRAY = '#abb8c3';
+const GRADIENT_GREEN =
+	'linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)';
+
 // Simplified tree to render Cover edit within slot
 const CoverEdit = ( props ) => (
 	<SlotFillProvider>
-		<BlockEdit isSelected name={ name } clientId={ 0 } { ...props } />
+		<BlockEdit isSelected name={ cover.name } clientId={ 0 } { ...props } />
 		<BottomSheetSettings isVisible />
 	</SlotFillProvider>
 );
@@ -55,26 +79,24 @@ beforeAll( () => {
 	const getSizeSpy = jest.spyOn( Image, 'getSize' );
 	getSizeSpy.mockImplementation( ( _url, callback ) => callback( 300, 200 ) );
 
+	AccessibilityInfo.isScreenReaderEnabled.mockResolvedValue(
+		Promise.resolve( true )
+	);
+
 	// Register required blocks
-	registerBlockType( name, {
-		...metadata,
-		...settings,
-	} );
-	registerBlockType( 'core/paragraph', {
-		category: 'text',
-		title: 'Paragraph',
-		edit: () => {},
-		save: () => {},
-	} );
+	registerBlock( paragraph );
+	registerBlock( cover );
+	setDefaultBlockName( paragraph.name );
 } );
 
 afterAll( () => {
 	// Restore mocks
 	Image.getSize.mockRestore();
+	AccessibilityInfo.isScreenReaderEnabled.mockReset();
 
 	// Clean up registered blocks
-	unregisterBlockType( name );
-	unregisterBlockType( 'core/paragraph' );
+	unregisterBlockType( paragraph.name );
+	unregisterBlockType( cover.name );
 } );
 
 describe( 'when no media is attached', () => {
@@ -268,5 +290,161 @@ describe( 'when an image is attached', () => {
 				url: undefined,
 			} )
 		);
+	} );
+} );
+
+describe( 'color settings', () => {
+	it( 'sets a color for the overlay background when the placeholder is visible', async () => {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
+		} );
+
+		const block = await waitFor( () =>
+			getByA11yLabel( 'Cover block. Empty' )
+		);
+		expect( block ).toBeDefined();
+
+		// Select a color from the placeholder palette
+		const colorPalette = await waitFor( () =>
+			getByTestId( 'color-palette' )
+		);
+		const colorButton = within( colorPalette ).getByTestId( COLOR_PINK );
+
+		expect( colorButton ).toBeDefined();
+		fireEvent.press( colorButton );
+
+		// Wait for the block to be created
+		const coverBlockWithOverlay = await waitFor( () =>
+			getByA11yLabel( /Cover Block\. Row 1/ )
+		);
+		fireEvent.press( coverBlockWithOverlay );
+
+		// Open Block Settings
+		const settingsButton = await waitFor( () =>
+			getByA11yLabel( 'Open Settings' )
+		);
+		fireEvent.press( settingsButton );
+
+		// Wait for Block Settings to be visible
+		const blockSettingsModal = getByTestId( 'block-settings-modal' );
+		await waitFor( () => blockSettingsModal.props.isVisible );
+
+		// Open the overlay color settings
+		const colorOverlay = await waitFor( () =>
+			getByA11yLabel( 'Color. Empty' )
+		);
+		expect( colorOverlay ).toBeDefined();
+		fireEvent.press( colorOverlay );
+
+		// Find the selected color
+		const colorPaletteButton = await waitFor( () =>
+			getByTestId( COLOR_PINK )
+		);
+		expect( colorPaletteButton ).toBeDefined();
+
+		// Select another color
+		const newColorButton = await waitFor( () => getByTestId( COLOR_RED ) );
+		fireEvent.press( newColorButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'sets a gradient overlay background when a solid background was already selected', async () => {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
+		} );
+
+		// Wait for the block to be created
+		const coverBlock = await waitFor( () =>
+			getByA11yLabel( /Cover Block\. Row 1/ )
+		);
+		expect( coverBlock ).toBeDefined();
+		fireEvent.press( coverBlock );
+
+		// Open Block Settings
+		const settingsButton = await waitFor( () =>
+			getByA11yLabel( 'Open Settings' )
+		);
+		fireEvent.press( settingsButton );
+
+		// Wait for Block Settings to be visible
+		const blockSettingsModal = getByTestId( 'block-settings-modal' );
+		await waitFor( () => blockSettingsModal.props.isVisible );
+
+		// Open the overlay color settings
+		const colorOverlay = await waitFor( () =>
+			getByA11yLabel( 'Color. Empty' )
+		);
+		expect( colorOverlay ).toBeDefined();
+		fireEvent.press( colorOverlay );
+
+		// Find the selected color
+		const colorButton = await waitFor( () => getByTestId( COLOR_GRAY ) );
+		expect( colorButton ).toBeDefined();
+
+		// Open the gradients
+		const gradientsButton = await waitFor( () =>
+			getByA11yLabel( 'Gradient' )
+		);
+		expect( gradientsButton ).toBeDefined();
+
+		fireEvent( gradientsButton, 'layout', {
+			nativeEvent: { layout: { width: 80, height: 26 } },
+		} );
+		fireEvent.press( gradientsButton );
+
+		// Find the gradient color
+		const newGradientButton = await waitFor( () =>
+			getByTestId( GRADIENT_GREEN )
+		);
+		expect( newGradientButton ).toBeDefined();
+		fireEvent.press( newGradientButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'clears the selected overlay color and mantains the inner blocks', async () => {
+		const {
+			getByTestId,
+			getByA11yLabel,
+			getByText,
+		} = await initializeEditor( {
+			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
+		} );
+
+		// Wait for the block to be created
+		const coverBlock = await waitFor( () =>
+			getByA11yLabel( /Cover Block\. Row 1/ )
+		);
+		expect( coverBlock ).toBeDefined();
+		fireEvent.press( coverBlock );
+
+		// Open Block Settings
+		const settingsButton = await waitFor( () =>
+			getByA11yLabel( 'Open Settings' )
+		);
+		fireEvent.press( settingsButton );
+
+		// Wait for Block Settings to be visible
+		const blockSettingsModal = getByTestId( 'block-settings-modal' );
+		await waitFor( () => blockSettingsModal.props.isVisible );
+
+		// Open the overlay color settings
+		const colorOverlay = await waitFor( () =>
+			getByA11yLabel( 'Color. Empty' )
+		);
+		expect( colorOverlay ).toBeDefined();
+		fireEvent.press( colorOverlay );
+
+		// Find the selected color
+		const colorButton = await waitFor( () => getByTestId( COLOR_GRAY ) );
+		expect( colorButton ).toBeDefined();
+
+		// Reset the selected color
+		const resetButton = await waitFor( () => getByText( 'Reset' ) );
+		expect( resetButton ).toBeDefined();
+		fireEvent.press( resetButton );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/components/src/color-palette/index.native.js
+++ b/packages/components/src/color-palette/index.native.js
@@ -219,6 +219,7 @@ function ColorPalette( {
 			onScrollBeginDrag={ () => shouldEnableBottomSheetScroll( false ) }
 			onScrollEndDrag={ () => shouldEnableBottomSheetScroll( true ) }
 			ref={ scrollViewRef }
+			testID="color-palette"
 		>
 			{ shouldShowCustomIndicator && (
 				<View
@@ -266,6 +267,7 @@ function ColorPalette( {
 								selected: isSelected( color ),
 							} }
 							accessibilityHint={ color }
+							testID={ color }
 						>
 							<Animated.View
 								style={ {

--- a/packages/components/src/mobile/color-settings/index.native.js
+++ b/packages/components/src/mobile/color-settings/index.native.js
@@ -27,6 +27,7 @@ const ColorSettingsMemo = memo(
 		colorValue,
 		gradientValue,
 		onGradientChange,
+		onColorCleared,
 		label,
 		hideNavigation,
 	} ) => {
@@ -44,6 +45,7 @@ const ColorSettingsMemo = memo(
 						colorValue,
 						gradientValue,
 						onGradientChange,
+						onColorCleared,
 						label,
 						hideNavigation,
 					} }

--- a/packages/components/src/mobile/color-settings/palette.screen.native.js
+++ b/packages/components/src/mobile/color-settings/palette.screen.native.js
@@ -36,6 +36,7 @@ const PaletteScreen = () => {
 		label,
 		onColorChange,
 		onGradientChange,
+		onColorCleared,
 		colorValue,
 		defaultSettings,
 		hideNavigation = false,
@@ -84,6 +85,10 @@ const PaletteScreen = () => {
 			onColorChange( '' );
 		} else {
 			onGradientChange( '' );
+		}
+
+		if ( onColorCleared ) {
+			onColorCleared();
 		}
 	}
 


### PR DESCRIPTION
- Gutenberg mobile PR -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4384

Fixes https://github.com/WordPress/gutenberg/issues/37227

## Description
This PR fixes a [regression](https://github.com/WordPress/gutenberg/pull/36841) where the color/gradient of the Cover block wouldn't be applied. 

It replaces the usage of the `withColors` HOC and `__experimentalUseGradient` in favor of getting the colors directly from `useSetting`.

It also adds some tests in case of future changes related to the colors settings.

A while back the `Reset` button was added within the color palette, there's a fix as well to make it compatible with the Cover block. For this case, if you reset the overlay color, it will clear the color and maintain the cover block and its inner block. This also will benefit the case when an image/video is removed, the block should still be visible with its inner blocks.

## How has this been tested?

### Test case 1

- Open the app and add a `Cover` block
- Choose a color from the inline color palette
- Open the block settings
- Tap on the color setting
- Tap on a different color than the selected one
- **Expect** to see the newly selected color in the block

### Test case 2

- Open the app and add a `Cover` block
- Choose a color from the inline color palette
- Open the block settings
- Tap on the color setting
- Tap on a different color than the selected one
- **Expect** to see the newly selected color in the block
- Tap on the `Gradients` option
- Select a gradient
- **Expect** to see the newly selected color in the block
- Tap on the Back button
- **Expect** to see the block settings

### Test case 3

- Open the app and add a `Cover` block
- Choose a color from the inline color palette
- Open the block settings
- Tap on the color setting
- Tap on the Reset button (bottom right)
- **Expect** to see the default black color in the block

### Test case 4

- Open the app and add a `Cover` block
- Add an image to the block
- Open the block settings
- Tap on the Clear media option
- **Expect** to see the Cover block without the image and keeping its inner blocks

## Screenshots <!-- if applicable -->

### Test case 1 

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/146402442-785bc11c-f167-4748-b821-1d2c8011ba8a.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/146403060-f7e345e9-f56f-45a6-a00b-6cfbfa1d4186.gif" width="200" /></kbd>

### Test case 2

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/146402502-e43249a9-a938-4706-a4f3-196ae88a6ebb.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/146404074-1e5dd4db-a769-414f-b431-2ae0858e3f66.gif" width="200" /></kbd>

### Test case 3

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/146402578-639a743f-7160-42bb-a8fb-178ff8fe87c4.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/146405124-66cf8358-b9c5-4e5a-84eb-ff56e519639f.gif" width="200" /></kbd>

### Test case 4

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/146405689-80e7a167-d6db-4a0e-816a-d5593f059832.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/146405676-0023d7ce-90db-416c-aa5f-974aa0056767.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
