### PR TITLE
Late escape home link block

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -139,7 +139,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['label'] ) ) {
 		$html .= wp_kses(
-			esc_html( $attributes['label'] ),
+			$attributes['label'],
 			array(
 				'code'   => array(),
 				'em'     => array(),

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -99,12 +99,12 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
 		$font_sizes['css_classes']
 	);
 	$style_attribute = ( $colors['inline_styles'] . $font_sizes['inline_styles'] );
-	$css_classes     = trim( implode( ' ', $classes ) ) . ' wp-block-navigation-item';
+	$css_classes     = trim( implode( ' ', $classes ) . ' wp-block-navigation-item' );
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => $css_classes,
-			'style' => $style_attribute,
+			'class' => esc_attr( $css_classes ),
+			'style' => esc_attr( $style_attribute ),
 		)
 	);
 
@@ -129,7 +129,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 
-	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content wp-block-navigation-item__content" rel="home"' . $aria_current;
+	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content wp-block-navigation-item__content" rel="home"' . esc_attr( $aria_current );
 
 	// Start appending HTML attributes to anchor tag.
 	$html .= ' href="' . esc_url( home_url() ) . '"';

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -139,7 +139,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 	if ( isset( $attributes['label'] ) ) {
 		$html .= wp_kses(
-			$attributes['label'],
+			esc_html( $attributes['label'] ),
 			array(
 				'code'   => array(),
 				'em'     => array(),

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -103,8 +103,8 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => esc_attr( $css_classes ),
-			'style' => esc_attr( $style_attribute ),
+			'class' => $css_classes,
+			'style' => $style_attribute,
 		)
 	);
 

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -129,7 +129,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 
 	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 
-	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content wp-block-navigation-item__content" rel="home"' . esc_attr( $aria_current );
+	$html = '<li ' . $wrapper_attributes . '><a class="wp-block-home-link__content wp-block-navigation-item__content" rel="home"' . $aria_current;
 
 	// Start appending HTML attributes to anchor tag.
 	$html .= ' href="' . esc_url( home_url() ) . '"';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves escaping of all PHP output to be as "late" as possible. This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?

* Add Home link block.
* Check all functionality still works "as was" - especially adding class and style attrs.
* Check all tests pass.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
