### PR TITLE
[History]: Fix redo after update/publish with transient edits

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -431,7 +431,16 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 					// to continue as if we were creating an explicit undo level. This
 					// will result in an extra undo level being appended with the flattened
 					// undo values.
+					// We also have to take into account if the `lastEditAction` had opted out
+					// of being tracked in undo history, like the action that persists the latest
+					// content right before saving. In that case we have to update the `lastEditAction`
+					// to avoid returning early before applying the existing flattened undos.
 					isCreateUndoLevel = true;
+					if ( ! lastEditAction.meta.undo ) {
+						lastEditAction.meta.undo = {
+							edits: {},
+						};
+					}
 					action = lastEditAction;
 				} else {
 					return nextState;

--- a/packages/e2e-tests/specs/editor/various/undo.test.js
+++ b/packages/e2e-tests/specs/editor/various/undo.test.js
@@ -420,4 +420,25 @@ describe( 'undo', () => {
 		// Expect "1".
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
+
+	it( 'should be able to undo and redo when transient changes have been made and we update/publish', async () => {
+		// Typing consecutive characters in a `Paragraph` block updates the same
+		// block attribute as in the previous action and results in transient edits
+		// and skipping `undo` history steps.
+		const text = 'tonis';
+		await clickBlockAppender();
+		await page.keyboard.type( text );
+		await publishPost();
+		await pressKeyWithModifier( 'primary', 'z' );
+		expect( await getEditedPostContent() ).toBe( '' );
+		await page.waitForSelector(
+			'.editor-history__redo[aria-disabled="false"]'
+		);
+		await page.click( '.editor-history__redo[aria-disabled="false"]' );
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>tonis</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
 } );

--- a/test/emptytheme/block-templates/index.html
+++ b/test/emptytheme/block-templates/index.html
@@ -1,9 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
-<!-- wp:post-template -->
-<!-- wp:post-title {"isLink":true} /-->
-
-<!-- wp:post-excerpt /-->
-<!-- /wp:post-template -->
+<!-- wp:query {"queryId":1,"query":{"perPage"2,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:post-title {"isLink":true} /-->
+	<!-- wp:post-excerpt /-->
+	<!-- /wp:post-template -->
+</div>
 <!-- /wp:query -->

--- a/test/emptytheme/block-templates/index.html
+++ b/test/emptytheme/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"perPage"2,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <div class="wp-block-query">
 	<!-- wp:post-template -->
 	<!-- wp:post-title {"isLink":true} /-->


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37195

Maybe related: https://github.com/WordPress/gutenberg/issues/37760

Investigation started with @youknowriad 's: https://github.com/WordPress/gutenberg/pull/37446#discussion_r777423137.
>I skipped this test because there's an undo/redo bug that is only visible with the empty theme for some reason but not with the tt1-blocks theme.

When we `save` we do not create an undo step in history and was implemented In this [PR](https://github.com/WordPress/gutenberg/pull/17452). With that in place when we have transient edits and update/publish, if we `undo` we cannot `redo` then, as in that case we use the last action(`save`) which is deliberately handled to return early with `fake` no `edits`.

This PR handles this case to follow the normal flow we have for transient edits.

We create transient edits when we update the same block attribute as in the previous action and also when we use `__unstableMarkNextChangeAsNotPersistent` in a block for some initialization purposes in the first render. The latter case was the reason for the failing test with `empty theme`.  In `empty theme`'s index.html file we hadn't set `perPage` and there is [logic there](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/query/edit/index.js#L75) to set this value. So when we `reverted the template`, the Query Loop's rendering created transient edits. So after saving we had the above problem.

## Testing instructions
1. I a page type consecutive characters in a `Paragraph` and `update/publish`.
2. Click `redo`
3. Observe that `undo` is available and working as expected

#### Before

https://user-images.githubusercontent.com/16275880/148846443-df4c6c20-c9e8-43cd-a378-059602d593df.mov

 #### After

https://user-images.githubusercontent.com/16275880/148846468-77af7566-c7f1-4c21-a96c-2c9006344ef0.mov

I'd appreciate good testing here for any regression 😄 


