### PR TITLE
Fix navigation appender.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -100,6 +100,7 @@
 .is-editing > .wp-block-navigation__submenu-container > .block-list-appender {
 	display: block;
 	position: static;
+	width: 100%;
 }
 
 // Hide when hovering.


### PR DESCRIPTION
## Description

The navigation block implements a custom appender for submenus, to make the building flow more intuitive. This appeder collapsed horizontally inside the flex container when empty:

<img width="1271" alt="nav appender before" src="https://user-images.githubusercontent.com/1204802/146347570-9156ab20-d8af-4197-b448-d614013bafb8.png">

This PR fixes it:

<img width="928" alt="Screenshot 2021-12-16 at 10 36 44" src="https://user-images.githubusercontent.com/1204802/146347588-e3c19e21-56a2-4b32-8361-2bfe9a91a3ea.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
