### PR TITLE
Workflows: Add workflow to publish npm packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -90,7 +90,7 @@ jobs:
               run: |
                   PUBLIC_PACKAGES=$(ls -d packages/*/ | xargs -I{} sh -c "jq -e '.private != true' '{}'/package.json >/dev/null && test -f '{}'CHANGELOG.md && echo '{}'")
                   PUBLIC_PACKAGE_NAMES=$(jq '.dependencies' package.json )
-                  minimum_version_jump='patch'
+                  minimum_version_bump='patch'
                   while IFS= read -r package; do
                     changes_detected=false
                     while IFS= read -r line; do
@@ -115,7 +115,7 @@ jobs:
                           ;;
                         '### '*|*-*)
                           if [[ "$version_bump" != 'minor' ]]; then
-                            version_bump="$minimum_version_jump"
+                            version_bump="$minimum_version_bump"
                           fi
                       esac
                     done < "$package"CHANGELOG.md

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -144,3 +144,4 @@ jobs:
                       sed -i '' "s/## Unreleased/\n\n## ${next_version} ($(date +%F))/g" "$package"CHANGELOG.md
                     fi
                   done <<< $PUBLIC_PACKAGES
+                  git commit -am "Update changelog files"

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -59,6 +59,7 @@ jobs:
                   github.event.inputs.release_type == 'next'
               run: |
                   git rm -r .
+                  git fetch --depth=1 origin "${{ steps.get_version.outputs.plugin_release_branch }}"
                   git checkout origin/"${{ steps.get_version.outputs.plugin_release_branch }}" -- .
 
             - name: Commit the changes to the WordPress release branch

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -182,7 +182,7 @@ jobs:
                     npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private
                     npx lerna publish from-package --dist-tag next
                   elif [ '${{ github.event.inputs.release_type }}' = 'bugfix' ]; then
-                    npm run publish:latest
+                    npx lerna publish
                   else
                     npx lerna version "$minimum_version_bump" --no-private
                     npx lerna publish from-package

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -121,9 +121,9 @@ jobs:
                     done < "$package"CHANGELOG.md
                     package_name=${package#'packages/'}
                     package_name="@wordpress/${package_name%'/'}"
-                    if [ -n "$version_bump" ] && \\
-                       [ ${{ github.event.inputs.release_type }} != 'next' ] && \\
-                       [ "$minimum_version_bump" !== 'patch' ]
+                    if [ -n "$version_bump" ] && \
+                       [ '${{ github.event.inputs.release_type }}' != 'next' ] && \
+                       [ "$minimum_version_bump" != 'patch' ]
                     then
                         case "$production_package_names" in
                           *"'$package_name'"*)

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,11 +23,11 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    determine-feature-freeze:
-        name: Determine if Core is in Feature Freeze
+    get-wordpress-release-branch:
+        name: Determine whether to use wp/trunk or wp/next branch
         runs-on: ubuntu-latest
         outputs:
-            wordpress_release_branch: ${{ steps.get_wordpress_version.outputs.feature_freeze }}
+            wordpress_release_branch: ${{ steps.get_wordpress_version.outputs.wordpress_release_branch }}
 
         steps:
             - name: Get WordPress version from wordpress-develop trunk
@@ -38,21 +38,21 @@ jobs:
                   wp_version=$(awk -F "'" '/^\$wp_version = /{print $2}' version.php)
                   case "$wp_version" in
                     *"-beta"*|*"-RC1")
-                      echo "::set-output name=feature_freeze::true"
+                      echo "::set-output name=wordpress_release_branch::wp/next"
                     ;;
                     *)
-                      echo "::set-output name=feature_freeze::false"
+                      echo "::set-output name=wordpress_release_branch::wp/trunk"
                   esac
                   rm version.php
 
     sync-wordpress-branch:
         name: Sync the WordPress release branch
         if: |
-          github.event_name == 'release' &&
-          github.event.release.assets[0] &&
-          endsWith( github.event.release.tag_name, '-rc.1' )
+            github.event_name == 'release' &&
+            github.event.release.assets[0] &&
+            endsWith( github.event.release.tag_name, '-rc.1' )
+        needs: get-wordpress-release-branch
         runs-on: ubuntu-latest
-
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -66,32 +66,27 @@ jobs:
                   PLUGIN_RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
                   echo "::set-output name=plugin_release_branch::$(echo $PLUGIN_RELEASE_BRANCH)"
 
+            - name: Checkout WordPress release branch
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                fetch-depth: 100
+
             - name: Configure git user name and email
               run: |
                   git config user.name "Gutenberg Repository Automation"
                   git config user.email gutenberg@wordpress.org
 
-            - name: Switch to WordPress release branch
-              run: |
-                  git fetch --depth=100 origin "$WORDPRESS_RELEASE_BRANCH"
-                  git checkout "$WORDPRESS_RELEASE_BRANCH"
-
             - name: Sync the WordPress release branch with the changes from the latest plugin release
-              if: |
-                  github.event.inputs.release_type == 'latest' ||
-                  github.event.inputs.release_type == 'next'
               run: |
                   git rm -r .
                   git fetch --depth=1 origin "${{ steps.get_release_branch.outputs.plugin_release_branch }}"
                   git checkout origin/"${{ steps.get_release_branch.outputs.plugin_release_branch }}" -- .
 
             - name: Commit the changes to the WordPress release branch
-              if: |
-                  github.event.inputs.release_type == 'latest' ||
-                  github.event.inputs.release_type == 'next'
               run: |
                   git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_release_branch.outputs.plugin_release_branch }} branch"
-                  git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
+                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
 
     update-packages:
         name: Update Packages

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -146,3 +146,40 @@ jobs:
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
                   git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
+
+    publish-packages:
+        name: Update Packages
+        runs-on: ubuntu-latest
+        needs: update-packages
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  ref: ${{ env.WORDPRESS_RELEASE_BRANCH }}
+
+            - name: Use desired version of NodeJS
+              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              with:
+                  node-version: 14
+                  cache: npm
+
+            - name: Npm install and build
+              run: |
+                  npm ci
+                  npm run build
+
+            - name: Publish packages
+              if: github.event.inputs.release_type == 'next'
+              run: |
+                  minimum_version_bump='patch'
+                  if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
+                    sha=$(git rev-parse --short HEAD)
+                    npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private
+                    npx lerna publish from-package --dist-tag next
+                  elif [ '${{ github.event.inputs.release_type }}' = 'bugfix' ]; then
+                    npm run publish:latest
+                  else
+                    npx lerna version "$minimum_version_bump" --no-private
+                    npx lerna publish from-package
+                  fi

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -93,6 +93,8 @@ jobs:
                   minimum_version_bump='patch'
                   while IFS= read -r package; do
                     changes_detected=false
+                    version_bump=
+                    next_version=
                     while IFS= read -r line; do
                       if [[ "$line" = '## Unreleased' ]]; then
                         changes_detected=true

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -136,4 +136,7 @@ jobs:
                     if [ -n "$version_bump" ]; then
                       next_version=$(npx semver "$version" -i "$version_bump")
                     fi
+                    if [ -n "$next_version" ]; then
+                      cat <<< $(jq --tab --arg version "${next_version}-prerelease" '.version = $version' "$package"package.json) > "$package"package.json
+                    fi
                   done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -89,7 +89,7 @@ jobs:
 
             - name: Update package versions
               run: |
-                  PUBLIC_PACKAGES=$(ls -d packages/*/ | xargs -I{} sh -c "jq -e '.private != true' '{}'/package.json >/dev/null && test -f '{}'CHANGELOG.md && echo '{}'")
+                  PUBLIC_PACKAGES=$(find packages/*/ -type d -maxdepth 0 -exec sh -c 'jq -e ".private != true" "$1"/package.json > /dev/null && test -f "$1"/CHANGELOG.md && echo "$1"' shell {} \;)
                   production_package_names=$(jq '.dependencies | keys | @sh' package.json)
                   minimum_version_bump='patch'
                   while IFS= read -r package; do
@@ -142,7 +142,7 @@ jobs:
                       if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
                         next_version="${next_version}-next.0"
                       fi
-                      sed -i '' "s/## Unreleased/\n\n## ${next_version} ($(date +%F))/g" "$package"CHANGELOG.md
+                      sed -i "s/## Unreleased/\n\n## ${next_version} ($(date +%F))/g" "$package"CHANGELOG.md
                     fi
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -121,7 +121,7 @@ jobs:
                     done < "$package"CHANGELOG.md
                     package_name=${package#'packages/'}
                     package_name="@wordpress/${package_name%'/'}"
-                    if [ -n "$version_bump" ] && \
+                    if [ -z "$version_bump" ] && \
                        [ '${{ github.event.inputs.release_type }}' != 'next' ] && \
                        [ "$minimum_version_bump" != 'patch' ]
                     then

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -232,3 +232,14 @@ jobs:
                     npx lerna version "$minimum_version_bump" --no-private --yes
                     npx lerna publish from-package --yes
                   fi
+                  if [ '${{ github.ref }}' != 'refs/heads/wp/next' ]; then
+                    echo "::set-output name=publish_commit::$(git rev-parse --verify --short HEAD)"
+                  fi
+
+            - name: Cherry-pick the changelog update commit to trunk
+              if: ${{ steps.publish_packages.outputs.publish_commit }}
+              run: |
+                  git checkout trunk
+                  git pull
+                  git cherry-pick "${{ steps.publish_packages.outputs.publish_commit }}"
+                  git push

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -145,3 +145,4 @@ jobs:
                     fi
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
+                  git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -202,6 +202,7 @@ jobs:
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                  fetch-depth: 0 # Need all tags for lerna to correctly determine changed package.
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -12,9 +12,6 @@ on:
                 description: 'patch, minor, or major?'
                 required: true
 
-env:
-    WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' }}
-
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
     # The concurrency group contains the workflow name and the branch name for pull requests
@@ -91,13 +88,13 @@ jobs:
     update-packages:
         name: Update Packages
         runs-on: ubuntu-latest
-        needs: sync-wordpress-branch
+        needs: [get-wordpress-release-branch, sync-wordpress-branch]
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ env.WORDPRESS_RELEASE_BRANCH }}
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
@@ -170,7 +167,7 @@ jobs:
                     fi
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
-                  git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
+                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
                   echo "::set-output name=changelog_commit::$(git rev-parse --verify --short HEAD)"
 
             - name: Fetch trunk
@@ -186,13 +183,13 @@ jobs:
     publish-packages:
         name: Publish Packages
         runs-on: ubuntu-latest
-        needs: update-packages
+        needs: [get-wordpress-release-branch, update-packages]
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ env.WORDPRESS_RELEASE_BRANCH }}
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -89,7 +89,7 @@ jobs:
             - name: Update package versions
               run: |
                   PUBLIC_PACKAGES=$(ls -d packages/*/ | xargs -I{} sh -c "jq -e '.private != true' '{}'/package.json >/dev/null && test -f '{}'CHANGELOG.md && echo '{}'")
