### PR TITLE
Alternative: restrict Navigation permissions and show UI warning if cannot create 

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -51,7 +51,22 @@ function gutenberg_register_navigation_post_type() {
 			'revisions',
 		),
 		'capabilities'          => array(
-			'create_posts' => 'edit_theme_options',
+			// Meta Capabilities.
+			'edit_post'              => 'edit_post',
+			'read_post'              => 'read_post',
+			'delete_post'            => 'delete_post',
+			// Primitive Capabilities.
+			'edit_posts'             => 'edit_theme_options',
+			'edit_others_posts'      => 'edit_theme_options',
+			'delete_posts'           => 'edit_theme_options',
+			'publish_posts'          => 'edit_theme_options',
+			'read_private_posts'     => 'edit_theme_options',
+			'read'                   => 'read',
+			'delete_private_posts'   => 'edit_theme_options',
+			'delete_published_posts' => 'edit_theme_options',
+			'delete_others_posts'    => 'edit_theme_options',
+			'edit_private_posts'     => 'edit_theme_options',
+			'edit_published_posts'   => 'edit_theme_options',
 		),
 	);
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -51,22 +51,7 @@ function gutenberg_register_navigation_post_type() {
 			'revisions',
 		),
 		'capabilities'          => array(
-			// Meta Capabilities.
-			'edit_post'              => 'edit_post',
-			'read_post'              => 'read_post',
-			'delete_post'            => 'delete_post',
-			// Primitive Capabilities.
-			'edit_posts'             => 'edit_theme_options',
-			'edit_others_posts'      => 'edit_theme_options',
-			'delete_posts'           => 'edit_theme_options',
-			'publish_posts'          => 'edit_theme_options',
-			'read_private_posts'     => 'edit_theme_options',
-			'read'                   => 'read',
-			'delete_private_posts'   => 'edit_theme_options',
-			'delete_published_posts' => 'edit_theme_options',
-			'delete_others_posts'    => 'edit_theme_options',
-			'edit_private_posts'     => 'edit_theme_options',
-			'edit_published_posts'   => 'edit_theme_options',
+			'create_posts' => 'edit_theme_options',
 		),
 	);
 

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -50,6 +50,9 @@ function gutenberg_register_navigation_post_type() {
 			'editor',
 			'revisions',
 		),
+		'capabilities'          => array(
+			'create_posts' => 'edit_theme_options',
+		),
 	);
 
 	register_post_type( 'wp_navigation', $args );

