### PR TITLE
Move layout custom properties to filter.

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -96,9 +96,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style .= "flex-wrap: $flex_wrap;";
 		if ( 'horizontal' === $layout_orientation ) {
 			$style .= 'align-items: center;';
-			if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
-				$style .= '--layout-direction: row;';
-			}
 			/**
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented
@@ -106,27 +103,11 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			 */
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$style .= "justify-content: {$justify_content_options[ $layout['justifyContent'] ]};";
-				if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
-					// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
-					$style .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
-					$style .= "--layout-wrap: $flex_wrap;";
-					$style .= "--layout-justify: {$justify_content_options[ $layout['justifyContent'] ]};";
-					$style .= '--layout-align: center;';
-				}
 			}
 		} else {
 			$style .= 'flex-direction: column;';
-			if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
-				$style .= '--layout-direction: column;';
-			}
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$style .= "align-items: {$justify_content_options[ $layout['justifyContent'] ]};";
-				if ( ! empty( $layout['setCascadingProperties'] ) && $layout['setCascadingProperties'] ) {
-					// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
-					$style .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
-					$style .= '--layout-justify: initial;';
-					$style .= "--layout-align: {$justify_content_options[ $layout['justifyContent'] ]};";
-				}
 			}
 		}
 		$style .= '}';
@@ -134,7 +115,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style .= "$selector > * { margin: 0; }";
 	}
 
