### PR TITLE
Late escape Latest Posts block

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -92,22 +92,22 @@ function render_block_core_latest_posts( $attributes ) {
 			if ( $attributes['addLinkToFeaturedImage'] ) {
 				$featured_image = sprintf(
 					'<a href="%1$s" aria-label="%2$s">%3$s</a>',
-					$post_link,
-					$title,
-					$featured_image
+					esc_url( $post_link ),
+					esc_attr( $title ),
+					esc_html( $featured_image )
 				);
 			}
 			$list_items_markup .= sprintf(
 				'<div class="%1$s">%2$s</div>',
-				$image_classes,
+				esc_attr( $image_classes ),
 				$featured_image
 			);
 		}
 
 		$list_items_markup .= sprintf(
 			'<a href="%1$s">%2$s</a>',
-			$post_link,
-			$title
+			esc_url( $post_link ),
+			esc_html( $title )
 		);
 
 		if ( isset( $attributes['displayAuthor'] ) && $attributes['displayAuthor'] ) {
@@ -143,7 +143,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-excerpt">%1$s</div>',
-				$trimmed_excerpt
+				esc_html( $trimmed_excerpt )
 			);
 		}
 
@@ -158,7 +158,7 @@ function render_block_core_latest_posts( $attributes ) {
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
-				$post_content
+				esc_html( $post_content )
 			);
 		}
 
@@ -185,7 +185,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' has-author';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => esc_attr( $class ) ) );
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -150,15 +150,15 @@ function render_block_core_latest_posts( $attributes ) {
 		if ( isset( $attributes['displayPostContent'] ) && $attributes['displayPostContent']
 			&& isset( $attributes['displayPostContentRadio'] ) && 'full_post' === $attributes['displayPostContentRadio'] ) {
 
-			$post_content = wp_kses_post( html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) ) );
+			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
 
 			if ( post_password_required( $post ) ) {
-				$post_content = __( 'This content is password protected.' );
+				$post_content = esc_html__( 'This content is password protected.' );
 			}
 
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
-				esc_html( $post_content )
+				wp_kses_post( $post_content )
 			);
 		}
 

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -153,7 +153,7 @@ function render_block_core_latest_posts( $attributes ) {
 			$post_content = html_entity_decode( $post->post_content, ENT_QUOTES, get_option( 'blog_charset' ) );
 
 			if ( post_password_required( $post ) ) {
-				$post_content = esc_html__( 'This content is password protected.' );
+				$post_content = __( 'This content is password protected.' );
 			}
 
 			$list_items_markup .= sprintf(

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -185,7 +185,7 @@ function render_block_core_latest_posts( $attributes ) {
 		$class .= ' has-author';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => esc_attr( $class ) ) );
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $class ) );
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -86,7 +86,7 @@ function render_block_core_latest_posts( $attributes ) {
 				$post,
 				$attributes['featuredImageSizeSlug'],
 				array(
-					'style' => $image_style,
+					'style' => esc_attr( $image_style ),
 				)
 			);
 			if ( $attributes['addLinkToFeaturedImage'] ) {
@@ -94,7 +94,7 @@ function render_block_core_latest_posts( $attributes ) {
 					'<a href="%1$s" aria-label="%2$s">%3$s</a>',
 					esc_url( $post_link ),
 					esc_attr( $title ),
-					esc_html( $featured_image )
+					$featured_image
 				);
 			}
 			$list_items_markup .= sprintf(


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves escaping of all PHP output to be as "late" as possible. This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?
- add Latest Posts block
- check functionality is "as was"
- check all tests pass.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
