### PR TITLE
Testing: Allow type imports for React everywhere

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,11 +82,6 @@ module.exports = {
 						message: 'Please use `memize` instead.',
 					},
 					{
-						name: 'react',
-						message:
-							'Please use React API through `@wordpress/element` instead.',
-					},
-					{
 						name: 'reakit',
 						message:
 							'Please use Reakit API through `@wordpress/components` instead.',
@@ -106,6 +101,19 @@ module.exports = {
 						name: '@emotion/css',
 						message:
 							'Please use `@emotion/react` and `@emotion/styled` in order to maintain iframe support. As a replacement for the `cx` function, please use the `useCx` hook defined in `@wordpress/components` instead.',
+					},
+				],
+			},
+		],
+		'@typescript-eslint/no-restricted-imports': [
+			'error',
+			{
+				paths: [
+					{
+						name: 'react',
+						message:
+							'Please use React API through `@wordpress/element` instead.',
+						allowTypeImports: true,
 					},
 				],
 			},

--- a/packages/components/src/card/types.ts
+++ b/packages/components/src/card/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
-import { Ref } from 'react';
+import type { Ref } from 'react';
 import { colord, extend, Colord } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 

--- a/packages/components/src/color-picker/use-deprecated-props.ts
+++ b/packages/components/src/color-picker/use-deprecated-props.ts
@@ -10,7 +10,6 @@ import {
 	RgbColor,
 	RgbaColor,
 } from 'colord';
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentProps } from 'react';
 import memoize from 'memize';
 

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref, KeyboardEvent } from 'react';
 
 /**

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -1,9 +1,12 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
-import React, { useState } from 'react';
 import { text } from '@storybook/addon-knobs';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies

--- a/packages/components/src/confirm-dialog/types.ts
+++ b/packages/components/src/confirm-dialog/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { MouseEvent, KeyboardEvent, ReactNode } from 'react';
 
 export type DialogInputEvent =

--- a/packages/components/src/divider/component.tsx
+++ b/packages/components/src/divider/component.tsx
@@ -3,7 +3,6 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import { Separator } from 'reakit';
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/elevation/types.ts
+++ b/packages/components/src/elevation/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 export type Props = {

--- a/packages/components/src/flex/types.ts
+++ b/packages/components/src/flex/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/flyout/types.ts
+++ b/packages/components/src/flyout/types.ts
@@ -3,7 +3,6 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { PopoverStateReturn } from 'reakit';
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties, FunctionComponentElement } from 'react';
 
 /**

--- a/packages/components/src/grid/types.ts
+++ b/packages/components/src/grid/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 type ResponsiveCSSValue< T > = Array< T | undefined > | T;

--- a/packages/components/src/h-stack/types.ts
+++ b/packages/components/src/h-stack/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/heading/component.tsx
+++ b/packages/components/src/heading/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentType, HTMLProps, SVGProps } from 'react';
 
 /**

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -3,7 +3,6 @@
  */
 import { noop } from 'lodash';
 import classNames from 'classnames';
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/input-control/input-base.tsx
+++ b/packages/components/src/input-control/input-base.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -3,7 +3,6 @@
  */
 import { noop } from 'lodash';
 import { useDrag } from 'react-use-gesture';
