### PR TITLE
Post Excerpt: Add to and from Post Content transformations

### DIFF
--- a/packages/block-library/src/post-excerpt/index.js
+++ b/packages/block-library/src/post-excerpt/index.js
@@ -8,11 +8,13 @@ import { postExcerpt as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	icon,
+	transforms,
 	edit,
 };

--- a/packages/block-library/src/post-excerpt/transforms.js
+++ b/packages/block-library/src/post-excerpt/transforms.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-content' ],
+			transform: () => createBlock( 'core/post-excerpt' ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-content' ],
+			transform: () => createBlock( 'core/post-content' ),
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## Description
Resolves #31137.

PR adds transform between Post Excerpt and Post Content blocks.

## How has this been tested?
1. Go to Appearance > Editor, using TT2 or any block themes
2. Select the "Post Excerpt" block on the homepage
3. Using the "Change block type or styles" dropdown, transform it into a "Post Content" block.
4. Then, using the same dropdown, transform it back to an excerpt.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
