### PR TITLE
Fix BottomSheet navigation hardware back button support

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/navigation-screen.native.js
@@ -57,6 +57,25 @@ const BottomSheetNavigationScreen = ( {
 				onHandleHardwareButtonPress( null );
 				return false;
 			} );
+			/**
+			 * TODO: onHandleHardwareButtonPress stores a single value, which means
+			 * future invocations from sibling screens can replace the callback for
+			 * the currently active screen. Currently, the empty dependency array
+			 * passed to useCallback here is what prevents erroneous callback
+			 * replacements, but leveraging memoization to achieve this is brittle and
+			 * explicitly discouraged in the React documentation.
+			 * https://reactjs.org/docs/hooks-reference.html#usememo
+			 *
+			 * Ideally, we refactor onHandleHardwareButtonPress to manage multiple
+			 * callbacks triggered based upon which screen is currently active.
+			 *
+			 * Related: https://git.io/JD2no
+			 */
+		}, [] )
+	);
+
+	useFocusEffect(
+		useCallback( () => {
 			if ( fullScreen ) {
 				setHeight( '100%' );
 				setIsFullScreen( true );
@@ -67,6 +86,7 @@ const BottomSheetNavigationScreen = ( {
 			return () => {};
 		}, [ setHeight ] )
 	);
+
 	const onLayout = ( { nativeEvent } ) => {
 		if ( fullScreen ) {
 			return;
@@ -78,6 +98,7 @@ const BottomSheetNavigationScreen = ( {
 			setHeightDebounce( height );
 		}
 	};
+
 	return useMemo( () => {
 		return isScrollable || isNested ? (
 			<View


### PR DESCRIPTION
## Description
An earlier addition of `setHeight` to the dependencies array (https://github.com/WordPress/gutenberg/commit/2a8d738b40a5f803045eda68e29eca8c08918af0) meant the callback was recreated multiple times, which led to unintentional updates to the hardware button handler. This resulted in navigating backwards multiple screen instead of one when pressing the hardward back button in a deeply nested screen.

`onHandleHardwareButtonPress` stores a single value, which means future invocations from sibling screens can replace the callback for the currently active screen. Currently, the empty dependency array passed to `useCallback` here is what prevents erroneous callback replacements, but leveraging memoization to achieve this is brittle and explicitly discouraged in the React documentation. https://reactjs.org/docs/hooks-reference.html#usememo

Ideally, we refactor `onHandleHardwareButtonPress` to manage multiple callbacks triggered based upon which screen is currently active. I opted to postpone that work to avoid delaying a merge of the targeted RN upgrade PR. 

Related: https://github.com/WordPress/gutenberg/pull/36328#discussion_r768897546

## How has this been tested?
1. Open the editor on an Android device. 
1. Add a Buttons block. 
2. Open the Buttons block settings. 
3. Tap _Background color_. 
4. Scroll the palette colors left, and tap _Custom_. 
5. Tap the hardware back button. 
6. ℹ️ **Expected:** The palettes are displayed. 
5. Tap the hardware back button. 
6. ℹ️ **Expected:** The Buttons block settings are displayed. 
5. Tap the hardware back button. 
6. ℹ️ **Expected:** The bottom sheet is closed. 
5. Tap the hardware back button. 
6. ℹ️ **Expected:** The app is closed. 

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/438664/146266501-e94c2e4c-a28e-44a4-b053-0489d42afff4.mp4

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
