### PR TITLE
[Block Editor]: Restrict delete multi selected blocks shortcut

### DIFF
--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -95,6 +95,17 @@ export default function BlockTools( {
 		} else if (
 			isMatch( 'core/block-editor/delete-multi-selection', event )
 		) {
+			/**
+			 * Check if the target element is a text area, input or
+			 * event.defaultPrevented and return early. In all these
+			 * cases backspace could be handled elsewhere.
+			 */
+			if (
+				[ 'INPUT', 'TEXTAREA' ].includes( event.target.nodeName ) ||
+				event.defaultPrevented
+			) {
+				return;
+			}
 			const clientIds = getSelectedBlockClientIds();
 			if ( clientIds.length > 1 ) {
 				event.preventDefault();


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36513
Fixes: https://github.com/WordPress/gutenberg/issues/37316

Currently if the writing flow keyboard shortcuts ([BlockEditorKeyboardShortcuts](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/keyboard-shortcuts/index.js)) are registered, they can be also processed in the Inspector controls or in any modals created in a block because they're all nested in the same BlockTools tree.

This results to the above two issues where if we have multi selected blocks and press `escape` or `delete` on a modal's or Inspector controls inputs, the blocks are deleted and we're not just removing a character as expected.

@ellatrix explained the issue very well [here](https://github.com/WordPress/gutenberg/issues/36513#issuecomment-999576385) and I'm quoting part of it.

>I think this boils down to the question: do we want shortcuts to work when the options popover in the block toolbar is toggled (which shows some shortcuts). I think yes. In that case this popover is no different from any other thing that uses a portal (iframe, inspector...). There's no way to know where exactly ⇧⌘D (for example) should work. If we want it to work in the block toolbar popover, then it will also work in the inspector and modals created in a block because they're all nested in the same BlockTools tree.

This PR implements the first solution with some tweaks.
>Solution 1: check if the target element is a text area, input, content editable, or event.defaultPrevented is true and return early. In all these cases backspace could be handled elsewhere.

From the above solution I added this check only in the specific shortcut for deleting multi selected blocks, as IMO this is the only one that disrupts the expected flow.
In addition I'm checking only for `input and text area` because we can be in content editable(example paragraph) but we still want the other shortcuts to work like `duplicate`, etc...

## Testing instructions
1. In `post editor` or `site editor` multi select some blocks
1.1 observe that by pressing `escape` or `delete` even with the block setting open will still work.
1.2 either in `Add to Reusable blocks` input or in an input in Inspector controls like `color, line height, etc..` press `escape` or `delete` and observe that the blocks are not deleted.



## Before

https://user-images.githubusercontent.com/16275880/147129511-2d7cb4b6-6ecc-44ee-a39e-d992619d257b.mov



## After

https://user-images.githubusercontent.com/16275880/147129324-5f1cc797-3cd9-4a64-9a33-fd192b2fc04d.mov

--------
Noting that the block editor shortcuts were [just merged for site editor](https://github.com/WordPress/gutenberg/pull/37577) and that's why in previous testing from others the above issues couldn't be reproduced consistently between the two editors (post/site).
