### PR TITLE
Revert "[Paragraph Block] add font family support"

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -39,7 +39,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,


### PR DESCRIPTION
Reverts WordPress/gutenberg#37586

Per the [conversation](https://github.com/WordPress/gutenberg/pull/37586#issuecomment-999990800) over at https://github.com/WordPress/gutenberg/pull/37586 we are reverting this change for the moment