-                  PUBLIC_PACKAGE_NAMES=$(jq '.dependencies' package.json )
+                  PRODUCTION_PACKAGE_NAMES=$(jq '.dependencies' package.json )
                   minimum_version_bump='patch'
                   while IFS= read -r package; do
                     changes_detected=false

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -24,11 +24,25 @@ jobs:
         name: Determine whether to use wp/trunk or wp/next branch
         runs-on: ubuntu-latest
         outputs:
-            wordpress_release_branch: ${{ steps.get_wordpress_version.outputs.wordpress_release_branch }}
+            wordpress_release_branch: |
+              steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
+              steps.get_wordpress_branch_for_manual_release.wordpress_release_branch
 
         steps:
-            - name: Get WordPress version from wordpress-develop trunk
-              id: get_wordpress_version
+            - name: Get WordPress release branch for sync
+              id: get_wordpress_branch_for_manual_release
+              if: |
+                  github.event_name == 'workflow_dispatch' &&
+                  startsWith( github.ref, 'wp/' ) &&
+                  ! github.ref == 'wp/next'
+              run: echo "::set-output name=wordpress_release_branch::${GITHUB_REF#refs/heads/}"
+
+            - name: Get WordPress release branch for sync
+              id: get_wordpress_branch_for_sync
+              if: |
+                  github.event_name == 'release' &&
+                  github.event.release.assets[0] &&
+                  endsWith( github.event.release.tag_name, '-rc.1' )
               run: |
                   wp_version_url='https://raw.githubusercontent.com/WordPress/wordpress-develop/trunk/src/wp-includes/version.php'
                   curl -o version.php "$wp_version_url"
