### PR TITLE
Add the typography support to group/row blocks

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -43,6 +43,17 @@
 				"width": true
 			}
 		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
 		"__experimentalLayout": true
 	},
 	"editorStyle": "wp-block-group-editor",


### PR DESCRIPTION
While working on a block theme, on several occasions I had the need to define the base font size, and typography settings for a whole section (sidebar, row...), I ended up duplicating the same config over multiple blocks.

This PR solves that by adding the different typography block supports to the group/row blocks.

**Testing instructions**

 - Try changing font sizes (or any typography setting) for a group of blocks.