### PR TITLE
Elements: Add styles to the footer before the block is rendered

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -51,16 +51,6 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 
 	$class_name = gutenberg_get_elements_class_name( $block );
 
-	if ( strpos( $link_color, 'var:preset|color|' ) !== false ) {
-		// Get the name from the string and add proper styles.
-		$index_to_splice = strrpos( $link_color, '|' ) + 1;
-		$link_color_name = substr( $link_color, $index_to_splice );
-		$link_color      = "var(--wp--preset--color--$link_color_name)";
-	}
-	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
-
-	$style = ".$class_name a{" . $link_color_declaration . ';}';
-
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
 	// Retrieve the opening tag of the first HTML element.
 	$html_element_matches = array();
@@ -80,8 +70,6 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		$first_element_offset = $html_element_matches[0][1];
 		$content              = substr_replace( $block_content, ' class="' . $class_name . '"', $first_element_offset + strlen( $first_element ) - 1, 0 );
 	}
-
-	gutenberg_enqueue_block_support_styles( $style );
 
 	return $content;
 }
@@ -124,17 +112,9 @@ function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 	}
 	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
 
-	$style = "<style>.$class_name a{" . $link_color_declaration . ";}</style>\n";
+	$style = ".$class_name a{" . $link_color_declaration . ';}';
 
-	// Ideally styles should be loaded in the head, but blocks may be parsed
-	// after that, so loading in the footer for now.
-	// See https://core.trac.wordpress.org/ticket/53494.
-	add_action(
-		'wp_footer',
-		function () use ( $style ) {
-			echo $style;
-		}
-	);
+	gutenberg_enqueue_block_support_styles( $style );
 }
 
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -6,14 +6,23 @@
  */
 
 /**
- * Render the elements stylesheet.
+ * Get the elements class names.
+ *
+ * @param  array  $block         Block object.
+ * @return string                The unique class name.
+ */
+function gutenberg_get_elements_class_name ( $block ) {
+	return 'wp-elements-' . md5( serialize( $block ) );
+}
+
+/**
+ * Update the block content with elements class names.
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.
  * @return string                Filtered block content.
  */
 function gutenberg_render_elements_support( $block_content, $block ) {
-
 	if ( ! $block_content ) {
 		return $block_content;
 	}
@@ -40,17 +49,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 		return $block_content;
 	}
 
-	$class_name = wp_unique_id( 'wp-elements-' );
-
-	if ( strpos( $link_color, 'var:preset|color|' ) !== false ) {
-		// Get the name from the string and add proper styles.
-		$index_to_splice = strrpos( $link_color, '|' ) + 1;
-		$link_color_name = substr( $link_color, $index_to_splice );
-		$link_color      = "var(--wp--preset--color--$link_color_name)";
-	}
-	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
-
-	$style = ".$class_name a{" . $link_color_declaration . ';}';
+	$class_name = gutenberg_get_elements_class_name( $block );
 
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
 	// Retrieve the opening tag of the first HTML element.
@@ -77,6 +76,52 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 	return $content;
 }
 
+/**
+ * Render the elements stylesheet.
+ *
+ * @param string|null   $pre_render   The pre-rendered content. Default null.
+ * @param array         $parsed_block The block being rendered.
+ */
+function gutenberg_render_elements_support_footer( $pre_render, $block ) {
+	$link_color = null;
+	if ( ! empty( $block['attrs'] ) ) {
+		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );
+	}
+
+	/*
+	* For now we only care about link color.
+	* This code in the future when we have a public API
+	* should take advantage of WP_Theme_JSON_Gutenberg::compute_style_properties
+	* and work for any element and style.
+	*/
+	if ( null === $link_color ) {
+		return;
+	}
+
+	$class_name = gutenberg_get_elements_class_name( $block );
+
+	if ( strpos( $link_color, 'var:preset|color|' ) !== false ) {
+		// Get the name from the string and add proper styles.
+		$index_to_splice = strrpos( $link_color, '|' ) + 1;
+		$link_color_name = substr( $link_color, $index_to_splice );
+		$link_color      = "var(--wp--preset--color--$link_color_name)";
+	}
+	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
+
+	$style = "<style>.$class_name a{" . $link_color_declaration . ";}</style>\n";
+
+	// Ideally styles should be loaded in the head, but blocks may be parsed
+	// after that, so loading in the footer for now.
+	// See https://core.trac.wordpress.org/ticket/53494.
+	add_action(
+		'wp_footer',
+		function () use ( $style ) {
+			echo $style;
+		}
+	);
+}
+
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.
 remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_elements_support', 10, 2 );
