### PR TITLE
Update jsxBracketSameLine to renamed bracketSameLine

### DIFF
--- a/packages/prettier-config/lib/index.js
+++ b/packages/prettier-config/lib/index.js
@@ -18,7 +18,7 @@ const config = {
 	trailingComma: 'es5',
 	bracketSpacing: true,
 	parenSpacing: true,
-	jsxBracketSameLine: false,
+	bracketSameLine: false,
 	semi: true,
 	arrowParens: 'always',
 };


### PR DESCRIPTION
## Description

For #37516

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes

Renamed `jsxBracketSameLine` option to `bracketSameLine` as per [change in Prittier](https://prettier.io/blog/2021/09/09/2.4.0.html).

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
