### PR TITLE
Simplify the embed loading state

### DIFF
--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -9,22 +9,7 @@
 
 	&.is-loading {
 		display: flex;
-		flex-direction: column;
-		align-items: center;
 		justify-content: center;
-		padding: 1em;
-		min-height: 200px;
-		text-align: center;
-
-		// Block UI appearance.
-		border-radius: $radius-block-ui;
-		background-color: $white;
-		box-shadow: inset 0 0 0 $border-width $gray-900;
-
-		p {
-			font-family: $default-font;
-			font-size: $default-font-size;
-		}
 	}
 
 	// Stops long URLs from breaking out of the no preview available screen

--- a/packages/block-library/src/embed/embed-loading.js
+++ b/packages/block-library/src/embed/embed-loading.js
@@ -1,13 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { Spinner } from '@wordpress/components';
 
 const EmbedLoading = () => (
 	<div className="wp-block-embed is-loading">
 		<Spinner />
-		<p>{ __( 'Embedding…' ) }</p>
 	</div>
 );
 


### PR DESCRIPTION
Part of #37523.

This PR removes all visual styling from the embed block loading state, showing just the spinner.

Before:

https://user-images.githubusercontent.com/846565/146912030-13fc024f-0d31-4a6f-9cf2-495dc5165caa.mp4

After:

https://user-images.githubusercontent.com/846565/146912143-ae8b46b6-18b2-4eab-ad5e-b0221427b6ba.mp4

