### PR TITLE
Scope list styles to UL/OL elements that are not blocks

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -55,7 +55,7 @@
 			"link": true
 		},
 		"__unstablePasteTextInline": true,
-		"__experimentalSelector": "ol,ul",
+		"__experimentalSelector": "ol:not([class*='wp-block']),ul:not([class*='wp-block'])",
 		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-list-editor",

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -55,7 +55,7 @@
 			"link": true
 		},
 		"__unstablePasteTextInline": true,
-		"__experimentalSelector": "ol:not([class*='wp-block']),ul:not([class*='wp-block'])",
+		"__experimentalSelector": "ol:where(:not([class*='wp-block'])),ul:where(:not([class*='wp-block'])), ol:where(.wp-block-list), ul:where(.wp-block-list)",
 		"__experimentalSlashInserter": true
 	},
 	"editorStyle": "wp-block-list-editor",


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37388

This PR changes how the styles of the list block are scoped to avoid applying them to top-level blocks that use the `ol`/`ul` HTML tags.

See https://github.com/WordPress/gutenberg/issues/37388 for test instructions.