### PR TITLE
Borders: Add new BorderControl component

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -612,6 +612,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "BorderControl",
+		"slug": "border-control",
+		"markdown_source": "../packages/components/src/border-control/border-control/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "BoxControl",
 		"slug": "box-control",
 		"markdown_source": "../packages/components/src/box-control/README.md",

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -33,6 +33,7 @@ const BorderControlDropdown = (
 		disableCustomColors,
 		enableAlpha,
 		indicatorClassName,
+		indicatorWrapperClassName,
 		onReset,
 		onColorChange,
 		onStyleChange,
@@ -45,16 +46,6 @@ const BorderControlDropdown = (
 	} = useBorderControlDropdown( props );
 
 	const { color, style } = border || {};
-	const fallbackColor = !! style && style !== 'none' ? '#ddd' : undefined;
-	const indicatorBorderStyles = {
-		// The border style is set to `none` when border width is zero. Forcing
-		// the solid style in this case maintains the positioning of the inner
-		// ColorIndicator.
-		borderStyle: style === 'none' ? 'solid' : style,
-		// If there is no color selected but we have a style to display, apply
-		// a border color anyway.
-		borderColor: color || fallbackColor,
-	};
 
 	const renderToggle = ( { onToggle = noop } ) => (
 		<Button
@@ -62,7 +53,7 @@ const BorderControlDropdown = (
 			variant="tertiary"
 			aria-label={ __( 'Open border options' ) }
 		>
-			<span style={ indicatorBorderStyles }>
+			<span className={ indicatorWrapperClassName }>
 				<ColorIndicator
 					className={ indicatorClassName }
 					colorValue={ color }

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -23,7 +23,7 @@ const noop = () => undefined;
 
 const BorderControlDropdown = (
 	props: WordPressComponentProps< DropdownProps, 'div' >,
-	forwardedRef: React.Ref< any >
+	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
 		__experimentalHasMultipleOrigins,

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { closeSmall } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import BorderControlStylePicker from '../border-control-style-picker';
+import Button from '../../button';
+// @ts-ignore
+import ColorIndicator from '../../color-indicator';
+// @ts-ignore
+import ColorPalette from '../../color-palette';
+import Dropdown from '../../dropdown';
+import { HStack } from '../../h-stack';
+import { VStack } from '../../v-stack';
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
+import { useBorderControlDropdown } from './hook';
+import { StyledLabel } from '../../base-control/styles/base-control-styles';
+
+import type { DropdownProps, PopoverProps } from '../types';
+const noop = () => undefined;
+
+const BorderControlDropdown = (
+	props: WordPressComponentProps< DropdownProps, 'div' >,
+	forwardedRef: React.Ref< any >
+) => {
+	const {
+		__experimentalHasMultipleOrigins,
+		__experimentalIsRenderedInSidebar,
+		border,
+		colors,
+		disableCustomColors,
+		enableAlpha,
+		indicatorClassName,
+		onReset,
+		onColorChange,
+		onStyleChange,
+		popoverClassName,
+		popoverContentClassName,
+		popoverControlsClassName,
+		resetButtonClassName,
+		enableStyle = true,
+		...otherProps
+	} = useBorderControlDropdown( props );
+
+	const { color, style } = border || {};
+	const fallbackColor = !! style && style !== 'none' ? '#ddd' : undefined;
+	const indicatorBorderStyles = {
+		// The border style is set to `none` when border width is zero. Forcing
+		// the solid style in this case maintains the positioning of the inner
+		// ColorIndicator.
+		borderStyle: style === 'none' ? 'solid' : style,
+		// If there is no color selected but we have a style to display, apply
+		// a border color anyway.
+		borderColor: color || fallbackColor,
+	};
+
+	const renderToggle = ( { onToggle = noop } ) => (
+		<Button
+			onClick={ onToggle }
+			variant="tertiary"
+			aria-label={ __( 'Open border options' ) }
+		>
+			<span style={ indicatorBorderStyles }>
+				<ColorIndicator
+					className={ indicatorClassName }
+					colorValue={ color }
+				/>
+			</span>
+		</Button>
+	);
+
+	const renderContent = ( { onClose }: PopoverProps ) => (
+		<>
+			<VStack className={ popoverControlsClassName } spacing={ 6 }>
+				<HStack>
+					<StyledLabel>{ __( 'Border color' ) }</StyledLabel>
+					<Button
+						isSmall
+						label={ __( 'Close border color' ) }
+						icon={ closeSmall }
+						onClick={ onClose }
+					/>
+				</HStack>
+				<ColorPalette
+					className={ popoverContentClassName }
+					value={ color }
+					onChange={ onColorChange }
+					{ ...{ colors, disableCustomColors } }
+					__experimentalHasMultipleOrigins={
+						__experimentalHasMultipleOrigins
+					}
+					__experimentalIsRenderedInSidebar={
+						__experimentalIsRenderedInSidebar
+					}
+					clearable={ false }
+					enableAlpha={ enableAlpha }
+				/>
+				{ enableStyle && (
+					<BorderControlStylePicker
+						label={ __( 'Style' ) }
+						value={ style }
+						onChange={ onStyleChange }
+					/>
+				) }
+			</VStack>
+			<Button
+				className={ resetButtonClassName }
+				variant="tertiary"
+				onClick={ () => {
+					onReset();
+					onClose();
+				} }
+			>
+				{ __( 'Reset to default' ) }
+			</Button>
+		</>
+	);
+
+	return (
+		<Dropdown
+			renderToggle={ renderToggle }
+			renderContent={ renderContent }
+			contentClassName={ popoverClassName }
+			{ ...otherProps }
+			ref={ forwardedRef }
+		/>
+	);
+};
+
+const ConnectedBorderControlDropdown = contextConnect(
+	BorderControlDropdown,
+	'BorderControlDropdown'
+);
+
+export default ConnectedBorderControlDropdown;

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -9,9 +9,7 @@ import { closeSmall } from '@wordpress/icons';
  */
 import BorderControlStylePicker from '../border-control-style-picker';
 import Button from '../../button';
-// @ts-ignore
 import ColorIndicator from '../../color-indicator';
-// @ts-ignore
 import ColorPalette from '../../color-palette';
 import Dropdown from '../../dropdown';
 import { HStack } from '../../h-stack';

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -163,11 +163,16 @@ const BorderControlDropdown = (
 		enableStyle
 	);
 
+	const dropdownPosition = __experimentalIsRenderedInSidebar
+		? 'bottom left'
+		: undefined;
+
 	const renderToggle = ( { onToggle = noop } ) => (
 		<Button
 			onClick={ onToggle }
 			variant="tertiary"
 			aria-label={ toggleAriaLabel }
+			position={ dropdownPosition }
 		>
 			<span className={ indicatorWrapperClassName }>
 				<ColorIndicator

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -145,6 +145,7 @@ const BorderControlDropdown = (
 		popoverContentClassName,
 		popoverControlsClassName,
 		resetButtonClassName,
+		showDropdownHeader,
 		enableStyle = true,
 		...otherProps
 	} = useBorderControlDropdown( props );
@@ -186,15 +187,17 @@ const BorderControlDropdown = (
 	const renderContent = ( { onClose }: PopoverProps ) => (
 		<>
 			<VStack className={ popoverControlsClassName } spacing={ 6 }>
-				<HStack>
-					<StyledLabel>{ __( 'Border color' ) }</StyledLabel>
-					<Button
-						isSmall
-						label={ __( 'Close border color' ) }
-						icon={ closeSmall }
-						onClick={ onClose }
-					/>
-				</HStack>
+				{ showDropdownHeader ? (
+					<HStack>
+						<StyledLabel>{ __( 'Border color' ) }</StyledLabel>
+						<Button
+							isSmall
+							label={ __( 'Close border color' ) }
+							icon={ closeSmall }
+							onClick={ onClose }
+						/>
+					</HStack>
+				) : undefined }
 				<ColorPalette
 					className={ popoverContentClassName }
 					value={ color }

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -1,0 +1,92 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import { parseUnit } from '../../unit-control/utils';
+import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+
+import type { DropdownProps } from '../types';
+
+export function useBorderControlDropdown(
+	props: WordPressComponentProps< DropdownProps, 'div' >
+) {
+	const {
+		border,
+		className,
+		colors,
+		onChange,
+		previousStyleSelection,
+		...otherProps
+	} = useContextSystem( props, 'BorderControlDropdown' );
+
+	const [ widthValue ] = parseUnit( border?.width );
+	const hasZeroWidth = widthValue === 0;
+
+	const onColorChange = ( color?: string ) => {
+		const style =
+			border?.style === 'none' ? previousStyleSelection : border?.style;
+		const width = hasZeroWidth && !! color ? '1px' : border?.width;
+
+		onChange( { color, style, width } );
+	};
+
+	const onStyleChange = ( style?: string ) => {
+		const width = hasZeroWidth && !! style ? '1px' : border?.width;
+		onChange( { ...border, style, width } );
+	};
+
+	const onReset = () => {
+		onChange( {
+			...border,
+			color: undefined,
+			style: undefined,
+		} );
+	};
+
+	// Generate class names.
+	const cx = useCx();
+	const classes = useMemo( () => {
+		return cx( styles.BorderControlDropdown, className );
+	}, [ className ] );
+
+	const indicatorClassName = useMemo( () => {
+		return cx( styles.BorderColorIndicator );
+	}, [] );
+
+	const popoverClassName = useMemo( () => {
+		return cx( styles.BorderControlPopover );
+	}, [] );
+
+	const popoverControlsClassName = useMemo( () => {
+		return cx( styles.BorderControlPopoverControls );
+	}, [] );
+
+	const popoverContentClassName = useMemo( () => {
+		return cx( styles.BorderControlPopoverContent );
+	}, [] );
+
+	const resetButtonClassName = useMemo( () => {
+		return cx( styles.ResetButton );
+	}, [] );
+
+	return {
+		...otherProps,
+		border,
+		className: classes,
+		colors,
+		indicatorClassName,
+		onColorChange,
+		onStyleChange,
+		onReset,
+		popoverClassName,
+		popoverContentClassName,
+		popoverControlsClassName,
+		resetButtonClassName,
+	};
+}

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -7,7 +7,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import * as styles from '../styles';
-import { parseUnit } from '../../unit-control/utils';
+import { parseQuantityAndUnitFromRawValue } from '../../unit-control/utils';
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
 
@@ -25,7 +25,7 @@ export function useBorderControlDropdown(
 		...otherProps
 	} = useContextSystem( props, 'BorderControlDropdown' );
 
-	const [ widthValue ] = parseUnit( border?.width );
+	const [ widthValue ] = parseQuantityAndUnitFromRawValue( border?.width );
 	const hasZeroWidth = widthValue === 0;
 
 	const onColorChange = ( color?: string ) => {

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -53,27 +53,27 @@ export function useBorderControlDropdown(
 	const cx = useCx();
 	const classes = useMemo( () => {
 		return cx( styles.BorderControlDropdown, className );
-	}, [ className ] );
+	}, [ className, cx ] );
 
 	const indicatorClassName = useMemo( () => {
 		return cx( styles.BorderColorIndicator );
-	}, [] );
+	}, [ cx ] );
 
 	const popoverClassName = useMemo( () => {
 		return cx( styles.BorderControlPopover );
-	}, [] );
+	}, [ cx ] );
 
 	const popoverControlsClassName = useMemo( () => {
 		return cx( styles.BorderControlPopoverControls );
-	}, [] );
+	}, [ cx ] );
 
 	const popoverContentClassName = useMemo( () => {
 		return cx( styles.BorderControlPopoverContent );
-	}, [] );
+	}, [ cx ] );
 
 	const resetButtonClassName = useMemo( () => {
 		return cx( styles.ResetButton );
-	}, [] );
+	}, [ cx ] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -59,6 +59,10 @@ export function useBorderControlDropdown(
 		return cx( styles.BorderColorIndicator );
 	}, [ cx ] );
 
