### PR TITLE
Add `since` field to theme.json doc reference

### DIFF
--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -77,15 +77,16 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 		return '';
 	}
 
-	let markup = '| Property  | Type   | Default | Props  |\n';
-	markup += '| ---       | ---    | ---    |---   |\n';
+	let markup = '| Property  | Type   | Default | Props  | Since |\n';
+	markup += '| ---       | ---    | ---    |---   | --- |\n';
 	ks.forEach( ( key ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
+		const since = props[key].since ? props[key].since : '';
 		const ps =
 			props[ key ].type === 'array'
 				? keys( props[ key ].items.properties ).sort().join( ', ' )
 				: '';
-		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } |\n`;
+		markup += `| ${ key } | ${ props[ key ].type } | ${ def } | ${ ps } | ${ since } |\n`;
 	} );
 
 	return markup;

--- a/bin/api-docs/gen-theme-reference.js
+++ b/bin/api-docs/gen-theme-reference.js
@@ -81,7 +81,7 @@ const getSettingsPropertiesMarkup = ( struct ) => {
 	markup += '| ---       | ---    | ---    |---   | --- |\n';
 	ks.forEach( ( key ) => {
 		const def = 'default' in props[ key ] ? props[ key ].default : '';
-		const since = props[key].since ? props[key].since : '';
+		const since = props[ key ].since ? props[ key ].since : '';
 		const ps =
 			props[ key ].type === 'array'
 				? keys( props[ key ].items.properties ).sort().join( ', ' )
@@ -108,14 +108,15 @@ const getStylePropertiesMarkup = ( struct ) => {
 		return '';
 	}
 
-	let markup = '| Property  | Type   |  Props  |\n';
-	markup += '| ---       | ---    |---   |\n';
+	let markup = '| Property  | Type   |  Props  | Since |\n';
+	markup += '| ---       | ---    |---   | --- |\n';
 	ks.forEach( ( key ) => {
+		const since = props[ key ].since ? props[ key ].since : '';
 		const ps =
 			props[ key ].type === 'object'
 				? keys( props[ key ].properties ).sort().join( ', ' )
 				: '';
-		markup += `| ${ key } | ${ props[ key ].type } | ${ ps } |\n`;
+		markup += `| ${ key } | ${ props[ key ].type } | ${ ps } | ${ since } |\n`;
 	} );
 
 	return markup;

--- a/docs/reference-guides/theme-json-reference.md
+++ b/docs/reference-guides/theme-json-reference.md
@@ -25,7 +25,7 @@ Settings related to borders.
 | Property  | Type   | Default | Props  | Since |
 | ---       | ---    | ---    |---   | --- |
 | color | boolean | true |  | v2 |
-| radius | boolean | false |  | v1 |
+| radius | boolean | false |  | v2 (was customRadius in v1) |
 | style | boolean | false |  | v2 |
 | width | boolean | false |  | v2 |
 
@@ -37,17 +37,17 @@ Settings related to colors.
 
 | Property  | Type   | Default | Props  | Since |
 | ---       | ---    | ---    |---   | --- |
-| background | boolean | true |  | v1 |
+| background | boolean | true |  | v2 |
 | custom | boolean | true |  | v1 |
 | customDuotone | boolean | true |  | v1 |
 | customGradient | boolean | true |  | v1 |
-| defaultGradients | boolean | true |  | v1 |
-| defaultPalette | boolean | true |  | v1 |
+| defaultGradients | boolean | true |  | v2 |
+| defaultPalette | boolean | true |  | v2 |
 | duotone | array |  | colors, name, slug | v1 |
 | gradients | array |  | gradient, name, slug | v1 |
 | link | boolean | false |  | v1 |
 | palette | array |  | color, name, slug | v1 |
-| text | boolean | true |  | v1 |
+| text | boolean | true |  | v2 |
 
 ---
 
@@ -57,8 +57,8 @@ Settings related to layout.
 
 | Property  | Type   | Default | Props  | Since |
 | ---       | ---    | ---    |---   | --- |
-| contentSize | string |  |  | v1 |
-| wideSize | string |  |  | v1 |
+| contentSize | string |  |  | v2 |
+| wideSize | string |  |  | v2 |
 
 ---
 
@@ -85,7 +85,7 @@ Settings related to typography.
 | fontStyle | boolean | true |  | v2 |
 | fontWeight | boolean | true |  | v2 |
 | letterSpacing | boolean | true |  | v2 |
-| lineHeight | boolean | false |  | v1 |
+| lineHeight | boolean | false |  | v2 (was customLineHeight in v1) |
 | textDecoration | boolean | true |  | v2 |
 | textTransform | boolean | true |  | v2 |
 | dropCap | boolean | true |  | v1 |
@@ -110,7 +110,7 @@ Border styles.
 | Property  | Type   |  Props  | Since |
 | ---       | ---    |---   | --- |
 | color | string |  | v2 |
-| radius | string |  | v2 |
+| radius | string |  | v1 |
 | style | string |  | v2 |
 | width | string |  | v2 |
 

--- a/docs/reference-guides/theme-json-reference.md
+++ b/docs/reference-guides/theme-json-reference.md
@@ -107,12 +107,12 @@ Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-
 
 Border styles.
 
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| color | string |  |
-| radius | string |  |
-| style | string |  |
-| width | string |  |
+| Property  | Type   |  Props  | Since |
+| ---       | ---    |---   | --- |
+| color | string |  | v2 |
+| radius | string |  | v2 |
+| style | string |  | v2 |
+| width | string |  | v2 |
 
 ---
 
@@ -120,11 +120,11 @@ Border styles.
 
 Color styles.
 
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| background | string |  |
-| gradient | string |  |
-| text | string |  |
+| Property  | Type   |  Props  | Since |
+| ---       | ---    |---   | --- |
+| background | string |  | v1 |
+| gradient | string |  | v1 |
+| text | string |  | v1 |
 
 ---
 
@@ -132,11 +132,11 @@ Color styles.
 
 Spacing styles.
 
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| blockGap | string |  |
-| margin | object | bottom, left, right, top |
-| padding | object | bottom, left, right, top |
+| Property  | Type   |  Props  | Since |
+| ---       | ---    |---   | --- |
+| blockGap | string |  | v2 |
+| margin | object | bottom, left, right, top | v1 |
+| padding | object | bottom, left, right, top | v1 |
 
 ---
 
@@ -144,16 +144,16 @@ Spacing styles.
 
 Typography styles.
 
-| Property  | Type   |  Props  |
-| ---       | ---    |---   |
-| fontFamily | string |  |
-| fontSize | string |  |
-| fontStyle | string |  |
-| fontWeight | string |  |
-| letterSpacing | string |  |
-| lineHeight | string |  |
-| textDecoration | string |  |
-| textTransform | string |  |
+| Property  | Type   |  Props  | Since |
+| ---       | ---    |---   | --- |
+| fontFamily | string |  | v2 |
+| fontSize | string |  | v1 |
+| fontStyle | string |  | v2 |
+| fontWeight | string |  | v2 |
+| letterSpacing | string |  | v2 |
+| lineHeight | string |  | v1 |
+| textDecoration | string |  | v2 |
+| textTransform | string |  | v2 |
 
 ---
 

--- a/docs/reference-guides/theme-json-reference.md
+++ b/docs/reference-guides/theme-json-reference.md
@@ -15,6 +15,8 @@ Setting that enables the following UI tools:
 - spacing: blockGap, margin, padding
 - typography: lineHeight
 
+Since v2.
+
 
 ---
 
@@ -96,7 +98,11 @@ Settings related to typography.
 
 ### custom
 
-Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.
+Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. 
+
+`camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema and keys at different depth levels are separated by `--` (so keys should not include `--` in the name).
+
+Since v1.
 
 
 ---

--- a/docs/reference-guides/theme-json-reference.md
+++ b/docs/reference-guides/theme-json-reference.md
@@ -22,12 +22,12 @@ Setting that enables the following UI tools:
 
 Settings related to borders.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| color | boolean | false |  |
-| radius | boolean | false |  |
-| style | boolean | false |  |
-| width | boolean | false |  |
+| Property  | Type   | Default | Props  | Since |
+| ---       | ---    | ---    |---   | --- |
+| color | boolean | true |  | v2 |
+| radius | boolean | false |  | v1 |
+| style | boolean | false |  | v2 |
+| width | boolean | false |  | v2 |
 
 ---
 
@@ -35,19 +35,19 @@ Settings related to borders.
 
 Settings related to colors.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| background | boolean | true |  |
-| custom | boolean | true |  |
-| customDuotone | boolean | true |  |
-| customGradient | boolean | true |  |
-| defaultGradients | boolean | true |  |
-| defaultPalette | boolean | true |  |
-| duotone | array |  | colors, name, slug |
-| gradients | array |  | gradient, name, slug |
-| link | boolean | false |  |
-| palette | array |  | color, name, slug |
-| text | boolean | true |  |
+| Property  | Type   | Default | Props  | Since |
+| ---       | ---    | ---    |---   | --- |
+| background | boolean | true |  | v1 |
+| custom | boolean | true |  | v1 |
+| customDuotone | boolean | true |  | v1 |
+| customGradient | boolean | true |  | v1 |
+| defaultGradients | boolean | true |  | v1 |
+| defaultPalette | boolean | true |  | v1 |
+| duotone | array |  | colors, name, slug | v1 |
+| gradients | array |  | gradient, name, slug | v1 |
+| link | boolean | false |  | v1 |
+| palette | array |  | color, name, slug | v1 |
+| text | boolean | true |  | v1 |
 
 ---
 
@@ -55,10 +55,10 @@ Settings related to colors.
 
 Settings related to layout.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| contentSize | string |  |  |
-| wideSize | string |  |  |
+| Property  | Type   | Default | Props  | Since |
+| ---       | ---    | ---    |---   | --- |
+| contentSize | string |  |  | v1 |
+| wideSize | string |  |  | v1 |
 
 ---
 
@@ -66,12 +66,12 @@ Settings related to layout.
 
 Settings related to spacing.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| blockGap | undefined | null |  |
-| margin | boolean | false |  |
-| padding | boolean | false |  |
-| units | array | px,em,rem,vh,vw,% |  |
+| Property  | Type   | Default | Props  | Since |
+| ---       | ---    | ---    |---   | --- |
+| blockGap | undefined | null |  | v2 |
+| margin | boolean | false |  | v2 (was customMargin in v1) |
+| padding | boolean | false |  | v2 (was customPadding in v1) |
+| units | array | px,em,rem,vh,vw,% |  | v1 |
 
 ---
 
@@ -79,18 +79,18 @@ Settings related to spacing.
 
 Settings related to typography.
 
-| Property  | Type   | Default | Props  |
-| ---       | ---    | ---    |---   |
-| customFontSize | boolean | true |  |
-| fontStyle | boolean | true |  |
-| fontWeight | boolean | true |  |
-| letterSpacing | boolean | true |  |
-| lineHeight | boolean | false |  |
-| textDecoration | boolean | true |  |
-| textTransform | boolean | true |  |
-| dropCap | boolean | true |  |
-| fontSizes | array |  | name, size, slug |
-| fontFamilies | array |  | fontFamily, name, slug |
+| Property  | Type   | Default | Props  | Since |
+| ---       | ---    | ---    |---   | --- |
+| customFontSize | boolean | true |  | v1 |
+| fontStyle | boolean | true |  | v2 |
+| fontWeight | boolean | true |  | v2 |
+| letterSpacing | boolean | true |  | v2 |
+| lineHeight | boolean | false |  | v1 |
+| textDecoration | boolean | true |  | v2 |
+| textTransform | boolean | true |  | v2 |
+| dropCap | boolean | true |  | v1 |
+| fontSizes | array |  | name, size, slug | v1 |
+| fontFamilies | array |  | fontFamily, name, slug | v2 |
 
 ---
 

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -28,7 +28,7 @@
 							"description": "Allow users to set custom border radius.",
 							"type": "boolean",
 							"default": false,
-							"since": "v1"
+							"since": "v2 (was customRadius in v1)"
 						},
 						"style": {
 							"description": "Allow users to set custom border styles.",
@@ -57,7 +57,7 @@
 							"description": "Allow users to set background colors.",
 							"type": "boolean",
 							"default": true,
-							"since": "v1"
+							"since": "v2"
 						},
 						"custom": {
 							"description": "Allow users to select custom colors.",
@@ -81,13 +81,13 @@
 							"description": "Allow users to choose colors from the default gradients.",
 							"type": "boolean",
 							"default": true,
-							"since": "v1"
+							"since": "v2"
 						},
 						"defaultPalette": {
 							"description": "Allow users to choose colors from the default palette.",
 							"type": "boolean",
 							"default": true,
-							"since": "v1"
+							"since": "v2"
 						},
 						"duotone": {
 							"description": "Duotone presets for the duotone picker.\nDoesn't generate classes or properties.",
@@ -175,7 +175,7 @@
 							"description": "Allow users to set text colors.",
 							"type": "boolean",
 							"default": true,
-							"since": "v1"
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false
@@ -192,12 +192,12 @@
 						"contentSize": {
 							"description": "Sets the max-width of the content.",
 							"type": "string",
-							"since": "v1"
+							"since": "v2"
 						},
 						"wideSize": {
 							"description": "Sets the max-width of wide (`.alignwide`) content.",
 							"type": "string",
-							"since": "v1"
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false
@@ -280,7 +280,7 @@
 							"description": "Allow users to set custom line height.",
 							"type": "boolean",
 							"default": false,
-							"since": "v1"
+							"since": "v2 (was customLineHeight in v1)"
 						},
 						"textDecoration": {
 							"description": "Allow users to set custom text decorations.",
@@ -699,7 +699,7 @@
 						"radius": {
 							"description": "Sets the `border-radius` CSS property.",
 							"type": "string",
-							"since": "v2"
+							"since": "v1"
 						},
 						"style": {
 							"description": "Sets the `border-style` CSS property.",

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -21,22 +21,26 @@
 						"color": {
 							"description": "Allow users to set custom border colors.",
 							"type": "boolean",
-							"default": false
+							"default": true,
+							"since": "v2"
 						},
 						"radius": {
 							"description": "Allow users to set custom border radius.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v1"
 						},
 						"style": {
 							"description": "Allow users to set custom border styles.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v2"
 						},
 						"width": {
 							"description": "Allow users to set custom border widths.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false
@@ -52,32 +56,38 @@
 						"background": {
 							"description": "Allow users to set background colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"custom": {
 							"description": "Allow users to select custom colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"customDuotone": {
 							"description": "Allow users to create custom duotone filters.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"customGradient": {
 							"description": "Allow users to create custom gradients.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"defaultGradients": {
 							"description": "Allow users to choose colors from the default gradients.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"defaultPalette": {
 							"description": "Allow users to choose colors from the default palette.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"duotone": {
 							"description": "Duotone presets for the duotone picker.\nDoesn't generate classes or properties.",
@@ -104,7 +114,8 @@
 								},
 								"required": [ "name", "slug", "colors" ],
 								"additionalProperties": false
-							}
+							},
+							"since": "v1"
 						},
 						"gradients": {
 							"description": "Gradient presets for the gradient picker.\nGenerates a single class (`.has-{slug}-background`) and custom property (`--wp--preset--gradient--{slug}`) per preset value.",
@@ -127,12 +138,14 @@
 								},
 								"required": [ "name", "slug", "gradient" ],
 								"additionalProperties": false
-							}
+							},
+							"since": "v1"
 						},
 						"link": {
 							"description": "Allow users to set link colors.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v1"
 						},
 						"palette": {
 							"description": "Color palette presets for the color picker.\nGenerates three classes (`.has-{slug}-color`, `.has-{slug}-background-color`, and `.has-{slug}-border-color`) and a single custom property (`--wp--preset--color--{slug}`) per preset value.",
@@ -155,12 +168,14 @@
 								},
 								"required": [ "name", "slug", "color" ],
 								"additionalProperties": false
