### PR TITLE
Navigation: Fix page list issues in overlay

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -432,6 +432,8 @@ button.wp-block-navigation-item__content {
 			// as a column.
 			display: flex;
 			flex-direction: column;
+			flex-wrap: nowrap;
+
 			// Inherit alignment settings from container.
 			align-items: var(--layout-justification-setting, inherit);
 
@@ -580,14 +582,12 @@ button.wp-block-navigation-item__content {
 // The menu adds wrapping containers.
 .wp-block-navigation__responsive-close {
 	width: 100%;
-	height: 100%;
 }
 
 .is-menu-open .wp-block-navigation__responsive-close,
 .is-menu-open .wp-block-navigation__responsive-dialog,
 .is-menu-open .wp-block-navigation__responsive-container-content {
 	box-sizing: border-box;
-	height: 100%;
 }
 
 .wp-block-navigation__responsive-dialog {

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -460,20 +460,19 @@ button.wp-block-navigation-item__content {
 				// Position and style.
 				position: static;
 				border: none;
-				padding-left: 32px;
-				padding-right: 32px;
+				padding-left: 2em;
+				padding-right: 2em;
 			}
 
 			// Space unfolded items using gap and padding for submenus.
 			.wp-block-navigation__submenu-container,
 			.wp-block-navigation__container {
 				gap: var(--wp--style--block-gap, 2em);
+			}
 
-				// Apply top padding to nested submenus.
-				.wp-block-navigation__submenu-container,
-				.wp-block-navigation__container {
-					padding-top: var(--wp--style--block-gap, 2em);
-				}
+			// Apply top padding to nested submenus.
+			.wp-block-navigation__submenu-container {
+				padding-top: var(--wp--style--block-gap, 2em);
 			}
 
 			// A default padding is added to submenu items. It's not appropriate inside the modal.


### PR DESCRIPTION
## Description

Fixes #37413.

If you mix manual/custom navigation items with a Page List, the two containers would wrap inappropriately:

<img width="568" alt="before" src="https://user-images.githubusercontent.com/1204802/146343149-10e62de2-25be-45f0-8af0-2d0133de1544.png">

This PR fixes that so it wraps correctly:

![wrapping fixed](https://user-images.githubusercontent.com/1204802/146343177-c7c98b67-7a95-469f-af6e-793cf9f6b678.gif)

It also fixes an issue with padding, both for indentation of page list items, and bottom padding for long overlays that scroll:

![padding now fixed](https://user-images.githubusercontent.com/1204802/146343789-5cf7d6ed-6984-4e11-ba45-2d1b23c29e34.gif)


## How has this been tested?

Insert a navigation menu that features lots of items, and notably including both manually added items, and a Page List. Set it to always open as an overlay, then verify the menu items stack vertically on a small screen.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
