### PR TITLE
Use useCallback hook from @wordpress/elements in color-picker

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -2,14 +2,14 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { Ref, useCallback } from 'react';
+import { Ref } from 'react';
 import { colord, extend, Colord } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useCallback, useState, useMemo } from '@wordpress/element';
 import { settings } from '@wordpress/icons';
 import { useDebounce } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';


### PR DESCRIPTION
## Description
Using `useCallback` directly from react may cause that another version of `react` then the one used in @wordpress/elements will be loaded.

I'm using @wordpress/components package and it has [react-dates](https://www.npmjs.com/package/react-dates) sub-dependency. [React-dates require react 16](https://github.com/airbnb/react-dates/blob/master/package.json#L100-L101). When I install the components package using `npm install @wordpress/components` it installs react 16 into `@wordpress/components/node_modules`. Importing `useCallback` directly from react was causing an error when I wanted to open the color picker in my application.
```
Uncaught Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.
    at resolveDispatcher (webpack-internal:///./node_modules/@wordpress/components/node_modules/react/cjs/react.development.js:1465)
    at useCallback (webpack-internal:///./node_modules/@wordpress/components/node_modules/react/cjs/react.development.js:1516)
    at ColorPicker (webpack-internal:///./node_modules/@wordpress/components/build-module/color-picker/component.js:81)
```

## How has this been tested?
I made the change and tested the color picker functionality on a dev site ran via `npm run wp-env start`

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
