### PR TITLE
Label components: improve consistency by setting to 8px margin-bottom

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/style.scss
+++ b/packages/block-editor/src/components/border-radius-control/style.scss
@@ -2,7 +2,7 @@
 	margin-bottom: $grid-unit-15;
 
 	legend {
-		padding-bottom: $grid-unit-05;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.components-border-radius-control__wrapper {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fix
 
+-   Update label spacing for the `BoxControl`, `CustomGradientPicker`, `FormTokenField`, `InputControl`, and `ToolsPanel` components to use a bottom margin of `8px` for consistency. ([#37844](https://github.com/WordPress/gutenberg/pull/37844))
 -   Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
 
 ## 19.2.0 (2022-01-04)

--- a/packages/components/src/box-control/styles/box-control-styles.js
+++ b/packages/components/src/box-control/styles/box-control-styles.js
@@ -19,7 +19,7 @@ export const Root = styled.div`
 
 export const Header = styled( Flex )`
 	color: ${ COLORS.ui.label };
-	padding-bottom: 8px;
+	margin-bottom: 8px;
 `;
 
 export const HeaderControlWrapper = styled( Flex )`

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -113,7 +113,6 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 .components-custom-gradient-picker {
 	.components-input-control__label {
 		line-height: 1;
-		padding-bottom: $grid-unit-10 !important;
 	}
 	label {
 		text-transform: uppercase;

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -53,7 +53,7 @@
 
 .components-form-token-field__label {
 	display: inline-block;
-	margin-bottom: $grid-unit-05;
+	margin-bottom: $grid-unit-10;
 }
 
 .components-form-token-field__help {

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -228,18 +228,18 @@ export const Input = styled.input< InputProps >`
 	}
 `;
 
-const labelPadding = ( {
+const labelMargin = ( {
 	labelPosition,
 }: {
 	labelPosition?: LabelPosition;
 } ) => {
-	let paddingBottom = 4;
+	let marginBottom = 8;
 
 	if ( labelPosition === 'edge' || labelPosition === 'side' ) {
-		paddingBottom = 0;
+		marginBottom = 0;
 	}
 
-	return css( { paddingTop: 0, paddingBottom } );
+	return css( { marginTop: 0, marginRight: 0, marginBottom, marginLeft: 0 } );
 };
 
 const BaseLabel = styled( Text )< { labelPosition?: LabelPosition } >`
@@ -247,11 +247,12 @@ const BaseLabel = styled( Text )< { labelPosition?: LabelPosition } >`
 		box-sizing: border-box;
 		color: currentColor;
 		display: block;
-		margin: 0;
+		padding-top: 0;
+		padding-bottom: 0;
 		max-width: 100%;
 		z-index: 1;
 
-		${ labelPadding }
+		${ labelMargin }
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;

--- a/packages/components/src/tools-panel/styles.ts
+++ b/packages/components/src/tools-panel/styles.ts
@@ -130,8 +130,6 @@ export const ToolsPanelItem = css`
 	 */
 	&& ${ LabelWrapper } {
 		label {
-			margin-bottom: ${ space( 2 ) };
-			padding-bottom: 0;
 			line-height: 1.4em;
 		}
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following on from https://github.com/WordPress/gutenberg/pull/37747 and https://github.com/WordPress/gutenberg/pull/36387 this PR adjusts the `SelectControl`'s bottom padding from `4px` to a bottom margin of `8px` for consistency with other component labels. The changes for consistency in this PR also include:

* Update the bottom spacing for the `InputControl`'s label to be `8px` for consistency with other labels, and switch to using `margin-bottom` instead of `padding-bottom` (since we're dealing with the spacing _between_ the label and another element instead of spacing within the label).
* Update the `BorderRadiusControl` label to use margin-bottom instead of padding-bottom and switch to `8px`
* Update the `BoxControl` header to use margin-bottom instead of padding-bottom and switch to `8px`
* Update the `CustomGradientPicker` styling to no longer set a bottom padding for the label, as the `8px` value is now used in the underlying `InputControl` component
* Update the `FormTokenField` component to use a bottom margin of `8px`
* Remove the bottom margin / padding overrides from the `ToolsPanel` styles as the underlying label should now have the correct spacing 🤞 (note I've left the `line-height` rule in place as there's still some inconsistent usage of that value around the place)

A note on padding vs margin: while arguably padding or margin are fairly interchangeable for controlling the spacing between the label and an input element, I think `margin` is probably the better fit — if we imagine giving a label a border or a background color, then I think `margin` becomes the clearer choice as otherwise the background color or border would sit right next to the input element.
 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Tested in Storybook after running `npm run storybook:dev`:

* http://localhost:50240/?path=/story/components-inputcontrol--default
* http://localhost:50240/?path=/story/components-boxcontrol--default
* http://localhost:50240/?path=/story/components-customgradientpicker--default
* http://localhost:50240/?path=/story/components-formtokenfield--default
* http://localhost:50240/?path=/story/components-experimental-toolspanel--default

Tested in real world usage of the above components. Below are some screenshots from the sidebar. Good things to test include:

* Sidebar components in the Video block
* All Typography controls for the Paragraph block
* Border controls for the Group block
* The color controls when selecting a background gradient

Note that the spacing is _slightly_ different in the labels for the color controls in the background gradient as it sets a different line-height for the labels than other usage. I've constrained this PR to just dealing with bottom padding / margin to avoid the PR becoming too large.

## Screenshots <!-- if applicable -->

| InputControl / SelectControl (Preload dropdown in Video block) | BorderRadiusControl |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/148881589-124c35d3-2696-451b-84b9-edb3f04ee4c7.png) | ![image](https://user-images.githubusercontent.com/14988353/148881701-65b3d65a-bfdb-481c-a4fb-5e175a066988.png) |
| BoxControl | CustomGradientControl labels |
| ![image](https://user-images.githubusercontent.com/14988353/148881801-5e6ada18-0ccf-4790-bc0d-568bd8a4da1d.png) | ![image](https://user-images.githubusercontent.com/14988353/148881910-dfdf6b90-e360-433e-b022-a3dbad191c9e.png) |
| FormTokenField label (Add new tag to a post) | ToolsPanel labels |
| ![image](https://user-images.githubusercontent.com/14988353/148882000-4a06a069-e0f5-431c-8f0c-b36706659974.png) | ![image](https://user-images.githubusercontent.com/14988353/148882128-be4a5f97-65e8-42c4-a678-58a6ab5fdb07.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
