### PR TITLE
ToolsPanel: Add CSS classes to first and last displayed ToolsPanelItems

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `ToggleGroupControl`: Avoid calling `onChange` if radio state changed from an incoming value ([#37224](https://github.com/WordPress/gutenberg/pull/37224/)).
 -   `ToggleGroupControl`: fix the computation of the backdrop dimensions when rendered in a Popover ([#37067](https://github.com/WordPress/gutenberg/pull/37067)).
 -   Add `__experimentalIsRenderedInSidebar` property to the `GradientPicker`and `CustomGradientPicker`. The property changes the color popover behavior to have a special placement behavior appropriate for sidebar UI's.
+-   Add `first` and `last` classes to displayed `ToolsPanelItem` group within a `ToolsPanel` ([#37546](https://github.com/WordPress/gutenberg/pull/37546))
 
 ### Bug Fix
 

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -449,6 +449,7 @@ export const WithConditionallyRenderedControl = () => {
 };
 
 export { TypographyPanel } from './typography-panel';
+export { ToolsPanelWithItemGroupSlot } from './tools-panel-with-item-group-slot';
 
 const PanelWrapperView = styled.div`
 	max-width: 280px;

--- a/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
+++ b/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
@@ -7,6 +7,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
+import { ContrastChecker } from '@wordpress/block-editor';
 import { useContext, useState } from '@wordpress/element';
 
 /**
@@ -193,6 +194,14 @@ export const ToolsPanelWithItemGroupSlot = () => {
 					value={ link }
 				/>
 			</ToolsPanelItems>
+			<ToolsPanelItems>
+				{ !! text && !! background && (
+					<ContrastChecker
+						backgroundColor={ background }
+						textColor={ text }
+					/>
+				) }
+			</ToolsPanelItems>
 		</SlotFillProvider>
 	);
 };
@@ -213,6 +222,10 @@ const SlotWrapper = css`
 
 	> div {
 		grid-column: span 2;
+	}
+
+	.block-editor-contrast-checker {
+		margin-top: 16px;
 	}
 `;
 
@@ -237,10 +250,5 @@ const ToolsPanelItemClass = css`
 	&& > div > button {
 		width: 100%;
 		border-radius: inherit;
-	}
-
-	/* .components-dropdown class overrides ToolsPanelItemPlaceholder styles */
-	&[class*='ToolsPanelItemPlaceholder'] {
-		display: none;
 	}
 `;

--- a/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
+++ b/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
@@ -7,7 +7,6 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { ContrastChecker } from '@wordpress/block-editor';
 import { useContext, useState } from '@wordpress/element';
 
 /**
@@ -172,6 +171,9 @@ export const ToolsPanelWithItemGroupSlot = () => {
 				<Panel>
 					<ToolsPanelItems.Slot
 						as={ ItemGroup }
+						isBordered
+						isSeparated
+						isRounded={ false }
 						className={ slotWrapperClassName }
 						resetAll={ resetAll }
 					/>
@@ -196,14 +198,6 @@ export const ToolsPanelWithItemGroupSlot = () => {
 					value={ link }
 				/>
 			</ToolsPanelItems>
-			<ToolsPanelItems>
-				{ !! text && !! background && (
-					<ContrastChecker
-						backgroundColor={ background }
-						textColor={ text }
-					/>
-				) }
-			</ToolsPanelItems>
 		</SlotFillProvider>
 	);
 };
@@ -220,34 +214,28 @@ const PanelWrapperView = styled.div`
 const SlotWrapper = css`
 	&&& {
 		row-gap: 0;
+		border-radius: 20px;
 	}
 
 	> div {
 		grid-column: span 2;
-	}
-
-	.block-editor-contrast-checker {
-		margin-top: 16px;
+		border-radius: inherit;
 	}
 `;
 
 const ToolsPanelItemClass = css`
 	padding: 0;
-	border-left: 1px solid rgba( 0, 0, 0, 0.1 );
-	border-right: 1px solid rgba( 0, 0, 0, 0.1 );
-	border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
 
 	&&.first {
-		border-top-left-radius: 10px;
-		border-top-right-radius: 10px;
-		border-top: 1px solid rgba( 0, 0, 0, 0.1 );
+		border-top-left-radius: inherit;
+		border-top-right-radius: inherit;
 	}
 
 	&.last {
-		border-bottom-left-radius: 10px;
-		border-bottom-right-radius: 10px;
+		border-bottom-left-radius: inherit;
+		border-bottom-right-radius: inherit;
+		border-bottom-color: transparent;
 	}
-
 	&& > div,
 	&& > div > button {
 		width: 100%;

--- a/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
+++ b/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
@@ -1,0 +1,236 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+import { css } from '@emotion/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useContext, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ColorIndicator from '../../color-indicator';
+import ColorPalette from '../../color-palette';
+import Dropdown from '../../dropdown';
+import Panel from '../../panel';
+import { FlexItem } from '../../flex';
+import { HStack } from '../../h-stack';
+import { Item, ItemGroup } from '../../item-group';
+import { ToolsPanel, ToolsPanelItem, ToolsPanelContext } from '..';
+import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
+import { useCx } from '../../utils';
+
+// Available border colors.
+const colors = [
+	{ name: 'Gray 0', color: '#f6f7f7' },
+	{ name: 'Gray 5', color: '#dcdcde' },
+	{ name: 'Gray 20', color: '#a7aaad' },
+	{ name: 'Gray 70', color: '#3c434a' },
+	{ name: 'Gray 100', color: '#101517' },
+	{ name: 'Blue 20', color: '#72aee6' },
+	{ name: 'Blue 40', color: '#3582c4' },
+	{ name: 'Blue 70', color: '#0a4b78' },
+	{ name: 'Red 40', color: '#e65054' },
+	{ name: 'Red 70', color: '#8a2424' },
+	{ name: 'Green 10', color: '#68de7c' },
+	{ name: 'Green 40', color: '#00a32a' },
+	{ name: 'Green 60', color: '#007017' },
+	{ name: 'Yellow 10', color: '#f2d675' },
+	{ name: 'Yellow 40', color: '#bd8600' },
+];
+const panelId = 'unique-tools-panel-id';
+
+const { Fill, Slot } = createSlotFill( 'ToolsPanelSlot' );
+
+// This storybook example aims to replicate a virtual bubbling SlotFill use case
+// for the `ToolsPanel` when the Slot itself is an `ItemGroup`.
+
+// In this scenario the `ToolsPanel` has to render item placeholders so fills
+// maintain their order in the DOM. These placeholders in the DOM prevent the
+// normal styling of the `ItemGroup` in particular the border radii on the first
+// and last items. In case consumers of the ItemGroup and ToolsPanel are
+// applying their own styles to these components, the ToolsPanel needs to assist
+// consumers in identifying which of its visible items are first and last.
+
+// This custom fill is required to re-establish the ToolsPanelContext for
+// injected ToolsPanelItem components as they will not have access to the React
+// Context as the Provider is part of the ToolsPanelItems.Slot tree.
+const ToolsPanelItems = ( { children } ) => {
+	return (
+		<Fill>
+			{ ( fillProps ) => (
+				<ToolsPanelContext.Provider value={ fillProps }>
+					{ children }
+				</ToolsPanelContext.Provider>
+			) }
+		</Fill>
+	);
+};
+
+// This fetches the ToolsPanelContext and passes it through `fillProps` so that
+// rendered fills can re-establish the `ToolsPanelContext.Provider`.
+const SlotContainer = ( { Slot: ToolsPanelSlot, ...props } ) => {
+	const toolsPanelContext = useContext( ToolsPanelContext );
+
+	return (
+		<ToolsPanelSlot
+			{ ...props }
+			fillProps={ toolsPanelContext }
+			bubblesVirtually
+		/>
+	);
+};
+
+// This wraps the slot with a `ToolsPanel` mimicking a real-world use case from
+// the block editor.
+ToolsPanelItems.Slot = ( { resetAll, ...props } ) => (
+	<ToolsPanel
+		label="Tools Panel with Item Group"
+		resetAll={ resetAll }
+		panelId={ panelId }
+		hasInnerWrapper={ true }
+		shouldRenderPlaceholderItems={ true }
+	>
+		<SlotContainer { ...props } Slot={ Slot } />
+	</ToolsPanel>
+);
+
+export const ToolsPanelWithItemGroupSlot = () => {
+	const [ attributes, setAttributes ] = useState( {} );
+	const { text, background, link } = attributes;
+
+	const cx = useCx();
+	const slotWrapperClassName = cx( SlotWrapper );
+	const itemClassName = cx( ToolsPanelItemClass );
+
+	const resetAll = ( resetFilters = [] ) => {
+		let newAttributes = {};
+
+		resetFilters.forEach( ( resetFilter ) => {
+			newAttributes = {
+				...newAttributes,
+				...resetFilter( newAttributes ),
+			};
+		} );
+
+		setAttributes( newAttributes );
+	};
+
+	const updateAttribute = ( name, value ) => {
+		setAttributes( {
+			...attributes,
+			[ name ]: value,
+		} );
+	};
+
+	const ToolsPanelColorDropdown = ( { attribute, label, value } ) => {
+		return (
+			<ToolsPanelItem
+				className={ itemClassName }
+				hasValue={ () => !! value }
+				label={ label }
+				onDeselect={ () => updateAttribute( attribute, undefined ) }
+				resetAllFilter={ () => ( { [ attribute ]: undefined } ) }
+				panelId={ panelId }
+				as={ Dropdown }
+				renderToggle={ ( { onToggle } ) => (
+					<Item onClick={ onToggle }>
+						<HStack justify="flex-start">
+							<ColorIndicator colorValue={ value } />
+							<FlexItem>{ label }</FlexItem>
+						</HStack>
+					</Item>
+				) }
+				renderContent={ () => (
+					<ColorPalette
+						value={ value }
+						colors={ colors }
+						onChange={ ( newColor ) =>
+							updateAttribute( attribute, newColor )
+						}
+					/>
+				) }
+			/>
+		);
+	};
+
+	// ToolsPanelItems are rendered via two different fills to simulate
+	// injection from multiple locations.
+	return (
+		<SlotFillProvider>
+			<PanelWrapperView>
+				<Panel>
+					<ToolsPanelItems.Slot
+						as={ ItemGroup }
+						className={ slotWrapperClassName }
+						resetAll={ resetAll }
+					/>
+				</Panel>
+			</PanelWrapperView>
+			<ToolsPanelItems>
+				<ToolsPanelColorDropdown
+					attribute="text"
+					label="Text"
+					value={ text }
+				/>
+				<ToolsPanelColorDropdown
+					attribute="background"
+					label="Background"
+					value={ background }
+				/>
+			</ToolsPanelItems>
+			<ToolsPanelItems>
+				<ToolsPanelColorDropdown
+					attribute="link"
+					label="Link"
+					value={ link }
+				/>
+			</ToolsPanelItems>
+		</SlotFillProvider>
+	);
+};
+
+const PanelWrapperView = styled.div`
+	max-width: 280px;
+	font-size: 13px;
+
+	.components-dropdown-menu__menu {
+		max-width: 220px;
+	}
+`;
+
+const SlotWrapper = css`
+	&&& {
+		row-gap: 0;
+	}
+`;
+
+const ToolsPanelItemClass = css`
+	border-left: 1px solid rgba( 0, 0, 0, 0.1 );
+	border-right: 1px solid rgba( 0, 0, 0, 0.1 );
+	border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
+
+	&.first {
+		border-top-left-radius: 20px;
+		border-top-right-radius: 20px;
+		border-top: 1px solid rgba( 0, 0, 0, 0.1 );
+	}
+
+	&.last {
+		border-bottom-left-radius: 20px;
+		border-bottom-right-radius: 20px;
+	}
+
+	&& > div,
+	&& > div > button {
+		border-radius: inherit;
+	}
+
+	/* .components-dropdown class overrides ToolsPanelItemPlaceholder styles */
+	&[class*='ToolsPanelItemPlaceholder'] {
+		display: none;
+	}
+`;

--- a/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
+++ b/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
@@ -95,6 +95,8 @@ ToolsPanelItems.Slot = ( { resetAll, ...props } ) => (
 		panelId={ panelId }
 		hasInnerWrapper={ true }
 		shouldRenderPlaceholderItems={ true }
+		__experimentalFirstVisibleItemClass="first"
+		__experimentalLastVisibleItemClass="last"
 	>
 		<SlotContainer { ...props } Slot={ Slot } />
 	</ToolsPanel>

--- a/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
+++ b/packages/components/src/tools-panel/stories/tools-panel-with-item-group-slot.js
@@ -12,6 +12,7 @@ import { useContext, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import Button from '../../button';
 import ColorIndicator from '../../color-indicator';
 import ColorPalette from '../../color-palette';
 import Dropdown from '../../dropdown';
@@ -135,25 +136,28 @@ export const ToolsPanelWithItemGroupSlot = () => {
 				onDeselect={ () => updateAttribute( attribute, undefined ) }
 				resetAllFilter={ () => ( { [ attribute ]: undefined } ) }
 				panelId={ panelId }
-				as={ Dropdown }
-				renderToggle={ ( { onToggle } ) => (
-					<Item onClick={ onToggle }>
-						<HStack justify="flex-start">
-							<ColorIndicator colorValue={ value } />
-							<FlexItem>{ label }</FlexItem>
-						</HStack>
-					</Item>
-				) }
-				renderContent={ () => (
-					<ColorPalette
-						value={ value }
-						colors={ colors }
-						onChange={ ( newColor ) =>
-							updateAttribute( attribute, newColor )
-						}
-					/>
-				) }
-			/>
+				as={ Item }
+			>
+				<Dropdown
+					renderToggle={ ( { onToggle } ) => (
+						<Button onClick={ onToggle }>
+							<HStack justify="flex-start">
+								<ColorIndicator colorValue={ value } />
+								<FlexItem>{ label }</FlexItem>
+							</HStack>
+						</Button>
+					) }
+					renderContent={ () => (
+						<ColorPalette
+							value={ value }
+							colors={ colors }
+							onChange={ ( newColor ) =>
+								updateAttribute( attribute, newColor )
+							}
+						/>
+					) }
+				/>
+			</ToolsPanelItem>
 		);
 	};
 
@@ -206,26 +210,32 @@ const SlotWrapper = css`
 	&&& {
 		row-gap: 0;
 	}
+
+	> div {
+		grid-column: span 2;
+	}
 `;
 
 const ToolsPanelItemClass = css`
+	padding: 0;
 	border-left: 1px solid rgba( 0, 0, 0, 0.1 );
 	border-right: 1px solid rgba( 0, 0, 0, 0.1 );
 	border-bottom: 1px solid rgba( 0, 0, 0, 0.1 );
 
-	&.first {
-		border-top-left-radius: 20px;
-		border-top-right-radius: 20px;
+	&&.first {
+		border-top-left-radius: 10px;
+		border-top-right-radius: 10px;
 		border-top: 1px solid rgba( 0, 0, 0, 0.1 );
 	}
 
 	&.last {
-		border-bottom-left-radius: 20px;
-		border-bottom-right-radius: 20px;
+		border-bottom-left-radius: 10px;
+		border-bottom-right-radius: 10px;
 	}
 
 	&& > div,
 	&& > div > button {
+		width: 100%;
 		border-radius: inherit;
 	}
 

--- a/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
+++ b/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
@@ -1,0 +1,224 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ToolsPanel first and last panel items should apply first/last classes to appropriate items 1`] = `
+.emotion-0 {
+  display: grid;
+  gap: calc( 4px * 3 );
+  grid-template-columns: repeat( 2, 1fr );
+  -webkit-column-gap: calc(4px * 4);
+  column-gap: calc(4px * 4);
+  row-gap: calc(4px * 6);
+  border-top: 1px solid #ddd;
+  margin-top: -1px;
+  padding: calc(4px * 4);
+}
+
+.emotion-0>div:not( :first-of-type ) {
+  display: grid;
+  grid-template-columns: repeat( 2, 1fr );
+  -webkit-column-gap: calc(4px * 4);
+  column-gap: calc(4px * 4);
+  row-gap: calc(4px * 6);
+  grid-column: 1/-1;
+}
+
+.emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+  grid-column: 1/-1;
+  gap: calc(4px * 2);
+}
+
+.emotion-2>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-2>* {
+  min-width: 0;
+}
+
+.emotion-2 .components-dropdown-menu {
+  margin: calc(4px * -1) 0;
+  line-height: 0;
+}
+
+.emotion-2.emotion-2.emotion-2.emotion-2 .components-dropdown-menu__toggle {
+  padding: 0;
+  min-width: calc(4px * 6);
+}
+
+.emotion-4 {
+  color: #1e1e1e;
+  line-height: 1.2;
+  margin: 0;
+  color: #050505;
+  font-size: calc(1.95 * 13px);
+  font-weight: 600;
+  display: block;
+  font-size: inherit;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.emotion-4.emotion-4 {
+  margin: 0;
+}
+
+.emotion-6 {
+  grid-column: 1/-1;
+  display: none;
+}
+
+.emotion-6>div,
+.emotion-6>fieldset {
+  padding-bottom: 0;
+  margin-bottom: 0;
+  max-width: 100%;
+}
+
+.emotion-6.emotion-6 .e1puf3u3 {
+  margin-bottom: 0;
+}
+
+.emotion-6.emotion-6 .e1puf3u3 .e1puf3u2:last-child {
+  margin-bottom: 0;
+}
+
+.emotion-6 .e1puf3u0 {
+  margin-bottom: 0;
+}
+
+.emotion-6.emotion-6 .em5sgkm3 label {
+  margin-bottom: calc(4px * 2);
+  padding-bottom: 0;
+  line-height: 1.4em;
+}
+
+.emotion-6 .components-custom-select-control__label,
+.emotion-6 .e1puf3u1 {
+  line-height: 1.4em;
+}
+
+.emotion-8 {
+  grid-column: 1/-1;
+}
+
+.emotion-8>div,
+.emotion-8>fieldset {
+  padding-bottom: 0;
+  margin-bottom: 0;
+  max-width: 100%;
+}
+
+.emotion-8.emotion-8 .e1puf3u3 {
+  margin-bottom: 0;
+}
+
+.emotion-8.emotion-8 .e1puf3u3 .e1puf3u2:last-child {
+  margin-bottom: 0;
+}
+
+.emotion-8 .e1puf3u0 {
+  margin-bottom: 0;
+}
+
+.emotion-8.emotion-8 .em5sgkm3 label {
+  margin-bottom: calc(4px * 2);
+  padding-bottom: 0;
+  line-height: 1.4em;
+}
+
+.emotion-8 .components-custom-select-control__label,
+.emotion-8 .e1puf3u1 {
+  line-height: 1.4em;
+}
+
+<div>
+  <div
+    class="components-grid components-tools-panel emotion-0 emotion-1"
+    data-wp-c16t="true"
+    data-wp-component="ToolsPanel"
+  >
+    <div
+      class="components-flex components-h-stack components-tools-panel-header emotion-2 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ToolsPanelHeader"
+    >
+      <h2
+        class="components-truncate components-text components-heading emotion-4 emotion-1"
+        data-wp-c16t="true"
+        data-wp-component="Heading"
+      >
+        Panel header
+      </h2>
+      <div
+        class="components-dropdown components-dropdown-menu"
+        tabindex="-1"
+      >
+        <button
+          aria-expanded="false"
+          aria-haspopup="true"
+          aria-label="View options"
+          class="components-button components-dropdown-menu__toggle is-small has-icon"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            height="24"
+            role="img"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M13 19h-2v-2h2v2zm0-6h-2v-2h2v2zm0-6h-2V5h2v2z"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      class="components-tools-panel-item emotion-6 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ToolsPanelItem"
+    />
+    <div
+      class="components-tools-panel-item first emotion-8 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ToolsPanelItem"
+    >
+      <div>
+        Item 2
+      </div>
+    </div>
+    <div
+      class="components-tools-panel-item last emotion-8 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ToolsPanelItem"
+    >
+      <div>
+        Item 3
+      </div>
+    </div>
+    <div
+      class="components-tools-panel-item emotion-6 emotion-1"
+      data-wp-c16t="true"
+      data-wp-component="ToolsPanelItem"
+    />
+  </div>
+</div>
+`;

--- a/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
+++ b/packages/components/src/tools-panel/test/__snapshots__/index.js.snap
@@ -89,26 +89,24 @@ exports[`ToolsPanel first and last panel items should apply first/last classes t
   max-width: 100%;
 }
 
-.emotion-6.emotion-6 .e1puf3u3 {
+.emotion-6.emotion-6 .e1puf3u4 {
   margin-bottom: 0;
 }
 
-.emotion-6.emotion-6 .e1puf3u3 .e1puf3u2:last-child {
+.emotion-6.emotion-6 .e1puf3u4 .e1puf3u3:last-child {
   margin-bottom: 0;
 }
 
-.emotion-6 .e1puf3u0 {
+.emotion-6 .e1puf3u1 {
   margin-bottom: 0;
 }
 
 .emotion-6.emotion-6 .em5sgkm3 label {
-  margin-bottom: calc(4px * 2);
-  padding-bottom: 0;
   line-height: 1.4em;
 }
 
 .emotion-6 .components-custom-select-control__label,
-.emotion-6 .e1puf3u1 {
+.emotion-6 .e1puf3u2 {
   line-height: 1.4em;
 }
 
@@ -123,26 +121,24 @@ exports[`ToolsPanel first and last panel items should apply first/last classes t
   max-width: 100%;
 }
 
-.emotion-8.emotion-8 .e1puf3u3 {
+.emotion-8.emotion-8 .e1puf3u4 {
   margin-bottom: 0;
 }
 
-.emotion-8.emotion-8 .e1puf3u3 .e1puf3u2:last-child {
+.emotion-8.emotion-8 .e1puf3u4 .e1puf3u3:last-child {
   margin-bottom: 0;
 }
 
-.emotion-8 .e1puf3u0 {
+.emotion-8 .e1puf3u1 {
   margin-bottom: 0;
 }
 
 .emotion-8.emotion-8 .em5sgkm3 label {
-  margin-bottom: calc(4px * 2);
-  padding-bottom: 0;
   line-height: 1.4em;
 }
 
 .emotion-8 .components-custom-select-control__label,
-.emotion-8 .e1puf3u1 {
+.emotion-8 .e1puf3u2 {
   line-height: 1.4em;
 }
 

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -986,7 +986,7 @@ describe( 'ToolsPanel', () => {
 
 	describe( 'first and last panel items', () => {
 		it( 'should apply first/last classes to appropriate items', () => {
-			render(
+			const { container } = render(
 				<SlotFillProvider>
 					<ToolsPanelItems>
 						<ToolsPanelItem { ...altControlProps }>
@@ -1028,11 +1028,7 @@ describe( 'ToolsPanel', () => {
 			expect( item3 ).toBeInTheDocument();
 			expect( screen.queryByText( 'Item 4' ) ).not.toBeInTheDocument();
 
-			expect( item2.parentNode ).toHaveClass( 'first' );
-			expect( item2.parentNode ).not.toHaveClass( 'last' );
-
-			expect( item3.parentNode ).not.toHaveClass( 'first' );
-			expect( item3.parentNode ).toHaveClass( 'last' );
+			expect( container ).toMatchSnapshot();
 		} );
 	} );
 } );

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -983,4 +983,56 @@ describe( 'ToolsPanel', () => {
 			expect( optionsDisplayedIcon ).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'first and last panel items', () => {
+		it( 'should apply first/last classes to appropriate items', () => {
+			render(
+				<SlotFillProvider>
+					<ToolsPanelItems>
+						<ToolsPanelItem { ...altControlProps }>
+							<div>Item 1</div>
+						</ToolsPanelItem>
+						<ToolsPanelItem { ...controlProps }>
+							<div>Item 2</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanelItems>
+						<ToolsPanelItem
+							{ ...altControlProps }
+							label="Item 3"
+							isShownByDefault={ true }
+						>
+							<div>Item 3</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanelItems>
+						<ToolsPanelItem { ...altControlProps } label="Item 4">
+							<div>Item 4</div>
+						</ToolsPanelItem>
+					</ToolsPanelItems>
+					<ToolsPanel
+						{ ...defaultProps }
+						hasInnerWrapper={ true }
+						shouldRenderPlaceholderItems={ true }
+					>
+						<Slot />
+					</ToolsPanel>
+				</SlotFillProvider>
+			);
+
+			const item2 = screen.getByText( 'Item 2' );
+			const item3 = screen.getByText( 'Item 3' );
+
+			expect( screen.queryByText( 'Item 1' ) ).not.toBeInTheDocument();
+			expect( item2 ).toBeInTheDocument();
+			expect( item3 ).toBeInTheDocument();
+			expect( screen.queryByText( 'Item 4' ) ).not.toBeInTheDocument();
+
+			expect( item2.parentNode ).toHaveClass( 'first' );
+			expect( item2.parentNode ).not.toHaveClass( 'last' );
+
+			expect( item3.parentNode ).not.toHaveClass( 'first' );
+			expect( item3.parentNode ).toHaveClass( 'last' );
+		} );
+	} );
 } );

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -1014,6 +1014,8 @@ describe( 'ToolsPanel', () => {
 						{ ...defaultProps }
 						hasInnerWrapper={ true }
 						shouldRenderPlaceholderItems={ true }
+						__experimentalFirstVisibleItemClass="first"
+						__experimentalLastVisibleItemClass="last"
 					>
 						<Slot />
 					</ToolsPanel>

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -38,6 +38,8 @@ export function useToolsPanelItem(
 		shouldRenderPlaceholderItems: shouldRenderPlaceholder,
 		firstDisplayedItem,
 		lastDisplayedItem,
+		__experimentalFirstVisibleItemClass,
+		__experimentalLastVisibleItemClass,
 	} = useToolsPanelContext();
 
 	const hasValueCallback = useCallback( hasValue, [ panelId ] );
@@ -131,8 +133,10 @@ export function useToolsPanelItem(
 			shouldRenderPlaceholder &&
 			! isShown &&
 			styles.ToolsPanelItemPlaceholder;
-		const firstItemStyle = firstDisplayedItem === label && 'first';
-		const lastItemStyle = lastDisplayedItem === label && 'last';
+		const firstItemStyle =
+			firstDisplayedItem === label && __experimentalFirstVisibleItemClass;
+		const lastItemStyle =
+			lastDisplayedItem === label && __experimentalLastVisibleItemClass;
 		return cx(
 			styles.ToolsPanelItem,
 			placeholderStyle,
@@ -146,6 +150,8 @@ export function useToolsPanelItem(
 		className,
 		firstDisplayedItem,
 		lastDisplayedItem,
+		__experimentalFirstVisibleItemClass,
+		__experimentalLastVisibleItemClass,
 	] );
 
 	return {

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -36,6 +36,8 @@ export function useToolsPanelItem(
 		flagItemCustomization,
 		isResetting,
 		shouldRenderPlaceholderItems: shouldRenderPlaceholder,
+		firstDisplayedItem,
+		lastDisplayedItem,
 	} = useToolsPanelContext();
 
 	const hasValueCallback = useCallback( hasValue, [ panelId ] );
@@ -129,8 +131,22 @@ export function useToolsPanelItem(
 			shouldRenderPlaceholder &&
 			! isShown &&
 			styles.ToolsPanelItemPlaceholder;
-		return cx( styles.ToolsPanelItem, placeholderStyle, className );
-	}, [ isShown, shouldRenderPlaceholder, className ] );
+		const firstItemStyle = firstDisplayedItem === label && 'first';
+		const lastItemStyle = lastDisplayedItem === label && 'last';
+		return cx(
+			styles.ToolsPanelItem,
+			placeholderStyle,
+			className,
+			firstItemStyle,
+			lastItemStyle
+		);
+	}, [
+		isShown,
+		shouldRenderPlaceholder,
+		className,
+		firstDisplayedItem,
+		lastDisplayedItem,
+	] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -253,13 +253,39 @@ export function useToolsPanel(
 		setMenuItems,
 	] );
 
+	// Assist ItemGroup styling when there are potentially hidden placeholder
+	// items by identifying first & last items that are toggled on for display.
+	const getFirstItem = () => {
+		const optionalItems = menuItems.optional || {};
+		const firstItem = panelItems.find(
+			( item ) => item.isShownByDefault || !! optionalItems[ item.label ]
+		);
+
+		return firstItem?.label;
+	};
+
+	const getLastItem = () => {
+		const reversedPanelItems = [ ...panelItems ].reverse();
+		const optionalItems = menuItems.optional || {};
+		const lastItem = reversedPanelItems.find(
+			( item ) => item.isShownByDefault || !! optionalItems[ item.label ]
+		);
+
+		return lastItem?.label;
+	};
+
+	const firstDisplayedItem = getFirstItem();
+	const lastDisplayedItem = getLastItem();
+
 	const panelContext = useMemo(
 		() => ( {
 			areAllOptionalControlsHidden,
 			deregisterPanelItem,
+			firstDisplayedItem,
 			flagItemCustomization,
 			hasMenuItems: !! panelItems.length,
 			isResetting: isResetting.current,
+			lastDisplayedItem,
 			menuItems,
 			panelId,
 			registerPanelItem,
@@ -268,8 +294,10 @@ export function useToolsPanel(
 		[
 			areAllOptionalControlsHidden,
 			deregisterPanelItem,
+			firstDisplayedItem,
 			flagItemCustomization,
 			isResetting.current,
+			lastDisplayedItem,
 			menuItems,
 			panelId,
 			panelItems,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -57,6 +57,8 @@ export function useToolsPanel(
 		panelId,
 		hasInnerWrapper,
 		shouldRenderPlaceholderItems,
+		__experimentalFirstVisibleItemClass,
+		__experimentalLastVisibleItemClass,
 		...otherProps
 	} = useContextSystem( props, 'ToolsPanel' );
 
@@ -288,6 +290,8 @@ export function useToolsPanel(
 			panelId,
 			registerPanelItem,
 			shouldRenderPlaceholderItems,
+			__experimentalFirstVisibleItemClass,
+			__experimentalLastVisibleItemClass,
 		} ),
 		[
 			areAllOptionalControlsHidden,
@@ -301,6 +305,8 @@ export function useToolsPanel(
 			panelItems,
 			registerPanelItem,
 			shouldRenderPlaceholderItems,
+			__experimentalFirstVisibleItemClass,
+			__experimentalLastVisibleItemClass,
 		]
 	);
 

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -255,23 +255,21 @@ export function useToolsPanel(
 
 	// Assist ItemGroup styling when there are potentially hidden placeholder
 	// items by identifying first & last items that are toggled on for display.
-	const getFirstItem = () => {
+	const getFirstVisibleItemLabel = ( items: ToolsPanelItem[] ) => {
 		const optionalItems = menuItems.optional || {};
-		const firstItem = panelItems.find(
+		const firstItem = items.find(
 			( item ) => item.isShownByDefault || !! optionalItems[ item.label ]
 		);
 
 		return firstItem?.label;
 	};
 
-	const getLastItem = () => {
-		const reversedPanelItems = [ ...panelItems ].reverse();
-		const optionalItems = menuItems.optional || {};
-		const lastItem = reversedPanelItems.find(
-			( item ) => item.isShownByDefault || !! optionalItems[ item.label ]
-		);
+	const getFirstItem = () => {
+		return getFirstVisibleItemLabel( panelItems );
+	};
 
-		return lastItem?.label;
+	const getLastItem = () => {
+		return getFirstVisibleItemLabel( [ ...panelItems ].reverse() );
 	};
 
 	const firstDisplayedItem = getFirstItem();

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -266,16 +266,10 @@ export function useToolsPanel(
 		return firstItem?.label;
 	};
 
-	const getFirstItem = () => {
-		return getFirstVisibleItemLabel( panelItems );
-	};
-
-	const getLastItem = () => {
-		return getFirstVisibleItemLabel( [ ...panelItems ].reverse() );
-	};
-
-	const firstDisplayedItem = getFirstItem();
-	const lastDisplayedItem = getLastItem();
+	const firstDisplayedItem = getFirstVisibleItemLabel( panelItems );
+	const lastDisplayedItem = getFirstVisibleItemLabel(
+		[ ...panelItems ].reverse()
+	);
 
 	const panelContext = useMemo(
 		() => ( {

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -130,6 +130,8 @@ export type ToolsPanelContext = {
 	isResetting: boolean;
 	shouldRenderPlaceholderItems: boolean;
 	areAllOptionalControlsHidden: boolean;
+	firstDisplayedItem?: string;
+	lastDisplayedItem?: string;
 };
 
 export type ToolsPanelControlsGroupProps = {

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -37,6 +37,16 @@ export type ToolsPanelProps = {
 	 * placeholder content instead of null when they are toggled off and hidden.
 	 */
 	shouldRenderPlaceholderItems: boolean;
+	/**
+	 * Experimental prop allowing for a custom CSS class to be applied to the
+	 * first visible `ToolsPanelItem` within the `ToolsPanel`.
+	 */
+	__experimentalFirstVisibleItemClass?: string;
+	/**
+	 * Experimental prop allowing for a custom CSS class to be applied to the
+	 * last visible `ToolsPanelItem` within the `ToolsPanel`.
+	 */
+	__experimentalLastVisibleItemClass?: string;
 };
 
 export type ToolsPanelHeaderProps = {
@@ -132,6 +142,8 @@ export type ToolsPanelContext = {
 	areAllOptionalControlsHidden: boolean;
 	firstDisplayedItem?: string;
 	lastDisplayedItem?: string;
+	__experimentalFirstVisibleItemClass?: string;
+	__experimentalLastVisibleItemClass?: string;
 };
 
 export type ToolsPanelControlsGroupProps = {


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/34027

## Description

The switch of the Color block support panel to the `ToolsPanel` requires rendering the color controls as the new color dropdowns within an `ItemGroup`. To maintain the order of controls when some are injected via SlotFill, the `ToolsPanel` will render placeholder elements that are hidden. These placeholders interfere with the normal `ItemGroup` styling which relies on CSS pseudo-selectors e.g. `:last-child`. 

To achieve the same result we need to be able to target the first and last displayed `ToolsPanelItem`s. This PR aims to achieve that by applying `first` and `last` CSS classes to the appropriate `ToolsPanelItem`.

## How has this been tested?

A simple unit test is included with these changes.

##### Manually:
1. Load the block editor, add a group block, and select it.
2. Inspect the various `ToolsPanel` panels in the sidebar and ensure the correct items get the new classes
3. Update the group block's configuration via its `block.json` file. Test various options like mixing optional and default controls etc.
4. Bonus points: Inject some test ad hoc controls into the group block and confirm panel item order and classes.

<details>
    <summary><strong>Example ad hoc control for group block</strong></summary>

#### Note this control isn't meant to be fully functional.
   
```diff
diff --git a/packages/block-library/src/group/edit.js b/packages/block-library/src/group/edit.js
index 3209106ff8..aef9e240a9 100644
--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -9,6 +9,7 @@ import {
 	useInnerBlocksProps,
 	useSetting,
 	store as blockEditorStore,
+	__experimentalToolsPanelColorDropdown as ToolsPanelColorDropdown,
 } from '@wordpress/block-editor';
 import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -68,6 +69,22 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 
 	return (
 		<>
+			<InspectorControls __experimentalGroup="color">
+				<ToolsPanelColorDropdown
+					settings={ {
+						label: 'Overlay',
+						colorValue: undefined,
+						onColorChange: () => undefined,
+						gradientValue: undefined,
+						onGradientChange: () => undefined,
+						isShownByDefault: false,
+						hasValue: () => undefined,
+						onDeselect: () => undefined,
+						resetAllFilter: undefined,
+					} }
+					panelId={ clientId }
+				/>
+			</InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

   ```
</details>

## Types of changes
New feature.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
