### PR TITLE
Use inset shadow on color indicators and adjust spacing

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -7,7 +7,7 @@
 .block-editor-panel-color-gradient-settings {
 	.block-editor-panel-color-gradient-settings__panel-title {
 		display: flex;
-		gap: $grid-unit-15 * 0.5;
+		gap: $grid-unit-10;
 
 		.component-color-indicator {
 			width: $grid-unit-15;

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -7,12 +7,16 @@
 .block-editor-panel-color-gradient-settings {
 	.block-editor-panel-color-gradient-settings__panel-title {
 		display: flex;
-		gap: $grid-unit-15;
+		gap: $grid-unit-15 * 0.5;
 
 		.component-color-indicator {
 			width: $grid-unit-15;
 			height: $grid-unit-15;
 			align-self: center;
+
+			&:first-child {
+				margin-left: $grid-unit-15;
+			}
 		}
 	}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -33,6 +33,7 @@
 -   Unify styles for `ColorIndicator` with how they appear in Global Styles ([#37028](https://github.com/WordPress/gutenberg/pull/37028))
 -   Add support for rendering the `ColorPalette` in a `Dropdown` when opened in the sidebar ([#37067](https://github.com/WordPress/gutenberg/pull/37067))
 -   Show an incremental sequence of numbers (1/2/3/4/5) as a label of the font size, when we have at most five font sizes, where at least one the them contains a complex css value(clamp, var, etc..). We do this because complex css values cannot be calculated properly and the incremental sequence of numbers as labels can help the user better mentally map the different available font sizes. ([#37038](https://github.com/WordPress/gutenberg/pull/37038))
+-   Add support for proper borders to color indicators ([#37500](https://github.com/WordPress/gutenberg/pull/37500))
 
 ## 19.1.4 (2021-12-13)
 

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -1,20 +1,8 @@
 .component-color-indicator {
 	width: $grid-unit-50 * 0.5;
 	height: $grid-unit-50 * 0.5;
+	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 	border-radius: 50%;
 	display: inline-block;
 	padding: 0;
-	position: relative;
-
-	&::after {
-		content: "";
-		position: absolute;
-		top: -1px;
-		left: -1px;
-		bottom: -1px;
-		right: -1px;
-		border-radius: 50%;
-		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-		border: 1px solid transparent;
-	}
 }

--- a/packages/components/src/color-indicator/style.scss
+++ b/packages/components/src/color-indicator/style.scss
@@ -2,7 +2,19 @@
 	width: $grid-unit-50 * 0.5;
 	height: $grid-unit-50 * 0.5;
 	border-radius: 50%;
-	border: $border-width solid $gray-300;
 	display: inline-block;
 	padding: 0;
+	position: relative;
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: -1px;
+		left: -1px;
+		bottom: -1px;
+		right: -1px;
+		border-radius: 50%;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+		border: 1px solid transparent;
+	}
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
I noticed that the color indicators were using a border, instead of an inset shadow (which we use elsewhere for colors). With a border, those indicators would lead to "fuzzy" edges with most color choices. By using the inset shadow, we resolve that. 

I also tweaked the spacing around the color indicators to bring them closer together and space them appropriately from the label. 

## How has this been tested?
Tested locally. 

## Screenshots <!-- if applicable -->

### Before: 
<img width="588" alt="CleanShot 2021-12-17 at 14 09 29@2x" src="https://user-images.githubusercontent.com/1813435/146595738-7a1536d6-b33b-40d7-8a16-0a624a37fa03.png">

### After: 
<img width="555" alt="CleanShot 2021-12-17 at 14 07 47@2x" src="https://user-images.githubusercontent.com/1813435/146595683-db236805-cf48-4de8-8dc4-4917452dcac0.png">

## Types of changes
CSS
