### PR TITLE
Try: Polish post takeover modal.

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -158,13 +158,13 @@ export default function PostLockedModal() {
 	const allPostsUrl = getWPAdminURL( 'edit.php', {
 		post_type: get( postType, [ 'slug' ] ),
 	} );
-	const allPostsLabel = __( 'Exit the Editor' );
+	const allPostsLabel = __( 'Exit editor' );
 	return (
 		<Modal
 			title={
 				isTakeover
-					? __( 'Someone else has taken over this post.' )
-					: __( 'This post is already being edited.' )
+					? __( 'Someone else has taken over this post' )
+					: __( 'This post is already being edited' )
 			}
 			focusOnMount={ true }
 			shouldCloseOnClickOutside={ false }
@@ -181,7 +181,7 @@ export default function PostLockedModal() {
 			) }
 			{ !! isTakeover && (
 				<div>
-					<div>
+					<p>
 						{ userDisplayName
 							? sprintf(
 									/* translators: %s: user's display name */
@@ -193,7 +193,7 @@ export default function PostLockedModal() {
 							: __(
 									'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
 							  ) }
-					</div>
+					</p>
 
 					<div className="editor-post-locked-modal__buttons">
 						<Button variant="primary" href={ allPostsUrl }>
@@ -204,7 +204,7 @@ export default function PostLockedModal() {
 			) }
 			{ ! isTakeover && (
 				<div>
-					<div>
+					<p>
 						{ userDisplayName
 							? sprintf(
 									/* translators: %s: user's display name */
@@ -216,15 +216,15 @@ export default function PostLockedModal() {
 							: __(
 									'Another user is currently working on this post, which means you cannot make changes, unless you take over.'
 							  ) }
-					</div>
+					</p>
 
 					<div className="editor-post-locked-modal__buttons">
-						<Button variant="secondary" href={ allPostsUrl }>
-							{ allPostsLabel }
-						</Button>
 						<PostPreviewButton />
-						<Button variant="primary" href={ unlockUrl }>
-							{ __( 'Take Over' ) }
+						<Button variant="tertiary" href={ unlockUrl }>
+							{ __( 'Take over' ) }
+						</Button>
+						<Button variant="primary" href={ allPostsUrl }>
+							{ allPostsLabel }
 						</Button>
 					</div>
 				</div>

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -1,29 +1,16 @@
 .editor-post-locked-modal {
-	height: auto;
-	padding-right: 10px;
-	padding-left: 10px;
-	padding-top: 10px;
-	max-width: 480px;
-
-	.components-modal__header {
-		height: 36px;
-	}
-
-	.components-modal__content {
-		height: auto;
-	}
+	max-width: 400px;
 }
 
 .editor-post-locked-modal__buttons {
-	margin-top: 10px;
-
-	.components-button {
-		margin-right: 5px;
-	}
+	margin-top: $grid-unit-30;
+	display: flex;
+	justify-content: flex-end;
+	gap: $grid-unit-10;
 }
 
 .editor-post-locked-modal__avatar {
 	float: left;
-	margin: 5px;
-	margin-right: 15px;
+	margin: $grid-unit-10;
+	margin-right: $grid-unit-15;
 }


### PR DESCRIPTION
## Description

Starts work on https://github.com/WordPress/gutenberg/issues/37725#issuecomment-1008683721. Before:

<img width="582" alt="Screenshot 2022-01-10 at 13 01 51" src="https://user-images.githubusercontent.com/1204802/148763074-531dd964-c575-4d42-a64d-0eb3eb94b96d.png">

After:

<img width="531" alt="Screenshot 2022-01-10 at 13 01 02" src="https://user-images.githubusercontent.com/1204802/148763096-864266d7-de89-4dd8-82d5-fa71340bc7f8.png">

Note that a number of aspects aren't yet implemented, not for lack of desire but I need to read up on (or get help with) how to piece together complex strings for localization. These include:

- Bold text for the user editing.
- The new "Preview" link, with an external link icon.
- The added extra paragraph.

In diving into this work, it also highlights some of the changes we need to happen at the component level, so the content of modals can be systematically the same without bespoke CSS. That would also benefit the Page List conversion modal, which this PR also bases its max-width on:

<img width="515" alt="Screenshot 2022-01-10 at 12 54 15" src="https://user-images.githubusercontent.com/1204802/148763450-d23fb017-b3b6-442e-9d45-1820356e3c5b.png">

Such component changes are out of scope for this PR, but are nevertheless worth mentioning.

## How has this been tested?

Create two admin user accounts, for example an editor and an admin. Save a post as one user, then log in as the other user in an incognito window and load the same post. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas ->
