### PR TITLE
Fix alignment of the "Delete template" button in the post editor

### DIFF
--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -63,6 +63,7 @@
 
 		.components-menu-item__item {
 			margin-right: 0;
+			min-width: 0;
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -51,9 +51,9 @@
 }
 
 .edit-post-template-top-area__second-menu-group {
-	margin-left: -$grid-unit-15;
-	margin-right: -$grid-unit-15;
-	padding: $grid-unit-15;
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+	padding: $grid-unit-10;
 	padding-bottom: 0;
 	border-top: $border-width solid $gray-300;
 


### PR DESCRIPTION
Just a tiny patch this one. The `min-width` applied to menu items was causing an odd text alignment issue in the Delete Template button.

| Before | After |
| --- | --- |
| <img width="307" alt="Screenshot 2021-12-16 at 10 58 35" src="https://user-images.githubusercontent.com/846565/146360258-67d4e518-0261-4b75-bca8-8391556858fd.png"> |  <img width="332" alt="Screenshot 2021-12-16 at 11 02 03" src="https://user-images.githubusercontent.com/846565/146360273-92db576b-483d-4d51-9a0b-8c9d66987626.png"> |

