### PR TITLE
Input Control: add prop to prevent bubbling on delete

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -38,6 +38,7 @@ export default function LetterSpacingControl( {
 			__unstableInputWidth={ __unstableInputWidth }
 			units={ units }
 			onChange={ onChange }
+			preventDeleteBubbling={ true }
 		/>
 	);
 }

--- a/packages/components/src/color-picker/color-input.tsx
+++ b/packages/components/src/color-picker/color-input.tsx
@@ -15,6 +15,7 @@ interface ColorInputProps {
 	color: Colord;
 	onChange: ( nextColor: Colord ) => void;
 	enableAlpha: boolean;
+	preventDeleteBubbling?: boolean;
 }
 
 export const ColorInput = ( {
@@ -22,8 +23,9 @@ export const ColorInput = ( {
 	color,
 	onChange,
 	enableAlpha,
+	preventDeleteBubbling,
 }: ColorInputProps ) => {
-	const props = { color, onChange, enableAlpha };
+	const props = { color, onChange, enableAlpha, preventDeleteBubbling };
 	switch ( colorType ) {
 		case 'hsl':
 			return <HslInput { ...props } />;

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -136,6 +136,7 @@ const ColorPicker = (
 						color={ safeColordColor }
 						onChange={ handleChange }
 						enableAlpha={ enableAlpha }
+						preventDeleteBubbling={ true }
 					/>
 				) }
 			</AuxiliaryColorArtefactWrapper>

--- a/packages/components/src/color-picker/hex-input.tsx
+++ b/packages/components/src/color-picker/hex-input.tsx
@@ -21,9 +21,15 @@ interface HexInputProps {
 	color: Colord;
 	onChange: ( nextColor: Colord ) => void;
 	enableAlpha: boolean;
+	preventDeleteBubbling?: boolean;
 }
 
-export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
+export const HexInput = ( {
+	color,
+	onChange,
+	enableAlpha,
+	preventDeleteBubbling,
+}: HexInputProps ) => {
 	const handleValidate = ( value: string ) => {
 		if ( ! colord( '#' + value ).isValid() ) {
 			throw new Error( 'Invalid hex color input' );
@@ -50,6 +56,7 @@ export const HexInput = ( { color, onChange, enableAlpha }: HexInputProps ) => {
 			maxLength={ enableAlpha ? 8 : 6 }
 			label={ __( 'Hex color' ) }
 			hideLabelFromVision
+			preventDeleteBubbling={ preventDeleteBubbling }
 		/>
 	);
 };

--- a/packages/components/src/input-control/README.md
+++ b/packages/components/src/input-control/README.md
@@ -42,6 +42,14 @@ If true, the `ENTER` key press is required in order to trigger an `onChange`. If
 -   Required: No
 -   Default: `false`
 
+### preventDeleteBubbling
+
+If true, the `DELETE` and `BACKSPACE` key presses for the `onKeyDown` event will not bubble up through the DOM.
+
+-   Type: `Boolean`
+-   Required: No
+-   Default: `false`
+
 ### hideLabelFromVision
 
 If true, the label will only be visible to screen readers.

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -18,7 +18,7 @@ import type {
  * WordPress dependencies
  */
 import { forwardRef, useRef } from '@wordpress/element';
-import { UP, DOWN, ENTER } from '@wordpress/keycodes';
+import { UP, DOWN, ENTER, DELETE, BACKSPACE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
@@ -39,6 +39,7 @@ function InputField(
 		isDragEnabled = false,
 		isFocused,
 		isPressEnterToChange = false,
+		preventDeleteBubbling = false,
 		onBlur = noop,
 		onChange = noop,
 		onDrag = noop,
@@ -161,6 +162,13 @@ function InputField(
 				if ( isPressEnterToChange ) {
 					event.preventDefault();
 					handleOnCommit( event );
+				}
+				break;
+
+			case DELETE:
+			case BACKSPACE:
+				if ( preventDeleteBubbling ) {
+					event.stopPropagation();
 				}
 				break;
 		}

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -43,6 +43,7 @@ export interface InputFieldProps extends BaseProps {
 	dragThreshold?: number;
 	isDragEnabled?: boolean;
 	isPressEnterToChange?: boolean;
+	preventDeleteBubbling?: boolean;
 	onChange?: InputChangeCallback;
 	onValidate?: (
 		nextValue: string,


### PR DESCRIPTION
## Description

An alternative to https://github.com/WordPress/gutenberg/pull/37326

This PR is an experiment that stops propagation `onKeyDown` for `<InputControl />` when deleting values from the field.

The Block Editor execute [certain callbacks](https://github.com/WordPress/gutenberg/blob/5864da50b5b1e3e13af49d061a119303be2d3ad9/packages/block-editor/src/components/block-tools/index.js#L111), most notably `core/block-editor/delete-multi-selection`, based on registered [key events](https://github.com/WordPress/gutenberg/blob/48df97fb78346d7b4b372f7f1d500f775b08232a/packages/block-editor/src/components/keyboard-shortcuts/index.js#L61).

After multi-selecting blocks, deleting values in the Block Inspector Toolbar inputs will also delete the selected blocks due to the `onKeyDown` event bubbling up the DOM. 

**Before**
![Dec-17-2021 13-12-40](https://user-images.githubusercontent.com/6458278/146477894-94798257-1b9e-4236-ae85-c76972a5b666.gif)


**After**
![Dec-17-2021 13-15-55](https://user-images.githubusercontent.com/6458278/146477903-2bbcd2ab-249d-4e43-95b0-159beda04bae.gif)

## Todos
- [ ] Track down all the inputs

## How has this been tested?

Close to not at all. Just trying out some things.


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
