### PR TITLE
Docs: Improve Gutenberg release documentation

### DIFF
--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -162,7 +162,7 @@ There is also an option to perform [Standalone Bugfix Package Releases](#standal
 
 For each Gutenberg plugin release, WordPress trunk should be synchronized.
 
-Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, feature freeze in WordPress Core happens about 2 weeks before Beta 1 and remains in effect until RC1 when the trunk gets branched. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
+Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, feature freeze in WordPress Core happens about 2 weeks before Beta 1 and remains in effect until RC1 when the `trunk` gets branched. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
 
 For the normal plugin release process, you shouldn't worry about either synchronizing WordPress trunk or publishing the npm packages. A different person usually handles this. If you are still unsure, please ask in the #core-editor Slack channel.
 

--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -164,7 +164,7 @@ For each Gutenberg plugin release, WordPress trunk should be synchronized.
 
 Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, feature freeze in WordPress Core happens about 2 weeks before Beta 1 and remains in effect until RC1 when the `trunk` gets branched. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
 
-A different person usually synchronizes the WordPress `trunk` branch and publishes the npm packages. So you shouldn't worry about it for the normal plugin release process. However, if you are still unsure whether you should do it or not, please ask in the #core-editor Slack channel.
+A different person usually synchronizes the WordPress `trunk` branch and publishes the npm packages. Therefore, you typically shouldn't need to worry about handling this for the normal plugin release process. However, if you are still unsure, ask in [the #core-editor Slack channel](https://wordpress.slack.com/archives/C02QB2JS7).
 
 The process has three steps: 1) update the `wp/trunk` branch within the Gutenberg repo 2) publish the new package versions to npm 3) update the WordPress `trunk` branch.
 

--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -160,7 +160,11 @@ There is also an option to perform [Standalone Bugfix Package Releases](#standal
 
 ### Synchronizing WordPress Trunk
 
-For each Gutenberg plugin release, WordPress trunk should be synchronized. Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, this happens between the first `beta` and the first `RC` of the WordPress release cycle. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
+For each Gutenberg plugin release, WordPress trunk should be synchronized.
+
+Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, feature freeze in WordPress Core happens about 2 weeks before Beta 1 and remains in effect until RC1 when the trunk gets branched. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
+
+For the normal plugin release process, you shouldn't worry about either synchronizing WordPress trunk or publishing the npm packages. A different person usually handles this. If you are still unsure, please ask in the #core-editor Slack channel.
 
 The process has three steps: 1) update the `wp/trunk` branch within the Gutenberg repo 2) publish the new package versions to npm 3) update the WordPress `trunk` branch.
 

--- a/docs/contributors/code/release.md
+++ b/docs/contributors/code/release.md
@@ -164,7 +164,7 @@ For each Gutenberg plugin release, WordPress trunk should be synchronized.
 
 Note that the WordPress `trunk` branch can be closed or in "feature-freeze" mode. Usually, feature freeze in WordPress Core happens about 2 weeks before Beta 1 and remains in effect until RC1 when the `trunk` gets branched. During this period, the Gutenberg plugin releases should not be synchronized with WordPress Core.
 
-For the normal plugin release process, you shouldn't worry about either synchronizing WordPress trunk or publishing the npm packages. A different person usually handles this. If you are still unsure, please ask in the #core-editor Slack channel.
+A different person usually synchronizes the WordPress `trunk` branch and publishes the npm packages. So you shouldn't worry about it for the normal plugin release process. However, if you are still unsure whether you should do it or not, please ask in the #core-editor Slack channel.
 
 The process has three steps: 1) update the `wp/trunk` branch within the Gutenberg repo 2) publish the new package versions to npm 3) update the WordPress `trunk` branch.
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
We need to update Gutenberg release documentation to better explain if one needs to synchronize WordPress trunk and publish the npm packages or not.
This always causes some confusion during the release process.

## How has this been tested?
This PR doesn't have to be tested.

## Screenshots
No screenshots are needed.

## Types of changes
Improvement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
