### PR TITLE
Remove the Large style option from the quote block

### DIFF
--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -49,8 +49,7 @@
 			"label": "Default",
 			"isDefault": true
 		},
-		{ "name": "plain", "label": "Plain" },
-		{ "name": "large", "label": "Large" }
+		{ "name": "plain", "label": "Plain" }
 	],
 	"editorStyle": "wp-block-quote-editor",
 	"style": "wp-block-quote"

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -24,7 +24,6 @@ export const settings = {
 			value:
 				'<p>' + __( 'In quoting others, we cite ourselves.' ) + '</p>',
 			citation: 'Julio Cortázar',
-			className: 'is-style-large',
 		},
 	},
 	transforms,

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,8 +1,8 @@
 .wp-block-quote {
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
-	// .is-style-large and .is-large are kept for backwards compatibility.
-	&.is-style-large,
-	&.is-large {
+	// .is-style-large and .is-large are kept for backwards compatibility. The :not pseudo-class is used to enable switching styles. See PR #37580.
+	&.is-style-large:not(.is-style-plain),
+	&.is-large:not(.is-style-plain) {
 		margin-bottom: 1em;
 		padding: 0 1em;
 

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,6 +1,6 @@
 .wp-block-quote {
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
-
+	// .is-style-large and .is-large are kept for backwards compatibility.
 	&.is-style-large,
 	&.is-large {
 		margin-bottom: 1em;

--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -22,7 +22,7 @@
 		border: none;
 		padding-left: 0;
 	}
-
+	// .is-style-large and .is-large are kept for backwards compatibility.
 	&.is-style-plain,
 	&.is-style-large,
 	&.is-large {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/style-variation.test.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`adding blocks Should switch to the large style of the quote block 1`] = `
-"<!-- wp:quote {\\"className\\":\\"is-style-large\\"} -->
-<blockquote class=\\"wp-block-quote is-style-large\\"><p>Quote content</p></blockquote>
-<!-- /wp:quote -->"
-`;

--- a/packages/e2e-tests/specs/editor/various/style-variation.test.js
+++ b/packages/e2e-tests/specs/editor/various/style-variation.test.js
@@ -20,10 +20,10 @@ describe( 'adding blocks', () => {
 
 		await clickBlockToolbarButton( 'Quote' );
 
-		const largeStyleButton = await page.waitForXPath(
-			'//*[@role="menuitem"][contains(., "Large")]'
+		const plainStyleButton = await page.waitForXPath(
+			'//*[@role="menuitem"][contains(., "Plain")]'
 		);
-		await largeStyleButton.click();
+		await plainStyleButton.click();
 
 		// Check the content
 		const content = await getEditedPostContent();

--- a/packages/e2e-tests/specs/editor/various/style-variation.test.js
+++ b/packages/e2e-tests/specs/editor/various/style-variation.test.js
@@ -13,7 +13,7 @@ describe( 'adding blocks', () => {
 		await createNewPost();
 	} );
 
-	it( 'Should switch to the large style of the quote block', async () => {
+	it( 'Should switch to the plain style of the quote block', async () => {
 		// Inserting a quote block
 		await insertBlock( 'Quote' );
 		await page.keyboard.type( 'Quote content' );
@@ -27,6 +27,10 @@ describe( 'adding blocks', () => {
 
 		// Check the content
 		const content = await getEditedPostContent();
-		expect( content ).toMatchSnapshot();
+		expect( content ).toMatchInlineSnapshot( `
+		"<!-- wp:quote {\\"className\\":\\"is-style-plain\\"} -->
+		<blockquote class=\\"wp-block-quote is-style-plain\\"><p>Quote content</p></blockquote>
+		<!-- /wp:quote -->"
+	` );
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Removes the large style option from the quote block.
The style can no longer be selected from the UI, but the CSS class and style is kept.
Closes https://github.com/WordPress/gutenberg/issues/37202

_-This was a small code change, so I'm wondering if I missed a step._


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested manually by placing the following code in the block editor:

```
<!-- wp:quote -->
<blockquote class="wp-block-quote"><p>Default quote</p><cite>citation</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:quote {"className":"is-style-plain"} -->
<blockquote class="wp-block-quote is-style-plain"><p>Plain quote</p><cite>citation</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:quote {"className":"is-style-large"} -->
<blockquote class="wp-block-quote is-style-large"><p>large quote</p><cite>citation</cite></blockquote>
<!-- /wp:quote -->
```

The large style should no longer be selectable in the editor, but should work when the `.is-style-large` CSS class is added.
The plain and default styles should still be available,

All three quote styles should look correct in the editor and on the front.
(There is an unrelated problem with the right aligned text for the large style)

## Screenshots <!-- if applicable -->

![the style section in the settings sidebar for the quote block has two options, default and plain.](https://user-images.githubusercontent.com/7422055/147070188-673add21-94bf-4bc7-8303-5d8637790394.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