--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -51,7 +51,16 @@ function gutenberg_register_navigation_post_type() {
 			'revisions',
 		),
 		'capabilities'          => array(
-			'create_posts' => 'edit_theme_options',
+			'edit_others_posts'      => 'edit_theme_options',
+			'delete_posts'           => 'edit_theme_options',
+			'publish_posts'          => 'edit_theme_options',
+			'create_posts'           => 'edit_theme_options',
+			'read_private_posts'     => 'edit_theme_options',
+			'delete_private_posts'   => 'edit_theme_options',
+			'delete_published_posts' => 'edit_theme_options',
+			'delete_others_posts'    => 'edit_theme_options',
+			'edit_private_posts'     => 'edit_theme_options',
+			'edit_published_posts'   => 'edit_theme_options',
 		),
 	);
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -174,6 +174,8 @@ function Navigation( {
 				? _uncontrolledInnerBlocks
 				: _controlledInnerBlocks;
 
+			const { canUser, hasFinishedResolution } = select( coreStore );
+
 			return {
 				hasSubmenus: !! innerBlocks.find(
 					( block ) => block.name === 'core/navigation-submenu'
@@ -182,9 +184,16 @@ function Navigation( {
 				uncontrolledInnerBlocks: _uncontrolledInnerBlocks,
 				controlledInnerBlocks: _controlledInnerBlocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
+				canUserPublishNavigation: ref
+					? canUser( 'publish', 'navigation', ref )
+					: undefined,
+				hasResolvedcanUserPublishNavigationEntity: hasFinishedResolution(
+					'canUser',
+					[ 'publish', 'navigation', ref ]
+				),
 			};
 		},
-		[ clientId ]
+		[ clientId, ref ]
 	);
 	const {
 		replaceInnerBlocks,
@@ -671,6 +680,15 @@ function Navigation( {
 						</ResponsiveWrapper>
 					) }
 				</nav>
+				{ ref &&
+					hasResolvedcanUserPublishNavigationEntity &&
+					! canUserPublishNavigation && (
+						<Warning>
+							{ __(
+								'You do not have permission to publish Navigations. Any items you add here will not be saved.'
+							) }
+						</Warning>
+					) }
 			</RecursionProvider>
 		</EntityProvider>
 	);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -344,7 +344,7 @@ function Navigation( {
 			hasResolvedCanUserUpdateNavigationEntity &&
 			! canUserUpdateNavigationEntity,
 		destroyOn: ! isSelected && ! isInnerBlockSelected,
-		ref,
+		navEntityIdRef: ref,
 	} );
 
 	useNavigationNotice( {
@@ -356,7 +356,7 @@ function Navigation( {
 			hasResolvedCanUserCreateNavigation &&
 			! canUserCreateNavigation,
 		destroyOn: ref || ( ! isSelected && ! isInnerBlockSelected ),
-		ref,
+		navEntityIdRef: ref,
 	} );
 
 	const startWithEmptyMenu = useCallback( () => {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -347,6 +347,18 @@ function Navigation( {
 		ref,
 	} );
 
+	useNavigationNotice( {
+		name: 'block-library/core/navigation/permissions/create',
+		message: __( 'You do not have permission to create Navigation Menus.' ),
+		createOn:
+			( isSelected || isInnerBlockSelected ) &&
+			! ref &&
+			hasResolvedCanUserCreateNavigation &&
+			! canUserCreateNavigation,
+		destroyOn: ref || ( ! isSelected && ! isInnerBlockSelected ),
+		ref,
+	} );
+
 	const startWithEmptyMenu = useCallback( () => {
 		if ( navigationArea ) {
 			setAreaMenu( 0 );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -463,9 +463,7 @@ function Navigation( {
 											onClose();
 										} }
 										onCreateNew={ startWithEmptyMenu }
-										canUserCreateNavigation={
-											canUserCreateNavigation
-										}
+										showCreate={ canUserCreateNavigation }
 									/>
 								) }
 							</ToolbarDropdownMenu>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -184,16 +184,15 @@ function Navigation( {
 				uncontrolledInnerBlocks: _uncontrolledInnerBlocks,
 				controlledInnerBlocks: _controlledInnerBlocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-				canUserPublishNavigation: ref
-					? canUser( 'publish', 'navigation', ref )
-					: undefined,
-				hasResolvedcanUserPublishNavigationEntity: hasFinishedResolution(
+				canUserCreateNavigation:
+					canUser( 'create', 'navigation' ) || undefined,
+				hasResolvedCanUserCreateNavigation: hasFinishedResolution(
 					'canUser',
-					[ 'publish', 'navigation', ref ]
+					[ 'create', 'navigation' ]
 				),
 			};
 		},
-		[ clientId, ref ]
+		[ clientId ]
 	);
 	const {
 		replaceInnerBlocks,
@@ -316,7 +315,7 @@ function Navigation( {
 			setDetectedColor,
 			setDetectedBackgroundColor
 		);
-		const subMenuElement = navRef.current.querySelector(
+		const subMenuElement = navRef.current?.querySelector(
 			'[data-type="core/navigation-link"] [data-type="core/navigation-link"]'
 		);
 		if ( subMenuElement ) {
@@ -651,11 +650,13 @@ function Navigation( {
 								hasResolvedNavigationMenus
 							}
 							clientId={ clientId }
+							canUserCreateNavigation={ canUserCreateNavigation }
 						/>
 					) }
-					{ ! isEntityAvailable && ! isPlaceholderShown && (
-						<PlaceholderPreview isLoading />
-					) }
+					{ ! hasResolvedCanUserCreateNavigation ||
+						( ! isEntityAvailable && ! isPlaceholderShown && (
+							<PlaceholderPreview isLoading />
+						) ) }
 					{ ! isPlaceholderShown && (
 						<ResponsiveWrapper
 							id={ clientId }
@@ -680,15 +681,6 @@ function Navigation( {
 						</ResponsiveWrapper>
 					) }
 				</nav>
-				{ ref &&
-					hasResolvedcanUserPublishNavigationEntity &&
-					! canUserPublishNavigation && (
-						<Warning>
-							{ __(
-								'You do not have permission to publish Navigations. Any items you add here will not be saved.'
-							) }
-						</Warning>
-					) }
 			</RecursionProvider>
 		</EntityProvider>
 	);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -463,6 +463,9 @@ function Navigation( {
 											onClose();
 										} }
 										onCreateNew={ startWithEmptyMenu }
+										canUserCreateNavigation={
+											canUserCreateNavigation
+										}
 									/>
 								) }
 							</ToolbarDropdownMenu>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -174,8 +174,6 @@ function Navigation( {
 				? _uncontrolledInnerBlocks
 				: _controlledInnerBlocks;
 
-			const { canUser, hasFinishedResolution } = select( coreStore );
-
 			return {
 				hasSubmenus: !! innerBlocks.find(
 					( block ) => block.name === 'core/navigation-submenu'
@@ -184,12 +182,6 @@ function Navigation( {
 				uncontrolledInnerBlocks: _uncontrolledInnerBlocks,
 				controlledInnerBlocks: _controlledInnerBlocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
-				canUserCreateNavigation:
-					canUser( 'create', 'navigation' ) || undefined,
-				hasResolvedCanUserCreateNavigation: hasFinishedResolution(
-					'canUser',
-					[ 'create', 'navigation' ]
-				),
 			};
 		},
 		[ clientId ]
@@ -228,6 +220,8 @@ function Navigation( {
 		hasResolvedCanUserUpdateNavigationEntity,
 		canUserDeleteNavigationEntity,
 		hasResolvedCanUserDeleteNavigationEntity,
+		canUserCreateNavigation,
+		hasResolvedCanUserCreateNavigation,
 	} = useNavigationMenu( ref );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -334,30 +334,53 @@ function Navigation( {
 		}
 	}, [ clientId, ref, hasUncontrolledInnerBlocks, controlledInnerBlocks ] );
 
-	useNavigationNotice( {
+	const [ showCantEditNotice, hideCantEditNotice ] = useNavigationNotice( {
 		name: 'block-library/core/navigation/permissions/update',
 		message: __(
 			'You do not have permission to edit this Menu. Any changes made will not be saved.'
 		),
-		createOn:
-			( isSelected || isInnerBlockSelected ) &&
-			hasResolvedCanUserUpdateNavigationEntity &&
-			! canUserUpdateNavigationEntity,
-		destroyOn: ! isSelected && ! isInnerBlockSelected,
-		navEntityIdRef: ref,
 	} );
 
-	useNavigationNotice( {
-		name: 'block-library/core/navigation/permissions/create',
-		message: __( 'You do not have permission to create Navigation Menus.' ),
-		createOn:
-			( isSelected || isInnerBlockSelected ) &&
-			! ref &&
-			hasResolvedCanUserCreateNavigation &&
-			! canUserCreateNavigation,
-		destroyOn: ref || ( ! isSelected && ! isInnerBlockSelected ),
-		navEntityIdRef: ref,
-	} );
+	const [ showCantCreateNotice, hideCantCreateNotice ] = useNavigationNotice(
+		{
+			name: 'block-library/core/navigation/permissions/create',
+			message: __(
+				'You do not have permission to create Navigation Menus.'
+			),
+		}
+	);
+
+	useEffect( () => {
+		if ( ! isSelected && ! isInnerBlockSelected ) {
+			hideCantEditNotice();
+			hideCantCreateNotice();
+		}
+
+		if ( isSelected || isInnerBlockSelected ) {
+			if (
+				hasResolvedCanUserUpdateNavigationEntity &&
+				! canUserUpdateNavigationEntity
+			) {
+				showCantEditNotice();
+			}
+
+			if (
+				! ref &&
+				hasResolvedCanUserCreateNavigation &&
+				! canUserCreateNavigation
+			) {
+				showCantCreateNotice();
+			}
+		}
+	}, [
+		isSelected,
+		isInnerBlockSelected,
+		canUserUpdateNavigationEntity,
+		hasResolvedCanUserUpdateNavigationEntity,
+		canUserCreateNavigation,
+		hasResolvedCanUserCreateNavigation,
+		ref,
+	] );
 
 	const startWithEmptyMenu = useCallback( () => {
 		if ( navigationArea ) {

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -15,7 +15,7 @@ import useNavigationMenu from '../use-navigation-menu';
 export default function NavigationMenuSelector( {
 	onSelect,
 	onCreateNew,
-	canUserCreateNavigation = false,
+	showCreate = false,
 } ) {
 	const { navigationMenus } = useNavigationMenu();
 	const ref = useEntityId( 'postType', 'wp_navigation' );
@@ -46,7 +46,7 @@ export default function NavigationMenuSelector( {
 					} ) }
 				/>
 			</MenuGroup>
-			{ canUserCreateNavigation && (
+			{ showCreate && (
 				<MenuGroup>
 					<MenuItem onClick={ onCreateNew }>
 						{ __( 'Create new menu' ) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -12,7 +12,11 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import useNavigationMenu from '../use-navigation-menu';
 
-export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
+export default function NavigationMenuSelector( {
+	onSelect,
+	onCreateNew,
+	canUserCreateNavigation = false,
+} ) {
 	const { navigationMenus } = useNavigationMenu();
 	const ref = useEntityId( 'postType', 'wp_navigation' );
 
@@ -42,18 +46,20 @@ export default function NavigationMenuSelector( { onSelect, onCreateNew } ) {
 					} ) }
 				/>
 			</MenuGroup>
-			<MenuGroup>
-				<MenuItem onClick={ onCreateNew }>
-					{ __( 'Create new menu' ) }
-				</MenuItem>
-				<MenuItem
-					href={ addQueryArgs( 'edit.php', {
-						post_type: 'wp_navigation',
-					} ) }
-				>
-					{ __( 'Manage menus' ) }
-				</MenuItem>
-			</MenuGroup>
+			{ canUserCreateNavigation && (
+				<MenuGroup>
+					<MenuItem onClick={ onCreateNew }>
+						{ __( 'Create new menu' ) }
+					</MenuItem>
+					<MenuItem
+						href={ addQueryArgs( 'edit.php', {
+							post_type: 'wp_navigation',
+						} ) }
+					>
+						{ __( 'Manage menus' ) }
+					</MenuItem>
+				</MenuGroup>
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -183,12 +183,8 @@ export default function NavigationPlaceholder( {
 							</div>
 
 							<hr />
-							{ ! canUserCreateNavigation &&
-								__(
-									'You do not have permission to create Navigation Menus'
-								) }
-							{ canUserCreateNavigation &&
-							( hasMenus || navigationMenus.length ) ? (
+
+							{ hasMenus || navigationMenus?.length ? (
 								<>
 									<ExistingMenusDropdown
 										canSwitchNavigationMenu={

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -31,6 +31,7 @@ const ExistingMenusDropdown = ( {
 	onFinish,
 	menus,
 	onCreateFromMenu,
+	canUserCreateNavigation = false,
 } ) => {
 	const toggleProps = {
 		variant: 'tertiary',
@@ -65,22 +66,24 @@ const ExistingMenusDropdown = ( {
 								);
 							} ) }
 					</MenuGroup>
-					<MenuGroup label={ __( 'Classic Menus' ) }>
-						{ menus?.map( ( menu ) => {
-							return (
-								<MenuItem
-									onClick={ () => {
-										setSelectedMenu( menu.id );
-										onCreateFromMenu( menu.name );
-									} }
-									onClose={ onClose }
-									key={ menu.id }
-								>
-									{ decodeEntities( menu.name ) }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
+					{ canUserCreateNavigation && (
+						<MenuGroup label={ __( 'Classic Menus' ) }>
+							{ menus?.map( ( menu ) => {
+								return (
+									<MenuItem
+										onClick={ () => {
+											setSelectedMenu( menu.id );
+											onCreateFromMenu( menu.name );
+										} }
+										onClose={ onClose }
+										key={ menu.id }
+									>
+										{ decodeEntities( menu.name ) }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
 				</>
 			) }
 		</DropdownMenu>
@@ -195,6 +198,9 @@ export default function NavigationPlaceholder( {
 										onFinish={ onFinish }
 										menus={ menus }
 										onCreateFromMenu={ onCreateFromMenu }
+										canUserCreateNavigation={
+											canUserCreateNavigation
+										}
 									/>
 									<hr />
 								</>

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -181,8 +181,13 @@ export default function NavigationPlaceholder( {
 								<Icon icon={ navigation } />{ ' ' }
 								{ __( 'Navigation' ) }
 							</div>
+
 							<hr />
-							{ hasMenus || navigationMenus.length ? (
+							{ __(
+								'You do not have permission to create Navigation Menus'
+							) }
+							{ canUserCreateNavigation &&
+							( hasMenus || navigationMenus.length ) ? (
 								<>
 									<ExistingMenusDropdown
 										canSwitchNavigationMenu={

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -92,6 +92,7 @@ export default function NavigationPlaceholder( {
 	onFinish,
 	canSwitchNavigationMenu,
 	hasResolvedNavigationMenus,
+	canUserCreateNavigation = false,
 } ) {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
@@ -102,6 +103,10 @@ export default function NavigationPlaceholder( {
 		blocks,
 		navigationMenuTitle = null
 	) => {
+		if ( ! canUserCreateNavigation ) {
+			return;
+		}
+
 		const navigationMenu = await createNavigationMenu(
 			navigationMenuTitle,
 			blocks
@@ -192,7 +197,7 @@ export default function NavigationPlaceholder( {
 									<hr />
 								</>
 							) : undefined }
-							{ hasPages ? (
+							{ canUserCreateNavigation && hasPages ? (
 								<>
 									<Button
 										variant="tertiary"
@@ -203,12 +208,15 @@ export default function NavigationPlaceholder( {
 									<hr />
 								</>
 							) : undefined }
-							<Button
-								variant="tertiary"
-								onClick={ onCreateEmptyMenu }
-							>
-								{ __( 'Start empty' ) }
-							</Button>
+
+							{ canUserCreateNavigation && (
+								<Button
+									variant="tertiary"
+									onClick={ onCreateEmptyMenu }
+								>
+									{ __( 'Start empty' ) }
+								</Button>
+							) }
 						</div>
 					</div>
 				</Placeholder>

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -183,9 +183,10 @@ export default function NavigationPlaceholder( {
 							</div>
 
 							<hr />
-							{ __(
-								'You do not have permission to create Navigation Menus'
-							) }
+							{ ! canUserCreateNavigation &&
+								__(
+									'You do not have permission to create Navigation Menus'
+								) }
 							{ canUserCreateNavigation &&
 							( hasMenus || navigationMenus.length ) ? (
 								<>

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -31,7 +31,7 @@ const ExistingMenusDropdown = ( {
 	onFinish,
 	menus,
 	onCreateFromMenu,
-	canUserCreateNavigation = false,
+	showClassicMenus = false,
 } ) => {
 	const toggleProps = {
 		variant: 'tertiary',
@@ -66,7 +66,7 @@ const ExistingMenusDropdown = ( {
 								);
 							} ) }
 					</MenuGroup>
-					{ canUserCreateNavigation && (
+					{ showClassicMenus && (
 						<MenuGroup label={ __( 'Classic Menus' ) }>
 							{ menus?.map( ( menu ) => {
 								return (
@@ -198,7 +198,7 @@ export default function NavigationPlaceholder( {
 										onFinish={ onFinish }
 										menus={ menus }
 										onCreateFromMenu={ onCreateFromMenu }
-										canUserCreateNavigation={
+										showClassicMenus={
 											canUserCreateNavigation
 										}
 									/>

--- a/packages/block-library/src/navigation/edit/use-navigation-notice.js
+++ b/packages/block-library/src/navigation/edit/use-navigation-notice.js
@@ -1,51 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { store as noticeStore } from '@wordpress/notices';
 
-function useNavigationNotice( {
-	name,
-	message,
-	createOn,
-	destroyOn,
-	navEntityIdRef,
-} = {} ) {
+function useNavigationNotice( { name, message } = {} ) {
 	const noticeRef = useRef();
 
 	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
 
-	useEffect( () => {
-		const setPermissionsNotice = () => {
-			if ( noticeRef.current ) {
-				return;
-			}
-
-			noticeRef.current = name;
-
-			createWarningNotice( message, {
-				id: noticeRef.current,
-				type: 'snackbar',
-			} );
-		};
-
-		const removePermissionsNotice = () => {
-			if ( ! noticeRef.current ) {
-				return;
-			}
-			removeNotice( noticeRef.current );
-			noticeRef.current = null;
-		};
-
-		if ( destroyOn ) {
-			removePermissionsNotice();
+	const showNotice = () => {
+		if ( noticeRef.current ) {
+			return;
 		}
 
-		if ( createOn ) {
-			setPermissionsNotice();
+		noticeRef.current = name;
+
+		createWarningNotice( message, {
+			id: noticeRef.current,
+			type: 'snackbar',
+		} );
+	};
+
+	const hideNotice = () => {
+		if ( ! noticeRef.current ) {
+			return;
 		}
-	}, [ navEntityIdRef, createOn, destroyOn ] );
+		removeNotice( noticeRef.current );
+		noticeRef.current = null;
+	};
+
+	return [ showNotice, hideNotice ];
 }
 
 export default useNavigationNotice;

--- a/packages/block-library/src/navigation/edit/use-navigation-notice.js
+++ b/packages/block-library/src/navigation/edit/use-navigation-notice.js
@@ -1,0 +1,51 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { store as noticeStore } from '@wordpress/notices';
+
+function useNavigationNotice( {
+	name,
+	message,
+	createOn,
+	destroyOn,
+	ref,
+} = {} ) {
+	const noticeRef = useRef();
+
+	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
+
+	useEffect( () => {
+		const setPermissionsNotice = () => {
+			if ( noticeRef.current ) {
+				return;
+			}
+
+			noticeRef.current = name;
+
+			createWarningNotice( message, {
+				id: noticeRef.current,
+				type: 'snackbar',
+			} );
+		};
+
+		const removePermissionsNotice = () => {
+			if ( ! noticeRef.current ) {
+				return;
+			}
+			removeNotice( noticeRef.current );
+			noticeRef.current = null;
+		};
+
+		if ( destroyOn ) {
+			removePermissionsNotice();
+		}
+
+		if ( createOn ) {
+			setPermissionsNotice();
+		}
+	}, [ ref, createOn, destroyOn ] );
+}
+
+export default useNavigationNotice;

--- a/packages/block-library/src/navigation/edit/use-navigation-notice.js
+++ b/packages/block-library/src/navigation/edit/use-navigation-notice.js
@@ -10,7 +10,7 @@ function useNavigationNotice( {
 	message,
 	createOn,
 	destroyOn,
-	ref,
+	navEntityIdRef,
 } = {} ) {
 	const noticeRef = useRef();
 
@@ -45,7 +45,7 @@ function useNavigationNotice( {
 		if ( createOn ) {
 			setPermissionsNotice();
 		}
-	}, [ ref, createOn, destroyOn ] );
+	}, [ navEntityIdRef, createOn, destroyOn ] );
 }
 
 export default useNavigationNotice;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -372,6 +372,7 @@ $color-control-label-height: 20px;
 	font-size: $default-font-size;
 	font-family: $default-font;
 	gap: $grid-unit-15 * 0.5;
+	align-items: center;
 
 	// Margins.
 	.components-dropdown,

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -79,8 +79,7 @@ export default function useNavigationMenu( ref ) {
 					'canUser',
 					[ 'delete', 'navigation', ref ]
 				),
-				canUserCreateNavigation:
-					canUser( 'create', 'navigation' ) || undefined,
+				canUserCreateNavigation: canUser( 'create', 'navigation' ),
 				hasResolvedCanUserCreateNavigation: hasFinishedResolution(
 					'canUser',
 					[ 'create', 'navigation' ]

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -79,6 +79,12 @@ export default function useNavigationMenu( ref ) {
 					'canUser',
 					[ 'delete', 'navigation', ref ]
 				),
+				canUserCreateNavigation:
+					canUser( 'create', 'navigation' ) || undefined,
+				hasResolvedCanUserCreateNavigation: hasFinishedResolution(
+					'canUser',
+					[ 'create', 'navigation' ]
+				),
 			};
 		},
 		[ ref ]

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -20,6 +20,7 @@ import {
 	createUser,
 	loginUser,
 	deleteUser,
+	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -756,6 +757,7 @@ describe( 'Navigation', () => {
 
 		afterAll( async () => {
 			await deleteUser( contributorUsername );
+			await switchUserToAdmin();
 		} );
 
 		it( 'shows a warning if user does not have permission to edit or update navigation menus', async () => {

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -755,9 +755,12 @@ describe( 'Navigation', () => {
 			} );
 		} );
 
+		afterEach( async () => {
+			await switchUserToAdmin();
+		} );
+
 		afterAll( async () => {
 			await deleteUser( contributorUsername );
-			await switchUserToAdmin();
 		} );
 
 		it( 'shows a warning if user does not have permission to edit or update navigation menus', async () => {
@@ -820,6 +823,13 @@ describe( 'Navigation', () => {
 			await page.waitForXPath(
 				`//*[contains(@class, 'components-snackbar__content')][ text()="${ noticeText }" ]`
 			);
+
+			// Expect a console 403 for request to Navigation Areas for lower permission users.
+			// This is because reading requires the `edit_theme_options` capability
+			// which the Contributor level user does not have.
+			// See: https://github.com/WordPress/gutenberg/blob/4cedaf0c4abb0aeac4bfd4289d63e9889efe9733/lib/class-wp-rest-block-navigation-areas-controller.php#L81-L91.
+			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
+			expect( console ).toHaveErrored();
 		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -436,6 +436,19 @@ describe( 'Navigation', () => {
 	} );
 
 	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
+		// The URL Details endpoint 404s for the created page, since it will
+		// be a draft that is inaccessible publicly. To avoid this we mock
+		// out the endpoint response to be empty which will be handled gracefully
+		// in the UI whilst avoiding any 404s.
+		await setUpResponseMocking( [
+			{
+				match: ( request ) =>
+					request.url().includes( `rest_route` ) &&
+					request.url().includes( `url-details` ),
+				onRequestMatch: createJSONResponse( [] ),
+			},
+		] );
+
 		await createNewPost();
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
@@ -469,12 +482,6 @@ describe( 'Navigation', () => {
 		await page.waitForXPath(
 			`//a[contains(@class, "block-editor-link-control__search-item-title") and contains(., "${ pageTitle }")]`
 		);
-
-		// The URL Details endpoint 404s for the created page, since it will
-		// be a draft that is inaccessible publicly. Wait for the HTTP request
-		// to finish, since this seems to make the test more stable.
-		await page.waitForNetworkIdle();
-		expect( console ).toHaveErrored();
 
 		await publishPost();
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -803,5 +803,28 @@ describe( 'Navigation', () => {
 			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
 			expect( console ).toHaveErrored();
 		} );
+
+		it( 'shows a warning if user does not have permission to create navigation menus', async () => {
+			const noticeText =
+				'You do not have permission to create Navigation Menus.';
+			// Switch to a Contributor role user - they should not have
+			// permission to update Navigations.
+			await loginUser( username, contribUserPassword );
+
+			await createNewPost();
+			await insertBlock( 'Navigation' );
+
+			// Make sure the snackbar error shows up
+			await page.waitForXPath(
+				`//*[contains(@class, 'components-snackbar__content')][ text()="${ noticeText }" ]`
+			);
+
+			// Expect a console 403 for request to Navigation Areas for lower permisison users.
+			// This is because reading requires the `edit_theme_options` capability
+			// which the Contributor level user does not have.
+			// See: https://github.com/WordPress/gutenberg/blob/4cedaf0c4abb0aeac4bfd4289d63e9889efe9733/lib/class-wp-rest-block-navigation-areas-controller.php#L81-L91.
+			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
+			expect( console ).toHaveErrored();
+		} );
 	} );
 } );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -809,7 +809,7 @@ describe( 'Navigation', () => {
 				'You do not have permission to create Navigation Menus.';
 			// Switch to a Contributor role user - they should not have
 			// permission to update Navigations.
-			await loginUser( username, contribUserPassword );
+			await loginUser( contributorUsername, contributorPassword );
 
 			await createNewPost();
 			await insertBlock( 'Navigation' );
@@ -818,13 +818,6 @@ describe( 'Navigation', () => {
 			await page.waitForXPath(
 				`//*[contains(@class, 'components-snackbar__content')][ text()="${ noticeText }" ]`
 			);
-
-			// Expect a console 403 for request to Navigation Areas for lower permisison users.
-			// This is because reading requires the `edit_theme_options` capability
-			// which the Contributor level user does not have.
-			// See: https://github.com/WordPress/gutenberg/blob/4cedaf0c4abb0aeac4bfd4289d63e9889efe9733/lib/class-wp-rest-block-navigation-areas-controller.php#L81-L91.
-			// Todo: removed once Nav Areas are removed from the Gutenberg Plugin.
-			expect( console ).toHaveErrored();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/37289 we were exploring trying to show a warning if the user cannot "make" new Navigation Menus. However this was proving difficult as whilst even low Role users had permission to `create` they don't have the permission to `publish`. This makes it impossible to show an upfront warning to the user if they are likely to not have permission to publish because the publish action is specific to an individual `wp_navigation` Post which is not created when you insert the Nav block.

This PR proposes another route. We increase the permission gate for the `create` action on the  `wp_navigation` Post type to `edit_theme_options`.

This will effectively mean that _only_ Admins can "create" Navigation posts whilst all other users can only "read". 

This matches nicely with the current `Menus` system in WordPress which is also only accessible to Admin users.

There is [a precedent in Core for adding custom capabilities to "special" post types](https://github.com/WordPress/wordpress-develop/blob/11753b9481676210779bb0622e77c5aa76fabf67/src/wp-includes/post.php#L332). This PR takes the same approach for Navigation posts.

### Why not set _all_ permissions to `edit_theme_options`?

This PR **does not** use the changes from [this Core ticket](https://github.com/WordPress/wordpress-develop/pull/2056) which seeks to alter the perms on the `wp_navigation` post to match those of the Menu post type. Why? Because by adjusting the permissions in this way the [post types endpoint will not show the `wp_navigation` post](https://github.com/WordPress/gutenberg/blob/trunk/packages/core-data/src/entities.js#L207-L208) and thus it will not be loaded as an entity in Gutenberg. This will mean [the check for the entity will fail in `getEntityRecord()`](https://github.com/WordPress/gutenberg/blob/1dc4af3d55e637244774fb73f047ca853ecbd748/packages/core-data/src/resolvers.js#L57) before the API request is fired. Therefore we will not be able to "view" the Navigation post.

## ⚠️ String changes post string freeze in WP 5.9 Beta 3

Having spoken with release leads, as requested I have raised [this Trac ticket](https://core.trac.wordpress.org/ticket/54643#ticket). 

## ⚠️ Requires Core patch

As this PR modifies `navigation.php` we will need a corresponding Core patch. The best candidate is probably the one @spacedmonkey already has open in https://github.com/WordPress/wordpress-develop/pull/2056.

Closes https://github.com/WordPress/gutenberg/issues/36286

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

First check you cannot create Navigations as a low permission user:

1. Login as Contributor.
2. Add new Post and add Nav block.
3. See warning that you are not allowed to create Navigation Menus.
4. Check you cannot `Create` a Navigation via buttons in the placeholder.
5. Switch to Admin. Repeat above. See that there is _no_ warning.

Now check you can still view existing Navigations:
1. As a contributor create a Post.
2. Switch to Admin and edit the same Post.
3. Add a Nav block and save.
4. Switch back to Contributor and edit the same post again.
5. You should be able to view the Navigation (you will see a warning about editing not being possible).
6. Check that you _cannot_ see the `Create Menu` option in the `Select Menu` dropdown.

## Screenshots <!-- if applicable -->

<img width="1279" alt="Screen Shot 2021-12-17 at 09 27 10" src="https://user-images.githubusercontent.com/444434/146521702-dd8964b4-5254-4daa-a24a-6c158af9ee95.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
