### PR TITLE
Enable alpha on Block Inspector Color ToolsPanel

### DIFF
--- a/packages/block-editor/src/components/contrast-checker/README.md
+++ b/packages/block-editor/src/components/contrast-checker/README.md
@@ -1,6 +1,8 @@
 # ContrastChecker
 
-ContrastChecker component determines if contrast for text styles is sufficient (WCAG 2.0 AA) when used with a given background color. ContrastCheker also accounts for background color transparency (alpha) as well as font sizes.
+ContrastChecker component determines if contrast for text styles is sufficient (WCAG 2.0 AA) when used with a given background color. 
+
+ContrastChecker also accounts for font sizes.
 
 A notice will be rendered if the color combination of text and background colors are low.
 

--- a/packages/block-editor/src/components/contrast-checker/index.js
+++ b/packages/block-editor/src/components/contrast-checker/index.js
@@ -67,7 +67,7 @@ function ContrastChecker( {
 	fontSize, // font size value in pixels
 	isLargeText,
 	textColor,
-	__experimentalEnableAlphaChecker = false,
+	enableAlphaChecker = false,
 } ) {
 	if (
 		! ( backgroundColor || fallbackBackgroundColor ) ||
@@ -100,7 +100,7 @@ function ContrastChecker( {
 	if ( hasTransparency ) {
 		if (
 			// If there's transparency, don't show the message if the alpha checker is disabled.
-			! __experimentalEnableAlphaChecker ||
+			! enableAlphaChecker ||
 			// If the alpha checker is enabled, we only show the warning if the text has transparency.
 			( isReadable && ! textColorHasTransparency )
 		) {

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -56,7 +56,7 @@ describe( 'ContrastChecker', () => {
 				backgroundColor={ backgroundColor }
 				textColor={ textColor }
 				isLargeText={ isLargeText }
-				__experimentalEnableAlphaChecker={ true }
+				enableAlphaChecker={ true }
 			/>
 		);
 
@@ -273,14 +273,14 @@ describe( 'ContrastChecker', () => {
 		expect( speak ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	// __experimentalEnableAlphaChecker tests
+	// enableAlphaChecker tests
 	test( 'should render component when the colors meet AA WCAG guidelines but the text color only has alpha transparency with alpha checker enabled.', () => {
 		const wrapper = mount(
 			<ContrastChecker
 				backgroundColor={ backgroundColor }
 				textColor={ 'rgba(0,0,0,0.9)' }
 				isLargeText={ isLargeText }
-				__experimentalEnableAlphaChecker={ true }
+				enableAlphaChecker={ true }
 			/>
 		);
 
@@ -298,7 +298,7 @@ describe( 'ContrastChecker', () => {
 				backgroundColor={ 'rgba(255,255,255,0.7)' }
 				textColor={ textColor }
 				isLargeText={ isLargeText }
-				__experimentalEnableAlphaChecker={ true }
+				enableAlphaChecker={ true }
 			/>
 		);
 
@@ -312,7 +312,7 @@ describe( 'ContrastChecker', () => {
 				backgroundColor={ 'rgba(255,255,255,0.7)' }
 				textColor={ 'rgba(0,0,0,0.7)' }
 				isLargeText={ isLargeText }
-				__experimentalEnableAlphaChecker={ true }
+				enableAlphaChecker={ true }
 			/>
 		);
 

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -274,25 +274,25 @@ describe( 'ContrastChecker', () => {
 	} );
 
 	// __experimentalEnableAlphaChecker tests
-	test( 'should render component when the colors meet AA WCAG guidelines but the text color has alpha transparency with alpha checker enabled.', () => {
+	test( 'should render component when the colors meet AA WCAG guidelines but the text color only has alpha transparency with alpha checker enabled.', () => {
 		const wrapper = mount(
 			<ContrastChecker
-				backgroundColor={ 'rgba(255,255,255,0.7)' }
-				textColor={ textColor }
+				backgroundColor={ backgroundColor }
+				textColor={ 'rgba(0,0,0,0.9)' }
 				isLargeText={ isLargeText }
 				__experimentalEnableAlphaChecker={ true }
 			/>
 		);
 
 		expect( speak ).toHaveBeenCalledWith(
-			'Transparent colors may be hard for people to read.'
+			'Transparent text may be hard for people to read.'
 		);
 		expect( wrapper.find( Notice ).children().text() ).toBe(
-			'Transparent background and/or text colors may be hard for people to read.'
+			'Transparent text may be hard for people to read.'
 		);
 	} );
 
-	test( 'should render component when the colors meet AA WCAG guidelines but the background color has alpha transparency with alpha checker enabled.', () => {
+	test( 'should render null when the colors meet AA WCAG guidelines but the background color only has alpha transparency with alpha checker enabled.', () => {
 		const wrapper = mount(
 			<ContrastChecker
 				backgroundColor={ 'rgba(255,255,255,0.7)' }
@@ -302,12 +302,8 @@ describe( 'ContrastChecker', () => {
 			/>
 		);
 
-		expect( speak ).toHaveBeenCalledWith(
-			'Transparent colors may be hard for people to read.'
-		);
-		expect( wrapper.find( Notice ).children().text() ).toBe(
-			'Transparent background and/or text colors may be hard for people to read.'
-		);
+		expect( speak ).not.toHaveBeenCalled();
+		expect( wrapper.html() ).toBeNull();
 	} );
 
 	test( 'should render component when the colors meet AA WCAG guidelines but all colors have alpha transparency with alpha checker enabled.', () => {
@@ -321,10 +317,10 @@ describe( 'ContrastChecker', () => {
 		);
 
 		expect( speak ).toHaveBeenCalledWith(
-			'Transparent colors may be hard for people to read.'
+			'Transparent text may be hard for people to read.'
 		);
 		expect( wrapper.find( Notice ).children().text() ).toBe(
-			'Transparent background and/or text colors may be hard for people to read.'
+			'Transparent text may be hard for people to read.'
 		);
 	} );
 } );

--- a/packages/block-editor/src/components/contrast-checker/test/index.js
+++ b/packages/block-editor/src/components/contrast-checker/test/index.js
@@ -50,6 +50,20 @@ describe( 'ContrastChecker', () => {
 		expect( wrapper.html() ).toBeNull();
 	} );
 
+	test( 'should render null when the colors meet AA WCAG guidelines and alpha checker enabled.', () => {
+		const wrapper = mount(
+			<ContrastChecker
+				backgroundColor={ backgroundColor }
+				textColor={ textColor }
+				isLargeText={ isLargeText }
+				__experimentalEnableAlphaChecker={ true }
+			/>
+		);
+
+		expect( speak ).not.toHaveBeenCalled();
+		expect( wrapper.html() ).toBeNull();
+	} );
+
 	test( 'should render component when the colors do not meet AA WCAG guidelines.', () => {
 		const wrapper = mount(
 			<ContrastChecker
@@ -257,5 +271,60 @@ describe( 'ContrastChecker', () => {
 		} );
 
 		expect( speak ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	// __experimentalEnableAlphaChecker tests
+	test( 'should render component when the colors meet AA WCAG guidelines but the text color has alpha transparency with alpha checker enabled.', () => {
+		const wrapper = mount(
+			<ContrastChecker
+				backgroundColor={ 'rgba(255,255,255,0.7)' }
+				textColor={ textColor }
+				isLargeText={ isLargeText }
+				__experimentalEnableAlphaChecker={ true }
+			/>
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Transparent colors may be hard for people to read.'
+		);
+		expect( wrapper.find( Notice ).children().text() ).toBe(
+			'Transparent background and/or text colors may be hard for people to read.'
+		);
+	} );
+
+	test( 'should render component when the colors meet AA WCAG guidelines but the background color has alpha transparency with alpha checker enabled.', () => {
+		const wrapper = mount(
+			<ContrastChecker
+				backgroundColor={ 'rgba(255,255,255,0.7)' }
+				textColor={ textColor }
+				isLargeText={ isLargeText }
+				__experimentalEnableAlphaChecker={ true }
+			/>
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Transparent colors may be hard for people to read.'
+		);
+		expect( wrapper.find( Notice ).children().text() ).toBe(
+			'Transparent background and/or text colors may be hard for people to read.'
+		);
+	} );
+
+	test( 'should render component when the colors meet AA WCAG guidelines but all colors have alpha transparency with alpha checker enabled.', () => {
+		const wrapper = mount(
+			<ContrastChecker
+				backgroundColor={ 'rgba(255,255,255,0.7)' }
+				textColor={ 'rgba(0,0,0,0.7)' }
+				isLargeText={ isLargeText }
+				__experimentalEnableAlphaChecker={ true }
+			/>
+		);
+
+		expect( speak ).toHaveBeenCalledWith(
+			'Transparent colors may be hard for people to read.'
+		);
+		expect( wrapper.find( Notice ).children().text() ).toBe(
+			'Transparent background and/or text colors may be hard for people to read.'
+		);
 	} );
 } );

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -17,11 +17,12 @@ function getComputedStyle( node ) {
 }
 
 export default function ColorPanel( {
-	enableAlpha,
+	enableAlpha = false,
 	settings,
 	clientId,
 	enableContrastChecking = true,
 	showTitle = true,
+	enableAlphaChecking = false,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -69,6 +70,7 @@ export default function ColorPanel( {
 					<ContrastChecker
 						backgroundColor={ detectedBackgroundColor }
 						textColor={ detectedColor }
+						__experimentalEnableAlphaChecker={ enableAlphaChecking }
 					/>
 				) }
 			</PanelColorGradientSettings>

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -17,6 +17,7 @@ function getComputedStyle( node ) {
 }
 
 export default function ColorPanel( {
+	enableAlpha,
 	settings,
 	clientId,
 	enableContrastChecking = true,
@@ -60,6 +61,7 @@ export default function ColorPanel( {
 				initialOpen={ false }
 				settings={ settings }
 				showTitle={ showTitle }
+				enableAlpha={ enableAlpha }
 				__experimentalHasMultipleOrigins
 				__experimentalIsRenderedInSidebar
 			>

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -69,7 +69,7 @@ export default function ColorPanel( {
 					<ContrastChecker
 						backgroundColor={ detectedBackgroundColor }
 						textColor={ detectedColor }
-						__experimentalEnableAlphaChecker={ enableAlpha }
+						enableAlphaChecker={ enableAlpha }
 					/>
 				) }
 			</PanelColorGradientSettings>

--- a/packages/block-editor/src/hooks/color-panel.js
+++ b/packages/block-editor/src/hooks/color-panel.js
@@ -22,7 +22,6 @@ export default function ColorPanel( {
 	clientId,
 	enableContrastChecking = true,
 	showTitle = true,
-	enableAlphaChecking = false,
 } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
@@ -70,7 +69,7 @@ export default function ColorPanel( {
 					<ContrastChecker
 						backgroundColor={ detectedBackgroundColor }
 						textColor={ detectedColor }
-						__experimentalEnableAlphaChecker={ enableAlphaChecking }
+						__experimentalEnableAlphaChecker={ enableAlpha }
 					/>
 				) }
 			</PanelColorGradientSettings>

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -377,7 +377,6 @@ export function ColorEdit( props ) {
 	return (
 		<ColorPanel
 			enableContrastChecking={ enableContrastChecking }
-			enableAlphaChecking={ enableContrastChecking }
 			clientId={ props.clientId }
 			enableAlpha={ true }
 			settings={ [

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -378,6 +378,7 @@ export function ColorEdit( props ) {
 				Platform.OS === 'web' && ! gradient && ! style?.color?.gradient
 			}
 			clientId={ props.clientId }
+			enableAlpha={ true }
 			settings={ [
 				...( hasTextColor
 					? [

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -371,12 +371,13 @@ export function ColorEdit( props ) {
 		props.setAttributes( { style: newStyle } );
 	};
 
+	const enableContrastChecking =
+		Platform.OS === 'web' && ! gradient && ! style?.color?.gradient;
+
 	return (
 		<ColorPanel
-			enableContrastChecking={
-				// Turn on contrast checker for web only since it's not supported on mobile yet.
-				Platform.OS === 'web' && ! gradient && ! style?.color?.gradient
-			}
+			enableContrastChecking={ enableContrastChecking }
+			enableAlphaChecking={ enableContrastChecking }
 			clientId={ props.clientId }
 			enableAlpha={ true }
 			settings={ [


### PR DESCRIPTION
Resolves #18095

## Description

This PR add alpha controls to Color Picker panels in the Block Inspector. 

We're doing this by passing enableAlpha=true to the underlying ColorPicker component from the color tools panel.

Where **text color** alpha transparency goes below a minimum threshold (currently 1), we'll also show a warning about readability where the text is otherwise "readable" according to the colord library.

Changes to background color transparency are ignored due to the difficultly in accounting for multiple alpha layers or image backgrounds and so on.

See: https://github.com/WordPress/gutenberg/issues/18095#issuecomment-1005377529


https://user-images.githubusercontent.com/6458278/150261226-82aa23ff-bec4-4965-8f47-02a08cd329a4.mp4


#### Considerations

Here we're enabling alpha controls for all blocks and all colors.

Is the availability to adjust alpha something we'd want to enable at a block level, e.g., via color supports and/or for certain colors, e.g., background, text, link?

Or is it okay to leave it on as a permanent citizen of the color panel?

## How has this been tested?
Insert any block that has color support, for example a group block!

Select a background color, or any color. Click on the custom color picker, then play with the alpha slider.

<img width="844" alt="Screen Shot 2022-01-18 at 10 49 03 am" src="https://user-images.githubusercontent.com/6458278/149848671-7f932f91-6137-4777-9687-5765e441f255.png">

The colors in the editor should match the frontend.

Take note of the warning.
<img width="273" alt="Screen Shot 2022-01-19 at 10 56 35 pm" src="https://user-images.githubusercontent.com/6458278/150125098-1bfcfd5e-dac1-46a6-b240-1017c4211e82.png">

The warning should show where **only the text color has transparency** AND the color panel does not show any contrast warnings otherwise.


## Types of changes
Enabling an existing feature.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
