### PR TITLE
Site Editor: Update the template list action labels

### DIFF
--- a/packages/edit-site/src/components/list/actions/index.js
+++ b/packages/edit-site/src/components/list/actions/index.js
@@ -39,14 +39,14 @@ export default function Actions( { template } ) {
 				template.id
 			);
 
-			createSuccessNotice( __( 'Template reverted.' ), {
+			createSuccessNotice( __( 'Entity reverted.' ), {
 				type: 'snackbar',
 			} );
 		} catch ( error ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while reverting the template.' );
+					: __( 'An error occurred while reverting the entity.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
@@ -74,13 +74,13 @@ export default function Actions( { template } ) {
 									onClose();
 								} }
 							>
-								{ __( 'Delete template' ) }
+								{ __( 'Delete' ) }
 							</MenuItem>
 						</>
 					) }
 					{ isRevertable && (
 						<MenuItem
-							info={ __( 'Restore template to default state' ) }
+							info={ __( 'Restore to default state' ) }
 							onClick={ () => {
 								revertAndSaveTemplate();
 								onClose();

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -61,14 +61,14 @@ export default function RenameMenuItem( { template, onClose } ) {
 				throw lastError;
 			}
 
-			createSuccessNotice( __( 'Template has been renamed.' ), {
+			createSuccessNotice( __( 'Entity renamed.' ), {
 				type: 'snackbar',
 			} );
 		} catch ( error ) {
 			const errorMessage =
 				error.message && error.code !== 'unknown_error'
 					? error.message
-					: __( 'An error occurred while renaming the template.' );
+					: __( 'An error occurred while renaming the entity.' );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
 		}
@@ -86,7 +86,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			</MenuItem>
 			{ isModalOpen && (
 				<Modal
-					title={ __( 'Rename template' ) }
+					title={ __( 'Rename' ) }
 					closeLabel={ __( 'Close' ) }
 					onRequestClose={ () => {
 						setIsModalOpen( false );


### PR DESCRIPTION
## Description
PR updates button labels for Site Edtiro template list actions and makes them more general.

I've also updated the Snackbar messages to use "Entity" instead of the "Template."

Closes #37439.

## How has this been tested?
1. Go to Site Editor > Templates or Template Parts
2. Check that action button labels don't container template type.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-22 at 10 11 28](https://user-images.githubusercontent.com/240569/147044792-78276504-8c5f-40a0-83d5-757a6418950c.png)

## Types of changes
Copy change

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
