### PR TITLE
[Block Library - Query Loop]: Check for `zero` `queryId` on initialization

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -79,7 +79,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 	// We need this for multi-query block pagination.
 	// Query parameters for each block are scoped to their ID.
 	useEffect( () => {
-		if ( ! queryId ) {
+		if ( ! Number.isFinite( queryId ) ) {
 			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { queryId: instanceId } );
 		}


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/37629

This minor PR just adds a proper `zero` check for `queryId` during initial rendering if not provided. In that case it would call `setAttributes` twice with the `zero`.

Everything should work as before.