### PR TITLE
ServerSideRender: Fix loading state

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -182,14 +182,6 @@ export default function ServerSideRender( props ) {
 	const hasEmptyResponse = response === '';
 	const hasError = response?.error;
 
-	if ( hasEmptyResponse || ! hasResponse ) {
-		return <EmptyResponsePlaceholder { ...props } />;
-	}
-
-	if ( hasError ) {
-		return <ErrorResponsePlaceholder response={ response } { ...props } />;
-	}
-
 	if ( isLoading ) {
 		return (
 			<LoadingResponsePlaceholder { ...props } showLoader={ showLoader }>
@@ -198,6 +190,14 @@ export default function ServerSideRender( props ) {
 				) }
 			</LoadingResponsePlaceholder>
 		);
+	}
+
+	if ( hasEmptyResponse || ! hasResponse ) {
+		return <EmptyResponsePlaceholder { ...props } />;
+	}
+
+	if ( hasError ) {
+		return <ErrorResponsePlaceholder response={ response } { ...props } />;
 	}
 
 	return <RawHTML className={ className }>{ response }</RawHTML>;


### PR DESCRIPTION
## Description
Resolves #37552.

PR fixes the ServerSideRender component by re-arranging placeholder return orders. 

## How has this been tested?
1. Add RSS block to a post.
2. Trottle network connection to Slow 3 using DevTools.
3. Paster RSS feed URL - https://make.wordpress.org/core/
4. Click "Use URL".
5. Check that Spinner is displayed. The spinner delay is intentional - #35033

The same testing flow will work for the Archives block as well.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/147352731-0e55d6a0-f9c9-4959-9477-88d60539f11a.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
