### PR TITLE
PostLockedModal: Display preview link as part of the text

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -187,8 +187,8 @@ export default function PostLockedModal() {
 					className="editor-post-locked-modal__avatar"
 				/>
 			) }
-			{ !! isTakeover && (
-				<div>
+			<div>
+				{ !! isTakeover && (
 					<p>
 						{ createInterpolateElement(
 							userDisplayName
@@ -212,16 +212,8 @@ export default function PostLockedModal() {
 							}
 						) }
 					</p>
-
-					<div className="editor-post-locked-modal__buttons">
-						<Button variant="primary" href={ allPostsUrl }>
-							{ allPostsLabel }
-						</Button>
-					</div>
-				</div>
-			) }
-			{ ! isTakeover && (
-				<div>
+				) }
+				{ ! isTakeover && (
 					<p>
 						{ createInterpolateElement(
 							userDisplayName
@@ -245,25 +237,27 @@ export default function PostLockedModal() {
 							}
 						) }
 					</p>
+				) }
 
-					<Flex
-						className="editor-post-locked-modal__buttons"
-						justify="flex-end"
-						expanded={ false }
-					>
+				<Flex
+					className="editor-post-locked-modal__buttons"
+					justify="flex-end"
+					expanded={ false }
+				>
+					{ ! isTakeover && (
 						<FlexItem>
 							<Button variant="tertiary" href={ unlockUrl }>
 								{ __( 'Take over' ) }
 							</Button>
 						</FlexItem>
-						<FlexItem>
-							<Button variant="primary" href={ allPostsUrl }>
-								{ allPostsLabel }
-							</Button>
-						</FlexItem>
-					</Flex>
-				</div>
-			) }
+					) }
+					<FlexItem>
+						<Button variant="primary" href={ allPostsUrl }>
+							{ allPostsLabel }
+						</Button>
+					</FlexItem>
+				</Flex>
+			</div>
 		</Modal>
 	);
 }

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -7,10 +7,16 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Modal, Button, Flex, FlexItem } from '@wordpress/components';
+import {
+	Modal,
+	Button,
+	ExternalLink,
+	Flex,
+	FlexItem,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect } from '@wordpress/element';
+import { useEffect, createInterpolateElement } from '@wordpress/element';
 import { addAction, removeAction } from '@wordpress/hooks';
 import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -19,7 +25,6 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { getWPAdminURL } from '../../utils/url';
-import PostPreviewButton from '../post-preview-button';
 import { store as editorStore } from '../../store';
 
 export default function PostLockedModal() {
@@ -34,6 +39,7 @@ export default function PostLockedModal() {
 		postLockUtils,
 		activePostLock,
 		postType,
+		previewLink,
 	} = useSelect( ( select ) => {
 		const {
 			isPostLocked,
@@ -42,6 +48,7 @@ export default function PostLockedModal() {
 			getCurrentPostId,
 			getActivePostLock,
 			getEditedPostAttribute,
+			getEditedPostPreviewLink,
 			getEditorSettings,
 		} = select( editorStore );
 		const { getPostType } = select( coreStore );
@@ -53,6 +60,7 @@ export default function PostLockedModal() {
 			postLockUtils: getEditorSettings().postLockUtils,
 			activePostLock: getActivePostLock(),
 			postType: getPostType( getEditedPostAttribute( 'type' ) ),
+			previewLink: getEditedPostPreviewLink(),
 		};
 	}, [] );
 
@@ -182,17 +190,27 @@ export default function PostLockedModal() {
 			{ !! isTakeover && (
 				<div>
 					<p>
-						{ userDisplayName
-							? sprintf(
-									/* translators: %s: user's display name */
-									__(
-										'%s now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
-									),
-									userDisplayName
-							  )
-							: __(
-									'Another user now has editing control of this post. Don’t worry, your changes up to this moment have been saved.'
-							  ) }
+						{ createInterpolateElement(
+							userDisplayName
+								? sprintf(
+										/* translators: %s: user's display name */
+										__(
+											'<strong>%s</strong> now has editing control of this posts (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
+										),
+										userDisplayName
+								  )
+								: __(
+										'Another user now has editing control of this post (<PreviewLink />). Don’t worry, your changes up to this moment have been saved.'
+								  ),
+							{
+								strong: <strong />,
+								PreviewLink: (
+									<ExternalLink href={ previewLink }>
+										{ __( 'preview' ) }
+									</ExternalLink>
+								),
+							}
+						) }
 					</p>
 
 					<div className="editor-post-locked-modal__buttons">
@@ -205,17 +223,27 @@ export default function PostLockedModal() {
 			{ ! isTakeover && (
 				<div>
 					<p>
-						{ userDisplayName
-							? sprintf(
-									/* translators: %s: user's display name */
-									__(
-										'%s is currently working on this post, which means you cannot make changes, unless you take over.'
-									),
-									userDisplayName
-							  )
-							: __(
-									'Another user is currently working on this post, which means you cannot make changes, unless you take over.'
-							  ) }
+						{ createInterpolateElement(
+							userDisplayName
+								? sprintf(
+										/* translators: %s: user's display name */
+										__(
+											'<strong>%s</strong> is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+										),
+										userDisplayName
+								  )
+								: __(
+										'Another user is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+								  ),
+							{
+								strong: <strong />,
+								PreviewLink: (
+									<ExternalLink href={ previewLink }>
+										{ __( 'preview' ) }
+									</ExternalLink>
+								),
+							}
+						) }
 					</p>
 
 					<Flex
@@ -223,9 +251,6 @@ export default function PostLockedModal() {
 						justify="flex-end"
 						expanded={ false }
 					>
-						<FlexItem>
-							<PostPreviewButton />
-						</FlexItem>
 						<FlexItem>
 							<Button variant="tertiary" href={ unlockUrl }>
 								{ __( 'Take over' ) }


### PR DESCRIPTION
## Description
Part of #37725.

PR updates Post Locked modal to display preview link inside the text instead of the separate button. It also shows the user's display name in bold.

## How has this been tested?
Create two admin user accounts. Save a post as one user, then log in as the other user in an incognito mode and load the same post.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-11 at 12 07 53](https://user-images.githubusercontent.com/240569/148907210-ef577dfa-fd09-4bd3-9490-6a66fa552288.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
