### PR TITLE
Schema: Fix appearanceTools in theme.json schema

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -7,13 +7,17 @@
 			"createTheme": "https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/",
 			"reference": "https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/"
 		},
-		"settingsPropertiesBorder": {
+		"settingsPropertiesAppearanceTools": {
 			"properties": {
 				"appearanceTools": {
 					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
 					"type": "boolean",
 					"default": false
-				},
+				}
+			}
+		},
+		"settingsPropertiesBorder": {
+			"properties": {
 				"border": {
 					"description": "Settings related to borders.",
 					"type": "object",
@@ -165,7 +169,6 @@
 					},
 					"additionalProperties": false
 				}
-
 			}
 		},
 		"settingsPropertiesLayout": {
@@ -187,8 +190,7 @@
 				}
 			}
 		},
-
-		"settingsPropertiesSpacing":{
+		"settingsPropertiesSpacing": {
 			"properties": {
 				"spacing": {
 					"description": "Settings related to spacing.",
@@ -225,7 +227,7 @@
 				}
 			}
 		},
-		"settingsPropertiesTypography":{
+		"settingsPropertiesTypography": {
 			"properties": {
 				"typography": {
 					"description": "Settings related to typography.",
@@ -329,7 +331,8 @@
 			}
 		},
 		"settingsProperties": {
-			"allOf":[
+			"allOf": [
+				{ "$ref": "#/definitions/settingsPropertiesAppearanceTools" },
 				{ "$ref": "#/definitions/settingsPropertiesBorder" },
 				{ "$ref": "#/definitions/settingsPropertiesColor" },
 				{ "$ref": "#/definitions/settingsPropertiesLayout" },
@@ -346,6 +349,7 @@
 				},
 				{
 					"properties": {
+						"appearanceTools": {},
 						"border": {},
 						"color": {},
 						"layout": {},
@@ -370,7 +374,10 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/button": {
-					"allOf":[
+					"allOf": [
+						{
+							"$ref": "#/definitions/settingsPropertiesAppearanceTools"
+						},
 						{
 							"properties": {
 								"border": {
@@ -389,7 +396,9 @@
 						{ "$ref": "#/definitions/settingsPropertiesColor" },
 						{ "$ref": "#/definitions/settingsPropertiesLayout" },
 						{ "$ref": "#/definitions/settingsPropertiesSpacing" },
-						{ "$ref": "#/definitions/settingsPropertiesTypography" },
+						{
+							"$ref": "#/definitions/settingsPropertiesTypography"
+						},
 						{ "$ref": "#/definitions/settingsPropertiesCustom" }
 					]
 				},
@@ -1141,6 +1150,7 @@
 				},
 				{
 					"properties": {
+						"appearanceTools": {},
 						"color": {},
 						"layout": {},
 						"spacing": {},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Fix `appearanceTools` property in the theme.json schema.

Fixes #37710

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Create a theme.json file and confirmed `appearanceTools` is allowed.

```json
{
	"version": 2,
	"settings": {
		"appearanceTools": true,
		"blocks": {
			"core/group": {
				"appearanceTools": true
			}
		}
	}
}
```
