### PR TITLE
Fix: Impossible to clear colors if color palettes are removed.

### DIFF
--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -136,9 +136,10 @@ export default function ColorPalette( {
 	__experimentalIsRenderedInSidebar = false,
 } ) {
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
-	const Component = __experimentalHasMultipleOrigins
-		? MultiplePalettes
-		: SinglePalette;
+	const Component =
+		__experimentalHasMultipleOrigins && colors?.length
+			? MultiplePalettes
+			: SinglePalette;
 
 	const renderCustomColorPicker = () => (
 		<ColorPicker


### PR DESCRIPTION
If the colors palette are disabled it is impossible to clear a custom color.
This PR fixes the issue and applies the missing logic to colors that was already part of the gradient picker.

## How has this been tested?
I disabled all the color palettes by making sure there are no custom colors on the global styles, and adding the following to theme.json under settings.color.
```
			"defaultPalette": false,
			"palette": []
```

I verified I could set a custom color and the clear button was always available as it was in WordPress 5.8. On trunk the button never appears.
## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/148593954-6a97eb8f-c52a-4cb9-9bd8-1b3017f5dc25.png)
