### PR TITLE
Update copyright year to 2022 in `license.md`.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## Gutenberg
 
-    Copyright 2016-2021 by the contributors
+    Copyright 2016-2022 by the contributors
 
 **License for Contributions (on and after April 15, 2021)**
 


### PR DESCRIPTION
## Description
Updates the license copyright to 2022

Related: https://github.com/WordPress/wordpress-develop/commit/19ce57fc10d54a4196da2fe74bba0c9d803c9850