### PR TITLE
Add unlock icon.

### DIFF
--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -229,6 +229,7 @@ export { default as trendingUp } from './library/trending-up';
 export { default as typography } from './library/typography';
 export { default as undo } from './library/undo';
 export { default as ungroup } from './library/ungroup';
+export { default as unlock } from './library/unlock';
 export { default as update } from './library/update';
 export { default as upload } from './library/upload';
 export { default as verse } from './library/verse';

--- a/packages/icons/src/library/unlock.js
+++ b/packages/icons/src/library/unlock.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const unlock = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M18 9h-2V5c0-1.7-1.3-3-3-3h-2C9.3 2 8 3.3 8 5v1h1.5V5c0-.8.7-1.5 1.5-1.5h2c.8 0 1.5.7 1.5 1.5v4H6c-1.3 0-2 1-2 2v8c0 1 .7 2 2 2h12c1.3 0 2-1 2-2v-8c0-1-.7-2-2-2z" />
+	</SVG>
+);
+
+export default unlock;


### PR DESCRIPTION
## Description

This PR adds an icon for "unlock" that matches in style with "lock". It is likely to be useful in future evolutions of block locking or otherwise:

<img width="369" alt="Screenshot 2022-01-11 at 10 31 06" src="https://user-images.githubusercontent.com/1204802/148918063-7dd980f4-7c94-4fa2-84b9-015eb2439ef2.png">

## How has this been tested?

Change a component that uses an icon to point to the unlock icon, verify it shows up as expected.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