@@ -66,8 +80,8 @@ jobs:
             - name: Checkout WordPress release branch
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
-                fetch-depth: 100
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                  fetch-depth: 100
 
             - name: Configure git user name and email
               run: |

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -5,9 +5,6 @@ on:
         types: [published]
     workflow_dispatch:
         inputs:
-            release_type:
-                description: 'latest, next, or bugfix?'
-                required: true
             version:
                 description: 'patch, minor, or major?'
                 required: true
@@ -158,7 +155,7 @@ jobs:
                     package_name=${package#'packages/'}
                     package_name="@wordpress/${package_name%'/'}"
                     if [ -z "$version_bump" ] && \
-                       [ '${{ github.event.inputs.release_type }}' != 'next' ] && \
+                       [ '${{ github.ref }}' != 'refs/heads/wp/next' ] && \
                        [ "$minimum_version_bump" != 'patch' ]
                     then
                         case "$production_package_names" in
@@ -172,7 +169,7 @@ jobs:
                     fi
                     if [ -n "$next_version" ]; then
                       cat <<< $(jq --tab --arg version "${next_version}-prerelease" '.version = $version' "$package"package.json) > "$package"package.json
-                      if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
+                      if [ '${{ github.ref }}' = 'refs/heads/wp/next' ]; then
                         next_version="${next_version}-next.0"
                       fi
                       sed -i "s/## Unreleased/\n\n## ${next_version} ($(date +%F))/g" "$package"CHANGELOG.md
@@ -218,11 +215,12 @@ jobs:
             - name: Publish packages
               run: |
                   minimum_version_bump='patch'
-                  if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
+                  if [ '${{ github.ref }}' = 'refs/heads/wp/next' ]; then
                     sha=$(git rev-parse --short HEAD)
                     npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private
                     npx lerna publish from-package --dist-tag next
-                  elif [ '${{ github.event.inputs.release_type }}' = 'bugfix' ]; then
+                  elif [ '${{ github.event_name }}' = 'workflow_dispatch' ] && \
+                    [ '${{ github.ref }}' = 'refs/heads/wp/trunk' ]; then
                     npx lerna publish
                   else
                     npx lerna version "$minimum_version_bump" --no-private

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
         outputs:
             wordpress_release_branch: |
                 steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
-                steps.get_wordpress_branch_for_manual_release.wordpress_release_branch
+                steps.get_wordpress_branch_for_manual_release.outputs.wordpress_release_branch
 
         steps:
             - name: Get WordPress release branch for sync

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -218,12 +218,12 @@ jobs:
                   minimum_version_bump='patch'
                   if [ '${{ github.ref }}' = 'refs/heads/wp/next' ]; then
                     sha=$(git rev-parse --short HEAD)
-                    npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private
-                    npx lerna publish from-package --dist-tag next
+                    npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private --yes
+                    npx lerna publish from-package --dist-tag next --yes
                   elif [ '${{ github.event_name }}' = 'workflow_dispatch' ] && \
                     [ '${{ github.ref }}' = 'refs/heads/wp/trunk' ]; then
-                    npx lerna publish
+                    npx lerna publish --yes
                   else
-                    npx lerna version "$minimum_version_bump" --no-private
-                    npx lerna publish from-package
+                    npx lerna version "$minimum_version_bump" --no-private --yes
+                    npx lerna publish from-package --yes
                   fi

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -148,7 +148,7 @@ jobs:
                   git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
 
     publish-packages:
-        name: Update Packages
+        name: Publish Packages
         runs-on: ubuntu-latest
         needs: update-packages
 

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -21,9 +21,11 @@ jobs:
         name: Determine whether to use wp/trunk or wp/next branch
         runs-on: ubuntu-latest
         outputs:
-            wordpress_release_branch: |
-                steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
-                steps.get_wordpress_branch_for_manual_release.outputs.wordpress_release_branch
+            wordpress_release_branch: >-
+                ${{
+                  steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
+                  steps.get_wordpress_branch_for_manual_release.outputs.wordpress_release_branch
+                }}
 
         steps:
             - name: Get WordPress release branch for sync

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -50,7 +50,7 @@ jobs:
 
             - name: Switch to WordPress release branch
               run: |
-                  git fetch --depth=1 origin "$WORDPRESS_RELEASE_BRANCH"
+                  git fetch --depth=100 origin "$WORDPRESS_RELEASE_BRANCH"
                   git checkout "$WORDPRESS_RELEASE_BRANCH"
 
             - name: Sync the WordPress release branch with the changes from the latest plugin release

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -21,6 +21,28 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    determine-feature-freeze:
+        name: Determine if Core is in Feature Freeze
+        runs-on: ubuntu-latest
+        outputs:
+            wordpress_release_branch: ${{ steps.get_wordpress_version.outputs.feature_freeze }}
+
+        steps:
+            - name: Get WordPress version from wordpress-develop trunk
+              id: get_wordpress_version
+              run: |
+                  wp_version_url='https://raw.githubusercontent.com/WordPress/wordpress-develop/trunk/src/wp-includes/version.php'
+                  curl -o version.php "$wp_version_url"
+                  wp_version=$(awk -F "'" '/^\$wp_version = /{print $2}' version.php)
+                  case "$wp_version" in
+                    *"-beta"*|*"-RC1")
+                      echo "::set-output name=feature_freeze::true"
+                    ;;
+                    *)
+                      echo "::set-output name=feature_freeze::false"
+                  esac
+                  rm version.php
+
     sync-wordpress-branch:
         name: Sync the WordPress release branch
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -209,10 +209,8 @@ jobs:
                   node-version: 14
                   cache: npm
 
