### PR TITLE
Remove "experimental" from full site editing docs

### DIFF
--- a/docs/explanations/architecture/full-site-editing-templates.md
+++ b/docs/explanations/architecture/full-site-editing-templates.md
@@ -3,7 +3,7 @@
 ## Template and template part flows
 
 <div class="callout callout-alert">
-This documentation is for block templates and template parts, these features  are part of the Full Site Editing project releasing in WordPress 5.9.
+This documentation is for block templates and template parts, these features are part of the Full Site Editing project releasing in WordPress 5.9.
 </div>
 
 This document will explain the internals of how templates and templates parts are rendered in the frontend and edited in the backend. For an introduction about block themes and Full site editing templates, refer to the [block theme documentation](/docs/how-to-guides/themes/block-theme-overview.md).

--- a/docs/explanations/architecture/full-site-editing-templates.md
+++ b/docs/explanations/architecture/full-site-editing-templates.md
@@ -3,7 +3,7 @@
 ## Template and template part flows
 
 <div class="callout callout-alert">
-This is the documentation for the current implementation of the block templates and template parts themes. This is part of the Full Site Editing project. These features are still experimental in the plugin. “Experimental” means this is just an early implementation that is subject to potential drastic and breaking changes in iterations based on feedback from users, contributors, and theme authors.
+This documentation is for block templates and template parts, these features  are part of the Full Site Editing project releasing in WordPress 5.9.
 </div>
 
 This document will explain the internals of how templates and templates parts are rendered in the frontend and edited in the backend. For an introduction about block themes and Full site editing templates, refer to the [block theme documentation](/docs/how-to-guides/themes/block-theme-overview.md).

--- a/docs/explanations/glossary.md
+++ b/docs/explanations/glossary.md
@@ -38,7 +38,7 @@
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
 
 <dt>Full Site Editing </dt>
-<dd>This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). Currently, it's still in an experimental phase.</dd>
+<dd>This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). First released in WordPres 5.9</dd>
 
 <dt>Inspector</dt>
 <dd>Deprecated term. See <a href="#settings-sidebar">Settings Sidebar.</a></dd>

--- a/docs/explanations/glossary.md
+++ b/docs/explanations/glossary.md
@@ -38,7 +38,7 @@
 <dd>A type of block where the content of which may change and cannot be determined at the time of saving a post, instead calculated any time the post is shown on the front of a site. These blocks may save fallback content or no content at all in their JavaScript implementation, instead deferring to a PHP block implementation for runtime rendering.</dd>
 
 <dt>Full Site Editing </dt>
-<dd>This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). First released in WordPres 5.9</dd>
+<dd>This refers to a collection of features that ultimately allows users to edit their entire website using blocks as the starting point. This feature set includes everything from block patterns to global styles to templates to design tools for blocks (and more). First released in WordPress 5.9.</dd>
 
 <dt>Inspector</dt>
 <dd>Deprecated term. See <a href="#settings-sidebar">Settings Sidebar.</a></dd>

--- a/docs/how-to-guides/themes/block-theme-overview.md
+++ b/docs/how-to-guides/themes/block-theme-overview.md
@@ -1,9 +1,7 @@
 # Block Theme
 
 <div class="callout callout-alert">
-These features are still experimental in the plugin. “Experimental” means this is just an early implementation that is subject to potential drastic and breaking changes in iterations based on feedback from users, contributors and theme authors.
-
-Documentation is shared early to surface what’s being worked on and invite feedback from those experimenting with the APIs. You can provide feedback in the weekly #core-editor chats, or #fse-outreach-experiment channels, or async via Github issues.
+These features are part of the full site editing project releasing in WordPress 5.9. You can provide feedback in the weekly #core-editor chats, or #fse-outreach-experiment channels, or async using GitHub issues.
 </div>
 
 ## What is a block theme?
@@ -131,11 +129,11 @@ A pattern block can be used to insert translatable content inside a block templa
 
 #### Example
 
-Register a pattern: 
+Register a pattern:
 
 ```php
 <?php
-register_block_pattern( 
+register_block_pattern(
 	'myblocktheme/wordpress-credit',
 	array(
 		'title'      => __( 'Wordpress credit', 'myblocktheme' ),
@@ -158,7 +156,7 @@ Load the pattern in a template or template part:
 ```html
 <!-- wp:group -->
 <div class="wp-block-group">
