### PR TITLE
Add: Mechanism to keep styles during block transforms.

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { isObject, setWith, clone } from 'lodash';
+import { isObject } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -26,7 +26,7 @@ import {
 	getGradientValueBySlug,
 	getGradientSlugByValue,
 } from '../components/gradients';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, transformStyles, immutableSet } from './utils';
 import ColorPanel from './color-panel';
 import useSetting from '../components/use-setting';
 
@@ -202,10 +202,6 @@ const getLinkColorFromAttributeValue = ( colors, value ) => {
 	}
 	return value;
 };
-
-function immutableSet( object, path, value ) {
-	return setWith( object ? clone( object ) : {}, path, value, clone );
-}
 
 /**
  * Inspector control panel containing the color related configuration
@@ -484,6 +480,34 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 	}
 );
 
+const MIGRATION_PATHS = {
+	linkColor: [ [ 'style', 'elements', 'link', 'color', 'text' ] ],
+	textColor: [ [ 'textColor' ], [ 'style', 'color', 'text' ] ],
+	backgroundColor: [
+		[ 'backgroundColor' ],
+		[ 'style', 'color', 'background' ],
+	],
+	gradient: [ [ 'gradient' ], [ 'style', 'color', 'gradient' ] ],
+};
+
+export function addTransforms( result, source, index, results ) {
+	const destinationBlockType = result.name;
+	const activeSupports = {
+		linkColor: hasLinkColorSupport( destinationBlockType ),
+		textColor: hasTextColorSupport( destinationBlockType ),
+		backgroundColor: hasBackgroundColorSupport( destinationBlockType ),
+		gradient: hasGradientSupport( destinationBlockType ),
+	};
+	return transformStyles(
+		activeSupports,
+		MIGRATION_PATHS,
+		result,
+		source,
+		index,
+		results
+	);
+}
+
 addFilter(
 	'blocks.registerBlockType',
 	'core/color/addAttribute',
@@ -506,4 +530,10 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/color/with-color-palette-styles',
 	withColorPaletteStyles
+);
+
+addFilter(
+	'blocks.switchToBlockType.transformedBlock',
+	'core/color/addTransforms',
+	addTransforms
 );

--- a/packages/block-editor/src/hooks/font-size.js
+++ b/packages/block-editor/src/hooks/font-size.js
@@ -15,7 +15,7 @@ import {
 	getFontSizeObjectByValue,
 	FontSizePicker,
 } from '../components/font-sizes';
-import { cleanEmptyObject } from './utils';
+import { cleanEmptyObject, transformStyles } from './utils';
 import useSetting from '../components/use-setting';
 
 export const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
@@ -255,6 +255,28 @@ const withFontSizeInlineStyles = createHigherOrderComponent(
 	'withFontSizeInlineStyles'
 );
 
+const MIGRATION_PATHS = {
+	fontSize: [ [ 'fontSize' ], [ 'style', 'typography', 'fontSize' ] ],
+};
+
+export function addTransforms( result, source, index, results ) {
+	const destinationBlockType = result.name;
+	const activeSupports = {
+		fontSize: hasBlockSupport(
+			destinationBlockType,
+			FONT_SIZE_SUPPORT_KEY
+		),
+	};
+	return transformStyles(
+		activeSupports,
+		MIGRATION_PATHS,
+		result,
+		source,
+		index,
+		results
+	);
+}
+
 addFilter(
 	'blocks.registerBlockType',
 	'core/font/addAttribute',
@@ -273,4 +295,10 @@ addFilter(
 	'editor.BlockListBlock',
 	'core/font-size/with-font-size-inline-styles',
 	withFontSizeInlineStyles
+);
+
+addFilter(
+	'blocks.switchToBlockType.transformedBlock',
+	'core/font-size/addTransforms',
+	addTransforms
 );

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -1,7 +1,18 @@
 /**
  * External dependencies
  */
-import { pickBy, isEmpty, isObject, identity, mapValues } from 'lodash';
+import {
+	pickBy,
+	isEmpty,
+	isObject,
+	identity,
+	mapValues,
+	forEach,
+	get,
+	setWith,
+	clone,
+	every,
+} from 'lodash';
 
 /**
  * Removed falsy values from nested object.
@@ -19,3 +30,60 @@ export const cleanEmptyObject = ( object ) => {
 	);
 	return isEmpty( cleanedNestedObjects ) ? undefined : cleanedNestedObjects;
 };
+
+export function immutableSet( object, path, value ) {
+	return setWith( object ? clone( object ) : {}, path, value, clone );
+}
+
+export function transformStyles(
+	activeSupports,
+	migrationPaths,
+	result,
+	source,
+	index,
+	results
+) {
+	// If there are no active supports return early.
+	if ( every( activeSupports, ( isActive ) => ! isActive ) ) {
+		return result;
+	}
+	// If the condition verifies we are probably in the presence of a wrapping transform
+	// e.g: nesting paragraphs in a group or columns and in that case the styles should not be transformed.
+	if ( results.length === 1 && result.innerBlocks.length === source.length ) {
+		return result;
+	}
+	// For cases where we have a transform from one block to multiple blocks
+	// or multiple blocks to one block we apply the styles of the first source block
+	// to the result(s).
+	let referenceBlockAttributes = source[ 0 ]?.attributes;
+	// If we are in presence of transform between more than one block in the source
+	// that has more than one block in the result
+	// we apply the styles on source N to the result N,
+	// if source N does not exists we do nothing.
+	if ( results.length > 1 && source.length > 1 ) {
+		if ( source[ index ] ) {
+			referenceBlockAttributes = source[ index ]?.attributes;
+		} else {
+			return result;
+		}
+	}
+	let returnBlock = result;
+	forEach( activeSupports, ( isActive, support ) => {
+		if ( isActive ) {
+			migrationPaths[ support ].forEach( ( path ) => {
+				const styleValue = get( referenceBlockAttributes, path );
+				if ( styleValue ) {
+					returnBlock = {
+						...returnBlock,
+						attributes: immutableSet(
+							returnBlock.attributes,
+							path,
+							styleValue
+						),
+					};
+				}
+			} );
+		}
+	} );
+	return returnBlock;
+}

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -552,7 +552,7 @@ export function switchToBlockType( blocks, name ) {
 		return null;
 	}
 
-	const ret = transformationResults.map( ( result ) => {
+	const ret = transformationResults.map( ( result, index, results ) => {
 		/**
 		 * Filters an individual transform result from block transformation.
 		 * All of the original blocks are passed, since transformations are
@@ -560,11 +560,15 @@ export function switchToBlockType( blocks, name ) {
 		 *
 		 * @param {Object}   transformedBlock The transformed block.
 		 * @param {Object[]} blocks           Original blocks transformed.
+		 * @param {Object[]} index            Index of the transformed block on the array of results.
+		 * @param {Object[]} results          An array all the blocks that resulted from the transformation.
 		 */
 		return applyFilters(
 			'blocks.switchToBlockType.transformedBlock',
 			result,
-			blocks
+			blocks,
+			index,
+			results
 		);
 	} );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36745

This PR proposes a mechanism to keep block styles during transforms. The mechanism is applied for color and font-size if this PR is accepted the mechanism will be expanded into other styles where it makes sense.


## How has this been tested?
I created a paragraph.
I added a custom text color.
I added a named background color, and a named link color.
I added a custom font size.
I converted the paragraph to a list and verified all the styles were kept.
I added another list item.
I selected a preset font size.
I converted the list to paragraphs and verified all the styles were kept.
I selected the paragraphs and converted back to a list and verified the styles persisted on the list.
