### PR TITLE
Rename WP_Theme_JSON_Resolver methods

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -274,7 +274,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Returns the user's origin config.
 	 *
-	 * @return WP_Theme_JSON_Gutenberg Entity that holds user data.
+	 * @return WP_Theme_JSON_Gutenberg Entity that holds styles for user data.
 	 */
 	public static function get_user_data() {
 		if ( null !== self::$user ) {

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -205,7 +205,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @param WP_Theme $theme              The theme object.  If empty, it
 	 *                                     defaults to the current theme.
-	 * @param bool     $should_create_cpt  Optional. Whether a new custom post
+	 * @param bool     $create_post        Optional. Whether a new custom post
 	 *                                     type should be created if none are
 	 *                                     found.  False by default.
 	 * @param array    $post_status_filter Filter Optional. custom post type by
@@ -213,7 +213,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *                                     so it only fetches published posts.
 	 * @return array Custom Post Type for the user's origin config.
 	 */
-	public static function get_user_data_from_custom_post_type( $theme, $should_create_cpt = false, $post_status_filter = array( 'publish' ) ) {
+	public static function get_user_data_from_wp_global_styles( $theme, $create_post = false, $post_status_filter = array( 'publish' ) ) {
 		if ( ! $theme instanceof WP_Theme ) {
 			$theme = wp_get_theme();
 		}
@@ -242,14 +242,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		// Special case: '-1' is a results not found.
-		if ( -1 === $post_id && ! $should_create_cpt ) {
+		if ( -1 === $post_id && ! $create_post ) {
 			return $user_cpt;
 		}
 
 		$recent_posts = wp_get_recent_posts( $args );
 		if ( is_array( $recent_posts ) && ( count( $recent_posts ) === 1 ) ) {
 			$user_cpt = $recent_posts[0];
-		} elseif ( $should_create_cpt ) {
+		} elseif ( $create_post ) {
 			$cpt_post_id = wp_insert_post(
 				array(
 					'post_content' => '{"version": ' . WP_Theme_JSON_Gutenberg::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
@@ -282,7 +282,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$config   = array();
-		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme() );
+		$user_cpt = self::get_user_data_from_wp_global_styles( wp_get_theme() );
 
 		if ( array_key_exists( 'post_content', $user_cpt ) ) {
 			$decoded_data = json_decode( $user_cpt['post_content'], true );
@@ -352,12 +352,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @return integer|null
 	 */
-	public static function get_user_custom_post_type_id() {
+	public static function get_user_global_styles_post_id() {
 		if ( null !== self::$user_custom_post_type_id ) {
 			return self::$user_custom_post_type_id;
 		}
 
-		$user_cpt = self::get_user_data_from_custom_post_type( wp_get_theme(), true );
+		$user_cpt = self::get_user_data_from_wp_global_styles( wp_get_theme(), true );
 
 		if ( array_key_exists( 'ID', $user_cpt ) ) {
 			self::$user_custom_post_type_id = $user_cpt['ID'];

--- a/lib/compat/wordpress-5.9/rest-active-global-styles.php
+++ b/lib/compat/wordpress-5.9/rest-active-global-styles.php
@@ -14,9 +14,9 @@
 function gutenberg_add_active_global_styles_link( $response, $theme ) {
 	if ( $theme->get_stylesheet() === wp_get_theme()->get_stylesheet() ) {
 		// This creates a record for the current theme if not existent.
-		$id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+		$id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	} else {
-		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( $theme );
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( $theme );
 		$id       = isset( $user_cpt['ID'] ) ? $user_cpt['ID'] : null;
 	}
 

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -133,7 +133,7 @@ function gutenberg_edit_site_init( $hook ) {
 
 	$site_editor_context     = new WP_Block_Editor_Context();
 	$settings                = gutenberg_get_block_editor_settings( $custom_settings, $site_editor_context );
-	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_custom_post_type_id();
+	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	$active_theme            = wp_get_theme()->get_stylesheet();
 	gutenberg_initialize_editor(
 		'edit_site_editor',

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -268,25 +268,25 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_get_user_data_from_custom_post_type_does_not_use_uncached_queries() {
+	function test_get_user_data_from_wp_global_styles_does_not_use_uncached_queries() {
 		add_filter( 'query', array( $this, 'filter_db_query' ) );
 		$query_count = count( $this->queries );
 		for ( $i = 0; $i < 3; $i++ ) {
-			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
 			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 		}
 		$query_count = count( $this->queries ) - $query_count;
-		$this->assertEquals( 1, $query_count, 'Only one SQL query should be peformed for multiple invocations of WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type()' );
+		$this->assertEquals( 1, $query_count, 'Only one SQL query should be peformed for multiple invocations of WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles()' );
 
-		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
 		$this->assertEmpty( $user_cpt );
 
-		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme(), true );
+		$user_cpt = WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme(), true );
 		$this->assertNotEmpty( $user_cpt );
 
 		$query_count = count( $this->queries );
 		for ( $i = 0; $i < 3; $i++ ) {
-			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_custom_post_type( wp_get_theme() );
+			WP_Theme_JSON_Resolver_Gutenberg::get_user_data_from_wp_global_styles( wp_get_theme() );
 			WP_Theme_JSON_Resolver_Gutenberg::clean_cached_data();
 		}
 		$query_count = count( $this->queries ) - $query_count;


### PR DESCRIPTION
## Description
PR sync `WP_Theme_JSON_Resolver` method names with the core.

Resolves #37379.

## How has this been tested?
All checks are green.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