-<!-- wp:pattern {"slug":"myblocktheme/wordpress-credit"} /-->
+	<!-- wp:pattern {"slug":"myblocktheme/wordpress-credit"} /-->
 </div>
 <!-- /wp:group -->
 ```

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -242,7 +242,6 @@ are saved to the database as custom post types. To export them as theme files, f
 -   Select the **Export** option to download a zip file containing the files. Unpack the files.
 -   Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
 -   Copy template part one and two from `theme/parts/` to your theme's `parts` folder.
--   Open `index.html` and update the template part slugs in the block markup.
 
 Saved templates have precedence over theme files. To use the updated theme files, go to **Appearance > Templates** and
 **Appearance > Template parts** and delete the saved templates.

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -241,7 +241,7 @@ are saved to the database as custom post types. To export them as theme files, f
 -   In the site editor, open the **More tools and options** menu.
 -   Select the **Export** option to download a zip file containing the files. Unpack the files.
 -   Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
--   Copy template part one and two from `theme/parts/` to your theme's `parts` folder.
+-   Copy template parts from `theme/parts/` to your theme's `parts` folder.
 
 Saved templates have precedence over theme files. To use the updated theme files, go to **Appearance > Templates** and
 **Appearance > Template parts** and delete the saved templates.

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -243,8 +243,9 @@ are saved to the database as custom post types. To export them as theme files, f
 -   Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
 -   Copy template parts from `theme/parts/` to your theme's `parts` folder.
 
-Saved templates have precedence over theme files. To use the updated theme files, go to **Appearance > Templates** and
-**Appearance > Template parts** and delete the saved templates.
+Saved templates have precedence over theme files.
+
+To learn more about the Site Editor, see the [support article](https://wordpress.org/support/article/site-editor/)
 
 ### Additional templates
 

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -242,7 +242,6 @@ are saved to the database as custom post types. To export them as theme files, f
 -   Select the **Export** option to download a zip file containing the files. Unpack the files.
 -   Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
 -   Copy template part one and two from `theme/parts/` to your theme's `parts` folder.
--   Rename the template parts to `header.html` and `footer.html`, respectively.
 -   Open `index.html` and update the template part slugs in the block markup.
 
 Saved templates have precedence over theme files. To use the updated theme files, go to **Appearance > Templates** and

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -1,13 +1,10 @@
 # Create a block theme
 
-The purpose of this tutorial is to show how to create a block theme and help theme developers transition to full site editing.
-It is recommended that you first read the [block theme overview](/docs/how-to-guides/themes/block-theme-overview.md).
+The purpose of this tutorial is to show how to create a block theme and help theme developers transition to full site editing. It is recommended that you first read the [block theme overview](/docs/how-to-guides/themes/block-theme-overview.md).
 
 You will learn about the required files, how to combine templates and template parts, how to add presets for global styles, and how to add blocks and export the templates in the site editor.
 
-Full site editing is an experimental feature, and the workflow in this tutorial is likely to change.
-
-This tutorial is up to date with Gutenberg version 11.0.0.
+Block themes are releasing in WordPress 5.9 as part of the full site editing project.
 
 ## Table of Contents
 
@@ -32,6 +29,7 @@ The theme may optionally include a `functions.php` file and a [theme.json file](
 Template parts are optional. If they are included they must be placed inside a `parts` folder.
 
 File structure:
+
 ```
 theme
 |__ style.css
@@ -139,13 +137,14 @@ theme
 ```
 
 ## Creating the templates and template parts
+
 Before continuing, install and activate your theme.
 
 There are several ways to create templates and template parts:
 
-- Manually, by creating HTML files containing block markup.
-- Using the site editor.
-- Using the template editing mode in the block editor.
+-   Manually, by creating HTML files containing block markup.
+-   Using the site editor.
+-   Using the template editing mode in the block editor.
 
 The fourth way is temporary and involves going to the Appearance menu > Templates, and is not recommended because of its limitations.
 
@@ -197,7 +196,9 @@ All block attributes are placed inside these curly brackets. If you wanted the p
 
 ```html
 <!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">Proudly powered by <a href="https://wordpress.org/">WordPress</a>.</p>
