### PR TITLE
Lower the specificity of font size CSS Custom Properties in the editor

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -50,8 +50,11 @@
 	@include background-colors-deprecated();
 	@include foreground-colors-deprecated();
 	@include gradient-colors-deprecated();
-	// This CSS Custom Properties aren't used anymore as defaults,
-	// but we still need to keep them for backward compatibility.
+}
+
+// This CSS Custom Properties aren't used anymore as defaults,
+// but we still need to keep them for backward compatibility.
+.editor-styles-wrapper {
 	--wp--preset--font-size--normal: 16px;
 	--wp--preset--font-size--huge: 42px;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/pull/37381#issuecomment-996923073

## How to test

- Use a theme with `theme.json`. For example, TwentyTwentyTwo.
- Add a `normal` font size to the list of font sizes:

```
{
    "size": "23px",
    "slug": "normal"
}
```

- Associate that font size with the default font size used by adding this to the `styles` section of the `theme.json`:

```
"styles": {
    "typography": {
        "fontSize": "var(--wp--preset--font-size--normal)"
    }
}
```

- Open the Gutenberg demo post (or open a new one and add some paragraphs to it.

The expected result is that the default font size for the paragraph is `23px` and not `16px`.

