### PR TITLE
Load the global styles before the theme styles in the editor

### DIFF
--- a/lib/global-styles.php
+++ b/lib/global-styles.php
@@ -79,7 +79,7 @@ function gutenberg_experimental_global_styles_settings( $settings ) {
 			}
 		}
 
-		$settings['styles'] = array_merge( $styles_without_existing_global_styles, $new_global_styles );
+		$settings['styles'] = array_merge( $new_global_styles, $styles_without_existing_global_styles );
 	}
 
 	// Copied from get_block_editor_settings() at wordpress-develop/block-editor.php.


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/37839
Related core patch https://github.com/WordPress/wordpress-develop/pull/2139

This follows what we do in the front-end, where theme styles are loaded after global styles by default.

## How to test

- Use empty theme and apply the patch below via `git apply <file.patch>`:

<details>
<summary>Patch for empty theme</summary>
<p>

```
diff --git a/emptytheme/functions.php b/emptytheme/functions.php
index 5ee5593..a50baf4 100644
--- a/emptytheme/functions.php
+++ b/emptytheme/functions.php
@@ -6,8 +6,17 @@ if ( ! function_exists( 'emptytheme_support' ) ) :
 		// Adding support for core block visual styles.
 		add_theme_support( 'wp-block-styles' );
 
+		register_block_style(
+			'core/group',
+			array(
+				'name'  => 'background-color-hotpink',
+				'label' => 'BG Hotpink'
+			)
+		);
+
 		// Enqueue editor styles.
 		add_editor_style( 'style.css' );
+
 	}
 	add_action( 'after_setup_theme', 'emptytheme_support' );
 endif;
diff --git a/emptytheme/style.css b/emptytheme/style.css
index c10d92f..0dc53b7 100644
--- a/emptytheme/style.css
+++ b/emptytheme/style.css
@@ -14,3 +14,6 @@ Text Domain: emptytheme
 Emptytheme WordPress Theme, (C) 2021 WordPress.org
 Emptytheme is distributed under the terms of the GNU GPL.
 */
+.is-style-background-color-hotpink {
+    background-color: hotpink;
+}
\ No newline at end of file
diff --git a/emptytheme/theme.json b/emptytheme/theme.json
index 46b0979..1925b81 100644
--- a/emptytheme/theme.json
+++ b/emptytheme/theme.json
@@ -6,5 +6,14 @@
 			"contentSize": "840px",
 			"wideSize": "1100px"
 		}
+	},
+	"styles": {
+		"blocks": {
+			"core/group": {
+				"color": {
+					"background": "green"
+				}
+			}
+		}
 	}
 }
```

</p>
</details>

- Go to the editor and create a group block. Verify background color of the block is green.
- Go to the block sidebar and select the "BG Hotpink" style. Verify the background color of the block is now hotpink.