### PR TITLE
Block editor: Add `post-type-x` classname to iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -195,6 +195,7 @@ function Iframe(
 				Array.from( ownerDocument.body.classList ).filter(
 					( name ) =>
 						name.startsWith( 'admin-color-' ) ||
+						name.startsWith( 'post-type-' ) ||
 						name === 'wp-embed-responsive'
 				)
 			);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Styling the block editor on a specific post type you have the option to use the body classname `post-type-{postType}`. When previewing the editor in tablet/mobile the iframe doesn't have the `post-type-{postType}` classname. This means that the expected style isn't applied to these previews.

This PR passes the `post-type-{postType}` classname to the iframe.

## How has this been tested?
Confirmed that the block editor iframe has the classname `post-type-{postType}` when previewing the page in mobile/tablet view

## Screenshots <!-- if applicable -->
### Example of styled title field on page post type
| Trunk | With PR applied |
|-----|-----|
| ![missing-body-class](https://user-images.githubusercontent.com/1415747/146281978-1d31b643-7a72-4a2f-990c-f7ae0867f864.gif) | ![missing-body-class-fixed](https://user-images.githubusercontent.com/1415747/146281992-640c2adc-f47e-43d4-9212-9a0302a6f9ae.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