+	const indicatorWrapperClassName = useMemo( () => {
+		return cx( styles.ColorIndicatorWrapper( border ) );
+	}, [ border, cx ] );
+
 	const popoverClassName = useMemo( () => {
 		return cx( styles.BorderControlPopover );
 	}, [ cx ] );
@@ -81,6 +85,7 @@ export function useBorderControlDropdown(
 		className: classes,
 		colors,
 		indicatorClassName,
+		indicatorWrapperClassName,
 		onColorChange,
 		onStyleChange,
 		onReset,

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -52,31 +52,31 @@ export function useBorderControlDropdown(
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.BorderControlDropdown, className );
+		return cx( styles.borderControlDropdown(), className );
 	}, [ className, cx ] );
 
 	const indicatorClassName = useMemo( () => {
-		return cx( styles.BorderColorIndicator );
+		return cx( styles.borderColorIndicator );
 	}, [ cx ] );
 
 	const indicatorWrapperClassName = useMemo( () => {
-		return cx( styles.ColorIndicatorWrapper( border ) );
+		return cx( styles.colorIndicatorWrapper( border ) );
 	}, [ border, cx ] );
 
 	const popoverClassName = useMemo( () => {
-		return cx( styles.BorderControlPopover );
+		return cx( styles.borderControlPopover );
 	}, [ cx ] );
 
 	const popoverControlsClassName = useMemo( () => {
-		return cx( styles.BorderControlPopoverControls );
+		return cx( styles.borderControlPopoverControls );
 	}, [ cx ] );
 
 	const popoverContentClassName = useMemo( () => {
-		return cx( styles.BorderControlPopoverContent );
+		return cx( styles.borderControlPopoverContent );
 	}, [ cx ] );
 
 	const resetButtonClassName = useMemo( () => {
-		return cx( styles.ResetButton );
+		return cx( styles.resetButton );
 	}, [ cx ] );
 
 	return {

--- a/packages/components/src/border-control/border-control-dropdown/index.ts
+++ b/packages/components/src/border-control/border-control-dropdown/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/packages/components/src/border-control/border-control-style-picker/component.tsx
+++ b/packages/components/src/border-control/border-control-style-picker/component.tsx
@@ -39,7 +39,7 @@ const Label = ( props: LabelProps ) => {
 
 const BorderControlStylePicker = (
 	props: WordPressComponentProps< StylePickerProps, 'div' >,
-	forwardedRef: React.Ref< any >
+	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
 		buttonClassName,

--- a/packages/components/src/border-control/border-control-style-picker/component.tsx
+++ b/packages/components/src/border-control/border-control-style-picker/component.tsx
@@ -72,6 +72,8 @@ const BorderControlStylePicker = (
 							)
 						}
 						aria-label={ borderStyle.label }
+						label={ borderStyle.label }
+						showTooltip={ true }
 					/>
 				) ) }
 			</Flex>

--- a/packages/components/src/border-control/border-control-style-picker/component.tsx
+++ b/packages/components/src/border-control/border-control-style-picker/component.tsx
@@ -1,0 +1,86 @@
+/**
+ * WordPress dependencies
+ */
+import { lineDashed, lineDotted, lineSolid } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Button from '../../button';
+import { StyledLabel } from '../../base-control/styles/base-control-styles';
+import { View } from '../../view';
+import { VisuallyHidden } from '../../visually-hidden';
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
+import { useBorderControlStylePicker } from './hook';
+
+import type { LabelProps, StylePickerProps } from '../types';
+
+const BORDER_STYLES = [
+	{ label: __( 'Solid' ), icon: lineSolid, value: 'solid' },
+	{ label: __( 'Dashed' ), icon: lineDashed, value: 'dashed' },
+	{ label: __( 'Dotted' ), icon: lineDotted, value: 'dotted' },
+];
+
+const Label = ( props: LabelProps ) => {
+	const { label, hideLabelFromVision } = props;
+
+	if ( ! label ) {
+		return null;
+	}
+
+	return hideLabelFromVision ? (
+		<VisuallyHidden as="label">{ label }</VisuallyHidden>
+	) : (
+		<StyledLabel>{ label }</StyledLabel>
+	);
+};
+
+const BorderControlStylePicker = (
+	props: WordPressComponentProps< StylePickerProps, 'div' >,
+	forwardedRef: React.Ref< any >
+) => {
+	const {
+		buttonClassName,
+		hideLabelFromVision,
+		label,
+		onChange,
+		value,
+		...otherProps
+	} = useBorderControlStylePicker( props );
+
+	return (
+		<View { ...otherProps } ref={ forwardedRef }>
+			<Label
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+			<View>
+				{ BORDER_STYLES.map( ( borderStyle ) => (
+					<Button
+						key={ borderStyle.value }
+						className={ buttonClassName }
+						icon={ borderStyle.icon }
+						isSmall
+						isPressed={ borderStyle.value === value }
+						onClick={ () =>
+							onChange(
+								borderStyle.value === value
+									? undefined
+									: borderStyle.value
+							)
+						}
+						aria-label={ borderStyle.label }
+					/>
+				) ) }
+			</View>
+		</View>
+	);
+};
+
+const ConnectedBorderControlStylePicker = contextConnect(
+	BorderControlStylePicker,
+	'BorderControlStylePicker'
+);
+
+export default ConnectedBorderControlStylePicker;

--- a/packages/components/src/border-control/border-control-style-picker/component.tsx
+++ b/packages/components/src/border-control/border-control-style-picker/component.tsx
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import Button from '../../button';
 import { StyledLabel } from '../../base-control/styles/base-control-styles';
 import { View } from '../../view';
+import { Flex } from '../../flex';
 import { VisuallyHidden } from '../../visually-hidden';
 import { contextConnect, WordPressComponentProps } from '../../ui/context';
 import { useBorderControlStylePicker } from './hook';
@@ -55,7 +56,7 @@ const BorderControlStylePicker = (
 				label={ label }
 				hideLabelFromVision={ hideLabelFromVision }
 			/>
-			<View>
+			<Flex justify="flex-start" gap={ 1 }>
 				{ BORDER_STYLES.map( ( borderStyle ) => (
 					<Button
 						key={ borderStyle.value }
@@ -73,7 +74,7 @@ const BorderControlStylePicker = (
 						aria-label={ borderStyle.label }
 					/>
 				) ) }
-			</View>
+			</Flex>
 		</View>
 	);
 };

--- a/packages/components/src/border-control/border-control-style-picker/hook.ts
+++ b/packages/components/src/border-control/border-control-style-picker/hook.ts
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+
+import type { StylePickerProps } from '../types';
+
+export function useBorderControlStylePicker(
+	props: WordPressComponentProps< StylePickerProps, 'div' >
+) {
+	const { className, ...otherProps } = useContextSystem(
+		props,
+		'BorderControlStylePicker'
+	);
+
+	// Generate class names.
+	const cx = useCx();
+	const classes = useMemo( () => {
+		return cx( styles.BorderControlStylePicker, className );
+	}, [ className ] );
+
+	const buttonClassName = useMemo( () => {
+		return cx( styles.BorderStyleButton );
+	}, [] );
+
+	return { ...otherProps, className: classes, buttonClassName };
+}

--- a/packages/components/src/border-control/border-control-style-picker/hook.ts
+++ b/packages/components/src/border-control/border-control-style-picker/hook.ts
@@ -24,11 +24,11 @@ export function useBorderControlStylePicker(
 	const cx = useCx();
 	const classes = useMemo( () => {
 		return cx( styles.BorderControlStylePicker, className );
-	}, [ className ] );
+	}, [ className, cx ] );
 
 	const buttonClassName = useMemo( () => {
 		return cx( styles.BorderStyleButton );
-	}, [] );
+	}, [ cx ] );
 
 	return { ...otherProps, className: classes, buttonClassName };
 }

--- a/packages/components/src/border-control/border-control-style-picker/hook.ts
+++ b/packages/components/src/border-control/border-control-style-picker/hook.ts
@@ -23,11 +23,11 @@ export function useBorderControlStylePicker(
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.BorderControlStylePicker, className );
+		return cx( styles.borderControlStylePicker, className );
 	}, [ className, cx ] );
 
 	const buttonClassName = useMemo( () => {
-		return cx( styles.BorderStyleButton );
+		return cx( styles.borderStyleButton );
 	}, [ cx ] );
 
 	return { ...otherProps, className: classes, buttonClassName };

--- a/packages/components/src/border-control/border-control-style-picker/index.ts
+++ b/packages/components/src/border-control/border-control-style-picker/index.ts
@@ -1,0 +1,1 @@
+export { default } from './component';

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -133,7 +133,8 @@ Example:
 
 ### `width`: `string`
 
