### PR TITLE
E2E: Switch to using a $eval to fill user creation fields

### DIFF
--- a/packages/e2e-test-utils/src/create-user.js
+++ b/packages/e2e-test-utils/src/create-user.js
@@ -28,13 +28,29 @@ export async function createUser(
 	await switchUserToAdmin();
 	await visitAdminPage( 'user-new.php' );
 	await page.waitForSelector( '#user_login', { visible: true } );
-	await page.type( '#user_login', username );
-	await page.type( '#email', snakeCase( username ) + '@example.com' );
+	await page.$eval(
+		'#user_login',
+		( el, value ) => ( el.value = value ),
+		username
+	);
+	await page.$eval(
+		'#email',
+		( el, value ) => ( el.value = value ),
+		snakeCase( username ) + '@example.com'
+	);
 	if ( firstName ) {
-		await page.type( '#first_name', firstName );
+		await page.$eval(
+			'#first_name',
+			( el, value ) => ( el.value = value ),
+			firstName
+		);
 	}
 	if ( lastName ) {
-		await page.type( '#last_name', lastName );
+		await page.$eval(
+			'#last_name',
+			( el, value ) => ( el.value = value ),
+			lastName
+		);
 	}
 	if ( role ) {
 		await page.select( '#role', role );


### PR DESCRIPTION
## Description
In some circumstances `page.type` fails to enter the string in some user creation form fields - which seems to be the cause of a currently failing navigation e2e test. Using page.$eval to set the field value in one go rather than letter by letter seems more robust. 

## How has this been tested?

- Run `PUPPETEER_HEADLESS="false" npm run test-e2e specs/editor/blocks/navigation.test.js` locally and make sure all tests pass
- Run `wp-env destroy` and `wp-env start` and run tests again and make sure they still pass
- Check that tests pass in CI

