### PR TITLE
Post Content/Title: Reflect changes when previewing post

### DIFF
--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -40,7 +40,10 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		the_post();
 	}
 
-	$content = get_the_content( null, false, $post_id );
+	// When inside the main loop, we want to use queried object
+	// so that `the_preview` for the current post can apply.
+	// We force this behavior by passing `null` instead of the post ID.
+	$content = get_the_content( null, false, in_the_loop() ? null : $post_id );
 	/** This filter is documented in wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 	unset( $seen_ids[ $post_id ] );

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -36,14 +36,16 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 
 	$seen_ids[ $post_id ] = true;
 
+	// Check is needed for backward compatibility with third-party plugins
+	// that might rely on the `in_the_loop` check; calling `the_post` sets it to true.
 	if ( ! in_the_loop() && have_posts() ) {
 		the_post();
 	}
 
 	// When inside the main loop, we want to use queried object
 	// so that `the_preview` for the current post can apply.
-	// We force this behavior by passing `null` instead of the post ID.
-	$content = get_the_content( null, false, in_the_loop() ? null : $post_id );
+	// We force this behavior by omitting the third argument (post ID) from the `get_the_content`.
+	$content = get_the_content( null, false );
 	/** This filter is documented in wp-includes/post-template.php */
 	$content = apply_filters( 'the_content', str_replace( ']]>', ']]&gt;', $content ) );
 	unset( $seen_ids[ $post_id ] );

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 	}
 
 	$post_ID = $block->context['postId'];
-	$title   = get_the_title( $post_ID );
+	$title   = get_the_title();
 
 	if ( ! $title ) {
 		return '';


### PR DESCRIPTION
## Description
Resolves #37463.

The preview filter applies content from autosave to the queries object (and global post). When we pass a post ID to the `get_the_content`, it uses an instance of the post where those changes aren't applied. Using `null` instead of `$post_id` in this scenario fixes the issue.

## How has this been tested?
Using TT2 theme.

1. Makes a change to a post without saving.
2. Click Preview -> Preview in new tab
3. Confirm that changes are reflected in the preview.

**Test Query Loops**

1. Add Query block to a page (you can use one of the patterns).
2. Disable "Inherit query from template"
3. Replace Post Expert with Post Content.
4. Check that post content is correctly displayed in the loop.

Additionally, check that main queries like index or archive page work as expected.

## Screencast
https://user-images.githubusercontent.com/240569/147348087-4830611b-76f9-4445-ad45-29b7c370d91e.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
