### PR TITLE
Fixed Theme Editor menu under Tools when there is Gutenberg activated

### DIFF
--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -9,6 +9,7 @@
  * Moves the "theme editor" under "tools" in block themes.
  */
 function gutenberg_move_theme_editor_in_block_themes() {
+	global $wp_version; 
 	if ( ! wp_is_block_theme() || is_multisite() || ($wp_version >= '5.9')) {
 		return;
 	}

--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -9,7 +9,7 @@
  * Moves the "theme editor" under "tools" in block themes.
  */
 function gutenberg_move_theme_editor_in_block_themes() {
-	if ( ! wp_is_block_theme() || is_multisite() ) {
+	if ( ! wp_is_block_theme() || is_multisite() || ($wp_version >= '5.9')) {
 		return;
 	}
 	remove_submenu_page( 'themes.php', 'theme-editor.php' );


### PR DESCRIPTION
From WP 5.9, Theme Editor is moved under Tools and when Gutenberg is activated, we will have two Theme Editor menu. So, this PR will fix the Theme Editor menu when Gutenberg is activated in WordPress 5.9 or later. 

When we have Gutenberg is activated on WordPress 5.9 Beta 4
![theme-editor](https://user-images.githubusercontent.com/13062231/147210487-ab514fa9-67d9-49a3-baae-7cb3d7e39a18.png)

