### PR TITLE
[Block Library - Query Pagination Next]: Hide block if custom query has no results

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -44,8 +44,9 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$content = get_next_posts_link( $label, $max_page );
 		remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 	} elseif ( ! $max_page || $max_page > $page ) {
-		$custom_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-		if ( (int) $custom_query->max_num_pages !== $page ) {
+		$custom_query           = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		$custom_query_max_pages = (int) $custom_query->max_num_pages;
+		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$content = sprintf(
 				'<a href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),


### PR DESCRIPTION
There is a bug in `Query Pagination Next` block that when is used in a custom query (`inherit:false`) and there are no results the block would display providing obviously a wrong link. This PR fixes that.

## Testing instructions
1. In a page insert a `Query Loop` block and set the `inherit` prop to `false` (any core query pattern or core block variation would do as they set this property to `false`.
2. The easiest way (for me) would be to go to `Keyword` filter in `Query Loop` Inspector controls and type something that will lead to no results.
3. Update the page and view the frontend.
4. No `Next Page` link should be shown

https://user-images.githubusercontent.com/16275880/146934485-e3cbdddf-edc3-4461-bb19-68b305c5bbc5.mov


