### PR TITLE
Docs: Add link to meta-block example in gutenberg-examples repo

### DIFF
--- a/docs/how-to-guides/metabox.md
+++ b/docs/how-to-guides/metabox.md
@@ -26,6 +26,8 @@ You will need:
 -   A minimal plugin activated and ready to edit
 -   JavaScript setup for building and enqueuing
 
+A [complete meta-block example](https://github.com/WordPress/gutenberg-examples/tree/trunk/meta-block) is available that you can use as a reference for your setup.
+
 ## Step-by-step guide
 
 1. [Register Meta Field](#step-1-register-meta-field)


### PR DESCRIPTION

## Description

Add link to gutenberg-examples repo to meta-block setup.

Pairs with this gutenberg-examples repo:
https://github.com/WordPress/gutenberg-examples/pull/186

## How has this been tested?

Confirm link works as expected.


## Types of changes

Documentation. Adds link to examples repo.
