### PR TITLE
Fix Home template description typo 

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -114,7 +114,7 @@ if ( ! function_exists( 'get_default_block_template_types' ) ) {
 			),
 			'home'           => array(
 				'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page it set.', 'gutenberg' ),
+				'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page isn\'t set.', 'gutenberg' ),
 			),
 			'front-page'     => array(
 				'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),


### PR DESCRIPTION
## Description
Fixes #37841

## How has this been tested?
It's only really possible to test this in WordPress 5.8 with gutenberg active. To test:
1. Open the site editor
2. Open the sidebar using the 'W' icon
3. Click Templates
4. Find the 'Home' template and read its description.

When running WordPress 5.9 the string from WordPress core is used:
https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-template-utils.php#L122

I've made a matching ticket and PR for core, but it's unclear to me if this can be changed for 5.9 now that the hard string freeze is in place:
- https://core.trac.wordpress.org/ticket/54787
- https://github.com/WordPress/wordpress-develop/pull/2136

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
