### PR TITLE
Expose pluralised form of entity label 

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -217,6 +217,7 @@ async function loadPostTypeEntities() {
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.labels.singular_name,
+			labelPlural: postType.labels.name,
 			transientEdits: {
 				blocks: true,
 				selection: true,

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -48,11 +48,9 @@ export default function EntityTypeList( {
 			select( coreStore ).getEntity( firstRecord.kind, firstRecord.name ),
 		[ firstRecord.kind, firstRecord.name ]
 	);
+
 	const { name } = firstRecord;
-	const entityLabel =
-		name === 'wp_template_part'
-			? _n( 'Template Part', 'Template Parts', list.length )
-			: entity.label;
+	const entityLabel = list.length > 1 ? entity.labelPlural : entity.label;
 	// Set description based on type of entity.
 	const description = getEntityDescription( name, list.length );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Currently in `entities.js` we only access the singular form of the entity label. However when registering a Post Type we provide both singular and plural forms. This plural form comes in handy in many places including when we want to differentiate between singular or multiple copies of an entity.

An example of this is the multi-entity saving flow where we want to show the singular or plural form of the entity name depending on the quantity of entities of a given type being saved.

This PR updates the entities to include `labelPlural` as well as `label` (singular). It then applies that to the multi-entity saving flow.

Note we were already doing this manually for the Template Parts so it makes sense to do it for all entity types.

Please also https://github.com/WordPress/gutenberg/pull/37685 which if committed would make this change impossible.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- New Post
- Add some content
- Add a Nav block and add some times to it
- Click "Publish"
- See sections for `Post` and `Navigation Menu` - note the singular form.
- Close the multi-entity saving panel.
- Add a _2nd_ Nav block and add some items to that as well
- Click "Publish" to bring up the multi-saving panel.
- See there are now two items under `Navigation Menus` - note this is now using the plural form.
- Try for other Posts types - particular Templates.


## Screenshots <!-- if applicable -->
<img width="560" alt="Screen Shot 2022-01-10 at 15 08 19" src="https://user-images.githubusercontent.com/444434/148788681-77571e66-0c45-4c17-a739-46bd1bc056e5.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas ->