-// eslint-disable-next-line no-restricted-imports
 import type {
 	SyntheticEvent,
 	ChangeEvent,

--- a/packages/components/src/input-control/reducer/actions.ts
+++ b/packages/components/src/input-control/reducer/actions.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { SyntheticEvent } from 'react';
 
 /**

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { isEmpty } from 'lodash';
-// eslint-disable-next-line no-restricted-imports
 import type { SyntheticEvent } from 'react';
 
 /**

--- a/packages/components/src/input-control/reducer/state.ts
+++ b/packages/components/src/input-control/reducer/state.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Reducer } from 'react';
 
 /**

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -3,7 +3,6 @@
  */
 import { css, SerializedStyles } from '@emotion/react';
 import styled from '@emotion/styled';
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties, ReactNode } from 'react';
 
 /**

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type {
 	CSSProperties,
 	ReactNode,

--- a/packages/components/src/item-group/item-group/component.tsx
+++ b/packages/components/src/item-group/item-group/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/item-group/item/component.tsx
+++ b/packages/components/src/item-group/item/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ElementType } from 'react';
 
 /**

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 import { css } from '@emotion/react';
 

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { motion, MotionProps } from 'framer-motion';

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ReactNode } from 'react';
 
 type NavigatorPathOptions = {

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -9,7 +9,6 @@ import { forwardRef } from '@wordpress/element';
 import classnames from 'classnames';
 import { Resizable } from 're-resizable';
 import type { ResizableProps } from 're-resizable';
-// eslint-disable-next-line no-restricted-imports
 import type { ReactNode, Ref } from 'react';
 
 /**

--- a/packages/components/src/resizable-box/resize-tooltip/index.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/index.tsx
@@ -3,13 +3,12 @@
  */
 import { noop } from 'lodash';
 import classnames from 'classnames';
+import type { Ref } from 'react';
 
 /**
  * WordPress dependencies
  */
 import { forwardRef } from '@wordpress/element';
-// eslint-disable-next-line no-restricted-imports
-import type { Ref } from 'react';
 
 /**
  * Internal dependencies

--- a/packages/components/src/resizable-box/resize-tooltip/label.tsx
+++ b/packages/components/src/resizable-box/resize-tooltip/label.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/scrollable/stories/index.js
+++ b/packages/components/src/scrollable/stories/index.js
@@ -2,8 +2,11 @@
  * External dependencies
  */
 import { boolean, select } from '@storybook/addon-knobs';
