### PR TITLE
Changed the letter case for Post Type to Post type

### DIFF
--- a/packages/block-library/src/query/edit/query-inspector-controls.js
+++ b/packages/block-library/src/query/edit/query-inspector-controls.js
@@ -189,10 +189,10 @@ export default function QueryInspectorControls( {
 					<SelectControl
 						options={ postTypesSelectOptions }
 						value={ postType }
-						label={ __( 'Post Type' ) }
+						label={ __( 'Post type' ) }
 						onChange={ onPostTypeChange }
 						help={ __(
-							'WordPress contains different types of content and they are divided into collections called "Post Types". By default there are a few different ones such as blog posts and pages, but plugins could add more.'
+							'WordPress contains different types of content and they are divided into collections called "Post types". By default there are a few different ones such as blog posts and pages, but plugins could add more.'
 						) }
 					/>
 				) }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Changed the letter case for `Post Type` to `Post type` to stay consistent with other titles in the settings. 

In this [article](https://wordpress.org/support/article/post-types/), post types is used as both title case and lower case.

## Screenshots

![Screen Shot 2021-12-17 at 11 51 12 AM](https://user-images.githubusercontent.com/2229643/146593760-3a1fc99b-7722-4c8d-99cc-842944913317.png)

## Types of changes
Just a copy change