### PR TITLE
Late escape Social block

### DIFF
--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -45,7 +45,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		)
 	);
 
-	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor"> ' . esc_html( $icon ) . '</a></li>';
+	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">' . $icon . '</a></li>';
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -32,9 +32,9 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$attribute = '';
+	$rel_target_attributes = '';
 	if ( $open_in_new_tab ) {
-		$attribute = 'rel="noopener nofollow" target="_blank"';
+		$rel_target_attributes = 'rel="' . esc_attr( 'noopener nofollow' ) . '" target="' . esc_attr( '_blank' ) . '"';
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );
@@ -45,7 +45,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		)
 	);
 
-	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $attribute . ' class="wp-block-social-link-anchor"> ' . $icon . '</a></li>';
+	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor"> ' . esc_html( $icon ) . '</a></li>';
 }
 
 /**

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -34,7 +34,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 
 	$rel_target_attributes = '';
 	if ( $open_in_new_tab ) {
-		$rel_target_attributes = 'rel="' . esc_attr( 'noopener nofollow' ) . '" target="' . esc_attr( '_blank' ) . '"';
+		$rel_target_attributes = 'rel="noopener nofollow" target="_blank"';
 	}
 
 	$icon               = block_core_social_link_get_icon( $service );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This is not a security problem. This PR simply moves [escaping of all PHP output to be as "late" as possible](https://developer.wordpress.org/themes/theme-security/data-sanitization-escaping/#:~:text=esc_textarea(%20%24text%20)%3B%20%3F%3E%3C/textarea%3E-,Tip%3A,Output%20escaping%20should%20occur%20as%20late%20as%20possible.,-Top%20%E2%86%91). This means we avoid escaping variables until they are output in the HTML markup.

This is a WP Core best practice.

## How has this been tested?
- add blocks
- check functionality is "as was"
- check all tests pass

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
