### PR TITLE
Navigation: Use rems for padding.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -412,7 +412,7 @@ button.wp-block-navigation-item__content {
 		background-color: inherit;
 
 		// Use em units to apply padding, so themes can more easily style this in various ways.
-		padding: 2em;
+		padding: 2rem;
 
 		// Allow modal to scroll.
 		overflow: auto;
@@ -422,7 +422,7 @@ button.wp-block-navigation-item__content {
 
 		.wp-block-navigation__responsive-container-content {
 			// Add padding above to accommodate close button.
-			padding-top: calc(2em + #{ $navigation-icon-size });
+			padding-top: calc(2rem + #{ $navigation-icon-size });
 
 			// Don't crop the focus style.
 			overflow: visible;
@@ -462,8 +462,8 @@ button.wp-block-navigation-item__content {
 				// Position and style.
 				position: static;
 				border: none;
-				padding-left: 2em;
-				padding-right: 2em;
+				padding-left: 2rem;
+				padding-right: 2rem;
 			}
 
 			// Space unfolded items using gap and padding for submenus.


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/37444/commits/8bc64b783038baecc597b7b5d9b6d86f833d117d#r770651645. 

In trying to be as easy for a theme to style as possible, and as agnostic to its metrics, the padding and spacing inside the navigation modal overlay used `em` units instead of pixels. That lets it scale with the font size.

This is potentially less successful for the inner _padding_ of the modal, which along with a larger font size might grow very big. This PR changes the padding to use `rem` units instead, scaling to the root font size:

![rems](https://user-images.githubusercontent.com/1204802/146511537-78f0ce05-63fe-4136-be63-82b01d321b14.gif)


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