-            - name: Npm install and build
-              run: |
-                  npm ci
-                  npm run build
+            - name: Npm install
+              run: npm ci
 
             - name: Publish packages
               run: |

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -130,5 +130,8 @@ jobs:
                             version_bump="$minimum_version_bump"
                         esac
                     fi
-                    package_version=$(jq --raw-output '.version' "$package"package.json)
+                    version=$(jq --raw-output '.version' "$package"package.json)
+                    if [ -n "$version_bump" ]; then
+                      next_version=$(npx semver "$version" -i "$version_bump")
+                    fi
                   done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -89,7 +89,7 @@ jobs:
             - name: Update package versions
               run: |
                   PUBLIC_PACKAGES=$(ls -d packages/*/ | xargs -I{} sh -c "jq -e '.private != true' '{}'/package.json >/dev/null && test -f '{}'CHANGELOG.md && echo '{}'")
-                  PRODUCTION_PACKAGE_NAMES=$(jq '.dependencies' package.json )
+                  production_package_names=$(jq '.dependencies | keys | @sh' package.json)
                   minimum_version_bump='patch'
                   while IFS= read -r package; do
                     changes_detected=false
@@ -121,5 +121,14 @@ jobs:
                     done < "$package"CHANGELOG.md
                     package_name=${package#'packages/'}
                     package_name="@wordpress/${package_name%'/'}"
+                    if [ -n "$version_bump" ] && \\
+                       [ ${{ github.event.inputs.release_type }} != 'next' ] && \\
+                       [ "$minimum_version_bump" !== 'patch' ]
+                    then
+                        case "$production_package_names" in
+                          *"'$package_name'"*)
+                            version_bump="$minimum_version_bump"
+                        esac
+                    fi
                     package_version=$(jq --raw-output '.version' "$package"package.json)
                   done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -64,8 +64,6 @@ jobs:
             endsWith( github.event.release.tag_name, '-rc.1' )
         needs: get-wordpress-release-branch
         runs-on: ubuntu-latest
-        env:
-            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
         steps:
             - name: Compute plugin release branch name
               id: get_release_branch
@@ -79,7 +77,7 @@ jobs:
             - name: Checkout WordPress release branch
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ env.WP_RELEASE_BRANCH }}
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
                   fetch-depth: 100
 
             - name: Configure git user name and email
@@ -96,21 +94,19 @@ jobs:
             - name: Commit the changes to the WordPress release branch
               run: |
                   git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_release_branch.outputs.plugin_release_branch }} branch"
-                  git push --set-upstream origin "${WP_RELEASE_BRANCH}"
+                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
 
     update-packages:
         name: Update Packages
         runs-on: ubuntu-latest
         needs: [get-wordpress-release-branch, sync-wordpress-branch]
         if: ${{ always() }}
-        env:
-            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ env.WP_RELEASE_BRANCH }}
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
@@ -183,7 +179,7 @@ jobs:
                     fi
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
-                  git push --set-upstream origin "${WP_RELEASE_BRANCH}"
+                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
                   echo "::set-output name=changelog_commit::$(git rev-parse --verify --short HEAD)"
 
             - name: Fetch trunk
@@ -201,14 +197,12 @@ jobs:
         runs-on: ubuntu-latest
         needs: [get-wordpress-release-branch, update-packages]
         if: ${{ always() }}
-        env:
-            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ env.WP_RELEASE_BRANCH }}
+                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,69 @@
+name: Publish npm packages
+
+on:
+    workflow_dispatch:
+        inputs:
+            release_type:
+                description: 'latest, next, or bugfix?'
+                required: true
+            version:
+                description: 'patch, minor, or major?'
+                required: true
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    sync-wordpress-branch:
+        name: Sync the WordPress release branch
+        runs-on: ubuntu-latest
+        env:
+            WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
+        outputs:
+            plugin_version: ${{ steps.get_version.outputs.plugin_version }}
+            plugin_release_branch: ${{ steps.get_version.outputs.plugin_release_branch }}
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Compute plugin release branch
+              id: get_version
+              run: |
+                  PLUGIN_VERSION=$(jq --raw-output '.version' package.json)
+                  echo "::set-output name=plugin_version::$(echo $PLUGIN_VERSION)"
+                  IFS='.' read -r -a PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
+                  PLUGIN_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
+                  echo "::set-output name=plugin_release_branch::$(echo $PLUGIN_RELEASE_BRANCH)"
+
+            - name: Configure git user name and email
+              run: |
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Switch to WordPress release branch
+              run: |
+                  git fetch --depth=1 origin "$WORDPRESS_RELEASE_BRANCH"
+                  git checkout "$WORDPRESS_RELEASE_BRANCH"
+
+            - name: Sync the WordPress release branch with the changes from the latest plugin release
+              if: |
+                  github.event.inputs.release_type == 'latest' ||
+                  github.event.inputs.release_type == 'next'
+              run: |
+                  git rm -r .
+                  git checkout origin/"${{ steps.get_version.outputs.plugin_release_branch }}" -- .
+
+            - name: Commit the changes to the WordPress release branch
+              if: |
+                  github.event.inputs.release_type == 'latest' ||
+                  github.event.inputs.release_type == 'next'
+              run: |
+                  git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_version.outputs.plugin_release_branch }} branch"
+                  git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -11,7 +11,7 @@ on:
                 required: true
 
 env:
-    WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
+    WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' }}
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -65,9 +65,6 @@ jobs:
         needs: get-wordpress-release-branch
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout code
-              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-
             - name: Compute plugin release branch name
               id: get_release_branch
               env:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -31,8 +31,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-              with:
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
 
             - name: Compute plugin release branch
               id: get_version

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -216,7 +216,6 @@ jobs:
                   npm run build
 
             - name: Publish packages
-              if: github.event.inputs.release_type == 'next'
               run: |
                   minimum_version_bump='patch'
                   if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -18,11 +18,12 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    env:
+        WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
+
     sync-wordpress-branch:
         name: Sync the WordPress release branch
         runs-on: ubuntu-latest
-        env:
-            WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
         outputs:
             plugin_version: ${{ steps.get_version.outputs.plugin_version }}
             plugin_release_branch: ${{ steps.get_version.outputs.plugin_release_branch }}
@@ -67,3 +68,58 @@ jobs:
               run: |
                   git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_version.outputs.plugin_release_branch }} branch"
                   git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
+
+    update-packages:
+        name: Update Packages
+        runs-on: ubuntu-latest
+        needs: sync-wordpress-branch
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  ref: ${{ env.WORDPRESS_RELEASE_BRANCH }}
+
+            - name: Use desired version of NodeJS
+              uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
+              with:
+                  node-version: 14
+                  cache: npm
+
+            - name: Update package versions
+              run: |
+                  PUBLIC_PACKAGES=$(ls -d packages/*/ | xargs -I{} sh -c "jq -e '.private != true' '{}'/package.json >/dev/null && test -f '{}'CHANGELOG.md && echo '{}'")
+                  PUBLIC_PACKAGE_NAMES=$(jq '.dependencies' package.json )
+                  minimum_version_jump='patch'
+                  while IFS= read -r package; do
+                    changes_detected=false
+                    while IFS= read -r line; do
+                      if [[ "$line" = '## Unreleased' ]]; then
+                        changes_detected=true
+                        continue
+                      fi
+                      if [[ "$changes_detected" = false ]]; then
+                        continue;
+                      fi
+                      case $line in
+                        '## '*)
+                          break
+                          ;;
+                        '### Breaking Change'*)
+                          version_jump=major
+                          break
+                          ;;
+                        '### Deprecation'*|'### Enhancement'*|'### New API'*|'### New Feature'*)
+                          version_jump=minor
+                          continue
+                          ;;
+                        '### '*|*-*)
+                          if [[ "$version_jump" != 'minor' ]]; then
+                            version_jump="$minimum_version_jump"
+                          fi
+                      esac
+                    done < "$package"CHANGELOG.md
+                    package_name=${my_package#'packages/'}
+                    package_name="@wordpress/${package_name%'/'}"
+                    package_version=$(jq --raw-output '.version' "$package"package.json)
+                  done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -213,6 +213,11 @@ jobs:
             - name: Npm install
               run: npm ci
 
+            - name: Configure git user name and email
+              run: |
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
             - name: Publish packages
               run: |
                   minimum_version_bump='patch'

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -91,6 +91,7 @@ jobs:
                   git config user.email gutenberg@wordpress.org
 
             - name: Update package versions
+              id: update_package_versions
               run: |
                   PUBLIC_PACKAGES=$(find packages/*/ -type d -maxdepth 0 -exec sh -c 'jq -e ".private != true" "$1"/package.json > /dev/null && test -f "$1"/CHANGELOG.md && echo "$1"' shell {} \;)
                   production_package_names=$(jq '.dependencies | keys | @sh' package.json)
@@ -150,6 +151,17 @@ jobs:
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
                   git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
+                  echo "::set-output name=changelog_commit::$(git rev-parse --verify --short HEAD)"
+
+            - name: Fetch trunk
+              run: git fetch --depth=1 origin trunk
+
+            - name: Cherry-pick the changelog update commit to trunk
+              run: |
+                  git checkout trunk
+                  git pull
+                  git cherry-pick "${{ steps.update_package_versions.outputs.changelog_commit }}"
+                  git push
 
     publish-packages:
         name: Publish Packages

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -119,7 +119,7 @@ jobs:
                           fi
                       esac
                     done < "$package"CHANGELOG.md
-                    package_name=${my_package#'packages/'}
+                    package_name=${package#'packages/'}
                     package_name="@wordpress/${package_name%'/'}"
                     package_version=$(jq --raw-output '.version' "$package"package.json)
                   done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -87,6 +87,11 @@ jobs:
                   node-version: 14
                   cache: npm
 
+            - name: Configure git user name and email
+              run: |
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
             - name: Update package versions
               run: |
                   PUBLIC_PACKAGES=$(find packages/*/ -type d -maxdepth 0 -exec sh -c 'jq -e ".private != true" "$1"/package.json > /dev/null && test -f "$1"/CHANGELOG.md && echo "$1"' shell {} \;)

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -25,8 +25,8 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             wordpress_release_branch: |
-              steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
-              steps.get_wordpress_branch_for_manual_release.wordpress_release_branch
+                steps.get_wordpress_branch_for_sync.outputs.wordpress_release_branch ||
+                steps.get_wordpress_branch_for_manual_release.wordpress_release_branch
 
         steps:
             - name: Get WordPress release branch for sync
@@ -64,6 +64,8 @@ jobs:
             endsWith( github.event.release.tag_name, '-rc.1' )
         needs: get-wordpress-release-branch
         runs-on: ubuntu-latest
+        env:
+            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
         steps:
             - name: Compute plugin release branch name
               id: get_release_branch
@@ -77,7 +79,7 @@ jobs:
             - name: Checkout WordPress release branch
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                  ref: ${{ env.WP_RELEASE_BRANCH }}
                   fetch-depth: 100
 
             - name: Configure git user name and email
@@ -94,18 +96,21 @@ jobs:
             - name: Commit the changes to the WordPress release branch
               run: |
                   git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_release_branch.outputs.plugin_release_branch }} branch"
