### PR TITLE
Show UI warning if Pages cannot be retrieved in Page List block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -12,7 +12,12 @@ import {
 	useBlockProps,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import { ToolbarButton, Placeholder, Spinner } from '@wordpress/components';
+import {
+	ToolbarButton,
+	Placeholder,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -29,7 +34,7 @@ import { ItemSubmenuIcon } from '../navigation-link/icons';
 const MAX_PAGE_COUNT = 100;
 
 export default function PageListEdit( { context, clientId } ) {
-	const { pagesByParentId, totalPages } = usePageData();
+	const { pagesByParentId, totalPages, hasResolvedPages } = usePageData();
 
 	const isNavigationChild = 'showSubmenuIcon' in context;
 	const allowConvertToLinks =
@@ -70,16 +75,29 @@ export default function PageListEdit( { context, clientId } ) {
 					clientId={ clientId }
 				/>
 			) }
-			{ totalPages === undefined && (
+			{ ! hasResolvedPages && (
 				<div { ...blockProps }>
 					<Placeholder>
 						<Spinner />
 					</Placeholder>
 				</div>
 			) }
+
+			{ hasResolvedPages && totalPages === null && (
+				<div { ...blockProps }>
+					<div { ...blockProps }>
+						<Notice status={ 'warning' } isDismissible={ false }>
+							{ __( 'Page List: Cannot retrieve Pages.' ) }
+						</Notice>
+					</div>
+				</div>
+			) }
+
 			{ totalPages === 0 && (
 				<div { ...blockProps }>
-					<span>{ __( 'Page List: No pages to show.' ) }</span>
+					<Notice status={ 'info' } isDismissible={ false }>
+						{ __( 'Page List: Cannot retrieve Pages.' ) }
+					</Notice>
 				</div>
 			) }
 			{ totalPages > 0 && (
@@ -102,8 +120,8 @@ function useFrontPageId() {
 }
 
 function usePageData() {
-	const { pages } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreStore );
+	const { pages, hasResolvedPages } = useSelect( ( select ) => {
+		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
 
 		return {
 			pages: getEntityRecords( 'postType', 'page', {
@@ -112,6 +130,16 @@ function usePageData() {
 				_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
 				per_page: -1,
 			} ),
+			hasResolvedPages: hasFinishedResolution( 'getEntityRecords', [
+				'postType',
+				'page',
+				{
+					orderby: 'menu_order',
+					order: 'asc',
+					_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
+					per_page: -1,
+				},
+			] ),
 		};
 	}, [] );
 
@@ -132,9 +160,10 @@ function usePageData() {
 
 		return {
 			pagesByParentId,
-			totalPages: pages?.length,
+			hasResolvedPages,
+			totalPages: pages?.length ?? null,
 		};
-	}, [ pages ] );
+	}, [ pages, hasResolvedPages ] );
 }
 
 const PageItems = memo( function PageItems( {

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -64,3 +64,7 @@
 		}
 	}
 }
+
+.wp-block-page-list .components-notice {
+	margin-left: 0;
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

In https://github.com/WordPress/gutenberg/issues/37368 we learnt that the Page List will show a spinner forever if you are logged in as a lower permission user (e.g. Contributor).

[The reason for this is complicated](https://github.com/WordPress/gutenberg/issues/37368#issuecomment-996729798) and a true fix would be _far_ outside the scope of this PR. 

As a result, all we can do is show an error message to the user that Pages cannot be retrieved. 

This is what this PR does. If the API returns no response (i.e. `null` rather than `undefined`), we show an error to say we couldn't retrieve the Pages. 

Whilst far from ideal, this is somewhat better than an infinite loading state.



### Why do we need to include this in 5.9

The reason I feel this is important is that Page List is used extensively by the Navigation block and also by block Themes which often use the Page List as the default state for the Navigation block (e.g. in patterns).

Currently if a lower permission user were to encounter a Nav block with a Page List inside it, they would see an infinite loading state spinner and assume that Nav block was broken when in fact if would be the Page List. This is shown in the screenshot below:

<img width="1275" alt="Screen Shot 2021-12-17 at 14 06 47" src="https://user-images.githubusercontent.com/444434/146556390-012192e9-eda1-4235-8123-3f9c300ced8b.png">


### String freeze change

If we cannot include this PR in 5.9 due to string freeze, then another option would be to reuse the existing error notice which whilst not ideal would still suffice.

Closes https://github.com/WordPress/gutenberg/issues/37368

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Switch to Contributor role user.
- Add Page List block.
- See no infinite loading state.
- See warning / error notice.

- Now switch to Admin.
- Create a Nav block and click `Add all Pages`.
- Save.
- Switch to Contributor.
- new Post
- Add Nav block.
- Click `Select menu` and select the menu you created as Admin.
- See the Page List block inserted and showing the error message and _not_ the infinite loading state.

## Screenshots <!-- if applicable -->
### Standalone Page List
<img width="1277" alt="Screen Shot 2021-12-17 at 14 01 28" src="https://user-images.githubusercontent.com/444434/146555790-ac2ed07a-9f95-40cd-a35d-6d9e53de719a.png">

### Page List inside Nav block
<img width="1276" alt="Screen Shot 2021-12-17 at 14 12 04" src="https://user-images.githubusercontent.com/444434/146557102-a896c38b-88e4-47c9-a65d-625b5816958c.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
