### PR TITLE
Gallery: Fix block registration hook priority

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -48,4 +48,4 @@ function register_block_core_gallery() {
 	);
 }
 
-add_action( 'init', 'register_block_core_gallery', 20 );
+add_action( 'init', 'register_block_core_gallery' );


### PR DESCRIPTION
## Description
Fixes #37391.

All core blocks use the default (`10`) `init` hook priority for registration. Using higher priority causes `gutenberg_reregister_core_block_types` (which also uses default priority) to incorrectly re-register blocks.

@gziolo's flow summary:
- register from block.json with priority 10
- unregister the block, register from core later at priority 20
- nothing to unregister, register from plugin later at priority 20

## Testing
This needs to be backported to the core for proper testing. Meanwhile, you can temporarily edit the WP core file and match changes in this PR.

The following PHP notice shouldn't be visible:

```
Notice: WP_Block_Type_Registry::register was called incorrectly. Block type "core/gallery" is already registered.
```  

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
