### PR TITLE
Inserter: Update categories for theme blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -544,7 +544,7 @@ Displays the next or previous post link that is adjacent to the current post.
 Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more.
 
 -	**Name:** core/post-template
--	**Category:** design
+-	**Category:** theme
 -	**Supports:** align, ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
@@ -598,7 +598,7 @@ An advanced block that allows displaying post types based on different query par
 Displays a paginated navigation to next/previous set of posts, when applicable.
 
 -	**Name:** core/query-pagination
--	**Category:** design
+-	**Category:** theme
 -	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow
 
@@ -607,7 +607,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable.
 Displays the next posts page link.
 
 -	**Name:** core/query-pagination-next
--	**Category:** design
+-	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
@@ -616,7 +616,7 @@ Displays the next posts page link.
 Displays a list of page numbers for pagination
 
 -	**Name:** core/query-pagination-numbers
--	**Category:** design
+-	**Category:** theme
 -	**Supports:** ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
@@ -625,7 +625,7 @@ Displays a list of page numbers for pagination
 Displays the previous posts page link.
 
 -	**Name:** core/query-pagination-previous
--	**Category:** design
+-	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "core/post-template",
 	"title": "Post Template",
-	"category": "design",
+	"category": "theme",
 	"parent": [ "core/query" ],
 	"description": "Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more.",
 	"textdomain": "default",

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "core/query-pagination-next",
 	"title": "Next Page",
-	"category": "design",
+	"category": "theme",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the next posts page link.",
 	"textdomain": "default",

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "core/query-pagination-numbers",
 	"title": "Page Numbers",
-	"category": "design",
+	"category": "theme",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays a list of page numbers for pagination",
 	"textdomain": "default",

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "core/query-pagination-previous",
 	"title": "Previous Page",
-	"category": "design",
+	"category": "theme",
 	"parent": [ "core/query-pagination" ],
 	"description": "Displays the previous posts page link.",
 	"textdomain": "default",

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -3,7 +3,7 @@
 	"apiVersion": 2,
 	"name": "core/query-pagination",
 	"title": "Pagination",
-	"category": "design",
+	"category": "theme",
 	"parent": [ "core/query" ],
 	"description": "Displays a paginated navigation to next/previous set of posts, when applicable.",
 	"textdomain": "default",


### PR DESCRIPTION
## Description
Similar to #32568.

PR moves remaining blocks from the "design" to the "theme" category.

* Post Template
* Pagination
* Next Page
* Page Numbers
* Previous Page

Resolves #37721.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
