### PR TITLE
[Block Library - Query Loop]: Add block settings menu item to reset(remove the Innerblocks)

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -29,13 +29,14 @@ import { getFirstQueryClientIdFromBlocks } from '../utils';
 
 const TEMPLATE = [ [ 'core/post-template' ] ];
 
-function ResetQueryLoopMenuItem( { clientId } ) {
-	const selectedBlockClientId = useSelect(
-		( select ) => select( blockEditorStore ).getSelectedBlockClientId(),
-		[]
+function ResetQueryLoopMenuItem( { clientId, isSelected } ) {
+	const rootClientId = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockRootClientId( clientId ),
+		[ clientId ]
 	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
-	if ( selectedBlockClientId !== clientId ) {
+	if ( ! isSelected || rootClientId ) {
 		return null;
 	}
 	return (
@@ -55,7 +56,12 @@ function ResetQueryLoopMenuItem( { clientId } ) {
 	);
 }
 
-export function QueryContent( { attributes, setAttributes, clientId } ) {
+export function QueryContent( {
+	attributes,
+	setAttributes,
+	clientId,
+	isSelected,
+} ) {
 	const {
 		queryId,
 		query,
@@ -132,7 +138,10 @@ export function QueryContent( { attributes, setAttributes, clientId } ) {
 					setDisplayLayout={ updateDisplayLayout }
 				/>
 			</BlockControls>
-			<ResetQueryLoopMenuItem clientId={ clientId } />
+			<ResetQueryLoopMenuItem
+				clientId={ clientId }
+				isSelected={ isSelected }
+			/>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -13,8 +13,9 @@ import {
 	store as blockEditorStore,
 	useInnerBlocksProps,
 	__experimentalBlockPatternSetup as BlockPatternSetup,
+	BlockSettingsMenuControls,
 } from '@wordpress/block-editor';
-import { SelectControl } from '@wordpress/components';
+import { SelectControl, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,7 +28,34 @@ import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 import { getFirstQueryClientIdFromBlocks } from '../utils';
 
 const TEMPLATE = [ [ 'core/post-template' ] ];
-export function QueryContent( { attributes, setAttributes } ) {
+
+function ResetQueryLoopMenuItem( { clientId } ) {
+	const selectedBlockClientId = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockClientId(),
+		[]
+	);
+	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
+	if ( selectedBlockClientId !== clientId ) {
+		return null;
+	}
+	return (
+		<BlockSettingsMenuControls>
+			{ ( { onClose } ) => (
+				<MenuItem
+					onClick={ () => {
+						replaceInnerBlocks( clientId, [] );
+						onClose();
+					} }
+					info={ __( 'Remove all innerblocks and start fresh' ) }
+				>
+					{ __( 'Reset Query Loop' ) }
+				</MenuItem>
+			) }
+		</BlockSettingsMenuControls>
+	);
+}
+
+export function QueryContent( { attributes, setAttributes, clientId } ) {
 	const {
 		queryId,
 		query,
@@ -104,6 +132,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 					setDisplayLayout={ updateDisplayLayout }
 				/>
 			</BlockControls>
+			<ResetQueryLoopMenuItem clientId={ clientId } />
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -30,13 +30,8 @@ import { getFirstQueryClientIdFromBlocks } from '../utils';
 const TEMPLATE = [ [ 'core/post-template' ] ];
 
 function ResetQueryLoopMenuItem( { clientId, isSelected } ) {
-	const rootClientId = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockRootClientId( clientId ),
-		[ clientId ]
-	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
-	if ( ! isSelected || rootClientId ) {
+	if ( ! isSelected ) {
 		return null;
 	}
 	return (


### PR DESCRIPTION

Related: https://github.com/WordPress/gutenberg/issues/30925


When we insert a `Query Loop` block a user can select from a variety of available patterns or its block variations. The need for being able to go back to this selection state after having selected something, has been expressed quite some times.

Currently the way to do this is to remove the existing block(s) and start fresh. This PR adds an extra menu item in block settings toolbar in `Query Loop`, so you can do it with an easier way.

Here is the catch though.. Query Patterns are just block patterns which means they can contain any number of blocks and a common thing seems to be to wrap a `Query Loop` block with a `Group` block or even have multiple `Query Loop` blocks.

When we insert any pattern in content they become blocks and there is no way currently to identify that they were part of a pattern. So this menu item here, might be confusing depending on the selected pattern... 

In the below video I showcase the menu item for patterns without a wrapper and at the end with a `Group` wrapper to illustrate my above point.


https://user-images.githubusercontent.com/16275880/147767361-f8898937-6d04-4d96-af56-96b493e42d52.mov



I don't think this is an approach we will follow, but made this quick prototype to gather some feedback.

What do you think?