### PR TITLE
Template Editor: Change color of welcome dialog close icon so it is visible against black background

### DIFF
--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -30,4 +30,8 @@
 		margin: 0 4px;
 		vertical-align: text-top;
 	}
+
+	.components-button svg {
+		fill: $white;
+	}
 }

--- a/packages/edit-post/src/components/welcome-guide/style.scss
+++ b/packages/edit-post/src/components/welcome-guide/style.scss
@@ -1,4 +1,5 @@
-.edit-post-welcome-guide {
+.edit-post-welcome-guide,
+.edit-template-welcome-guide {
 	width: 312px;
 
 	&__image {
@@ -30,7 +31,9 @@
 		margin: 0 4px;
 		vertical-align: text-top;
 	}
+}
 
+.edit-template-welcome-guide {
 	.components-button svg {
 		fill: $white;
 	}

--- a/packages/edit-post/src/components/welcome-guide/template.js
+++ b/packages/edit-post/src/components/welcome-guide/template.js
@@ -16,7 +16,7 @@ export default function WelcomeGuideTemplate() {
 
 	return (
 		<Guide
-			className="edit-post-welcome-guide"
+			className="edit-template-welcome-guide"
 			contentLabel={ __( 'Welcome to the template editor' ) }
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ () => toggleFeature( 'welcomeGuideTemplate' ) }


### PR DESCRIPTION
## Description
The default color of the close icon is dark grey, so it is barely visible against the black background of the template editor welcome dialog, so this PR changes the color of the icon to white.

Fixes: #37399

## How to test

- Check out this PR
- Clear the local application storage for your dev env (In Chrome this is under the Application tab in the dev console)
- Edit a new post and in the right-hand post settings panel choose the option to add a new template
- Check that the close icon is white and visible at the top right of the welcome dialog

## Screenshots 

Before:
<img width="331" alt="Screen Shot 2021-12-16 at 4 51 44 PM" src="https://user-images.githubusercontent.com/3629020/146305634-062f5a8d-f8e1-4e13-b0e5-6cf97fcf0e61.png">

After:
<img width="336" alt="Screen Shot 2021-12-16 at 4 49 06 PM" src="https://user-images.githubusercontent.com/3629020/146305647-cbd82852-78fb-4584-a4ff-c7fee7871426.png">


