### PR TITLE
[Automated Testing]: Add block editor shortcuts e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/block-editor-keyboard-shortcuts.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/block-editor-keyboard-shortcuts.test.js.snap
@@ -2,112 +2,126 @@
 
 exports[`block editor keyboard shortcuts move blocks multiple blocks selected should move the blocks down 1`] = `
 "<!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks multiple blocks selected should move the blocks down 2`] = `
 "<!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks multiple blocks selected should move the blocks up 1`] = `
 "<!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks multiple blocks selected should move the blocks up 2`] = `
 "<!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks single block selected should move the block down 1`] = `
 "<!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks single block selected should move the block down 2`] = `
 "<!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks single block selected should move the block up 1`] = `
 "<!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->"
 `;
 
 exports[`block editor keyboard shortcuts move blocks single block selected should move the block up 2`] = `
 "<!-- wp:paragraph -->
-<p>Third paragraph</p>
+<p>3rd</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>First paragraph</p>
+<p>1st</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:paragraph -->
-<p>Second paragraph</p>
+<p>2nd</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`block editor keyboard shortcuts test shortcuts handling through portals in the same tree should prevent deleting multiple selected blocks from inputs 1`] = `
+"<!-- wp:paragraph -->
+<p>1st</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>2nd</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>3rd</p>
 <!-- /wp:paragraph -->"
 `;

--- a/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-editor-keyboard-shortcuts.test.js
@@ -6,15 +6,18 @@ import {
 	clickBlockAppender,
 	getEditedPostContent,
 	pressKeyWithModifier,
+	clickBlockToolbarButton,
+	clickMenuItem,
+	clickOnCloseModalButton,
 } from '@wordpress/e2e-test-utils';
 
 const createTestParagraphBlocks = async () => {
 	await clickBlockAppender();
-	await page.keyboard.type( 'First paragraph' );
+	await page.keyboard.type( '1st' );
 	await page.keyboard.press( 'Enter' );
-	await page.keyboard.type( 'Second paragraph' );
+	await page.keyboard.type( '2nd' );
 	await page.keyboard.press( 'Enter' );
-	await page.keyboard.type( 'Third paragraph' );
+	await page.keyboard.type( '3rd' );
 };
 
 describe( 'block editor keyboard shortcuts', () => {
@@ -64,6 +67,43 @@ describe( 'block editor keyboard shortcuts', () => {
 				await moveDown();
 				expect( await getEditedPostContent() ).toMatchSnapshot();
 			} );
+		} );
+	} );
+	describe( 'test shortcuts handling through portals in the same tree', () => {
+		beforeEach( async () => {
+			await createTestParagraphBlocks();
+			// Multiselect via keyboard.
+			await pressKeyWithModifier( 'primary', 'a' );
+			await pressKeyWithModifier( 'primary', 'a' );
+		} );
+		it( 'should propagate properly and delete selected blocks', async () => {
+			await clickBlockToolbarButton( 'Options' );
+			const label = 'Duplicate';
+			await page.$x(
+				`//div[@role="menu"]//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ label }")]`
+			);
+			await page.keyboard.press( 'Delete' );
+			expect( await getEditedPostContent() ).toMatchInlineSnapshot(
+				`""`
+			);
+		} );
+		it( 'should prevent deleting multiple selected blocks from inputs', async () => {
+			await clickBlockToolbarButton( 'Options' );
+			await clickMenuItem( 'Add to Reusable blocks' );
+			const reusableBlockNameInputSelector =
+				'.reusable-blocks-menu-items__convert-modal .components-text-control__input';
+			const nameInput = await page.waitForSelector(
+				reusableBlockNameInputSelector
+			);
+			await nameInput.click();
+			await page.keyboard.type( 'hi' );
+			await page.keyboard.press( 'Backspace' );
+			await page.keyboard.press( 'ArrowLeft' );
+			await page.keyboard.press( 'Delete' );
+			await clickOnCloseModalButton(
+				'.reusable-blocks-menu-items__convert-modal'
+			);
+			expect( await getEditedPostContent() ).toMatchSnapshot();
 		} );
 	} );
 } );


### PR DESCRIPTION
Follow up PR of https://github.com/WordPress/gutenberg/pull/37595 which just adds some e2e tests about the `delete multiple selected blocks` block editor shortcut. 

Unrelated with this PR I also changed the demo content text we're typing to be smaller (ex First Paragraph -> 1st).