### PR TITLE
fix typo (hanle -> handle)

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -623,7 +623,7 @@ if ( ! function_exists( 'wp_enqueue_block_style' ) ) {
 
 				// Add RTL stylesheet.
 				if ( file_exists( $rtl_file_path ) ) {
-					wp_style_add_data( $args['hanle'], 'rtl', 'replace' );
+					wp_style_add_data( $args['handle'], 'rtl', 'replace' );
 
 					if ( is_rtl() ) {
 						wp_style_add_data( $args['handle'], 'path', $rtl_file_path );


### PR DESCRIPTION
## Description
There's a typo in the `wp_enqueue_block_style` function (`hanle` instead of `handle`).
This PR fixes the typo and should be backported to WP 5.9 since we have the same issue there as well.

## Types of changes
* Fixed typo

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
