### PR TITLE
Try: parse shortcode blocks outside the content

### DIFF
--- a/lib/compat/wordpress-5.9/block-template.php
+++ b/lib/compat/wordpress-5.9/block-template.php
@@ -217,6 +217,7 @@ function gutenberg_get_the_template_html() {
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
 	$content = wp_filter_content_tags( $content );
+	$content = do_shortcode( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );
 
 	// Wrap block template in .wp-site-blocks to allow for specific descendant styles

--- a/lib/compat/wordpress-5.9/block-template.php
+++ b/lib/compat/wordpress-5.9/block-template.php
@@ -216,6 +216,8 @@ function gutenberg_get_the_template_html() {
 	$content = $wp_embed->autoembed( $content );
 	$content = do_blocks( $content );
 	$content = wptexturize( $content );
+	$content = convert_smilies( $content );
+	$content = shortcode_unautop( $content );
 	$content = wp_filter_content_tags( $content );
 	$content = do_shortcode( $content );
 	$content = str_replace( ']]>', ']]&gt;', $content );

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Performs wpautop() and do_shortcode() on the shortcode block content.
+ * Performs wpautop() on the shortcode block content.
  *
  * @param array  $attributes The block attributes.
  * @param string $content    The block content.
@@ -14,7 +14,7 @@
  * @return string Returns the block content.
  */
 function render_block_core_shortcode( $attributes, $content ) {
-	return wpautop( do_shortcode( $content ) );
+	return wpautop( $content );
 }
 
 /**

--- a/packages/block-library/src/shortcode/index.php
+++ b/packages/block-library/src/shortcode/index.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Performs wpautop() on the shortcode block content.
+ * Performs wpautop() and do_shortcode() on the shortcode block content.
  *
  * @param array  $attributes The block attributes.
  * @param string $content    The block content.
@@ -14,7 +14,7 @@
  * @return string Returns the block content.
  */
 function render_block_core_shortcode( $attributes, $content ) {
-	return wpautop( $content );
+	return wpautop( do_shortcode( $content ) );
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Adds [do_shortcode()](https://developer.wordpress.org/reference/functions/do_shortcode/) to parse the shortcode when it is placed outside the content (block templates, block patterns).

Closes https://github.com/WordPress/gutenberg/issues/35258. Partially https://github.com/WordPress/gutenberg/issues/37312

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Sample shortcode block and smilies:
```
<!-- wp:shortcode -->
[caption align="aligncenter" width="300"]<img src="https://pd.w.org/2021/12/46561c16fc18dc371.43208413.jpeg" width="300"
	height="205" class="size-medium " />Testing[/caption]
<!-- /wp:shortcode -->

<!-- wp:paragraph --><p>:) ;) :D</p><!-- /wp:paragraph -->

;)
```


Tested manually by:
1) Activating Twenty Twenty-Two
2) Placing the sample code in the home.html template of Twenty Twenty-Two.
3) Placing the sample code in a post, using the block editor code editor mode.
4) Viewing the front and confirming both shortcodes are rendered.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