-Controls the visual width of the `BorderControl`.
+Controls the visual width of the `BorderControl`. It has no effect if the
+`isCompact` prop is set to `true`.
 
 - Required: No
 

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -1,0 +1,159 @@
+#  BorderControl
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+<br />
+This component provides control over a border's color, style, and width.
+
+## Development guidelines
+
+The `BorderControl` brings together internal sub-components which allow users to
+set the various properties of a border. The first sub-component, a
+`BorderDropdown` contains options representing border color and style. The
+border width is controlled via a `UnitControl` and an optional `RangeControl`.
+
+Border radius is not covered by this control as it may be desired separate to
+color, style, and width. For example, the border radius may be absorbed under
+a "shape" abstraction.
+
+## Usage
+
+```jsx
+import { __experimentalBorderControl as BorderControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const colors = [
+	{ name: 'Blue 20', color: '#72aee6' },
+	// ...
+];
+
+const MyBorderControl = () => {
+	const [ border, setBorder ] = useState();
+	const onChange = ( newBorder ) => setBorder( newBorder );
+
+	return (
+		<BorderControl
+			colors={ colors }
+			label={ __( 'Border' ) }
+			onChange={ onChange }
+			value={ border }
+		/>
+	);
+};
+```
+
+## Props
+
+### `colors`: `Array`
+
+An array of color definitions. This may also be a multi-dimensional array where
+colors are organized by multiple origins.
+
+Each color may be an object containing a `name` and `color` value.
+
+- Required: No
+
+### `disableCustomColors`: `boolean`
+
+This toggles the ability to choose custom colors.
+
+- Required: No
+
+### `enableAlpha`: `boolean`
+
+This controls whether the alpha channel will be offered when selecting
+custom colors.
+
+- Required: No
+
+### `enableStyle`: `boolean`
+
+This controls whether to include border style options within the
+`BorderDropdown` sub-component.
+
+- Required: No
+- Default: `true`
+
+### `hideLabelFromVision`: `boolean`
+
+Provides control over whether the label will only be visible to screen readers.
+
+- Required: No
+
+### `isCompact`: `boolean`
+
+This flags the `BorderControl` to render with a more compact appearance. It
+restricts the width of the control and prevents it from expanding to take up
+additional space.
+
+- Required: No
+
+### `label`: `string`
+
+If provided, a label will be generated using this as the content.
+
+_Whether it is visible only to screen readers is controlled via
+`hideLabelFromVision`._
+
+- Required: No
+
+### `onChange`: `( value?: Object ) => void`
+
+A callback function invoked when the border value is changed via an interaction
+that selects or clears, border color, style, or width.
+
+_Note: the value may be `undefined` if a user clears all border properties._
+
+- Required: Yes
+
+### `shouldSanitizeBorder`: `boolean`
+
+If opted into, sanitizing the border means that if no width or color have been
+selected, the border style is also cleared and `undefined` is returned as the
+new border value.
+
+- Required: No
+
+### `value`: `Object`
+
+An object representing a border or `undefined`. Used to set the current border
+configuration for this component.
+
+Example:
+```js
+ {
+	color: '#72aee6',
+	style: 'solid',
+	width: '2px,
+}
+```
+
+- Required: No
+
+### `width`: `string`
+
+Controls the visual width of the `BorderControl`.
+
+- Required: No
+
+### `withSlider`: `boolean`
+
+Flags whether this `BorderControl` should also render a `RangeControl` for
+additional control over a border's width.
+
+- Required: No
+
+### `__experimentalHasMultipleOrigins`: `boolean`
+
+This is passed on to the color related sub-components which need to be made
+aware of whether the colors prop contains multiple origins.
+
+- Required: No
+
+### `__experimentalIsRenderedInSidebar`: `boolean`
+
+This is passed on to the color related sub-components so they may render more
+effectively when used within a sidebar.
+
+- Required: No

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -132,7 +132,7 @@ Example:
 
 - Required: No
 
-### `width`: `string`
+### `width`: `CSSProperties[ 'width' ]`
 
 Controls the visual width of the `BorderControl`. It has no effect if the
 `isCompact` prop is set to `true`.

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -114,6 +114,7 @@ selected, the border style is also cleared and `undefined` is returned as the
 new border value.
 
 - Required: No
+- Default: true
 
 ### `value`: `Object`
 

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -116,6 +116,13 @@ new border value.
 - Required: No
 - Default: true
 
+### `showDropdownHeader`: `boolean`
+
+Whether or not to render a header for the border color and style picker
+dropdown. The header includes a label for the color picker and a close button.
+
+- Required: No
+
 ### `value`: `Object`
 
 An object representing a border or `undefined`. Used to set the current border

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -62,7 +62,7 @@ const BorderControl = (
 				hideLabelFromVision={ hideLabelFromVision }
 			/>
 			<HStack spacing={ 3 }>
-				<HStack className={ innerWrapperClassName }>
+				<HStack className={ innerWrapperClassName } alignment="stretch">
 					<BorderControlDropdown
 						border={ border }
 						colors={ colors }

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -29,7 +29,7 @@ const BorderLabel = ( props: LabelProps ) => {
 
 const BorderControl = (
 	props: WordPressComponentProps< BorderControlProps, 'div' >,
-	forwardedRef: React.Ref< any >
+	forwardedRef: React.ForwardedRef< any >
 ) => {
 	const {
 		colors,

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -1,0 +1,108 @@
+/**
+ * Internal dependencies
+ */
+import BorderControlDropdown from '../border-control-dropdown';
+import UnitControl from '../../unit-control';
+import RangeControl from '../../range-control';
+import { HStack } from '../../h-stack';
+import { StyledLabel } from '../../base-control/styles/base-control-styles';
+import { View } from '../../view';
+import { VisuallyHidden } from '../../visually-hidden';
+import { contextConnect, WordPressComponentProps } from '../../ui/context';
+import { useBorderControl } from './hook';
+
+import type { BorderControlProps, LabelProps } from '../types';
+
+const BorderLabel = ( props: LabelProps ) => {
+	const { label, hideLabelFromVision } = props;
+
+	if ( ! label ) {
+		return null;
+	}
+
+	return hideLabelFromVision ? (
+		<VisuallyHidden as="label">{ label }</VisuallyHidden>
+	) : (
+		<StyledLabel>{ label }</StyledLabel>
+	);
+};
+
+const BorderControl = (
+	props: WordPressComponentProps< BorderControlProps, 'div' >,
+	forwardedRef: React.Ref< any >
+) => {
+	const {
+		colors,
+		disableCustomColors,
+		enableAlpha,
+		enableStyle = true,
+		hideLabelFromVision,
+		innerWrapperClassName,
+		label,
+		onBorderChange,
+		onSliderChange,
+		onWidthChange,
+		placeholder,
+		previousStyleSelection,
+		sliderClassName,
+		value: border,
+		widthControlClassName,
+		widthUnit,
+		widthValue,
+		withSlider,
+		__experimentalHasMultipleOrigins,
+		__experimentalIsRenderedInSidebar,
+		...otherProps
+	} = useBorderControl( props );
+
+	return (
+		<View { ...otherProps } ref={ forwardedRef }>
+			<BorderLabel
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+			<HStack spacing={ 3 }>
+				<HStack className={ innerWrapperClassName }>
+					<BorderControlDropdown
+						border={ border }
+						colors={ colors }
+						disableCustomColors={ disableCustomColors }
+						enableAlpha={ enableAlpha }
+						enableStyle={ enableStyle }
+						onChange={ onBorderChange }
+						previousStyleSelection={ previousStyleSelection }
+						__experimentalHasMultipleOrigins={
+							__experimentalHasMultipleOrigins
+						}
+						__experimentalIsRenderedInSidebar={
+							__experimentalIsRenderedInSidebar
+						}
+					/>
+					<UnitControl
+						className={ widthControlClassName }
+						min={ 0 }
+						onChange={ onWidthChange }
+						value={ border?.width || '' }
+						placeholder={ placeholder }
+					/>
+				</HStack>
+				{ withSlider && (
+					<RangeControl
+						className={ sliderClassName }
+						initialPosition={ 0 }
+						max={ 100 }
+						min={ 0 }
+						onChange={ onSliderChange }
+						step={ [ 'px', '%' ].includes( widthUnit ) ? 1 : 0.1 }
+						value={ widthValue || undefined }
+						withInputField={ false }
+					/>
+				) }
+			</HStack>
+		</View>
+	);
+};
+
+const ConnectedBorderControl = contextConnect( BorderControl, 'BorderControl' );
+
+export default ConnectedBorderControl;

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -44,6 +44,7 @@ const BorderControl = (
 		onWidthChange,
 		placeholder,
 		previousStyleSelection,
+		showDropdownHeader,
 		sliderClassName,
 		value: border,
 		widthControlClassName,
@@ -71,6 +72,7 @@ const BorderControl = (
 						enableStyle={ enableStyle }
 						onChange={ onBorderChange }
 						previousStyleSelection={ previousStyleSelection }
+						showDropdownHeader={ showDropdownHeader }
 						__experimentalHasMultipleOrigins={
 							__experimentalHasMultipleOrigins
 						}

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -1,0 +1,141 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from '../styles';
+import { parseUnit } from '../../unit-control/utils';
+import { useContextSystem, WordPressComponentProps } from '../../ui/context';
+import { useCx } from '../../utils/hooks/use-cx';
+
+import type { Border, BorderControlProps } from '../types';
+
+const sanitizeBorder = ( border?: Border ) => {
+	const hasNoWidth = border?.width === undefined || border.width === '';
+	const hasNoColor = border?.color === undefined;
+
+	// If width and color are undefined, unset any style selection as well.
+	if ( hasNoWidth && hasNoColor ) {
+		return undefined;
+	}
+
+	return border;
+};
+
+export function useBorderControl(
+	props: WordPressComponentProps< BorderControlProps, 'div' >
+) {
+	const {
+		className,
+		isCompact,
+		onChange,
+		shouldSanitizeBorder = true,
+		value: border,
+		width,
+		...otherProps
+	} = useContextSystem( props, 'BorderControl' );
+
+	const [ widthValue, originalWidthUnit ] = parseUnit( border?.width );
+	const widthUnit = originalWidthUnit || 'px';
+	const hadPreviousZeroWidth = widthValue === 0;
+
+	const [ colorSelection, setColorSelection ] = useState< string >();
+	const [ styleSelection, setStyleSelection ] = useState< string >();
+
+	const onBorderChange = useCallback(
+		( newBorder?: Border ) => {
+			if ( shouldSanitizeBorder ) {
+				return onChange( sanitizeBorder( newBorder ) );
+			}
+
+			onChange( newBorder );
+		},
+		[ onChange, shouldSanitizeBorder, sanitizeBorder ]
+	);
+
+	const onWidthChange = useCallback(
+		( newWidth?: string ) => {
+			const newWidthValue = newWidth === '' ? undefined : newWidth;
+			const [ parsedValue ] = parseUnit( newWidth );
+			const hasZeroWidth = parsedValue === 0;
+
+			const updatedBorder = { ...border, width: newWidthValue };
+
+			// Setting the border width explicitly to zero will also set the
+			// border style to `none` and clear the border color.
+			if ( hasZeroWidth && ! hadPreviousZeroWidth ) {
+				// Before clearing the color and style selections, keep track of
+				// the current selections so they can be restored when the width
+				// changes to a non-zero value.
+				setColorSelection( border?.color );
+				setStyleSelection( border?.style );
+
+				// Clear the color and style border properties.
+				updatedBorder.color = undefined;
+				updatedBorder.style = 'none';
+			}
+
+			// Selection has changed from zero border width to non-zero width.
+			if ( ! hasZeroWidth && hadPreviousZeroWidth ) {
+				// Restore previous border color and style selections if width
+				// is now not zero.
+				if ( updatedBorder.color === undefined ) {
+					updatedBorder.color = colorSelection;
+				}
+				if ( updatedBorder.style === 'none' ) {
+					updatedBorder.style = styleSelection;
+				}
+			}
+
+			onBorderChange( updatedBorder );
+		},
+		[ border, hadPreviousZeroWidth, onBorderChange ]
+	);
+
+	const onSliderChange = useCallback(
+		( value: string ) => {
+			onWidthChange( `${ value }${ widthUnit }` );
+		},
+		[ onWidthChange, widthUnit ]
+	);
+
+	// Generate class names.
+	const cx = useCx();
+	const classes = useMemo( () => {
+		return cx( styles.BorderControl, className );
+	}, [ className ] );
+
+	const innerWrapperClassName = useMemo( () => {
+		const wrapperWidth = isCompact ? '90px' : width;
+		const widthStyle =
+			!! wrapperWidth && styles.WrapperWidth( wrapperWidth );
+
+		return cx( styles.InnerWrapper, widthStyle );
+	}, [ isCompact, width ] );
+
+	const widthControlClassName = useMemo( () => {
+		return cx( styles.BorderWidthControl );
+	}, [] );
+
+	const sliderClassName = useMemo( () => {
+		return cx( styles.BorderSlider );
+	}, [] );
+
+	return {
+		...otherProps,
+		className: classes,
+		innerWrapperClassName,
+		onBorderChange,
+		onSliderChange,
+		onWidthChange,
+		previousStyleSelection: styleSelection,
+		sliderClassName,
+		value: border,
+		widthControlClassName,
+		widthUnit,
+		widthValue,
+	};
+}

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -106,7 +106,7 @@ export function useBorderControl(
 	const cx = useCx();
 	const classes = useMemo( () => {
 		return cx( styles.BorderControl, className );
-	}, [ className ] );
+	}, [ className, cx ] );
 
 	const innerWrapperClassName = useMemo( () => {
 		const wrapperWidth = isCompact ? '90px' : width;
@@ -114,15 +114,15 @@ export function useBorderControl(
 			!! wrapperWidth && styles.WrapperWidth( wrapperWidth );
 
 		return cx( styles.InnerWrapper, widthStyle );
-	}, [ isCompact, width ] );
+	}, [ isCompact, width, cx ] );
 
 	const widthControlClassName = useMemo( () => {
 		return cx( styles.BorderWidthControl );
-	}, [] );
+	}, [ cx ] );
 
 	const sliderClassName = useMemo( () => {
 		return cx( styles.BorderSlider );
-	}, [] );
+	}, [ cx ] );
 
 	return {
 		...otherProps,

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -7,7 +7,7 @@ import { useCallback, useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import * as styles from '../styles';
-import { parseUnit } from '../../unit-control/utils';
+import { parseQuantityAndUnitFromRawValue } from '../../unit-control/utils';
 import { useContextSystem, WordPressComponentProps } from '../../ui/context';
 import { useCx } from '../../utils/hooks/use-cx';
 
@@ -38,7 +38,9 @@ export function useBorderControl(
 		...otherProps
 	} = useContextSystem( props, 'BorderControl' );
 
-	const [ widthValue, originalWidthUnit ] = parseUnit( border?.width );
+	const [ widthValue, originalWidthUnit ] = parseQuantityAndUnitFromRawValue(
+		border?.width
+	);
 	const widthUnit = originalWidthUnit || 'px';
 	const hadPreviousZeroWidth = widthValue === 0;
 
@@ -59,7 +61,9 @@ export function useBorderControl(
 	const onWidthChange = useCallback(
 		( newWidth?: string ) => {
 			const newWidthValue = newWidth === '' ? undefined : newWidth;
-			const [ parsedValue ] = parseUnit( newWidth );
+			const [ parsedValue ] = parseQuantityAndUnitFromRawValue(
+				newWidth
+			);
 			const hasZeroWidth = parsedValue === 0;
 
 			const updatedBorder = { ...border, width: newWidthValue };

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -109,23 +109,23 @@ export function useBorderControl(
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.BorderControl, className );
+		return cx( styles.borderControl, className );
 	}, [ className, cx ] );
 
 	const innerWrapperClassName = useMemo( () => {
 		const wrapperWidth = isCompact ? '90px' : width;
 		const widthStyle =
-			!! wrapperWidth && styles.WrapperWidth( wrapperWidth );
+			!! wrapperWidth && styles.wrapperWidth( wrapperWidth );
 
-		return cx( styles.InnerWrapper, widthStyle );
+		return cx( styles.innerWrapper(), widthStyle );
 	}, [ isCompact, width, cx ] );
 
 	const widthControlClassName = useMemo( () => {
-		return cx( styles.BorderWidthControl );
+		return cx( styles.borderWidthControl() );
 	}, [ cx ] );
 
 	const sliderClassName = useMemo( () => {
-		return cx( styles.BorderSlider );
+		return cx( styles.borderSlider() );
 	}, [ cx ] );
 
 	return {

--- a/packages/components/src/border-control/border-control/index.ts
+++ b/packages/components/src/border-control/border-control/index.ts
@@ -1,0 +1,2 @@
+export { default as BorderControl } from './component';
+export { useBorderControl } from './hook';

--- a/packages/components/src/border-control/index.ts
+++ b/packages/components/src/border-control/index.ts
@@ -1,0 +1,2 @@
+export { default as BorderControl } from './border-control/component';
+export { useBorderControl } from './border-control/hook';

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { BorderControl } from '../';
+
+export default {
+	title: 'Components (Experimental)/BorderControl',
+	component: BorderControl,
+};
+
+// Available border colors.
+const colors = [
+	{ name: 'Gray 0', color: '#f6f7f7' },
+	{ name: 'Gray 5', color: '#dcdcde' },
+	{ name: 'Gray 20', color: '#a7aaad' },
+	{ name: 'Gray 70', color: '#3c434a' },
+	{ name: 'Gray 100', color: '#101517' },
+	{ name: 'Blue 20', color: '#72aee6' },
+	{ name: 'Blue 40', color: '#3582c4' },
+	{ name: 'Blue 70', color: '#0a4b78' },
+	{ name: 'Red 40', color: '#e65054' },
+	{ name: 'Red 70', color: '#8a2424' },
+	{ name: 'Green 10', color: '#68de7c' },
+	{ name: 'Green 40', color: '#00a32a' },
+	{ name: 'Green 60', color: '#007017' },
+	{ name: 'Yellow 10', color: '#f2d675' },
+	{ name: 'Yellow 40', color: '#bd8600' },
+];
+
+const _default = ( props ) => {
+	const [ border, setBorder ] = useState();
+	const onChange = ( newBorder ) => setBorder( newBorder );
+
+	return (
+		<WrapperView>
+			<BorderControl
+				{ ...props }
+				colors={ colors }
+				label="Border"
+				onChange={ onChange }
+				value={ border }
+				width={ ! props.isCompact && props.width }
+			/>
+		</WrapperView>
+	);
+};
+
+export const Default = _default.bind( {} );
+Default.args = {
+	disableCustomColors: false,
+	enableAlpha: true,
+	enableStyle: true,
+	isCompact: true,
+	width: '110px',
+	withSlider: true,
+};
+
+const WrapperView = styled.div`
+	max-width: 280px;
+`;

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -61,6 +61,7 @@ Default.args = {
 	enableAlpha: true,
 	enableStyle: true,
 	isCompact: true,
+	shouldSanitizeBorder: true,
 	width: '110px',
 	withSlider: true,
 };

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -101,6 +101,7 @@ Default.args = {
 	enableStyle: true,
 	isCompact: true,
 	shouldSanitizeBorder: true,
+	showDropdownHeader: false,
 	width: '110px',
 	withSlider: true,
 	__experimentalIsRenderedInSidebar: false,

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -64,6 +64,7 @@ Default.args = {
 	shouldSanitizeBorder: true,
 	width: '110px',
 	withSlider: true,
+	__experimentalIsRenderedInSidebar: false,
 };
 
 const WrapperView = styled.div`

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -12,6 +12,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { BorderControl } from '../';
+import { Provider as SlotFillProvider } from '../../slot-fill';
+import Popover from '../../popover';
 
 export default {
 	title: 'Components (Experimental)/BorderControl',
@@ -77,20 +79,23 @@ const _default = ( props ) => {
 	const { __experimentalHasMultipleOrigins } = props;
 
 	return (
-		<WrapperView>
-			<BorderControl
-				{ ...props }
-				colors={
-					__experimentalHasMultipleOrigins
-						? multipleOriginColors
-						: colors
-				}
-				label="Border"
-				onChange={ onChange }
-				value={ border }
-				width={ ! props.isCompact && props.width }
-			/>
-		</WrapperView>
+		<SlotFillProvider>
+			<WrapperView>
+				<BorderControl
+					{ ...props }
+					colors={
+						__experimentalHasMultipleOrigins
+							? multipleOriginColors
+							: colors
+					}
+					label="Border"
+					onChange={ onChange }
+					value={ border }
+					width={ ! props.isCompact && props.width }
+				/>
+			</WrapperView>
+			<Popover.Slot />
+		</SlotFillProvider>
 	);
 };
 

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -37,15 +37,54 @@ const colors = [
 	{ name: 'Yellow 40', color: '#bd8600' },
 ];
 
+// Multiple origin colors.
+const multipleOriginColors = [
+	{
+		name: 'Default',
+		colors: [
+			{ name: 'Gray 0', color: '#f6f7f7' },
+			{ name: 'Gray 5', color: '#dcdcde' },
+			{ name: 'Gray 20', color: '#a7aaad' },
+			{ name: 'Gray 70', color: '#3c434a' },
+			{ name: 'Gray 100', color: '#101517' },
+		],
+	},
+	{
+		name: 'Theme',
+		colors: [
+			{ name: 'Blue 20', color: '#72aee6' },
+			{ name: 'Blue 40', color: '#3582c4' },
+			{ name: 'Blue 70', color: '#0a4b78' },
+			{ name: 'Red 40', color: '#e65054' },
+			{ name: 'Red 70', color: '#8a2424' },
+		],
+	},
+	{
+		name: 'User',
+		colors: [
+			{ name: 'Green 10', color: '#68de7c' },
+			{ name: 'Green 40', color: '#00a32a' },
+			{ name: 'Green 60', color: '#007017' },
+			{ name: 'Yellow 10', color: '#f2d675' },
+			{ name: 'Yellow 40', color: '#bd8600' },
+		],
+	},
+];
+
 const _default = ( props ) => {
 	const [ border, setBorder ] = useState();
 	const onChange = ( newBorder ) => setBorder( newBorder );
+	const { __experimentalHasMultipleOrigins } = props;
 
 	return (
 		<WrapperView>
 			<BorderControl
 				{ ...props }
-				colors={ colors }
+				colors={
+					__experimentalHasMultipleOrigins
+						? multipleOriginColors
+						: colors
+				}
 				label="Border"
 				onChange={ onChange }
 				value={ border }
@@ -65,6 +104,7 @@ Default.args = {
 	width: '110px',
 	withSlider: true,
 	__experimentalIsRenderedInSidebar: false,
+	__experimentalHasMultipleOrigins: false,
 };
 
 const WrapperView = styled.div`

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -11,6 +11,10 @@ import { space } from '../ui/utils/space';
 import { StyledLabel } from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
 
+const labelStyles = css`
+	font-weight: 500;
+`;
+
 export const BorderControl = css`
 	position: relative;
 `;
@@ -98,7 +102,7 @@ export const BorderControlPopoverControls = css`
 
 	> div:first-of-type > ${ StyledLabel } {
 		margin-bottom: 0;
-		font-weight: 500;
+		${ labelStyles }
 	}
 
 	&& ${ StyledLabel } + button:not( .has-text ) {
@@ -135,9 +139,8 @@ export const BorderWidthControl = css`
 `;
 
 export const BorderControlStylePicker = css`
-	> label {
-		display: block;
-		font-weight: 500;
+	${ StyledLabel } {
+		${ labelStyles }
 	}
 `;
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -13,6 +13,7 @@ import {
 	StyledLabel,
 } from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
+import { Root as UnitControlWrapper } from '../unit-control/styles/unit-control-styles';
 
 import type { Border } from './types';
 
@@ -40,7 +41,7 @@ export const InnerWrapper = css`
 	 * Forces the width control to fill available space given UnitControl
 	 * passes its className directly through to the input.
 	 */
-	> div:last-child {
+	${ UnitControlWrapper } {
 		flex: 1;
 		${ rtl( { marginLeft: 0 } )() }
 	}

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { css } from '@emotion/react';
+import type { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
@@ -52,7 +53,7 @@ export const InnerWrapper = css`
 	}
 `;
 
-export const WrapperWidth = ( width: string ) => {
+export const WrapperWidth = ( width: CSSProperties[ 'width' ] ) => {
 	return css`
 		width: ${ width };
 		flex: 0 0 auto;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -9,6 +9,7 @@ import { css } from '@emotion/react';
 import { COLORS, CONFIG } from '../utils';
 import { space } from '../ui/utils/space';
 import { StyledLabel } from '../base-control/styles/base-control-styles';
+import { BackdropUI } from '../input-control/styles/input-control-styles';
 
 export const BorderControl = css`
 	position: relative;
@@ -113,8 +114,8 @@ export const ResetButton = css`
 `;
 
 export const BorderWidthControl = css`
-	/* Target the UnitControl backdrop */
-	&&& > div > div {
+	/* Target the InputControl's backdrop */
+	&&& ${ BackdropUI } {
 		border: none;
 	}
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -8,7 +8,10 @@ import { css } from '@emotion/react';
  */
 import { COLORS, CONFIG, rtl } from '../utils';
 import { space } from '../ui/utils/space';
-import { StyledLabel } from '../base-control/styles/base-control-styles';
+import {
+	StyledField,
+	StyledLabel,
+} from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
 
 const labelStyles = css`
@@ -157,7 +160,7 @@ export const BorderSlider = css`
 	flex: 1 1 60%;
 	${ rtl( { marginRight: space( 3 ) } )() }
 
-	> div {
+	${ StyledField } {
 		margin-bottom: 0;
 		display: flex;
 		align-items: center;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -46,11 +46,6 @@ export const InnerWrapper = css`
 		flex: 1;
 		${ rtl( { marginLeft: 0 } )() }
 	}
-
-	/* If arbitrary width is supplied honor it. */
-	&[style*='width'] {
-		flex: 0 0 auto;
-	}
 `;
 
 export const WrapperWidth = ( width: CSSProperties[ 'width' ] ) => {

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -1,0 +1,158 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+/**
+ * Internal dependencies
+ */
+import { COLORS, CONFIG } from '../utils';
+import { space } from '../ui/utils/space';
+import { StyledLabel } from '../base-control/styles/base-control-styles';
+
+export const BorderControl = css`
+	position: relative;
+`;
+
+export const InnerWrapper = css`
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
+	border-radius: 2px;
+	flex: 1 0 40%;
+
+	/*
+	 * Needs more thought. Aim is to prevent the border for BorderBoxControl
+	 * showing through the control. Likely needs to take into account
+	 * light/dark themes etc.
+	 */
+	background: #fff;
+
+	/*
+	 * Forces the width control to fill available space given UnitControl
+	 * passes its className directly through to the input.
+	 */
+	> div:last-child {
+		flex: 1;
+		margin-left: 0;
+	}
+
+	/* If arbitrary width is supplied honor it. */
+	&[style*='width'] {
+		flex: 0 0 auto;
+	}
+`;
+
+export const WrapperWidth = ( width: string ) => {
+	return css`
+		width: ${ width };
+		flex: 0 0 auto;
+	`;
+};
+
+export const BorderControlDropdown = css`
+	border-radius: 1px 0 0 1px;
+	border-right: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
+	background: #fff;
+
+	&& > button {
+		padding: ${ space( 1 ) };
+		border-radius: inherit;
+
+		> span {
+			border-radius: 9999px;
+			border: 2px solid transparent;
+			width: 28px;
+			height: 28px;
+			padding: 2px;
+
+			& > span {
+				background: linear-gradient(
+					-45deg,
+					transparent 48%,
+					rgb( 0 0 0 / 20% ) 48%,
+					rgb( 0 0 0 / 20% ) 52%,
+					transparent 52%
+				);
+			}
+		}
+	}
+`;
+
+export const BorderControlPopover = css`
+	/* Remove padding from content, this will be re-added via inner elements*/
+	&& > div > div {
+		padding: 0;
+	}
+`;
+
+export const BorderControlPopoverControls = css`
+	padding: ${ space( 4 ) };
+
+	> div:first-of-type > ${ StyledLabel } {
+		margin-bottom: 0;
+		font-weight: 500;
+	}
+
+	&& ${ StyledLabel } + button:not( .has-text ) {
+		min-width: 24px;
+		padding: 0;
+	}
+`;
+
+export const BorderControlPopoverContent = css``;
+export const BorderColorIndicator = css``;
+
+export const ResetButton = css`
+	justify-content: center;
+	width: 100%;
+
+	/* Override button component styling */
+	&& {
+		border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
+		height: 46px;
+	}
+`;
+
+export const BorderWidthControl = css`
+	/* Target the UnitControl backdrop */
+	&&& > div > div {
+		border: none;
+	}
+
+	/* Specificity required to overcome UnitControl padding */
+	/* See packages/components/src/unit-control/styles/unit-control-styles.ts */
+	&&& input {
+		padding-right: 0;
+	}
+`;
+
+export const BorderControlStylePicker = css`
+	> label {
+		display: block;
+		font-weight: 500;
+	}
+
+	> div {
+		display: inline-flex;
+	}
+`;
+
+export const BorderStyleButton = css`
+	&&&&& {
+		min-width: 30px;
+		width: 30px;
+		height: 30px;
+		padding: 3px;
+		margin-right: ${ space( 1 ) };
+	}
+`;
+
+export const BorderSlider = css`
+	flex: 1 1 60%;
+	margin-right: ${ space( 3 ) };
+
+	> div {
+		margin-bottom: 0;
+		display: flex;
+		align-items: center;
+	}
+`;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -89,7 +89,12 @@ export const ColorIndicatorWrapper = ( border?: Border ) => {
 		height: 28px;
 		padding: 2px;
 
-		/* ColorIndicator */
+		/*
+		 * ColorIndicator
+		 *
+		 * The transparent colors used here ensure visibility of the indicator
+		 * over the active state of the border control dropdown's toggle button.
+		 */
 		& > span {
 			background: linear-gradient(
 				-45deg,

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -14,6 +14,8 @@ import {
 } from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
 
+import type { Border } from './types';
+
 const labelStyles = css`
 	font-weight: 500;
 `;
@@ -72,26 +74,36 @@ export const BorderControlDropdown = css`
 	&& > button {
 		padding: ${ space( 1 ) };
 		border-radius: inherit;
-
-		> span {
-			border-radius: 9999px;
-			border: 2px solid transparent;
-			width: 28px;
-			height: 28px;
-			padding: 2px;
-
-			& > span {
-				background: linear-gradient(
-					-45deg,
-					transparent 48%,
-					rgb( 0 0 0 / 20% ) 48%,
-					rgb( 0 0 0 / 20% ) 52%,
-					transparent 52%
-				);
-			}
-		}
 	}
 `;
+
+export const ColorIndicatorWrapper = ( border?: Border ) => {
+	const { color, style } = border || {};
+
+	const fallbackColor =
+		!! style && style !== 'none' ? COLORS.gray[ 300 ] : undefined;
+
+	return css`
+		border-radius: 9999px;
+		border: 2px solid transparent;
+		border-style: ${ style === 'none' ? 'solid' : style };
+		border-color: ${ color || fallbackColor };
+		width: 28px;
+		height: 28px;
+		padding: 2px;
+
+		/* ColorIndicator */
+		& > span {
+			background: linear-gradient(
+				-45deg,
+				transparent 48%,
+				rgb( 0 0 0 / 20% ) 48%,
+				rgb( 0 0 0 / 20% ) 52%,
+				transparent 52%
+			);
+		}
+	`;
+};
 
 export const BorderControlPopover = css`
 	/* Remove padding from content, this will be re-added via inner elements*/

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 /**
  * Internal dependencies
  */
-import { COLORS, CONFIG } from '../utils';
+import { COLORS, CONFIG, rtl } from '../utils';
 import { space } from '../ui/utils/space';
 import { StyledLabel } from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
@@ -33,7 +33,7 @@ export const InnerWrapper = css`
 	 */
 	> div:last-child {
 		flex: 1;
-		margin-left: 0;
+		${ rtl( { marginLeft: 0 } )() }
 	}
 
 	/* If arbitrary width is supplied honor it. */
@@ -50,9 +50,17 @@ export const WrapperWidth = ( width: string ) => {
 };
 
 export const BorderControlDropdown = css`
-	border-radius: 1px 0 0 1px;
-	border-right: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
 	background: #fff;
+	${ rtl(
+		{
+			borderRadius: `1px 0 0 1px`,
+			borderRight: `${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] }`,
+		},
+		{
+			borderRadius: `0 1px 1px 0`,
+			borderLeft: `${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] }`,
+		}
+	)() }
 
 	&& > button {
 		padding: ${ space( 1 ) };
@@ -122,7 +130,7 @@ export const BorderWidthControl = css`
 	/* Specificity required to overcome UnitControl padding */
 	/* See packages/components/src/unit-control/styles/unit-control-styles.ts */
 	&&& input {
-		padding-right: 0;
+		${ rtl( { paddingRight: 0 } )() }
 	}
 `;
 
@@ -143,13 +151,13 @@ export const BorderStyleButton = css`
 		width: 30px;
 		height: 30px;
 		padding: 3px;
-		margin-right: ${ space( 1 ) };
+		${ rtl( { marginRight: space( 1 ) } )() }
 	}
 `;
 
 export const BorderSlider = css`
 	flex: 1 1 60%;
-	margin-right: ${ space( 3 ) };
+	${ rtl( { marginRight: space( 3 ) } )() }
 
 	> div {
 		margin-bottom: 0;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -139,10 +139,6 @@ export const BorderControlStylePicker = css`
 		display: block;
 		font-weight: 500;
 	}
-
-	> div {
-		display: inline-flex;
-	}
 `;
 
 export const BorderStyleButton = css`
@@ -151,7 +147,6 @@ export const BorderStyleButton = css`
 		width: 30px;
 		height: 30px;
 		padding: 3px;
-		${ rtl( { marginRight: space( 1 ) } )() }
 	}
 `;
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -74,17 +74,25 @@ export const BorderControlDropdown = css`
 	}
 `;
 
-export const ColorIndicatorWrapper = ( border?: Border ) => {
+export const ColorIndicatorBorder = ( border?: Border ) => {
 	const { color, style } = border || {};
 
 	const fallbackColor =
 		!! style && style !== 'none' ? COLORS.gray[ 300 ] : undefined;
 
 	return css`
-		border-radius: 9999px;
-		border: 2px solid transparent;
 		border-style: ${ style === 'none' ? 'solid' : style };
 		border-color: ${ color || fallbackColor };
+	`;
+};
+
+export const ColorIndicatorWrapper = ( border?: Border ) => {
+	const { style } = border || {};
+
+	return css`
+		border-radius: 9999px;
+		border: 2px solid transparent;
+		${ style ? ColorIndicatorBorder( border ) : undefined }
 		width: 28px;
 		height: 28px;
 		padding: 2px;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -22,11 +22,11 @@ const labelStyles = css`
 	font-weight: 500;
 `;
 
-export const BorderControl = css`
+export const borderControl = css`
 	position: relative;
 `;
 
-export const InnerWrapper = css`
+export const innerWrapper = () => css`
 	border: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
 	border-radius: 2px;
 	flex: 1 0 40%;
@@ -48,14 +48,14 @@ export const InnerWrapper = css`
 	}
 `;
 
-export const WrapperWidth = ( width: CSSProperties[ 'width' ] ) => {
+export const wrapperWidth = ( width: CSSProperties[ 'width' ] ) => {
 	return css`
 		width: ${ width };
 		flex: 0 0 auto;
 	`;
 };
 
-export const BorderControlDropdown = css`
+export const borderControlDropdown = () => css`
 	background: #fff;
 	${ rtl(
 		{
@@ -74,7 +74,7 @@ export const BorderControlDropdown = css`
 	}
 `;
 
-export const ColorIndicatorBorder = ( border?: Border ) => {
+export const colorIndicatorBorder = ( border?: Border ) => {
 	const { color, style } = border || {};
 
 	const fallbackColor =
@@ -86,13 +86,13 @@ export const ColorIndicatorBorder = ( border?: Border ) => {
 	`;
 };
 
-export const ColorIndicatorWrapper = ( border?: Border ) => {
+export const colorIndicatorWrapper = ( border?: Border ) => {
 	const { style } = border || {};
 
 	return css`
 		border-radius: 9999px;
 		border: 2px solid transparent;
-		${ style ? ColorIndicatorBorder( border ) : undefined }
+		${ style ? colorIndicatorBorder( border ) : undefined }
 		width: 28px;
 		height: 28px;
 		padding: 2px;
@@ -115,14 +115,14 @@ export const ColorIndicatorWrapper = ( border?: Border ) => {
 	`;
 };
 
-export const BorderControlPopover = css`
+export const borderControlPopover = css`
 	/* Remove padding from content, this will be re-added via inner elements*/
 	&& > div > div {
 		padding: 0;
 	}
 `;
 
-export const BorderControlPopoverControls = css`
+export const borderControlPopoverControls = css`
 	padding: ${ space( 4 ) };
 
 	> div:first-of-type > ${ StyledLabel } {
@@ -136,10 +136,10 @@ export const BorderControlPopoverControls = css`
 	}
 `;
 
-export const BorderControlPopoverContent = css``;
-export const BorderColorIndicator = css``;
+export const borderControlPopoverContent = css``;
+export const borderColorIndicator = css``;
 
-export const ResetButton = css`
+export const resetButton = css`
 	justify-content: center;
 	width: 100%;
 
@@ -150,7 +150,7 @@ export const ResetButton = css`
 	}
 `;
 
-export const BorderWidthControl = css`
+export const borderWidthControl = () => css`
 	/* Target the InputControl's backdrop */
 	&&& ${ BackdropUI } {
 		border: none;
@@ -163,13 +163,13 @@ export const BorderWidthControl = css`
 	}
 `;
 
-export const BorderControlStylePicker = css`
+export const borderControlStylePicker = css`
 	${ StyledLabel } {
 		${ labelStyles }
 	}
 `;
 
-export const BorderStyleButton = css`
+export const borderStyleButton = css`
 	&&&&& {
 		min-width: 30px;
 		width: 30px;
@@ -178,7 +178,7 @@ export const BorderStyleButton = css`
 	}
 `;
 
-export const BorderSlider = css`
+export const borderSlider = () => css`
 	flex: 1 1 60%;
 	${ rtl( { marginRight: space( 3 ) } )() }
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -184,7 +184,6 @@ export const borderSlider = () => css`
 
 	${ StyledField } {
 		margin-bottom: 0;
-		display: flex;
-		align-items: center;
+		font-size: 0;
 	}
 `;

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -1,0 +1,336 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { BorderControl } from '../';
+
+const colors = [
+	{ name: 'Gray', color: '#f6f7f7' },
+	{ name: 'Blue', color: '#72aee6' },
+	{ name: 'Red', color: '#e65054' },
+	{ name: 'Green', color: '#00a32a' },
+	{ name: 'Yellow', color: '#bd8600' },
+];
+
+const defaultBorder = {
+	color: '#72aee6',
+	style: 'solid',
+	width: '1px',
+};
+
+const props = {
+	colors,
+	label: 'Border',
+	onChange: jest.fn().mockImplementation( ( newValue ) => {
+		props.value = newValue;
+	} ),
+	value: defaultBorder,
+};
+
+const renderBorderControl = ( customProps ) => {
+	return render( <BorderControl { ...{ ...props, ...customProps } } /> );
+};
+
+const rerenderBorderControl = ( rerender, customProps ) => {
+	return rerender( <BorderControl { ...{ ...props, ...customProps } } /> );
+};
+
+const openPopover = ( dropdownToggle ) => {
+	const toggleButton =
+		dropdownToggle || screen.getByLabelText( 'Open border options' );
+	fireEvent.click( toggleButton );
+};
+
+const getButton = ( name ) => {
+	return screen.getByRole( 'button', { name } );
+};
+
+const queryButton = ( name ) => {
+	return screen.queryByRole( 'button', { name } );
+};
+
+const clickButton = ( name ) => {
+	fireEvent.click( getButton( name ) );
+};
+
+const setWidthInput = ( value ) => {
+	const widthInput = screen.getByRole( 'spinbutton' );
+	widthInput.focus();
+	fireEvent.change( widthInput, { target: { value } } );
+};
+
+const clearWidthInput = () => setWidthInput( '' );
+
+describe( 'BorderControl', () => {
+	describe( 'basic rendering', () => {
+		it( 'should render standard border control', () => {
+			renderBorderControl();
+
+			const label = screen.getByText( props.label );
+			const colorButton = screen.getByLabelText( 'Open border options' );
+			const widthInput = screen.getByRole( 'spinbutton' );
+			const unitSelect = screen.getByRole( 'combobox' );
+			const slider = screen.queryByRole( 'slider' );
+
+			expect( label ).toBeInTheDocument();
+			expect( colorButton ).toBeInTheDocument();
+			expect( widthInput ).toBeInTheDocument();
+			expect( unitSelect ).toBeInTheDocument();
+			expect( slider ).not.toBeInTheDocument();
+		} );
+
+		it( 'should hide label', () => {
+			renderBorderControl( { hideLabelFromVision: true } );
+			const label = screen.getByText( props.label );
+
+			// As visually hidden labels are still included in the document
+			// and do not have `display: none` styling, we can't rely on
+			// `.toBeInTheDocument()` or `.toBeVisible()` assertions.
+			expect( label ).toHaveAttribute(
+				'data-wp-component',
+				'VisuallyHidden'
+			);
+		} );
+
+		it( 'should render with slider', () => {
+			renderBorderControl( { withSlider: true } );
+
+			const slider = screen.getByRole( 'slider' );
+			expect( slider ).toBeInTheDocument();
+		} );
+
+		it( 'should render placeholder in UnitControl', () => {
+			renderBorderControl( { placeholder: 'Mixed' } );
+			const widthInput = screen.getByRole( 'spinbutton' );
+
+			expect( widthInput ).toHaveAttribute( 'placeholder', 'Mixed' );
+		} );
+
+		it( 'should render color and style popover', () => {
+			renderBorderControl();
+			openPopover();
+
+			const headerLabel = screen.getByText( 'Border color' );
+			const closeButton = getButton( 'Close border color' );
+			const customColorPicker = getButton( 'Custom color picker' );
+			const colorSwatchButtons = screen.getAllByRole( 'button', {
+				name: /^Color:/,
+			} );
+			const styleLabel = screen.getByText( 'Style' );
+			const solidButton = getButton( 'Solid' );
+			const dashedButton = getButton( 'Dashed' );
+			const dottedButton = getButton( 'Dotted' );
+			const resetButton = getButton( 'Reset to default' );
+
+			expect( headerLabel ).toBeInTheDocument();
+			expect( closeButton ).toBeInTheDocument();
+			expect( customColorPicker ).toBeInTheDocument();
+			expect( colorSwatchButtons.length ).toEqual( colors.length );
+			expect( styleLabel ).toBeInTheDocument();
+			expect( solidButton ).toBeInTheDocument();
+			expect( dashedButton ).toBeInTheDocument();
+			expect( dottedButton ).toBeInTheDocument();
+			expect( resetButton ).toBeInTheDocument();
+		} );
+
+		it( 'should not render style options when opted out of', () => {
+			renderBorderControl( { enableStyle: false } );
+			openPopover();
+
+			const styleLabel = screen.queryByText( 'Style' );
+			const solidButton = queryButton( 'Solid' );
+			const dashedButton = queryButton( 'Dashed' );
+			const dottedButton = queryButton( 'Dotted' );
+
+			expect( styleLabel ).not.toBeInTheDocument();
+			expect( solidButton ).not.toBeInTheDocument();
+			expect( dashedButton ).not.toBeInTheDocument();
+			expect( dottedButton ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'onChange handling', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+			props.value = defaultBorder;
+		} );
+
+		it( 'should update width with slider value', () => {
+			const { rerender } = renderBorderControl( { withSlider: true } );
+
+			const slider = screen.getByRole( 'slider' );
+			fireEvent.change( slider, { target: { value: '5' } } );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, {
+				...defaultBorder,
+				width: '5px',
+			} );
+
+			rerenderBorderControl( rerender, { withSlider: true } );
+			const widthInput = screen.getByRole( 'spinbutton' );
+
+			expect( widthInput.value ).toEqual( '5' );
+		} );
+
+		it( 'should update color selection', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Color: Green' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, {
+				...defaultBorder,
+				color: '#00a32a',
+			} );
+		} );
+
+		it( 'should clear color selection when toggling swatch off', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Color: Blue' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, {
+				...defaultBorder,
+				color: undefined,
+			} );
+		} );
+
+		it( 'should update style selection', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Dashed' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, {
+				...defaultBorder,
+				style: 'dashed',
+			} );
+		} );
+
+		it( 'should take no action when color and style popover is closed', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Close border color' );
+
+			expect( props.onChange ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reset color and style only when popover reset button clicked', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Reset to default' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, {
+				color: undefined,
+				style: undefined,
+				width: defaultBorder.width,
+			} );
+		} );
+
+		it( 'should sanitize border when width and color are undefined', () => {
+			const { rerender } = renderBorderControl();
+			clearWidthInput();
+			rerenderBorderControl( rerender );
+			openPopover();
+			clickButton( 'Color: Blue' );
+
+			expect( props.onChange ).toHaveBeenCalledWith( undefined );
+		} );
+
+		it( 'should not sanitize border when requested', () => {
+			const { rerender } = renderBorderControl( {
+				shouldSanitizeBorder: false,
+			} );
+			clearWidthInput();
+			rerenderBorderControl( rerender, { shouldSanitizeBorder: false } );
+			openPopover();
+			clickButton( 'Color: Blue' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 2, {
+				color: undefined,
+				style: defaultBorder.style,
+				width: undefined,
+			} );
+		} );
+
+		it( 'should clear color and set style to `none` when setting zero width', () => {
+			renderBorderControl();
+			openPopover();
+			clickButton( 'Color: Green' );
+			clickButton( 'Dotted' );
+			setWidthInput( '0' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 3, {
+				color: undefined,
+				style: 'none',
+				width: '0px',
+			} );
+		} );
+
+		it( 'should reselect color and style selections when changing to non-zero width', () => {
+			const { rerender } = renderBorderControl();
+			openPopover();
+			clickButton( 'Color: Green' );
+			rerenderBorderControl( rerender );
+			clickButton( 'Dotted' );
+			rerenderBorderControl( rerender );
+			setWidthInput( '0' );
+			setWidthInput( '5' );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 4, {
+				color: '#00a32a',
+				style: 'dotted',
+				width: '5px',
+			} );
+		} );
+
+		it( 'should set a non-zero width when applying color to zero width border', () => {
+			const { rerender } = renderBorderControl( { value: undefined } );
+			openPopover();
+			clickButton( 'Color: Yellow' );
+
+			expect( props.onChange ).toHaveBeenCalledWith( {
+				color: '#bd8600',
+				style: undefined,
+				width: undefined,
+			} );
+
+			setWidthInput( '0' );
+			rerenderBorderControl( rerender );
+			clickButton( 'Color: Green' );
+
+			expect( props.onChange ).toHaveBeenCalledWith( {
+				color: '#00a32a',
+				style: undefined,
+				width: '1px',
+			} );
+		} );
+
+		it( 'should set a non-zero width when applying style to zero width border', () => {
+			const { rerender } = renderBorderControl( {
+				value: undefined,
+				shouldSanitizeBorder: false,
+			} );
+			openPopover();
+			clickButton( 'Dashed' );
+
+			expect( props.onChange ).toHaveBeenCalledWith( {
+				color: undefined,
+				style: 'dashed',
+				width: undefined,
+			} );
+
+			setWidthInput( '0' );
+			rerenderBorderControl( rerender, { shouldSanitizeBorder: false } );
+			clickButton( 'Dotted' );
+
+			expect( props.onChange ).toHaveBeenCalledWith( {
+				color: undefined,
+				style: 'dotted',
+				width: '1px',
+			} );
+		} );
+	} );
+} );

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -31,6 +31,8 @@ const props = {
 	value: defaultBorder,
 };
 
+const toggleLabelRegex = /Border color( and style)* picker/;
+
 const renderBorderControl = ( customProps ) => {
 	return render( <BorderControl { ...{ ...props, ...customProps } } /> );
 };
@@ -39,9 +41,8 @@ const rerenderBorderControl = ( rerender, customProps ) => {
 	return rerender( <BorderControl { ...{ ...props, ...customProps } } /> );
 };
 
-const openPopover = ( dropdownToggle ) => {
-	const toggleButton =
-		dropdownToggle || screen.getByLabelText( 'Open border options' );
+const openPopover = () => {
+	const toggleButton = screen.getByLabelText( toggleLabelRegex );
 	fireEvent.click( toggleButton );
 };
 
@@ -71,7 +72,7 @@ describe( 'BorderControl', () => {
 			renderBorderControl();
 
 			const label = screen.getByText( props.label );
-			const colorButton = screen.getByLabelText( 'Open border options' );
+			const colorButton = screen.getByLabelText( toggleLabelRegex );
 			const widthInput = screen.getByRole( 'spinbutton' );
 			const unitSelect = screen.getByRole( 'combobox' );
 			const slider = screen.queryByRole( 'slider' );
@@ -116,7 +117,7 @@ describe( 'BorderControl', () => {
 
 			const headerLabel = screen.getByText( 'Border color' );
 			const closeButton = getButton( 'Close border color' );
-			const customColorPicker = getButton( 'Custom color picker' );
+			const customColorPicker = getButton( /Custom color picker/ );
 			const colorSwatchButtons = screen.getAllByRole( 'button', {
 				name: /^Color:/,
 			} );
@@ -150,6 +151,98 @@ describe( 'BorderControl', () => {
 			expect( solidButton ).not.toBeInTheDocument();
 			expect( dashedButton ).not.toBeInTheDocument();
 			expect( dottedButton ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'color and style picker aria labels', () => {
+		describe( 'with style selection enabled', () => {
+			it( 'should include both color and style in label', () => {
+				renderBorderControl( { value: undefined } );
+
+				expect(
+					screen.getByLabelText( 'Border color and style picker.' )
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe named color selection', () => {
+				renderBorderControl( { value: { color: '#72aee6' } } );
+
+				expect(
+					screen.getByLabelText(
+						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+					)
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe custom color selection', () => {
+				renderBorderControl( { value: { color: '#4b1d80' } } );
+
+				expect(
+					screen.getByLabelText(
+						'Border color and style picker. The currently selected color has a value of "#4b1d80".'
+					)
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe named color and style selections', () => {
+				renderBorderControl( {
+					value: { color: '#72aee6', style: 'dotted' },
+				} );
+
+				expect(
+					screen.getByLabelText(
+						'Border color and style picker. The currently selected color is called "Blue" and has a value of "#72aee6". The currently selected style is "dotted".'
+					)
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe custom color and style selections', () => {
+				renderBorderControl( {
+					value: { color: '#4b1d80', style: 'dashed' },
+				} );
+
+				expect(
+					screen.getByLabelText(
+						'Border color and style picker. The currently selected color has a value of "#4b1d80". The currently selected style is "dashed".'
+					)
+				).toBeInTheDocument();
+			} );
+		} );
+
+		describe( 'with style selection disabled', () => {
+			it( 'should only include color in the label', () => {
+				renderBorderControl( { value: undefined, enableStyle: false } );
+
+				expect(
+					screen.getByLabelText( 'Border color picker.' )
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe named color selection', () => {
+				renderBorderControl( {
+					value: { color: '#72aee6' },
+					enableStyle: false,
+				} );
+
+				expect(
+					screen.getByLabelText(
+						'Border color picker. The currently selected color is called "Blue" and has a value of "#72aee6".'
+					)
+				).toBeInTheDocument();
+			} );
+
+			it( 'should correctly describe custom color selection', () => {
+				renderBorderControl( {
+					value: { color: '#4b1d80' },
+					enableStyle: false,
+				} );
+
+				expect(
+					screen.getByLabelText(
+						'Border color picker. The currently selected color has a value of "#4b1d80".'
+					)
+				).toBeInTheDocument();
+			} );
 		} );
 	} );
 

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -115,8 +115,6 @@ describe( 'BorderControl', () => {
 			renderBorderControl();
 			openPopover();
 
-			const headerLabel = screen.getByText( 'Border color' );
-			const closeButton = getButton( 'Close border color' );
 			const customColorPicker = getButton( /Custom color picker/ );
 			const colorSwatchButtons = screen.getAllByRole( 'button', {
 				name: /^Color:/,
@@ -127,8 +125,6 @@ describe( 'BorderControl', () => {
 			const dottedButton = getButton( 'Dotted' );
 			const resetButton = getButton( 'Reset to default' );
 
-			expect( headerLabel ).toBeInTheDocument();
-			expect( closeButton ).toBeInTheDocument();
 			expect( customColorPicker ).toBeInTheDocument();
 			expect( colorSwatchButtons.length ).toEqual( colors.length );
 			expect( styleLabel ).toBeInTheDocument();
@@ -136,6 +132,17 @@ describe( 'BorderControl', () => {
 			expect( dashedButton ).toBeInTheDocument();
 			expect( dottedButton ).toBeInTheDocument();
 			expect( resetButton ).toBeInTheDocument();
+		} );
+
+		it( 'should render color and style popover header', () => {
+			renderBorderControl( { showDropdownHeader: true } );
+			openPopover();
+
+			const headerLabel = screen.getByText( 'Border color' );
+			const closeButton = getButton( 'Close border color' );
+
+			expect( headerLabel ).toBeInTheDocument();
+			expect( closeButton ).toBeInTheDocument();
 		} );
 
 		it( 'should not render style options when opted out of', () => {
@@ -303,7 +310,7 @@ describe( 'BorderControl', () => {
 		} );
 
 		it( 'should take no action when color and style popover is closed', () => {
-			renderBorderControl();
+			renderBorderControl( { showDropdownHeader: true } );
 			openPopover();
 			clickButton( 'Close border color' );
 

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -1,0 +1,137 @@
+/**
+ * External dependencies
+ */
+import type { CSSProperties } from 'react';
+
+export type Border = {
+	color?: CSSProperties[ 'borderColor' ];
+	style?: CSSProperties[ 'borderStyle' ];
+	width?: CSSProperties[ 'borderWidth' ];
+};
+
+export type Color = {
+	name: string;
+	color: CSSProperties[ 'color' ];
+};
+
+export type ColorProps = {
+	/**
+	 * An array of color definitions. This may also be a multi-dimensional array
+	 * where colors are organized by multiple origins.
+	 */
+	colors?: Color[];
+	/**
+	 * This toggles the ability to choose custom colors.
+	 */
+	disableCustomColors?: boolean;
+	/**
+	 * This controls whether the alpha channel will be offered when selecting
+	 * custom colors.
+	 */
+	enableAlpha?: boolean;
+	/**
+	 * This is passed on to the color related sub-components which need to be
+	 * made aware of whether the colors prop contains multiple origins.
+	 */
+	__experimentalHasMultipleOrigins?: boolean;
+	/**
+	 * This is passed on to the color related sub-components so they may render
+	 * more effectively when used within a sidebar.
+	 */
+	__experimentalIsRenderedInSidebar?: boolean;
+};
+
+export type LabelProps = {
+	/**
+	 * Provides control over whether the label will only be visible to
+	 * screen readers.
+	 */
+	hideLabelFromVision?: boolean;
+	/**
+	 * If provided, a label will be generated using this as the content.
+	 */
+	label?: string;
+};
+
+export type BorderControlProps = ColorProps &
+	LabelProps & {
+		/**
+		 * This controls whether to include border style options within the
+		 * `BorderDropdown` sub-component.
+		 */
+		enableStyle?: boolean;
+		/**
+		 * This flags the `BorderControl` to render with a more compact appearance.
+		 * It restricts the width of the control and prevents it from expanding to
+		 * take up additional space.
+		 */
+		isCompact?: boolean;
+		/**
+		 * A callback function invoked when the border value is changed via an
+		 * interaction that selects or clears, border color, style, or width.
+		 */
+		onChange: ( value?: Border ) => void;
+		/**
+		 * If opted into, sanitizing the border means that if no width or color have
+		 * been selected, the border style is also cleared and `undefined`
+		 * is returned as the new border value.
+		 */
+		shouldSanitizeBorder?: boolean;
+		/**
+		 * An object representing a border or `undefined`. Used to set the current
+		 * border configuration for this component.
+		 */
+		value?: Border;
+		/**
+		 * Controls the visual width of the `BorderControl`.
+		 */
+		width?: string;
+		/**
+		 * Flags whether this `BorderControl` should also render a `RangeControl`
+		 * for additional control over a border's width.
+		 */
+		withSlider?: boolean;
+	};
+
+export type DropdownProps = ColorProps & {
+	/**
+	 * An object representing a border or `undefined`. This component will
+	 * extract the border color and style selections from this object to use as
+	 * values for its popover controls.
+	 */
+	border?: Border;
+	/**
+	 * This controls whether to render border style options.
+	 */
+	enableStyle?: boolean;
+	/**
+	 * A callback invoked when the border color or style selections change.
+	 */
+	onChange: ( newBorder?: Border ) => void;
+	/**
+	 * Any previous style selection made by the user. This can be used to
+	 * reapply that previous selection when, for example, a zero border width is
+	 * to a non-zero value.
+	 */
+	previousStyleSelection?: string;
+};
+
+export type StylePickerProps = LabelProps & {
+	/**
+	 * A callback function invoked when a border style is selected or cleared.
+	 */
+	onChange: ( style?: string ) => void;
+	/**
+	 * The currently selected border style if there is one. Styles available via
+	 * this control are `solid`, `dashed` & `dotted`, however the possibility
+	 * to store other valid CSS values is maintained e.g. `none`, `inherit` etc.
+	 */
+	value?: string;
+};
+
+export type PopoverProps = {
+	/**
+	 * Callback function to invoke when closing the border dropdown's popover.
+	 */
+	onClose: () => void;
+};

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -14,12 +14,19 @@ export type Color = {
 	color: CSSProperties[ 'color' ];
 };
 
+export type ColorOrigin = {
+	name: string;
+	colors: Color[];
+};
+
+export type Colors = ColorOrigin[] | Color[];
+
 export type ColorProps = {
 	/**
 	 * An array of color definitions. This may also be a multi-dimensional array
 	 * where colors are organized by multiple origins.
 	 */
-	colors?: Color[];
+	colors?: Colors;
 	/**
 	 * This toggles the ability to choose custom colors.
 	 */

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -107,6 +107,8 @@ export type DropdownProps = ColorProps & {
 	border?: Border;
 	/**
 	 * This controls whether to render border style options.
+	 *
+	 * @default true
 	 */
 	enableStyle?: boolean;
 	/**

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -75,6 +75,8 @@ export type BorderControlProps = ColorProps &
 		 * If opted into, sanitizing the border means that if no width or color have
 		 * been selected, the border style is also cleared and `undefined`
 		 * is returned as the new border value.
+		 *
+		 * @default true
 		 */
 		shouldSanitizeBorder?: boolean;
 		/**

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -90,7 +90,7 @@ export type BorderControlProps = ColorProps &
 		 * Controls the visual width of the `BorderControl`. It has no effect if
 		 * the `isCompact` prop is set to `true`.
 		 */
-		width?: string;
+		width?: CSSProperties[ 'width' ];
 		/**
 		 * Flags whether this `BorderControl` should also render a `RangeControl`
 		 * for additional control over a border's width.

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -58,6 +58,8 @@ export type BorderControlProps = ColorProps &
 		/**
 		 * This controls whether to include border style options within the
 		 * `BorderDropdown` sub-component.
+		 *
+		 * @default true
 		 */
 		enableStyle?: boolean;
 		/**

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -83,7 +83,8 @@ export type BorderControlProps = ColorProps &
 		 */
 		value?: Border;
 		/**
-		 * Controls the visual width of the `BorderControl`.
+		 * Controls the visual width of the `BorderControl`. It has no effect if
+		 * the `isCompact` prop is set to `true`.
 		 */
 		width?: string;
 		/**

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -70,9 +70,9 @@ export type BorderControlProps = ColorProps &
 		 */
 		enableStyle?: boolean;
 		/**
-		 * This flags the `BorderControl` to render with a more compact appearance.
-		 * It restricts the width of the control and prevents it from expanding to
-		 * take up additional space.
+		 * This flags the `BorderControl` to render with a more compact
+		 * appearance. It restricts the width of the control and prevents it
+		 * from expanding to take up additional space.
 		 */
 		isCompact?: boolean;
 		/**
@@ -81,16 +81,22 @@ export type BorderControlProps = ColorProps &
 		 */
 		onChange: ( value?: Border ) => void;
 		/**
-		 * If opted into, sanitizing the border means that if no width or color have
-		 * been selected, the border style is also cleared and `undefined`
+		 * If opted into, sanitizing the border means that if no width or color
+		 * have been selected, the border style is also cleared and `undefined`
 		 * is returned as the new border value.
 		 *
 		 * @default true
 		 */
 		shouldSanitizeBorder?: boolean;
 		/**
-		 * An object representing a border or `undefined`. Used to set the current
-		 * border configuration for this component.
+		 * Whether or not to show the header for the border color and style
+		 * picker dropdown. The header includes a label for the color picker
+		 * and a close button.
+		 */
+		showDropdownHeader?: boolean;
+		/**
+		 * An object representing a border or `undefined`. Used to set the
+		 * current border configuration for this component.
 		 */
 		value?: Border;
 		/**
@@ -99,8 +105,8 @@ export type BorderControlProps = ColorProps &
 		 */
 		width?: CSSProperties[ 'width' ];
 		/**
-		 * Flags whether this `BorderControl` should also render a `RangeControl`
-		 * for additional control over a border's width.
+		 * Flags whether this `BorderControl` should also render a
+		 * `RangeControl` for additional control over a border's width.
 		 */
 		withSlider?: boolean;
 	};
@@ -128,6 +134,12 @@ export type DropdownProps = ColorProps & {
 	 * to a non-zero value.
 	 */
 	previousStyleSelection?: string;
+	/**
+	 * Whether or not to render a header for the border color and style picker
+	 * dropdown. The header includes a label for the color picker and a
+	 * close button.
+	 */
+	showDropdownHeader?: boolean;
 };
 
 export type StylePickerProps = LabelProps & {

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -23,6 +23,7 @@ export {
 	useAutocompleteProps as __unstableUseAutocompleteProps,
 } from './autocomplete';
 export { default as BaseControl } from './base-control';
+export { BorderControl as __experimentalBorderControl } from './border-control';
 export { default as __experimentalBoxControl } from './box-control';
 export { default as Button } from './button';
 export { default as ButtonGroup } from './button-group';

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -26,6 +26,7 @@
 		"src/animate/**/*",
 		"src/base-control/**/*",
 		"src/base-field/**/*",
+		"src/border-control/**/*",
 		"src/button/**/*",
 		"src/card/**/*",
 		"src/circular-option-picker/**/*",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -30,6 +30,7 @@
 		"src/button/**/*",
 		"src/card/**/*",
 		"src/circular-option-picker/**/*",
+		"src/color-indicator/**/*",
 		"src/color-palette/**/*",
 		"src/color-picker/**/*",
 		"src/confirm-dialog/**/*",


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/issues/35602
- https://github.com/WordPress/gutenberg/pull/38876

## Description

This PR adds a new `BorderControl` component aimed at improving the UX around configuring borders.

- `BorderControl`
    - This allows the selection of a border color, style, and width.
    - Works off an object as its value e.g. `{ color: '#000000', style: 'solid', width: '0.5em' }`
    - Can optionally display a slider for alternative means of setting border width.
    - Border style controls can be disabled
    - The color palettes used are configurable
    - The width of the input field is customizable

#### Note
_The PR began life introducing two new components, `BorderControl` and `BorderBoxControl`. They have now been separated into separate PRs. Some of the implementation decisions in this were driven by the component's bigger picture use as part of the `BorderBoxControl`_

## How has this been tested?
Via unit tests;

1. Run `npm run test-unit packages/components/src/border-control/test/index.js`

Manually:

1. Checkout this PR branch
2. Run `npm run storybook:dev`
3. [Check out the `BorderControl`](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default)

## Screenshots

<img src="https://user-images.githubusercontent.com/60436221/151919644-e661afd2-b777-45b1-ba5f-733e13161503.gif" width="500"/>

## Types of changes
New feature.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
