### PR TITLE
Fix overlay menu errant focus style on scrim.

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -622,6 +622,14 @@ button.wp-block-navigation-item__content {
 // The menu adds wrapping containers.
 .wp-block-navigation__responsive-close {
 	width: 100%;
+
+	// This element is not keyboard accessible, and is focusable only using the mouse.
+	// It is part of the MicroModal library that adds a scrim outside of a modal dialog that is not fullscreen,
+	// where clicking that scrim closes the overlay just like the close button.
+	// It should not have a visible focus rectangle.
+	&:focus {
+		outline: none;
+	}
 }
 
 .is-menu-open .wp-block-navigation__responsive-close,


### PR DESCRIPTION
## Description

Fixes https://github.com/WordPress/twentytwentytwo/issues/323. 

The navigation block uses [MicroModal](https://micromodal.vercel.app/) for the overlay menu, a library to help create accessible modal dialogs. The default library offers a classic modal window with a close button and content you can tab and loop through inside. Behind this modal is a dark scrim to dim the content below:

![micromodal](https://user-images.githubusercontent.com/1204802/148774059-aa00279f-5c61-4c2b-b7cf-5566232ae21c.gif)

Notice how the scrim is clickable, and on click closes the dialog. This scrim is not keyboard accessible — instead you can just press Escape to close the modal, or focus the Close button and press space or enter.

The navigation block does not use a scrim, and uses instead a fullscreen dialog. But the markup to make the scrim clickable (`tabindex="-1"`) still exists. In Safari you could accidentally set focus there if you clicked a menu item, bubbling the click to the scrim element, causing this blue focus to sit there:

![safari focus before](https://user-images.githubusercontent.com/1204802/148774365-60fbe250-75eb-468d-af84-776657cea7ca.gif)

Because the scrim is not used in the navigation block, nor meant to be keyboard interactive, this PR removes the focus style from it:

![safari focus after](https://user-images.githubusercontent.com/1204802/148774488-9c90213b-7c51-4ada-8088-84d9c9d5a8ea.gif)

## How has this been tested?

Insert a navigation block, set it to always open a modal. Using Safari, visit the frontend, click the burger menu, then click and drag outside on a menu item, and you should see focus only on the menu item. 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->