### PR TITLE
Late escape site blocks

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -40,7 +40,7 @@ function render_block_core_site_logo( $attributes ) {
 		// Add the link target after the rel="home".
 		// Add an aria-label for informing that the page opens in a new tab.
 		$aria_label  = 'aria-label="' . esc_attr__( '(Home link, opens in a new tab)' ) . '"';
-		$custom_logo = str_replace( 'rel="home"', 'rel="home" target="' . $attributes['linkTarget'] . '"' . $aria_label, $custom_logo );
+		$custom_logo = str_replace( 'rel="home"', 'rel="home" target="' . esc_attr( $attributes['linkTarget'] ) . '"' . $aria_label, $custom_logo );
 	}
 
 	$classnames = array();

--- a/packages/block-library/src/site-tagline/index.php
+++ b/packages/block-library/src/site-tagline/index.php
@@ -23,7 +23,7 @@ function render_block_core_site_tagline( $attributes ) {
 	return sprintf(
 		'<p %1$s>%2$s</p>',
 		$wrapper_attributes,
-		$site_tagline
+		esc_html( $site_tagline )
 	);
 }
 

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -24,7 +24,7 @@ function render_block_core_site_title( $attributes ) {
 	$aria_current = is_home() || ( is_front_page() && 'page' === get_option( 'show_on_front' ) ) ? ' aria-current="page"' : '';
 
 	if ( isset( $attributes['level'] ) ) {
-		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
+		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . (int) $attributes['level'];
 	}
 
 	if ( $attributes['isLink'] ) {

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -29,15 +29,15 @@ function render_block_core_site_title( $attributes ) {
 
 	if ( $attributes['isLink'] ) {
 		$link_attrs = array(
-			'href="' . get_bloginfo( 'url' ) . '"',
-			'rel="home"',
+			'href="' . esc_url( get_bloginfo( 'url' ) ) . '"',
+			esc_attr( 'rel="home"' ),
 			$aria_current,
 		);
 		if ( '_blank' === $attributes['linkTarget'] ) {
 			$link_attrs[] = 'target="_blank"';
 			$link_attrs[] = 'aria-label="' . esc_attr__( '(opens in a new tab)' ) . '"';
 		}
-		$site_title = sprintf( '<a %1$s>%2$s</a>', implode( ' ', $link_attrs ), $site_title );
+		$site_title = sprintf( '<a %1$s>%2$s</a>', implode( ' ', $link_attrs ), esc_html( $site_title ) );
 	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -30,7 +30,7 @@ function render_block_core_site_title( $attributes ) {
 	if ( $attributes['isLink'] ) {
 		$link_attrs = array(
 			'href="' . esc_url( get_bloginfo( 'url' ) ) . '"',
-			esc_attr( 'rel="home"' ),
+			'rel="' . esc_attr( 'home') . '"',
 			$aria_current,
 		);
 		if ( '_blank' === $attributes['linkTarget'] ) {

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -30,7 +30,7 @@ function render_block_core_site_title( $attributes ) {
 	if ( $attributes['isLink'] ) {
 		$link_attrs = array(
 			'href="' . esc_url( get_bloginfo( 'url' ) ) . '"',
-			'rel="' . esc_attr( 'home') . '"',
+			'rel="' . esc_attr( 'home' ) . '"',
 			$aria_current,
 		);
 		if ( '_blank' === $attributes['linkTarget'] ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves [escaping of all PHP output to be as "late" as possible](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/#:~:text=esc_textarea(%20%24text%20)%3B%20%3F%3E%3C/textarea%3E-,Tip%3A,Output%20escaping%20should%20occur%20as%20late%20as%20possible.,-Top%20%E2%86%91). This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?
- add both blocks
- check functionality is "as was"
- check all tests pass
## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
