### PR TITLE
Add the `gutenberg_enable_block_templates` callback func to the `switch_theme` action

### DIFF
--- a/lib/compat/wordpress-5.9/theme-templates.php
+++ b/lib/compat/wordpress-5.9/theme-templates.php
@@ -85,3 +85,4 @@ function gutenberg_enable_block_templates() {
 // Remove 5.8 filter if existant.
 remove_action( 'setup_theme', 'wp_enable_block_templates' );
 add_action( 'setup_theme', 'gutenberg_enable_block_templates' );
+add_action( 'switch_theme', 'gutenberg_enable_block_templates' );

--- a/phpunit/data/themedir1/block-theme/templates/page-home.html
+++ b/phpunit/data/themedir1/block-theme/templates/page-home.html
@@ -1,0 +1,3 @@
+<!-- wp:paragraph -->
+<p>Home Template</p>
+<!-- /wp:paragraph -->

--- a/phpunit/theme-templates-test.php
+++ b/phpunit/theme-templates-test.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Test the block-templates theme feature.
+ *
+ * @package Gutenberg
+ */
+
+class Theme_Templates_Test extends WP_UnitTestCase {
+
+       function setUp() {
+               parent::setUp();
+               $this->theme_root = realpath( __DIR__ . '/data/themedir1' );
+
+               $this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+
+               // /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+               $GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+               add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+               add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+               add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+               $this->queries = array();
+               // Clear caches.
+               wp_clean_themes_cache();
+               unset( $GLOBALS['wp_themes'] );
+       }
+
+       function tearDown() {
+               $GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+               wp_clean_themes_cache();
+               unset( $GLOBALS['wp_themes'] );
+               parent::tearDown();
+       }
+
+       function filter_set_theme_root() {
+               return $this->theme_root;
+       }
+
+       /**
+        * Tests whether the default non-block theme properly returns
+        * false when checking if the current theme supports the block-teplates
+        * feature.
+        */
+       function test_gutenberg_enable_block_templates_default_theme() {
+               // The `default` theme is not a block theme.
+               $this->assertSame( false, current_theme_supports( 'block-templates' ) );
+
+       }
+
+       /**
+        * Tests whether switching to block theme would make the `current_theme_supports`
+        * function properly return true when checking for `block-templates` feature,
+        * which is being dynamicly added by the Gutenberg plguin to any block theme.
+        */
+       function test_gutenberg_enable_block_templates_swith_theme() {
+               switch_theme( 'block-theme' );
+
+               $this->assertSame( true, current_theme_supports( 'block-templates' ) );
+       }
+
+       /**
+        * tests whether block theme's page templates are available upon switch_theme
+        * function call, in case the newly loaded theme is a block theme.
+        */
+       function test_page_templates_after_theme_switch() {
+               switch_theme( 'block-theme' );
+
+               $block_theme = wp_get_theme();
+
+               $this->assertSame( array( 'page-home' => 'Homepage template' ), $block_theme->get_page_templates() );
+       }
+}


### PR DESCRIPTION
## Description

The newly introduced `block-templates` theme feature, which is being dynamically added to any block based theme ( a theme passing the `wp_is_block_theme()` or `WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()` ) is not being properly applied upon `switch_theme` call.
 
The `gutenberg_enable_block_templates` is currently only hooked to `setup_theme` and thus the new feature is being applied to a theme loaded during the initial WordPress bootstrap (if applicable), but any call to `switch_theme` makes the feature to disappear, even if the switched theme is a block theme.
 
The major drawback of this behavior is that the block theme's page templates can't be properly read, as Gutenberg treats the switched theme as a non-block theme.
 
In order to unlock all Gutenberg features even for themes that are switched to after the WordPress bootstrap, we should hook the `gutenberg_enable_block_templates` callback to `switch_theme` action along with the `setup_theme` one.

_Big kudos to @david-binda for the help with the original fix concept, the description, and the unit tests!_

## How has this been tested?

Unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
