### PR TITLE
Replace `clipboard.js` with native Clipboard API — second try

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15988,7 +15988,6 @@
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/priority-queue": "file:packages/priority-queue",
-				"clipboard": "^2.0.8",
 				"lodash": "^4.17.21",
 				"mousetrap": "^1.6.5",
 				"react-resize-aware": "^3.1.0",
@@ -27864,16 +27863,6 @@
 			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
 			"dev": true
 		},
-		"clipboard": {
-			"version": "2.0.8",
-			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-			"integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-			"requires": {
-				"good-listener": "^1.2.2",
-				"select": "^1.1.2",
-				"tiny-emitter": "^2.0.0"
-			}
-		},
 		"cliui": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -30268,11 +30257,6 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
-		},
-		"delegate": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -35610,14 +35594,6 @@
 			"resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
 			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
-		},
-		"good-listener": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"requires": {
-				"delegate": "^3.1.2"
-			}
 		},
 		"got": {
 			"version": "10.7.0",
@@ -51908,11 +51884,6 @@
 				}
 			}
 		},
-		"select": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
-		},
 		"select-hose": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -55884,11 +55855,6 @@
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
-		},
-		"tiny-emitter": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
 		"tinycolor2": {
 			"version": "1.4.2",

--- a/packages/compose/CHANGELOG.md
+++ b/packages/compose/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Refactored `useCopyToClipboard` and (deprecated) `useCopyOnClick` hooks to use native Clipboard API instead of third-party dependency `clipboard.js`, removing it from the repo ([#37713](https://github.com/WordPress/gutenberg/pull/37713)).
+
 ## 5.0.0 (2021-07-29)
 
 ### Breaking Change

--- a/packages/compose/package.json
+++ b/packages/compose/package.json
@@ -38,7 +38,6 @@
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/priority-queue": "file:../priority-queue",
-		"clipboard": "^2.0.8",
 		"lodash": "^4.17.21",
 		"mousetrap": "^1.6.5",
 		"react-resize-aware": "^3.1.0",

--- a/packages/compose/src/hooks/use-copy-on-click/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/index.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import Clipboard from 'clipboard';
-
-/**
  * WordPress dependencies
  */
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
 /* eslint-disable jsdoc/no-undefined-types */
@@ -30,45 +25,60 @@ export default function useCopyOnClick( ref, text, timeout = 4000 ) {
 		alternative: 'wp.compose.useCopyToClipboard',
 	} );
 
-	/** @type {import('react').MutableRefObject<Clipboard | undefined>} */
-	const clipboard = useRef();
 	const [ hasCopied, setHasCopied ] = useState( false );
 
 	useEffect( () => {
 		/** @type {number | undefined} */
 		let timeoutId;
+		/** @type Array<Element>) */
+		let triggers = [];
 
 		if ( ! ref.current ) {
 			return;
 		}
 
-		// Clipboard listens to click events.
-		clipboard.current = new Clipboard( ref.current, {
-			text: () => ( typeof text === 'function' ? text() : text ),
-		} );
+		// `triggers` is always an array, regardless of the value of the `ref` param.
+		if ( typeof ref.current === 'string' ) {
+			// expect `ref` to be a DOM selector
+			triggers = Array.from( document.querySelectorAll( ref.current ) );
+		} else if ( 'length' in ref.current ) {
+			// Expect `ref` to be a `NodeList`
+			triggers = Array.from( ref.current );
+		} else {
+			// Expect `ref` to be a single `Element`
+			triggers = [ ref.current ];
+		}
 
-		clipboard.current.on( 'success', ( { clearSelection, trigger } ) => {
-			// Clearing selection will move focus back to the triggering button,
-			// ensuring that it is not reset to the body, and further that it is
-			// kept within the rendered node.
-			clearSelection();
+		/**
+		 * @param {Event} e
+		 */
+		const copyTextToClipboard = ( e ) => {
+			const trigger = /** @type {HTMLElement | null} */ ( e.target );
+			const currentWindow = trigger?.ownerDocument.defaultView || window;
+			const textToCopy = typeof text === 'function' ? text() : text || '';
 
-			// Handle ClipboardJS focus bug, see https://github.com/zenorocha/clipboard.js/issues/680
-			if ( trigger ) {
-				/** @type {HTMLElement} */ ( trigger ).focus();
-			}
+			currentWindow?.navigator?.clipboard
+				?.writeText( textToCopy )
+				.then( () => {
+					if ( timeout ) {
+						setHasCopied( true );
+						clearTimeout( timeoutId );
+						timeoutId = setTimeout(
+							() => setHasCopied( false ),
+							timeout
+						);
+					}
+				} );
+		};
 
-			if ( timeout ) {
-				setHasCopied( true );
-				clearTimeout( timeoutId );
-				timeoutId = setTimeout( () => setHasCopied( false ), timeout );
-			}
-		} );
+		triggers.forEach( ( t ) =>
+			t.addEventListener( 'click', copyTextToClipboard )
+		);
 
 		return () => {
-			if ( clipboard.current ) {
-				clipboard.current.destroy();
-			}
+			triggers.forEach( ( t ) =>
+				t.removeEventListener( 'click', copyTextToClipboard )
+			);
 			clearTimeout( timeoutId );
 		};
 	}, [ text, timeout, setHasCopied ] );

--- a/packages/compose/src/hooks/use-copy-on-click/test/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/test/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useCopyOnClick from '../';
+
+const ExampleComponent = ( { text, ...props } ) => {
+	const ref = useRef();
+
+	const hasCopied = useCopyOnClick( ref, text, 1000 );
+
+	return (
+		<button ref={ ref } { ...props }>
+			{ hasCopied ? 'Copied' : 'Click to copy' }
+		</button>
+	);
+};
+
+let clipboardValue;
+
+const originalClipboard = global.navigator.clipboard;
+const mockClipboard = {
+	writeText: jest.fn().mockImplementation( ( text ) => {
+		return new Promise( ( resolve ) => {
+			clipboardValue = text;
+			resolve();
+		} );
+	} ),
+};
+
+global.navigator.clipboard = mockClipboard;
+
+describe( 'useCopyOnClick', () => {
+	beforeEach( () => {
+		clipboardValue = undefined;
+	} );
+
+	afterAll( () => {
+		global.navigator.clipboard = originalClipboard;
+	} );
+
+	it( 'should copy the text to the clipboard and display a warning notice', async () => {
+		const textToBeCopied = 'mango';
+		render( <ExampleComponent text={ textToBeCopied } /> );
+
+		expect( console ).toHaveWarned();
+
+		const triggerButton = screen.getByText( 'Click to copy' );
+		fireEvent.click( triggerButton );
+
+		await waitFor( () =>
+			expect( clipboardValue ).toEqual( textToBeCopied )
+		);
+
+		// Check that the displayed text changes as a way of testing
+		// the `hasCopied` logic
+		expect( screen.getByText( 'Copied' ) ).toBeInTheDocument();
+		await waitFor( () =>
+			expect( screen.getByText( 'Click to copy' ) ).toBeInTheDocument()
+		);
+	} );
+} );

--- a/packages/compose/src/hooks/use-copy-on-click/test/index.js
+++ b/packages/compose/src/hooks/use-copy-on-click/test/index.js
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+	act,
+	render,
+	screen,
+	fireEvent,
+	waitFor,
+} from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -37,9 +43,11 @@ const mockClipboard = {
 	} ),
 };
 
