### PR TITLE
Fix failing / flaky Navigation block e2e test by removing unnecessary validation steps for creation of draft page

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -436,16 +436,26 @@ describe( 'Navigation', () => {
 	} );
 
 	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
+		const pageTitle = 'A really long page name that will not exist';
+
 		// The URL Details endpoint 404s for the created page, since it will
 		// be a draft that is inaccessible publicly. To avoid this we mock
-		// out the endpoint response to be empty which will be handled gracefully
-		// in the UI whilst avoiding any 404s.
+		// out the endpoint response to be valid and allow the UI to handle
+		// gracefully. This avoids indeterminism in this test caused by
+		// waiting on network 404 which was preivously making it unstable.
+		// Consider that the rich previews feature is not under test here
+		// and so it is valid to mock out this endpoint.
 		await setUpResponseMocking( [
 			{
 				match: ( request ) =>
 					request.url().includes( `rest_route` ) &&
 					request.url().includes( `url-details` ),
-				onRequestMatch: createJSONResponse( [] ),
+				onRequestMatch: createJSONResponse( {
+					description: '',
+					icon: '',
+					image: '',
+					title: pageTitle,
+				} ),
 			},
 		] );
 
@@ -460,7 +470,7 @@ describe( 'Navigation', () => {
 
 		// Wait for URL input to be focused
 		// Insert name for the new page.
-		const pageTitle = 'A really long page name that will not exist';
+
 		const input = await page.waitForSelector(
 			'input.block-editor-url-input__input:focus'
 		);

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -435,7 +435,7 @@ describe( 'Navigation', () => {
 		expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 	} );
 
-	it.skip( 'allows pages to be created from the navigation block and their links added to menu', async () => {
+	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
 		// The URL Details endpoint 404s for the created page, since it will
 		// be a draft that is inaccessible publicly. To avoid this we mock
 		// out the endpoint response to be empty which will be handled gracefully
@@ -471,11 +471,6 @@ describe( 'Navigation', () => {
 			'.block-editor-link-control__search-create'
 		);
 		await createPageButton.click();
-
-		const draftLink = await page.waitForSelector(
-			'.wp-block-navigation-item__content'
-		);
-		await draftLink.click();
 
 		// Creating a draft is async, so wait for a sign of completion. In this
 		// case the link that shows in the URL popover once a link is added.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The test `allows pages to be created from the navigation block and their links added to menu` from the Navigation block e2e tests is (still) intermittently failing.

We tried to fix this in https://github.com/WordPress/gutenberg/pull/37501 but it appears that was only half the battle!

Running locally it appears we've got some additional steps which attempt to validate that a draft page has been created that might not be necessary. 

I believe the behaviour of the Nav block no longer requires that we **re**select the Nav item in order to show the link preview. 

I've removed that step and it seems to pass. 

Fixes https://github.com/WordPress/gutenberg/issues/37479

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

We need to re-run CI several times (let's say x5) and check that the test is no longer flaky.

Please feel free to mark test runs below:

- [x] [Test round 1.](https://github.com/WordPress/gutenberg/actions/runs/1663782841/attempts/1)
- [x] [Test round 2](https://github.com/WordPress/gutenberg/actions/runs/1663782841/attempts/2).
- [x] [Test round 3](https://github.com/WordPress/gutenberg/actions/runs/1663782841/attempts/3).
- [x] [Test round 4](https://github.com/WordPress/gutenberg/actions/runs/1663782841/attempts/4).
- [x] Test round 5.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
