### PR TITLE
Navigation Block: Revert all margins on navigation-item in editor

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -12,11 +12,10 @@
 		padding-left: 0;
 	}
 
-	// Revert any left/right margins.
+	// Revert any margins.
 	// This also makes it work with classic theme auto margins.
 	.wp-block-navigation-item.wp-block {
-		margin-left: revert;
-		margin-right: revert;
+		margin: revert;
 	}
 }
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR reverts the top and bottom margins for each `navigation-item` in the editor. 

The left and right margins are already being reverted to allow this block to work with classic theme auto margins. However, in a theme that doesn't support theme.json, when a background is applied to the `navigation` block, the default vertical margins from the 'Edit Post' classic stylesheet create too much spacing in the editor, compared to what is output on the front end.

These are the styles from the Edit Post [classic stylesheet](https://github.com/WordPress/gutenberg/blob/459bff5eb29fc18f04917c68a16be414b3f79d24/packages/edit-post/src/classic.scss#L16) that these changes override:

```
html :where(.wp-block) {
	margin-top: $default-block-margin;
	margin-bottom: $default-block-margin;
```

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
This bug was originally found when working on an issue in the Seedlet theme: https://github.com/Automattic/themes/issues/3684

It can also be tested by activating any other theme that does not support theme.json, and then:

- Insert a navigation block
- Add at least one navigation item
- Apply a background color to the navigation block

There should be larger (or different) vertical margins on the navigation block in the editor compared to the front end.

## Screenshots <!-- if applicable -->
These are from testing with Seedlet.

Without this PR:

| Editor | Front end |
| ------ | --------- |
|  ![image](https://user-images.githubusercontent.com/1645628/147092853-ea5afc36-c194-4efb-9718-53eef8dd3b39.png)      |  ![image](https://user-images.githubusercontent.com/1645628/147092781-64126f39-aaf1-4f31-9e2b-0ce31a85b65a.png)    |

With this PR:

| Editor | Front end |
| ------ | --------- |
|  ![image](https://user-images.githubusercontent.com/1645628/147093081-280a3ca1-2992-49c6-9374-2330245e946e.png)     |  ![image](https://user-images.githubusercontent.com/1645628/147092996-14c91fb3-e307-45d7-bd5a-338611377b1a.png)    |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement / bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
