### PR TITLE
Storybook: Tweak config for v6.4 update

### DIFF
--- a/storybook/.babelrc
+++ b/storybook/.babelrc
@@ -1,7 +1,0 @@
-{
-	"presets": [ "@wordpress/babel-preset-default" ],
-	"plugins": [
-		"@emotion/babel-plugin",
-		"babel-plugin-inline-json-import"
-	]
-}

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,5 +1,5 @@
 const stories = [
-	process.env.NODE_ENV !== 'test' && './stories/**/*.(js|mdx)',
+	process.env.NODE_ENV !== 'test' && './stories/**/*.@(js|mdx)',
 	'../packages/block-editor/src/**/stories/*.js',
 	'../packages/components/src/**/stories/*.js',
 	'../packages/icons/src/**/stories/*.js',

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -1,8 +1,3 @@
-/**
- * External dependencies
- */
-const path = require( 'path' );
-
 const stories = [
 	process.env.NODE_ENV !== 'test' && './stories/**/*.(js|mdx)',
 	'../packages/block-editor/src/**/stories/*.js',
@@ -11,24 +6,6 @@ const stories = [
 ].filter( Boolean );
 
 const customEnvVariables = {};
-
-const modulesDir = path.join( __dirname, '../node_modules' );
-
-// Workaround for Emotion 11
-// https://github.com/storybookjs/storybook/pull/13300#issuecomment-783268111
-const updateEmotionAliases = ( config ) => ( {
-	...config,
-	resolve: {
-		...config.resolve,
-		alias: {
-			...config.resolve.alias,
-			'@emotion/core': path.join( modulesDir, '@emotion/react' ),
-			'@emotion/styled': path.join( modulesDir, '@emotion/styled' ),
-			'@emotion/styled-base': path.join( modulesDir, '@emotion/styled' ),
-			'emotion-theming': path.join( modulesDir, '@emotion/react' ),
-		},
-	},
-} );
 
 module.exports = {
 	core: {
@@ -47,7 +24,7 @@ module.exports = {
 		'@storybook/addon-a11y',
 		'@storybook/addon-toolbars',
 	],
-	managerWebpack: updateEmotionAliases,
+	features: { emotionAlias: false },
 	// Workaround:
 	// https://github.com/storybookjs/storybook/issues/12270
 	webpackFinal: async ( config ) => {
@@ -62,6 +39,6 @@ module.exports = {
 			);
 		} );
 
-		return updateEmotionAliases( config );
+		return config;
 	},
 };

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -24,7 +24,10 @@ module.exports = {
 		'@storybook/addon-a11y',
 		'@storybook/addon-toolbars',
 	],
-	features: { emotionAlias: false },
+	features: {
+		babelModeV7: true,
+		emotionAlias: false,
+	},
 	// Workaround:
 	// https://github.com/storybookjs/storybook/issues/12270
 	webpackFinal: async ( config ) => {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/37367#issuecomment-993868927

## Description

Some quick follow-ups to the Storybook 6.4 update in #37367:

- [Simplify Emotion alias handling](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#emotion11-quasi-compatibility) 
- [Fix invalid globs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#correct-globs-in-mainjs) 
- [Consolidate babel config](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#babel-mode-v7) 

The opt-in [Story Store v7](https://github.com/storybookjs/storybook/blob/3e5d6601ba3de7e1d6bd64bca97917dc9d40244b/MIGRATION.md#story-store-v7) feature looks very promising, but I've punted this to a later date since it requires a bit more migration work.

## How has this been tested?

Smoke test `npm run storybook:dev` and `npm run storybook:build`.

## Types of changes

Non-breaking change, Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
