### PR TITLE
Comments Pagination Next block: fix accidental division by zero

### DIFF
--- a/packages/block-library/src/comments-pagination-next/index.php
+++ b/packages/block-library/src/comments-pagination-next/index.php
@@ -23,7 +23,7 @@ function render_block_core_comments_pagination_next( $attributes, $content, $blo
 		}
 	}
 	$comments_number  = (int) get_comments_number();
-	$max_page         = isset( $per_page ) ? (int) floor( $comments_number / $per_page ) : 0;
+	$max_page         = 0 !== $per_page ? (int) floor( $comments_number / $per_page ) : 0;
 	$default_label    = __( 'Next Comments' );
 	$label            = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 	$pagination_arrow = get_comments_pagination_arrow( $block, 'next' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### What

It fixes #37785, a small bug of the Comments Pagination Next block that triggers a `division by zero` warning when no `per_page` was set in either the parent Comments Query Loop block or in the WordPress settings.

### Why

Under those conditions, it was possible to run a division by zero in the code.

### How

I replaced an `isset( $per_page )` which always returns true for a comparison of `0 !== $per_page`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I tested it manually by adding a new Comment Query Loop block in a WordPress site with the default comments configuration.

## Screenshots <!-- if applicable -->

I made a small video to explain the problem and this possible solution in more detail: https://www.loom.com/share/3aa2b9d8ab73417bac074a7c7d84cd50

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

This is a bug fix.

## Checklist:
- [x] My code is manually tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->