### PR TITLE
RichText: Fix dead key input on Windows

### DIFF
--- a/packages/rich-text/src/component/use-space.js
+++ b/packages/rich-text/src/component/use-space.js
@@ -21,10 +21,35 @@ export function useSpace() {
 				return;
 			}
 
-			const { keyCode, altKey, metaKey, ctrlKey } = event;
+			const { keyCode, altKey, metaKey, ctrlKey, key } = event;
 
 			// Only consider the space key without modifiers pressed.
 			if ( keyCode !== SPACE || altKey || metaKey || ctrlKey ) {
+				return;
+			}
+
+			// Disregard character composition that involves the Space key.
+			//
+			// @see https://github.com/WordPress/gutenberg/issues/35086
+			//
+			// For example, to input a standalone diacritic (like ´ or `) using a
+			// keyboard with dead keys, one must first press the dead key and then
+			// press the Space key.
+			//
+			// Many operating systems handle this in such a way that the second
+			// KeyboardEvent contains the property `keyCode: 229`. According to the
+			// spec, 229 allows the system to indicate that an Input Method Editor
+			// (IDE) is processing some key input.
+			//
+			// However, Windows doesn't use `keyCode: 229` for dead key composition,
+			// instead emitting an event with values `keyCode: SPACE` and `key: '´'`.
+			// That is why checking the `key` property for values other than `SPACE`
+			// is important.
+			//
+			// This should serve as a reminder that the `KeyboardEvent.keyCode`
+			// attribute is officially deprecated and that we should consider more
+			// consistent interfaces.
+			if ( key !== ' ' ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/35086

## Description

In `useSpace`, don't intercept character composition that involves the Space key. For example, to input a standalone diacritic (like <kbd>´</kbd> or <kbd>`</kbd>) using a keyboard with dead keys, one must first press the dead key and then press the Space key.

Many operating systems handle this in such a way that the second KeyboardEvent contains the property `keyCode: 229`. According to the spec, 229 allows the system to indicate that an Input Method Editor (IDE) is processing some key input.

However, Windows doesn't use `keyCode: 229` for dead key composition, instead emitting an event with values `keyCode: SPACE` and `key: '´'`. That is why checking the `key` property for values other than `SPACE` is important.

This should serve as a reminder that the `KeyboardEvent.keyCode` attribute is officially deprecated and that we should consider more consistent interfaces.

cc @ellatrix @Flameeyes 

## How has this been tested?

See parent issue (#35086).

* Make sure you switch to a keyboard layout with dead keys (e.g. US International w/ dead keys).
* Start a new post.
* Input text that contains spaces, accented letters (pressing an accent's dead key followed by a vowel key), and standalone diacritics (pressing an accent's dead key followed by the Space key). Make sure everything behaves as intended.
  * On non-Windows systems, no changes should be observed.
  * On Windows, it should now be possible to input a standalone diacritic. No other changes should be observed.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (regression) affecting a particular system.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
