### PR TITLE
Font sizes: update default values

### DIFF
--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -210,7 +210,7 @@
 					"size": "36px"
 				},
 				{
-					"name": "x-large",
+					"name": "Extra Large",
 					"slug": "x-large",
 					"size": "42px"
 				}

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -200,11 +200,6 @@
 					"size": "13px"
 				},
 				{
-					"name": "Normal",
-					"slug": "normal",
-					"size": "16px"
-				},
-				{
 					"name": "Medium",
 					"slug": "medium",
 					"size": "20px"
@@ -215,8 +210,8 @@
 					"size": "36px"
 				},
 				{
-					"name": "Huge",
-					"slug": "huge",
+					"name": "x-large",
+					"slug": "x-large",
 					"size": "42px"
 				}
 			],

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -538,3 +538,13 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
+
+// Deprecated from UI, kept for back-compatibility
+@mixin font-sizes-deprecated() {
+	.has-normal-font-size {
+		font-size: var(--wp--preset--font-size--normal);
+	}
+	.has-huge-font-size {
+		font-size: var(--wp--preset--font-size--huge);
+	}
+}

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -538,13 +538,3 @@
 	}
 	/* stylelint-enable function-comma-space-after */
 }
-
-// Deprecated from UI, kept for back-compatibility
-@mixin font-sizes-deprecated() {
-	.has-normal-font-size {
-		font-size: var(--wp--preset--font-size--normal);
-	}
-	.has-huge-font-size {
-		font-size: var(--wp--preset--font-size--huge);
-	}
-}

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -6,6 +6,8 @@
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();
+	// This CSS Custom Properties aren't used anymore as defaults,
+	// but we still need to keep them for backward compatibility.
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
 }

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -6,6 +6,9 @@
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();
+	--wp--preset--font-size--normal: 16px;
+	--wp--preset--font-size--huge: 42px;
+	@include font-sizes-deprecated();
 }
 
 // Font sizes (not used now, kept because of backward compatibility).

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -8,7 +8,6 @@
 	@include gradient-colors-deprecated();
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
-	@include font-sizes-deprecated();
 }
 
 // Font sizes (not used now, kept because of backward compatibility).
@@ -18,6 +17,14 @@
 
 .has-larger-font-size {
 	font-size: 2.625em;
+}
+
+.has-normal-font-size {
+	font-size: var(--wp--preset--font-size--normal);
+}
+
+.has-huge-font-size {
+	font-size: var(--wp--preset--font-size--huge);
 }
 
 // Text alignments.

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -22,11 +22,11 @@
 }
 
 .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal);
+	font-size: var(--wp--preset--font-size--normal) !important;
 }
 
 .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge);
+	font-size: var(--wp--preset--font-size--huge) !important;
 }
 
 // Text alignments.

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -52,7 +52,6 @@
 	@include gradient-colors-deprecated();
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
-	@include font-sizes-deprecated();
 }
 
 // Font sizes (not used now, kept because of backward compatibility).
@@ -65,6 +64,14 @@
 
 .editor-styles-wrapper .has-larger-font-size {
 	font-size: 42px;
+}
+
+.editor-styles-wrapper .has-normal-font-size {
+	font-size: var(--wp--preset--font-size--normal);
+}
+
+.editor-styles-wrapper .has-huge-font-size {
+	font-size: var(--wp--preset--font-size--huge);
 }
 
 /**

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -69,11 +69,11 @@
 }
 
 .editor-styles-wrapper .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal);
+	font-size: var(--wp--preset--font-size--normal) !important;
 }
 
 .editor-styles-wrapper .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge);
+	font-size: var(--wp--preset--font-size--huge) !important;
 }
 
 /**

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -50,6 +50,8 @@
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();
+	// This CSS Custom Properties aren't used anymore as defaults,
+	// but we still need to keep them for backward compatibility.
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
 }

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -50,6 +50,9 @@
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();
+	--wp--preset--font-size--normal: 16px;
+	--wp--preset--font-size--huge: 42px;
+	@include font-sizes-deprecated();
 }
 
 // Font sizes (not used now, kept because of backward compatibility).


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37378
Related https://github.com/WordPress/gutenberg/pull/37038

## Testing

- Content that uses the huge & normal classes (`.has-<slug>-font-size`) or variables (`--wp--preset--font-size-<slug>`) should still work as expected.
- Themes that define normal/huge classes should not notice anything with this change (in terms of specificity, etc.).
