### PR TITLE
[WIP] Post Template: Add click handler for switching between selected blocks when clicking on the block preview

### DIFF
--- a/packages/block-editor/src/components/block-preview/style.scss
+++ b/packages/block-editor/src/components/block-preview/style.scss
@@ -43,10 +43,6 @@
 }
 
 .block-editor-block-preview__live-content {
-	* {
-		pointer-events: none;
-	}
-
 	// Hide the block appender, as the block is not editable in this context.
 	.block-list-appender {
 		display: none;

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { memo, useMemo, useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
@@ -40,8 +40,19 @@ function PostTemplateBlockPreview( {
 		blocks,
 	} );
 
-	const handleOnClick = () => {
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	const handleOnClick = ( event ) => {
+		const blockElement = !! event.target.getAttribute( 'data-block' )
+			? event.target
+			: event.target.closest( '[data-block]' );
+		const clientId = blockElement.getAttribute( 'data-block' );
+		event.preventDefault();
+		event.stopPropagation();
 		setActiveBlockContextId( blockContextId );
+		if ( clientId ) {
+			selectBlock( clientId );
+		}
 	};
 
 	const style = {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

🚧 🚧 🚧 🚧 🚧 🚧 

Follows on from discussion in https://github.com/WordPress/gutenberg/issues/37154#issuecomment-995272261 and https://github.com/WordPress/gutenberg/pull/36431.

This is a WIP exploration PR at the moment, details TBC.

The goal is to ensure in the Post Template block, that when clicking between blocks within instances of the Query Loop, that when the block context is switched to another instance of the loop, we _also_ change the selected block to the block that the user clicked on. This is to help it not feel like the user is dealing with a preview, but with a normal editor canvas.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

TBC

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
