### PR TITLE
Add comment-form and comment-list to default html5 theme support

### DIFF
--- a/lib/compat/wordpress-5.9/default-theme-supports.php
+++ b/lib/compat/wordpress-5.9/default-theme-supports.php
@@ -14,6 +14,8 @@ if ( wp_is_block_theme() ) {
 		array(
 			'style',
 			'script',
+			'comment-form',
+			'comment-list',
 		)
 	);
 	add_theme_support( 'automatic-feed-links' );

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -29,7 +29,6 @@
 
 	.comment-author {
 		line-height: 1.5;
-		margin-left: -3.25em;
 
 		.avatar {
 			border-radius: 1.5em;


### PR DESCRIPTION
## Description
Adds comment-form and comment-list to default html5 theme support for compatibility with core 5.9 and fixes comment layout issue caused by this change.

Fixes: #37464

## How has this been tested?
Ran 5.9 beta 3 without Gutenberg plugin and checked comment markup
Ran Gutenberg plugin on 5.8 with this PR applied and checked that comment markup matched 5.9 beta 3, and that comment layout was correct

## Screenshots

Before:
<img width="811" alt="Screen Shot 2021-12-21 at 10 38 18 AM" src="https://user-images.githubusercontent.com/3629020/146836286-8b41b856-70f7-4003-aca4-8f3d26b6ddaa.png">

After:
<img width="901" alt="Screen Shot 2021-12-21 at 10 37 00 AM" src="https://user-images.githubusercontent.com/3629020/146836306-47779f2a-3318-4c44-9ab8-2319cef48996.png">

Without the CSS change in this PR the comment avatar alignment is incorrect:
<img width="640" alt="comment-bad" src="https://user-images.githubusercontent.com/3629020/146848801-6013fcc4-98f9-4460-ab9b-826b924287f2.png">

so check that these are in alignment with parent post width.