-                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
+                  git push --set-upstream origin "${WP_RELEASE_BRANCH}"
 
     update-packages:
         name: Update Packages
         runs-on: ubuntu-latest
         needs: [get-wordpress-release-branch, sync-wordpress-branch]
+        if: ${{ always() }}
+        env:
+            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                  ref: ${{ env.WP_RELEASE_BRANCH }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2
@@ -178,7 +183,7 @@ jobs:
                     fi
                   done <<< $PUBLIC_PACKAGES
                   git commit -am "Update changelog files"
-                  git push --set-upstream origin "${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}"
+                  git push --set-upstream origin "${WP_RELEASE_BRANCH}"
                   echo "::set-output name=changelog_commit::$(git rev-parse --verify --short HEAD)"
 
             - name: Fetch trunk
@@ -195,12 +200,15 @@ jobs:
         name: Publish Packages
         runs-on: ubuntu-latest
         needs: [get-wordpress-release-branch, update-packages]
+        if: ${{ always() }}
+        env:
+            WP_RELEASE_BRANCH: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: ${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }}
+                  ref: ${{ env.WP_RELEASE_BRANCH }}
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@38d90ce44d5275ad62cc48384b3d8a58c500bb5f # v2.2.2

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
     get-wordpress-release-branch:
-        name: Determine whether to use wp/trunk or wp/next branch
+        name: Determine which WordPress release branch to use
         runs-on: ubuntu-latest
         outputs:
             wordpress_release_branch: >-
