### PR TITLE
Update the Post Author block description

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -433,7 +433,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 ## Post Author
 
-Displays post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
+Display post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
 
 -	**Name:** core/post-author
 -	**Category:** theme

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -433,7 +433,7 @@ Show a block pattern. ([Source](https://github.com/WordPress/gutenberg/tree/trun
 
 ## Post Author
 
-Add the author of this post. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
+Displays post author details such as name, avatar, and bio. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-author))
 
 -	**Name:** core/post-author
 -	**Category:** theme

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-author",
 	"title": "Post Author",
 	"category": "theme",
-	"description": "Displays post author details such as name, avatar, and bio.",
+	"description": "Display post author details such as name, avatar, and bio.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-author",
 	"title": "Post Author",
 	"category": "theme",
-	"description": "Add the author of this post.",
+	"description": "Displays post author details such as name, avatar, and bio.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {


### PR DESCRIPTION
The current descriptions reads:

> Add the author of this post.

This doesn't make much sense in the context of template editing – if I'm editing the post template in the site editor then there is no post, and no author. I've updated this to read:

> Displays post author details such as name, avatar, and bio.

Which is a more agnostic description.