+<p class="has-text-align-center">
+	Proudly powered by <a href="https://wordpress.org/">WordPress</a>.
+</p>
 <!-- /wp:paragraph -->
 ```
 
@@ -238,12 +239,12 @@ Edit and save the template in the same way as in the site editor.
 Templates and template parts that have been created or edited in the site editor or template editing mode
 are saved to the database as custom post types. To export them as theme files, follow these steps:
 
-- In the site editor, open the **More tools and options** menu.
-- Select the **Export** option to download a zip file containing the files. Unpack the files.
-- Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
-- Copy template part one and two from `theme/parts/` to your theme's `parts` folder.
-- Rename the template parts to `header.html` and `footer.html`, respectively.
-- Open `index.html` and update the template part slugs in the block markup.
+-   In the site editor, open the **More tools and options** menu.
+-   Select the **Export** option to download a zip file containing the files. Unpack the files.
+-   Copy the updated `index.html` file from `theme/templates/` to your theme's `templates` folder.
+-   Copy template part one and two from `theme/parts/` to your theme's `parts` folder.
+-   Rename the template parts to `header.html` and `footer.html`, respectively.
+-   Open `index.html` and update the template part slugs in the block markup.
 
 Saved templates have precedence over theme files. To use the updated theme files, go to **Appearance > Templates** and
 **Appearance > Template parts** and delete the saved templates.
@@ -287,11 +288,13 @@ Example markup:
 
 ```html
 <!-- wp:query -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-title /-->
-<!-- wp:post-date /-->
-<!-- wp:post-excerpt /-->
-<!-- /wp:post-template --></div>
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:post-title /-->
+	<!-- wp:post-date /-->
+	<!-- wp:post-excerpt /-->
+	<!-- /wp:post-template -->
+</div>
 <!-- /wp:query -->
 ```
 
@@ -299,19 +302,20 @@ The query pagination block can only be used inside the query loop. Place it insi
 
 ```html
 <!-- wp:query -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-title /-->
-<!-- wp:post-date /-->
-<!-- wp:post-excerpt /-->
-<!-- /wp:post-template -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:post-title /-->
+	<!-- wp:post-date /-->
+	<!-- wp:post-excerpt /-->
+	<!-- /wp:post-template -->
 
-<!-- wp:query-pagination -->
-<div class="wp-block-query-pagination">
-<!-- wp:query-pagination-previous /-->
-<!-- wp:query-pagination-numbers /-->
-<!-- wp:query-pagination-next /--></div>
-<!-- /wp:query-pagination -->
-
+	<!-- wp:query-pagination -->
+	<div class="wp-block-query-pagination">
+		<!-- wp:query-pagination-previous /-->
+		<!-- wp:query-pagination-numbers /-->
+		<!-- wp:query-pagination-next /-->
+	</div>
+	<!-- /wp:query-pagination -->
 </div>
 <!-- /wp:query -->
 ```
@@ -341,14 +345,14 @@ Add a group block that will work as a container for your post:
 
 Add your preferred blocks inside the group block. Some new blocks that are available are:
 
-- Post content: `<!-- wp:post-content /-->`
-- Post title: `<!-- wp:post-title /-->`
-- Post author: `<!-- wp:post-author /-->`
-- Post date: `<!-- wp:post-date /-->`
-- Post featured image: `<!-- wp:post-featured-image /-->`
-- Post tags: `<!-- wp:post-terms {"term":"post_tag"} /-->`
-- Post categories: `<!-- wp:post-terms {"term":"category"} /-->`
-- Next and previous post: `<!-- wp:post-navigation-link /--><!-- wp:post-navigation-link {"type":"previous"} /-->`
+-   Post content: `<!-- wp:post-content /-->`
+-   Post title: `<!-- wp:post-title /-->`
+-   Post author: `<!-- wp:post-author /-->`
+-   Post date: `<!-- wp:post-date /-->`
+-   Post featured image: `<!-- wp:post-featured-image /-->`
+-   Post tags: `<!-- wp:post-terms {"term":"post_tag"} /-->`
+-   Post categories: `<!-- wp:post-terms {"term":"category"} /-->`
+-   Next and previous post: `<!-- wp:post-navigation-link /--><!-- wp:post-navigation-link {"type":"previous"} /-->`
 
 Save the HTML file, or save and export the post template if you are working in the site editor.
 
@@ -382,34 +386,29 @@ Create a file called `theme.json` and save it inside the main theme folder.
 Start by adding two curly brackets to the file:
 
 ```json
