### PR TITLE
PostLockedModal: Update action buttons markup

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -7,7 +7,7 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Modal, Button } from '@wordpress/components';
+import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect } from '@wordpress/element';
@@ -218,15 +218,25 @@ export default function PostLockedModal() {
 							  ) }
 					</p>
 
-					<div className="editor-post-locked-modal__buttons">
-						<PostPreviewButton />
-						<Button variant="tertiary" href={ unlockUrl }>
-							{ __( 'Take over' ) }
-						</Button>
-						<Button variant="primary" href={ allPostsUrl }>
-							{ allPostsLabel }
-						</Button>
-					</div>
+					<Flex
+						className="editor-post-locked-modal__buttons"
+						justify="flex-end"
+						expanded={ false }
+					>
+						<FlexItem>
+							<PostPreviewButton />
+						</FlexItem>
+						<FlexItem>
+							<Button variant="tertiary" href={ unlockUrl }>
+								{ __( 'Take over' ) }
+							</Button>
+						</FlexItem>
+						<FlexItem>
+							<Button variant="primary" href={ allPostsUrl }>
+								{ allPostsLabel }
+							</Button>
+						</FlexItem>
+					</Flex>
 				</div>
 			) }
 		</Modal>

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -4,9 +4,6 @@
 
 .editor-post-locked-modal__buttons {
 	margin-top: $grid-unit-30;
-	display: flex;
-	justify-content: flex-end;
-	gap: $grid-unit-10;
 }
 
 .editor-post-locked-modal__avatar {


### PR DESCRIPTION
## Description
PR updates Post Locked modal action buttons markup to match other similar models in the core.

Part of #37725.

## How has this been tested?
Modal should look the same design-wise.

Create two admin user accounts. Save a post as one user, then log in as the other user in an incognito mode and load the same post.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-10 at 21 01 38](https://user-images.githubusercontent.com/240569/148809050-b4b9ec10-e828-482c-9545-117eb4f1a831.png)


## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
