### PR TITLE
Tidy up Post Comments default styling

### DIFF
--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -14,9 +14,9 @@
 			padding-left: 3.25em;
 
 			p {
-				font-size: 0.875em;
+				font-size: 1em;
 				line-height: 1.8;
-				margin: 0.36em 0 1.4em;
+				margin: 1em 0;
 			}
 		}
 
@@ -35,6 +35,7 @@
 			display: block;
 			float: left;
 			height: 2.5em;
+			margin-top: 0.5em;
 			margin-right: 0.75em;
 			width: 2.5em;
 		}
@@ -45,12 +46,17 @@
 	}
 
 	.comment-meta {
+		font-size: 0.875em;
 		line-height: 1.5;
 		margin-left: -3.25em;
+
+		b {
+			font-weight: normal;
+		}
 	}
 
 	.comment-body .commentmetadata {
-		font-size: 0.75em;
+		font-size: 0.875em;
 	}
 
 	.comment-form-comment,
@@ -82,7 +88,7 @@
 	}
 
 	.reply {
-		font-size: 0.75em;
+		font-size: 0.875em;
 		margin-bottom: 1.4em;
 	}
 


### PR DESCRIPTION
With the change that resolved https://github.com/WordPress/gutenberg/issues/37464, we lost some of the comments form refinement that was introduced in https://github.com/WordPress/gutenberg/pull/30382. It looks a bit messy at the moment. This PR takes a quick stab at tidying things up again. 

- It scales down the post meta font size so that it's smaller than the comment content. This seems like a more natural hierarchy to me. 
- It un-bolds the comment author name. I don't think this should be bold by default, since that may not work with all themes, and it's not changeable in the UI at this point. Having it be a normal weight feels like a less opinionated move.
- It brings the author avatar back in alignment with the post meta. 
- It uses just two font sizes instead of three.
- It re-adjusts the paragraph spacing to be more even. 

In the long term, this should go away in favor of the comments query loop. But fixing this would be helpful in the meantime. 

Before|After
---|---
<img width="633" alt="Screen Shot 2022-01-04 at 2 38 36 PM" src="https://user-images.githubusercontent.com/1202812/148114562-5592d709-5df4-45c1-8c33-55f0e3b2c3f8.png">|<img width="657" alt="Screen Shot 2022-01-04 at 2 34 35 PM" src="https://user-images.githubusercontent.com/1202812/148114566-a491c009-56be-40f5-9dd0-74e9fa753928.png">