+add_filter( 'pre_render_block', 'gutenberg_render_elements_support_footer', 10, 2 );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -79,8 +79,14 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 /**
  * Render the elements stylesheet.
  *
+ * In the case of nested blocks we want the parent element styles to be rendered before their descendants.
+ * This solves the issue of an element (e.g.: link color) being styled in both the parent and a descendant:
+ * we want the descendant style to take priority, and this is done by loading it after, in DOM order.
+ *
  * @param string|null   $pre_render   The pre-rendered content. Default null.
  * @param array         $parsed_block The block being rendered.
+ *
+ * @return null
  */
 function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 	$link_color = null;
@@ -95,7 +101,7 @@ function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 	* and work for any element and style.
 	*/
 	if ( null === $link_color ) {
-		return;
+		return null;
 	}
 
 	$class_name = gutenberg_get_elements_class_name( $block );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -8,10 +8,10 @@
 /**
  * Get the elements class names.
  *
- * @param  array  $block         Block object.
- * @return string                The unique class name.
+ * @param array $block Block object.
+ * @return string      The unique class name.
  */
-function gutenberg_get_elements_class_name ( $block ) {
+function gutenberg_get_elements_class_name( $block ) {
 	return 'wp-elements-' . md5( serialize( $block ) );
 }
 
@@ -83,8 +83,8 @@ function gutenberg_render_elements_support( $block_content, $block ) {
  * This solves the issue of an element (e.g.: link color) being styled in both the parent and a descendant:
  * we want the descendant style to take priority, and this is done by loading it after, in DOM order.
  *
- * @param string|null   $pre_render   The pre-rendered content. Default null.
- * @param array         $parsed_block The block being rendered.
+ * @param string|null $pre_render   The pre-rendered content. Default null.
+ * @param array       $block The block being rendered.
  *
  * @return null
  */

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -51,6 +51,16 @@ function gutenberg_render_elements_support( $block_content, $block ) {
 
 	$class_name = gutenberg_get_elements_class_name( $block );
 
+	if ( strpos( $link_color, 'var:preset|color|' ) !== false ) {
+		// Get the name from the string and add proper styles.
+		$index_to_splice = strrpos( $link_color, '|' ) + 1;
+		$link_color_name = substr( $link_color, $index_to_splice );
+		$link_color      = "var(--wp--preset--color--$link_color_name)";
+	}
+	$link_color_declaration = esc_html( safecss_filter_attr( "color: $link_color" ) );
+
+	$style = ".$class_name a{" . $link_color_declaration . ';}';
+
 	// Like the layout hook this assumes the hook only applies to blocks with a single wrapper.
 	// Retrieve the opening tag of the first HTML element.
 	$html_element_matches = array();

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -115,6 +115,7 @@ function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 	$style = ".$class_name a{" . $link_color_declaration . ';}';
 
 	gutenberg_enqueue_block_support_styles( $style );
+	return $style;
 }
 
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -115,7 +115,8 @@ function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 	$style = ".$class_name a{" . $link_color_declaration . ';}';
 
 	gutenberg_enqueue_block_support_styles( $style );
-	return $style;
+
+	return null;
 }
 
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -86,7 +86,7 @@ function gutenberg_render_elements_support( $block_content, $block ) {
  *
  * @return null
  */
-function gutenberg_render_elements_support_footer( $pre_render, $block ) {
+function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );
@@ -122,4 +122,4 @@ function gutenberg_render_elements_support_footer( $pre_render, $block ) {
 // Remove WordPress core filter to avoid rendering duplicate elements stylesheet.
 remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_elements_support', 10, 2 );
-add_filter( 'pre_render_block', 'gutenberg_render_elements_support_footer', 10, 2 );
+add_filter( 'pre_render_block', 'gutenberg_render_elements_support_styles', 10, 2 );

--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -87,6 +87,12 @@ function gutenberg_render_elements_support( $block_content, $block ) {
  * @return null
  */
 function gutenberg_render_elements_support_styles( $pre_render, $block ) {
+	$block_type                    = WP_Block_Type_Registry::get_instance()->get_registered( $block['blockName'] );
+	$skip_link_color_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'link' );
+	if ( $skip_link_color_serialization ) {
+		return null;
+	}
+
 	$link_color = null;
 	if ( ! empty( $block['attrs'] ) ) {
 		$link_color = _wp_array_get( $block['attrs'], array( 'style', 'elements', 'link', 'color', 'text' ), null );

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -129,7 +129,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame(
 			$result,
-			'.wp-elements-1 a{color:var(--wp--preset--color--subtle-background);}'
+			'.wp-elements-1 a{color: var(--wp--preset--color--subtle-background);}'
 		);
 	}
 }

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -103,4 +103,33 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 			'<p id="anchor" class="wp-elements-1">Hello <a href="http://www.wordpress.org/">WordPress</a>!</p>'
 		);
 	}
+
+	/**
+	 * Test gutenberg_render_elements_support_footer() with a simple paragraph and link color preset.
+	 */
+	public function test_simple_paragraph_link_color_footer() {
+		$result = self::make_unique_id_one(
+			gutenberg_render_elements_support_footer(
+				null,
+				array(
+					'blockName' => 'core/paragraph',
+					'attrs'     => array(
+						'style' => array(
+							'elements' => array(
+								'link' => array(
+									'color' => array(
+										'text' => 'var:preset|color|subtle-background',
+									),
+								),
+							),
+						),
+					),
+				)
+			)
+		);
+		$this->assertSame(
+			$result,
+			'.wp-elements-1 a{color:var(--wp--preset--color--subtle-background);}'
+		);
+	}
 }

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -13,7 +13,7 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 	 * @return string                String where the unique id classes were replaced with "wp-elements-1".
 	 */
 	private static function make_unique_id_one( $string ) {
-		return preg_replace( '/wp-elements-\d+/', 'wp-elements-1', $string );
+		return preg_replace( '/wp-elements-[a-zA-Z0-9]+/', 'wp-elements-1', $string );
 	}
 
 	/**

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -104,32 +104,4 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 		);
 	}
 
-	/**
-	 * Test gutenberg_render_elements_support_styles() with a simple paragraph and link color preset.
-	 */
-	public function test_simple_paragraph_link_color_footer() {
-		$result = self::make_unique_id_one(
-			gutenberg_render_elements_support_styles(
-				null,
-				array(
-					'blockName' => 'core/paragraph',
-					'attrs'     => array(
-						'style' => array(
-							'elements' => array(
-								'link' => array(
-									'color' => array(
-										'text' => 'var:preset|color|subtle-background',
-									),
-								),
-							),
-						),
-					),
-				)
-			)
-		);
-		$this->assertSame(
-			$result,
-			'.wp-elements-1 a{color: var(--wp--preset--color--subtle-background);}'
-		);
-	}
 }

--- a/phpunit/class-elements-test.php
+++ b/phpunit/class-elements-test.php
@@ -105,11 +105,11 @@ class Gutenberg_Elements_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test gutenberg_render_elements_support_footer() with a simple paragraph and link color preset.
+	 * Test gutenberg_render_elements_support_styles() with a simple paragraph and link color preset.
 	 */
 	public function test_simple_paragraph_link_color_footer() {
 		$result = self::make_unique_id_one(
-			gutenberg_render_elements_support_footer(
+			gutenberg_render_elements_support_styles(
 				null,
 				array(
 					'blockName' => 'core/paragraph',


### PR DESCRIPTION
Related #37582 
An alternative to https://github.com/WordPress/gutenberg/pull/37593

## What

This uses the pre_render hook of the block to render its styles, so the parent styles are enqueued before the children's.

## Why

See #37582 for details. Essentially, this fixes an use case where both the parent and the inner block set the link color, and the expectation is that the child link color takes precedence.

## How to test

See #37582 for comprehensive instructions

