### PR TITLE
Migrate post privacy confirmation from `confirm()` to `ConfirmDialog`

### DIFF
--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -26,6 +26,11 @@ describe( 'Post visibility', () => {
 			);
 			await privateLabel.click();
 
+			await page.waitForSelector( '.components-confirm-dialog' );
+
+			const [ confirmButton ] = await page.$x( '//button[text()="OK"]' );
+			await confirmButton.click();
+
 			const currentStatus = await page.evaluate( () => {
 				return wp.data
 					.select( 'core/editor' )
@@ -59,6 +64,11 @@ describe( 'Post visibility', () => {
 
 		const [ privateLabel ] = await page.$x( '//label[text()="Private"]' );
 		await privateLabel.click();
+
+		await page.waitForSelector( '.components-confirm-dialog' );
+
+		const [ confirmButton ] = await page.$x( '//button[text()="OK"]' );
+		await confirmButton.click();
 
 		// Enter a title for this post.
 		await page.type( '.editor-post-title__input', ' Changed' );

--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -60,9 +60,8 @@ describe( 'Post visibility', () => {
 			);
 			await privateLabel.click();
 			await page.waitForSelector( '.components-confirm-dialog' );
-
-			const cancelButton = await page.waitForSelector(
-				'.components-confirm-dialog button.is-tertiary'
+			const cancelButton = await page.waitForXPath(
+				'//*[@role="dialog"][not(@id="wp-link-wrap")]//button[text()="Cancel"]'
 			);
 			await cancelButton.click();
 

--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -26,9 +26,13 @@ describe( 'Post visibility', () => {
 			);
 			await privateLabel.click();
 
-			await page.waitForSelector( '.components-confirm-dialog' );
+			await page.waitForXPath(
+				'//*[text()="Would you like to privately publish this post now?"]'
+			);
 
-			const [ confirmButton ] = await page.$x( '//button[text()="OK"]' );
+			const [ confirmButton ] = await page.$x(
+				'//*[@role="dialog"]//button[text()="OK"]'
+			);
 			await confirmButton.click();
 
 			const currentStatus = await page.evaluate( () => {
@@ -59,7 +63,9 @@ describe( 'Post visibility', () => {
 				'//label[text()="Private"]'
 			);
 			await privateLabel.click();
-			await page.waitForSelector( '.components-confirm-dialog' );
+			await page.waitForXPath(
+				'//*[text()="Would you like to privately publish this post now?"]'
+			);
 			const cancelButton = await page.waitForXPath(
 				'//*[@role="dialog"][not(@id="wp-link-wrap")]//button[text()="Cancel"]'
 			);
@@ -99,9 +105,13 @@ describe( 'Post visibility', () => {
 		const [ privateLabel ] = await page.$x( '//label[text()="Private"]' );
 		await privateLabel.click();
 
-		await page.waitForSelector( '.components-confirm-dialog' );
+		await page.waitForXPath(
+			'//*[text()="Would you like to privately publish this post now?"]'
+		);
 
-		const [ confirmButton ] = await page.$x( '//button[text()="OK"]' );
+		const [ confirmButton ] = await page.$x(
+			'//*[@role="dialog"]//button[text()="OK"]'
+		);
 		await confirmButton.click();
 
 		// Enter a title for this post.

--- a/packages/e2e-tests/specs/editor/various/post-visibility.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-visibility.test.js
@@ -39,6 +39,41 @@ describe( 'Post visibility', () => {
 
 			expect( currentStatus ).toBe( 'private' );
 		} );
+
+		it( `can be canceled when the viewport is ${ viewport }`, async () => {
+			await setBrowserViewport( viewport );
+
+			await createNewPost();
+
+			await openDocumentSettingsSidebar();
+
+			const initialStatus = await page.evaluate( () => {
+				return wp.data
+					.select( 'core/editor' )
+					.getEditedPostAttribute( 'status' );
+			} );
+
+			await page.click( '.edit-post-post-visibility__toggle' );
+
+			const [ privateLabel ] = await page.$x(
+				'//label[text()="Private"]'
+			);
+			await privateLabel.click();
+			await page.waitForSelector( '.components-confirm-dialog' );
+
+			const cancelButton = await page.waitForSelector(
+				'.components-confirm-dialog button.is-tertiary'
+			);
+			await cancelButton.click();
+
+			const currentStatus = await page.evaluate( () => {
+				return wp.data
+					.select( 'core/editor' )
+					.getEditedPostAttribute( 'status' );
+			} );
+
+			expect( currentStatus ).toBe( initialStatus );
+		} );
 	} );
 
 	it( 'visibility remains private even if the publish date is in the future', async () => {

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -16,17 +16,6 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
-function PublishPrivateConfirm( props ) {
-	return props.showPrivateConfirmDialog ? (
-		<ConfirmDialog
-			onConfirm={ props.confirmPrivateHandler }
-			onCancel={ props.cancelPrivateHandler }
-		>
-			{ __( 'Would you like to privately publish this post now?' ) }
-		</ConfirmDialog>
-	) : null;
-}
-
 export class PostVisibility extends Component {
 	constructor( props ) {
 		super( ...arguments );
@@ -38,6 +27,7 @@ export class PostVisibility extends Component {
 
 		this.state = {
 			hasPassword: !! props.password,
+			showPrivateConfirmDialog: false,
 		};
 	}
 
@@ -52,16 +42,15 @@ export class PostVisibility extends Component {
 		this.setState( { showPrivateConfirmDialog: true } );
 	}
 
-	confirmPrivateHandler = () => {
+	confirmPrivate = () => {
 		const { onUpdateVisibility, onSave } = this.props;
 
 		onUpdateVisibility( 'private' );
-		this.setState( { hasPassword: false } );
+		this.setState( {
+			hasPassword: false,
+			showPrivateConfirmDialog: false,
+		} );
 		onSave();
-	};
-
-	cancelPrivateHandler = () => {
-		this.setState( { showPrivateConfirmDialog: false } );
 	};
 
 	setPasswordProtected() {
@@ -158,14 +147,16 @@ export class PostVisibility extends Component {
 					/>
 				</div>
 			),
-			<PublishPrivateConfirm
+			<ConfirmDialog
 				key={ 'private-publish-confirmation' }
-				showPrivateConfirmDialog={ this.state.showPrivateConfirmDialog }
-				confirmPrivateHandler={ this.confirmPrivateHandler }
-				cancelPrivateHandler={ this.cancelPrivateHandler }
+				isOpen={ this.state.showPrivateConfirmDialog }
+				onConfirm={ this.confirmPrivate }
+				onCancel={ () => {
+					this.setState( { showPrivateConfirmDialog: false } );
+				} }
 			>
 				{ __( 'Would you like to privately publish this post now?' ) }
-			</PublishPrivateConfirm>,
+			</ConfirmDialog>,
 		];
 	}
 }

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -53,6 +53,10 @@ export class PostVisibility extends Component {
 		onSave();
 	};
 
+	handleDialogCancel = () => {
+		this.setState( { showPrivateConfirmDialog: false } );
+	};
+
 	setPasswordProtected() {
 		const { visibility, onUpdateVisibility, status, password } = this.props;
 
@@ -151,9 +155,7 @@ export class PostVisibility extends Component {
 				key="private-publish-confirmation"
 				isOpen={ this.state.showPrivateConfirmDialog }
 				onConfirm={ this.confirmPrivate }
-				onCancel={ () => {
-					this.setState( { showPrivateConfirmDialog: false } );
-				} }
+				onCancel={ this.handleDialogCancel }
 			>
 				{ __( 'Would you like to privately publish this post now?' ) }
 			</ConfirmDialog>,

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -148,7 +148,7 @@ export class PostVisibility extends Component {
 				</div>
 			),
 			<ConfirmDialog
-				key={ 'private-publish-confirmation' }
+				key="private-publish-confirmation"
 				isOpen={ this.state.showPrivateConfirmDialog }
 				onConfirm={ this.confirmPrivate }
 				onCancel={ () => {

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -3,7 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Component } from '@wordpress/element';
-import { VisuallyHidden } from '@wordpress/components';
+import {
+	VisuallyHidden,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 
@@ -12,6 +15,17 @@ import { withSelect, withDispatch } from '@wordpress/data';
  */
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
+
+function PublishPrivateConfirm( props ) {
+	return props.showPrivateConfirmDialog ? (
+		<ConfirmDialog
+			onConfirm={ props.confirmPrivateHandler }
+			onCancel={ props.cancelPrivateHandler }
+		>
+			{ __( 'Would you like to privately publish this post now?' ) }
+		</ConfirmDialog>
+	) : null;
+}
 
 export class PostVisibility extends Component {
 	constructor( props ) {
@@ -35,21 +49,20 @@ export class PostVisibility extends Component {
 	}
 
 	setPrivate() {
-		if (
-			// eslint-disable-next-line no-alert
-			! window.confirm(
-				__( 'Would you like to privately publish this post now?' )
-			)
-		) {
-			return;
-		}
+		this.setState( { showPrivateConfirmDialog: true } );
+	}
 
+	confirmPrivateHandler = () => {
 		const { onUpdateVisibility, onSave } = this.props;
 
 		onUpdateVisibility( 'private' );
 		this.setState( { hasPassword: false } );
 		onSave();
-	}
+	};
+
+	cancelPrivateHandler = () => {
+		this.setState( { showPrivateConfirmDialog: false } );
+	};
 
 	setPasswordProtected() {
 		const { visibility, onUpdateVisibility, status, password } = this.props;
@@ -145,6 +158,14 @@ export class PostVisibility extends Component {
 					/>
 				</div>
 			),
+			<PublishPrivateConfirm
+				key={ 'private-publish-confirmation' }
+				showPrivateConfirmDialog={ this.state.showPrivateConfirmDialog }
+				confirmPrivateHandler={ this.confirmPrivateHandler }
+				cancelPrivateHandler={ this.cancelPrivateHandler }
+			>
+				{ __( 'Would you like to privately publish this post now?' ) }
+			</PublishPrivateConfirm>,
 		];
 	}
 }


### PR DESCRIPTION
## Description
This PR aims to migrate the post editor's `Switch to draft` button away from the current `confirm()` implementation and instead use the new experimental `ConfirmDialog` component.

## How has this been tested?
Before testing, cherrypick https://github.com/WordPress/gutenberg/pull/37959 on top of this PR. That will ensure the `ConfirmDialog` has the proper z-index to render on top of its parent component.

Running WordPress 5.8.2 via `wp-env`:
1. Create and publish a new post
2. In the **Post > Status & visibility** settings, click the current visibility (Public) to open the popover
3.  Choose **Private** and look for any unexpected console errors
4. Click **Cancel** and confirm that the post's visibility is not changed (no toast notification, and it should still appear private if you check the post list in another tab).
5. Open the Visibility popover again, and this time click **OK**
6. Confirm there are no unexpected console errors
7. Confirm the post updates to Private. You should see the usual updating animation on the Update/Publish button, and a toast notification should appear when complete
8. Confirm the post has been updated to Private.

I've tested in the latest Chrome, Firefox, and Safari.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
ironment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
