### PR TITLE
Update: Allow color gradient popover to be above the color toggle

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
+++ b/packages/block-editor/src/components/colors-gradients/panel-color-gradient-settings.js
@@ -137,10 +137,8 @@ export const PanelColorGradientSettingsInner = ( {
 	);
 
 	let dropdownPosition;
-	let popoverProps;
 	if ( __experimentalIsRenderedInSidebar ) {
 		dropdownPosition = isRTL() ? 'bottom right' : 'bottom left';
-		popoverProps = { __unstableForcePosition: true };
 	}
 
 	return (
@@ -160,7 +158,6 @@ export const PanelColorGradientSettingsInner = ( {
 				{ settings.map( ( setting, index ) => (
 					<Dropdown
 						position={ dropdownPosition }
-						popoverProps={ popoverProps }
 						className="block-editor-panel-color-gradient-settings__dropdown"
 						key={ index }
 						contentClassName="block-editor-panel-color-gradient-settings__dropdown-content"

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -51,9 +51,18 @@
 }
 
 @include break-medium() {
-	.block-editor-panel-color-gradient-settings__dropdown-content .components-popover__content {
-		margin-right: #{ math.div($sidebar-width, 2) + $grid-unit-20 } !important;
-		margin-top: #{ -($grid-unit-60 + $grid-unit-15) } !important;
+	.block-editor-panel-color-gradient-settings__dropdown-content {
+		.components-popover__content {
+			margin-right: #{ math.div($sidebar-width, 2) + $grid-unit-20 } !important;
+		}
+
+		&.is-from-top .components-popover__content {
+			margin-top: #{ -($grid-unit-60 + $grid-unit-15) } !important;
+		}
+
+		&.is-from-bottom .components-popover__content {
+			margin-bottom: #{ -($grid-unit-60 + $grid-unit-15) } !important;
+		}
 	}
 }
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -149,10 +149,8 @@ export default function ColorPalette( {
 	);
 
 	let dropdownPosition;
-	let popoverProps;
 	if ( __experimentalIsRenderedInSidebar ) {
 		dropdownPosition = isRTL() ? 'bottom right' : 'bottom left';
-		popoverProps = { __unstableForcePosition: true };
 	}
 
 	const colordColor = colord( value );
@@ -164,7 +162,6 @@ export default function ColorPalette( {
 					position={ dropdownPosition }
 					isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
 					renderContent={ renderCustomColorPicker }
-					popoverProps={ popoverProps }
 					renderToggle={ ( { isOpen, onToggle } ) => (
 						<button
 							className="components-color-palette__custom-color"

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -31,6 +31,7 @@
 	box-shadow: 0 4px 4px rgba(0, 0, 0, 0.05);
 	border: none;
 	border-radius: $radius-block-ui;
+	max-height: fit-content !important;
 	& > div {
 		padding: 0;
 	}
@@ -41,8 +42,15 @@
 }
 
 @include break-medium() {
-	.components-dropdown__content.components-color-palette__custom-color-dropdown-content.is-rendered-in-sidebar.is-from-top .components-popover__content {
-		margin-right: #{ math.div($sidebar-width, 2) + $grid-unit-20 };
-		margin-top: #{ -($grid-unit-60 + $grid-unit-15) };
+	.components-dropdown__content.components-color-palette__custom-color-dropdown-content.is-rendered-in-sidebar {
+		.components-popover__content.components-popover__content {
+			margin-right: #{ math.div($sidebar-width, 2) + $grid-unit-20 };
+		}
+		&.is-from-top .components-popover__content {
+			margin-top: #{ -($grid-unit-60 + $grid-unit-15) };
+		}
+		&.is-from-bottom .components-popover__content {
+			margin-bottom: #{ -($grid-unit-60 + $grid-unit-15) };
+		}
 	}
 }

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -87,7 +87,6 @@ function GradientColorPickerDropdown( {
 		if ( isRenderedInSidebar ) {
 			result.anchorRef = gradientPickerDomRef.current;
 			result.position = isRTL() ? 'bottom right' : 'bottom left';
-			result.__unstableForcePosition = true;
 		}
 		return result;
 	}, [ gradientPickerDomRef.current, isRenderedInSidebar ] );


### PR DESCRIPTION
This PR allows the color popover to be above the color buttons if there is no space below. Disables the position forcing and allows us to take advantage of the popover automatic position mechanism.

## How has this been tested?
I made the window height equal to 700px.
I added a group block.
I opened the background color picker and verified the popover appears above and is completely visible as the screenshot shows.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/146283043-f87191e3-93b5-4af2-9e18-780a715dd988.png)
