### PR TITLE
Cover: Add layout support

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -86,7 +86,8 @@
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
 			"text": false,
 			"background": false
-		}
+		},
+		"__experimentalLayout": true
 	},
 	"editorStyle": "wp-block-cover-editor",
 	"style": "wp-block-cover"

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -328,6 +328,7 @@ function CoverEdit( {
 		alt,
 		allowedBlocks,
 		templateLock,
+		layout = {},
 	} = attributes;
 	const {
 		gradientClass,
@@ -618,6 +619,12 @@ function CoverEdit( {
 		fontSize: hasFontSizes ? 'large' : undefined,
 	} );
 
+	const themeSupportsLayout = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings()?.supportsLayout;
+	}, [] );
+	const defaultLayout = useSetting( 'layout' ) || {};
+	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-cover__inner-container',
@@ -627,6 +634,7 @@ function CoverEdit( {
 			templateInsertUpdatesSelection: true,
 			allowedBlocks,
 			templateLock,
+			__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 		}
 	);
 


### PR DESCRIPTION
## Description
PR adds experimental layout support to the Cover block.

Resolves #37036.
Similar to #29982 and #30077.

## How has this been tested?
1. Use TT2 or emptytheme
2. Add the Cover block with inner blocks to the post (you can use a snippet from the issue)
3. Try "Inherit default layout" and define the custom layout.
4. Check that editor and fronted work properly.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/240569/147749149-fc9e664f-b2de-40f6-93a0-2206a3749217.mp4


## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