@@ -28,7 +28,7 @@ jobs:
                 }}
 
         steps:
-            - name: Get WordPress release branch for sync
+            - name: Get WordPress release branch for manual release
               id: get_wordpress_branch_for_manual_release
               if: |
                   github.event_name == 'workflow_dispatch' &&
@@ -56,7 +56,7 @@ jobs:
                   rm version.php
 
     sync-wordpress-branch:
-        name: Sync the WordPress release branch
+        name: Sync the WordPress release branch (${{ needs.get-wordpress-release-branch.outputs.wordpress_release_branch }})
         if: |
             github.event_name == 'release' &&
             github.event.release.assets[0] &&

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,6 +1,8 @@
 name: Publish npm packages
 
 on:
+    release:
+        types: [published]
     workflow_dispatch:
         inputs:
             release_type:
@@ -45,22 +47,23 @@ jobs:
 
     sync-wordpress-branch:
         name: Sync the WordPress release branch
+        if: |
+          github.event_name == 'release' &&
+          github.event.release.assets[0] &&
+          endsWith( github.event.release.tag_name, '-rc.1' )
         runs-on: ubuntu-latest
-        outputs:
-            plugin_version: ${{ steps.get_version.outputs.plugin_version }}
-            plugin_release_branch: ${{ steps.get_version.outputs.plugin_release_branch }}
 
         steps:
             - name: Checkout code
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
 
