### PR TITLE
Restore canvas padding for classic themes

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -6,6 +6,18 @@
 	margin-right: auto;
 }
 
+// Add a default 8px padding for classic themes around the canvas.
+// Themes with theme.json can control this themselves.
+// For full-wide blocks, we compensate for the base padding.
+// These margins should match the padding value above.
+html :where(.editor-styles-wrapper) {
+	padding: 8px;
+	.block-editor-block-list__layout.is-root-container > .wp-block[data-align="full"] {
+		margin-left: -8px;
+		margin-right: -8px;
+	}
+}
+
 // Deprecated style needed for the block widths and alignments.
 // for themes that don't support the new layout (theme.json).
 html :where(.wp-block) {


### PR DESCRIPTION
closes #35884 

This PR restores the 8px padding for classic themes like suggested by the discussion in the issue.
It adds the style to classic.scss meaning it's going to only apply to themes without theme.json (themes with theme.json can add their own padding in the file directly).

cc @noisysocks on whether we can still include this in 5.9 or not (like suggested in the issue)