### PR TITLE
WP59: Contextualize "Export" string to differentiate it from other occurrences in WP Core

### DIFF
--- a/packages/edit-site/src/plugins/site-export.js
+++ b/packages/edit-site/src/plugins/site-export.js
@@ -6,7 +6,7 @@ import downloadjs from 'downloadjs';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { MenuItem } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
 import { download } from '@wordpress/icons';
@@ -46,7 +46,7 @@ export default function SiteExport() {
 			onClick={ handleExport }
 			info={ __( 'Download your templates and template parts.' ) }
 		>
-			{ __( 'Export' ) }
+			{ _x( 'Export', 'site exporter menu item' ) }
 		</MenuItem>
 	);
 }


### PR DESCRIPTION
## Description

This change aims to differentiate the Site export menuitem from other occurrences of the string in WP Core, because in Core it's not used in the same context. So it several languages, having the same string for both occurrences may lead to inappropriate translations.

See this report from zh_TW locale: https://wordpress.org/support/topic/wordpress-5-9-beta-4-i18n-issue-string-export/
The same goes at least for fr_FR.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
