### PR TITLE
Show "group" in multi-select toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -9,8 +9,14 @@ import classnames from 'classnames';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { getBlockType, hasBlockSupport } from '@wordpress/blocks';
-import { ToolbarGroup } from '@wordpress/components';
+import {
+	getBlockType,
+	hasBlockSupport,
+	switchToBlockType,
+} from '@wordpress/blocks';
+import { ToolbarGroup, Tooltip, Button } from '@wordpress/components';
+import { group } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -22,6 +28,7 @@ import BlockControls from '../block-controls';
 import BlockSettingsMenu from '../block-settings-menu';
 import { useShowMoversGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
+import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 
 export default function BlockToolbar( { hideDragHandle } ) {
 	const {
@@ -63,6 +70,26 @@ export default function BlockToolbar( { hideDragHandle } ) {
 			),
 		};
 	}, [] );
+
+	// Handle grouping of blocks
+	const convertToGroupButtonProps = useConvertToGroupButtonProps();
+	const {
+		blocksSelection,
+		groupingBlockName,
+		clientIds,
+	} = convertToGroupButtonProps;
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	// Convert to group
+	const onConvertToGroup = () => {
+		const newBlocks = switchToBlockType(
+			blocksSelection,
+			groupingBlockName
+		);
+		if ( newBlocks ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
 
 	// Handles highlighting the current block outline on hover or focus of the
 	// block type toolbar area.
@@ -114,6 +141,14 @@ export default function BlockToolbar( { hideDragHandle } ) {
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) && (
 					<ToolbarGroup className="block-editor-block-toolbar__block-controls">
 						<BlockSwitcher clientIds={ blockClientIds } />
+						{ isMultiToolbar && (
+							<Tooltip text={ __( 'Group' ) }>
+								<Button
+									icon={ group }
+									onClick={ onConvertToGroup }
+								/>
+							</Tooltip>
+						) }
 						<BlockMover
 							clientIds={ blockClientIds }
 							hideDragHandle={ hideDragHandle || hasReducedUI }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR solves this https://github.com/WordPress/gutenberg/issues/34461 issue, add a Group Icon button to Multi Block Toolbar.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Create Multiple Blocks
- Select Multiple blocks
- You will see Group icon in toolbar, click on it group them.


## Screenshots <!-- if applicable -->
<img width="1147" alt="Screenshot 2021-12-23 at 9 41 11 PM" src="https://user-images.githubusercontent.com/46275049/147266376-061cdc44-1d32-4b78-bb43-6c9201a0d55a.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
