### PR TITLE
Docs: Fix type of saved $content

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -115,7 +115,7 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
  * Renders the `core/home-link` block.
  *
  * @param array    $attributes The block attributes.
- * @param array    $content    The saved content.
+ * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
  *
  * @return string Returns the post content with the home url added.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -117,7 +117,7 @@ function block_core_navigation_link_render_submenu_icon() {
  * Renders the `core/navigation-link` block.
  *
  * @param array    $attributes The block attributes.
- * @param array    $content    The saved content.
+ * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -352,7 +352,7 @@ function block_core_navigation_get_fallback_blocks() {
  * Renders the `core/navigation` block on server.
  *
  * @param array    $attributes The block attributes.
- * @param array    $content    The saved content.
+ * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
  *
  * @return string Returns the post content with the legacy widget added.

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -231,7 +231,7 @@ function block_core_page_list_nest_pages( $current_level, $children ) {
  * Renders the `core/page-list` block on server.
  *
  * @param array    $attributes The block attributes.
- * @param array    $content    The saved content.
+ * @param string   $content    The saved content.
  * @param WP_Block $block      The parsed block.
  *
  * @return string Returns the page list markup.


### PR DESCRIPTION
## Description
Fixes type of $content to `string`, it is not an `array`.