### PR TITLE
Late escape comments link block

### DIFF
--- a/packages/block-library/src/post-comments-link/index.php
+++ b/packages/block-library/src/post-comments-link/index.php
@@ -48,7 +48,7 @@ function render_block_core_post_comments_link( $attributes, $content, $block ) {
 		);
 	}
 
-	return "<div {$wrapper_attributes}><a href='{$comments_link}'>{$comment_text}</a></div>";
+	return '<div ' . $wrapper_attributes . '><a href=' . esc_url( $comments_link ) . '>' . esc_html( $comment_text ) . '</a></div>';
 }
 
 /**

--- a/packages/block-library/src/post-comments-link/index.php
+++ b/packages/block-library/src/post-comments-link/index.php
@@ -27,28 +27,28 @@ function render_block_core_post_comments_link( $attributes, $content, $block ) {
 	$comments_number    = (int) get_comments_number( $block->context['postId'] );
 	$comments_link      = get_comments_link( $block->context['postId'] );
 	$post_title         = get_the_title( $block->context['postId'] );
-	$comment_text       = '';
+	$comment_html       = '';
 
 	if ( 0 === $comments_number ) {
-		$comment_text = sprintf(
+		$comment_html = sprintf(
 			/* translators: %s post title */
 			__( 'No comments<span class="screen-reader-text"> on %s</span>' ),
-			$post_title
+			esc_html( $post_title )
 		);
 	} else {
-		$comment_text = sprintf(
+		$comment_html = sprintf(
 			/* translators: 1: Number of comments, 2: post title */
 			_n(
 				'%1$s comment<span class="screen-reader-text"> on %2$s</span>',
 				'%1$s comments<span class="screen-reader-text"> on %2$s</span>',
 				$comments_number
 			),
-			number_format_i18n( $comments_number ),
-			$post_title
+			esc_html( number_format_i18n( $comments_number ) ),
+			esc_html( $post_title )
 		);
 	}
 
-	return '<div ' . $wrapper_attributes . '><a href=' . esc_url( $comments_link ) . '>' . esc_html( $comment_text ) . '</a></div>';
+	return '<div ' . $wrapper_attributes . '><a href=' . esc_url( $comments_link ) . '>' . $comment_html . '</a></div>';
 }
 
 /**


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves [escaping of all PHP output to be as "late" as possible](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/#:~:text=esc_textarea(%20%24text%20)%3B%20%3F%3E%3C/textarea%3E-,Tip%3A,Output%20escaping%20should%20occur%20as%20late%20as%20possible.,-Top%20%E2%86%91). This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?
- add both blocks
- check functionality is "as was"
- check all tests pass

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
