### PR TITLE
Load the entities list using the view context

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -205,7 +205,7 @@ export const prePersistPostType = ( persistedRecord, edits ) => {
  * @return {Promise} Entities promise
  */
 async function loadPostTypeEntities() {
-	const postTypes = await apiFetch( { path: '/wp/v2/types?context=edit' } );
+	const postTypes = await apiFetch( { path: '/wp/v2/types?context=view' } );
 	return map( postTypes, ( postType, name ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
@@ -216,7 +216,7 @@ async function loadPostTypeEntities() {
 			baseURL: `/${ namespace }/${ postType.rest_base }`,
 			baseURLParams: { context: 'edit' },
 			name,
-			label: postType.labels.singular_name,
+			label: postType.name,
 			transientEdits: {
 				blocks: true,
 				selection: true,
@@ -240,7 +240,7 @@ async function loadPostTypeEntities() {
  */
 async function loadTaxonomyEntities() {
 	const taxonomies = await apiFetch( {
-		path: '/wp/v2/taxonomies?context=edit',
+		path: '/wp/v2/taxonomies?context=view',
 	} );
 	return map( taxonomies, ( taxonomy, name ) => {
 		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
@@ -249,7 +249,7 @@ async function loadTaxonomyEntities() {
 			baseURL: `/${ namespace }/${ taxonomy.rest_base }`,
 			baseURLParams: { context: 'edit' },
 			name,
-			label: taxonomy.labels.singular_name,
+			label: taxonomy.name,
 		};
 	} );
 }


### PR DESCRIPTION
See #37489 

Some users have access to "view" entities but not to "edit" theme. These users should be able to use the "core-data" package to fetch these entities. This is not possible sometimes in trunk because the way we "discover" entities is by making an "edit" context request to the `/types` endpoint. 

I think it makes more sense to use the "view" context to discover entities instead. That said, right now we rely on the "singular" label that is not returned in the "view" context. We have a number of options:

 - Accept that we use the "plural" one in some parts of the UI (not ideal)
 - Add the `singular label` (we already have the "name", we could add a "singlularName") or the entirely "labels" property to the returned value of the "view" context. Not sure if the REST team discussed this.

In this current PR, I'm trying the first approach to check the results.