### PR TITLE
Custom keys from `theme.json`: fix kebabCase conversion

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -1168,7 +1168,7 @@ class WP_Theme_JSON_Gutenberg {
 			$new_key = $prefix . str_replace(
 				'/',
 				'-',
-				strtolower( preg_replace( '/(?<!^)[A-Z]/', '-$0', $property ) ) // CamelCase to kebab-case.
+				strtolower( _wp_to_kebab_case( $property ) )
 			);
 
 			if ( is_array( $value ) ) {

--- a/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/edit-site/src/components/global-styles/test/use-global-styles-output.js
@@ -217,10 +217,16 @@ describe( 'global styles renderer', () => {
 									slug: 'black',
 									color: 'black',
 								},
+								{
+									name: 'White to Black',
+									slug: 'white2black',
+									color: 'value',
+								},
 							],
 						},
 					},
 					custom: {
+						white2black: 'value',
 						'font-primary': 'value',
 						'line-height': {
 							body: 1.7,
@@ -257,7 +263,7 @@ describe( 'global styles renderer', () => {
 			};
 
 			expect( toCustomProperties( tree, blockSelectors ) ).toEqual(
-				'body{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
+				'body{--wp--preset--color--white: white;--wp--preset--color--black: black;--wp--preset--color--white-2-black: value;--wp--custom--white-2-black: value;--wp--custom--font-primary: value;--wp--custom--line-height--body: 1.7;--wp--custom--line-height--heading: 1.3;}h1,h2,h3,h4,h5,h6{--wp--preset--font-size--small: 12px;--wp--preset--font-size--medium: 23px;}'
 			);
 		} );
 	} );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -611,12 +611,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEquals( $variables, $theme_json->get_stylesheet( array( 'variables' ) ) );
 	}
 
-	function test_get_stylesheet_generates_proper_classes_from_slugs() {
+	function test_get_stylesheet_generates_proper_classes_and_css_vars_from_slugs() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
 				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
-					'color' => array(
+					'color'  => array(
 						'palette' => array(
 							array(
 								'slug'  => 'grey',
@@ -636,6 +636,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 							),
 						),
 					),
+					'custom' => array(
+						'white2black' => 'value',
+					),
 				),
 			)
 		);
@@ -645,7 +648,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			$theme_json->get_stylesheet( array( 'presets' ) )
 		);
 		$this->assertEquals(
-			'body{--wp--preset--color--grey: grey;--wp--preset--color--dark-grey: grey;--wp--preset--color--light-grey: grey;--wp--preset--color--white-2-black: grey;}',
+			'body{--wp--preset--color--grey: grey;--wp--preset--color--dark-grey: grey;--wp--preset--color--light-grey: grey;--wp--preset--color--white-2-black: grey;--wp--custom--white-2-black: value;}',
 			$theme_json->get_stylesheet( array( 'variables' ) )
 		);
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/36875

The conversion of the `custom` CSS variables in the front-end wasn't following the same rules as in the site editor. Additionally, it was also following different rules from the preset CSS variables.

## How to test

Add something like this to a theme with theme.json (eg: empty theme):

```json
{
	"version": 1,
	"settings": {
		"color": {
                    "palette": [
                        {
			"slug": "white2black",
			"color": "value",
			"name": "White to Black"
			}
                    ]
		},
		"custom": {
			"white2black": "value"
		}
	}
}
```

Visit the front-end, post, and site editor and verify that the values are serialized like this in all cases:

```css
body {
  --wp--preset--color--white-2-black: value;
  --wp--custom--white-2-black: value;
}
```

Note how `white2black` is converted into `white-2-black`.
