### PR TITLE
Components: Introduce getAuxiliaryColorArtefactWrapper prop for color picker

### DIFF
--- a/packages/components/src/color-picker/README.md
+++ b/packages/components/src/color-picker/README.md
@@ -41,6 +41,16 @@ Defaults to `false`. When `true` the color picker will display the alpha channel
 - Required: No
 - Default: `false`
 
+### `getAuxiliaryColorArtefactWrapper`: `(WordPressComponentProps< ColorPickerProps, 'div', false >) => ReactElement`
+
+Defaults to a function that returns `null`. When passed to the color picker, allows
+to replace the bottom part of the color picker editor with a custom React element. Useful
+for using the color picker in more tight spaces when the auxiliary part of the picker
+is not relevant or needs to be swapped with something more minimal.
+
+- Required: No
+- Default: `(props) => null`
+
 ### `defaultValue`: `string | undefined`
 
 An optional default value to use for the color picker.

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -37,10 +37,16 @@ import { useControlledValue } from '../utils/hooks';
 
 import type { ColorType } from './types';
 
+// eslint-disable-next-line no-restricted-imports
+import type { ReactElement } from 'react';
+
 extend( [ namesPlugin ] );
 
 export interface ColorPickerProps {
 	enableAlpha?: boolean;
+	getAuxiliaryColorArtefactWrapper?: (
+		props: WordPressComponentProps< ColorPickerProps, 'div', false >
+	) => ReactElement;
 	color?: string;
 	onChange?: ( color: string ) => void;
 	defaultValue?: string;
@@ -63,6 +69,7 @@ const ColorPicker = (
 		onChange,
 		defaultValue = '#fff',
 		copyFormat,
+		getAuxiliaryColorArtefactWrapper = () => null,
 		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
@@ -91,6 +98,10 @@ const ColorPicker = (
 		copyFormat || 'hex'
 	);
 
+	const customAuxiliaryColorArtefactWrapper = getAuxiliaryColorArtefactWrapper(
+		props
+	);
+
 	return (
 		<ColorfulWrapper ref={ forwardedRef } { ...divProps }>
 			<Picker
@@ -98,47 +109,51 @@ const ColorPicker = (
 				color={ safeColordColor }
 				enableAlpha={ enableAlpha }
 			/>
-			<AuxiliaryColorArtefactWrapper>
-				<HStack justify="space-between">
-					{ showInputs ? (
-						<SelectControl
-							options={ options }
-							value={ colorType }
-							onChange={ ( nextColorType ) =>
-								setColorType( nextColorType as ColorType )
+			{ customAuxiliaryColorArtefactWrapper ? (
+				customAuxiliaryColorArtefactWrapper
+			) : (
+				<AuxiliaryColorArtefactWrapper>
+					<HStack justify="space-between">
+						{ showInputs ? (
+							<SelectControl
+								options={ options }
+								value={ colorType }
+								onChange={ ( nextColorType ) =>
+									setColorType( nextColorType as ColorType )
+								}
+								label={ __( 'Color format' ) }
+								hideLabelFromVision
+							/>
+						) : (
+							<ColorDisplay
+								color={ safeColordColor }
+								colorType={ copyFormat || colorType }
+								enableAlpha={ enableAlpha }
+							/>
+						) }
+						<DetailsControlButton
+							isSmall
+							onClick={ () => setShowInputs( ! showInputs ) }
+							icon={ settings }
+							isPressed={ showInputs }
+							label={
+								showInputs
+									? __( 'Hide detailed inputs' )
+									: __( 'Show detailed inputs' )
 							}
-							label={ __( 'Color format' ) }
-							hideLabelFromVision
 						/>
-					) : (
-						<ColorDisplay
+					</HStack>
+					<Spacer margin={ 4 } />
+					{ showInputs && (
+						<ColorInput
+							colorType={ colorType }
 							color={ safeColordColor }
-							colorType={ copyFormat || colorType }
+							onChange={ handleChange }
 							enableAlpha={ enableAlpha }
 						/>
 					) }
-					<DetailsControlButton
-						isSmall
-						onClick={ () => setShowInputs( ! showInputs ) }
-						icon={ settings }
-						isPressed={ showInputs }
-						label={
-							showInputs
-								? __( 'Hide detailed inputs' )
-								: __( 'Show detailed inputs' )
-						}
-					/>
-				</HStack>
-				<Spacer margin={ 4 } />
-				{ showInputs && (
-					<ColorInput
-						colorType={ colorType }
-						color={ safeColordColor }
-						onChange={ handleChange }
-						enableAlpha={ enableAlpha }
-					/>
-				) }
-			</AuxiliaryColorArtefactWrapper>
+				</AuxiliaryColorArtefactWrapper>
+			) }
 		</ColorfulWrapper>
 	);
 };

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -109,6 +109,7 @@ function ControlPoints( {
 	onStartControlPointChange,
 	onStopControlPointChange,
 	__experimentalIsRenderedInSidebar,
+	colorPickerProps = {},
 } ) {
 	const controlPointMoveState = useRef();
 
@@ -252,6 +253,7 @@ function ControlPoints( {
 										)
 									);
 								} }
+								{ ...( colorPickerProps || {} ) }
 							/>
 							{ ! disableRemove && controlPoints.length > 2 && (
 								<Button
@@ -287,6 +289,7 @@ function InsertPoint( {
 	disableAlpha,
 	__experimentalIsRenderedInSidebar,
 	gradientPickerDomRef,
+	colorPickerProps = {},
 } ) {
 	const [ alreadyInsertedPoint, setAlreadyInsertedPoint ] = useState( false );
 	return (
@@ -343,6 +346,7 @@ function InsertPoint( {
 							);
 						}
 					} }
+					{ ...( colorPickerProps || {} ) }
 				/>
 			) }
 		/>

--- a/packages/components/src/custom-gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-bar/index.js
@@ -79,6 +79,8 @@ export default function CustomGradientBar( {
 	disableInserter = false,
 	disableAlpha = false,
 	__experimentalIsRenderedInSidebar,
+
+	controlPointsProps = {},
 } ) {
 	const gradientPickerDomRef = useRef();
 
@@ -153,6 +155,7 @@ export default function CustomGradientBar( {
 									type: 'CLOSE_INSERTER',
 								} );
 							} }
+							{ ...controlPointsProps }
 						/>
 					) }
 				<ControlPoints
@@ -179,6 +182,7 @@ export default function CustomGradientBar( {
 							type: 'STOP_CONTROL_CHANGE',
 						} );
 					} }
