### PR TITLE
Simplify and unify a few modal dialogs.

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -193,13 +193,13 @@ figure.wp-block-gallery {
 }
 
 .wp-block-update-gallery-modal {
-	max-width: 400px;
-	.wp-block-update-gallery-modal-buttons {
-		display: flex;
-		justify-content: flex-end;
-
-		.components-button {
-			margin-left: $grid-unit-15;
-		}
+	@include break-small() {
+		max-width: $break-mobile;
 	}
+}
+
+.wp-block-update-gallery-modal-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: $grid-unit-15;
 }

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -39,16 +39,15 @@
 
 // Modal that shows conversion option.
 .wp-block-page-list-modal {
-	max-width: 400px;
+	@include break-small() {
+		max-width: $break-mobile;
+	}
 }
 
 .wp-block-page-list-modal-buttons {
 	display: flex;
 	justify-content: flex-end;
-
-	.components-button {
-		margin-left: $grid-unit-15;
-	}
+	gap: $grid-unit-15;
 }
 
 // Simulate open on click behaviour in the editor by opening on focus instead.

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -1,5 +1,7 @@
 .editor-post-locked-modal {
-	max-width: 400px;
+	@include break-small() {
+		max-width: $break-mobile;
+	}
 }
 
 .editor-post-locked-modal__buttons {


### PR DESCRIPTION
## Description

Followup to #37821 and #37852, part of #37725.

We add max-widths to a few of the modal dialogs we have, but those max-widths should only apply when the modal isn't meant to be fullscreen, which it is on mobile. That results in a not quite fullscreen modal:
<img width="679" alt="Screenshot 2022-01-11 at 10 41 24" src="https://user-images.githubusercontent.com/1204802/148919860-730ed7f4-a942-47ee-8b12-d93e9d6ddf3e.png">

This PR fixes it for Page List to menu item link conversion dialogs, legacy gallery upgrade dialogs, and post takeover dialogs. Here's the page list after:

<img width="666" alt="Screenshot 2022-01-11 at 10 43 05" src="https://user-images.githubusercontent.com/1204802/148919943-cca8a8f9-2ad3-4482-968e-c696e2d12b07.png">

<img width="652" alt="Screenshot 2022-01-11 at 10 43 09" src="https://user-images.githubusercontent.com/1204802/148919954-11851ce9-5687-4fd0-8409-0a292e6e3d38.png">

It also unifies and simplifies a bit the code used. It's really starting to look like we could move towards something like #34153 for a bunch of these.

## How has this been tested?

Ideally test the page list conversion, the gallery upgrade, and the post takeover modals.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
