### PR TITLE
ExternalLink: Update icon to be smaller, have no margin.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Refine `ExternalLink` to be same size as the text, to appear more as a glyph than an icon.
+
 ### Bug Fix
 
 -   Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Refine `ExternalLink` to be same size as the text, to appear more as a glyph than an icon.
+-   Refine `ExternalLink` to be same size as the text, to appear more as a glyph than an icon. ([#37859](https://github.com/WordPress/gutenberg/pull/37859))
 
 ### Bug Fix
 

--- a/packages/components/src/external-link/styles/external-link-styles.js
+++ b/packages/components/src/external-link/styles/external-link-styles.js
@@ -9,9 +9,9 @@ import styled from '@emotion/styled';
 import { Icon } from '@wordpress/icons';
 
 export const StyledIcon = styled( Icon )`
-	width: 1.4em;
-	height: 1.4em;
-	margin: -0.2em 0.1em 0;
+	width: 1em;
+	height: 1em;
+	margin: 0;
 	vertical-align: middle;
 	fill: currentColor;
 `;


### PR DESCRIPTION
## Description

Followup to #37852. 

The `ExternalLink` component appears to exist to enable the visual indication of a link that points to an external URL, i.e. to be used as part of a sentence or prose. But at 1.4em size and with margin around it, the icon does not feel harmoniusly balanced with the text, looking both too large, and as if there's a trailing space after it:

<img width="495" alt="before" src="https://user-images.githubusercontent.com/1204802/148927009-f5a76745-8db3-4ef6-9122-f2f3f0316ef1.png">

This PR make the icon maller, and remove the margin to make it feel like it's part of the link:

<img width="511" alt="after" src="https://user-images.githubusercontent.com/1204802/148927075-76896ff3-0d41-497f-a454-51f6e76eddc7.png">

## How has this been tested?

Test in Storybook. Before:

<img width="195" alt="Screenshot 2022-01-11 at 11 29 54" src="https://user-images.githubusercontent.com/1204802/148927105-93673a26-28bf-44ce-8d3f-3a07dda6077e.png">

After:

<img width="203" alt="Screenshot 2022-01-11 at 11 30 09" src="https://user-images.githubusercontent.com/1204802/148927116-27014e60-1ec1-49f3-9ae5-359ec565f969.png">

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
