### PR TITLE
Change the priority of the block supports styles

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -5,6 +5,10 @@
  * @package gutenberg
  */
 
+/*function gutenberg_get_nested_level( $block ) {
+	if ( ! empty( $block['innerBlocks'] )
+}*/
+
 /**
  * Render the elements stylesheet.
  *
@@ -13,7 +17,6 @@
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content, $block ) {
-
 	if ( ! $block_content ) {
 		return $block_content;
 	}
@@ -68,11 +71,21 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.
 	// See https://core.trac.wordpress.org/ticket/53494.
+
+	// Styles for innerBlocks need to be added after styles for their parents.
+	// This is so that the cascade works as expected.
+	// To do this we work out how many levels of innerBlocks each block has inside it.
+	// First we convert the block to a string.
+	$printed_block = print_r( $block, true );
+	// Then we count the number of instances of innerBlocks inside that string.
+	$number_of_inner_blocks = substr_count( $printed_block, 'innerBlocks' ) - 1;
 	add_action(
 		'wp_footer',
 		function () use ( $style ) {
 			echo $style;
-		}
+		},
+		// If this block has a lot of innerBlocks we need to output the styles earlier so that the child blocks CSS wins.
+		10 - $number_of_inner_blocks
 	);
 
 	return $content;


### PR DESCRIPTION
## Description
When we output CSS for block supports (for example link color), the parent block CSS is output after the child block. This is the opposite of what is expected, since with CSS inheritance the child block should take priority, as happens in the editor.

The solution that I've gone with here converts the block to a string, and then counts how many innerBlocks are inside it. We use this count to increase the priority at which the CSS is added to the footer. Therefore the more innerBlocks a block has, the earlier the CSS is added. This should ensure that the CSS for the inner blocks is always added later.

I tried to find a Gutenberg function that would tell me how many innerBlocks a block has, but I couldn't find one. The idea to convert the block to a string and the count the instances of `innerBlocks` feels like a bad code smell, but it is also much more efficient and simple than iterating arrays.

Other solutions I considered and rejected:
1. Reverse the order that blocks are rendered - so we render parents before children
2. Store all the CSS in a global variable, and prepend new CSS to is, so the order is reversed, and then append it to the body once all blocks are rendered.
3. Use a global variable to count the number of CSS rules we are adding and decrease the priority of each.

I think the solution I have here is better than any of these, but there might still be a better one!

## How has this been tested?
See https://github.com/WordPress/gutenberg/issues/37582 for comprehensive instructions

## Screenshots <!-- if applicable -->
See https://github.com/WordPress/gutenberg/issues/37582

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->