### PR TITLE
Gallery block: pass any custom attributes through the gallery v2 migration script

### DIFF
--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -82,7 +82,16 @@ export function getHrefAndDestination( image, destination ) {
 	return {};
 }
 
-function runV2Migration( attributes ) {
+function runV2Migration( attributes, versionAttributes ) {
+	// First see if the block has any custom attributes that
+	// need to be passed through.
+	const customAttributes = {};
+	for ( const key in attributes ) {
+		if ( ! versionAttributes.hasOwnProperty( key ) ) {
+			customAttributes[ key ] = attributes[ key ];
+		}
+	}
+
 	let linkTo = attributes.linkTo ? attributes.linkTo : 'none';
 
 	if ( linkTo === 'post' ) {
@@ -103,6 +112,7 @@ function runV2Migration( attributes ) {
 			linkTo,
 			sizeSlug: attributes.sizeSlug,
 			allowResize: false,
+			...customAttributes,
 		},
 		imageBlocks,
 	];
@@ -282,7 +292,7 @@ const v6 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v6.attributes );
 		}
 
 		return attributes;
@@ -372,7 +382,7 @@ const v5 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v5.attributes );
 		}
 
 		let linkTo = attributes.linkTo;
@@ -535,7 +545,7 @@ const v4 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v4.attributes );
 		}
 
 		return {
@@ -741,7 +751,7 @@ const v3 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v3.attributes );
 		}
 		return attributes;
 	},
@@ -810,7 +820,7 @@ const v2 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v2.attributes );
 		}
 		return {
 			...attributes,
@@ -974,7 +984,7 @@ const v1 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes );
+			return runV2Migration( attributes, v1.attributes );
 		}
 
 		return attributes;

--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { map, some } from 'lodash';
+import { map, some, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -82,16 +82,7 @@ export function getHrefAndDestination( image, destination ) {
 	return {};
 }
 
-function runV2Migration( attributes, versionAttributes ) {
-	// First see if the block has any custom attributes that
-	// need to be passed through.
-	const customAttributes = {};
-	for ( const key in attributes ) {
-		if ( ! versionAttributes.hasOwnProperty( key ) ) {
-			customAttributes[ key ] = attributes[ key ];
-		}
-	}
-
+function runV2Migration( attributes ) {
 	let linkTo = attributes.linkTo ? attributes.linkTo : 'none';
 
 	if ( linkTo === 'post' ) {
@@ -106,13 +97,9 @@ function runV2Migration( attributes, versionAttributes ) {
 
 	return [
 		{
-			caption: attributes.caption,
-			columns: attributes.columns,
-			imageCrop: attributes.imageCrop,
+			...omit( attributes, [ 'images', 'ids' ] ),
 			linkTo,
-			sizeSlug: attributes.sizeSlug,
 			allowResize: false,
-			...customAttributes,
 		},
 		imageBlocks,
 	];
@@ -292,7 +279,7 @@ const v6 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v6.attributes );
+			return runV2Migration( attributes );
 		}
 
 		return attributes;
@@ -382,7 +369,7 @@ const v5 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v5.attributes );
+			return runV2Migration( attributes );
 		}
 
 		let linkTo = attributes.linkTo;
@@ -545,7 +532,7 @@ const v4 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v4.attributes );
+			return runV2Migration( attributes );
 		}
 
 		return {
@@ -751,7 +738,7 @@ const v3 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v3.attributes );
+			return runV2Migration( attributes );
 		}
 		return attributes;
 	},
@@ -820,7 +807,7 @@ const v2 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v2.attributes );
+			return runV2Migration( attributes );
 		}
 		return {
 			...attributes,
@@ -984,7 +971,7 @@ const v1 = {
 	},
 	migrate( attributes ) {
 		if ( isGalleryV2Enabled() ) {
-			return runV2Migration( attributes, v1.attributes );
+			return runV2Migration( attributes );
 		}
 
 		return attributes;

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-1.json
@@ -7,6 +7,7 @@
 			"columns": 2,
 			"imageCrop": true,
 			"linkTo": "none",
+			"align": "wide",
 			"allowResize": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-1.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:gallery {"columns":2,"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-2 is-cropped"><!-- wp:image {"linkDestination":"none"} -->
+<!-- wp:gallery {"columns":2,"linkTo":"none","align":"wide"} -->
+<figure class="wp-block-gallery alignwide has-nested-images columns-2 is-cropped"><!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/></figure>
 <!-- /wp:image -->
 

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-2.json
@@ -7,6 +7,7 @@
 			"columns": 2,
 			"imageCrop": true,
 			"linkTo": "none",
+			"align": "wide",
 			"allowResize": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-2.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:gallery {"columns":2,"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-2 is-cropped"><!-- wp:image {"id":1,"linkDestination":"none"} -->
+<!-- wp:gallery {"columns":2,"linkTo":"none","align":"wide"} -->
+<figure class="wp-block-gallery alignwide has-nested-images columns-2 is-cropped"><!-- wp:image {"id":1,"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title" class="wp-image-1"/></figure>
 <!-- /wp:image -->
 

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-3.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-3.json
@@ -6,6 +6,7 @@
 		"attributes": {
 			"imageCrop": true,
 			"linkTo": "none",
+			"align": "wide",
 			"allowResize": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-3.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"linkDestination":"none"} -->
+<!-- wp:gallery {"linkTo":"none","align":"wide"} -->
+<figure class="wp-block-gallery alignwide has-nested-images columns-default is-cropped"><!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="title"/></figure>
 <!-- /wp:image -->
 

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-4.json
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-4.json
@@ -7,6 +7,7 @@
 			"caption": "",
 			"imageCrop": true,
 			"linkTo": "none",
+			"align": "wide",
 			"allowResize": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__gallery__deprecated-4.serialized.html
+++ b/test/integration/fixtures/blocks/core__gallery__deprecated-4.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:gallery {"linkTo":"none"} -->
-<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":1421,"linkDestination":"none"} -->
+<!-- wp:gallery {"linkTo":"none","align":"wide"} -->
+<figure class="wp-block-gallery alignwide has-nested-images columns-default is-cropped"><!-- wp:image {"id":1421,"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="https://sergioestevaofolio.files.wordpress.com/2016/09/cropped-img_9054-1.jpg?w=190" alt="" class="wp-image-1421"/></figure>
 <!-- /wp:image -->
 


### PR DESCRIPTION
## Description
Fixes: #37675

The migrations to the new Gallery block version were not taking into account any custom attributes that may have been added by plugins, so these were lost during the block migration process.

This PR gets any attributes that are not part of the version currently being migrated and passes them through the migration untouched.

## Testing

- In a local dev install WP 5.8 without GB plugin and also install this [test-plugin.zip](https://github.com/WordPress/gutenberg/files/7836647/test-plugin.zip) 
- Add a gallery with several images, and under the Advanced panel in block sidebar set a block gap and save
- Install a build of GB plugin based on this PR and reload post and make sure the Gallery is migrated to the new version and that Gap attribute is still set
- Try set all of the different attributes in a v1 gallery and update to v2 and make sure all settings are passed through to the new gallery as expected. Also make sure that `images` and `ids` attributes are not present on the new gallery.

## Screenshots

Before:
![custom-attribs-before](https://user-images.githubusercontent.com/3629020/148717294-bb5ca773-d64c-4fbc-9fd9-fc6f1d2d1007.gif)

After:
![custom-gallery-attribs-after](https://user-images.githubusercontent.com/3629020/148717305-ee45e850-61a7-4c0b-85d6-e0e7cc567172.gif)
 