### PR TITLE
Marking test that consistently fails as skipped.

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -435,7 +435,7 @@ describe( 'Navigation', () => {
 		expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 	} );
 
-	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
+	it.skip( 'allows pages to be created from the navigation block and their links added to menu', async () => {
 		// The URL Details endpoint 404s for the created page, since it will
 		// be a draft that is inaccessible publicly. To avoid this we mock
 		// out the endpoint response to be empty which will be handled gracefully


### PR DESCRIPTION
## Description
Based on @youknowriad  comment here - https://github.com/WordPress/gutenberg/pull/37446#discussion_r777909007. This test has been consistently falling and blocking PRs

## Types of changes
Marks a test as skipped.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
