### PR TITLE
Fix enqueueing additional styles for blocks only when rendered

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -605,10 +605,9 @@ if ( ! function_exists( 'wp_enqueue_block_style' ) ) {
 		 * @param string $content When the callback is used for the render_block filter,
 		 *                        the content needs to be returned so the function parameter
 		 *                        is to ensure the content exists.
-		 *
-		 * @return string
+		 * @return string Block content.
 		 */
-		$callback = function( $content ) use ( $args ) {
+		$callback = static function( $content ) use ( $args ) {
 			// Register the stylesheet.
 			if ( ! empty( $args['src'] ) ) {
 				wp_register_style( $args['handle'], $args['src'], $args['deps'], $args['ver'], $args['media'] );

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -652,6 +652,7 @@ if ( ! function_exists( 'wp_enqueue_block_style' ) ) {
 				}
 				return $content;
 			};
+
 			/*
 			 * The filter's callback here is an anonymous function because
 			 * using a named function in this case is not possible.

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -639,10 +639,41 @@ if ( ! function_exists( 'wp_enqueue_block_style' ) ) {
 
 		$hook = did_action( 'wp_enqueue_scripts' ) ? 'wp_footer' : 'wp_enqueue_scripts';
 		if ( wp_should_load_separate_core_block_assets() ) {
-			$hook = "render_block_$block_name";
+			/**
+			 * Callback function to register and enqueue styles.
+			 *
+			 * @param string $content The block content.
+			 * @param array  $block   The full block, including name and attributes.
+			 * @return string Block content.
+			 */
+			$callback_separate = static function( $content, $block ) use ( $block_name, $callback ) {
+				if ( ! empty( $block['blockName'] ) && $block_name === $block['blockName'] ) {
+					return $callback( $content );
+				}
+				return $content;
+			};
+			/*
+			 * The filter's callback here is an anonymous function because
+			 * using a named function in this case is not possible.
+			 *
+			 * The function cannot be unhooked, however, users are still able
+			 * to dequeue the stylesheets registered/enqueued by the callback
+			 * which is why in this case, using an anonymous function
+			 * was deemed acceptable.
+			 */
+			add_filter( 'render_block', $callback_separate, 10, 2 );
+			return;
 		}
 
-		// Enqueue assets in the frontend.
+		/*
+		 * The filter's callback here is an anonymous function because
+		 * using a named function in this case is not possible.
+		 *
+		 * The function cannot be unhooked, however, users are still able
+		 * to dequeue the stylesheets registered/enqueued by the callback
+		 * which is why in this case, using an anonymous function
+		 * was deemed acceptable.
+		 */
 		add_filter( $hook, $callback );
 
 		// Enqueue assets in the editor.


### PR DESCRIPTION
## Description

Issue reported in https://make.wordpress.org/core/2021/12/15/using-multiple-stylesheets-per-block/#comment-42320

In a block theme, additional block styles registered using the `wp_enqueue_block_style` function should only get printed when the block exists on a page. However, they currently always get rendered.

This PR fixes the issue so that these styles will only get printed when a block gets rendered.

## How has this been tested?

Using 5.0-RC, with the twentytwentytwo theme:
Added this in the theme's `functions.php` file:
```php
add_action( 'after_setup_theme', function() {
	wp_enqueue_block_style( 'core/gallery', array(
		'handle' => 'my-theme-gallery',
		'src'    => get_theme_file_uri( 'assets/blocks/gallery.css' ),
		'path'   => get_theme_file_path( 'assets/blocks/gallery.css' ),
	) );
} );
```
Then, I added a new `assets/blocks/gallery.css` file in the theme with these contents:
```css
img {
	padding: 10px;
	background: #000;
	color: #fff;
}
```
Tested and confirmed that the styles only get added when the block exists.
Then switched to the twentytwentyone theme (or any other non-block theme), and confirmed that the styles get added regardless of whether the block exists on a page or not (conditional stylesheets loading should only work for block themes)

This should be backported to 5.9 👍 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
