### PR TITLE
Site Editor: Fix template author avatar check

### DIFF
--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -87,9 +87,11 @@ function AddedByAuthor( { id } ) {
 	return (
 		<HStack alignment="left">
 			<div
-				className={ classnames( {
-					'edit-site-list-added-by__avatar': hasAvatar,
-					'edit-site-list-added-by__icon': ! hasAvatar,
+				className={ classnames(
+					hasAvatar 
+						? 'edit-site-list-added-by__avatar'
+						: 'edit-site-list-added-by__icon',
+				{
 					'is-loaded': isImageLoaded,
 				} ) }
 			>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -87,7 +87,7 @@ function AddedByAuthor( { id } ) {
 				<img
 					onLoad={ () => setIsImageLoaded( true ) }
 					alt=""
-					src={ user?.avatar_urls[ 48 ] }
+					src={ user?.avatar_urls?.[ 48 ] }
 				/>
 			</div>
 			<span>{ user?.nickname }</span>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -14,7 +14,11 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { layout as themeIcon, plugins as pluginIcon } from '@wordpress/icons';
+import {
+	commentAuthorAvatar as authorIcon,
+	layout as themeIcon,
+	plugins as pluginIcon,
+} from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 const TEMPLATE_POST_TYPE_NAMES = [ 'wp_template', 'wp_template_part' ];
@@ -77,18 +81,26 @@ function AddedByAuthor( { id } ) {
 	] );
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 
+	const hasAvatar = !! user?.avatar_urls?.[ 48 ];
+
 	return (
 		<HStack alignment="left">
 			<div
-				className={ classnames( 'edit-site-list-added-by__avatar', {
+				className={ classnames( {
+					'edit-site-list-added-by__avatar': hasAvatar,
+					'edit-site-list-added-by__icon': ! hasAvatar,
 					'is-loaded': isImageLoaded,
 				} ) }
 			>
-				<img
-					onLoad={ () => setIsImageLoaded( true ) }
-					alt=""
-					src={ user?.avatar_urls?.[ 48 ] }
-				/>
+				{ hasAvatar ? (
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt=""
+						src={ user?.avatar_urls[ 48 ] }
+					/>
+				) : (
+					<Icon icon={ authorIcon } />
+				) }
 			</div>
 			<span>{ user?.nickname }</span>
 		</HStack>

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -81,7 +81,8 @@ function AddedByAuthor( { id } ) {
 	] );
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 
-	const hasAvatar = !! user?.avatar_urls?.[ 48 ];
+	const avatarURL = user?.avatar_urls?.[ 48 ];
+	const hasAvatar = !! avatarURL;
 
 	return (
 		<HStack alignment="left">

--- a/packages/edit-site/src/components/list/added-by.js
+++ b/packages/edit-site/src/components/list/added-by.js
@@ -88,18 +88,19 @@ function AddedByAuthor( { id } ) {
 		<HStack alignment="left">
 			<div
 				className={ classnames(
-					hasAvatar 
+					hasAvatar
 						? 'edit-site-list-added-by__avatar'
 						: 'edit-site-list-added-by__icon',
-				{
-					'is-loaded': isImageLoaded,
-				} ) }
+					{
+						'is-loaded': isImageLoaded,
+					}
+				) }
 			>
 				{ hasAvatar ? (
 					<img
 						onLoad={ () => setIsImageLoaded( true ) }
 						alt=""
-						src={ user?.avatar_urls[ 48 ] }
+						src={ avatarURL }
 					/>
 				) : (
 					<Icon icon={ authorIcon } />


### PR DESCRIPTION
## Description
Closes #37452

Fixes error on Template list screen when user avatars are disabled.

## How has this been tested?
1. Disable avatars through Options > Discussion
2. Go to Site Editor and then Templates.
3. Screens shouldn't crash and display a black circle instead of the user avatar.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-16 at 16 44 05](https://user-images.githubusercontent.com/240569/146374839-555ea98c-747d-4590-ad8b-591a082a5373.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
