### PR TITLE
Block styles: remove box-sizing rule on Post Editor container to achieve editor/frontend parity 

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -120,12 +120,3 @@ html :where(.has-border-color) {
 html :where([style*="border-width"]) {
 	border-style: solid;
 }
-
-/**
- * Ensures that the default box-sizing: border-box in the editor
- * is reflected on the frontend.
- * See: https://github.com/WordPress/gutenberg/pull/37818
- */
-:where(*) {
-	box-sizing: border-box;
-}

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -120,3 +120,12 @@ html :where(.has-border-color) {
 html :where([style*="border-width"]) {
 	border-style: solid;
 }
+
+/**
+ * Ensures that the default box-sizing: border-box in the editor
+ * is reflected on the frontend.
+ * See: https://github.com/WordPress/gutenberg/pull/37818
+ */
+:where(*) {
+	box-sizing: border-box;
+}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -59,9 +59,8 @@ body.block-editor-page {
 	}
 }
 
-// Target the editor UI excluding the metaboxes and custom fields areas.
+// Target the editor UI excluding the visual editor contents, metaboxes and custom fields areas.
 .edit-post-header,
-.edit-post-visual-editor,
 .edit-post-text-editor,
 .edit-post-sidebar,
 .editor-post-publish-panel,


### PR DESCRIPTION
## Description

For editor blocks, there's a [blanket CSS rule for box sizing:border-box](https://github.com/WordPress/gutenberg/blob/a4e3977aa2ed12d61515828d95001e531521eb51/packages/edit-post/src/style.scss#L71) based on a [reset mixin](https://github.com/WordPress/gutenberg/blob/a4e3977aa2ed12d61515828d95001e531521eb51/packages/base-styles/_mixins.scss#L392).

No such blanket rule exists on the frontend or in the Site Editor.

So you might see the following:

| Editor  | Frontend |
| ------------- | ------------- |
|  <img width="400" alt="Screen Shot 2022-01-12 at 2 05 14 pm" src="https://user-images.githubusercontent.com/6458278/149057113-b671b042-1dd3-49a4-833d-75a0399a11fd.png">  | <img width="400" alt="Screen Shot 2022-01-12 at 2 05 27 pm" src="https://user-images.githubusercontent.com/6458278/149057109-1c30be40-c9fa-4762-9187-68649a14bf22.png">  |

Many blocks, for example, Group, Column, Cover, already define their own `box sizing:border-box` rule.

As you can see from the above screenshots, Heading and List do not. 

**This PR proposes to remove the box-sizing rule for elements in the Post Editor (visual editor) to ensure the Post Editor ❤️  Site Editor ❤️ Frontend parity.**

This change could affect existing blocks and patterns with the assumption that some users may expect the editor and frontend to differ in these respects. 

The arguments for this PR are:

- The Post Editor does not reflect the frontend for this specific case
- Removing the anomaly (the Post Editor box-sizing) rather than adding box-sizing to the frontend might avoid unexpected side-effects. At the very least, the box-sizing will be more consistent event if  it's more desirable for blocks to define their own `box sizing:border-box` rule.

For context, see discussion over at:

https://github.com/WordPress/gutenberg/pull/37818#pullrequestreview-847667836

## How has this been tested?

Add patterns, blocks (make sure to liberally add Heading and List blocks) to a new post. 

Apply borders, padding and margins where the block supports them.

Test in various core themes.

In all scenarios, check that the `box sizing:border-box` is consistent across the frontend and Site/Post editors.

## Types of changes
Removing a CSS rule from the post editor

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
