### PR TITLE
Migrate Edit Navigation screen "Delete menu" button from `confirm()` …

### DIFF
--- a/packages/edit-navigation/src/components/sidebar/delete-menu.js
+++ b/packages/edit-navigation/src/components/sidebar/delete-menu.js
@@ -12,6 +12,11 @@ import { useState } from '@wordpress/element';
 export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
+	const handleConfirm = () => {
+		setShowConfirmDialog( false );
+		onDeleteMenu();
+	};
+
 	return (
 		<PanelBody>
 			<>
@@ -28,7 +33,7 @@ export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 				</Button>
 				<ConfirmDialog
 					isOpen={ showConfirmDialog }
-					onConfirm={ onDeleteMenu }
+					onConfirm={ handleConfirm }
 					onCancel={ () => setShowConfirmDialog( false ) }
 				>
 					{ __(

--- a/packages/edit-navigation/src/components/sidebar/delete-menu.js
+++ b/packages/edit-navigation/src/components/sidebar/delete-menu.js
@@ -9,24 +9,8 @@ import {
 } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
-function DeleteMenuConfirm( props ) {
-	return props.showConfirmDialog ? (
-		<ConfirmDialog
-			onConfirm={ props.onDeleteMenu }
-			onCancel={ props.confirmStateResetHandler }
-		>
-			Are you sure you want to delete this navigation? This action cannot
-			be undone.
-		</ConfirmDialog>
-	) : null;
-}
-
 export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
-
-	const confirmStateResetHandler = () => {
-		setShowConfirmDialog( false );
-	};
 
 	return (
 		<PanelBody>
@@ -42,11 +26,15 @@ export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 				>
 					{ __( 'Delete menu' ) }
 				</Button>
-				<DeleteMenuConfirm
-					onDeleteMenu={ onDeleteMenu }
-					showConfirmDialog={ showConfirmDialog }
-					confirmStateResetHandler={ confirmStateResetHandler }
-				/>
+				<ConfirmDialog
+					isOpen={ showConfirmDialog }
+					onConfirm={ onDeleteMenu }
+					onCancel={ () => setShowConfirmDialog( false ) }
+				>
+					{ __(
+						'Are you sure you want to delete this navigation? This action cannot be undone.'
+					) }
+				</ConfirmDialog>
 			</>
 		</PanelBody>
 	);

--- a/packages/edit-navigation/src/components/sidebar/delete-menu.js
+++ b/packages/edit-navigation/src/components/sidebar/delete-menu.js
@@ -11,7 +11,10 @@ import { useState } from '@wordpress/element';
 
 function DeleteMenuConfirm( props ) {
 	return props.showConfirmDialog ? (
-		<ConfirmDialog onConfirm={ props.onDeleteMenu }>
+		<ConfirmDialog
+			onConfirm={ props.onDeleteMenu }
+			onCancel={ props.confirmStateResetHandler }
+		>
 			Are you sure you want to delete this navigation? This action cannot
 			be undone.
 		</ConfirmDialog>
@@ -20,6 +23,11 @@ function DeleteMenuConfirm( props ) {
 
 export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
+	const confirmStateResetHandler = () => {
+		setShowConfirmDialog( false );
+	};
+
 	return (
 		<PanelBody>
 			<>
@@ -37,6 +45,7 @@ export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
 				<DeleteMenuConfirm
 					onDeleteMenu={ onDeleteMenu }
 					showConfirmDialog={ showConfirmDialog }
+					confirmStateResetHandler={ confirmStateResetHandler }
 				/>
 			</>
 		</PanelBody>

--- a/packages/edit-navigation/src/components/sidebar/delete-menu.js
+++ b/packages/edit-navigation/src/components/sidebar/delete-menu.js
@@ -2,31 +2,43 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, PanelBody } from '@wordpress/components';
+import {
+	Button,
+	PanelBody,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+function DeleteMenuConfirm( props ) {
+	return props.showConfirmDialog ? (
+		<ConfirmDialog onConfirm={ props.onDeleteMenu }>
+			Are you sure you want to delete this navigation? This action cannot
+			be undone.
+		</ConfirmDialog>
+	) : null;
+}
 
 export default function DeleteMenu( { onDeleteMenu, isMenuBeingDeleted } ) {
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 	return (
 		<PanelBody>
-			<Button
-				className="edit-navigation-inspector-additions__delete-menu-button"
-				variant="secondary"
-				isDestructive
-				isBusy={ isMenuBeingDeleted }
-				onClick={ () => {
-					if (
-						// eslint-disable-next-line no-alert
-						window.confirm(
-							__(
-								'Are you sure you want to delete this navigation? This action cannot be undone.'
-							)
-						)
-					) {
-						onDeleteMenu();
-					}
-				} }
-			>
-				{ __( 'Delete menu' ) }
-			</Button>
+			<>
+				<Button
+					className="edit-navigation-inspector-additions__delete-menu-button"
+					variant="secondary"
+					isDestructive
+					isBusy={ isMenuBeingDeleted }
+					onClick={ () => {
+						setShowConfirmDialog( true );
+					} }
+				>
+					{ __( 'Delete menu' ) }
+				</Button>
+				<DeleteMenuConfirm
+					onDeleteMenu={ onDeleteMenu }
+					showConfirmDialog={ showConfirmDialog }
+				/>
+			</>
 		</PanelBody>
 	);
 }


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/34153

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR aims to migrate the beta Navigation Editor's `Delete menu` button away from the current `confirm()` implementation and instead use the new experimental `ConfirmDialog` component.

## How has this been tested?
Running WordPress 5.8.2 via `wp-env`:
1. Ensure the beta Navigation editor is activated from `Gutenberg > Experiments`
2. Open `Gutenberg > Navigation (beta)`
3. Create multiple menus (two or more)
4. Click the `Delete menu` button. Confirm there are no unexpected console errors and the new `ConfirmDialog` component is rendered instead of the browser's `confirm()` prompt.
5. Click the `Cancel` button. Confirm that the menu is still intact.
6. Click the `Delete menu` button again, and this time select `OK`
7. Confirm the menu in question is, in fact, deleted
8. Deleting one menu should automatically load the next menu that's in the database. Use `Delete menu` on all of them
9. Confirm that deleting the final/only menu returns you to the `Create your first menu` UI

Note, if you already have a menu saved from a previous session, attempting to delete it will result in an error. This doesn't appear to be related to this PR, and has been reported in #37794

I've tested in the latest Chrome, Firefox, and Safari.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
