### PR TITLE
[RNMobile] Buttons block: Fix content justification attribute

### DIFF
--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -9,6 +9,7 @@ import './generated-class-name';
 import './style';
 import './color';
 import './font-size';
+import './layout';
 
 export { getBorderClassesAndStyles, useBorderProps } from './use-border-props';
 export { getColorClassesAndStyles, useColorProps } from './use-color-props';

--- a/packages/block-editor/src/hooks/layout.native.js
+++ b/packages/block-editor/src/hooks/layout.native.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { removeFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import './layout.js';
+
+// This filter is removed because layout styles shouldn't be added
+// until layout types are supported in the native version.
+removeFilter(
+	'editor.BlockListBlock',
+	'core/editor/layout/with-layout-styles'
+);
+
+// This filter is removed because the layout controls shouldn't be
+// enabled until layout types are supported in the native version.
+removeFilter(
+	'editor.BlockEdit',
+	'core/editor/layout/with-inspector-controls'
+);

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -30,7 +30,7 @@ const ALLOWED_BLOCKS = [ buttonBlockName ];
 const layoutProp = { type: 'default', alignments: [] };
 
 export default function ButtonsEdit( {
-	attributes: { contentJustification, align },
+	attributes: { layout, align },
 	clientId,
 	isSelected,
 	setAttributes,
@@ -39,6 +39,7 @@ export default function ButtonsEdit( {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	const { marginLeft: spacing } = styles.spacing;
+	const { justifyContent } = layout || {};
 
 	const { isInnerButtonSelected, shouldDelete } = useSelect(
 		( select ) => {
@@ -126,9 +127,11 @@ export default function ButtonsEdit( {
 				<BlockControls group="block">
 					<JustifyContentControl
 						allowedControls={ justifyControls }
-						value={ contentJustification }
+						value={ justifyContent }
 						onChange={ ( value ) =>
-							setAttributes( { contentJustification: value } )
+							setAttributes( {
+								layout: { ...layout, justifyContent: value },
+							} )
 						}
 						popoverProps={ {
 							position: 'bottom right',
@@ -154,7 +157,7 @@ export default function ButtonsEdit( {
 					shouldRenderFooterAppender && renderFooterAppender.current
 				}
 				orientation="horizontal"
-				horizontalAlignment={ contentJustification }
+				horizontalAlignment={ justifyContent }
 				onDeleteBlock={ shouldDelete ? remove : undefined }
 				onAddBlock={ onAddNextButton }
 				parentWidth={ maxWidth } // This value controls the width of that the buttons are able to expand to.

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -13,7 +13,7 @@ import {
 	JustifyContentControl,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockSupport } from '@wordpress/blocks';
 import { useResizeObserver } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
@@ -35,11 +35,17 @@ export default function ButtonsEdit( {
 	isSelected,
 	setAttributes,
 	blockWidth,
+	name,
 } ) {
 	const [ resizeObserver, sizes ] = useResizeObserver();
 	const [ maxWidth, setMaxWidth ] = useState( 0 );
 	const { marginLeft: spacing } = styles.spacing;
-	const { justifyContent } = layout || {};
+
+	// Extract attributes from block layout
+	const layoutBlockSupport = getBlockSupport( name, '__experimentalLayout' );
+	const defaultBlockLayout = layoutBlockSupport?.default;
+	const usedLayout = layout || defaultBlockLayout || {};
+	const { justifyContent } = usedLayout;
 
 	const { isInnerButtonSelected, shouldDelete } = useSelect(
 		( select ) => {
@@ -130,7 +136,10 @@ export default function ButtonsEdit( {
 						value={ justifyContent }
 						onChange={ ( value ) =>
 							setAttributes( {
-								layout: { ...layout, justifyContent: value },
+								layout: {
+									...usedLayout,
+									justifyContent: value,
+								},
 							} )
 						}
 						popoverProps={ {

--- a/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Buttons block when a button is shown adjusts the border radius 1`] = `
+"<!-- wp:buttons -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button {\\"style\\":{\\"border\\":{\\"radius\\":\\"6px\\"}}} -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\" href=\\"\\" style=\\"border-radius:6px\\">Hello</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->"
+`;

--- a/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Buttons block justify content sets Justify items center option 1`] = `
+"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"center\\"}} -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+<!-- /wp:buttons -->"
+`;
+
+exports[`Buttons block justify content sets Justify items left option 1`] = `
+"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"left\\"}} -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+<!-- /wp:buttons -->"
+`;
+
+exports[`Buttons block justify content sets Justify items right option 1`] = `
+"<!-- wp:buttons {\\"layout\\":{\\"type\\":\\"flex\\",\\"justifyContent\\":\\"right\\"}} -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
+<!-- /wp:buttons -->"
+`;
+
 exports[`Buttons block when a button is shown adjusts the border radius 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button {\\"style\\":{\\"border\\":{\\"radius\\":\\"6px\\"}}} -->

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -27,59 +27,56 @@ afterAll( () => {
 	} );
 } );
 
-describe( 'when a button is shown', () => {
-	it( 'adjusts the border radius', async () => {
-		const initialHtml = `<!-- wp:buttons -->
-		<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"5px"}}} -->
-		<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
-		<!-- /wp:button --></div>
-		<!-- /wp:buttons -->`;
-		const { getByA11yLabel } = await initializeEditor( {
-			initialHtml,
-		} );
+describe( 'Buttons block', () => {
+	describe( 'when a button is shown', () => {
+		it( 'adjusts the border radius', async () => {
+			const initialHtml = `<!-- wp:buttons -->
+			<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"5px"}}} -->
+			<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
+			<!-- /wp:button --></div>
+			<!-- /wp:buttons -->`;
+			const { getByA11yLabel } = await initializeEditor( {
+				initialHtml,
+			} );
 
-		const buttonsBlock = await waitFor( () =>
-			getByA11yLabel( /Buttons Block\. Row 1/ )
-		);
-		fireEvent.press( buttonsBlock );
+			const buttonsBlock = await waitFor( () =>
+				getByA11yLabel( /Buttons Block\. Row 1/ )
+			);
+			fireEvent.press( buttonsBlock );
 
-		// onLayout event has to be explicitly dispatched in BlockList component,
-		// otherwise the inner blocks are not rendered.
-		const innerBlockListWrapper = await waitFor( () =>
-			within( buttonsBlock ).getByTestId( 'block-list-wrapper' )
-		);
-		fireEvent( innerBlockListWrapper, 'layout', {
-			nativeEvent: {
-				layout: {
-					width: 100,
+			// onLayout event has to be explicitly dispatched in BlockList component,
+			// otherwise the inner blocks are not rendered.
+			const innerBlockListWrapper = await waitFor( () =>
+				within( buttonsBlock ).getByTestId( 'block-list-wrapper' )
+			);
+			fireEvent( innerBlockListWrapper, 'layout', {
+				nativeEvent: {
+					layout: {
+						width: 100,
+					},
 				},
-			},
+			} );
+
+			const buttonInnerBlock = await waitFor( () =>
+				within( buttonsBlock ).getByA11yLabel( /Button Block\. Row 1/ )
+			);
+			fireEvent.press( buttonInnerBlock );
+
+			const settingsButton = await waitFor( () =>
+				getByA11yLabel( 'Open Settings' )
+			);
+			fireEvent.press( settingsButton );
+
+			const radiusStepper = await waitFor( () =>
+				getByA11yLabel( /Border Radius/ )
+			);
+
+			const incrementButton = await waitFor( () =>
+				within( radiusStepper ).getByTestId( 'Increment' )
+			);
+			fireEvent( incrementButton, 'onPressIn' );
+
+			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
-
-		const buttonInnerBlock = await waitFor( () =>
-			within( buttonsBlock ).getByA11yLabel( /Button Block\. Row 1/ )
-		);
-		fireEvent.press( buttonInnerBlock );
-
-		const settingsButton = await waitFor( () =>
-			getByA11yLabel( 'Open Settings' )
-		);
-		fireEvent.press( settingsButton );
-
-		const radiusStepper = await waitFor( () =>
-			getByA11yLabel( /Border Radius/ )
-		);
-
-		const incrementButton = await waitFor( () =>
-			within( radiusStepper ).getByTestId( 'Increment' )
-		);
-		fireEvent( incrementButton, 'onPressIn' );
-
-		const expectedHtml = `<!-- wp:buttons -->
-<div class="wp-block-buttons"><!-- wp:button {"style":{"border":{"radius":"6px"}}} -->
-<div class="wp-block-button"><a class="wp-block-button__link" href="" style="border-radius:6px">Hello</a></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->`;
-		expect( getEditorHtml() ).toBe( expectedHtml );
 	} );
 } );

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -79,4 +79,37 @@ describe( 'Buttons block', () => {
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );
 	} );
+
+	describe( 'justify content', () => {
+		[
+			'Justify items left',
+			'Justify items center',
+			'Justify items right',
+		].forEach( ( justificationOption ) =>
+			it( `sets ${ justificationOption } option`, async () => {
+				const initialHtml = `<!-- wp:buttons -->
+				<div class="wp-block-buttons"><!-- wp:button /--></div>
+				<!-- /wp:buttons -->`;
+				const { getByA11yLabel, getByText } = await initializeEditor( {
+					initialHtml,
+				} );
+
+				const block = await waitFor( () =>
+					getByA11yLabel( /Buttons Block\. Row 1/ )
+				);
+				fireEvent.press( block );
+
+				fireEvent.press(
+					getByA11yLabel( 'Change items justification' )
+				);
+
+				// Select alignment option
+				fireEvent.press(
+					await waitFor( () => getByText( justificationOption ) )
+				);
+
+				expect( getEditorHtml() ).toMatchSnapshot();
+			} )
+		);
+	} );
 } );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -10,6 +10,7 @@ For each user feature we should also add a importance categorization label  to i
 -->
 
 ## Unreleased
+-   [**] Fix content justification attribute in Buttons block [#37887]
 
 ## 1.69.0
 -   [*] Give multi-line block names central alignment in inserter [#37185]


### PR DESCRIPTION
**Gutenberg Mobile PR:** https://github.com/wordpress-mobile/gutenberg-mobile/pull/4451

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

In https://github.com/WordPress/gutenberg/pull/35819 the attributes `contentJustification` and `orientation` were removed from the Buttons block schema and replaced by the `__experimentalLayout` attribute. However, the native version of the block wasn't updated and led to the content justification alignment option stops working.
https://github.com/WordPress/gutenberg/blob/43f9ad7e3dbffd90a330229c2a731d368c95f2cf/packages/block-library/src/buttons/edit.native.js#L33

As outlined in the deprecation code for the Buttons block:
https://github.com/WordPress/gutenberg/blob/43f9ad7e3dbffd90a330229c2a731d368c95f2cf/packages/block-library/src/buttons/deprecated.js#L18-L34

These attributes are now provided within the `layout` attribute, however, for having access to this attribute first, we need to enable the layout hooks:
https://github.com/WordPress/gutenberg/blob/43f9ad7e3dbffd90a330229c2a731d368c95f2cf/packages/block-editor/src/hooks/layout.js#L228-L242

Specifically the hook `core/layout/addAttribute` which is in charge of adding the `layout` attribute to the block:
https://github.com/WordPress/gutenberg/blob/43f9ad7e3dbffd90a330229c2a731d368c95f2cf/packages/block-editor/src/hooks/layout.js#L137-L158

This PR imports the layout hooks for the native version, but it only enables the required hook by removing the rest, as the native version doesn't support yet the different layout types hence, we can't include either the layout styles or layout controls.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

### Manual test
1. Open a post/page.
2. Add a Buttons block and select the parent block (Buttons block).
3. Tap on the justification options located in the toolbar (the title of the setting is "Change items justification")
4. Tap the "Justify items center"  or "Justify items right" option.
5. Observe that the justification is applied to the buttons within the editor.
6. Preview the post/page and observe that the same justification is applied.

### Integration test
Additionally, test cases have been added to verify that the content justification attribute produces the expected HTML output using snapshot testing.

If the introduced test would have been run before the https://github.com/WordPress/gutenberg/pull/35819 changes, we would have produced the following snapshot with the old attributes:

<details><summary>Click here to reveal the snapshot</summary>

```
exports[`Buttons block justify content sets Justify items center option 1`] = `
"<!-- wp:buttons {\\"contentJustification\\":\\"center\\"} -->
<div class=\\"wp-block-buttons is-content-justification-center\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;

exports[`Buttons block justify content sets Justify items left option 1`] = `
"<!-- wp:buttons {\\"contentJustification\\":\\"left\\"} -->
<div class=\\"wp-block-buttons is-content-justification-left\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;

exports[`Buttons block justify content sets Justify items right option 1`] = `
"<!-- wp:buttons {\\"contentJustification\\":\\"right\\"} -->
<div class=\\"wp-block-buttons is-content-justification-right\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;
```

</details>

So if the same test is run with current changes in `trunk`, it would have failed because the HTML output is different:

<details><summary>Click here to reveal the snapshot</summary>

```
exports[`Buttons block justify content sets Justify items center option 1`] = `
"<!-- wp:buttons -->
<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;

exports[`Buttons block justify content sets Justify items left option 1`] = `
"<!-- wp:buttons -->
<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;

exports[`Buttons block justify content sets Justify items right option 1`] = `
"<!-- wp:buttons -->
<div class=\\"wp-block-buttons\\"><!-- wp:button /--></div>
<!-- /wp:buttons -->"
`;
```

</details>

As a side note, the snapshot generated after applying this fix can be checked [here](https://github.com/WordPress/gutenberg/blob/1131588cae9d0c1da62aba0e201227419cd31025/packages/block-library/src/buttons/test/__snapshots__/edit.native.js.snap#L3-L19).

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/14905380/148977549-9de6acaa-bde4-425a-ae72-4f72538af915.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