+					{ ...controlPointsProps }
 				/>
 			</div>
 		</div>

--- a/packages/components/src/custom-gradient-picker/index.js
+++ b/packages/components/src/custom-gradient-picker/index.js
@@ -108,6 +108,7 @@ export default function CustomGradientPicker( {
 	value,
 	onChange,
 	__experimentalIsRenderedInSidebar,
+	customGradientBarProps,
 } ) {
 	const gradientAST = getGradientAstWithDefault( value );
 	// On radial gradients the bar should display a linear gradient.
@@ -141,6 +142,7 @@ export default function CustomGradientPicker( {
 						)
 					);
 				} }
+				{ ...( customGradientBarProps || {} ) }
 			/>
 			<Flex
 				gap={ 3 }

--- a/packages/components/src/gradient-picker/index.js
+++ b/packages/components/src/gradient-picker/index.js
@@ -104,6 +104,7 @@ export default function GradientPicker( {
 	onChange,
 	value,
 	clearable = true,
+	customGradientPickerProps = {},
 	disableCustomGradients = false,
 	__experimentalHasMultipleOrigins,
 	__experimentalIsRenderedInSidebar,
@@ -142,6 +143,7 @@ export default function GradientPicker( {
 						}
 						value={ value }
 						onChange={ onChange }
+						{ ...( customGradientPickerProps || {} ) }
 					/>
 				)
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This pull request adds two things:

1. `getAuxiliaryColorArtefactWrapper` prop for the color picker component
2. Implement a serie of props for the gradient-picker that allows passing custom props to the color picker from the custom gradient UI

Reason for this being allowing client code to use a simpler version of the color & gradient pickers without completely re-implementing those from the plugin side. This will cause a lot of duplication on the plugin end and we'll also be forced to bundle [`react-colorful`](https://github.com/omgovich/react-colorful) twice to make that happen.
Reasoning for this is also described in the updated README.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
By consuming the new props from the code that uses the color picker and gradient picker components from the [Blocksy](https://wordpress.org/themes/blocksy/) theme.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Non-breaking additions into the existing components.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
