### PR TITLE
Multi-entity saving: Allow publishing a post while not saving changes to non-post entities

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -45,7 +45,7 @@ export class PostPublishButton extends Component {
 				hasNonPostEntityChanges,
 				setEntitiesSavedStatesCallback,
 			} = this.props;
-			// If a post with non-post entitities is published, but the user
+			// If a post with non-post entities is published, but the user
 			// elects to not save changes to the non-post entities, those
 			// entities will still be dirty when the Publish button is clicked.
 			// We also need to check that the `setEntitiesSavedStatesCallback`

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -41,16 +41,16 @@ export class PostPublishButton extends Component {
 
 	createOnClick( callback ) {
 		return ( ...args ) => {
-			const { hasNonPostEntityChanges } = this.props;
+			const {
+				hasNonPostEntityChanges,
+				setEntitiesSavedStatesCallback,
+			} = this.props;
 			// If a post with non-post entitities is published, but the user
 			// elects to not save changes to the non-post entities, those
 			// entities will still be dirty when the Publish button is clicked.
 			// We also need to check that the `setEntitiesSavedStatesCallback`
 			// prop was passed. See https://github.com/WordPress/gutenberg/pull/37383
-			if (
-				hasNonPostEntityChanges &&
-				this.props.setEntitiesSavedStatesCallback
-			) {
+			if ( hasNonPostEntityChanges && setEntitiesSavedStatesCallback ) {
 				// The modal for multiple entity saving will open,
 				// hold the callback for saving/publishing the post
 				// so that we can call it if the post entity is checked.
@@ -62,7 +62,7 @@ export class PostPublishButton extends Component {
 				// To set a function on the useState hook, we must set it
 				// with another function (() => myFunction). Passing the
 				// function on its own will cause an error when called.
-				this.props.setEntitiesSavedStatesCallback(
+				setEntitiesSavedStatesCallback(
 					() => this.closeEntitiesSavedStates
 				);
 				return noop;

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -42,13 +42,22 @@ export class PostPublishButton extends Component {
 	createOnClick( callback ) {
 		return ( ...args ) => {
 			const { hasNonPostEntityChanges } = this.props;
-			if ( hasNonPostEntityChanges ) {
+			// If a post with non-post entitities is published, but the user
+			// elects to not save changes to the non-post entities, those
+			// entities will still be dirty when the Publish button is clicked.
+			// We also need to check that the `setEntitiesSavedStatesCallback`
+			// prop was passed. See https://github.com/WordPress/gutenberg/pull/37383
+			if (
+				hasNonPostEntityChanges &&
+				this.props.setEntitiesSavedStatesCallback
+			) {
 				// The modal for multiple entity saving will open,
 				// hold the callback for saving/publishing the post
 				// so that we can call it if the post entity is checked.
 				this.setState( {
 					entitiesSavedStatesCallback: () => callback( ...args ),
 				} );
+
 				// Open the save panel by setting its callback.
 				// To set a function on the useState hook, we must set it
 				// with another function (() => myFunction). Passing the


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

Fixes #36096

## Description
<!-- Please describe what you have changed or added -->

This PR provides a quick fix for a bug which makes it impossible to publish a new post that makes changes to non-post entities (like a template part or the Site Logo), but does not save them. Eg:

* Create a new post
* Add a Site Logo block
* Update the image in the Site Logo
* Click 'Publish', and deselect 'Site Logo' in the pre-publish panel
* Click `Save`, then `Publish`.

This PR resolves the error by checking for the existence of the `setEntitiesSavedStatesCallback` prop before attempting to open the pre-publish panel.

### Explanation of the bug

We were getting an error at [this line](https://github.com/WordPress/gutenberg/blob/22814c75b0c0041493f791399c70299a037bf3f3/packages/editor/src/components/post-publish-button/index.js#L56). The problem is that when the Publish button is clicked, we check `hasNonPostEntityChanges` to see if there are changes to non-post entities, and then perform some logic to open the pre-publish panel that allows you to check what entities you'd like saved (see screenshot). But if those entities _aren't_ saved (user deselected them), they will still be dirty and the logic will attempt to run again when you hit `Publish` the second time.

When the `Publish` button is rendered the second time, it's [rendered by the `PostPublishPanel`](https://github.com/WordPress/gutenberg/blob/22814c75b0c0041493f791399c70299a037bf3f3/packages/editor/src/components/post-publish-panel/index.js#L93) and the `setEntitiesSavedStatesCallback` prop is not passed. It's the absence of this prop (which is used to open the pre-publish panel) that causes the error. Notably it doesn't make sense to pass it here, since at this point we don't expect to open that panel.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**It is important to always test with a _new_ post, publishing for the first time.**
Verify that you can reproduce the bug on trunk. Then:

### Test that you can publish while deselecting non-post Entities
* Create a new post and add a Site Logo block
* Update the image in the Site Logo
* Click `Publish` and deselect `Site Logo`. Hit `Save`, then `Publish` again.
* Verify that the post was published and any changes other than the Site Logo were saved. Verify that the post is still dirty (the `Update` button can be clicked), and shows the option to save Site Logo.

### Test that you can publish when you *do* save non-post Entities
* Create a new post and add a Site Logo block.
* Update the image in the Site Logo
* Click `Publish` and do _not_ deselect anything. Hit `Save` then `Publish`
* Verify the post was published and changes to Site Logo were saved.


## Screenshots <!-- if applicable -->
<img width="277" alt="Screen Shot 2021-12-14 at 11 55 22 AM" src="https://user-images.githubusercontent.com/63313398/146070095-374464ca-d017-4fd1-a643-24f89cd4c794.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
