### PR TITLE
Add '.git-blame-ignore-revs' to the project

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Set line width to 80
+4857ad58c1241b3d63d21a6880c989b85746c3dc

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
-# Set line width to 80
+# Set line width to 80.
 4857ad58c1241b3d63d21a6880c989b85746c3dc
+
+# ESLint updates.
+f63053cace3c02e284f00918e1854284c85b9132

--- a/docs/contributors/code/git-workflow.md
+++ b/docs/contributors/code/git-workflow.md
@@ -135,3 +135,21 @@ git push
 ```
 
 The above commands will update your `trunk` branch from _upstream_. To update any other branch replace `trunk` with the respective branch name.
+
+## Miscellaneous
+
+### Git Archeology
+
+When looking for a commit that introduced a specific change, it might be helpful to ignore revisions that only contain styling or formatting changes.
+
+Fortunately, newer versions of `git` gained the ability to skip commits in history:
+
+```
+git blame --ignore-rev f63053cace3c02e284f00918e1854284c85b9132 -L 66,73 packages/api-fetch/src/middlewares/media-upload.js
+```
+
+All styling and formatting revisions are tracked using the `.git-blame-ignore-revs` file in the Gutenberg repository. You can use this file to ignore them all at once:
+
+```
+git blame --ignore-revs-file .git-blame-ignore-revs -L 66,73 packages/api-fetch/src/middlewares/media-upload.js
+```


### PR DESCRIPTION
## Description
PR adds `.git-blame-ignore-revs` to the project to improve git archeology.

You can read more about the `ignore-rev` in the following articles:
* https://akrabat.com/ignoring-revisions-with-git-blame/
* https://michaelheap.com/git-ignore-rev/

## How has this been tested?
Test using the command below and it should ignore 4857ad58c1241b3d63d21a6880c989b85746c3dc commit.

```
git blame --ignore-revs-file .git-blame-ignore-revs -L 66,73 packages/api-fetch/src/middlewares/media-upload.js
```

## Types of changes
DX

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas ->