-/* eslint-disable-next-line no-restricted-imports */
-import React from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +23,7 @@ export default {
 };
 
 export const _default = () => {
-	const targetRef = React.useRef( null );
+	const targetRef = useRef( null );
 
 	const onButtonClick = () => {
 		targetRef.current?.focus();

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -3,7 +3,6 @@
  */
 import { isEmpty, noop } from 'lodash';
 import classNames from 'classnames';
-// eslint-disable-next-line no-restricted-imports
 import type { ChangeEvent, FocusEvent, Ref } from 'react';
 
 /**

--- a/packages/components/src/spacer/component.tsx
+++ b/packages/components/src/spacer/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/spacer/types.ts
+++ b/packages/components/src/spacer/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ReactNode } from 'react';
 
 /**

--- a/packages/components/src/text/get-line-height.ts
+++ b/packages/components/src/text/get-line-height.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/text/types.ts
+++ b/packages/components/src/text/types.ts
@@ -6,7 +6,6 @@ import type { Props as TruncateProps } from '../truncate/types';
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 type TextAdjustLineHeightForInnerControls =

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { Radio } from 'reakit';

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import { RadioGroup, useRadioState } from 'reakit';

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { MutableRefObject, ReactNode, ReactText } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type { RadioStateReturn } from 'reakit';

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/tools-panel/tools-panel-item/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-item/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/tools-panel/types.ts
+++ b/packages/components/src/tools-panel/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ReactNode } from 'react';
 
 type ResetAllFilter = () => void;

--- a/packages/components/src/ui/context/wordpress-component.ts
+++ b/packages/components/src/ui/context/wordpress-component.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type * as React from 'react';
 
 /**

--- a/packages/components/src/ui/control-group/types.ts
+++ b/packages/components/src/ui/control-group/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/ui/form-group/types.ts
+++ b/packages/components/src/ui/form-group/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties, ReactNode, ReactText } from 'react';
 
 /**

--- a/packages/components/src/ui/shortcut/component.tsx
+++ b/packages/components/src/ui/shortcut/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref } from 'react';
 
 /**

--- a/packages/components/src/ui/tooltip/types.ts
+++ b/packages/components/src/ui/tooltip/types.ts
@@ -3,7 +3,6 @@
  */
 // eslint-disable-next-line no-restricted-imports
 import type { TooltipInitialState, TooltipProps } from 'reakit';
-// eslint-disable-next-line no-restricted-imports
 import type { ReactElement, ReactNode } from 'react';
 
 /**

--- a/packages/components/src/ui/utils/font-size.ts
+++ b/packages/components/src/ui/utils/font-size.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties, ReactText } from 'react';
 
 /**

--- a/packages/components/src/ui/utils/get-valid-children.ts
+++ b/packages/components/src/ui/utils/get-valid-children.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ReactNode, ReactNodeArray } from 'react';
 
 /**

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type {
 	FocusEventHandler,
 	KeyboardEvent,

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { SyntheticEvent } from 'react';
 
 /**

--- a/packages/components/src/unit-control/unit-select-control.tsx
+++ b/packages/components/src/unit-control/unit-select-control.tsx
@@ -3,7 +3,6 @@
  */
 import { noop } from 'lodash';
 import classnames from 'classnames';
-// eslint-disable-next-line no-restricted-imports
 import type { ChangeEvent } from 'react';
 
 /**

--- a/packages/components/src/utils/hooks/use-combined-ref.ts
+++ b/packages/components/src/utils/hooks/use-combined-ref.ts
@@ -5,7 +5,6 @@ import { useRef, useEffect } from '@wordpress/element';
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { MutableRefObject, RefCallback } from 'react';
 
 type Ref< T > = MutableRefObject< T | null > | RefCallback< T | null >;

--- a/packages/components/src/utils/hooks/use-latest-ref.ts
+++ b/packages/components/src/utils/hooks/use-latest-ref.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { RefObject } from 'react';
 
 /**

--- a/packages/components/src/v-stack/types.ts
+++ b/packages/components/src/v-stack/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { CSSProperties } from 'react';
 
 /**

--- a/packages/components/src/z-stack/component.tsx
+++ b/packages/components/src/z-stack/component.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { Ref, ReactNode } from 'react';
 
 /**

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -13,7 +13,6 @@ import type { SimpleHigherOrderComponent } from '../../utils/create-higher-order
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentType, ComponentClass } from 'react';
 
 /**

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentType } from 'react';
 
 /**

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { without } from 'lodash';
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentType } from 'react';
 
 /**

--- a/packages/compose/src/hooks/use-ref-effect/index.ts
+++ b/packages/compose/src/hooks/use-ref-effect/index.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
 import type { DependencyList, RefCallback } from 'react';
 
 /**

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { camelCase, upperFirst } from 'lodash';
-// eslint-disable-next-line no-restricted-imports
 import type { ComponentType } from 'react';
 
 /**

--- a/packages/element/src/react.js
+++ b/packages/element/src/react.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-// eslint-disable-next-line no-restricted-imports
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import {
 	Children,
 	cloneElement,

--- a/packages/react-i18n/src/index.tsx
+++ b/packages/react-i18n/src/index.tsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-// Disable reason: Type-only import, this is fine. See https://github.com/typescript-eslint/typescript-eslint/issues/2661
-// eslint-disable-next-line no-restricted-imports
 import type {
 	ComponentType,
 	FunctionComponent,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Addresses the issue raised in https://github.com/WordPress/gutenberg/pull/37795#discussion_r780578679.

> There are almost ninety other instances of disabling this error for a type import. I'm happy to try and get back to adjust `@wordpress/element` but it's still a JavaScript file without exported types. I'd prefer to not hold up this PR while waiting to change `@wordpress/element` and update all of those other existing cases.

Switches from `no-restricted-imports` rule to `@typescript-eslint/no-restricted-imports` in the ESlint config for `react` imports to allow importing types.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

`npm run lint-js` should still pass but without the need for comments that disable the rule.

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code quality.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
