### PR TITLE
Add block gap support for group blocks

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -27,8 +27,10 @@
 		},
 		"spacing": {
 			"padding": true,
+			"blockGap": true,
 			"__experimentalDefaultControls": {
-				"padding": true
+				"padding": true,
+				"blockGap": true
 			}
 		},
 		"__experimentalBorder": {


### PR DESCRIPTION
While working on a block theme, I noticed that I needed to tweak the block gap for specific sections or "rows" in different places. This would have been possible simply using the block gap support.

This PR enables the block gap support for a group block. It works properly but at the moment it also highlights a conceptual bug in block gap which is being worked on in #37360: Basically when you apply a gap to a column or to a parent container, that same gap is being applied to all its children (including nested containers).

**Testing instructions**

 - Try the block gap control for both group and row blocks.