### PR TITLE
E2E Tests: Verify that we can publish even if some changes haven't been saved

### DIFF
--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -260,8 +260,12 @@ describe( 'Multi-entity save flow', () => {
 			await clickButton( 'Save' );
 			await page.waitForSelector( publishPanelSelector );
 
-			await clickButton( 'Publish' ); // Make sure we can publish.
-			expect( console ).not.toHaveErrored();
+			// Make sure we can publish.
+			page.on( 'pageerror', ( err ) => {
+				// eslint-disable-next-line no-console
+				console.log( 'Error when attempting to publish post:', err );
+			} );
+			await clickButton( 'Publish' );
 
 			// Reset site entity to default value to not affect other tests.
 			await page.evaluate( () => {

--- a/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
+++ b/packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
@@ -234,6 +234,47 @@ describe( 'Multi-entity save flow', () => {
 
 			expect( checkboxInputs ).toHaveLength( 1 );
 		} );
+
+		// Regression: https://github.com/WordPress/gutenberg/issues/36096
+		it( "Can publish even if some changes haven't been saved", async () => {
+			await createNewPost();
+			//await disablePrePublishChecks();
+
+			await insertBlock( 'Site Title' );
+			// Ensure title is retrieved before typing.
+			await page.waitForXPath( '//a[contains(text(), "gutenberg")]' );
+			const editableSiteTitleSelector =
+				'.wp-block-site-title a[contenteditable="true"]';
+			await page.waitForSelector( editableSiteTitleSelector );
+			await page.focus( editableSiteTitleSelector );
+			await page.keyboard.type( '...' );
+
+			await clickButton( 'Publish' );
+			await page.waitForSelector( savePanelSelector );
+			const checkboxInputs = await page.$$( checkboxInputSelector );
+			expect( checkboxInputs ).toHaveLength( 2 );
+
+			await checkboxInputs[ 0 ].click();
+			await page.click( entitiesSaveSelector );
+
+			await clickButton( 'Save' );
+			await page.waitForSelector( publishPanelSelector );
+
+			await clickButton( 'Publish' ); // Make sure we can publish.
+			expect( console ).not.toHaveErrored();
+
+			// Reset site entity to default value to not affect other tests.
+			await page.evaluate( () => {
+				wp.data
+					.dispatch( 'core' )
+					.editEntityRecord( 'root', 'site', undefined, {
+						title: 'gutenberg',
+					} );
+				wp.data
+					.dispatch( 'core' )
+					.saveEditedEntityRecord( 'root', 'site', undefined );
+			} );
+		} );
 	} );
 
 	describe( 'Site Editor', () => {


### PR DESCRIPTION
## Description
Based on https://github.com/WordPress/gutenberg/issues/36096#issuecomment-971926623. Provides test coverage for the issue described at https://github.com/WordPress/gutenberg/issues/36096#issuecomment-971926623, which has a fix at https://github.com/WordPress/gutenberg/pull/37383.

_Note that this is still a WIP: The test is currently **not** failing, even though the tested functionality **is**._

For background, see discussion starting at https://github.com/WordPress/gutenberg/issues/36096#issuecomment-971926623.

## How has this been tested?

```
npm run test-e2e -- packages/e2e-tests/specs/site-editor/multi-entity-saving.test.js
```

## Types of changes
Code quality