-            - name: Compute plugin release branch
-              id: get_version
+            - name: Compute plugin release branch name
+              id: get_release_branch
+              env:
+                  TAG: ${{ github.event.release.tag_name }}
               run: |
-                  PLUGIN_VERSION=$(jq --raw-output '.version' package.json)
-                  echo "::set-output name=plugin_version::$(echo $PLUGIN_VERSION)"
-                  IFS='.' read -r -a PLUGIN_VERSION_ARRAY <<< "$PLUGIN_VERSION"
-                  PLUGIN_RELEASE_BRANCH="release/${PLUGIN_VERSION_ARRAY[0]}.${PLUGIN_VERSION_ARRAY[1]}"
+                  IFS='.' read -r -a VERSION_ARRAY <<< "${TAG#v}"
+                  PLUGIN_RELEASE_BRANCH="release/${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
                   echo "::set-output name=plugin_release_branch::$(echo $PLUGIN_RELEASE_BRANCH)"
 
             - name: Configure git user name and email
@@ -79,15 +82,15 @@ jobs:
                   github.event.inputs.release_type == 'next'
               run: |
                   git rm -r .
-                  git fetch --depth=1 origin "${{ steps.get_version.outputs.plugin_release_branch }}"
-                  git checkout origin/"${{ steps.get_version.outputs.plugin_release_branch }}" -- .
+                  git fetch --depth=1 origin "${{ steps.get_release_branch.outputs.plugin_release_branch }}"
+                  git checkout origin/"${{ steps.get_release_branch.outputs.plugin_release_branch }}" -- .
 
             - name: Commit the changes to the WordPress release branch
               if: |
                   github.event.inputs.release_type == 'latest' ||
                   github.event.inputs.release_type == 'next'
               run: |
-                  git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_version.outputs.plugin_release_branch }} branch"
+                  git commit -m "Merge changes published in the Gutenberg plugin ${{ steps.get_release_branch.outputs.plugin_release_branch }} branch"
                   git push --set-upstream origin "$WORDPRESS_RELEASE_BRANCH"
 
     update-packages:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -138,5 +138,9 @@ jobs:
                     fi
                     if [ -n "$next_version" ]; then
                       cat <<< $(jq --tab --arg version "${next_version}-prerelease" '.version = $version' "$package"package.json) > "$package"package.json
+                      if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
+                        next_version="${next_version}-next.0"
+                      fi
+                      sed -i '' "s/## Unreleased/\n\n## ${next_version} ($(date +%F))/g" "$package"CHANGELOG.md
                     fi
                   done <<< $PUBLIC_PACKAGES

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -10,6 +10,9 @@ on:
                 description: 'patch, minor, or major?'
                 required: true
 
+env:
+    WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
+
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
     # The concurrency group contains the workflow name and the branch name for pull requests
@@ -18,9 +21,6 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    env:
-        WORDPRESS_RELEASE_BRANCH: ${{ github.event.inputs.release_type == 'next' && 'wp/next' || 'wp/trunk' ) }}
-
     sync-wordpress-branch:
         name: Sync the WordPress release branch
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -106,16 +106,16 @@ jobs:
                           break
                           ;;
                         '### Breaking Change'*)
-                          version_jump=major
+                          version_bump=major
                           break
                           ;;
                         '### Deprecation'*|'### Enhancement'*|'### New API'*|'### New Feature'*)
-                          version_jump=minor
+                          version_bump=minor
                           continue
                           ;;
                         '### '*|*-*)
-                          if [[ "$version_jump" != 'minor' ]]; then
-                            version_jump="$minimum_version_jump"
+                          if [[ "$version_bump" != 'minor' ]]; then
+                            version_bump="$minimum_version_jump"
                           fi
                       esac
                     done < "$package"CHANGELOG.md


### PR DESCRIPTION
## Description
Purports to fix https://github.com/WordPress/gutenberg/discussions/37820. See there for more background.

