### PR TITLE
[Block Library - Query Loop]: Use `gap` for the `grid` view

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -11,32 +11,21 @@
 	list-style: none;
 	padding: 0;
 
-	li {
-		clear: both;
-	}
-
 	&.is-flex-container {
 		flex-direction: row;
 		display: flex;
 		flex-wrap: wrap;
+		gap: 1.25em;
 
 		li {
-			margin: 0 0 1.25em 0;
+			margin: 0;
 			width: 100%;
 		}
 
 		@include break-small {
-			li {
-				margin-right: 1.25em;
-			}
-
 			@for $i from 2 through 6 {
 				&.is-flex-container.columns-#{ $i } > li {
 					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
-
-					&:nth-child( #{ $i }n ) {
-						margin-right: 0;
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37681

Recently @andrewserong [introduced](https://github.com/WordPress/gutenberg/pull/36431)  React's `memo` in `Post Template` block to avoid flickering when switching active block contexts. This added an extra `li` element which affected the css rule we had, as @iidastudio explained in the issue:

>When one list in the post-template is selected, the list (.block-editor-block-preview__live-content) becomes display:none, but it exists in the code. (At the same time, a .block-editor-block-list__layout is created.)
So the unintended list becomes :nth-child(3n) and margin-right:0 is applied.

So in this PR, I removed the `margins` and used `gap` to achieve the same effect.

## Testing instructions
Everything should work as expected properly and no regression should be noticed 😄 

In general we need to revisit this adhoc `layout` implementation here and use the `layout` abstraction. 