-							}
+							},
+							"since": "v1"
 						},
 						"text": {
 							"description": "Allow users to set text colors.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						}
 					},
 					"additionalProperties": false
@@ -176,11 +191,13 @@
 					"properties": {
 						"contentSize": {
 							"description": "Sets the max-width of the content.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						},
 						"wideSize": {
 							"description": "Sets the max-width of wide (`.alignwide`) content.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						}
 					},
 					"additionalProperties": false
@@ -200,17 +217,20 @@
 								{ "type": "boolean" },
 								{ "type": "null" }
 							],
-							"default": null
+							"default": null,
+							"since": "v2"
 						},
 						"margin": {
 							"description": "Allow users to set a custom margin.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v2 (was customMargin in v1)"
 						},
 						"padding": {
 							"description": "Allow users to set a custom padding.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v2 (was customPadding in v1)"
 						},
 						"units": {
 							"description": "List of units the user can use for spacing values.",
@@ -218,7 +238,8 @@
 							"items": {
 								"type": "string"
 							},
-							"default": [ "px", "em", "rem", "vh", "vw", "%" ]
+							"default": [ "px", "em", "rem", "vh", "vw", "%" ],
+							"since": "v1"
 						}
 					},
 					"additionalProperties": false
@@ -234,42 +255,50 @@
 						"customFontSize": {
 							"description": "Allow users to set custom font sizes.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"fontStyle": {
 							"description": "Allow users to set custom font styles.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v2"
 						},
 						"fontWeight": {
 							"description": "Allow users to set custom font weights.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v2"
 						},
 						"letterSpacing": {
 							"description": "Allow users to set custom letter spacing.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v2"
 						},
 						"lineHeight": {
 							"description": "Allow users to set custom line height.",
 							"type": "boolean",
-							"default": false
+							"default": false,
+							"since": "v1"
 						},
 						"textDecoration": {
 							"description": "Allow users to set custom text decorations.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v2"
 						},
 						"textTransform": {
 							"description": "Allow users to set custom text transforms.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v2"
 						},
 						"dropCap": {
 							"description": "Enable drop cap.",
 							"type": "boolean",
-							"default": true
+							"default": true,
+							"since": "v1"
 						},
 						"fontSizes": {
 							"description": "Font size presets for the font size selector.\nGenerates a single class (`.has-{slug}-color`) and custom property (`--wp--preset--font-size--{slug}`) per preset value.",
@@ -291,7 +320,8 @@
 									}
 								},
 								"additionalProperties": false
