### PR TITLE
Late escape latest comments block

### DIFF
--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -111,7 +111,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 			}
 			$list_items_markup .= '</footer>';
 			if ( $attributes['displayExcerpt'] ) {
-				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . esc_html( wpautop( get_comment_excerpt( $comment ) ) ) . '</div>';
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
 			}
 			$list_items_markup .= '</article></li>';
 		}

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -130,7 +130,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	if ( empty( $comments ) ) {
 		$classnames[] = 'no-comments';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => esc_attr( implode( ' ', $classnames ) ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 
 	return ! empty( $comments ) ? sprintf(
 		'<ol %1$s>%2$s</ol>',

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -61,7 +61,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 		_prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
 
 		foreach ( $comments as $comment ) {
-			$list_items_markup .= '<li class="' . esc_attr( 'wp-block-latest-comments__comment' ) . '">';
+			$list_items_markup .= '<li class="wp-block-latest-comments__comment">';
 			if ( $attributes['displayAvatar'] ) {
 				$avatar = get_avatar(
 					$comment,
@@ -69,7 +69,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 					'',
 					'',
 					array(
-						'class' => esc_attr( 'wp-block-latest-comments__comment-avatar' ),
+						'class' => 'wp-block-latest-comments__comment-avatar',
 					)
 				);
 				if ( $avatar ) {

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -93,7 +93,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 
 			// `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in
 			// `esc_html`.
-			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) . '</a>';
+			$post_title = '<a class="wp-block-latest-comments__comment-link" href="' . esc_url( get_comment_link( $comment ) ) . '">' . esc_html( wp_latest_comments_draft_or_post_title( $comment->comment_post_ID ) ) . '</a>';
 
 			$list_items_markup .= sprintf(
 				/* translators: 1: author name (inside <a> or <span> tag, based on if they have a URL), 2: post title related to this comment */

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -28,7 +28,7 @@
 function wp_latest_comments_draft_or_post_title( $post = 0 ) {
 	$title = get_the_title( $post );
 	if ( empty( $title ) ) {
-		$title = __( '(no title)' );
+		$title = esc_html__( '(no title)' );
 	}
 	return esc_html( $title );
 }
@@ -61,7 +61,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 		_prime_post_caches( $post_ids, strpos( get_option( 'permalink_structure' ), '%category%' ), false );
 
 		foreach ( $comments as $comment ) {
-			$list_items_markup .= '<li class="wp-block-latest-comments__comment">';
+			$list_items_markup .= '<li class="' . esc_attr( 'wp-block-latest-comments__comment' ) . '">';
 			if ( $attributes['displayAvatar'] ) {
 				$avatar = get_avatar(
 					$comment,
@@ -69,7 +69,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 					'',
 					'',
 					array(
-						'class' => 'wp-block-latest-comments__comment-avatar',
+						'class' => esc_attr( 'wp-block-latest-comments__comment-avatar' ),
 					)
 				);
 				if ( $avatar ) {
@@ -106,7 +106,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 				$list_items_markup .= sprintf(
 					'<time datetime="%1$s" class="wp-block-latest-comments__comment-date">%2$s</time>',
 					esc_attr( get_comment_date( 'c', $comment ) ),
-					date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) )
+					esc_html( date_i18n( get_option( 'date_format' ), get_comment_date( 'U', $comment ) ) )
 				);
 			}
 			$list_items_markup .= '</footer>';
@@ -130,7 +130,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	if ( empty( $comments ) ) {
 		$classnames[] = 'no-comments';
 	}
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => esc_attr( implode( ' ', $classnames ) ) ) );
 
 	return ! empty( $comments ) ? sprintf(
 		'<ol %1$s>%2$s</ol>',
@@ -139,7 +139,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
-		__( 'No comments to show.' )
+		esc_html__( 'No comments to show.' )
 	);
 }
 

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -86,9 +86,9 @@ function render_block_core_latest_comments( $attributes = array() ) {
 
 			$author_markup = '';
 			if ( $author_url ) {
-				$author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . get_comment_author( $comment ) . '</a>';
+				$author_markup .= '<a class="wp-block-latest-comments__comment-author" href="' . esc_url( $author_url ) . '">' . esc_html( get_comment_author( $comment ) ) . '</a>';
 			} else {
-				$author_markup .= '<span class="wp-block-latest-comments__comment-author">' . get_comment_author( $comment ) . '</span>';
+				$author_markup .= '<span class="wp-block-latest-comments__comment-author">' . esc_html( get_comment_author( $comment ) ) . '</span>';
 			}
 
 			// `_draft_or_post_title` calls `esc_html()` so we don't need to wrap that call in

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -28,9 +28,9 @@
 function wp_latest_comments_draft_or_post_title( $post = 0 ) {
 	$title = get_the_title( $post );
 	if ( empty( $title ) ) {
-		$title = esc_html__( '(no title)' );
+		$title = __( '(no title)' );
 	}
-	return esc_html( $title );
+	return $title;
 }
 
 /**

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -139,7 +139,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 	) : sprintf(
 		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
-		esc_html__( 'No comments to show.' )
+		__( 'No comments to show.' )
 	);
 }
 

--- a/packages/block-library/src/latest-comments/index.php
+++ b/packages/block-library/src/latest-comments/index.php
@@ -111,7 +111,7 @@ function render_block_core_latest_comments( $attributes = array() ) {
 			}
 			$list_items_markup .= '</footer>';
 			if ( $attributes['displayExcerpt'] ) {
-				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . wpautop( get_comment_excerpt( $comment ) ) . '</div>';
+				$list_items_markup .= '<div class="wp-block-latest-comments__comment-excerpt">' . esc_html( wpautop( get_comment_excerpt( $comment ) ) ) . '</div>';
 			}
 			$list_items_markup .= '</article></li>';
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves escaping of all PHP output to be as "late" as possible. This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?

* Add Latest Comments block.
* Check functionality is "as was".
* Check all tests pass.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
