### PR TITLE
Add proper padding to ColorGradientControl 

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -1,4 +1,6 @@
 .block-editor-color-gradient-control {
+	padding: $grid-unit-10;
+
 	.block-editor-color-gradient-control__color-indicator {
 		margin-bottom: $grid-unit-15;
 	}

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -4,6 +4,7 @@
 	background: none;
 	display: block;
 	border-radius: $radius-block-ui;
+	padding: 0 $grid-unit-10;
 	height: $grid-unit-60;
 	text-align: right;
 	width: 100%;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Adds missing padding to the ColorGradientControl Dropdown, so that it is consistent with other Dropdown within the editor, and gives the UI visual space from the edge of the dropdown. 

## Screenshots <!-- if applicable -->

### Before
<img width="858" alt="CleanShot 2021-12-17 at 14 30 14@2x" src="https://user-images.githubusercontent.com/1813435/146597951-c6fb575d-ceaa-43f5-a244-a70a8673cf90.png">

### After
<img width="830" alt="CleanShot 2021-12-17 at 14 30 44@2x" src="https://user-images.githubusercontent.com/1813435/146597992-bb058f8c-725a-4a80-9dd3-b8cbbf7eb0d1.png">

### Reference
<img width="779" alt="CleanShot 2021-12-17 at 14 31 02@2x" src="https://user-images.githubusercontent.com/1813435/146598016-b53030b5-b15b-4907-96b1-83cb33942fe0.png">


## Types of changes
CSS

