### PR TITLE
Comments Avatar Block: Show avatar drag handles only when selected

### DIFF
--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -14,6 +14,7 @@ export default function Edit( {
 	attributes,
 	context: { commentId },
 	setAttributes,
+	isSelected,
 } ) {
 	const { height, width } = attributes;
 
@@ -64,6 +65,7 @@ export default function Edit( {
 				width,
 				height,
 			} }
+			showHandle={ isSelected }
 			onResizeStop={ ( event, direction, elt, delta ) => {
 				setAttributes( {
 					height: parseInt( height + delta.height, 10 ),


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Closes #37557 

When I click in order to drag it. The comment template block, which is parent, gets selected, is this behavior expected?

Loom video: 
https://loom.com/share/4dbf520748514874837f33f82ff56f34

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
- Create Comment Query Loop Block
- Select Avatar and check drag handles appears on click
- Unselect it and check drag handles dissapear.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix