### PR TITLE
Compose: Rework types of createHigherOrderComponent for closer match to API

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -79,12 +79,12 @@ name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
--   _mapComponentToEnhancedComponent_ `HigherOrderComponent< TInnerProps, TOuterProps >`: Function mapping component to enhanced component.
+-   _mapComponent_ `HigherOrderComponent< HOCProps >`: Function mapping component to enhanced component.
 -   _modifierName_ `string`: Seed name from which to generated display name.
 
 _Returns_
 
--   `HigherOrderComponent< TInnerProps, TOuterProps >`: Component class with generated display name assigned.
+-   ``: Component class with generated display name assigned.
 
 ### ifCondition
 
@@ -109,16 +109,12 @@ _Parameters_
 
 _Returns_
 
--   `HigherOrderComponent< TProps, TProps >`: Higher-order component.
+-   `( ( Wrapped: ComponentType< TProps > ) => ComponentType< TProps > )`: Higher-order component.
 
 ### pure
 
 Given a component returns the enhanced component augmented with a component
 only rerendering when its props/state change
-
-_Type_
-
--   `SimpleHigherOrderComponent`
 
 ### useAsyncList
 
@@ -528,18 +524,10 @@ _Returns_
 A Higher Order Component used to be provide a unique instance ID by
 component.
 
-_Type_
-
--   `PropInjectingHigherOrderComponent< { instanceId: string | number; } >`
-
 ### withSafeTimeout
 
 A higher-order component used to provide and manage delayed function calls
 that ought to be bound to a component's lifecycle.
-
-_Type_
-
--   `PropInjectingHigherOrderComponent< TimeoutProps >`
 
 ### withState
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -109,7 +109,7 @@ _Parameters_
 
 _Returns_
 
--   `ComponentType`: Higher-order component.
+-   `Object`: Higher-order component.
 
 ### pure
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -84,7 +84,7 @@ _Parameters_
 
 _Returns_
 
--   `ComponentType`: Component class with generated display name assigned.
+-   Component class with generated display name assigned.
 
 ### ifCondition
 
@@ -109,12 +109,12 @@ _Parameters_
 
 _Returns_
 
--   `Object`: Higher-order component.
+-   Higher-order component.
 
 ### pure
 
 Given a component returns the enhanced component augmented with a component
-only rerendering when its props/state change
+only re-rendering when its props/state change
 
 ### useAsyncList
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -84,7 +84,7 @@ _Parameters_
 
 _Returns_
 
--   ``: Component class with generated display name assigned.
+-   `ComponentType`: Component class with generated display name assigned.
 
 ### ifCondition
 
@@ -109,7 +109,7 @@ _Parameters_
 
 _Returns_
 
--   `( ( Wrapped: ComponentType< TProps > ) => ComponentType< TProps > )`: Higher-order component.
+-   `ComponentType`: Higher-order component.
 
 ### pure
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -18,7 +18,7 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  *
  * @param  predicate Function to test condition.
  *
- * @return {Object} Higher-order component.
+ * @return Higher-order component.
  */
 const ifCondition = < TProps extends Record< string, any > >(
 	predicate: ( props: TProps ) => boolean

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { ComponentType } from 'react';
-
-/**
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
@@ -23,7 +18,7 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  *
  * @param  predicate Function to test condition.
  *
- * @return {ComponentType} Higher-order component.
+ * @return {Object} Higher-order component.
  */
 const ifCondition = < TProps extends Record< string, any > >(
 	predicate: ( props: TProps ) => boolean

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
@@ -18,7 +23,7 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  *
  * @param  predicate Function to test condition.
  *
- * @return Higher-order component.
+ * @return {ComponentType} Higher-order component.
  */
 const ifCondition = < TProps extends Record< string, any > >(
 	predicate: ( props: TProps ) => boolean

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,8 +1,13 @@
 /**
+ * External dependencies
+ */
+// eslint-disable-next-line no-restricted-imports
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-import type { HigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * Higher-order component creator, creating a new component which renders if
@@ -21,12 +26,12 @@ import type { HigherOrderComponent } from '../../utils/create-higher-order-compo
  *
  * @return Higher-order component.
  */
-const ifCondition = < TProps, >(
+const ifCondition = < TProps extends Record< string, any > >(
 	predicate: ( props: TProps ) => boolean
-): HigherOrderComponent< TProps, TProps > =>
-	createHigherOrderComponent(
-		( WrappedComponent ) => ( props: TProps ) => {
-			if ( ! predicate( props ) ) {
+): ( ( Wrapped: ComponentType< TProps > ) => ComponentType< TProps > ) =>
+	createHigherOrderComponent< {} >(
+		( WrappedComponent ) => ( props ) => {
+			if ( ! predicate( props as TProps ) ) {
 				return null;
 			}
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-// eslint-disable-next-line no-restricted-imports
-import type { ComponentType } from 'react';
-
-/**
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
@@ -28,7 +22,7 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  */
 const ifCondition = < TProps extends Record< string, any > >(
 	predicate: ( props: TProps ) => boolean
-): ( ( Wrapped: ComponentType< TProps > ) => ComponentType< TProps > ) =>
+) =>
 	createHigherOrderComponent< {} >(
 		( WrappedComponent ) => ( props ) => {
 			if ( ! predicate( props as TProps ) ) {

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -8,7 +8,6 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-import type { SimpleHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * External dependencies
@@ -19,7 +18,7 @@ import type { ComponentType, ComponentClass } from 'react';
  * Given a component returns the enhanced component augmented with a component
  * only rerendering when its props/state change
  */
-const pure: SimpleHigherOrderComponent = createHigherOrderComponent(
+const pure = createHigherOrderComponent(
 	< TProps, >( Wrapped: ComponentType< TProps > ) => {
 		if ( Wrapped.prototype instanceof Component ) {
 			return class extends ( Wrapped as ComponentClass< TProps > ) {

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -16,7 +16,7 @@ import type { ComponentType, ComponentClass } from 'react';
 
 /**
  * Given a component returns the enhanced component augmented with a component
- * only rerendering when its props/state change
+ * only re-rendering when its props/state change
  */
 const pure = createHigherOrderComponent(
 	< TProps extends Record< string, any > >(

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -19,7 +19,9 @@ import type { ComponentType, ComponentClass } from 'react';
  * only rerendering when its props/state change
  */
 const pure = createHigherOrderComponent(
-	< TProps, >( Wrapped: ComponentType< TProps > ) => {
+	< TProps extends Record< string, any > >(
+		Wrapped: ComponentType< TProps >
+	) => {
 		if ( Wrapped.prototype instanceof Component ) {
 			return class extends ( Wrapped as ComponentClass< TProps > ) {
 				shouldComponentUpdate( nextProps: TProps, nextState: any ) {

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -46,6 +46,7 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 		alternative: 'useEffect',
 	} );
 
+	// @ts-ignore-next-line
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor( /** @type {any} */ props ) {

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -46,7 +46,7 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 		alternative: 'useEffect',
 	} );
 
-	// @ts-ignore We dont' need to fix the type-related issues because this is deprecated.
+	// @ts-ignore We don't need to fix the type-related issues because this is deprecated.
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor( /** @type {any} */ props ) {

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -46,7 +46,7 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 		alternative: 'useEffect',
 	} );
 
-	// @ts-ignore-next-line: We dont' need to fix the type-related issues because this is deprecated.
+	// @ts-ignore We dont' need to fix the type-related issues because this is deprecated.
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor( /** @type {any} */ props ) {

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -46,7 +46,7 @@ export default function withGlobalEvents( eventTypesToHandlers ) {
 		alternative: 'useEffect',
 	} );
 
-	// @ts-ignore-next-line
+	// @ts-ignore-next-line: We dont' need to fix the type-related issues because this is deprecated.
 	return createHigherOrderComponent( ( WrappedComponent ) => {
 		class Wrapper extends Component {
 			constructor( /** @type {any} */ props ) {

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import type { ComponentType } from 'react';
-
-/**
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
@@ -15,21 +10,12 @@ import useInstanceId from '../../hooks/use-instance-id';
  */
 const withInstanceId = createHigherOrderComponent< {
 	instanceId: string | number;
-} >(
-	< TProps extends { instanceId: string | number } >(
-		WrappedComponent: ComponentType< TProps >
-	) => {
-		return ( props: Omit< TProps, 'instanceId' > ) => {
-			const instanceId = useInstanceId( WrappedComponent );
-			return (
-				<WrappedComponent
-					{ ...( props as TProps ) }
-					instanceId={ instanceId }
-				/>
-			);
-		};
-	},
-	'withInstanceId'
-);
+} >( ( WrappedComponent ) => {
+	return ( props ) => {
+		const instanceId = useInstanceId( WrappedComponent );
+		// @ts-ignore
+		return <WrappedComponent { ...props } instanceId={ instanceId } />;
+	};
+}, 'withInstanceId' );
 
 export default withInstanceId;

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -7,16 +7,15 @@ import type { ComponentType } from 'react';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-import type { PropInjectingHigherOrderComponent } from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
 
 /**
  * A Higher Order Component used to be provide a unique instance ID by
  * component.
  */
-const withInstanceId: PropInjectingHigherOrderComponent< {
+const withInstanceId = createHigherOrderComponent< {
 	instanceId: string | number;
-} > = createHigherOrderComponent(
+} >(
 	< TProps extends { instanceId: string | number } >(
 		WrappedComponent: ComponentType< TProps >
 	) => {

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -13,7 +13,6 @@ import { Component } from '@wordpress/element';
  * Internal dependencies
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
-import type { PropInjectingHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * We cannot use the `Window['setTimeout']` and `Window['clearTimeout']`
@@ -32,7 +31,7 @@ type TimeoutProps = {
  * A higher-order component used to provide and manage delayed function calls
  * that ought to be bound to a component's lifecycle.
  */
-const withSafeTimeout: PropInjectingHigherOrderComponent< TimeoutProps > = createHigherOrderComponent(
+const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
 	< TProps extends TimeoutProps >(
 		OriginalComponent: ComponentType< TProps >
 	) => {
@@ -41,7 +40,7 @@ const withSafeTimeout: PropInjectingHigherOrderComponent< TimeoutProps > = creat
 		> {
 			timeouts: number[];
 
-			constructor( props: any ) {
+			constructor( props: Omit< TProps, keyof TimeoutProps > ) {
 				super( props );
 				this.timeouts = [];
 				this.setTimeout = this.setTimeout.bind( this );
@@ -71,8 +70,9 @@ const withSafeTimeout: PropInjectingHigherOrderComponent< TimeoutProps > = creat
 					...this.props,
 					setTimeout: this.setTimeout,
 					clearTimeout: this.clearTimeout,
-				};
-				return <OriginalComponent { ...( props as TProps ) } />;
+				} as TProps;
+
+				return <OriginalComponent { ...props } />;
 			}
 		};
 	},

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -28,7 +28,7 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  * @param mapComponent Function mapping component to enhanced component.
  * @param modifierName Seed name from which to generated display name.
  *
- * @return Component class with generated display name assigned.
+ * @return {ComponentType} Component class with generated display name assigned.
  */
 function createHigherOrderComponent<
 	HOCProps extends Record< string, any > = {}

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -32,10 +32,7 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  */
 function createHigherOrderComponent<
 	HOCProps extends Record< string, any > = {}
->(
-	mapComponent: HigherOrderComponent< HOCProps >,
-	modifierName: string
-): typeof mapComponent {
+>( mapComponent: HigherOrderComponent< HOCProps >, modifierName: string ) {
 	return < InnerProps extends HOCProps >(
 		Inner: ComponentType< InnerProps >
 	) => {
@@ -47,4 +44,5 @@ function createHigherOrderComponent<
 		return Outer;
 	};
 }
+
 export default createHigherOrderComponent;

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -28,7 +28,7 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  * @param mapComponent Function mapping component to enhanced component.
  * @param modifierName Seed name from which to generated display name.
  *
- * @return {ComponentType} Component class with generated display name assigned.
+ * @return Component class with generated display name assigned.
  */
 function createHigherOrderComponent<
 	HOCProps extends Record< string, any > = {}

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -13,35 +13,32 @@ import type { ComponentType } from 'react';
  * of this is the `pure` HOC which does not change the API surface of the component but
  * simply modifies the internals.
  */
-export type HigherOrderComponent< TInnerProps, TOuterProps > = (
-	Inner: ComponentType< TInnerProps >
-) => ComponentType< TOuterProps >;
-
-export type SimpleHigherOrderComponent = < TProps >(
-	Inner: ComponentType< TProps >
-) => ComponentType< TProps >;
-
-export type PropInjectingHigherOrderComponent< TRemovedProps > = <
-	TProps extends TRemovedProps
+export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
+	InnerProps extends HOCProps
 >(
-	Inner: ComponentType< TProps >
-) => ComponentType< Omit< TProps, keyof TRemovedProps > >;
+	Inner: ComponentType< InnerProps >
+) => {} extends HOCProps
+	? ComponentType< InnerProps >
+	: ComponentType< Omit< InnerProps, keyof HOCProps > >;
 
 /**
  * Given a function mapping a component to an enhanced component and modifier
  * name, returns the enhanced component augmented with a generated displayName.
  *
- * @param  mapComponentToEnhancedComponent Function mapping component to enhanced component.
- * @param  modifierName                    Seed name from which to generated display name.
+ * @param mapComponent Function mapping component to enhanced component.
+ * @param modifierName Seed name from which to generated display name.
  *
  * @return Component class with generated display name assigned.
  */
-
-function createHigherOrderComponent< TInnerProps, TOuterProps >(
-	mapComponent: HigherOrderComponent< TInnerProps, TOuterProps >,
+function createHigherOrderComponent<
+	HOCProps extends Record< string, any > = {}
+>(
+	mapComponent: HigherOrderComponent< HOCProps >,
 	modifierName: string
-): HigherOrderComponent< TInnerProps, TOuterProps > {
-	return ( Inner ) => {
+): typeof mapComponent {
+	return < InnerProps extends HOCProps >(
+		Inner: ComponentType< InnerProps >
+	) => {
 		const Outer = mapComponent( Inner );
 		const displayName = Inner.displayName || Inner.name || 'Component';
 		Outer.displayName = `${ upperFirst(


### PR DESCRIPTION
## Status

**Ready for final review ✓**

There are a couple things I'm unhappy with about this refactor. I think it's more accurate
than the existing types, which I find confusing and think might be _wrong_. Still, it doesn't
handle components with `ref` parameters well (see `with-global-events`) and I would
prefer that we have full inference with fewer necessary type annotations.

**Update**: For now I want to ignore the `ref` issues and `with-global-events` since that
component has a number of more difficult type issues _and_ it's marked as _deprecated_.
Let's not hold up this work to spend time describing a function we don't want people using.

<details closed>
<summary>Type annotations we don't want</summary>
Everything is passing the tests right now though so I don't want to totally hold off on this,
but I'd like to let it stew for a bit and see if anyone has suggestions on how to close the gap.
For reference, here is how I think `withInstanceId` should be able to be written (pay attention
to the lack of type annotations - we shouldn't be losing any auto-complete or type safety).

```ts
const withInstanceId = createHigherOrderComponent< {
	instanceId: string | number;
} >( WrappedComponent ) => {
	return ( props ) => {
		const instanceId = useInstanceId( WrappedComponent );
			return (
				<WrappedComponent
					{ ...props }
					instanceId={ instanceId }
				/>
			);
		};
	},
	'withInstanceId'
);
```
</details>

## Description

The existing types in `createHigherOrderComponent<TOuter, TInner>` are somewhat
_surprising_ because they require defining what possible prop types are allowed
for components wrapped by the higher order component it produces. Additionally
it doesn't concern itself with preventing the wrapped component from accepting
or demanding props it itself provides.

In this patch we're reworking the types to only require a single type parameter,
which is the type of props that the higher order component injects into the
wrapped component. The prop types for the wrapped component are inferred only
when wrapping a component, and the injected props are removed from the external
interface to avoid confusion.

## How has this been tested?
This is a type-only change that shouldn't impact the generated bundles.

## Types of changes
Updating type signature for `createHigherOrderComponent`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate.

cc: @sirbrillig