### PR TITLE
Update: Make the global styles subtitles font smaller

### DIFF
--- a/packages/components/src/palette-edit/styles.js
+++ b/packages/components/src/palette-edit/styles.js
@@ -57,7 +57,9 @@ export const NameContainer = styled.div`
 export const PaletteHeading = styled( Heading )`
 	text-transform: uppercase;
 	line-height: ${ space( 6 ) };
+	font-weight: 500;
 	&&& {
+		font-size: 11px;
 		margin-bottom: 0;
 	}
 `;

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -47,7 +47,8 @@
 	// Need to override the too specific styles for complementary areas.
 	margin-bottom: 0 !important;
 	text-transform: uppercase;
-	font-weight: 500;
+	font-weight: 500 !important;
+	font-size: 11px !important;
 }
 
 .edit-site-screen-color-palette-toggle.edit-site-screen-color-palette-toggle {


### PR DESCRIPTION
Follows a suggestion by @mtias and makes the subtitle component render the fonts smaller.


## How has this been tested?
I verified that the subtitle component renders as shown in the screenshots below.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/147145895-d2c6b469-4acf-4c88-8f5c-9a54e1fdbb02.png)
![image](https://user-images.githubusercontent.com/11271197/147145907-fd57c954-e295-4156-82d9-c5f70fde8a24.png)
