### PR TITLE
Fix: Coloring panel is unusable in RTL

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -14,7 +14,6 @@ import {
 	ColorIndicator,
 	Dropdown,
 } from '@wordpress/components';
-import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -33,7 +33,7 @@ export default function ColorGradientSettingsDropdown( {
 } ) {
 	let dropdownPosition;
 	if ( __experimentalIsRenderedInSidebar ) {
-		dropdownPosition = isRTL() ? 'bottom right' : 'bottom left';
+		dropdownPosition = 'bottom left';
 	}
 
 	return (

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -10,7 +10,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 
 /**

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -150,7 +150,7 @@ export default function ColorPalette( {
 
 	let dropdownPosition;
 	if ( __experimentalIsRenderedInSidebar ) {
-		dropdownPosition = isRTL() ? 'bottom right' : 'bottom left';
+		dropdownPosition = 'bottom left';
 	}
 
 	const colordColor = colord( value );

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -9,7 +9,7 @@ import { colord } from 'colord';
  */
 import { useInstanceId } from '@wordpress/compose';
 import { useEffect, useRef, useState, useMemo } from '@wordpress/element';
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
 import { LEFT, RIGHT } from '@wordpress/keycodes';
 

--- a/packages/components/src/custom-gradient-bar/control-points.js
+++ b/packages/components/src/custom-gradient-bar/control-points.js
@@ -86,7 +86,7 @@ function GradientColorPickerDropdown( {
 		};
 		if ( isRenderedInSidebar ) {
 			result.anchorRef = gradientPickerDomRef.current;
-			result.position = isRTL() ? 'bottom right' : 'bottom left';
+			result.position = 'bottom left';
 		}
 		return result;
 	}, [ gradientPickerDomRef.current, isRenderedInSidebar ] );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37605

We were positioning the popover dynamically using isRTL but we should not do that because our CSS to RTL transformer already handles that.

## How has this been tested?
I verified in a RTL language that the colors work as the screenshot bellow.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/147599622-89a65d3b-bb22-45a0-8781-f546addab1b6.png)

![image](https://user-images.githubusercontent.com/11271197/147599629-2267cd43-4ea9-476a-a3d6-e0d1f7e4e984.png)

