### PR TITLE
Update: make color styles labels simpler

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -383,7 +383,7 @@ export function ColorEdit( props ) {
 				...( hasTextColor
 					? [
 							{
-								label: __( 'Text color' ),
+								label: __( 'Text' ),
 								onColorChange: onChangeColor( 'text' ),
 								colorValue: getColorObjectByAttributeValues(
 									allSolids,
@@ -396,7 +396,7 @@ export function ColorEdit( props ) {
 				...( hasBackgroundColor || hasGradientColor
 					? [
 							{
-								label: __( 'Background color' ),
+								label: __( 'Background' ),
 								onColorChange: hasBackgroundColor
 									? onChangeColor( 'background' )
 									: undefined,
@@ -415,7 +415,7 @@ export function ColorEdit( props ) {
 				...( hasLinkColor
 					? [
 							{
-								label: __( 'Link Color' ),
+								label: __( 'Link' ),
 								onColorChange: onChangeLinkColor,
 								colorValue: getLinkColorFromAttributeValue(
 									allSolids,

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -192,7 +192,7 @@ export function SocialLinksEdit( props ) {
 									iconBackgroundColorValue: colorValue,
 								} );
 							},
-							label: __( 'Icon background color' ),
+							label: __( 'Icon background' ),
 						},
 					] }
 				/>


### PR DESCRIPTION
This PR Follows an enhancement suggested by @mtias on https://github.com/WordPress/gutenberg/issues/30719#issuecomment-996539641. It updates the color labels to be more simpler and consistent.


## How has this been tested?
I added a paragraph block, went to the color panel, and verified the labels are the ones in the first screenshot.
I added a social icons block, went to the color panel, and verified the labels are the ones in the second screenshot.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/146577748-022b5a2e-901c-4ff0-945c-cd5a3bea3f1e.png)

![image](https://user-images.githubusercontent.com/11271197/146577941-07891019-092e-4fc1-a2fa-af1a8e87f458.png)
