### PR TITLE
Fix conditional check "Theme File Editor" menu

### DIFF
--- a/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
+++ b/lib/compat/wordpress-5.9/move-theme-editor-menu-item.php
@@ -6,10 +6,10 @@
  */
 
 /*
- * If _add_plugin_file_editor_to_tools is defined, it means the plugin
+ * If wp_list_users is defined, it means the plugin
  * is running on WordPress 5.9, so no need to change menu location.
  */
-if ( ! function_exists( '_add_plugin_file_editor_to_tools' ) ) {
+if ( ! function_exists( 'wp_list_users' ) ) {
 	/**
 	 * Moves the "theme editor" under "tools" in block themes.
 	 */


### PR DESCRIPTION
## Description
Follow-up for #37592.

It looks like I messed up something when doing initial tests and was getting incorrect results 🙇‍♂️ 

The `_add_plugin_file_editor_to_tools` isn't available when we're performing the check, so we still end up with two "Theme File Editor" sub-menu items.

Cord now uses `wp_list_users` for version check. We're using this function for similar checks in a few other places, so it should be safe.

Props to @costdev for discovering the issue 🥇 

## How has this been tested?
1. Running WP 5.9 beta 4
2. Go to the Dashboard and click on the "Tools" menu
3. It should only display a single "Theme File Editor" sub-menu item.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
