### PR TITLE
Adds missing block template class properties

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-block-template.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-block-template.php
@@ -112,4 +112,20 @@ class Gutenberg_Block_Template {
 	 * @var int
 	 */
 	public $author = 0;
+
+	/**
+	 * Post types.
+	 *
+	 * @since 5.9.0
+	 * @var array
+	 */
+	public $post_types;
+
+	/**
+	 * Area.
+	 *
+	 * @since 5.9.0
+	 * @var string
+	 */
+	public $area;
 }


### PR DESCRIPTION
## Description
PR re-syncs `Gutenberg_Block_Template` changes from WP Core and adds two missing properties.

Resolves #37533.

## How has this been tested?
All checks are green; no manual testing is needed.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
