### PR TITLE
[Site Editor]: Register block editor shortcuts

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -17,6 +17,7 @@ import {
 	BlockTools,
 	__unstableBlockSettingsMenuFirstItem,
 	__unstableUseTypingObserver as useTypingObserver,
+	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
@@ -108,8 +109,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					}
 				} }
 			>
+				<BlockEditorKeyboardShortcuts.Register />
 				<BackButton />
-
 				<ResizableEditor
 					// Reinitialize the editor and reset the states when the template changes.
 					key={ templateId }
@@ -127,7 +128,6 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						renderAppender={ isTemplatePart ? false : undefined }
 					/>
 				</ResizableEditor>
-
 				<__unstableBlockSettingsMenuFirstItem>
 					{ ( { onClose } ) => (
 						<BlockInspectorButton onClick={ onClose } />


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/33948

It seems we never registered the block editor shortcuts in site editor and this PR does just that.

## Testing instructions
1. In site editor try the writing flow shortcuts and make sure they work as expected


## Notes
Examples can be found in block settings in a block's toolbar:

<img width="743" alt="Screenshot 2021-12-22 at 10 10 00 AM" src="https://user-images.githubusercontent.com/16275880/147058228-2a759fcd-b6b5-4994-9b25-278adf493910.png">

The full list of the block editor shortcuts[ is here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/keyboard-shortcuts/index.js) in code.