### PR TITLE
[Global Styles]: Add support for nameless font sizes

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -95,48 +95,53 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const PRESETS_METADATA = array(
 		array(
-			'path'       => array( 'color', 'palette' ),
-			'override'   => array( 'color', 'defaultPalette' ),
-			'value_key'  => 'color',
-			'css_vars'   => '--wp--preset--color--$slug',
-			'classes'    => array(
+			'path'                     => array( 'color', 'palette' ),
+			'override'                 => array( 'color', 'defaultPalette' ),
+			'should_use_default_names' => false,
+			'value_key'                => 'color',
+			'css_vars'                 => '--wp--preset--color--$slug',
+			'classes'                  => array(
 				'.has-$slug-color'            => 'color',
 				'.has-$slug-background-color' => 'background-color',
 				'.has-$slug-border-color'     => 'border-color',
 			),
-			'properties' => array( 'color', 'background-color', 'border-color' ),
+			'properties'               => array( 'color', 'background-color', 'border-color' ),
 		),
 		array(
-			'path'       => array( 'color', 'gradients' ),
-			'override'   => array( 'color', 'defaultGradients' ),
-			'value_key'  => 'gradient',
-			'css_vars'   => '--wp--preset--gradient--$slug',
-			'classes'    => array( '.has-$slug-gradient-background' => 'background' ),
-			'properties' => array( 'background' ),
+			'path'                     => array( 'color', 'gradients' ),
+			'override'                 => array( 'color', 'defaultGradients' ),
+			'should_use_default_names' => false,
+			'value_key'                => 'gradient',
+			'css_vars'                 => '--wp--preset--gradient--$slug',
+			'classes'                  => array( '.has-$slug-gradient-background' => 'background' ),
+			'properties'               => array( 'background' ),
 		),
 		array(
-			'path'       => array( 'color', 'duotone' ),
-			'override'   => true,
-			'value_func' => 'gutenberg_render_duotone_filter_preset',
-			'css_vars'   => '--wp--preset--duotone--$slug',
-			'classes'    => array(),
-			'properties' => array( 'filter' ),
+			'path'                     => array( 'color', 'duotone' ),
+			'override'                 => true,
+			'should_use_default_names' => false,
+			'value_func'               => 'gutenberg_render_duotone_filter_preset',
+			'css_vars'                 => '--wp--preset--duotone--$slug',
+			'classes'                  => array(),
+			'properties'               => array( 'filter' ),
 		),
 		array(
-			'path'       => array( 'typography', 'fontSizes' ),
-			'override'   => true,
-			'value_key'  => 'size',
-			'css_vars'   => '--wp--preset--font-size--$slug',
-			'classes'    => array( '.has-$slug-font-size' => 'font-size' ),
-			'properties' => array( 'font-size' ),
+			'path'                     => array( 'typography', 'fontSizes' ),
+			'override'                 => true,
+			'should_use_default_names' => true,
+			'value_key'                => 'size',
+			'css_vars'                 => '--wp--preset--font-size--$slug',
+			'classes'                  => array( '.has-$slug-font-size' => 'font-size' ),
+			'properties'               => array( 'font-size' ),
 		),
 		array(
-			'path'       => array( 'typography', 'fontFamilies' ),
-			'override'   => true,
-			'value_key'  => 'fontFamily',
-			'css_vars'   => '--wp--preset--font-family--$slug',
-			'classes'    => array( '.has-$slug-font-family' => 'font-family' ),
-			'properties' => array( 'font-family' ),
+			'path'                     => array( 'typography', 'fontFamilies' ),
+			'override'                 => true,
+			'should_use_default_names' => false,
+			'value_key'                => 'fontFamily',
+			'css_vars'                 => '--wp--preset--font-family--$slug',
+			'classes'                  => array( '.has-$slug-font-family' => 'font-family' ),
+			'properties'               => array( 'font-family' ),
 		),
 	);
 
@@ -1445,10 +1450,22 @@ class WP_Theme_JSON_Gutenberg {
 				$override_preset = self::should_override_preset( $this->theme_json, $node['path'], $preset['override'] );
 
 				foreach ( self::VALID_ORIGINS as $origin ) {
-					$path    = array_merge( $node['path'], $preset['path'], array( $origin ) );
-					$content = _wp_array_get( $incoming_data, $path, null );
+					$base_path = array_merge( $node['path'], $preset['path'] );
+					$path      = array_merge( $base_path, array( $origin ) );
+					$content   = _wp_array_get( $incoming_data, $path, null );
 					if ( ! isset( $content ) ) {
 						continue;
+					}
+
+					if ( 'theme' === $origin && $preset['should_use_default_names'] ) {
+						foreach ( $content as &$item ) {
+							if ( ! array_key_exists( 'name', $item ) ) {
+								$name = self::get_name_from_defaults( $item['slug'], $base_path );
+								if ( null !== $name ) {
+									$item['name'] = $name;
+								}
+							}
+						}
 					}
 
 					if (
@@ -1544,6 +1561,28 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return $slugs;
+	}
+
+	/**
+	 * Get a `default`'s preset name by a provided slug.
+	 *
+	 * @param string $slug The slug we want to find a match from default presets.
+	 * @param array  $base_path The path to inspect. It's 'settings' by default.
+	 *
+	 * @return string|null
+	 */
+	private function get_name_from_defaults( $slug, $base_path ) {
+		$path            = array_merge( $base_path, array( 'default' ) );
+		$default_content = _wp_array_get( $this->theme_json, $path, null );
+		if ( ! $default_content ) {
+			return null;
+		}
+		foreach ( $default_content as $item ) {
+			if ( $slug === $item['slug'] ) {
+				return $item['name'];
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -95,53 +95,53 @@ class WP_Theme_JSON_Gutenberg {
 	 */
 	const PRESETS_METADATA = array(
 		array(
-			'path'                     => array( 'color', 'palette' ),
-			'override'                 => array( 'color', 'defaultPalette' ),
-			'should_use_default_names' => false,
-			'value_key'                => 'color',
-			'css_vars'                 => '--wp--preset--color--$slug',
-			'classes'                  => array(
+			'path'              => array( 'color', 'palette' ),
+			'override'          => array( 'color', 'defaultPalette' ),
+			'use_default_names' => false,
+			'value_key'         => 'color',
+			'css_vars'          => '--wp--preset--color--$slug',
+			'classes'           => array(
 				'.has-$slug-color'            => 'color',
 				'.has-$slug-background-color' => 'background-color',
 				'.has-$slug-border-color'     => 'border-color',
 			),
-			'properties'               => array( 'color', 'background-color', 'border-color' ),
+			'properties'        => array( 'color', 'background-color', 'border-color' ),
 		),
 		array(
-			'path'                     => array( 'color', 'gradients' ),
-			'override'                 => array( 'color', 'defaultGradients' ),
-			'should_use_default_names' => false,
-			'value_key'                => 'gradient',
-			'css_vars'                 => '--wp--preset--gradient--$slug',
-			'classes'                  => array( '.has-$slug-gradient-background' => 'background' ),
-			'properties'               => array( 'background' ),
+			'path'              => array( 'color', 'gradients' ),
+			'override'          => array( 'color', 'defaultGradients' ),
+			'use_default_names' => false,
+			'value_key'         => 'gradient',
+			'css_vars'          => '--wp--preset--gradient--$slug',
+			'classes'           => array( '.has-$slug-gradient-background' => 'background' ),
+			'properties'        => array( 'background' ),
 		),
 		array(
-			'path'                     => array( 'color', 'duotone' ),
-			'override'                 => true,
-			'should_use_default_names' => false,
-			'value_func'               => 'gutenberg_render_duotone_filter_preset',
-			'css_vars'                 => '--wp--preset--duotone--$slug',
-			'classes'                  => array(),
-			'properties'               => array( 'filter' ),
+			'path'              => array( 'color', 'duotone' ),
+			'override'          => true,
+			'use_default_names' => false,
+			'value_func'        => 'gutenberg_render_duotone_filter_preset',
+			'css_vars'          => '--wp--preset--duotone--$slug',
+			'classes'           => array(),
+			'properties'        => array( 'filter' ),
 		),
 		array(
-			'path'                     => array( 'typography', 'fontSizes' ),
-			'override'                 => true,
-			'should_use_default_names' => true,
-			'value_key'                => 'size',
-			'css_vars'                 => '--wp--preset--font-size--$slug',
-			'classes'                  => array( '.has-$slug-font-size' => 'font-size' ),
-			'properties'               => array( 'font-size' ),
+			'path'              => array( 'typography', 'fontSizes' ),
+			'override'          => true,
+			'use_default_names' => true,
+			'value_key'         => 'size',
+			'css_vars'          => '--wp--preset--font-size--$slug',
+			'classes'           => array( '.has-$slug-font-size' => 'font-size' ),
+			'properties'        => array( 'font-size' ),
 		),
 		array(
-			'path'                     => array( 'typography', 'fontFamilies' ),
-			'override'                 => true,
-			'should_use_default_names' => false,
-			'value_key'                => 'fontFamily',
-			'css_vars'                 => '--wp--preset--font-family--$slug',
-			'classes'                  => array( '.has-$slug-font-family' => 'font-family' ),
-			'properties'               => array( 'font-family' ),
+			'path'              => array( 'typography', 'fontFamilies' ),
+			'override'          => true,
+			'use_default_names' => false,
+			'value_key'         => 'fontFamily',
+			'css_vars'          => '--wp--preset--font-family--$slug',
+			'classes'           => array( '.has-$slug-font-family' => 'font-family' ),
+			'properties'        => array( 'font-family' ),
 		),
 	);
 
@@ -1457,7 +1457,7 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
-					if ( 'theme' === $origin && $preset['should_use_default_names'] ) {
+					if ( 'theme' === $origin && $preset['use_default_names'] ) {
 						foreach ( $content as &$item ) {
 							if ( ! array_key_exists( 'name', $item ) ) {
 								$name = self::get_name_from_defaults( $item['slug'], $base_path );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -1431,6 +1431,97 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_merge_incoming_data_presets_use_default_names() {
+		$defaults   = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'name' => 'Small',
+								'slug' => 'small',
+								'size' => '12px',
+							),
+							array(
+								'name' => 'Large',
+								'slug' => 'large',
+								'size' => '20px',
+							),
+						),
+					),
+				),
+			),
+			'default'
+		);
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'settings' => array(
+					'typography' => array(
+						'fontSizes' => array(
+							array(
+								'slug' => 'small',
+								'size' => '1.1rem',
+							),
+							array(
+								'slug' => 'large',
+								'size' => '1.75rem',
+							),
+							array(
+								'name' => 'Huge',
+								'slug' => 'huge',
+								'size' => '3rem',
+							),
+						),
+					),
+				),
+			),
+			'theme'
+		);
+		$expected   = array(
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'settings' => array(
+				'typography' => array(
+					'fontSizes' => array(
+						'theme'   => array(
+							array(
+								'name' => 'Small',
+								'slug' => 'small',
+								'size' => '1.1rem',
+							),
+							array(
+								'name' => 'Large',
+								'slug' => 'large',
+								'size' => '1.75rem',
+							),
+							array(
+								'name' => 'Huge',
+								'slug' => 'huge',
+								'size' => '3rem',
+							),
+						),
+						'default' => array(
+							array(
+								'name' => 'Small',
+								'slug' => 'small',
+								'size' => '12px',
+							),
+							array(
+								'name' => 'Large',
+								'slug' => 'large',
+								'size' => '20px',
+							),
+						),
+					),
+				),
+			),
+		);
+		$defaults->merge( $theme_json );
+		$actual = $defaults->get_raw_data();
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
+
 	function test_remove_insecure_properties_removes_unsafe_styles() {
 		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties(
 			array(


### PR DESCRIPTION
Very recently in [this PR](https://github.com/WordPress/gutenberg/pull/37381) we updated the default font sizes - the new defaults have the slugs (`small`, `medium`, `large`, `x-large`.

With this PR we allow themes to skip the declaration of `name` of their `fontSizes`, if they want to support the defaults. What this means is that a theme can now provide their fontSizes like this:
```
"fontSizes": [
	{
		"slug": "small",
		"size": "1.3rem"
	},
	{
		"slug": "medium",
		"size": "1.75rem"
	},
	{
		"slug": "large",
		"size": "2rem"
	},
	{
		"slug": "x-large",
		"size": "3rem"
	}
],
```
** Note the missing `name` field and that the slugs match the `default` ones.

## Notes
- If a theme doesn't provide a name for a `slug` that isn't among the defaults, it will result to having no `name` with all the bad implications that entails. 
- If a theme uses a `slug` that is among the defaults, but provides a `name`, the provided name will be used.

## Testing instructions
1. Add to your `theme.json` nameless font sizes that use the core default slugs (example above)
2. Observe that in font size picker the `names` from the defaults are shown as labels.

