### PR TITLE
Chore: Update caniuse to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26027,11 +26027,6 @@
 				"picocolors": "^1.0.0"
 			},
 			"dependencies": {
-				"caniuse-lite": {
-					"version": "1.0.30001278",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001278.tgz",
-					"integrity": "sha512-mpF9KeH8u5cMoEmIic/cr7PNS+F5LWBk0t2ekGT60lFf0Wq+n9LspAj0g3P+o7DQhD3sUdlMln4YFAWhFYn9jg=="
-				},
 				"electron-to-chromium": {
 					"version": "1.3.889",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.889.tgz",
@@ -26604,10 +26599,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001255",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz",
-			"integrity": "sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==",
-			"dev": true
+			"version": "1.0.30001292",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+			"integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",


### PR DESCRIPTION
Executed npx browserslist@latest --update-db with the following result:

```diff
caniuse-lite has been successfully updated

Target browser changes:
- and_chr 95
+ and_chr 96
- android 95
+ android 96
- chrome 93
+ chrome 96
- edge 94
+ edge 96
- firefox 93
+ firefox 95
- ios_saf 15
+ ios_saf 15.2
+ ios_saf 15.0-15.1
- opera 80
+ opera 82
- safari 15
+ safari 15.2
+ safari 15.1
```

And then fixed up the package-lock.json spacing by executing:
```
sed -i -e 's/\(  \)?*/\t/g' package-lock.json
```
