### PR TITLE
Avoid Duplicated "Theme File Editor" menu

### DIFF
--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -5,15 +5,20 @@
  * @package gutenberg
  */
 
-/**
- * Moves the "theme editor" under "tools" in block themes.
+/*
+ * If _add_plugin_file_editor_to_tools is defined, it means the plugin
+ * is running on WordPress 5.9, so no need to change menu location.
  */
-function gutenberg_move_theme_editor_in_block_themes() {
-	if ( ! wp_is_block_theme() || is_multisite() ) {
-		return;
+if ( function_exists( '_add_plugin_file_editor_to_tools' ) ) {
+	/**
+	 * Moves the "theme editor" under "tools" in block themes.
+	 */
+	function gutenberg_move_theme_editor_in_block_themes() {
+		if ( ! wp_is_block_theme() || is_multisite() ) {
+			return;
+		}
+		remove_submenu_page( 'themes.php', 'theme-editor.php' );
+		add_submenu_page( 'tools.php', __( 'Theme File Editor', 'gutenberg' ), __( 'Theme File Editor', 'gutenberg' ), 'edit_themes', 'theme-editor.php' );
 	}
-	remove_submenu_page( 'themes.php', 'theme-editor.php' );
-	add_submenu_page( 'tools.php', __( 'Theme Editor', 'default' ), __( 'Theme Editor', 'default' ), 'edit_themes', 'theme-editor.php' );
+	add_action( 'admin_menu', 'gutenberg_move_theme_editor_in_block_themes', 102 );
 }
-
-add_action( 'admin_menu', 'gutenberg_move_theme_editor_in_block_themes', 102 );

--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -9,7 +9,7 @@
  * If _add_plugin_file_editor_to_tools is defined, it means the plugin
  * is running on WordPress 5.9, so no need to change menu location.
  */
-if ( function_exists( '_add_plugin_file_editor_to_tools' ) ) {
+if ( ! function_exists( '_add_plugin_file_editor_to_tools' ) ) {
 	/**
 	 * Moves the "theme editor" under "tools" in block themes.
 	 */


### PR DESCRIPTION
## Description
PR adds a conditional check before moving "Theme Editor" under the "Tools", to avoid duplicated sub-menu items in WP 5.9.

Closes #37568.

## How has this been tested?
1. Running WP 5.9 beta 4
2. Go to the Dashboard and click on the "Tools" menu
2. It should only display single "Theme File Editor" sub-menu item.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2021-12-22 at 19 14 51](https://user-images.githubusercontent.com/240569/147114571-8b27a766-7042-43d3-b930-e66d466fdc7f.png)|![CleanShot 2021-12-22 at 19 15 07](https://user-images.githubusercontent.com/240569/147114577-3a8fc42a-a2d1-4846-bbb6-3f9c5204fcdb.png)|

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
