### PR TITLE
Packages: Fix missing peer dependencies where React used indirectly

### DIFF
--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -72,6 +72,10 @@
 		"rememo": "^3.0.0",
 		"traverse": "^0.6.6"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,6 +69,10 @@
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -44,6 +44,9 @@
 		"react-resize-aware": "^3.1.0",
 		"use-memo-one": "^1.1.1"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -42,6 +42,9 @@
 		"turbo-combine-reducers": "^1.0.2",
 		"use-memo-one": "^1.1.1"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -65,6 +65,10 @@
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/jest-preset-default/package.json
+++ b/packages/jest-preset-default/package.json
@@ -39,7 +39,9 @@
 	},
 	"peerDependencies": {
 		"@babel/core": ">=7",
-		"jest": ">=26"
+		"jest": ">=26",
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Closes #37264.

The gist of it can be summarized with the https://github.com/WordPress/gutenberg/issues/37264#issuecomment-996872850 from @ZebulanStanphill:

> Logically, any package accessed directly by the files of a package should be declared as a dependency of that package, right? By definition, accessing exports from `react` means that `react` is a top-level dependency. If we were truly relying solely on `@wordpress/element`, we would be accessing the exports through that package (which could re-export them). But in many cases, we're not. Therefore, we ought to add `react` to the list of explicit dependencies, because that's how we're using it: explicitly.

A more detailed explanation from @jsnajdr is available in https://github.com/WordPress/gutenberg/issues/37264#issuecomment-997721085.

This PR adds `react` and `react-dom` in all the places shown in the report included by @jonshipman in #37264.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
