### PR TITLE
Fix and enable remaining navigation block e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -6,7 +6,7 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
 `;
 
-exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `""`;
+exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"`;
 
 exports[`Navigation encodes URL when create block if needed 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"wordpress.org/шеллы\\",\\"url\\":\\"https://wordpress.org/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -6,6 +6,8 @@ exports[`Navigation allows an empty navigation block to be created and manually 
 <!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
 `;
 
+exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `""`;
+
 exports[`Navigation encodes URL when create block if needed 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"wordpress.org/шеллы\\",\\"url\\":\\"https://wordpress.org/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -248,7 +248,7 @@ describe( 'Navigation', () => {
 			await allPagesButton.click();
 
 			// Wait for the page list block to be present
-			await page.waitForSelector( 'div[aria-label="Block: Page List"]' );
+			await page.waitForSelector( 'ul[aria-label="Block: Page List"]' );
 
 			expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 		} );
@@ -711,6 +711,9 @@ describe( 'Navigation', () => {
 		await page.keyboard.type( 'Hello' );
 
 		const previewPage = await openPreviewPage();
+		await previewPage.bringToFront();
+		await previewPage.waitForNetworkIdle();
+
 		const isScriptLoaded = await previewPage.evaluate(
 			() =>
 				null !==
@@ -726,14 +729,15 @@ describe( 'Navigation', () => {
 		await createNewPost();
 		await insertBlock( 'Navigation' );
 		await insertBlock( 'Navigation' );
+
 		const previewPage = await openPreviewPage();
+		await previewPage.bringToFront();
+		await previewPage.waitForNetworkIdle();
 
 		const tagCount = await previewPage.evaluate(
 			() =>
-				Array.from(
-					document.querySelectorAll(
-						'script[src*="navigation/view.min.js"]'
-					)
+				document.querySelectorAll(
+					'script[src*="navigation/view.min.js"]'
 				).length
 		);
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -488,6 +488,8 @@ describe( 'Navigation', () => {
 		await page.waitForNetworkIdle();
 		expect( console ).toHaveErrored();
 
+		await publishPost();
+
 		// Expect a Navigation Block with a link for "A really long page name that will not exist".
 		expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 	} );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -682,7 +682,7 @@ describe( 'Navigation', () => {
 			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
 		} );
 
-		it( 'only update a single entity currently linked with the block', async () => {
+		it( 'only updates a single entity currently linked with the block', async () => {
 			await createNewPost();
 			await insertBlock( 'Navigation' );
 


### PR DESCRIPTION
## Description
A few navigation block tests were skipped, either due to being unstable or because they were temporarily skipped while the block underwent a lot of changes.

Now things are a bit more stable, it's a good time to bring these tests back.
