### PR TITLE
Remove color from code theme.scss.

### DIFF
--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,6 +1,5 @@
 .wp-block-code > code {
 	font-family: $editor-html-font;
-	color: $gray-900;
 	padding: 0.8em 1em;
 	border: 1px solid $gray-300;
 	border-radius: 4px;


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/36282#issuecomment-1005625897.

When a theme opts into opinionated block styles (which loads theme.scss files bundled with blocks), some base styles are applied to the Code block:

<img width="768" alt="Screenshot 2022-01-10 at 09 24 09" src="https://user-images.githubusercontent.com/1204802/148736389-a7f309e2-3aad-4796-8c3e-bbbfb1a5a3ee.png">

Those base styles include a dark text color, which is problematic if you use a black background. This PR removes that explicitly defined text color, so the color is instead inherited:

<img width="751" alt="Screenshot 2022-01-10 at 09 23 59" src="https://user-images.githubusercontent.com/1204802/148736453-fc44afb6-31f0-4117-af0e-fcd4a749b7dd.png">

I would've liked to go further and affect the border as well, but omitted that to keep things small, and because the gray already works well enough in dark themes, and actual border color is applied to the parent `pre` element instead. So that's something to probably look at separately!

## How has this been tested?

Insert a code block with some code, in a theme that uses opinionated styles (such as TwentyTwentyTwo), and verify that code is legible on both light and dark backgrounds.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas ->
