### PR TITLE
Paragraph: Try to avoid a trailing word in the description.

### DIFF
--- a/docs/how-to-guides/designers/block-design.md
+++ b/docs/how-to-guides/designers/block-design.md
@@ -92,7 +92,7 @@ You can add a description by using the description attribute in the [registerBlo
 
 Stick to a single imperative sentence with an action + subject format. Examples:
 
--   Start with the building block of all narrative.
+-   Start with the basic building block of all narrative.
 -   Introduce new sections and organize content to help visitors (and search engines) understand the structure of your content.
 -   Create a bulleted or numbered list.
 

--- a/packages/block-editor/src/components/block-card/README.md
+++ b/packages/block-editor/src/components/block-card/README.md
@@ -25,7 +25,7 @@ const MyBlockCard = () => (
 	<BlockCard
 		icon={ paragraph }
 		title="Paragraph"
-		description="Start with the building block of all narrative."
+		description="Start with the basic building block of all narrative."
 	/>
 );
 ```

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -4,7 +4,7 @@
 	"name": "core/paragraph",
 	"title": "Paragraph",
 	"category": "text",
-	"description": "Start with the building block of all narrative.",
+	"description": "Start with the basic building block of all narrative.",
 	"keywords": [ "text" ],
 	"textdomain": "default",
 	"attributes": {

--- a/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-variations.test.js
@@ -181,7 +181,7 @@ describe( 'Block variations', () => {
 			).toBeTruthy();
 			const description = await getBlockCardDescription();
 			expect( description ).toEqual(
-				'Start with the building block of all narrative.'
+				'Start with the basic building block of all narrative.'
 			);
 		} );
 	} );


### PR DESCRIPTION
## Description

File this under _really small details that still feel important_: the description of the Paragraph block wraps on to two lines, but with only one word, "narrative":

<img width="316" alt="before" src="https://user-images.githubusercontent.com/1204802/146528218-7e8a0df0-370d-418d-b743-04a73ad33ad6.png">

There are a few typographic terms for when that happens, but the gist of it is that it looks slightly unbalanced, and that it would be better if there was either _less text_ so it stuck to one line, or there was _more_ text so it looked more balanced on two lines.

The PR changes the phrase to this:

`Start with the basic building block of all narrative.`

 <img width="304" alt="after" src="https://user-images.githubusercontent.com/1204802/146528607-d6fb2abc-cf38-4a11-999b-c5fb146eae5c.png">

The addition of the word "basic" allows it to better work on two lines. I also tried another option:

`Start with the building block of all good narrative.`

<img width="325" alt="one option" src="https://user-images.githubusercontent.com/1204802/146528983-6ea7b6d3-a16f-4b22-b13d-5c6b85fc2ee4.png">

That one doesn't feel right though, not as neutral.

I would _love_ advice if you have better suggestions for balancing out this phrase!

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
