### PR TITLE
Fix deprecated usage of passing null to explode()

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -39,8 +39,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 	$style = '';
 	if ( 'default' === $layout_type ) {
-		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : null;
-		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : null;
+		$content_size = isset( $layout['contentSize'] ) ? $layout['contentSize'] : '';
+		$wide_size    = isset( $layout['wideSize'] ) ? $layout['wideSize'] : '';
 
 		$all_max_width_value  = $content_size ? $content_size : $wide_size;
 		$wide_max_width_value = $wide_size ? $wide_size : $content_size;


### PR DESCRIPTION
## Description
Same as https://github.com/WordPress/wordpress-develop/pull/2053. Making the change here as well so that it's fixed when running Gutenberg with older versions of WordPress.

As of PHP 8.1, explode() does not permit null as its second argument. This results in warnings being spat out on every page because of a usage of this in wp-includes/block-supports/layout.php.

## How has this been tested?
1. Run WordPress / Gutenberg using PHP 8.1.
2. Open up any page.
3. See that there are no longer any warnings about passing `null` to `explode()` here.

## Screenshots 

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->