-{
-
-}
+{}
 ```
 
 Add the version number for the theme.json format. For Gutenberg 10.6, the version number is 1:
 
 ```json
 {
-	"version": 1,
+	"version": 1
 }
 ```
 
 Next, add three main sections:
 
-- Settings -Where you will enable features and create presets for styles.
-- Styles -Where you apply styles to the website, elements, and blocks.
-- templateParts -For assigning template part files to template areas.
+-   Settings -Where you will enable features and create presets for styles.
+-   Styles -Where you apply styles to the website, elements, and blocks.
+-   templateParts -For assigning template part files to template areas.
 
 ```json
 {
 	"version": 1,
-	"settings": {
-	},
-	"styles": {
-	},
-	"templateParts": [
-	]
+	"settings": {},
+	"styles": {},
+	"templateParts": []
 }
 ```
 
@@ -421,8 +420,8 @@ For a list of features that can be enabled or disabled, see the [documentation f
 
 There are two different ways that a block can support a feature:
 
-- By displaying a control in the block settings sidebar.
-- By allowing defaults to be set using `theme.json`.
+-   By displaying a control in the block settings sidebar.
+-   By allowing defaults to be set using `theme.json`.
 
 <div class="callout callout-tip">
 It is not possible to add controls to a block that does not support them by using theme.json.
@@ -461,7 +460,7 @@ To enable link colors, add a `color` setting and set `link` to true:
 			"width": true
 		},
 		"color": {
-			"link": true,
+			"link": true
 		}
 	}
 }
@@ -514,8 +513,6 @@ If you want to disable gradients, which are enabled by default, set `gradient` t
 }
 ```
 
-
-
 ### Content width and theme support for wide and full-width blocks
 
 The `layout` setting enables width settings for group blocks and template parts
@@ -526,8 +523,8 @@ block alignments or widths. You can also set more precise widths to blocks insid
 
 The keys used by `layout` are:
 
-- `contentSize` Default width for the blocks.
-- `wideSize` Wide width.
+-   `contentSize` Default width for the blocks.
+-   `wideSize` Wide width.
 
 The example uses pixels, but you can use any valid CSS value and unit.
 (The code example is truncated to illustrate where to add the option.)
@@ -552,9 +549,9 @@ You can add multiple color palettes: a default palette for all blocks, and color
 
 The keys used by `palette` are:
 
-- `slug` A unique identifier for the color.
-- `color` The hex color value.
-- `name` The visible name in the editor. Optional.
+-   `slug` A unique identifier for the color.
+-   `color` The hex color value.
+-   `name` The visible name in the editor. Optional.
 
 Multiple colors are added as an array using square brackets: `[]`.
 Add a default color palette inside `settings`, under `color`:
