### PR TITLE
Update: Use subtitle styles for the palette names.

### DIFF
--- a/packages/components/src/palette-edit/styles.js
+++ b/packages/components/src/palette-edit/styles.js
@@ -57,9 +57,7 @@ export const NameContainer = styled.div`
 export const PaletteHeading = styled( Heading )`
 	text-transform: uppercase;
 	line-height: ${ space( 6 ) };
-	font-weight: 500;
 	&&& {
-		font-size: 11px;
 		margin-bottom: 0;
 	}
 `;

--- a/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/gradients-palette-panel.js
@@ -9,8 +9,8 @@ import { noop } from 'lodash';
 import {
 	__experimentalVStack as VStack,
 	__experimentalPaletteEdit as PaletteEdit,
+	__experimentalSpacer as Spacer,
 	DuotonePicker,
-	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -18,6 +18,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSetting } from './hooks';
+import Subtitle from './subtitle';
 
 export default function GradientPalettePanel( { name } ) {
 	const [ themeGradients, setThemeGradients ] = useSetting(
@@ -83,9 +84,8 @@ export default function GradientPalettePanel( { name } ) {
 				slugPrefix="custom-"
 			/>
 			<div>
-				<Heading className="edit-site-global-styles-gradient-palette-panel__duotone-heading">
-					{ __( 'Duotone' ) }
-				</Heading>
+				<Subtitle>{ __( 'Duotone' ) }</Subtitle>
+				<Spacer margin={ 3 } />
 				<DuotonePicker
 					duotonePalette={ duotonePalette }
 					disableCustomDuotone={ true }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -59,14 +59,6 @@
 	}
 }
 
-h2.edit-site-global-styles-gradient-palette-panel__duotone-heading.components-heading {
-	text-transform: uppercase;
-	line-height: $grid-unit-30;
-	font-weight: 500;
-	font-size: 11px;
-	margin-bottom: $grid-unit-10;
-}
-
 .edit-site-screen-text-color__control,
 .edit-site-screen-link-color__control,
 .edit-site-screen-background-color__control {


### PR DESCRIPTION
Applies the suggestion made on https://github.com/WordPress/gutenberg/pull/37253#discussion_r770484143 by @youknowriad  to use the subtitle styles for the palette names.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/146384288-506e951f-0bdc-4bf8-9899-67a783507542.png)
