### PR TITLE
Try: Polish code styles to properly apply border properties.

### DIFF
--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,6 +1,10 @@
-.wp-block-code > code {
-	font-family: $editor-html-font;
-	padding: 0.8em 1em;
-	border: 1px solid $gray-300;
+.wp-block-code {
+	border: 1px solid #ccc;
 	border-radius: 4px;
+	box-sizing: border-box;
+}
+
+.wp-block-code > code {
+	font-family: Menlo, Consolas, monaco, monospace;
+	padding: 0.8em 1em;
 }

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,7 +1,6 @@
 .wp-block-code {
 	border: 1px solid #ccc;
 	border-radius: 4px;
-	box-sizing: border-box;
 }
 
 .wp-block-code > code {


### PR DESCRIPTION
## Description

Followup to https://github.com/WordPress/gutenberg/pull/36282#issuecomment-1005625897 and #37816.

A recent change moved the code block border definition to the `code` element inside the `pre`. This meant that the border and radius properties you could apply using the inspector did not replace the predefined border, but added another:

<img width="740" alt="before" src="https://user-images.githubusercontent.com/1204802/148755136-16ffd8be-5e0b-4f29-babd-13b23d067322.png">

This PR tweaks and polishes things:

<img width="773" alt="after" src="https://user-images.githubusercontent.com/1204802/148755162-95b897ef-098e-4e31-b529-f8e55a01592a.png">

- It moves the border and radius definitions back to the `pre` element, so they are affected by global styles.
- It uses inline values for colors and fonts: the SASS variables are meant for UI. This is just a tiny change.
- It uses a slightly darker gray border. It still looks light gray in light backgrounds, but it looks darker in dark themes. I did look at adopting `currentColor` for the border, so the color would be fully inherited by theme colors, but this was a bigger departure from the visual style that's been shipping for a while, so I held off.

## How has this been tested?

Insert a code block. Try it in light and dark themes. Try changing the border radius, color, and width. Try styling it using theme.json, for example using [this snippet](https://github.com/WordPress/gutenberg/pull/36282#issuecomment-1005660736).

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas ->