-	return $style;
+	return apply_filters( 'layout_styles', $style, $selector, $layout );
 }
 
 /**

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -102,8 +102,7 @@
 			"allowSwitching": false,
 			"allowInheriting": false,
 			"default": {
-				"type": "flex",
-				"setCascadingProperties": true
+				"type": "flex"
 			}
 		}
 	},

--- a/packages/block-library/src/navigation/deprecated.js
+++ b/packages/block-library/src/navigation/deprecated.js
@@ -43,7 +43,6 @@ const migrateWithLayout = ( attributes ) => {
 		Object.assign( updatedAttributes, {
 			layout: {
 				type: 'flex',
-				setCascadingProperties: 'true',
 				...( itemsJustification && {
 					justifyContent: itemsJustification,
 				} ),
@@ -135,7 +134,6 @@ const v6 = {
 			allowInheriting: false,
 			default: {
 				type: 'flex',
-				setCascadingProperties: true,
 			},
 		},
 	},

--- a/packages/block-library/src/navigation/hooks.js
+++ b/packages/block-library/src/navigation/hooks.js
@@ -1,0 +1,56 @@
+// Used with the default, horizontal flex orientation.
+const justifyContentMap = {
+	left: 'flex-start',
+	right: 'flex-end',
+	center: 'center',
+	'space-between': 'space-between',
+};
+
+// Used with the vertical (column) flex orientation.
+const alignItemsMap = {
+	left: 'flex-start',
+	right: 'flex-end',
+	center: 'center',
+};
+
+export function addStylesToLayout(
+	styleContent,
+	selector,
+	appendSelectors,
+	layout
+) {
+	if ( ! layout ) {
+		return styleContent;
+	}
+
+	const { orientation = 'horizontal' } = layout;
+	const justifyContent =
+		justifyContentMap[ layout.justifyContent ] || justifyContentMap.left;
+	const alignItems =
+		alignItemsMap[ layout.justifyContent ] || alignItemsMap.left;
+
+	let customProperties = ``;
+
+	if ( orientation === 'horizontal' ) {
+		// --layout-justification-setting allows children to inherit the value
+		// regardless or row or column direction.
+		customProperties += `
+		--layout-justification-setting: ${ justifyContent };
+			--layout-direction: row;
+			--layout-wrap: ${ layout.flexWrap || 'wrap' };
+			--layout-justify: ${ justifyContent };
+			--layout-align: center;
+			`;
+	} else {
+		customProperties += `
+		--layout-justification-setting: ${ alignItems };
+		--layout-direction: column;
+		--layout-justify: initial;
+		--layout-align: ${ alignItems };
+		`;
+	}
+
+	return `${ styleContent } ${ appendSelectors( selector ) } {
+		${ customProperties }
+	}`;
+}

--- a/packages/block-library/src/navigation/index.js
+++ b/packages/block-library/src/navigation/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { navigation as icon } from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import metadata from './block.json';
 import edit from './edit';
 import save from './save';
 import deprecated from './deprecated';
+import { addStylesToLayout } from './hooks';
 
 const { name } = metadata;
 
@@ -50,3 +52,10 @@ export const settings = {
 	save,
 	deprecated,
 };
+
+// Importing this file includes side effects. This is whitelisted in block-library/package.json under sideEffects
+addFilter(
+	'blockEditor.FlexLayoutStyle',
+	'core/navigation',
+	addStylesToLayout
+);

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -605,3 +605,48 @@ function block_core_navigation_typographic_presets_backcompatibility( $parsed_bl
 }
 
 add_filter( 'render_block_data', 'block_core_navigation_typographic_presets_backcompatibility' );
+
+function block_core_navigation_add_styles_to_layout( $style, $selector, $layout ) {
+	if ( ! isset( $layout['type'] ) || 'flex' !== $layout['type'] ) {
+		return $style;	
+	}
+
+	$custom_properties       =  '';
+	$layout_orientation      = isset( $layout['orientation'] ) ? $layout['orientation'] : 'horizontal';
+	$justify_content_options = array(
+		'left'   => 'flex-start',
+		'right'  => 'flex-end',
+		'center' => 'center',
+	);
+	$flex_wrap_options       = array( 'wrap', 'nowrap' );
+		$flex_wrap           = ! empty( $layout['flexWrap'] ) && in_array( $layout['flexWrap'], $flex_wrap_options, true ) ?
+			$layout['flexWrap'] :
+			'wrap';
+
+	if ( 'horizontal' === $layout_orientation ) {
+		$custom_properties .= '--layout-direction: row;';
+
+		if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
+			// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
+			$custom_properties .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
+			$custom_properties .= "--layout-wrap: $flex_wrap;";
+			$custom_properties .= "--layout-justify: {$justify_content_options[ $layout['justifyContent'] ]};";
+			$custom_properties .= '--layout-align: center;';
+		}
+	} else {
+		$custom_properties .= '--layout-direction: column;';
+
+		if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
+			// --layout-justification-setting allows children to inherit the value regardless or row or column direction.
+			$custom_properties .= "--layout-justification-setting: {$justify_content_options[ $layout['justifyContent'] ]};";
+			$custom_properties .= '--layout-justify: initial;';
+			$custom_properties .= "--layout-align: {$justify_content_options[ $layout['justifyContent'] ]};";
+		}
+	}
+
+	$style .= "$selector { $custom_properties }";
+
+	return $style;
+}
+
+add_filter( 'layout_styles', 'block_core_navigation_add_styles_to_layout', 10, 3 );

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.json
@@ -9,7 +9,6 @@
 			"overlayMenu": "mobile",
 			"layout": {
 				"type": "flex",
-				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} -->
+<!-- wp:navigation {"layout":{"type":"flex","orientation":"horizontal"}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v4.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v4.json
@@ -10,7 +10,6 @@
 			"fontFamily": "cambria-georgia",
 			"layout": {
 				"type": "flex",
-				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v4.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"overlayMenu":"never","fontFamily":"cambria-georgia","layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} /-->
+<!-- wp:navigation {"overlayMenu":"never","fontFamily":"cambria-georgia","layout":{"type":"flex","orientation":"horizontal"}} /-->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v5.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v5.json
@@ -9,7 +9,6 @@
 			"overlayMenu": "never",
 			"layout": {
 				"type": "flex",
-				"setCascadingProperties": "true",
 				"justifyContent": "center",
 				"orientation": "vertical"
 			}

--- a/test/integration/fixtures/blocks/core__navigation__deprecated-v5.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated-v5.serialized.html
@@ -1,1 +1,1 @@
-<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":"true","justifyContent":"center","orientation":"vertical"}} /-->
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","justifyContent":"center","orientation":"vertical"}} /-->

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.json
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.json
@@ -15,7 +15,6 @@
 			},
 			"layout": {
 				"type": "flex",
-				"setCascadingProperties": "true",
 				"orientation": "horizontal"
 			}
 		},

--- a/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
+++ b/test/integration/fixtures/blocks/core__navigation__deprecated.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"layout":{"type":"flex","setCascadingProperties":"true","orientation":"horizontal"}} -->
+<!-- wp:navigation {"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"layout":{"type":"flex","orientation":"horizontal"}} -->
 <!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
 <!-- /wp:navigation -->


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up from [this discussion](https://github.com/WordPress/gutenberg/pull/36292#pullrequestreview-820027056). Moves the custom properties optionally added to layout with `setCascadingProperties` to a custom filter in the Navigation block.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create a Navigation block; change justification/orientation and verify everything works as expected in both editor and front end.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
