### PR TITLE
Docs: Add mising end tag for codetabs in stylesheet guide

### DIFF
--- a/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
+++ b/docs/how-to-guides/block-tutorial/applying-styles-with-stylesheets.md
@@ -96,6 +96,8 @@ registerBlockType( 'gutenberg-examples/example-02-stylesheets', {
 } )( window.wp.blocks, window.wp.element, window.wp.blockEditor );
 ```
 
+{% end %}
+
 ## Method 2: Block classname
 
 The inline style works well for a small amount of CSS to apply. If you have much more than the above you will likely find that it is easier to manage with them in a separate stylesheet file.


### PR DESCRIPTION

## Description

The `{% end %}` tag is missing from the codetabs in the stylesheets guide and the formatting is off.

You can confirm the issue here:
https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/applying-styles-with-stylesheets/


## How has this been tested?

Difficult to test since it is used only after publishing.
You can visually confirm the open close tags look right.


## Types of changes

Documentation.

