### PR TITLE
Docs: Fix type of saved content - part two

### DIFF
--- a/lib/class-wp-widget-block.php
+++ b/lib/class-wp-widget-block.php
@@ -101,7 +101,7 @@ class WP_Widget_Block extends WP_Widget {
 	 *
 	 * @since 9.3.0
 	 *
-	 * @param array $content The HTML content of the current block widget.
+	 * @param string $content The HTML content of the current block widget.
 	 *
 	 * @return string The classname to use in the block widget's container HTML.
 	 */

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -10,7 +10,7 @@
  * adding a data-id attribute to the element if core/gallery has added on pre-render.
  *
  * @param  array $attributes The block attributes.
- * @param  array $content    The block content.
+ * @param  string $content    The block content.
  * @return string Returns the block content with the data-id attribute added.
  */
 function render_block_core_image( $attributes, $content ) {


### PR DESCRIPTION
## Description
Follow-up for #37688.

Fixes type of `$content` to string, it is not an array.
