### PR TITLE
Revert Query Pagination Next/Previous placeholder(36681)

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -145,15 +145,13 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$id              = uniqid();
-	$style           = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
-	$container_class = 'wp-container-' . $id . ' ';
-	$justify_class   = isset( $used_layout['justifyContent'] ) ? 'wp-justify-' . $used_layout['justifyContent'] . ' ' : '';
+	$id    = uniqid();
+	$style = gutenberg_get_layout_style( ".wp-container-$id", $used_layout, $has_block_gap_support );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
-		'class="' . $container_class . $justify_class,
+		'class="wp-container-' . $id . ' ',
 		$block_content,
 		1
 	);

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -17,63 +17,41 @@
 function render_block_core_query_pagination_next( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes        = get_block_wrapper_attributes();
-	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
-	$default_label             = __( 'Next Page' );
-	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow          = get_query_pagination_arrow( $block, true );
-	$content                   = '';
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$default_label      = __( 'Next Page' );
+	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow   = get_query_pagination_arrow( $block, true );
 
 	if ( $pagination_arrow ) {
 		$label .= $pagination_arrow;
 	}
+	$content = '';
 
 	// Check if the pagination is for Query that inherits the global context.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		global $wp_query;
-		// Take into account if we have set a bigger `max page`
-		// than what the query has.
-		$max_page               = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 		add_filter( 'next_posts_link_attributes', $filter_link_attributes );
-
-		// If there are pages to paginate.
-		if ( 1 < $max_page ) {
-			if ( (int) $max_page !== $paged ) { // If we are NOT in the last one.
-				$content = get_next_posts_link( $label, $max_page );
-			} else { // If we are in the last one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
+		// Take into account if we have set a bigger `max page`
+		// than what the query has.
+		global $wp_query;
+		if ( $max_page > $wp_query->max_num_pages ) {
+			$max_page = $wp_query->max_num_pages;
 		}
+		$content = get_next_posts_link( $label, $max_page );
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_num_pages = $custom_query->max_num_pages ? $custom_query->max_num_pages : 1;
-		// If there are pages to paginate.
-		if ( 1 < $max_num_pages ) {
-			if ( (int) $max_num_pages !== $page ) { // If we are NOT in the last one.
-				$content = sprintf(
-					'<a href="%1$s" %2$s>%3$s</a>',
-					esc_url( add_query_arg( $page_key, $page + 1 ) ),
-					$wrapper_attributes,
-					$label
-				);
-			} else { // If we are in the last one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
+		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		if ( (int) $custom_query->max_num_pages !== $page ) {
+			$content = sprintf(
+				'<a href="%1$s" %2$s>%3$s</a>',
+				esc_url( add_query_arg( $page_key, $page + 1 ) ),
+				$wrapper_attributes,
+				$label
+			);
 		}
 		wp_reset_postdata(); // Restore original Post Data.
 	}

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -17,63 +17,32 @@
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$paged    = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
-	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
-	$wrapper_attributes        = get_block_wrapper_attributes();
-	$hidden_wrapper_attributes = get_block_wrapper_attributes( array( 'aria-hidden' => 'true' ) );
-	$default_label             = __( 'Previous Page' );
-	$label                     = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-	$pagination_arrow          = get_query_pagination_arrow( $block, false );
-	$content                   = '';
-
+	$wrapper_attributes = get_block_wrapper_attributes();
+	$default_label      = __( 'Previous Page' );
+	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+	$pagination_arrow   = get_query_pagination_arrow( $block, false );
 	if ( $pagination_arrow ) {
 		$label = $pagination_arrow . $label;
 	}
+	$content = '';
 	// Check if the pagination is for Query that inherits the global context
 	// and handle appropriately.
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
-		global $wp_query;
-		$max_page               = ! $max_page || $max_page > $wp_query->max_num_pages ? $wp_query->max_num_pages : $max_page;
 		$filter_link_attributes = function() use ( $wrapper_attributes ) {
 			return $wrapper_attributes;
 		};
 
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-
-		// If there are pages to paginate...
-		if ( 1 < $max_page ) {
-			if ( 1 !== $paged ) { // ... and we are NOT in the first one.
-				$content = get_previous_posts_link( $label );
-			} else { // ... and we are in the first one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
-		}
+		$content = get_previous_posts_link( $label );
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query  = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		$max_num_pages = $custom_query->max_num_pages ? $custom_query->max_num_pages : 1;
-		// If there are pages to paginate...
-		if ( 1 < $max_num_pages ) {
-			if ( 1 !== $page ) { // ... and we are NOT in the first one.
-				$content = sprintf(
-					'<a href="%1$s" %2$s>%3$s</a>',
-					esc_url( add_query_arg( $page_key, $page - 1 ) ),
-					$wrapper_attributes,
-					$label
-				);
-			} else {  // ... and we are in the first one.
-				$content = sprintf(
-					'<span %1$s>%2$s</span>',
-					$hidden_wrapper_attributes,
-					$label
-				);
-			}
-		}
+	} elseif ( 1 !== $page ) {
+		$content = sprintf(
+			'<a href="%1$s" %2$s>%3$s</a>',
+			esc_url( add_query_arg( $page_key, $page - 1 ) ),
+			$wrapper_attributes,
+			$label
+		);
 	}
 	return $content;
 }

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -32,17 +32,7 @@ $pagination-margin: 0.5em;
 		}
 	}
 
-	// Non-clickeable previous and next elements are not visible
-	>span.wp-block-query-pagination-next,
-	>span.wp-block-query-pagination-previous {
-		visibility: hidden;
+	&.aligncenter {
+		justify-content: center;
 	}
-
-	&.wp-justify-left,
-	&.wp-justify-right {
-		> [aria-hidden="true"] {
-			display: none;
-		}
-	}
-
 }


### PR DESCRIPTION
After discussions, some recent changes to Query Pagination Next/Previous blocks to show placeholders [were decided to be reverted](https://github.com/WordPress/gutenberg/pull/36681#issuecomment-996028742).

That PR couldn't be automatically reverted by GitHub, so this PR will do it.

In addition during the discussion about the changes a bug was found that will be addressed in a follow up.

>..the example you shared about the next page link when a custom query has no results at all, is a bug and an extra check of max_num_pages should be added.

## Testing instructions
1. Add a Query Loop with pagination and check that every link works properly as before without the addition of any placeholder.
2. You can also test the diff of the original PR here: https://github.com/WordPress/gutenberg/pull/36681/files