### PR TITLE
Create Block: Speed up scaffolding by omitting WordPress dependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
 		jsdoc: {
 			mode: 'typescript',
 		},
+		'import/internal-regex': null,
 		'import/resolver': require.resolve( './tools/eslint/import-resolver' ),
 	},
 	rules: {

--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Speed up scaffolding process by omitting WordPress dependencies in the template ([#37639](https://github.com/WordPress/gutenberg/pull/37639)).
+
 ## 1.3.0 (2021-07-21)
 
 ### Enhancement

--- a/packages/create-block-tutorial-template/index.js
+++ b/packages/create-block-tutorial-template/index.js
@@ -22,12 +22,6 @@ module.exports = {
 		supports: {
 			html: false,
 		},
-		npmDependencies: [
-			'@wordpress/block-editor',
-			'@wordpress/blocks',
-			'@wordpress/components',
-			'@wordpress/i18n',
-		],
 	},
 	templatesPath: join( __dirname, 'templates' ),
 	assetsPath: join( __dirname, 'assets' ),

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancement
+
+-   Speed up scaffolding process by omitting WordPress dependencies in the template ([#37639](https://github.com/WordPress/gutenberg/pull/37639)).
+
 ### Internal
 
 -   The bundled `npm-package-arg` dependency has been updated from requiring `^8.0.1` to requiring `^8.1.5` ([#37395](https://github.com/WordPress/gutenberg/pull/37395)).

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -48,7 +48,7 @@ module.exports = async ( {
 		)
 	);
 
-	if ( size( npmDependencies ) ) {
+	if ( wpScripts && size( npmDependencies ) ) {
 		info( '' );
 		info(
 			'Installing npm dependencies. It might take a couple of minutes...'

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -44,11 +44,6 @@ const predefinedBlockTemplates = {
 			supports: {
 				html: false,
 			},
-			npmDependencies: [
-				'@wordpress/block-editor',
-				'@wordpress/blocks',
-				'@wordpress/i18n',
-			],
 		},
 		templatesPath: join( __dirname, 'templates', 'esnext' ),
 	},

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -12,6 +12,10 @@
 -   The bundled `eslint-plugin-jsdoc` dependency has been updated from requiring `^36.0.8` to requiring `^37.0.3` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 -   The bundled `globals` dependency has been updated from requiring `^12.0.0` to requiring `^13.12.0` ([#36283](https://github.com/WordPress/gutenberg/pull/36283)).
 
+### Enhancement
+
+-   Omit verification for WordPress dependencies in the import statements since they get externalized when used with WordPress ([#37639](https://github.com/WordPress/gutenberg/pull/37639)).
+
 ### Bug Fix
 
 -   Fix Babel config resolution when a custom ESLint config present ([#37406](https://github.com/WordPress/gutenberg/pull/37406)). Warning: it won't recognize the `babel.config.json` file present in the project until the upstream bug in `cosmiconfig` is fixed.

--- a/packages/eslint-plugin/configs/custom.js
+++ b/packages/eslint-plugin/configs/custom.js
@@ -27,9 +27,4 @@ module.exports = {
 			},
 		},
 	],
-	settings: {
-		react: {
-			version: '16.6',
-		},
-	},
 };

--- a/packages/eslint-plugin/configs/react.js
+++ b/packages/eslint-plugin/configs/react.js
@@ -6,7 +6,9 @@ module.exports = {
 		},
 	},
 	settings: {
-		'import/extensions': [ '.js', '.jsx' ],
+		react: {
+			version: 'detect',
+		},
 	},
 	plugins: [ '@wordpress', 'react', 'react-hooks' ],
 	rules: {

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -3,6 +3,8 @@
  */
 const { isPackageInstalled } = require( '../utils' );
 
+const wpPackagesRegExp = '^@wordpress/(?!(icons|interface))';
+
 const config = {
 	extends: [
 		require.resolve( './jsx-a11y.js' ),
@@ -21,7 +23,7 @@ const config = {
 		wp: 'readonly',
 	},
 	settings: {
-		'import/internal-regex': '^@wordpress/',
+		'import/internal-regex': wpPackagesRegExp,
 		'import/extensions': [ '.js', '.jsx' ],
 	},
 	rules: {
@@ -34,7 +36,7 @@ const config = {
 		'import/no-unresolved': [
 			'error',
 			{
-				ignore: [ '^@wordpress/' ],
+				ignore: [ wpPackagesRegExp ],
 			},
 		],
 		'import/default': 'warn',

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -20,6 +20,10 @@ const config = {
 		document: true,
 		wp: 'readonly',
 	},
+	settings: {
+		'import/internal-regex': '^@wordpress/',
+		'import/extensions': [ '.js', '.jsx' ],
+	},
 	rules: {
 		'import/no-extraneous-dependencies': [
 			'error',
@@ -27,7 +31,12 @@ const config = {
 				peerDependencies: true,
 			},
 		],
-		'import/no-unresolved': 'error',
+		'import/no-unresolved': [
+			'error',
+			{
+				ignore: [ '^@wordpress/' ],
+			},
+		],
 		'import/default': 'warn',
 		'import/named': 'warn',
 	},

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -3,6 +3,7 @@
  */
 const { isPackageInstalled } = require( '../utils' );
 
+// Exclude bundled WordPress packages from the list.
 const wpPackagesRegExp = '^@wordpress/(?!(icons|interface))';
 
 const config = {

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -34,7 +34,6 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				extensions: [ '.js', '.jsx', '.ts', '.tsx' ],
 			},
 		},
-		'import/core-modules': [ 'react' ],
 	};
 	config.extends.push( 'plugin:@typescript-eslint/eslint-recommended' );
 	config.ignorePatterns = [ '**/*.d.ts' ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up for #27880.

**TLDR; Omit verification for WordPress dependencies in the import statements since they get externalized when used with WordPress.**

In #27880, I added an option to provide a list of npm dependencies to install when scaffolding the block with `@wordpress/create-block`. The rationale behind it was summarized as follows:

> - in development, those dependencies are necessary for linting and unit testing
> - Visual Studio Code and other IDEs use those packages for code completion and all the hints
> - in general, as a good practice `package.json` should list all production npm dependencies used in the project

In practice, it slows down the scaffolding process too much. It also created some follow-up discussion on whether we could skip linting for WordPress packages that are handled as externals anyway.

This PR explores changes to the ESLint Plugin which ignores all WordPress packages in the linting process for import statements. The exception is disabled in the Gutenberg plugin so we can ensure that npm packages are always correctly configured for usage from npm.

As part of the effort, I think we should remove WordPress packages from the listed npm dependencies in templates so they install way faster. In addition to that, I added a check for when `wp-scripts` gets explicitly disabled to skip npm dependencies because they aren't that useful in such cases.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I executed ` ./bin/test-create-block.sh ` to ensure that linting still passes for the scaffolded block with the default `esnext` template even when there are no WordPress dependencies installed.

I added a test dependency (`redux` that existed in `node_modules`) in the scaffolded template to ensure that the linting rule still throws errors for non-WordPress dependencies:

```diff
diff --git a/packages/create-block/lib/templates/esnext/src/edit.js.mustache b/packages/create-block/lib/templates/esnext/src/edit.js.mustache
index 8ed2bb5d38..24f4624aaf 100644
--- a/packages/create-block/lib/templates/esnext/src/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/src/edit.js.mustache
@@ -4,6 +4,7 @@
  * @see https://developer.wordpress.org/block-editor/packages/packages-i18n/
  */
 import { __ } from '@wordpress/i18n';
+import 'redux';
 
 /**
  * React hook that is used to mark the block wrapper element.
```

<img width="1583" alt="Screenshot 2021-12-28 at 12 56 06" src="https://user-images.githubusercontent.com/699132/147563940-87fbe46b-4601-49d9-95a3-0fc9e06c2463.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
