### PR TITLE
Suggest picking a category on the pre-publish panel

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { some } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { PanelBody } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import HierarchicalTermSelector from '../post-taxonomies/hierarchical-term-selector';
+import { store as editorStore } from '../../store';
+
+function MaybeCategoryPanel() {
+	const hasNoCategory = useSelect( ( select ) => {
+		const postType = select( editorStore ).getCurrentPostType();
+		const categoriesTaxonomy = select( coreStore ).getTaxonomy(
+			'category'
+		);
+		const defaultCategorySlug = 'uncategorized';
+		const defaultCategory = select( coreStore ).getEntityRecords(
+			'taxonomy',
+			'category',
+			{
+				slug: defaultCategorySlug,
+			}
+		)?.[ 0 ];
+
+		const categories =
+			categoriesTaxonomy &&
+			select( editorStore ).getEditedPostAttribute(
+				categoriesTaxonomy.rest_base
+			);
+
+		return (
+			categoriesTaxonomy !== undefined &&
+			defaultCategory &&
+			some( categoriesTaxonomy.types, ( type ) => type === postType ) &&
+			( categories?.length === 0 ||
+				( categories?.length === 1 &&
+					defaultCategory.id === categories[ 0 ] ) )
+		);
+	}, [] );
+	const [ shouldShowPanel, setShouldShowPanel ] = useState( false );
+	useEffect( () => {
+		// We use state to avoid hiding the panel if the user edits the categories
+		// and adds one within the panel itself (while visible).
+		if ( hasNoCategory ) {
+			setShouldShowPanel( true );
+		}
+	}, [ hasNoCategory ] );
+
+	if ( ! shouldShowPanel ) {
+		return null;
+	}
+
+	const panelBodyTitle = [
+		__( 'Suggestion:' ),
+		<span className="editor-post-publish-panel__link" key="label">
+			{ __( 'Assign a category' ) }
+		</span>,
+	];
+
+	return (
+		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
+			<HierarchicalTermSelector slug="category" />
+		</PanelBody>
+	);
+}
+
+export default MaybeCategoryPanel;

--- a/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-category-panel.js
@@ -32,17 +32,22 @@ function MaybeCategoryPanel() {
 				slug: defaultCategorySlug,
 			}
 		)?.[ 0 ];
-
+		const postTypeSupportsCategories =
+			categoriesTaxonomy &&
+			some( categoriesTaxonomy.types, ( type ) => type === postType );
 		const categories =
 			categoriesTaxonomy &&
 			select( editorStore ).getEditedPostAttribute(
 				categoriesTaxonomy.rest_base
 			);
 
+		// This boolean should return true if everything is loaded
+		// ( categoriesTaxonomy, defaultCategory )
+		// and the post has not been assigned a category different than "uncategorized".
 		return (
-			categoriesTaxonomy !== undefined &&
-			defaultCategory &&
-			some( categoriesTaxonomy.types, ( type ) => type === postType ) &&
+			!! categoriesTaxonomy &&
+			!! defaultCategory &&
+			postTypeSupportsCategories &&
 			( categories?.length === 0 ||
 				( categories?.length === 1 &&
 					defaultCategory.id === categories[ 0 ] ) )
@@ -70,6 +75,11 @@ function MaybeCategoryPanel() {
 
 	return (
 		<PanelBody initialOpen={ false } title={ panelBodyTitle }>
+			<p>
+				{ __(
+					'Categories provide a helpful way to group related posts together and to quickly tell readers what a post is about.'
+				) }
+			</p>
 			<HierarchicalTermSelector slug="category" />
 		</PanelBody>
 	);

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -24,6 +24,7 @@ import PostScheduleLabel from '../post-schedule/label';
 import MaybeTagsPanel from './maybe-tags-panel';
 import MaybePostFormatPanel from './maybe-post-format-panel';
 import { store as editorStore } from '../../store';
+import MaybeCategoryPanel from './maybe-category-panel';
 
 function PostPublishPanelPrepublish( { children } ) {
 	const {
@@ -145,6 +146,7 @@ function PostPublishPanelPrepublish( { children } ) {
 			) }
 			<MaybePostFormatPanel />
 			<MaybeTagsPanel />
+			<MaybeCategoryPanel />
 			{ children }
 		</div>
 	);


### PR DESCRIPTION
Before publishing a post, if it has no assigned category or has the "uncategorized" one, this PR shows a new suggestion on the panel to pick a category before publishing.

<img width="284" alt="Screen Shot 2022-01-04 at 10 11 57 AM" src="https://user-images.githubusercontent.com/272444/148035999-cf8edb2d-4f1f-4e69-9399-15e50df6d3cc.png">
