### PR TITLE
Audio: Add uploading state

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { getBlobByURL, isBlobURL } from '@wordpress/blob';
@@ -6,6 +11,7 @@ import {
 	Disabled,
 	PanelBody,
 	SelectControl,
+	Spinner,
 	ToggleControl,
 	withNotices,
 } from '@wordpress/components';
@@ -34,6 +40,7 @@ const ALLOWED_MEDIA_TYPES = [ 'audio' ];
 
 function AudioEdit( {
 	attributes,
+	className,
 	noticeOperations,
 	setAttributes,
 	onReplace,
@@ -42,7 +49,7 @@ function AudioEdit( {
 	insertBlocksAfter,
 } ) {
 	const { id, autoplay, caption, loop, preload, src } = attributes;
-	const blockProps = useBlockProps();
+	const isTemporaryAudio = ! id && isBlobURL( src );
 	const mediaUpload = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().mediaUpload;
@@ -101,7 +108,6 @@ function AudioEdit( {
 			: null;
 	}
 
-	// const { setAttributes, isSelected, noticeUI } = this.props;
 	function onSelectAudio( media ) {
 		if ( ! media || ! media.url ) {
 			// in this case there was an error and we should continue in the editing state
@@ -113,6 +119,15 @@ function AudioEdit( {
 		// selected media, then switches off the editing UI
 		setAttributes( { src: media.url, id: media.id } );
 	}
+
+	const classes = classnames( className, {
+		'is-transient': isTemporaryAudio,
+	} );
+
+	const blockProps = useBlockProps( {
+		className: classes,
+	} );
+
 	if ( ! src ) {
 		return (
 			<div { ...blockProps }>
@@ -186,6 +201,7 @@ function AudioEdit( {
 				<Disabled isDisabled={ ! isSelected }>
 					<audio controls="controls" src={ src } />
 				</Disabled>
+				{ isTemporaryAudio && <Spinner /> }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
 						tagName="figcaption"

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -4,7 +4,7 @@
 	margin-right: 0;
 	position: relative;
 
-	&.is-transient video {
+	&.is-transient audio {
 		opacity: 0.3;
 	}
 

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -11,7 +11,7 @@
 	// Shown while audio is being uploaded
 	.components-spinner {
 		position: absolute;
-		top: 35%;
+		top: 50%;
 		left: 50%;
 		margin-top: -9px;
 		margin-left: -9px;

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -2,4 +2,18 @@
 	// Remove the left and right margin the figure is born with.
 	margin-left: 0;
 	margin-right: 0;
+	position: relative;
+
+	&.is-transient video {
+		opacity: 0.3;
+	}
+
+	// Shown while audio is being uploaded
+	.components-spinner {
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		margin-top: -9px;
+		margin-left: -9px;
+	}
 }

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -11,7 +11,7 @@
 	// Shown while audio is being uploaded
 	.components-spinner {
 		position: absolute;
-		top: 50%;
+		top: 35%;
 		left: 50%;
 		margin-top: -9px;
 		margin-left: -9px;


### PR DESCRIPTION
## Description
PR adds uploading state to the Audio block.

Resolves #29991.

## How has this been tested?
1. Throttle network to 3G via DevTools.
2. Add a new audio block.
3. Upload audio (you can use file from block example).
4. The uploading state should be visible.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/148345602-f6b8baaa-f67f-4c72-9b58-f408f9100084.mp4

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
