### PR TITLE
`ColorPicker`: allow hiding auxiliary controls

### DIFF
--- a/packages/components/src/color-picker/component.tsx
+++ b/packages/components/src/color-picker/component.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 // eslint-disable-next-line no-restricted-imports
-import { Ref } from 'react';
+import { ReactNode, Ref } from 'react';
 import { colord, extend, Colord } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 
@@ -45,6 +45,8 @@ export interface ColorPickerProps {
 	onChange?: ( color: string ) => void;
 	defaultValue?: string;
 	copyFormat?: ColorType;
+	hideAuxiliaryControls?: boolean;
+	children?: ReactNode;
 }
 
 const options = [
@@ -63,6 +65,8 @@ const ColorPicker = (
 		onChange,
 		defaultValue = '#fff',
 		copyFormat,
+		hideAuxiliaryControls,
+		children,
 		...divProps
 	} = useContextSystem( props, 'ColorPicker' );
 
@@ -98,47 +102,51 @@ const ColorPicker = (
 				color={ safeColordColor }
 				enableAlpha={ enableAlpha }
 			/>
-			<AuxiliaryColorArtefactWrapper>
-				<HStack justify="space-between">
-					{ showInputs ? (
-						<SelectControl
-							options={ options }
-							value={ colorType }
-							onChange={ ( nextColorType ) =>
-								setColorType( nextColorType as ColorType )
+			{ hideAuxiliaryControls ? null : (
+				<AuxiliaryColorArtefactWrapper>
+					<HStack justify="space-between">
+						{ showInputs ? (
+							<SelectControl
+								options={ options }
+								value={ colorType }
+								onChange={ ( nextColorType ) =>
+									setColorType( nextColorType as ColorType )
+								}
+								label={ __( 'Color format' ) }
+								hideLabelFromVision
+							/>
+						) : (
+							<ColorDisplay
+								color={ safeColordColor }
+								colorType={ copyFormat || colorType }
+								enableAlpha={ enableAlpha }
+							/>
+						) }
+						<DetailsControlButton
+							isSmall
+							onClick={ () => setShowInputs( ! showInputs ) }
+							icon={ settings }
+							isPressed={ showInputs }
+							label={
+								showInputs
+									? __( 'Hide detailed inputs' )
+									: __( 'Show detailed inputs' )
 							}
-							label={ __( 'Color format' ) }
-							hideLabelFromVision
 						/>
-					) : (
-						<ColorDisplay
+					</HStack>
+					<Spacer margin={ 4 } />
+					{ showInputs && (
+						<ColorInput
+							colorType={ colorType }
 							color={ safeColordColor }
-							colorType={ copyFormat || colorType }
+							onChange={ handleChange }
 							enableAlpha={ enableAlpha }
 						/>
 					) }
-					<DetailsControlButton
-						isSmall
-						onClick={ () => setShowInputs( ! showInputs ) }
-						icon={ settings }
-						isPressed={ showInputs }
-						label={
-							showInputs
-								? __( 'Hide detailed inputs' )
-								: __( 'Show detailed inputs' )
-						}
-					/>
-				</HStack>
-				<Spacer margin={ 4 } />
-				{ showInputs && (
-					<ColorInput
-						colorType={ colorType }
-						color={ safeColordColor }
-						onChange={ handleChange }
-						enableAlpha={ enableAlpha }
-					/>
-				) }
-			</AuxiliaryColorArtefactWrapper>
+				</AuxiliaryColorArtefactWrapper>
+			) }
+
+			{ children }
 		</ColorfulWrapper>
 	);
 };

--- a/packages/components/src/color-picker/stories/index.js
+++ b/packages/components/src/color-picker/stories/index.js
@@ -30,6 +30,7 @@ const Example = () => {
 	const [ color, setColor ] = useState( undefined );
 	const props = {
 		enableAlpha: boolean( 'enableAlpha', false ),
+		hideAuxiliaryControls: boolean( 'hideAuxiliaryControls', false ),
 		copyFormat: select(
 			'copyFormat',
 			[ PROP_UNSET, 'rgb', 'hsl', 'hex' ],
@@ -79,3 +80,29 @@ const LegacyExample = () => {
 };
 
 export const legacy = () => <LegacyExample />;
+
+const CustomAuxiliaryControls = () => {
+	const [ color, setColor ] = useState( undefined );
+	const props = {
+		enableAlpha: boolean( 'enableAlpha', false ),
+	};
+
+	if ( props.copyFormat === PROP_UNSET ) {
+		delete props.copyFormat;
+	}
+
+	return (
+		<ColorPicker
+			{ ...props }
+			hideAuxiliaryControls
+			color={ color }
+			onChange={ setColor }
+		>
+			<input type="text" value={ color } />
+		</ColorPicker>
+	);
+};
+
+export const customAuxiliaryControls = () => {
+	return <CustomAuxiliaryControls />;
+};


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This is an exploration for a potential solution to the needs expressed in #37599 — hiding the default `ColorPicker`s auxiliary controls, in favour of some custom ones.

The only real drawback of this approach is that, as of now, the `children` don't get any exposure to the `colorType` internal state (which is used in the default auxiliary controls).

Done:
- add `hideAuxiliaryControls` and `children` props on `ColorPicker`
- update Storybook examples

TODO:
- refine Storybok examples
- add tests
- update documentation
- add changelog entry

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

![Screenshot 2022-01-11 at 12 15 57](https://user-images.githubusercontent.com/1083581/148933024-cb169e7d-8dde-4489-8f80-c4ccbb87bd94.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
