### PR TITLE
Add: Copy all content to edit site

### DIFF
--- a/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
+++ b/packages/edit-site/src/components/header/more-menu/copy-content-menu-item.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { MenuItem } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { useCopyToClipboard } from '@wordpress/compose';
+import { store as noticesStore } from '@wordpress/notices';
+import { store as coreStore } from '@wordpress/core-data';
+import { __unstableSerializeAndClean } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../../store';
+
+export default function CopyContentMenuItem() {
+	const { createNotice } = useDispatch( noticesStore );
+	const getText = useSelect( ( select ) => {
+		return () => {
+			const { getEditedPostId, getEditedPostType } = select(
+				editSiteStore
+			);
+			const { getEditedEntityRecord } = select( coreStore );
+			const record = getEditedEntityRecord(
+				'postType',
+				getEditedPostType(),
+				getEditedPostId()
+			);
+			if ( record ) {
+				if ( typeof record.content === 'function' ) {
+					return record.content( record );
+				} else if ( record.blocks ) {
+					return __unstableSerializeAndClean( record.blocks );
+				} else if ( record.content ) {
+					return record.content;
+				}
+			}
+			return '';
+		};
+	}, [] );
+
+	function onSuccess() {
+		createNotice( 'info', __( 'All content copied.' ), {
+			isDismissible: true,
+			type: 'snackbar',
+		} );
+	}
+
+	const ref = useCopyToClipboard( getText, onSuccess );
+
+	return <MenuItem ref={ ref }>{ __( 'Copy all content' ) }</MenuItem>;
+}

--- a/packages/edit-site/src/components/header/more-menu/index.js
+++ b/packages/edit-site/src/components/header/more-menu/index.js
@@ -22,6 +22,7 @@ import FeatureToggle from '../feature-toggle';
 import ToolsMoreMenuGroup from '../tools-more-menu-group';
 import SiteExport from './site-export';
 import WelcomeGuideMenuItem from './welcome-guide-menu-item';
+import CopyContentMenuItem from './copy-content-menu-item';
 
 const POPOVER_PROPS = {
 	className: 'edit-site-more-menu__content',
@@ -91,6 +92,7 @@ export default function MoreMenu() {
 								{ __( 'Keyboard shortcuts' ) }
 							</MenuItem>
 							<WelcomeGuideMenuItem />
+							<CopyContentMenuItem />
 							<MenuItem
 								icon={ external }
 								role="menuitem"


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/21245.
Bring the Copy all content functionality to the site editor.

## How has this been tested?
I verified the "Copy all content" button works well on both templates and template parts.

## Screenshots <!-- if applicable -->
![Jan-07-2022 15-54-15](https://user-images.githubusercontent.com/11271197/148571237-e9c75c3c-577b-4d08-822b-d231e1469aa3.gif)