@@ -636,9 +633,9 @@ To add custom font sizes, create a new section called `typography` under `settin
 
 The keys used by `fontSizes` are:
 
-- `slug` A unique identifier for the size.
-- `size` The size value. This can be unitless or use any valid CSS value.
-- `name` The visible name in the editor.
+-   `slug` A unique identifier for the size.
+-   `size` The size value. This can be unitless or use any valid CSS value.
+-   `name` The visible name in the editor.
 
 ```json
 "typography": {
@@ -783,9 +780,7 @@ Since the theme has custom padding enabled, you can add `padding` within the `sp
 ### Template parts
 
 In the templeParts section, assign the two template parts that you created to their template areas.
-Add two keys:
--`name`, the file name of the template part file without the file extension,
--`area`, the name of the template area.
+Add two keys: -`name`, the file name of the template part file without the file extension, -`area`, the name of the template area.
 
 There are three template areas to choose from: Header, footer, and general.
 
@@ -848,8 +843,6 @@ The key is `postTypes`, followed by the name of the post type:
 ## Example themes
 
 You can find a basic starter theme called "emptytheme" and other example themes
-on the [Experimental themes GitHub repository](https://github.com/WordPress/theme-experiments).
-When using a theme as reference, take note of which Gutenberg version the theme is built for,
-because the experimental features are updated frequently.
+on the [Theme Experiments GitHub repository](https://github.com/WordPress/theme-experiments). When using a theme as reference, take note of which Gutenberg version the theme is built for, because the experimental features are updated frequently.
 
 The theme directory lists block themes under the tag [full site editing](https://wordpress.org/themes/tags/full-site-editing/).

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -4,7 +4,7 @@ The purpose of this tutorial is to show how to create a block theme and help the
 
 You will learn about the required files, how to combine templates and template parts, how to add presets for global styles, and how to add blocks and export the templates in the site editor.
 
-Block themes are releasing in WordPress 5.9 as part of the full site editing project, previously required Gutenberg plugin 11.0+ or newer.
+Block themes require WordPress 5.9. To use block themes in earlier versions of WordPress requires the Gutenberg plugin version 11.0 or newer.
 
 ## Table of Contents
 

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -146,7 +146,6 @@ There are several ways to create templates and template parts:
 -   Using the site editor.
 -   Using the template editing mode in the block editor.
 
-The fourth way is temporary and involves going to the Appearance menu > Templates, and is not recommended because of its limitations.
 
 ### Manual template creation
 

--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -4,7 +4,7 @@ The purpose of this tutorial is to show how to create a block theme and help the
 
 You will learn about the required files, how to combine templates and template parts, how to add presets for global styles, and how to add blocks and export the templates in the site editor.
 
-Block themes are releasing in WordPress 5.9 as part of the full site editing project.
+Block themes are releasing in WordPress 5.9 as part of the full site editing project, previously required Gutenberg plugin 11.0+ or newer.
 
 ## Table of Contents
 
@@ -388,11 +388,11 @@ Start by adding two curly brackets to the file:
 {}
 ```
 
-Add the version number for the theme.json format. For Gutenberg 10.6, the version number is 1:
+Add the version number for the theme.json format. For WordPress 5.9, the version number is 2:
 
 ```json
 {
-	"version": 1
+	"version": 2
 }
 ```
 
@@ -404,7 +404,7 @@ Next, add three main sections:
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {},
 	"styles": {},
 	"templateParts": []
@@ -434,7 +434,7 @@ To enable border styles, add a `border` object under `settings` with the followi
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		"border": {
 			"color": true,
@@ -450,7 +450,7 @@ To enable link colors, add a `color` setting and set `link` to true:
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		"border": {
 			"color": true,
@@ -469,7 +469,7 @@ To enable padding, margin and custom spacing units, include a setting for spacin
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		"border": {
 			"color": true,
@@ -495,7 +495,7 @@ If you want to disable gradients, which are enabled by default, set `gradient` t
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		"border": {
 			"color": true,
@@ -530,7 +530,7 @@ The example uses pixels, but you can use any valid CSS value and unit.
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		...
 		"layout": {
@@ -557,7 +557,7 @@ Add a default color palette inside `settings`, under `color`:
 
 ```json
 {
-	"version": 1,
+	"version": 2,
 	"settings": {
 		...
 		"color": {
@@ -779,7 +779,7 @@ Since the theme has custom padding enabled, you can add `padding` within the `sp
 ### Template parts
 
 In the templeParts section, assign the two template parts that you created to their template areas.
-Add two keys: -`name`, the file name of the template part file without the file extension, -`area`, the name of the template area.
+Add three keys: -`name`, the file name of the template part file without the file extension, -`area`, the name of the template area, and `title` the visible name in the editor.
 
 There are three template areas to choose from: Header, footer, and general.
 
@@ -787,11 +787,13 @@ There are three template areas to choose from: Header, footer, and general.
 "templateParts": [
 	{
 		"name": "header",
-		"area": "header"
+		"area": "header",
+		"title": "Header"
 	},
 	{
 		"name": "footer",
-		"area": "footer"
+		"area": "footer",
+		"title": "Footer"
 	}
 ]
 ```


### PR DESCRIPTION

## Description

With the upcoming release of WordPress 5.9, update the documentation to no
longer refer to the features as experimental but as released in WP 5.9 version.


## How has this been tested?

Search /docs for "experimental" and update instances for full site editing,
rewording them to refer to WordPress 5.9 release.

Confirm wording makes sense and accurate.

## Types of changes

Documentation.

