### PR TITLE
Post Excerpt: Fix previews

### DIFF
--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -18,7 +18,7 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$excerpt = get_the_excerpt( $block->context['postId'] );
+	$excerpt = get_the_excerpt();
 
 	if ( empty( $excerpt ) ) {
 		return '';


### PR DESCRIPTION
## Description
Follow-up for #37622.

> The preview filter applies content from autosave to the queries object (and global post). When we pass a post ID to the get_the_content, it uses an instance of the post where those changes aren't applied. Using null instead of $post_id in this scenario fixes the issue.

The same applies to the `get_the_excerpt`. PR removes the post ID argument to fix previews.

## How has this been tested?
Using TT2 theme.

1. Update the "Single" template to use Post Excerpt.
2. Makes a change to a post without saving.
2. Click Preview -> Preview in new tab
3. Confirm that changes are reflected in the preview.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
