### PR TITLE
Template Mode: Trim long post titles in large viewports

### DIFF
--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -41,7 +41,7 @@
 		}
 
 		@include break-xlarge() {
-			max-width: none;
+			max-width: 400px;
 		}
 	}
 }


### PR DESCRIPTION
## Description
PR fixes the issue when the header doesn't trim long titles in large viewports. The `max-width: none` stopped `overflow` and `text-overflow` from applying.

Resolves #37719.

## How has this been tested?
1. Add or edit the post.
2. Change the title to something very long - _A new post with a long title and content in WordPress with embed blocks and videos in an attractive way where we can elegantly get everything. Do you need even more length of the site title?_
3. Switch to Template Editing Mode.
4. Check that title is correctly trimmed.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-05 at 12 06 20](https://user-images.githubusercontent.com/240569/148182314-3f2f9224-54d9-4aba-9a07-655399e1c165.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