-global.navigator.clipboard = mockClipboard;
-
 describe( 'useCopyOnClick', () => {
+	beforeAll( () => {
+		global.navigator.clipboard = mockClipboard;
+	} );
+
 	beforeEach( () => {
 		clipboardValue = undefined;
 	} );
@@ -64,8 +72,11 @@ describe( 'useCopyOnClick', () => {
 		// Check that the displayed text changes as a way of testing
 		// the `hasCopied` logic
 		expect( screen.getByText( 'Copied' ) ).toBeInTheDocument();
-		await waitFor( () =>
-			expect( screen.getByText( 'Click to copy' ) ).toBeInTheDocument()
-		);
+
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( screen.getByText( 'Click to copy' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import useCopyToClipboard from '../';
+
+const ExampleComponent = ( { onSuccess, text, ...props } ) => {
+	const ref = useCopyToClipboard( text, onSuccess );
+
+	return (
+		<button ref={ ref } { ...props }>
+			Click to copy
+		</button>
+	);
+};
+
+let clipboardValue;
+
+const originalClipboard = global.navigator.clipboard;
+const mockClipboard = {
+	writeText: jest.fn().mockImplementation( ( text ) => {
+		return new Promise( ( resolve ) => {
+			clipboardValue = text;
+			resolve();
+		} );
+	} ),
+};
+
+global.navigator.clipboard = mockClipboard;
+
+describe( 'useCopyToClipboard', () => {
+	beforeEach( () => {
+		clipboardValue = undefined;
+	} );
+
+	afterAll( () => {
+		global.navigator.clipboard = originalClipboard;
+	} );
+
+	it( 'should copy the text to the clipboard', async () => {
+		const successCallback = jest.fn();
+		const textToBeCopied = 'mango';
+		render(
+			<ExampleComponent
+				onSuccess={ successCallback }
+				text={ textToBeCopied }
+			/>
+		);
+
+		const triggerButton = screen.getByText( 'Click to copy' );
+		fireEvent.click( triggerButton );
+
+		await waitFor( () => expect( successCallback ).toHaveBeenCalled() );
+		expect( clipboardValue ).toEqual( textToBeCopied );
+	} );
+} );

--- a/packages/compose/src/hooks/use-copy-to-clipboard/test/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/test/index.js
@@ -30,9 +30,11 @@ const mockClipboard = {
 	} ),
 };
 
-global.navigator.clipboard = mockClipboard;
-
 describe( 'useCopyToClipboard', () => {
+	beforeAll( () => {
+		global.navigator.clipboard = mockClipboard;
+	} );
+
 	beforeEach( () => {
 		clipboardValue = undefined;
 	} );
@@ -43,7 +45,8 @@ describe( 'useCopyToClipboard', () => {
 
 	it( 'should copy the text to the clipboard', async () => {
 		const successCallback = jest.fn();
-		const textToBeCopied = 'mango';
+		const textToBeCopied = 'papaya';
+
 		render(
 			<ExampleComponent
 				onSuccess={ successCallback }
@@ -54,7 +57,9 @@ describe( 'useCopyToClipboard', () => {
 		const triggerButton = screen.getByText( 'Click to copy' );
 		fireEvent.click( triggerButton );
 
-		await waitFor( () => expect( successCallback ).toHaveBeenCalled() );
-		expect( clipboardValue ).toEqual( textToBeCopied );
+		await waitFor( () =>
+			expect( clipboardValue ).toEqual( textToBeCopied )
+		);
+		expect( successCallback ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Closes #37700

This is the second attempt, after the original PR #37713 [got reverted](https://github.com/WordPress/gutenberg/pull/37779)

Changes in this PR:
- rewrite the `useCopyToClipboard` and the (deprecated) `useCopyOnClick` hooks in `@wordpress/compose` so that they use the native [Clipboard API](https://w3c.github.io/clipboard-apis/#navigator-clipboard)
- note that the previous version had some code to handle text selection clearance and the focus management, which shouldn't be necessary when using the native Clipboard APIs
- remove the `clipboard` dependency from the project's list of dependencies (saving `2.55 kB (23%)` for the `@wordpress/compose`  package)
- add unit tests for both hooks

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Project builds correctly
- Test pass (including the ones added in this PR)
- Usages of the `useCopyToClipboard` hook work as expected (same as production) — see screenshots below for a few examples

**In particular, check that the issues flagged by @jorgefilipecosta in #37779 can't be reproduced**

## Screenshots <!-- if applicable -->

"Copy" menu item when editing any block in the editor:

https://user-images.githubusercontent.com/1083581/148126016-fa7dfa8b-2bd5-4f39-a14d-909e478fa830.mp4


"Copy URL to clipboard" button when viewing an attachment details in the media library:

![image](https://user-images.githubusercontent.com/1083581/148126072-66cd2e6d-e09f-418e-a7cf-0e18a659279b.png)

"Copy URL" button when editing an attachment in the File block:

![image](https://user-images.githubusercontent.com/1083581/148126312-3d0e59ff-6344-405a-9d56-391268bccf19.png)

"Copy" button when reviewing a post's info after publishing it:

![image](https://user-images.githubusercontent.com/1083581/148126296-71ce9730-b3a5-4ce7-ba53-ee5564e34e10.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