-							}
+							},
+							"since": "v1"
 						},
 						"fontFamilies": {
 							"description": "Font family presets for the font family selector.\nGenerates a single custom property (`--wp--preset--font-family--{slug}`) per preset value.",
@@ -313,7 +343,8 @@
 									}
 								},
 								"additionalProperties": false
-							}
+							},
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -10,7 +10,7 @@
 		"settingsPropertiesBorder": {
 			"properties": {
 				"appearanceTools": {
-					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight",
+					"description": "Setting that enables the following UI tools:\n\n- border: color, radius, style, width\n- color: link\n- spacing: blockGap, margin, padding\n- typography: lineHeight\n\nSince v2.",
 					"type": "boolean",
 					"default": false
 				},
@@ -354,7 +354,7 @@
 		"settingsPropertiesCustom": {
 			"properties": {
 				"custom": {
-					"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. `camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema. Keys at different depth levels are separated by `--`, so keys should not include `--` in the name.",
+					"description": "Generate custom CSS custom properties of the form `--wp--custom--{key}--{nested-key}: {value};`. \n\n`camelCased` keys are transformed to `kebab-case` as to follow the CSS property naming schema and keys at different depth levels are separated by `--` (so keys should not include `--` in the name).\n\nSince v1.",
 					"$ref": "#/definitions/settingsCustomAdditionalProperties"
 				}
 			}

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -693,19 +693,23 @@
 					"properties": {
 						"color": {
 							"description": "Sets the `border-color` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"radius": {
 							"description": "Sets the `border-radius` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"style": {
 							"description": "Sets the `border-style` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"width": {
 							"description": "Sets the `border-width` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false
@@ -716,15 +720,18 @@
 					"properties": {
 						"background": {
 							"description": "Sets the `background-color` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						},
 						"gradient": {
 							"description": "Sets the `background` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						},
 						"text": {
 							"description": "Sets the `color` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						}
 					},
 					"additionalProperties": false
@@ -735,7 +742,8 @@
 					"properties": {
 						"blockGap": {
 							"description": "Sets the `--wp--style--block-gap` CSS custom property when settings.spacing.blockGap is true.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"margin": {
 							"description": "Margin styles.",
@@ -758,6 +766,7 @@
 									"type": "string"
 								}
 							},
+							"since": "v1",
 							"additionalProperties": false
 						},
 						"padding": {
@@ -781,6 +790,7 @@
 									"type": "string"
 								}
 							},
+							"since": "v1",
 							"additionalProperties": false
 						}
 					},
@@ -792,35 +802,43 @@
 					"properties": {
 						"fontFamily": {
 							"description": "Sets the `font-family` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"fontSize": {
 							"description": "Sets the `font-size` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						},
 						"fontStyle": {
 							"description": "Sets the `font-style` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"fontWeight": {
 							"description": "Sets the `font-weight` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"letterSpacing": {
 							"description": "Sets the `letter-spacing` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"lineHeight": {
 							"description": "Sets the `line-height` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v1"
 						},
 						"textDecoration": {
 							"description": "Sets the `text-decoration` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						},
 						"textTransform": {
 							"description": "Sets the `text-transform` CSS property.",
-							"type": "string"
+							"type": "string",
+							"since": "v2"
 						}
 					},
 					"additionalProperties": false


### PR DESCRIPTION
In WordPress 5.9, we're evolving theme.json to the v2 version: it introduces new fields and renames some old ones. Since theme authors can use either v1 or v2, the documentation needs to clarify which fields are available in which version.

This PR updates the reference documentation to include the version info for any given field.

See [the resulting doc](https://github.com/WordPress/gutenberg/blob/529239c587bad1cdc272adad2d2ae0cfc3b0c06e/docs/reference-guides/theme-json-reference.md).