### PR TITLE
Add the WP version in which some JS APIs will be removed

### DIFF
--- a/packages/editor/src/components/deprecated.js
+++ b/packages/editor/src/components/deprecated.js
@@ -67,6 +67,7 @@ function deprecateComponent( name, Wrapped, staticsToHoist = [] ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
+			version: '6.2',
 		} );
 
 		return <Wrapped ref={ ref } { ...props } />;
@@ -87,6 +88,7 @@ function deprecateFunction( name, func ) {
 		deprecated( 'wp.editor.' + name, {
 			since: '5.3',
 			alternative: 'wp.blockEditor.' + name,
+			version: '6.2',
 		} );
 
 		return func( ...args );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -629,6 +629,7 @@ const getBlockEditorAction = ( name ) =>
 			since: '5.3',
 			alternative:
 				"`wp.data.dispatch( 'core/block-editor' )." + name + '`',
+			version: '6.2',
 		} );
 		yield controls.dispatch( blockEditorStore, name, ...args );
 	};

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1256,6 +1256,7 @@ function getBlockEditorSelector( name ) {
 		deprecated( "`wp.data.select( 'core/editor' )." + name + '`', {
 			since: '5.3',
 			alternative: "`wp.data.select( 'core/block-editor' )." + name + '`',
+			version: '6.2',
 		} );
 
 		return select( blockEditorStore )[ name ]( ...args );

--- a/packages/server-side-render/src/index.js
+++ b/packages/server-side-render/src/index.js
@@ -50,6 +50,7 @@ const ExportedServerSideRender = withSelect( ( select ) => {
 if ( window && window.wp && window.wp.components ) {
 	window.wp.components.ServerSideRender = forwardRef( ( props, ref ) => {
 		deprecated( 'wp.components.ServerSideRender', {
+			version: '6.2',
 			since: '5.3',
 			alternative: 'wp.serverSideRender',
 		} );


### PR DESCRIPTION
In previous WordPress versions, we've removed JS APIs that we deprecated between WP 5.0 and 5.3 but we kept some APIs that were deemed impactful.

In this PR, I'm adding an "expiration date" for these APIs. Basically I'm saying that we will be removing these APIs in WP 6.2 to warn plugin authors. 

These messages appear in the console, so they could potentially be considered not visible enough? On the alternative side, these APIs were deprecated like 3 years ago and plugins authors have had enough (and will have) time to see the messages (unless they're completely ignoring their plugin).

Any thoughts on the approach? @WordPress/gutenberg-core 