### PR TITLE
Add clear button to text inputs

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -191,17 +191,17 @@ class BottomSheetCell extends Component {
 			}
 		};
 
-		const setTextInputValue = (text) => {
-			this.setState({ localValue: text });
-			this.props.onChangeValue(text);
-		}
+		const setTextInputValue = ( text ) => {
+			this.setState( { localValue: text } );
+			this.props.onChangeValue( text );
+		};
 
 		const clearButton = () => {
 			return (
 				<>
-					{this.state.localValue !== '' &&
+					{ this.state.localValue !== '' && (
 						<TouchableOpacity
-							onPress={() => setTextInputValue('')}
+							onPress={ () => setTextInputValue( '' ) }
 						>
 							<Icon
 								icon={ isIOS ? cancelCircleFilled : close }
@@ -209,10 +209,10 @@ class BottomSheetCell extends Component {
 								size={ 24 }
 							/>
 						</TouchableOpacity>
-					}
+					) }
 				</>
-			)
-		}
+			);
+		};
 
 		const separatorStyle = () => {
 			//eslint-disable-next-line @wordpress/no-unused-vars-before-return
@@ -262,7 +262,7 @@ class BottomSheetCell extends Component {
 			// We also show the TextInput to display placeholder.
 			const shouldShowPlaceholder = isValueEditable && value === '';
 			return this.state.isEditingValue || shouldShowPlaceholder ? (
-				<View style={styles.cellTextInputContainer}>
+				<View style={ styles.cellTextInputContainer }>
 					<TextInput
 						ref={ ( c ) => ( this._valueTextInput = c ) }
 						numberOfLines={ 1 }
@@ -270,7 +270,7 @@ class BottomSheetCell extends Component {
 						value={ this.state.localValue }
 						placeholder={ valuePlaceholder }
 						placeholderTextColor={ '#87a6bc' }
-						onChangeText={(text) => setTextInputValue(text)}
+						onChangeText={ ( text ) => setTextInputValue( text ) }
 						editable={ isValueEditable }
 						pointerEvents={
 							this.state.isEditingValue ? 'auto' : 'none'
@@ -281,7 +281,7 @@ class BottomSheetCell extends Component {
 						keyboardType={ this.typeToKeyboardType( type, step ) }
 						{ ...valueProps }
 					/>
-					{displayClearButton && clearButton()}
+					{ displayClearButton && clearButton() }
 				</View>
 			) : (
 				<Text

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -198,7 +198,7 @@ class BottomSheetCell extends Component {
 					style={ styles.clearIconContainer }
 					accessibilityLabel={ __( 'Clear Button' ) }
 					accessibilityHint={ __(
-						'Will clear the value of the text input when pressed'
+						'Tap here to clear the value of the text input'
 					) }
 				>
 					<Icon
@@ -370,7 +370,6 @@ class BottomSheetCell extends Component {
 				onPress={ onCellPress }
 				onLongPress={ onLongPress }
 				style={ [ styles.clipToBounds, style ] }
-				testID={ 'cell-touchable' }
 				borderless={ borderless }
 			>
 				{ drawTopSeparator && <View style={ separatorStyle() } /> }

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -196,6 +196,7 @@ class BottomSheetCell extends Component {
 				<TouchableOpacity
 					onPress={ onClear }
 					style={ styles.clearIconContainer }
+					testID="clear-button"
 				>
 					<Icon
 						icon={ isIOS ? cancelCircleFilled : close }
@@ -260,6 +261,7 @@ class BottomSheetCell extends Component {
 						numberOfLines={ 1 }
 						style={ finalStyle }
 						value={ value }
+						testID="text-input"
 						placeholder={ valuePlaceholder }
 						placeholderTextColor={ '#87a6bc' }
 						onChangeText={ onChangeValue }
@@ -366,6 +368,7 @@ class BottomSheetCell extends Component {
 				onPress={ onCellPress }
 				onLongPress={ onLongPress }
 				style={ [ styles.clipToBounds, style ] }
+				testID={ 'cell-touchable' }
 				borderless={ borderless }
 			>
 				{ drawTopSeparator && <View style={ separatorStyle() } /> }

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -110,6 +110,7 @@ class BottomSheetCell extends Component {
 			valueStyle = {},
 			cellContainerStyle = {},
 			cellRowContainerStyle = {},
+			onClear,
 			onChangeValue,
 			onSubmit,
 			children,
@@ -191,26 +192,16 @@ class BottomSheetCell extends Component {
 			}
 		};
 
-		const setTextInputValue = ( text ) => {
-			this.setState( { localValue: text } );
-			this.props.onChangeValue( text );
-		};
-
 		const clearButton = () => {
 			return (
-				<>
-					{ this.state.localValue !== '' && (
-						<TouchableOpacity
-							onPress={ () => setTextInputValue( '' ) }
-						>
-							<Icon
-								icon={ isIOS ? cancelCircleFilled : close }
-								fill={ clearButtonIconStyle.color }
-								size={ 24 }
-							/>
-						</TouchableOpacity>
-					) }
-				</>
+				<TouchableOpacity onPress={ onClear }>
+					<Icon
+						icon={ isIOS ? cancelCircleFilled : close }
+						fill={ iconStyleBase.color }
+						size={ 24 }
+						style={ styles.clearIcon }
+					/>
+				</TouchableOpacity>
 			);
 		};
 
@@ -267,10 +258,10 @@ class BottomSheetCell extends Component {
 						ref={ ( c ) => ( this._valueTextInput = c ) }
 						numberOfLines={ 1 }
 						style={ finalStyle }
-						value={ this.state.localValue }
+						value={ value }
 						placeholder={ valuePlaceholder }
 						placeholderTextColor={ '#87a6bc' }
-						onChangeText={ ( text ) => setTextInputValue( text ) }
+						onChangeText={ onChangeValue }
 						editable={ isValueEditable }
 						pointerEvents={
 							this.state.isEditingValue ? 'auto' : 'none'
@@ -281,7 +272,7 @@ class BottomSheetCell extends Component {
 						keyboardType={ this.typeToKeyboardType( type, step ) }
 						{ ...valueProps }
 					/>
-					{ displayClearButton && clearButton() }
+					{ value !== '' && displayClearButton && clearButton() }
 				</View>
 			) : (
 				<Text
@@ -336,10 +327,6 @@ class BottomSheetCell extends Component {
 		const iconStyleBase = getStylesFromColorScheme(
 			styles.icon,
 			styles.iconDark
-		);
-		const clearButtonIconStyle = getStylesFromColorScheme(
-			styles.clearButtonIcon,
-			styles.clearButtonIconDark
 		);
 		const resetButtonStyle = getStylesFromColorScheme(
 			styles.resetButton,

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -193,12 +193,14 @@ class BottomSheetCell extends Component {
 
 		const clearButton = () => {
 			return (
-				<TouchableOpacity onPress={ onClear }>
+				<TouchableOpacity
+					onPress={ onClear }
+					style={ styles.clearIconContainer }
+				>
 					<Icon
 						icon={ isIOS ? cancelCircleFilled : close }
 						fill={ iconStyleBase.color }
 						size={ 24 }
-						style={ styles.clearIcon }
 					/>
 				</TouchableOpacity>
 			);

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -35,7 +35,6 @@ class BottomSheetCell extends Component {
 		this.state = {
 			isEditingValue: props.autoFocus || false,
 			isScreenReaderEnabled: false,
-			localValue: props.value ? props.value : '',
 		};
 
 		this.handleScreenReaderToggled = this.handleScreenReaderToggled.bind(

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -16,7 +16,7 @@ import { isEmpty, get } from 'lodash';
  * WordPress dependencies
  */
 import { Icon } from '@wordpress/components';
-import { check } from '@wordpress/icons';
+import { check, cancelCircleFilled, close } from '@wordpress/icons';
 import { Component } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { withPreferredColorScheme } from '@wordpress/compose';
@@ -35,6 +35,7 @@ class BottomSheetCell extends Component {
 		this.state = {
 			isEditingValue: props.autoFocus || false,
 			isScreenReaderEnabled: false,
+			localValue: props.value ? props.value : '',
 		};
 
 		this.handleScreenReaderToggled = this.handleScreenReaderToggled.bind(
@@ -94,6 +95,7 @@ class BottomSheetCell extends Component {
 			accessibilityHint,
 			accessibilityRole,
 			disabled = false,
+			displayClearButton,
 			activeOpacity,
 			onPress,
 			onLongPress,
@@ -189,6 +191,29 @@ class BottomSheetCell extends Component {
 			}
 		};
 
+		const setTextInputValue = (text) => {
+			this.setState({ localValue: text });
+			this.props.onChangeValue(text);
+		}
+
+		const clearButton = () => {
+			return (
+				<>
+					{this.state.localValue !== '' &&
+						<TouchableOpacity
+							onPress={() => setTextInputValue('')}
+						>
+							<Icon
+								icon={ isIOS ? cancelCircleFilled : close }
+								fill={ clearButtonIconStyle.color }
+								size={ 24 }
+							/>
+						</TouchableOpacity>
+					}
+				</>
+			)
+		}
+
 		const separatorStyle = () => {
 			//eslint-disable-next-line @wordpress/no-unused-vars-before-return
 			const defaultSeparatorStyle = this.props.getStylesFromColorScheme(
@@ -237,24 +262,27 @@ class BottomSheetCell extends Component {
 			// We also show the TextInput to display placeholder.
 			const shouldShowPlaceholder = isValueEditable && value === '';
 			return this.state.isEditingValue || shouldShowPlaceholder ? (
-				<TextInput
-					ref={ ( c ) => ( this._valueTextInput = c ) }
-					numberOfLines={ 1 }
-					style={ finalStyle }
-					value={ value }
-					placeholder={ valuePlaceholder }
-					placeholderTextColor={ '#87a6bc' }
-					onChangeText={ onChangeValue }
-					editable={ isValueEditable }
-					pointerEvents={
-						this.state.isEditingValue ? 'auto' : 'none'
-					}
-					onFocus={ startEditing }
-					onBlur={ finishEditing }
-					onSubmitEditing={ onSubmit }
-					keyboardType={ this.typeToKeyboardType( type, step ) }
-					{ ...valueProps }
-				/>
+				<View style={styles.cellTextInputContainer}>
+					<TextInput
+						ref={ ( c ) => ( this._valueTextInput = c ) }
+						numberOfLines={ 1 }
+						style={ finalStyle }
+						value={ this.state.localValue }
+						placeholder={ valuePlaceholder }
+						placeholderTextColor={ '#87a6bc' }
+						onChangeText={(text) => setTextInputValue(text)}
+						editable={ isValueEditable }
+						pointerEvents={
+							this.state.isEditingValue ? 'auto' : 'none'
+						}
+						onFocus={ startEditing }
+						onBlur={ finishEditing }
+						onSubmitEditing={ onSubmit }
+						keyboardType={ this.typeToKeyboardType( type, step ) }
+						{ ...valueProps }
+					/>
+					{displayClearButton && clearButton()}
+				</View>
 			) : (
 				<Text
 					style={ { ...cellValueStyle, ...valueStyle } }
@@ -308,6 +336,10 @@ class BottomSheetCell extends Component {
 		const iconStyleBase = getStylesFromColorScheme(
 			styles.icon,
 			styles.iconDark
+		);
+		const clearButtonIconStyle = getStylesFromColorScheme(
+			styles.clearButtonIcon,
+			styles.clearButtonIconDark
 		);
 		const resetButtonStyle = getStylesFromColorScheme(
 			styles.resetButton,

--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -196,7 +196,10 @@ class BottomSheetCell extends Component {
 				<TouchableOpacity
 					onPress={ onClear }
 					style={ styles.clearIconContainer }
-					testID="clear-button"
+					accessibilityLabel={ __( 'Clear Button' ) }
+					accessibilityHint={ __(
+						'Will clear the value of the text input when pressed'
+					) }
 				>
 					<Icon
 						icon={ isIOS ? cancelCircleFilled : close }
@@ -261,7 +264,6 @@ class BottomSheetCell extends Component {
 						numberOfLines={ 1 }
 						style={ finalStyle }
 						value={ value }
-						testID="text-input"
 						placeholder={ valuePlaceholder }
 						placeholderTextColor={ '#87a6bc' }
 						onChangeText={ onChangeValue }

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -148,20 +148,16 @@
 	flex: 1;
 }
 
+.clearIcon {
+	margin-left: 16;
+}
+
 .icon {
 	color: $toolbar-button;
 }
 
 .iconDark {
 	color: #c3c4c7;
-}
-
-.clearButtonIcon {
-	color: $gray-lighten-10;
-}
-
-.clearButtonIconDark {
-	color: $dark-tertiary;
 }
 
 // Footer Message Cell

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -148,7 +148,7 @@
 	flex: 1;
 }
 
-.clearIcon {
+.clearIconContainer {
 	margin-left: 16;
 }
 

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -142,12 +142,26 @@
 	text-align: left;
 }
 
+.cellTextInputContainer {
+	align-items: center;
+	flex-direction: row;
+	flex: 1;
+}
+
 .icon {
 	color: $toolbar-button;
 }
 
 .iconDark {
 	color: #c3c4c7;
+}
+
+.clearButtonIcon {
+	color: $gray-lighten-10;
+}
+
+.clearButtonIconDark {
+	color: $dark-tertiary;
 }
 
 // Footer Message Cell

--- a/packages/components/src/mobile/bottom-sheet/test/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/cell.native.js
@@ -10,8 +10,10 @@ import BottomSheetCell from '../cell.native.js';
 
 describe( '<BottomSheetCell />', () => {
 	it( 'renders the component', async () => {
-		const screen = render( <BottomSheetCell /> );
-		const cellTouchable = screen.getByTestId( 'cell-touchable' );
+		const screen = render(
+			<BottomSheetCell accessibilityLabel={ 'Text Input' } />
+		);
+		const cellTouchable = screen.getByA11yLabel( 'Text Input' );
 
 		expect( cellTouchable ).toBeTruthy();
 	} );
@@ -22,6 +24,7 @@ describe( '<BottomSheetCell />', () => {
 
 		const screen = render(
 			<BottomSheetCell
+				accessibilityLabel={ 'Text Input' }
 				displayClearButton={ true }
 				value={ testValueString }
 				onChangeValue={ onChangeValueMock }
@@ -29,7 +32,7 @@ describe( '<BottomSheetCell />', () => {
 		);
 
 		// Invoke editing behavior by pressing the Cell
-		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		const cellTouchable = await screen.getByA11yLabel( 'Text Input' );
 		fireEvent.press( cellTouchable );
 
 		const clearButton = await screen.getByA11yLabel( 'Clear Button' );
@@ -41,6 +44,7 @@ describe( '<BottomSheetCell />', () => {
 
 		const screen = render(
 			<BottomSheetCell
+				accessibilityLabel={ 'Text Input' }
 				displayClearButton={ true }
 				value={ '' }
 				onChangeValue={ onChangeValueMock }
@@ -48,7 +52,7 @@ describe( '<BottomSheetCell />', () => {
 		);
 
 		// Invoke editing behavior by pressing the Cell
-		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		const cellTouchable = await screen.getByA11yLabel( 'Text Input' );
 		fireEvent.press( cellTouchable );
 
 		const clearButton = await screen.queryByA11yLabel( 'Clear Button' );
@@ -76,6 +80,7 @@ describe( '<BottomSheetCell />', () => {
 
 		const screen = render(
 			<BottomSheetCell
+				accessibilityLabel={ 'Text Input' }
 				displayClearButton={ true }
 				value={ testValueString }
 				onClear={ clearMock }
@@ -84,7 +89,7 @@ describe( '<BottomSheetCell />', () => {
 		);
 
 		// Invoke editing behavior by pressing the Cell
-		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		const cellTouchable = await screen.getByA11yLabel( 'Text Input' );
 		fireEvent.press( cellTouchable );
 
 		// Press clear button to invoke the `onClear` handler function

--- a/packages/components/src/mobile/bottom-sheet/test/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/cell.native.js
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from 'test/helpers';
+
+/**
+ * Internal dependencies
+ */
+import BottomSheetCell from '../cell.native.js';
+
+describe( '<BottomSheetCell />', () => {
+	it( 'renders the component', async () => {
+		const screen = render( <BottomSheetCell /> );
+		const cellTouchable = screen.getByTestId( 'cell-touchable' );
+
+		expect( cellTouchable ).toBeTruthy();
+	} );
+
+	it( 'displays a clear button when the text has value', async () => {
+		const onChangeValueMock = jest.fn();
+		const testValueString = 'test value string';
+		const newTestValueString = 'new test value string';
+
+		const screen = render(
+			<BottomSheetCell
+				displayClearButton={ true }
+				value={ testValueString }
+				onChangeValue={ onChangeValueMock }
+			/>
+		);
+
+		// Invoke editing behavior by pressing the Cell
+		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		fireEvent.press( cellTouchable );
+
+		// Simulate onChangeValue events (without rerender)
+		const textInput = await screen.getByTestId( 'text-input' );
+		fireEvent( textInput, 'focus' );
+		fireEvent.changeText( textInput, newTestValueString );
+		expect( onChangeValueMock ).toHaveBeenCalledWith( newTestValueString );
+
+		const clearButton = await screen.getByTestId( 'clear-button' );
+		expect( clearButton ).toBeTruthy();
+	} );
+
+	it( 'does NOT display a clear button when the text is empty', async () => {
+		const onChangeValueMock = jest.fn();
+
+		const screen = render(
+			<BottomSheetCell
+				displayClearButton={ true }
+				value={ '' }
+				onChangeValue={ onChangeValueMock }
+			/>
+		);
+
+		// Invoke editing behavior by pressing the Cell
+		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		fireEvent.press( cellTouchable );
+
+		const clearButton = await screen.queryByTestId( 'clear-button' );
+		expect( clearButton ).toBeNull();
+	} );
+
+	it( 'does NOT display a clear button when displayClearButton is false', async () => {
+		const onChangeValueMock = jest.fn();
+
+		const screen = render(
+			<BottomSheetCell
+				displayClearButton={ false }
+				value={ '' }
+				onChangeValue={ onChangeValueMock }
+			/>
+		);
+
+		const clearButton = await screen.queryByTestId( 'clear-button' );
+		expect( clearButton ).toBeNull();
+	});
+
+	it( 'clears text input value when the clear button is pressed', async () => {
+		const clearMock = jest.fn();
+		const testValueString = 'test value string';
+
+		const screen = render(
+			<BottomSheetCell
+				displayClearButton={ true }
+				value={ testValueString }
+				onClear={ clearMock }
+				onChangeValue={ () => {} }
+			/>
+		);
+
+		// Invoke editing behavior by pressing the Cell
+		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
+		fireEvent.press( cellTouchable );
+
+		// Press clear button to invoke clear handler function
+		const clearButton = await screen.getByTestId( 'clear-button' );
+		fireEvent.press( clearButton );
+		expect( clearMock ).toHaveBeenCalled();
+	} );
+} );

--- a/packages/components/src/mobile/bottom-sheet/test/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/cell.native.js
@@ -75,7 +75,7 @@ describe( '<BottomSheetCell />', () => {
 
 		const clearButton = await screen.queryByTestId( 'clear-button' );
 		expect( clearButton ).toBeNull();
-	});
+	} );
 
 	it( 'clears text input value when the clear button is pressed', async () => {
 		const clearMock = jest.fn();

--- a/packages/components/src/mobile/bottom-sheet/test/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/test/cell.native.js
@@ -19,7 +19,6 @@ describe( '<BottomSheetCell />', () => {
 	it( 'displays a clear button when the text has value', async () => {
 		const onChangeValueMock = jest.fn();
 		const testValueString = 'test value string';
-		const newTestValueString = 'new test value string';
 
 		const screen = render(
 			<BottomSheetCell
@@ -33,13 +32,7 @@ describe( '<BottomSheetCell />', () => {
 		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
 		fireEvent.press( cellTouchable );
 
-		// Simulate onChangeValue events (without rerender)
-		const textInput = await screen.getByTestId( 'text-input' );
-		fireEvent( textInput, 'focus' );
-		fireEvent.changeText( textInput, newTestValueString );
-		expect( onChangeValueMock ).toHaveBeenCalledWith( newTestValueString );
-
-		const clearButton = await screen.getByTestId( 'clear-button' );
+		const clearButton = await screen.getByA11yLabel( 'Clear Button' );
 		expect( clearButton ).toBeTruthy();
 	} );
 
@@ -58,7 +51,7 @@ describe( '<BottomSheetCell />', () => {
 		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
 		fireEvent.press( cellTouchable );
 
-		const clearButton = await screen.queryByTestId( 'clear-button' );
+		const clearButton = await screen.queryByA11yLabel( 'Clear Button' );
 		expect( clearButton ).toBeNull();
 	} );
 
@@ -73,11 +66,11 @@ describe( '<BottomSheetCell />', () => {
 			/>
 		);
 
-		const clearButton = await screen.queryByTestId( 'clear-button' );
+		const clearButton = await screen.queryByA11yLabel( 'Clear Button' );
 		expect( clearButton ).toBeNull();
 	} );
 
-	it( 'clears text input value when the clear button is pressed', async () => {
+	it( 'calls `onClear` when the clear button is pressed', async () => {
 		const clearMock = jest.fn();
 		const testValueString = 'test value string';
 
@@ -94,8 +87,8 @@ describe( '<BottomSheetCell />', () => {
 		const cellTouchable = await screen.getByTestId( 'cell-touchable' );
 		fireEvent.press( cellTouchable );
 
-		// Press clear button to invoke clear handler function
-		const clearButton = await screen.getByTestId( 'clear-button' );
+		// Press clear button to invoke the `onClear` handler function
+		const clearButton = await screen.getByA11yLabel( 'Clear Button' );
 		fireEvent.press( clearButton );
 		expect( clearMock ).toHaveBeenCalled();
 	} );

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SafeAreaView, TouchableOpacity, View } from 'react-native';
+import { SafeAreaView, View } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { lowerCase, startsWith } from 'lodash';
 

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -10,9 +10,9 @@ import { lowerCase, startsWith } from 'lodash';
  */
 import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { BottomSheet, Icon } from '@wordpress/components';
+import { BottomSheet } from '@wordpress/components';
 import { getProtocol, isURL, prependHTTP } from '@wordpress/url';
-import { link, cancelCircleFilled } from '@wordpress/icons';
+import { link } from '@wordpress/icons';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
@@ -74,18 +74,9 @@ export const LinkPicker = ( {
 		pickLink( directEntry );
 	};
 
-	const clear = () => {
-		setValue( { value: '', clipboardUrl } );
-	};
-
 	const omniCellStyle = usePreferredColorSchemeStyle(
 		styles.omniCell,
 		styles.omniCellDark
-	);
-
-	const iconStyle = usePreferredColorSchemeStyle(
-		styles.icon,
-		styles.iconDark
 	);
 
 	useEffect( () => {
@@ -105,6 +96,7 @@ export const LinkPicker = ( {
 			</NavBar>
 			<View style={ styles.contentContainer }>
 				<BottomSheet.Cell
+					displayClearButton={ true }
 					icon={ link }
 					style={ omniCellStyle }
 					valueStyle={ styles.omniInput }
@@ -120,20 +112,7 @@ export const LinkPicker = ( {
 					/* eslint-disable-next-line jsx-a11y/no-autofocus */
 					autoFocus
 					separatorType="none"
-				>
-					{ value !== '' && (
-						<TouchableOpacity
-							onPress={ clear }
-							style={ styles.clearIcon }
-						>
-							<Icon
-								icon={ cancelCircleFilled }
-								fill={ iconStyle.color }
-								size={ 24 }
-							/>
-						</TouchableOpacity>
-					) }
-				</BottomSheet.Cell>
+				/>
 				{ !! clipboardUrl && clipboardUrl !== value && (
 					<BottomSheet.LinkSuggestionItemCell
 						accessible

--- a/packages/components/src/mobile/link-picker/index.native.js
+++ b/packages/components/src/mobile/link-picker/index.native.js
@@ -79,6 +79,10 @@ export const LinkPicker = ( {
 		styles.omniCellDark
 	);
 
+	const clearInput = () => {
+		setValue( { value: '', clipboardUrl } );
+	};
+
 	useEffect( () => {
 		getURLFromClipboard()
 			.then( ( url ) => setValue( { value, clipboardUrl: url } ) )
@@ -105,6 +109,7 @@ export const LinkPicker = ( {
 					autoCapitalize="none"
 					autoCorrect={ false }
 					keyboardType="url"
+					onClear={ () => clearInput() }
 					onChangeValue={ ( newValue ) => {
 						setValue( { value: newValue, clipboardUrl } );
 					} }

--- a/packages/components/src/mobile/link-picker/styles.native.scss
+++ b/packages/components/src/mobile/link-picker/styles.native.scss
@@ -16,18 +16,6 @@
 	justify-content: center;
 }
 
-.clearIcon {
-	margin-left: 16;
-}
-
-.icon {
-	color: $gray-lighten-10;
-}
-
-.iconDark {
-	color: $dark-tertiary;
-}
-
 .contentContainer {
 	padding-left: $grid-unit-20;
 	padding-right: $grid-unit-20;

--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -212,6 +212,14 @@ function LinkSettings( {
 		[ linkRelInputValue ]
 	);
 
+	const clearURLInput = () => {
+		setUrlInputValue( '' );
+	};
+
+	const clearLabelInput = () => {
+		setLabelInputValue( '' );
+	};
+
 	const onChangeLinkRel = useCallback( ( value ) => {
 		setLinkRelInputValue( value );
 	}, [] );
@@ -248,6 +256,7 @@ function LinkSettings( {
 							label={ options.url.label }
 							value={ urlInputValue }
 							valuePlaceholder={ options.url.placeholder }
+							onClear={ () => clearURLInput() }
 							onChange={ onChangeURL }
 							onSubmit={ onCloseSettingsSheet }
 							autoCapitalize="none"
@@ -265,6 +274,7 @@ function LinkSettings( {
 						label={ options.linkLabel.label }
 						value={ labelInputValue }
 						valuePlaceholder={ options.linkLabel.placeholder }
+						onClear={ () => clearLabelInput() }
 						onChange={ onChangeLabel }
 					/>
 				) }

--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -243,6 +243,7 @@ function LinkSettings( {
 						/>
 					) : (
 						<TextControl
+							displayClearButton={true}
 							icon={ showIcon && link }
 							label={ options.url.label }
 							value={ urlInputValue }
@@ -260,6 +261,7 @@ function LinkSettings( {
 					) ) }
 				{ options.linkLabel && (
 					<TextControl
+						displayClearButton={true}
 						label={ options.linkLabel.label }
 						value={ labelInputValue }
 						valuePlaceholder={ options.linkLabel.placeholder }

--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -220,6 +220,10 @@ function LinkSettings( {
 		setLabelInputValue( '' );
 	};
 
+	const clearLinkRelInput = () => {
+		setLinkRelInputValue( '' );
+	};
+
 	const onChangeLinkRel = useCallback( ( value ) => {
 		setLinkRelInputValue( value );
 	}, [] );
@@ -290,10 +294,12 @@ function LinkSettings( {
 						) }
 						{ options.linkRel && (
 							<TextControl
+								displayClearButton={ true }
 								icon={ showIcon && LinkRelIcon }
 								label={ options.linkRel.label }
 								value={ linkRelInputValue }
 								valuePlaceholder={ options.linkRel.placeholder }
+								onClear={ () => clearLinkRelInput() }
 								onChange={ onChangeLinkRel }
 								onSubmit={ onCloseSettingsSheet }
 								autoCapitalize="none"

--- a/packages/components/src/mobile/link-settings/index.native.js
+++ b/packages/components/src/mobile/link-settings/index.native.js
@@ -243,7 +243,7 @@ function LinkSettings( {
 						/>
 					) : (
 						<TextControl
-							displayClearButton={true}
+							displayClearButton={ true }
 							icon={ showIcon && link }
 							label={ options.url.label }
 							value={ urlInputValue }
@@ -261,7 +261,7 @@ function LinkSettings( {
 					) ) }
 				{ options.linkLabel && (
 					<TextControl
-						displayClearButton={true}
+						displayClearButton={ true }
 						label={ options.linkLabel.label }
 						value={ labelInputValue }
 						valuePlaceholder={ options.linkLabel.placeholder }

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -428,5 +428,147 @@ describe.each( [
 				}
 			);
 		} );
+
+		describe( 'Clear Button Behavior - Clear Button Presence', () => {
+			/**
+			 * GIVEN a LINK PICKER SHEET is displayed;
+			 * GIVEN the LINK PICKER field is FOCUSED but has NO text value;
+			 */
+			// eslint-disable-next-line jest/no-done-callback
+			it( 'should not display a CLEAR BUTTON within the LINK SETTINGS field', async ( done ) => {
+				// Arrange
+				const expectation =
+					'The LINK SETTINGS > LINK TO field value should not have a CLEAR BUTTON within it.';
+				const subject = await initializeEditor( { initialHtml } );
+
+				// Act
+				try {
+					const block = await waitFor( () =>
+						subject.getByA11yLabel(
+							type === 'core/image'
+								? /Image Block/
+								: /Button Block/
+						)
+					);
+					fireEvent.press( block );
+					fireEvent.press( block );
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByA11yLabel( 'Open Settings' )
+						)
+					);
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByA11yLabel(
+								`Link to, ${
+									type === 'core/image'
+										? 'None'
+										: 'Search or type URL'
+								}`
+							)
+						)
+					);
+					if ( type === 'core/image' ) {
+						fireEvent.press(
+							await waitFor( () =>
+								subject.getByA11yLabel( /Custom URL/ )
+							)
+						);
+					}
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByPlaceholderText(
+								__( 'Search or type URL' )
+							)
+						)
+					);
+				} catch ( error ) {
+					done.fail( error );
+				}
+
+				// Assert
+				waitFor( () => subject.getByA11yLabel( 'Clear Button' ), {
+					timeout: 50,
+					interval: 10,
+				} )
+					.then( () => done.fail( expectation ) )
+					.catch( () => done() );
+			} );
+		} );
+
+		describe( 'Clear Button Behavior - Press Clear Button', () => {
+			/**
+			 * GIVEN a LINK PICKER SHEET is displayed;
+			 * GIVEN the LINK PICKER field has text value;
+			 * WHEN the CLEAR BUTTON is PRESSED
+			 */
+			// eslint-disable-next-line jest/no-done-callback
+			it( 'should clear the value of LINK SETTINGS field using the CLEAR BUTTON', async ( done ) => {
+				// Arrange
+				const expectation =
+					'The LINK SETTINGS > LINK TO field value should be EMPTY when the CLEAR BUTTON is pressed.';
+				const url = 'https://tonytahmouchtest.files.wordpress.com';
+				const subject = await initializeEditor( { initialHtml } );
+
+				// Act
+				try {
+					const block = await waitFor( () =>
+						subject.getByA11yLabel(
+							type === 'core/image'
+								? /Image Block/
+								: /Button Block/
+						)
+					);
+					fireEvent.press( block );
+					fireEvent.press( block );
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByA11yLabel( 'Open Settings' )
+						)
+					);
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByA11yLabel(
+								`Link to, ${
+									type === 'core/image'
+										? 'None'
+										: 'Search or type URL'
+								}`
+							)
+						)
+					);
+					if ( type === 'core/image' ) {
+						fireEvent.press(
+							await waitFor( () =>
+								subject.getByA11yLabel( /Custom URL/ )
+							)
+						);
+					}
+					fireEvent.changeText(
+						await waitFor( () =>
+							subject.getByPlaceholderText(
+								__( 'Search or type URL' )
+							)
+						),
+						url
+					);
+					fireEvent.press(
+						await waitFor( () =>
+							subject.getByA11yLabel( 'Clear Button' )
+						)
+					);
+				} catch ( error ) {
+					done.fail( error );
+				}
+
+				// Assert
+				waitFor( () => subject.getByDisplayValue( url ), {
+					timeout: 50,
+					interval: 10,
+				} )
+					.then( () => done.fail( expectation ) )
+					.catch( () => done() );
+			} );
+		} );
 	} );
 } );

--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -83,6 +83,10 @@ const LinkSettingsScreen = ( {
 		linkValues.isRemovingLink,
 	] );
 
+	const clearInput = () => {
+		setText( '' );
+	};
+
 	const clearFormat = ( { skipStateUpdates = false } = {} ) => {
 		onChange( { ...value, activeFormats: [] } );
 		if ( ! skipStateUpdates ) {
@@ -201,6 +205,7 @@ const LinkSettingsScreen = ( {
 					label={ __( 'Link text' ) }
 					value={ text }
 					placeholder={ __( 'Add link text' ) }
+					onClear={ () => clearInput() }
 					onChangeValue={ setText }
 					onSubmit={ submit }
 					separatorType={ shouldShowLinkOptions ? undefined : 'none' }

--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -196,7 +196,7 @@ const LinkSettingsScreen = ( {
 					onPress={ onLinkCellPressed }
 				/>
 				<BottomSheet.Cell
-					displayClearButton={true}
+					displayClearButton={ true }
 					icon={ textColor }
 					label={ __( 'Link text' ) }
 					value={ text }

--- a/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
+++ b/packages/format-library/src/link/modal-screens/link-settings-screen.native.js
@@ -196,6 +196,7 @@ const LinkSettingsScreen = ( {
 					onPress={ onLinkCellPressed }
 				/>
 				<BottomSheet.Cell
+					displayClearButton={true}
 					icon={ textColor }
 					label={ __( 'Link text' ) }
 					value={ text }


### PR DESCRIPTION
## Description
Addresses [wordpress-mobile/gutenberg-mobile#3017](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3017) by adding clear button behavior to certain TextInput controls within BottomSheet.  See [#3017](https://github.com/wordpress-mobile/gutenberg-mobile/issues/3017) for further discussion on how text input behavior may be standardized.

## How has this been tested?

### Test Case 1: Display the Clear Button and Clear Text Input
- Open the app with metro running.
- Add a **Social Icons** block.
- Tap in to a **Social Icon** to invoke the **Link Settings** modal.
- Tap "URL" or "Link label" to focus the Text Input.
- Add text to the Text Input via the keyboard.
- _Expect_: A clear button should appear if text value has been entered.
- If text has been entered and the clear button is displayed, **tap the Clear Button**.
- _Expect_: Any text input value should disappear, and placeholder text should be shown; Clear Button should not be visible.

### Test Case 2: Do not display the Clear Button for Plain Text Editor components
- Open the app with metro running.
- Add a **Cover** block.
- Tap into the **Cover** caption Text Input to add a caption or text.
- _Expect_: A clear button **should not** appear if text value has been entered.


## Screenshots 

**Android, dark mode:**

https://user-images.githubusercontent.com/643285/146175802-eb6ea8c8-d01c-4ba4-99bf-b45012258caf.mov

**iOS, light mode:**

https://user-images.githubusercontent.com/643285/146175834-2129d1a8-997e-431e-8474-9577851ba6c6.mov




## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
