### PR TITLE
Columns: Avoid using CSS variables for block gap styles

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -95,7 +95,7 @@ Display content in multiple columns, with blocks added to each column.
 
 -	**Name:** core/columns
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (margin, padding), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), ~~html~~
 -	**Attributes:** isStackedOnMobile, verticalAlignment
 
 ## Comment Author Avatar

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -29,6 +29,14 @@
 			"__experimentalDefaultControls": {
 				"padding": true
 			}
+		},
+		"__experimentalLayout": {
+			"allowSwitching": false,
+			"allowInheriting": false,
+			"default": {
+				"type": "flex",
+				"flexWrap": "nowrap"
+			}
 		}
 	},
 	"editorStyle": "wp-block-columns-editor",

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -33,6 +33,7 @@
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
+			"allowEditing": false,
 			"default": {
 				"type": "flex",
 				"flexWrap": "nowrap"

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -24,6 +24,7 @@
 			"link": true
 		},
 		"spacing": {
+			"blockGap": true,
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {

--- a/packages/block-library/src/columns/editor.scss
+++ b/packages/block-library/src/columns/editor.scss
@@ -8,21 +8,6 @@
 	margin-right: 0;
 }
 
-// To do: remove horizontal margin override by the editor.
-@include break-small() {
-	.editor-styles-wrapper
-	.block-editor-block-list__block.wp-block-column:nth-child(even) {
-		margin-left: var(--wp--style--block-gap, 2em);
-	}
-}
-
-@include break-medium() {
-	.editor-styles-wrapper
-	.block-editor-block-list__block.wp-block-column:not(:first-child) {
-		margin-left: var(--wp--style--block-gap, 2em);
-	}
-}
-
 // Individual columns do not have top and bottom margins on the frontend.
 // So we make the editor match that.
 // We use :where to provide minimum specificity, so that intentional margins,

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -30,19 +30,10 @@
 	}
 
 	&:not(.is-not-stacked-on-mobile) > .wp-block-column {
-		@media (max-width: #{ ($break-small - 1) }) {
+		@media (max-width: #{ ($break-medium - 1) }) {
 			// Responsiveness: Show at most one columns on mobile. This must be
 			// important since the Column assigns its own width as an inline style.
 			flex-basis: 100% !important;
-		}
-
-		// Between mobile and large viewports, allow wrap and for columns to shrink.
-		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
-			// Only add ability to shrink if there are two or more columns.
-			&:not(:only-child) {
-				flex-grow: 1;
-				flex-shrink: 1;
-			}
 		}
 
 		// At large viewports, show all columns horizontally.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -4,10 +4,10 @@
 	box-sizing: border-box;
 
 	// Responsiveness: Allow wrapping on mobile.
-	flex-wrap: wrap;
+	flex-wrap: wrap !important;
 
 	@include break-medium() {
-		flex-wrap: nowrap;
+		flex-wrap: nowrap !important;
 	}
 
 	/**
@@ -33,22 +33,22 @@
 		}
 
 		// Between mobile and large viewports, allow 2 columns.
-		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
-			// Only add two column styling if there are two or more columns
-			&:not(:only-child) {
-				// As with mobile styles, this must be important since the Column
-				// assigns its own width as an inline style, which should take effect
-				// starting at `break-medium`.
-				flex-basis: calc(50% - calc(var(--wp--style--block-gap, 2em) / 2)) !important;
-				flex-grow: 0;
-			}
+		// @media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+		// 	// Only add two column styling if there are two or more columns
+		// 	&:not(:only-child) {
+		// 		// As with mobile styles, this must be important since the Column
+		// 		// assigns its own width as an inline style, which should take effect
+		// 		// starting at `break-medium`.
+		// 		flex-basis: calc(50% - calc(var(--wp--style--block-gap, 2em) / 2)) !important;
+		// 		flex-grow: 0;
+		// 	}
 
-			// Add space between the multiple columns. Themes can customize this if they wish to work differently.
-			// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-			&:nth-child(even) {
-				margin-left: var(--wp--style--block-gap, 2em);
-			}
-		}
+		// 	// Add space between the multiple columns. Themes can customize this if they wish to work differently.
+		// 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
+		// 	&:nth-child(even) {
+		// 		margin-left: var(--wp--style--block-gap, 2em);
+		// 	}
+		// }
 
 		// At large viewports, show all columns horizontally.
 		@include break-medium() {
@@ -67,11 +67,6 @@
 			&[style*="flex-basis"] {
 				flex-grow: 0;
 			}
-
-			// When columns are in a single row, add space before all except the first.
-			&:not(:first-child) {
-				margin-left: var(--wp--style--block-gap, 2em);
-			}
 		}
 	}
 
@@ -87,11 +82,6 @@
 			// `flex-basis` width and not grow.
 			&[style*="flex-basis"] {
 				flex-grow: 0;
-			}
-
-			// When columns are in a single row, add space before all except the first.
-			&:not(:first-child) {
-				margin-left: var(--wp--style--block-gap, 2em);
 			}
 		}
 	}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -10,6 +10,10 @@
 		flex-wrap: nowrap !important;
 	}
 
+	// Ensure full vertical column stretch when alignment is not set.
+	// This overrides the Layout block support's default align-items setting of `center`.
+	align-items: initial !important;
+
 	/**
 	* All Columns Alignment
 	*/
@@ -32,23 +36,14 @@
 			flex-basis: 100% !important;
 		}
 
