### PR TITLE
Fix flaky Navigation block e2e test by mocking out URL details endpoint to avoid 404

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -435,6 +435,19 @@ describe( 'Navigation', () => {
 	} );
 
 	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
+		// The URL Details endpoint 404s for the created page, since it will
+		// be a draft that is inaccessible publicly. To avoid this we mock
+		// out the endpoint response to be empty which will be handled gracefully
+		// in the UI whilst avoiding any 404s.
+		await setUpResponseMocking( [
+			{
+				match: ( request ) =>
+					request.url().includes( `rest_route` ) &&
+					request.url().includes( `url-details` ),
+				onRequestMatch: createJSONResponse( [] ),
+			},
+		] );
+
 		await createNewPost();
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
@@ -468,12 +481,6 @@ describe( 'Navigation', () => {
 		await page.waitForXPath(
 			`//a[contains(@class, "block-editor-link-control__search-item-title") and contains(., "${ pageTitle }")]`
 		);
-
-		// The URL Details endpoint 404s for the created page, since it will
-		// be a draft that is inaccessible publicly. Wait for the HTTP request
-		// to finish, since this seems to make the test more stable.
-		await page.waitForNetworkIdle();
-		expect( console ).toHaveErrored();
 
 		await publishPost();
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Since we re-enabled the Navigation block e2e tests the CI tests have been flaky.

This PR fixes https://github.com/WordPress/gutenberg/issues/37479 by mocking out the `url-details` endpoint to avoid having to handle the 404 using less resilient methods.

Note this commit was cherry picked from https://github.com/WordPress/gutenberg/pull/37454 which also contains the fix.


## How has this been tested?

Run tests check they pass on CI.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
