### PR TITLE
Mobile - Gallery block - Fix bug when migrating from V1

### DIFF
--- a/packages/block-library/src/gallery/deprecated.js
+++ b/packages/block-library/src/gallery/deprecated.js
@@ -192,6 +192,10 @@ const v6 = {
 			type: 'boolean',
 			default: true,
 		},
+		fixedHeight: {
+			type: 'boolean',
+			default: true,
+		},
 		linkTo: {
 			type: 'string',
 		},

--- a/packages/block-library/src/gallery/gallery.native.js
+++ b/packages/block-library/src/gallery/gallery.native.js
@@ -35,6 +35,7 @@ export const Gallery = ( props ) => {
 	const {
 		mediaPlaceholder,
 		attributes,
+		images,
 		isNarrow,
 		onBlur,
 		insertBlocksAfter,
@@ -49,7 +50,6 @@ export const Gallery = ( props ) => {
 	}, [ sizes ] );
 
 	const {
-		images,
 		align,
 		columns = defaultColumnsNumber( images.length ),
 	} = attributes;


### PR DESCRIPTION
- Gutenberg Mobile PR -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4456

## Description
There's a current bug on **iOS only** when saving an old version of the Gallery block it would generate a crash.

One of the changes is to use `images` from the props within `gallery.native.js`. Before it was getting it from `attributes` but in some cases when saving after migrating it would be `undefined` other than that it would always return `[]`.

The second change is updating the migration to include `fixedHeight` which is used within the `Image` block to show the size correctly. Without this, the image block wouldn't show the image and the expected size (When migrating). Here I'm not sure if we can update the latest version of the migration or if we should create a new one 🤔 what do you think @mkevins?

## How has this been tested?

- Open the WordPress app
- Create a new page
- Use one of the templates that have a Gallery block. (We need to update these to use the new format)
- Once the page is shown
- Tap on `Update`
- **Expect** the Gallery block to show up correctly without crashing.

## Screenshots <!-- if applicable -->
Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/148984714-bce39445-c4e3-4872-baa1-7d23e9f72889.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/148984491-6ad7905c-3fe6-4696-ae53-351900ebbc99.gif" width="200" /></kbd>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
