### PR TITLE
Navigation: Set the default for --navigation-layout-align to "flex-start" when using vertical orientation

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -116,6 +116,7 @@ $navigation-icon-size: 24px;
 
 	&.is-vertical {
 		--navigation-layout-direction: column;
+		--navigation-layout-justify: initial;
 		--navigation-layout-align: flex-start;
 	}
 

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -112,7 +112,7 @@ $navigation-icon-size: 24px;
 	--navigation-layout-direction: row;
 	--navigation-layout-wrap: wrap;
 	--navigation-layout-justify: flex-start;
-	--navigation-layout-align: center;
+	--navigation-layout-align: left;
 
 	&.is-vertical {
 		--navigation-layout-direction: column;

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -112,11 +112,11 @@ $navigation-icon-size: 24px;
 	--navigation-layout-direction: row;
 	--navigation-layout-wrap: wrap;
 	--navigation-layout-justify: flex-start;
-	--navigation-layout-align: left;
+	--navigation-layout-align: center;
 
 	&.is-vertical {
 		--navigation-layout-direction: column;
-		--navigation-layout-justify: initial;
+		--navigation-layout-align: flex-start;
 	}
 
 	&.no-wrap {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37695

When vertical orientation is active, `--navigation-layout-align` should be set to `flex-start`, so that items appear left-aligned as expected. 

## Screenshots

Before: 
![alignment](https://user-images.githubusercontent.com/1202812/147977179-c3e7205b-2bbc-4619-838b-b2a2e8ee349c.gif)


After: 
![alignment-new](https://user-images.githubusercontent.com/1202812/147977186-9e422401-fcba-4204-86b3-8cb481dc8b6a.gif)

