### PR TITLE
Show group on top in multi select toolbar

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -45,11 +45,13 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 
 	const isMultiToolbar = selectedClientIds.length > 1;
 
-	// Check if current selection of blocks is Groupable or Ungroupable
+	// Check if current selection of blocks is Groupable and is not Multiselect and is not Ungroupable
 	// and pass this props down to ConvertToGroupButton.
 	const convertToGroupButtonProps = useConvertToGroupButtonProps();
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
-	const showConvertToGroupButton = isGroupable || isUngroupable;
+	const showConvertToGroupButton =
+		isGroupable && ! isMultiToolbar && ! isUngroupable;
+
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks, selectedClientIds } }>
 			{ ( fills ) => {
@@ -57,7 +59,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 					return (
 						<MenuGroup>
 							{ fills }
-							{ ! isMultiToolbar && (
+							{ /* if it has come through fills */ }
+							{ showConvertToGroupButton && (
 								<ConvertToGroupButton
 									{ ...convertToGroupButtonProps }
 									onClose={ fillProps?.onClose }

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -43,6 +43,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		[ clientIds ]
 	);
 
+	const isMultiToolbar = selectedClientIds.length > 1;
+
 	// Check if current selection of blocks is Groupable or Ungroupable
 	// and pass this props down to ConvertToGroupButton.
 	const convertToGroupButtonProps = useConvertToGroupButtonProps();
@@ -55,10 +57,12 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 					return (
 						<MenuGroup>
 							{ fills }
-							<ConvertToGroupButton
-								{ ...convertToGroupButtonProps }
-								onClose={ fillProps?.onClose }
-							/>
+							{ ! isMultiToolbar && (
+								<ConvertToGroupButton
+									{ ...convertToGroupButtonProps }
+									onClose={ fillProps?.onClose }
+								/>
+							) }
 						</MenuGroup>
 					);
 				}

--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -45,7 +45,7 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 
 	const isMultiToolbar = selectedClientIds.length > 1;
 
-	// Check if current selection of blocks is Groupable and is not Multiselect and is not Ungroupable
+	// Check if current selection of blocks is Groupable and is not Multiselect or is not Ungroupable
 	// and pass this props down to ConvertToGroupButton.
 	const convertToGroupButtonProps = useConvertToGroupButtonProps();
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -26,6 +26,11 @@ import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-it
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
 
+import {
+	useConvertToGroupButtonProps,
+	ConvertToGroupButton,
+} from '../convert-to-group-buttons';
+
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
 	position: 'bottom right',
@@ -45,6 +50,7 @@ export function BlockSettingsDropdown( {
 } ) {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
+	const isMultiToolbar = blockClientIds.length > 1;
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const { onlyBlock, title } = useSelect(
 		( select ) => {
@@ -94,6 +100,10 @@ export function BlockSettingsDropdown( {
 	);
 	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 
+	const convertToGroupButtonProps = useConvertToGroupButtonProps();
+	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
+	const showConvertToGroupButton =
+		( isGroupable || isUngroupable ) && isMultiToolbar;
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -123,6 +133,12 @@ export function BlockSettingsDropdown( {
 					{ ( { onClose } ) => (
 						<>
 							<MenuGroup>
+								{ showConvertToGroupButton && (
+									<ConvertToGroupButton
+										{ ...convertToGroupButtonProps }
+										onClose={ onClose }
+									/>
+								) }
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -133,18 +133,18 @@ export function BlockSettingsDropdown( {
 					{ ( { onClose } ) => (
 						<>
 							<MenuGroup>
-								{ showConvertToGroupButton && (
-									<ConvertToGroupButton
-										{ ...convertToGroupButtonProps }
-										onClose={ onClose }
-									/>
-								) }
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
 								{ count === 1 && (
 									<BlockHTMLConvertButton
 										clientId={ firstBlockClientId }
+									/>
+								) }
+								{ showConvertToGroupButton && (
+									<ConvertToGroupButton
+										{ ...convertToGroupButtonProps }
+										onClose={ onClose }
 									/>
 								) }
 								<CopyMenuItem

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -103,7 +103,7 @@ export function BlockSettingsDropdown( {
 	const convertToGroupButtonProps = useConvertToGroupButtonProps();
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
 	const showConvertToGroupButton =
-		( isGroupable || isUngroupable ) && isMultiToolbar;
+		( isGroupable && isMultiToolbar ) || isUngroupable;
 	return (
 		<BlockActions
 			clientIds={ clientIds }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR Solves this Issue https://github.com/WordPress/gutenberg/issues/34461.
in multi-select toolbar it shows Group before copy, and in Single select it shows Group in current position. However Ungroup is always shows before copy.

<img width="879" alt="Screenshot 2021-12-17 at 6 51 33 PM" src="https://user-images.githubusercontent.com/46275049/146550866-c40cf05c-29af-4b5e-89be-438f0c7e029a.png">

<img width="900" alt="Screenshot 2021-12-17 at 6 45 20 PM" src="https://user-images.githubusercontent.com/46275049/146550086-7a6a0792-eb44-4dc5-b6dc-969032fdf7ba.png">

<img width="833" alt="Screenshot 2021-12-17 at 7 26 30 PM" src="https://user-images.githubusercontent.com/46275049/146555038-244ec1ed-5b53-47ba-b8f4-d752569b82ec.png">


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Steps - 
- Create Multiple Blocks 
- Select Multiple blocks, click on Kebab Menu (Three dots) icon
- You will see **Group** Menu after Copy (First Outcome)
- Now click on Group to group them.
- Click on Kebab Menu Again, you will see **Ungroup** Menu in Same position. (Second Outcome)
- Now Select a single Block, Click on Kebab Menu, and you will see Group Menu Next to **Add to Reusable Blocks** (Third Outcome), (its currently all the time on this position which this PR changes, for multi-select toolbar)

## Screenshots <!-- if applicable -->

<img width="1728" alt="Screenshot 2021-12-17 at 7 31 00 PM" src="https://user-images.githubusercontent.com/46275049/146555633-f7eecf43-1b41-4cbf-b66b-46f95c65edc6.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