This PR attempts to automate the publishing of npm packages, as is currently documented in [the docs](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#packages-releases-to-npm-and-wordpress-core-updates). Prior to this PR, publishing them meant locally running a number of commands on one's system.

As of this PR, this should no longer be necessary (aside from inherently manual processes, e.g. cherry-picking a number of selected commits from one branch to another). Instead, the publishing process can now be started from GitHub.

It is important to keep in mind that there are a [number of different scenarios listed](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#packages-releases-to-npm-and-wordpress-core-updates) in the docs in which publishing of npms can occur.

For the purpose of this PR, it's especially important to note that some of these scenarios ([Syncing WP trunk](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#synchronizing-wordpress-trunk), plus arguably [development releases](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#development-releases)) are supposed to happen basically any time a Gutenberg plugin RC1 is released -- in other words, they should happen _automatically_ (with no user interaction required). For this reason, this PR has them automatically triggered upon release of a Gutenberg plugin RC1.

The other scenarios ([Minor WP releases](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#minor-wordpress-releases) and [standalone bugfix releases](https://github.com/WordPress/gutenberg/blob/b54d4d1e20f161309d2c44d7f332a50e9e6b66c4/docs/contributors/code/release.md#standalone-bugfix-package-releases)) are of a more manual nature: Someone has to make the decision that a point or bugfix release is required. Consequently, this PR makes it so that these processes can be triggered manually from the corresponding GH Actions page.

## How has this been tested?

We're going to test both the automatically triggered scenario (when an RC1 is published), and the manual one. Both of them share a few common setup steps though.

First of all, apply the following patch on top of this PR's branch in order to disable actual publishing of npms:

```diff
diff --git a/.github/workflows/publish-npm-packages.yml b/.github/workflows/publish-npm-packages.yml
index 7c54dedf30..3aa9d176dc 100644
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -213,11 +213,7 @@ jobs:
                   minimum_version_bump='patch'
                   if [ '${{ github.event.inputs.release_type }}' = 'next' ]; then
                     sha=$(git rev-parse --short HEAD)
-                    npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private
-                    npx lerna publish from-package --dist-tag next
-                  elif [ '${{ github.event.inputs.release_type }}' = 'bugfix' ]; then
-                    npx lerna publish
+                    npx lerna version pre"$minimum_version_bump" --preid next."$sha" --no-private --yes --no-git-tag-version --no-push
                   else
-                    npx lerna version "$minimum_version_bump" --no-private
-                    npx lerna publish from-package
+                    npx lerna version "$minimum_version_bump" --no-private --yes --no-git-tag-version --no-push
                   fi
```

- Make sure you have your own fork of the Gutenberg repo, and that you've added it locally as a remote (E.g. `git remote add ockham git@github.com:ockham/gutenberg.git` if your GH username is `ockham` :slightly_smiling_face: ).
- Check out this PR's branch, and push the contents to your fork's `trunk` branch (you can reset later):
```
git push ockham add/publish-npm-packages-workflow:trunk --force
```
- Make sure that your fork also has the current release branch, plus up-to-date versions of `wp/trunk` and `wp/next`:
```
git checkout release/12.6 && git pull && git push ockham
git checkout wp/next && git pull && git push ockham
git checkout wp/trunk && git pull && git push ockham
```
- Furthermore, you fork also needs to have all tags (for lerna to correctly determine version bumps):
```
git push ockham --tags
```

### Automatic scenario

- Publish an RC1 release for the current release branch in your fork (under 'Releases', e.g. https://github.com/ockham/gutenberg/releases). Specify the correct tag (which will be created by GitHub when publishing the release), e.g. `v12.6.0-rc.1`. Don't forget the leading `v`. Set the release name accordingly (e.g. `12.6.0 RC1`). Make sure to attach a `gutenberg.zip` as an asset (e.g. downloaded from corresponding RC1 release in the upstream Gutenberg repo). Make sure for the upload to finish (progress bar!), tick the 'Prerelease' box, and then publish the release by clicking the green button.
- Go to the 'Actions' tab of your fork's GH page (e.g. https://github.com/ockham/gutenberg/actions).
- In the left sidebar (list of available actions), locate the action whose description reads "Publish npm packages", and click on it.
- You should see the workflow that was triggered by publishing the release at the top of the list. Click on it.
- Inspect the individual steps of the workflow (by expanding them) to verify that they worked.

### Manual scenario

- Go to the 'Actions' tab of your fork's GH page (e.g. https://github.com/ockham/gutenberg/actions).
- In the left sidebar (list of available actions), locate the action whose description reads "Publish npm packages", and click on it.
- Locate the blue "This workflow has a workflow_dispatch event trigger." header, and click the "Run workflow" button next to it.
- Keep the `trunk` branch as the base branch, and enter `next` and `patch` into the text input fields, respectively.

![image](https://user-images.githubusercontent.com/96308/149390667-4070207b-6da1-4d75-be37-853e535af0fe.png)

To be continued

## Screenshots <!-- if applicable -->
TBD

## TODO

- [x] The workflow gets currently stuck at the "Update package versions" step ([see](https://github.com/ockham/gutenberg/runs/4803403085?check_suite_focus=true)). Debug and fix.
- [x] Trigger workflow upon plugin RC release (see https://github.com/WordPress/gutenberg/discussions/37820#discussioncomment-1949319).
- [ ] Correctly set minimum version bump, depending on scenario.
- [x] Cherry-pick commits to `trunk` (see https://github.com/WordPress/gutenberg/discussions/37820#discussioncomment-1949262).
  - [x] Update changelog files
  - [x] Publish
- [ ] Use admin token when syncing to `wp/trunk` and cherry-picking to `trunk`
  - [ ] Make sure to carry over upstream's branch protection rules
- [ ] Use npm token for publishing (see https://github.com/WordPress/gutenberg/discussions/37820#discussioncomment-1961240)
- [ ] When syncing: Apply changes to Core `trunk`
- [ ] Stretch goal: Send Slack notification to #core-editor.

## Types of changes
Automation