### PR TITLE
Migrate Post Template Delete button from `confirm()` to `ConfirmDialog`

### DIFF
--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -244,13 +244,18 @@ describe( 'Delete Post Template Confirmation Dialog', () => {
 				await page.reload();
 				await page.waitForSelector( '.edit-post-layout' );
 			}
+			if ( viewport === 'small' ) {
+				await page.waitForXPath( '//button[@aria-label="Settings"]' );
+				await openDocumentSettingsSidebar();
+			}
 			const templateTitle = `${ viewport } Viewport Deletion Test`;
 
 			await createNewTemplate( templateTitle );
 			// Edit the template
 			if ( viewport === 'small' ) {
+				await page.waitForXPath( `//h2[text()="${ templateTitle }"]` );
 				const closeDocumentSettingsButton = await page.waitForXPath(
-					'//div[contains(@class,"interface-complementary-area-header__small")]/button[@aria-label="Close settings"]'
+					'//button[@aria-label="Close settings"]'
 				);
 				await closeDocumentSettingsButton.click();
 			}

--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -201,8 +201,8 @@ describe( 'Post Editor Template mode', () => {
 describe( 'Delete Post Template Confirmation Dialog', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-block-templates' );
-		await trashAllPosts( 'wp_template' );
-		await trashAllPosts( 'wp_template_part' );
+		await deleteAllTemplates( 'wp_template' );
+		await deleteAllTemplates( 'wp_template_part' );
 		await activateTheme( 'twentytwentyone' );
 		await createNewPost();
 		// Create a random post.

--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -341,6 +341,10 @@ describe( 'Delete Post Template Confirmation Dialog', () => {
 
 			await dialogConfirmButton.click();
 
+			// Saving isn't technically necessary, but for themes without any specified templates,
+			// the removal of the Templates dropdown is delayed. A save and reload allows for this
+			// delay and prevents flakiness
+			await saveDraft();
 			await page.reload();
 
 			const optionElementHandlers = await page.$x(

--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -57,7 +57,7 @@ const switchToTemplateMode = async () => {
 
 	// Check that we switched properly to edit mode.
 	await page.waitForXPath(
-		'//*[contains(@class, "components-snackbar")]/*[text()="Editing template. Changes made here affect all posts and pages that use the template."]'
+		'//*[text()="Editing template. Changes made here affect all posts and pages that use the template."]'
 	);
 	const title = await page.$eval(
 		'.edit-post-template-top-area',

--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -292,7 +292,11 @@ describe( 'Delete Post Template Confirmation Dialog', () => {
 			);
 			await dialogCancelButton.click();
 
-			await page.reload();
+			const exitTemplateModeButton = await page.waitForXPath(
+				'//button[text()="Back"]'
+			);
+			await exitTemplateModeButton.click();
+
 			await page.waitForXPath(
 				'//button[@aria-label="Settings"][@aria-expanded="false"]'
 			);

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -23,23 +23,6 @@ import { useState } from '@wordpress/element';
  */
 import { store as editPostStore } from '../../../store';
 
-function DeleteTemplateConfirm( props ) {
-	return props.showConfirmDialog ? (
-		<ConfirmDialog
-			onConfirm={ props.onConfirm }
-			onCancel={ props.confirmStateResetHandler }
-		>
-			{ sprintf(
-				/* translators: %s: template name */
-				__(
-					'Are you sure you want to delete the %s template? It may be used by other pages or posts.'
-				),
-				props.templateTitle
-			) }
-		</ConfirmDialog>
-	) : null;
-}
-
 export default function DeleteTemplate() {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
@@ -64,10 +47,6 @@ export default function DeleteTemplate() {
 	if ( template?.title ) {
 		templateTitle = template.title;
 	}
-
-	const confirmStateResetHandler = () => {
-		setShowConfirmDialog( false );
-	};
 
 	const onDelete = () => {
 		clearSelectedBlock();
@@ -104,12 +83,21 @@ export default function DeleteTemplate() {
 				>
 					{ __( 'Delete template' ) }
 				</MenuItem>
-				<DeleteTemplateConfirm
-					showConfirmDialog={ showConfirmDialog }
-					confirmStateResetHandler={ confirmStateResetHandler }
-					templateTitle={ templateTitle }
+				<ConfirmDialog
+					isOpen={ showConfirmDialog }
 					onConfirm={ onDelete }
-				/>
+					onCancel={ () => {
+						setShowConfirmDialog( false );
+					} }
+				>
+					{ sprintf(
+						/* translators: %s: template name */
+						__(
+							'Are you sure you want to delete the %s template? It may be used by other pages or posts.'
+						),
+						templateTitle
+					) }
+				</ConfirmDialog>
 			</>
 		</MenuGroup>
 	);

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -51,6 +51,7 @@ export default function DeleteTemplate() {
 	const onDelete = () => {
 		clearSelectedBlock();
 		setIsEditingTemplate( false );
+		setShowConfirmDialog( false );
 
 		editPost( {
 			template: '',

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -7,16 +7,35 @@ import { pickBy } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	MenuGroup,
+	MenuItem,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../../store';
+
+function DeleteTemplateConfirm( props ) {
+	return props.showConfirmDialog ? (
+		<ConfirmDialog onConfirm={ props.onConfirm }>
+			{ sprintf(
+				/* translators: %s: template name */
+				__(
+					'Are you sure you want to delete the %s template? It may be used by other pages or posts.'
+				),
+				props.templateTitle
+			) }
+		</ConfirmDialog>
+	) : null;
+}
 
 export default function DeleteTemplate() {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
@@ -33,6 +52,7 @@ export default function DeleteTemplate() {
 			template: _isEditing ? getEditedPostTemplate() : null,
 		};
 	}, [] );
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
 
 	if ( ! template || ! template.wp_id ) {
 		return null;
@@ -42,53 +62,47 @@ export default function DeleteTemplate() {
 		templateTitle = template.title;
 	}
 
+	const onDelete = () => {
+		clearSelectedBlock();
+		setIsEditingTemplate( false );
+
+		editPost( {
+			template: '',
+		} );
+		const settings = getEditorSettings();
+		const newAvailableTemplates = pickBy(
+			settings.availableTemplates,
+			( _title, id ) => {
+				return id !== template.slug;
+			}
+		);
+		updateEditorSettings( {
+			...settings,
+			availableTemplates: newAvailableTemplates,
+		} );
+		deleteEntityRecord( 'postType', 'wp_template', template.id );
+	};
+
 	return (
 		<MenuGroup className="edit-post-template-top-area__second-menu-group">
-			<MenuItem
-				className="edit-post-template-top-area__delete-template-button"
-				isDestructive
-				variant="secondary"
-				aria-label={ __( 'Delete template' ) }
-				onClick={ () => {
-					if (
-						// eslint-disable-next-line no-alert
-						window.confirm(
-							sprintf(
-								/* translators: %s: template name */
-								__(
-									'Are you sure you want to delete the %s template? It may be used by other pages or posts.'
-								),
-								templateTitle
-							)
-						)
-					) {
-						clearSelectedBlock();
-						setIsEditingTemplate( false );
-
-						editPost( {
-							template: '',
-						} );
-						const settings = getEditorSettings();
-						const newAvailableTemplates = pickBy(
-							settings.availableTemplates,
-							( _title, id ) => {
-								return id !== template.slug;
-							}
-						);
-						updateEditorSettings( {
-							...settings,
-							availableTemplates: newAvailableTemplates,
-						} );
-						deleteEntityRecord(
-							'postType',
-							'wp_template',
-							template.id
-						);
-					}
-				} }
-			>
-				{ __( 'Delete template' ) }
-			</MenuItem>
+			<>
+				<MenuItem
+					className="edit-post-template-top-area__delete-template-button"
+					isDestructive
+					variant="secondary"
+					aria-label={ __( 'Delete template' ) }
+					onClick={ () => {
+						setShowConfirmDialog( true );
+					} }
+				>
+					{ __( 'Delete template' ) }
+				</MenuItem>
+				<DeleteTemplateConfirm
+					showConfirmDialog={ showConfirmDialog }
+					templateTitle={ templateTitle }
+					onConfirm={ onDelete }
+				/>
+			</>
 		</MenuGroup>
 	);
 }

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -25,7 +25,10 @@ import { store as editPostStore } from '../../../store';
 
 function DeleteTemplateConfirm( props ) {
 	return props.showConfirmDialog ? (
-		<ConfirmDialog onConfirm={ props.onConfirm }>
+		<ConfirmDialog
+			onConfirm={ props.onConfirm }
+			onCancel={ props.confirmStateResetHandler }
+		>
 			{ sprintf(
 				/* translators: %s: template name */
 				__(
@@ -61,6 +64,10 @@ export default function DeleteTemplate() {
 	if ( template?.title ) {
 		templateTitle = template.title;
 	}
+
+	const confirmStateResetHandler = () => {
+		setShowConfirmDialog( false );
+	};
 
 	const onDelete = () => {
 		clearSelectedBlock();
@@ -99,6 +106,7 @@ export default function DeleteTemplate() {
 				</MenuItem>
 				<DeleteTemplateConfirm
 					showConfirmDialog={ showConfirmDialog }
+					confirmStateResetHandler={ confirmStateResetHandler }
 					templateTitle={ templateTitle }
 					onConfirm={ onDelete }
 				/>

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -197,6 +197,9 @@ export default function VisualEditor( { styles } ) {
 			<VisualEditorGlobalKeyboardShortcuts />
 			<motion.div
 				className="edit-post-visual-editor__content-area"
+				animate={ {
+					padding: isTemplateMode ? '48px 48px 0' : '0',
+				} }
 				ref={ blockSelectionClearerRef }
 			>
 				{ isTemplateMode && (

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -197,9 +197,6 @@ export default function VisualEditor( { styles } ) {
 			<VisualEditorGlobalKeyboardShortcuts />
 			<motion.div
 				className="edit-post-visual-editor__content-area"
-				animate={ {
-					padding: isTemplateMode ? '48px 48px 0' : '0',
-				} }
 				ref={ blockSelectionClearerRef }
 			>
 				{ isTemplateMode && (


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/34153

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR aims to migrate the FSE post template editor's `Delete template` menu item away from the current `confirm()` implementation and instead use the new experimental `ConfirmDialog` component.

## How has this been tested?
Before testing, cherrypick https://github.com/WordPress/gutenberg/pull/37959 on top of this PR. That will ensure the `ConfirmDialog` has the proper z-index to render on top of its parent component.

Running WordPress 5.8.2 via `wp-env`:

1. With a block-based theme active, create a new post with some basic content
2. In the editor sidebar, locate the **Post Template** section, and use the provided link to create a new template
3. Make any changes you'd like to the template and save it
4. Click the provided button to edit your new template
5. At the top of the editor open the dropdown that currently shows the name of your template
6. Click the **Delete template** button. Confirm no unexpected console errors appear.
7. Click the **Cancel** button. Confirm that the template remains intact.
8. Click **Delete template** again. This time, click **OK** and confirm that the template is deleted by trying to re-apply it to the post.

I've tested in the latest Chrome, Firefox, and Safari.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
