### PR TITLE
Navigation: Try always showing appender even when child is selected.

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -107,7 +107,6 @@ function Navigation( {
 	hasSubmenuIndicatorSetting = true,
 	hasColorSettings = true,
 	customPlaceholder: CustomPlaceholder = null,
-	customAppender: CustomAppender = null,
 } ) {
 	const {
 		openSubmenusOnClick,
@@ -696,7 +695,6 @@ function Navigation( {
 								<NavigationInnerBlocks
 									isVisible={ ! isPlaceholderShown }
 									clientId={ clientId }
-									appender={ CustomAppender }
 									hasCustomPlaceholder={
 										!! CustomPlaceholder
 									}

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -4,6 +4,7 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
+	InnerBlocks,
 	__experimentalBlockContentOverlay as BlockContentOverlay,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -39,7 +40,6 @@ const LAYOUT = {
 export default function NavigationInnerBlocks( {
 	isVisible,
 	clientId,
-	appender: CustomAppender,
 	hasCustomPlaceholder,
 	orientation,
 } ) {
@@ -95,7 +95,6 @@ export default function NavigationInnerBlocks( {
 	const parentOrChildHasSelection =
 		isSelected ||
 		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants );
-	const appender = isVisible && parentOrChildHasSelection ? undefined : false;
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
@@ -111,7 +110,21 @@ export default function NavigationInnerBlocks( {
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,
-			renderAppender: CustomAppender || appender,
+
+			// As an exception to other blocks which feature nesting, show
+			// the block appender even when a child block is selected.
+			// This should be a temporary fix, to be replaced by improvements to
+			// the sibling inserter.
+			// See https://github.com/WordPress/gutenberg/issues/37572.
+			renderAppender:
+				isSelected ||
+				( isImmediateParentOfSelectedBlock &&
+					! selectedBlockHasDescendants ) ||
+				// Show the appender while dragging to allow inserting element between item and the appender.
+				parentOrChildHasSelection
+					? InnerBlocks.ButtonBlockAppender
+					: false,
+
 			// Template lock set to false here so that the Nav
 			// Block on the experimental menus screen does not
 			// inherit templateLock={ 'all' }.

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -187,8 +187,25 @@ $color-control-label-height: 20px;
 	}
 }
 
+// Override inner padding on default appender.
+// This should be a temporary fix, to be replaced by improvements to
+// the sibling inserter.
+// See https://github.com/WordPress/gutenberg/issues/37572.
 .wp-block-navigation .block-editor-button-block-appender {
-	justify-content: flex-start;
+	background-color: $gray-900;
+	color: $white;
+
+	// This needs specificity to override an inherited padding.
+	// That source padding in turn has high specificity to protect
+	// from theme CSS bleed.
+	&.block-editor-button-block-appender.block-editor-button-block-appender {
+		padding: 0;
+	}
+}
+
+.wp-block-navigation .wp-block .wp-block .block-editor-button-block-appender {
+	background-color: transparent;
+	color: $gray-900;
 }
 
 


### PR DESCRIPTION
## Description

Fixes #37572. This PR is a draft as it needs a good sanity check, parts of the code are loaned from a similar change we made to submenus in #36720.

When manually building out a navigation block, the effort in #34041 is geared towards quickly adding items and choosing their destination. A separate effort in #36605 was merged to ensure we avoid layout shifts in the site editor. Those layout shifts occurred because the default appender would appear in the content and take up space when selected.

Both of those efforts are important, improvements are planned for both. But in the mean time, the experience of building out a navigation block from scratch has taken a step backwards, needing for the navigation container block itself to be selected to surface the appender:

![nav-before](https://user-images.githubusercontent.com/1204802/147550044-3f4fa2f8-420f-4393-98c4-b68904e818c3.gif)

While there are mitigations (just open the top left inserter and add as many items as you want) it's not an ideal interim state. This PR makes a change to the default appender behavior, and shows it even when a child block is selected:

![nav-after](https://user-images.githubusercontent.com/1204802/147550249-04c2be0e-c2ab-4212-aed1-94134422801d.gif)

This change has its own tradeoffs:

- It is a nonstandard behavior compared to Buttons and Social Icons.
- It's hacky, re-colorizing and repurposing the ButtonBlock appender to look like the default one.
- The fixed position appender plus benefits from sitting on the blue selection-border (see first GIF), without it it just floats in space.

Ultimately these interfaces all need more work. For example the need to manually build out a menu can be reduced by loading pages by default (see also #36667), or by enabling navigation to be edited in isolation just like template parts. The sibling inserter (the blue line) could also potentially replace the little black in-canvas plus entirely, by enabling it to work before first block or after the last block:

<img width="1667" alt="Screenshot 2021-12-28 at 10 12 53" src="https://user-images.githubusercontent.com/1204802/147549980-d6857290-57ec-4274-90bf-6961f987f924.png">

But those aren't near-term changes. In that light, this PR should be thought of (and comments reflect that) as a temporary solution: a bandaid we should work to remove. What do you think?

## How has this been tested?

Insert a navigation block, start empty, then add multiple top level navigation items. 

Test submenus and all other options for good measure.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
