### PR TITLE
Fix flaky test by using waitForResponse to ensure the url details request completes

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -467,12 +467,13 @@ describe( 'Navigation', () => {
 		const draftLink = await page.waitForSelector(
 			'.wp-block-navigation-item__content'
 		);
-		await draftLink.click();
-		await page.waitForResponse(
+		const responsePromise = page.waitForResponse(
 			( response ) =>
 				response.url().includes( 'url-details' ) &&
 				response.status() === 404
 		);
+		const draftCreationPromise = draftLink.click();
+		await Promise.all( [ responsePromise, draftCreationPromise ] );
 		expect( console ).toHaveErroredWith(
 			'Failed to load resource: the server responded with a status of 404 (Not Found)'
 		);

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -435,20 +435,7 @@ describe( 'Navigation', () => {
 		expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 	} );
 
-	it.skip( 'allows pages to be created from the navigation block and their links added to menu', async () => {
-		// The URL Details endpoint 404s for the created page, since it will
-		// be a draft that is inaccessible publicly. To avoid this we mock
-		// out the endpoint response to be empty which will be handled gracefully
-		// in the UI whilst avoiding any 404s.
-		await setUpResponseMocking( [
-			{
-				match: ( request ) =>
-					request.url().includes( `rest_route` ) &&
-					request.url().includes( `url-details` ),
-				onRequestMatch: createJSONResponse( [] ),
-			},
-		] );
-
+	it( 'allows pages to be created from the navigation block and their links added to menu', async () => {
 		await createNewPost();
 		await insertBlock( 'Navigation' );
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
@@ -472,10 +459,23 @@ describe( 'Navigation', () => {
 		);
 		await createPageButton.click();
 
+		// When creating a draft, the URLControl makes a request to the
+		// url-details endpoint to fetch information about the page.
+		// Because the draft is inaccessible publicly, this request
+		// returns a 404 response. Wait for the response and expect
+		// the error to have occurred.
 		const draftLink = await page.waitForSelector(
 			'.wp-block-navigation-item__content'
 		);
 		await draftLink.click();
+		await page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'url-details' ) &&
+				response.status() === 404
+		);
+		expect( console ).toHaveErroredWith(
+			'Failed to load resource: the server responded with a status of 404 (Not Found)'
+		);
 
 		// Creating a draft is async, so wait for a sign of completion. In this
 		// case the link that shows in the URL popover once a link is added.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -453,27 +453,21 @@ describe( 'Navigation', () => {
 		);
 		await input.type( pageTitle );
 
-		// Wait for the create button to appear and click it.
-		const createPageButton = await page.waitForSelector(
-			'.block-editor-link-control__search-create'
-		);
-		await createPageButton.click();
-
-		// When creating a draft, the URLControl makes a request to the
+		// When creating a page, the URLControl makes a request to the
 		// url-details endpoint to fetch information about the page.
 		// Because the draft is inaccessible publicly, this request
 		// returns a 404 response. Wait for the response and expect
 		// the error to have occurred.
-		const draftLink = await page.waitForSelector(
-			'.wp-block-navigation-item__content'
+		const createPageButton = await page.waitForSelector(
+			'.block-editor-link-control__search-create'
 		);
 		const responsePromise = page.waitForResponse(
 			( response ) =>
 				response.url().includes( 'url-details' ) &&
 				response.status() === 404
 		);
-		const draftCreationPromise = draftLink.click();
-		await Promise.all( [ responsePromise, draftCreationPromise ] );
+		const createPagePromise = createPageButton.click();
+		await Promise.all( [ responsePromise, createPagePromise ] );
 		expect( console ).toHaveErroredWith(
 			'Failed to load resource: the server responded with a status of 404 (Not Found)'
 		);


### PR DESCRIPTION
## Description
Alternative to #37755, Fixes #37479

My previous attempt to make this test more robust used the `waitForNetworkIdle` function to ensure the url-details request completed so that the test can handle the 404 it returns. But that didn't seem to work consistently and the test was reported as flaky.

Looking at the docs, I discovered puppeteer has a `waitForResponse` function that should improve the situation.
