### PR TITLE
ESLint Plugin: Fix Babel config resolution when a custom ESLint config present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16067,6 +16067,7 @@
 				"@babel/eslint-parser": "^7.16.0",
 				"@typescript-eslint/eslint-plugin": "^5.3.0",
 				"@typescript-eslint/parser": "^5.3.0",
+				"@wordpress/babel-preset-default": "file:packages/babel-preset-default",
 				"@wordpress/prettier-config": "file:packages/prettier-config",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Bug Fix
 
--   Fix Babel config resolution when a custom ESLint config present ([#37406](https://github.com/WordPress/gutenberg/pull/37406)).
+-   Fix Babel config resolution when a custom ESLint config present ([#37406](https://github.com/WordPress/gutenberg/pull/37406)). Warning: it won't recognize the `babel.config.json` file present in the project until the upstream bug in `cosmiconfig` is fixed.
 
 ## 9.3.0 (2021-11-15)
 

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^36.0.8` to requiring `^37.0.3` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The bundled `globals` dependency has been updated from requiring `^12.0.0` to requiring `^13.12.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 
+### Bug Fix
+
+-   Fix Babel config resolution when a custom ESLint config present ([#37406](https://github.com/WordPress/gutenberg/pull/37406)).
+
 ## 9.3.0 (2021-11-15)
 
 ### Enhancements

--- a/packages/eslint-plugin/configs/esnext.js
+++ b/packages/eslint-plugin/configs/esnext.js
@@ -52,6 +52,8 @@ const config = {
 	},
 };
 
+// It won't recognize the `babel.config.json` file used in the project until the upstream bug in `cosmiconfig` is fixed:
+// https://github.com/davidtheclark/cosmiconfig/issues/246.
 const result = cosmiconfigSync( 'babel' ).search();
 if ( ! result || ! result.filepath ) {
 	config.parserOptions = {

--- a/packages/eslint-plugin/configs/esnext.js
+++ b/packages/eslint-plugin/configs/esnext.js
@@ -1,11 +1,17 @@
-module.exports = {
+/**
+ * External dependencies
+ */
+const { cosmiconfigSync } = require( 'cosmiconfig' );
+
+const config = {
+	parser: '@babel/eslint-parser',
+	parserOptions: {
+		sourceType: 'module',
+	},
 	env: {
 		es6: true,
 	},
 	extends: [ require.resolve( './es5.js' ) ],
-	parserOptions: {
-		sourceType: 'module',
-	},
 	rules: {
 		// Disable ES5-specific (extended from ES5)
 		'vars-on-top': 'off',
@@ -45,3 +51,16 @@ module.exports = {
 		'template-curly-spacing': [ 'error', 'always' ],
 	},
 };
+
+const result = cosmiconfigSync( 'babel' ).search();
+if ( ! result || ! result.filepath ) {
+	config.parserOptions = {
+		...config.parserOptions,
+		requireConfigFile: false,
+		babelOptions: {
+			presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
+		},
+	};
+}
+
+module.exports = config;

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -4,7 +4,6 @@
 const { isPackageInstalled } = require( '../utils' );
 
 const config = {
-	parser: '@babel/eslint-parser',
 	extends: [
 		require.resolve( './jsx-a11y.js' ),
 		require.resolve( './custom.js' ),

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -34,6 +34,7 @@
 		"@babel/eslint-parser": "^7.16.0",
 		"@typescript-eslint/eslint-plugin": "^5.3.0",
 		"@typescript-eslint/parser": "^5.3.0",
+		"@wordpress/babel-preset-default": "file:../babel-preset-default",
 		"@wordpress/prettier-config": "file:../prettier-config",
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #37096.

> Now I set up a repo for a new theme, just the theme, and it seems like the combination of the file structure and a .eslint beeing present in root of project generates the following error when linting:
>
> ```
> Parsing error: No Babel config file detected for ..../src/index.js. Either disable config file checking with requireConfigFile: false, or configure Babel so that it can find the config files.
> ```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

You can use the reproduction repo https://github.com/kimmenbert/wordpress-scripts-babel-issue shared by @kimmenbert.

I also created a new project with:

```
npx @wordpress/create-block my-block
cd my-block
```

I created `.eslintrc` file with:

```json
{
  "extends":  [ "plugin:@wordpress/eslint-plugin/recommended" ]
}
```

The last step is the most tricky as you need to patch the `node_modules/@wordpress/eslint-plgin` with the changes applied in this branch in this file:

https://github.com/WordPress/gutenberg/blob/f457352eda91ea733a0eed8e1f2b8910b494650f/packages/eslint-plugin/configs/esnext.js

Linting should work correctly when running:

`npx wp-scripts lint-js`

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
