### PR TITLE
Site Editor: Add the "Help" link to the tools menu

### DIFF
--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { MenuItem } from '@wordpress/components';
+import { MenuItem, VisuallyHidden } from '@wordpress/components';
+import { external } from '@wordpress/icons';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -20,6 +21,7 @@ registerPlugin( 'edit-site', {
 					<SiteExport />
 					<WelcomeGuideMenuItem />
 					<MenuItem
+						icon={ external }
 						href={ __(
 							'https://wordpress.org/support/article/site-editor/'
 						) }
@@ -27,6 +29,12 @@ registerPlugin( 'edit-site', {
 						rel="noopener noreferrer"
 					>
 						{ __( 'Help' ) }
+						<VisuallyHidden as="span">
+							{
+								/* translators: accessibility text */
+								__( '(opens in a new tab)' )
+							}
+						</VisuallyHidden>
 					</MenuItem>
 				</ToolsMoreMenuGroup>
 			</>

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -22,6 +22,7 @@ registerPlugin( 'edit-site', {
 					<WelcomeGuideMenuItem />
 					<MenuItem
 						icon={ external }
+						role="menuitem"
 						href={ __(
 							'https://wordpress.org/support/article/site-editor/'
 						) }

--- a/packages/edit-site/src/plugins/index.js
+++ b/packages/edit-site/src/plugins/index.js
@@ -1,6 +1,8 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
+import { MenuItem } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -17,6 +19,15 @@ registerPlugin( 'edit-site', {
 				<ToolsMoreMenuGroup>
 					<SiteExport />
 					<WelcomeGuideMenuItem />
+					<MenuItem
+						href={ __(
+							'https://wordpress.org/support/article/site-editor/'
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'Help' ) }
+					</MenuItem>
 				</ToolsMoreMenuGroup>
 			</>
 		);


### PR DESCRIPTION
## Description
Part of #21245.

PR adds the "Help" link to the "More tools and options" dropdown. It was initially added via #22539, but it was removed after some time.

## How has this been tested?
1. Go to Appearance > Editor
2. Open the "More tools and options" dropdown.
3. Clicking on the "Help" menu item should redirect you to a document placeholder.

## Screenshots <!-- if applicable -->
![CleanShot 2021-12-29 at 09 46 40](https://user-images.githubusercontent.com/240569/147631280-53aaba1d-44ba-4f25-92ba-6ac2715a08b2.png)

## Types of changes
Regression

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
