### PR TITLE
Reduce specificity of legacy font sizes defined by core

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -22,11 +22,11 @@
 }
 
 .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal) !important;
+	font-size: var(--wp--preset--font-size--normal);
 }
 
 .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge) !important;
+	font-size: var(--wp--preset--font-size--huge);
 }
 
 // Text alignments.

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -72,11 +72,11 @@
 }
 
 .editor-styles-wrapper .has-normal-font-size {
-	font-size: var(--wp--preset--font-size--normal) !important;
+	font-size: var(--wp--preset--font-size--normal);
 }
 
 .editor-styles-wrapper .has-huge-font-size {
-	font-size: var(--wp--preset--font-size--huge) !important;
+	font-size: var(--wp--preset--font-size--huge);
 }
 
 /**


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/37617

There's an issue by which legacy font sizes (normal & huge) provided by core override the theme classes in WordPress 5.9 (or using the Gutenberg plugin).

## Why it happens

1. In WordPress 5.8 font-size classes were provided via a CSS stylesheet that we enqueued to all themes. In https://github.com/WordPress/gutenberg/pull/35182 these were removed in favor of the global stylesheet, as [to avoid enqueuing the same styles twice](https://github.com/WordPress/gutenberg/issues/34006). In doing so, the classes changed from

- class in WordPress 5.8: `.has-<slug>-font-size { font-size: value; }`
- class in WordPress 5.9: `.has-<slug>-font-size { font-size: var(--wp--preset--font-size-<slug>) !important; }`

2. Later on, the default values for font sizes were updated and two of them were removed: `normal` and `huge` at https://github.com/WordPress/gutenberg/pull/37381 Because we still need to make them available for old content, those classes were moved back to the old bundle. However, they still have an `!important` that makes it difficult for others to override, which doesn't make sense for a legacy default.

## The fix

For the two legacy font sizes (`normal` and `huge`) we should reduce the specificity back to what it was: `.has-<slug>-font-size { font-size: value; }`.

## How to test

- Use a WordPress 5.8 with the Gutenberg plugin active (this branch).
- Use the TwentyTwenty theme.
- Create a post with a paragraph. Set the paragraph font size to normal and publish.

The expected result is that the paragraph font size is the one defined by the theme, `21px`. If using the plugin from the `trunk` branch, what happens is that the font size is `16px` instead.
