### PR TITLE
Fix text decoration on navigation submenus

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -51,6 +51,43 @@ $navigation-icon-size: 24px;
 		padding: 0;
 	}
 
+	// Force links to inherit text decoration applied to navigation block.
+	// The extra selector adds specificity to ensure it works when user-set.
+	&[style*="text-decoration: underline"],
+	&[style*="text-decoration:underline"] {
+		.wp-block-navigation-item__content {
+			text-decoration: underline;
+
+			&:focus,
+			&:active {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	&[style*="text-decoration: line-through"],
+	&[style*="text-decoration:line-through"] {
+		.wp-block-navigation-item__content {
+			text-decoration: line-through;
+
+			&:focus,
+			&:active {
+				text-decoration: line-through;
+			}
+		}
+	}
+
+	&:not([style*="text-decoration"]) {
+		a {
+			text-decoration: none;
+
+			&:focus,
+			&:active {
+				text-decoration: none;
+			}
+		}
+	}
+
 	// Submenu indicator.
 	.wp-block-navigation__submenu-icon {
 		align-self: center; // This one affects nested submenu indicators.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -51,35 +51,6 @@ $navigation-icon-size: 24px;
 		padding: 0;
 	}
 
-	// Force links to inherit text decoration applied to navigation block.
-	// The extra selector adds specificity to ensure it works when user-set.
-	&[style*="text-decoration"] {
-		.wp-block-navigation-item,
-		.wp-block-navigation__submenu-container {
-			text-decoration: inherit;
-		}
-
-		a {
-			text-decoration: inherit;
-
-			&:focus,
-			&:active {
-				text-decoration: inherit;
-			}
-		}
-	}
-
-	&:not([style*="text-decoration"]) {
-		a {
-			text-decoration: none;
-
-			&:focus,
-			&:active {
-				text-decoration: none;
-			}
-		}
-	}
-
 	// Submenu indicator.
 	.wp-block-navigation__submenu-icon {
 		align-self: center; // This one affects nested submenu indicators.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #37726.

Text-decoration isn't an inherited property, but it applies by default to all text children of the container it's set on. The `text-decoration: inherit` rules that this PR deletes were causing text-decoration of submenu items to be set to `none`, because not all of the intermediate containers were inheriting the property from the nav element where it's set.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Create a Navigation with links, submenus, and a page list. 
Set Decoration (under Typography, in the block sidebar) to a non-default value. 
Check that text decoration applies to all children of the Nav.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
