### PR TITLE
Migrate the Post 'Switch to draft' button to `ConfirmDialog` component

### DIFF
--- a/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
+++ b/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
@@ -3,10 +3,30 @@
  */
 import {
 	createNewPost,
+	openDocumentSettingsSidebar,
 	publishPost,
 	setBrowserViewport,
 	trashAllPosts,
 } from '@wordpress/e2e-test-utils';
+
+async function prepTestPost( postType, viewport ) {
+	// Create a post
+	await createNewPost( { postType } );
+
+	await page.type(
+		'.editor-post-title__input',
+		`Switch scheduled ${ postType } to draft`
+	);
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type(
+		`This will be a scheduled ${ postType } edited in a ${ viewport } viewport`
+	);
+
+	// Unselect the blocks.
+	await page.evaluate( () => {
+		wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+	} );
+}
 
 async function publishTestPost( postType, viewport ) {
 	// Capitalize postType for use in snackbar XPath
@@ -14,21 +34,7 @@ async function publishTestPost( postType, viewport ) {
 		postType.charAt( 0 ).toUpperCase() + postType.slice( 1 );
 
 	// Create a post
-	await createNewPost( { postType } );
-
-	await page.type(
-		'.editor-post-title__input',
-		`Switch ${ postType } to draft`
-	);
-	await page.keyboard.press( 'Enter' );
-	await page.keyboard.type(
-		`This will be a published ${ postType } edited in a ${ viewport } viewport`
-	);
-
-	// Unselect the blocks.
-	await page.evaluate( () => {
-		wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
-	} );
+	await prepTestPost( postType, viewport );
 
 	// Publish the post
 	await publishPost();
@@ -43,7 +49,51 @@ async function publishTestPost( postType, viewport ) {
 	await closePublishingPanel.click();
 }
 
-describe( 'Switch to draft button', () => {
+async function scheduleTestPost( postType, viewport ) {
+	// Create a post
+	await prepTestPost( postType, viewport );
+
+	if ( viewport === 'small' ) {
+		await openDocumentSettingsSidebar();
+	}
+	// Set a publish date for the next month.
+	await page.click( '.edit-post-post-schedule__toggle' );
+	await page.click(
+		'div[aria-label="Move forward to switch to the next month."]'
+	);
+
+	await (
+		await page.$x(
+			'//td[contains(concat(" ", @class, " "), " CalendarDay ")]/div[contains(concat(" ", @class, " "), " components-datetime__date__day ")][text() = "15"]'
+		)
+	 )[ 0 ].click();
+
+	await page.click( '.edit-post-post-schedule__toggle' );
+
+	if ( viewport === 'small' ) {
+		const closeDocumentSettingsButton = await page.waitForXPath(
+			'//div[contains(@class,"interface-complementary-area-header__small")]/button[@aria-label="Close settings"]'
+		);
+		await closeDocumentSettingsButton.click();
+	}
+
+	// Important: target an ellipsis (…) and not three dots (...)
+	const scheduleButton = await page.waitForXPath(
+		'//button[text()="Schedule…"]'
+	);
+	await scheduleButton.click();
+	const secondScheduleButton = await page.waitForXPath(
+		'//button[text()="Schedule"]'
+	);
+	await secondScheduleButton.click();
+
+	const closePublishingPanel = await page.waitForXPath(
+		'//button[@aria-label="Close panel"]'
+	);
+	await closePublishingPanel.click();
+}
+
+describe( 'Clicking "Switch to draft" on a published post/page', () => {
 	beforeAll( async () => {
 		await trashAllPosts( 'post' );
 		await trashAllPosts( 'page' );
@@ -62,7 +112,7 @@ describe( 'Switch to draft button', () => {
 					await setBrowserViewport( viewport );
 				} );
 
-				it( `should leave a ${ postType } published if canceled`, async () => {
+				it( `should leave a published ${ postType } published if canceled`, async () => {
 					publishTestPost( postType, viewport );
 
 					const switchToDraftButton = await page.waitForXPath(
@@ -79,18 +129,14 @@ describe( 'Switch to draft button', () => {
 					);
 					await cancelButton.click();
 
-					// Confirm that the post is still published by verifying the presence of the "Update" button
-					const postPublishButton = await page.$(
-						'.editor-post-publish-button__button'
-					);
-					const postPublishButtonText = await page.evaluate(
-						( button ) => button.textContent,
-						postPublishButton
-					);
-
-					expect( postPublishButtonText ).toBe( 'Update' );
+					const postStatus = await page.evaluate( () => {
+						return wp.data
+							.select( 'core/editor' )
+							.getEditedPostAttribute( 'status' );
+					} );
+					expect( postStatus ).toBe( 'publish' );
 				} );
-				it( `should revert a ${ postType } to a draft if confirmed`, async () => {
+				it( `should revert a published ${ postType } to a draft if confirmed`, async () => {
 					// Switch to draft
 					const switchToDraftButton = await page.waitForXPath(
 						`//button[contains(text(), "${ buttonText }")]`
@@ -106,20 +152,88 @@ describe( 'Switch to draft button', () => {
 					);
 					await confirmButton.click();
 
+					const postStatus = await page.evaluate( () => {
+						return wp.data
+							.select( 'core/editor' )
+							.getEditedPostAttribute( 'status' );
+					} );
+					expect( postStatus ).toBe( 'draft' );
+				} );
+			} );
+		} );
+	} );
+} );
+describe( 'Clicking "Switch to draft" on a scheduled post/page', () => {
+	beforeAll( async () => {
+		await trashAllPosts( 'post' );
+		await trashAllPosts( 'page' );
+	} );
+	afterEach( async () => {
+		await setBrowserViewport( 'large' );
+	} );
+
+	[ 'large', 'small' ].forEach( ( viewport ) => {
+		describe( `in a ${ viewport } viewport`, () => {
+			[ 'post', 'page' ].forEach( ( postType ) => {
+				const buttonText =
+					viewport === 'large' ? 'Switch to draft' : 'Draft';
+				// Capitalize postType for use in snackbar XPath
+				beforeEach( async () => {
+					await setBrowserViewport( viewport );
+				} );
+
+				it( `should leave a scheduled ${ postType } scheduled if canceled`, async () => {
+					scheduleTestPost( postType, viewport );
+
+					const switchToDraftButton = await page.waitForXPath(
+						`//button[contains(text(), "${ buttonText }")]`
+					);
+					await switchToDraftButton.click();
+
+					// Process the ConfirmDialog
+					await page.waitForXPath(
+						'//*[text()="Are you sure you want to unschedule this post?"]'
+					);
+					const [ cancelButton ] = await page.$x(
+						'//*[@role="dialog"][not(@id="wp-link-wrap")]//button[text()="Cancel"]'
+					);
+					await cancelButton.click();
+
+					// Confirm post is still scheduled
+					const postStatus = await page.evaluate( () => {
+						return wp.data
+							.select( 'core/editor' )
+							.getEditedPostAttribute( 'status' );
+					} );
+					expect( postStatus ).toBe( 'future' );
+				} );
+				it( `should revert a scheduled ${ postType } to a draft if confirmed`, async () => {
+					// Switch to draft
+					const switchToDraftButton = await page.waitForXPath(
+						`//button[contains(text(), "${ buttonText }")]`
+					);
+					await switchToDraftButton.click();
+
+					// Process the ConfirmDialog
+					await page.waitForXPath(
+						'//*[text()="Are you sure you want to unschedule this post?"]'
+					);
+					const [ confirmButton ] = await page.$x(
+						'//*[@role="dialog"]//button[text()="OK"]'
+					);
+					await confirmButton.click();
+
 					// Confirm that the post is now a draft by verifying the presence of the "Publish" button
 					await page.waitForXPath(
 						'//button[contains(@class,"editor-post-publish-button__button")][not(contains(@class,"is-busy"))]'
 					);
 
-					const postPublishButton = await page.$(
-						'.editor-post-publish-button__button'
-					);
-					const postPublishButtonText = await page.evaluate(
-						( button ) => button.textContent,
-						postPublishButton
-					);
-
-					expect( postPublishButtonText ).toBe( 'Publish' );
+					const postStatus = await page.evaluate( () => {
+						return wp.data
+							.select( 'core/editor' )
+							.getEditedPostAttribute( 'status' );
+					} );
+					expect( postStatus ).toBe( 'draft' );
 				} );
 			} );
 		} );

--- a/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
+++ b/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
@@ -1,0 +1,127 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createNewPost,
+	publishPost,
+	setBrowserViewport,
+	trashAllPosts,
+} from '@wordpress/e2e-test-utils';
+
+async function publishTestPost( postType, viewport ) {
+	// Capitalize postType for use in snackbar XPath
+	const capitalizedPostType =
+		postType.charAt( 0 ).toUpperCase() + postType.slice( 1 );
+
+	// Create a post
+	await createNewPost( { postType } );
+
+	await page.type(
+		'.editor-post-title__input',
+		`Switch ${ postType } to draft`
+	);
+	await page.keyboard.press( 'Enter' );
+	await page.keyboard.type(
+		`This will be a published ${ postType } edited in a ${ viewport } viewport`
+	);
+
+	// Unselect the blocks.
+	await page.evaluate( () => {
+		wp.data.dispatch( 'core/block-editor' ).clearSelectedBlock();
+	} );
+
+	// Publish the post
+	await publishPost();
+
+	await page.waitForXPath(
+		`//*[contains(@class, "components-snackbar")]/*[text()="${ capitalizedPostType } published."]`
+	);
+
+	const closePublishingPanel = await page.waitForXPath(
+		'//button[@aria-label="Close panel"]'
+	);
+	await closePublishingPanel.click();
+}
+
+describe( 'Switch to draft button', () => {
+	beforeAll( async () => {
+		await trashAllPosts( 'post' );
+		await trashAllPosts( 'page' );
+	} );
+	afterEach( async () => {
+		await setBrowserViewport( 'large' );
+	} );
+
+	[ 'large', 'small' ].forEach( ( viewport ) => {
+		describe( `in a ${ viewport } viewport`, () => {
+			[ 'post', 'page' ].forEach( ( postType ) => {
+				const buttonText =
+					viewport === 'large' ? 'Switch to draft' : 'Draft';
+				// Capitalize postType for use in snackbar XPath
+				beforeEach( async () => {
+					await setBrowserViewport( viewport );
+				} );
+
+				it( `should leave a ${ postType } published if canceled`, async () => {
+					publishTestPost( postType, viewport );
+
+					const switchToDraftButton = await page.waitForXPath(
+						`//button[contains(text(), "${ buttonText }")]`
+					);
+					await switchToDraftButton.click();
+
+					// Process the ConfirmDialog
+					await page.waitForXPath(
+						'//*[text()="Are you sure you want to unpublish this post?"]'
+					);
+					const [ cancelButton ] = await page.$x(
+						'//*[@role="dialog"][not(@id="wp-link-wrap")]//button[text()="Cancel"]'
+					);
+					await cancelButton.click();
+
+					// Confirm that the post is still published by verifying the presence of the "Update" button
+					const postPublishButton = await page.$(
+						'.editor-post-publish-button__button'
+					);
+					const postPublishButtonText = await page.evaluate(
+						( button ) => button.textContent,
+						postPublishButton
+					);
+
+					expect( postPublishButtonText ).toBe( 'Update' );
+				} );
+				it( `should revert a ${ postType } to a draft if confirmed`, async () => {
+					// Switch to draft
+					const switchToDraftButton = await page.waitForXPath(
+						`//button[contains(text(), "${ buttonText }")]`
+					);
+					await switchToDraftButton.click();
+
+					// Process the ConfirmDialog
+					await page.waitForXPath(
+						'//*[text()="Are you sure you want to unpublish this post?"]'
+					);
+					const [ confirmButton ] = await page.$x(
+						'//*[@role="dialog"]//button[text()="OK"]'
+					);
+					await confirmButton.click();
+
+					// Confirm that the post is now a draft by verifying the presence of the "Publish" button
+					await page.waitForXPath(
+						'//button[contains(@class,"editor-post-publish-button__button")][not(contains(@class,"is-busy"))]'
+					);
+
+					const postPublishButton = await page.$(
+						'.editor-post-publish-button__button'
+					);
+					const postPublishButtonText = await page.evaluate(
+						( button ) => button.textContent,
+						postPublishButton
+					);
+
+					expect( postPublishButtonText ).toBe( 'Publish' );
+				} );
+			} );
+		} );
+	} );
+} );

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -35,6 +35,11 @@ function PostSwitchToDraftButton( {
 		alertMessage = __( 'Are you sure you want to unschedule this post?' );
 	}
 
+	const handleConfirm = () => {
+		setShowConfirmDialog( false );
+		onClick();
+	};
+
 	return (
 		<>
 			<Button
@@ -49,7 +54,7 @@ function PostSwitchToDraftButton( {
 			</Button>
 			<ConfirmDialog
 				isOpen={ showConfirmDialog }
-				onConfirm={ onClick }
+				onConfirm={ handleConfirm }
 				onCancel={ () => setShowConfirmDialog( false ) }
 			>
 				{ alertMessage }

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -1,15 +1,34 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import {
+	Button,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose, useViewportMatch } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+
+function SwitchToDraftConfirm( props ) {
+	let alertMessage;
+	if ( props.isPublished ) {
+		alertMessage = __( 'Are you sure you want to unpublish this post?' );
+	} else if ( props.isScheduled ) {
+		alertMessage = __( 'Are you sure you want to unschedule this post?' );
+	}
+
+	return props.showConfirmDialog ? (
+		<ConfirmDialog onConfirm={ props.onClick }>
+			{ alertMessage }
+		</ConfirmDialog>
+	) : null;
+}
 
 function PostSwitchToDraftButton( {
 	isSaving,
@@ -18,37 +37,31 @@ function PostSwitchToDraftButton( {
 	onClick,
 } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
 	if ( ! isPublished && ! isScheduled ) {
 		return null;
 	}
 
-	const onSwitch = () => {
-		let alertMessage;
-		if ( isPublished ) {
-			alertMessage = __(
-				'Are you sure you want to unpublish this post?'
-			);
-		} else if ( isScheduled ) {
-			alertMessage = __(
-				'Are you sure you want to unschedule this post?'
-			);
-		}
-		// eslint-disable-next-line no-alert
-		if ( window.confirm( alertMessage ) ) {
-			onClick();
-		}
-	};
-
 	return (
-		<Button
-			className="editor-post-switch-to-draft"
-			onClick={ onSwitch }
-			disabled={ isSaving }
-			variant="tertiary"
-		>
-			{ isMobileViewport ? __( 'Draft' ) : __( 'Switch to draft' ) }
-		</Button>
+		<>
+			<Button
+				className="editor-post-switch-to-draft"
+				onClick={ () => {
+					setShowConfirmDialog( true );
+				} }
+				disabled={ isSaving }
+				variant="tertiary"
+			>
+				{ isMobileViewport ? __( 'Draft' ) : __( 'Switch to draft' ) }
+			</Button>
+			<SwitchToDraftConfirm
+				isPublished={ isPublished }
+				isScheduled={ isScheduled }
+				onClick={ onClick }
+				showConfirmDialog={ showConfirmDialog }
+			/>
+		</>
 	);
 }
 

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -24,7 +24,10 @@ function SwitchToDraftConfirm( props ) {
 	}
 
 	return props.showConfirmDialog ? (
-		<ConfirmDialog onConfirm={ props.onClick }>
+		<ConfirmDialog
+			onConfirm={ props.onClick }
+			onCancel={ props.confirmStateResetHandler }
+		>
 			{ alertMessage }
 		</ConfirmDialog>
 	) : null;
@@ -38,6 +41,10 @@ function PostSwitchToDraftButton( {
 } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
+	const confirmStateResetHandler = () => {
+		setShowConfirmDialog( false );
+	};
 
 	if ( ! isPublished && ! isScheduled ) {
 		return null;
@@ -60,6 +67,7 @@ function PostSwitchToDraftButton( {
 				isScheduled={ isScheduled }
 				onClick={ onClick }
 				showConfirmDialog={ showConfirmDialog }
+				confirmStateResetHandler={ confirmStateResetHandler }
 			/>
 		</>
 	);

--- a/packages/editor/src/components/post-switch-to-draft-button/index.js
+++ b/packages/editor/src/components/post-switch-to-draft-button/index.js
@@ -15,24 +15,6 @@ import { useState } from '@wordpress/element';
  */
 import { store as editorStore } from '../../store';
 
-function SwitchToDraftConfirm( props ) {
-	let alertMessage;
-	if ( props.isPublished ) {
-		alertMessage = __( 'Are you sure you want to unpublish this post?' );
-	} else if ( props.isScheduled ) {
-		alertMessage = __( 'Are you sure you want to unschedule this post?' );
-	}
-
-	return props.showConfirmDialog ? (
-		<ConfirmDialog
-			onConfirm={ props.onClick }
-			onCancel={ props.confirmStateResetHandler }
-		>
-			{ alertMessage }
-		</ConfirmDialog>
-	) : null;
-}
-
 function PostSwitchToDraftButton( {
 	isSaving,
 	isPublished,
@@ -42,12 +24,15 @@ function PostSwitchToDraftButton( {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
-	const confirmStateResetHandler = () => {
-		setShowConfirmDialog( false );
-	};
-
 	if ( ! isPublished && ! isScheduled ) {
 		return null;
+	}
+
+	let alertMessage;
+	if ( isPublished ) {
+		alertMessage = __( 'Are you sure you want to unpublish this post?' );
+	} else if ( isScheduled ) {
+		alertMessage = __( 'Are you sure you want to unschedule this post?' );
 	}
 
 	return (
@@ -62,13 +47,13 @@ function PostSwitchToDraftButton( {
 			>
 				{ isMobileViewport ? __( 'Draft' ) : __( 'Switch to draft' ) }
 			</Button>
-			<SwitchToDraftConfirm
-				isPublished={ isPublished }
-				isScheduled={ isScheduled }
-				onClick={ onClick }
-				showConfirmDialog={ showConfirmDialog }
-				confirmStateResetHandler={ confirmStateResetHandler }
-			/>
+			<ConfirmDialog
+				isOpen={ showConfirmDialog }
+				onConfirm={ onClick }
+				onCancel={ () => setShowConfirmDialog( false ) }
+			>
+				{ alertMessage }
+			</ConfirmDialog>
 		</>
 	);
 }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/34153

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR aims to migrate the post editor's `Switch to draft` button away from the current `confirm()` implementation and instead use the new experimental `ConfirmDialog` component.

## How has this been tested?
Running WordPress 5.8.2 via `wp-env`:
1. Create a new post
2. Add some content, a title, etc.
3. Publish the post
4. Click the `Switch to draft` button
5. Monitor console for any unexpected errors
6. Confirm that the new `ConfirmDialog` component is rendered instead of the previous browser-based confirmation triggered by `confirm()`
7. Click `Cancel`, and confirm that the post remains published
8. Click `Switch to draft` again, and this time hit `OK`. Confirm the post is reverted to a draft

I've tested in the latest Chrome, Firefox, and Safari.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
