### PR TITLE
Update copy on Snackbar that appears when a template is deleted

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -138,7 +138,7 @@ export function* removeTemplate( template ) {
 			'createSuccessNotice',
 			sprintf(
 				/* translators: The template/part's name. */
-				__( '"%s" removed.' ),
+				__( '"%s" deleted.' ),
 				template.title.rendered
 			),
 			{ type: 'snackbar' }


### PR DESCRIPTION
Currently the Snackbar reads:

> "Archive" removed.

However, all other references to template deletion use the verb "delete" rather than "remove". E.g. the action to initiate template deletion is labeled "Delete", and the Snackbar that appears if there's an error states that "An error occurred while **deleting** the template."

This PR updates the Snackbar to read:

> "Archive" deleted.