### PR TITLE
Update core/archive block schema to reflect no block-level settings support.

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -361,7 +361,8 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
+					"description": "As of WordPress 5.9, this block does not support any block-level settings.",
+					"additionalProperties": false
 				},
 				"core/audio": {
 					"$ref": "#/definitions/settingsPropertiesComplete"

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -361,7 +361,7 @@
 			"type": "object",
 			"properties": {
 				"core/archives": {
-					"description": "As of WordPress 5.9, this block does not support any block-level settings.",
+					"description": "Archive block. Display a monthly archive of your posts. This block has no block-level settings",
 					"additionalProperties": false
 				},
 				"core/audio": {


### PR DESCRIPTION
## Description
Schema updates as part of #37735 for the core/archives block

## Types of changes
Schema changes to theme.json

This was tested by setting the $shema value to [this file](https://github.com/WordPress/gutenberg/pull/37778/files#diff-65c0d061536e5fa3369aba19faf1f475337c549f26828424fa224908f0bcf137) in a local theme.json file.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
