### PR TITLE
[Block Library]: Fix editable post blocks in Query Loop with `zero` `queryId`

### DIFF
--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -25,7 +25,7 @@ function PostAuthorEdit( {
 	attributes,
 	setAttributes,
 } ) {
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const { authorId, authorDetails, authors } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, getUser, getUsers } = select(

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -66,7 +66,7 @@ function EditableContent( { layout, context = {} } ) {
 
 function Content( props ) {
 	const { context: { queryId, postType, postId } = {} } = props;
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	const isEditable = userCanEdit && ! isDescendentOfQueryLoop;
 

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -33,7 +33,7 @@ export default function PostDateEdit( {
 	context: { postId, postType, queryId },
 	setAttributes,
 } ) {
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const [ siteFormat ] = useEntityProp( 'root', 'site', 'date_format' );
 	const [ date, setDate ] = useEntityProp(
 		'postType',

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -30,7 +30,7 @@ export default function PostExcerptEditor( {
 	isSelected,
 	context: { postId, postType, queryId },
 } ) {
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	const isEditable = userCanEdit && ! isDescendentOfQueryLoop;
 	const [

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -52,7 +52,7 @@ function PostFeaturedImageDisplay( {
 	setAttributes,
 	context: { postId, postType, queryId },
 } ) {
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const { isLink, height, width, scale } = attributes;
 	const [ featuredImage, setFeaturedImage ] = useEntityProp(
 		'postType',

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -30,7 +30,7 @@ export default function PostTitleEdit( {
 	context: { postType, postId, queryId },
 } ) {
 	const TagName = 0 === level ? 'p' : 'h' + level;
-	const isDescendentOfQueryLoop = !! queryId;
+	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
 	const [ rawTitle = '', setTitle, fullTitle ] = useEntityProp(
 		'postType',


### PR DESCRIPTION
There was a bug all along in some Post blocks that were editable inside a `Query Loop` when the `queryId` was zero due to the `!! queryId` check. This was surfaced by @annezazu [here](https://github.com/WordPress/gutenberg/issues/35689#issuecomment-998993855).

What happened was that for a long time we were testing with tt1-blocks that had a `queryId=1` in its templates and when we insert a `Query Loop` block inside an editor it first renders the `Query` patterns making it impossible for `queryId` to be zero. But with other themes that omit the `queryId` in their templates (as they should), `useInstanceId` can return zero making the check invalid and the post blocks inside it being editable.

This PR solves that.

## Testing instructions
1. Open the site editor with TwentyTwentyTwo and observe that the post blocks (like Post Date, Post Featured Image, etc..) are not editable.
2. Everything else should work as before.