-		// Between mobile and large viewports, allow 2 columns.
-		// @media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
-		// 	// Only add two column styling if there are two or more columns
-		// 	&:not(:only-child) {
-		// 		// As with mobile styles, this must be important since the Column
-		// 		// assigns its own width as an inline style, which should take effect
-		// 		// starting at `break-medium`.
-		// 		flex-basis: calc(50% - calc(var(--wp--style--block-gap, 2em) / 2)) !important;
-		// 		flex-grow: 0;
-		// 	}
-
-		// 	// Add space between the multiple columns. Themes can customize this if they wish to work differently.
-		// 	// Only apply this beyond the mobile breakpoint, as there's only a single column on mobile.
-		// 	&:nth-child(even) {
-		// 		margin-left: var(--wp--style--block-gap, 2em);
-		// 	}
-		// }
+		// Between mobile and large viewports, allow wrap and for columns to shrink.
+		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+			// Only add ability to shrink if there are two or more columns.
+			&:not(:only-child) {
+				flex-grow: 1;
+				flex-shrink: 1;
+			}
+		}
 
 		// At large viewports, show all columns horizontally.
 		@include break-medium() {

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -6,7 +6,7 @@
 	// Responsiveness: Allow wrapping on mobile.
 	flex-wrap: wrap !important;
 
-	@include break-medium() {
+	@include break-small() {
 		flex-wrap: nowrap !important;
 	}
 
@@ -57,7 +57,7 @@
 	}
 
 	&.is-not-stacked-on-mobile {
-		flex-wrap: nowrap;
+		flex-wrap: nowrap !important;
 
 		> .wp-block-column {
 			// Available space should be divided equally amongst columns.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -6,7 +6,7 @@
 	// Responsiveness: Allow wrapping on mobile.
 	flex-wrap: wrap !important;
 
-	@include break-small() {
+	@include break-medium() {
 		flex-wrap: nowrap !important;
 	}
 


### PR DESCRIPTION
## Description

An experimental PR to make the Columns block gap behave should we remove the CSS var from the block styles. See:

- https://github.com/WordPress/gutenberg/pull/37360

In short, we're forcing a [flex layout ](https://github.com/WordPress/gutenberg/blob/3606ae587f338de1a8783232bbec0fbe2c60fbd9/packages/block-editor/src/layouts/flex.js) via `__experimentalLayout` and related properties. The rest is allowing flex `gap` to do its thing. 

### This branch

![Kapture 2021-12-16 at 14 59 57](https://user-images.githubusercontent.com/6458278/146305952-519d5a20-faa7-4fb5-903a-c1097741e7c7.gif)

### Trunk

![Kapture 2021-12-16 at 15 03 24](https://user-images.githubusercontent.com/6458278/146306224-2652ab2f-1e23-4ab3-84da-14ff1588d1db.gif)

### Changes included

* Opt in to the Layout block support for flex styling, hides the layout controls in the inspector
* Update CSS to remove references to the block gap CSS variable
* Update "tablet" viewport rules to allow the columns to grow/shrink to smooth over the removal of the hard-coded `50%` width at that breakpoint (the 50% rule had to be removed as we can't calculate the appropriate gap without a CSS variable. See: https://github.com/WordPress/gutenberg/pull/37436#issuecomment-998488516)
* Add a couple of `!important` CSS rules to smooth over differences between the Layout support's styles and the current styles for the Columns block

## How has this been tested?

* Insert a columns block.
* Try out columns blocks with a variety of column numbers and widths (e.g. be sure to test non-standard widths like (`25%`, `50%`, `25%`) and hard-coded widths like `200px`.
* Test the per-column vertical alignment options.
* Test that de-selecting the stack on mobile setting still allows forcing columns all onto the one row
* Try adjusting the block gap at the parent Columns block level
* Test that the columns render correctly at desktop, tablet, and mobile viewports
* Test with a variety of patterns and themes

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix with a potential breaking change for tablet viewport widths.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
