### PR TITLE
Gallery block: add gap support 

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -248,7 +248,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Supports:** align, anchor
+-	**Supports:** align, anchor, spacing (blockGap), units (em, px, rem, vh, vw)
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -93,7 +93,12 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
 			$style    .= "gap: $gap_style;";
-			$style    .= "--wp--style--scoped-block-gap: $gap_style;";
+
+			/*
+			 * In some contexts a flex container's children may be need to recalculate their width
+			 * based on the current gap so this value is made available as a css var.
+			 */
+			$style .= "--wp--style--block-scoped-flex-gap: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -93,6 +93,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
 			$style    .= "gap: $gap_style;";
+			$style    .= "--gallery-block--gutter-size: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';
 		}

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -93,7 +93,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
 			$style    .= "gap: $gap_style;";
-			$style    .= "--gallery-block--gutter-size: $gap_style;";
+			$style    .= "--wp--style--scoped-block-gap: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';
 		}

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -113,7 +113,7 @@ export default {
 				${ appendSelectors( selector ) } {
 					display: flex;
 					gap: ${ hasBlockGapStylesSupport ? blockGapValue : '0.5em' };
-					--wp--style--scoped-block-gap: ${
+					--wp--style--block-scoped-flex-gap: ${
 						hasBlockGapStylesSupport ? blockGapValue : '0.5em'
 					}; 
 					flex-wrap: ${ flexWrap };

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -113,6 +113,9 @@ export default {
 				${ appendSelectors( selector ) } {
 					display: flex;
 					gap: ${ hasBlockGapStylesSupport ? blockGapValue : '0.5em' };
+					--wp--style--scoped-block-gap: ${
+						hasBlockGapStylesSupport ? blockGapValue : '0.5em'
+					}; 
 					flex-wrap: ${ flexWrap };
 					${ orientation === 'horizontal' ? rowOrientation : columnOrientation }
 				}

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -106,7 +106,22 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true
+		"align": true,
+		"units": [ "px", "em", "rem", "vh", "vw" ],
+		"spacing": {
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
+		},
+		"__experimentalLayout": {
+			"allowSwitching": false,
+			"allowInheriting": false,
+			"allowEditing": false,
+			"default": {
+				"type": "flex"
+			}
+		}
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -3,9 +3,9 @@ figure.wp-block-gallery {
 	// to avoid :not() selector specificity issues.
 	// See https://github.com/WordPress/gutenberg/pull/10358
 
-	display: block;
 	margin: 0;
 	&.has-nested-images {
+		display: grid;
 		.components-drop-zone {
 			display: none;
 			pointer-events: none;
@@ -13,11 +13,11 @@ figure.wp-block-gallery {
 	}
 
 	> .blocks-gallery-caption {
-		flex: 0 0 100%;
+		grid-column: 1 / -1;
 	}
 
 	> .blocks-gallery-media-placeholder-wrapper {
-		flex-basis: 100%;
+		grid-column: 1 / -1;
 	}
 
 	.wp-block-image {

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -3,9 +3,9 @@ figure.wp-block-gallery {
 	// to avoid :not() selector specificity issues.
 	// See https://github.com/WordPress/gutenberg/pull/10358
 
+	display: block;
 	margin: 0;
 	&.has-nested-images {
-		display: grid;
 		.components-drop-zone {
 			display: none;
 			pointer-events: none;
@@ -13,11 +13,11 @@ figure.wp-block-gallery {
 	}
 
 	> .blocks-gallery-caption {
-		grid-column: 1 / -1;
+		flex: 0 0 100%;
 	}
 
 	> .blocks-gallery-media-placeholder-wrapper {
-		grid-column: 1 / -1;
+		flex-basis: 100%;
 	}
 
 	.wp-block-image {

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -25,15 +25,7 @@ export const Gallery = ( props ) => {
 		blockProps,
 	} = props;
 
-	const {
-		align,
-		columns,
-		caption,
-		imageCrop,
-		style: {
-			spacing: { blockGap },
-		},
-	} = attributes;
+	const { align, columns, caption, imageCrop } = attributes;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
@@ -75,7 +67,6 @@ export const Gallery = ( props ) => {
 					'is-cropped': imageCrop,
 				}
 			) }
-			style={ { '--gallery-block--gutter-size': blockGap } }
 		>
 			{ children }
 

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -75,7 +75,6 @@ export const Gallery = ( props ) => {
 					'is-cropped': imageCrop,
 				}
 			) }
-			style={ { '--gallery-block--gutter-size': blockGap } }
 		>
 			{ children }
 

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -70,12 +70,6 @@ export const Gallery = ( props ) => {
 		>
 			{ children }
 
-			<View
-				className="blocks-gallery-media-placeholder-wrapper"
-				onClick={ removeCaptionFocus }
-			>
-				{ mediaPlaceholder }
-			</View>
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }
@@ -91,6 +85,14 @@ export const Gallery = ( props ) => {
 					insertBlocksAfter( createBlock( 'core/paragraph' ) )
 				}
 			/>
+			{ isSelected && (
+				<View
+					className="blocks-gallery-media-placeholder-wrapper"
+					onClick={ removeCaptionFocus }
+				>
+					{ mediaPlaceholder }
+				</View>
+			) }
 		</figure>
 	);
 };

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -75,6 +75,7 @@ export const Gallery = ( props ) => {
 					'is-cropped': imageCrop,
 				}
 			) }
+			style={ { '--gallery-block--gutter-size': blockGap } }
 		>
 			{ children }
 

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -25,7 +25,15 @@ export const Gallery = ( props ) => {
 		blockProps,
 	} = props;
 
-	const { align, columns, caption, imageCrop } = attributes;
+	const {
+		align,
+		columns,
+		caption,
+		imageCrop,
+		style: {
+			spacing: { blockGap },
+		},
+	} = attributes;
 
 	const { children, ...innerBlocksProps } = useInnerBlocksProps( blockProps, {
 		allowedBlocks,
@@ -67,6 +75,7 @@ export const Gallery = ( props ) => {
 					'is-cropped': imageCrop,
 				}
 			) }
+			style={ { '--gallery-block--gutter-size': blockGap } }
 		>
 			{ children }
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,23 +3,10 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	display: flex;
-	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 var(--gallery-block--gutter-size, #{$grid-unit-20}) var(--gallery-block--gutter-size, #{$grid-unit-20}) 0;
-
-		&:last-of-type:not(#individual-image) {
-			margin-right: 0;
-		}
-
 		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
-
-		&:nth-of-type(even) {
-			margin-right: 0;
-		}
 	}
 
 	figure.wp-block-image {
@@ -125,7 +112,6 @@
 	}
 
 	&.columns-1 figure.wp-block-image:not(#individual-image) {
-		margin-right: 0;
 		width: 100%;
 	}
 
@@ -133,30 +119,15 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
 				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
 
-			}
-
-			// Prevent collapsing margin while sibling is being dragged.
-			&.columns-#{$i} figure.wp-block-image:not(#individual-image).is-dragging ~ figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-			}
-		}
-		// Unset the right margin on every rightmost gallery item to ensure center balance.
-		@for $column-count from 1 through 8 {
-			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type(#{ $column-count }n) {
-				margin-right: 0;
 			}
 		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
+
 				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
-			}
-			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
-				margin-right: 0;
 			}
 			// If only 2 child images use 2 columns.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,15 +3,17 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
+	display: grid;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
+		width: 100%;
+    	height: 100%;
+    	object-fit: cover
 	}
 
 	figure.wp-block-image {
 		display: flex;
-		flex-grow: 1;
 		justify-content: center;
 		position: relative;
 		margin-top: auto;
@@ -80,8 +82,10 @@
 
 	// Non cropped images.
 	&:not(.is-cropped) {
-
 		figure.wp-block-image:not(#individual-image) {
+			width: 100%;
+			height: initial;
+			object-fit: initial;
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
@@ -111,33 +115,17 @@
 		}
 	}
 
-	&.columns-1 figure.wp-block-image:not(#individual-image) {
-		width: 100%;
-	}
-
 	// Beyond mobile viewports, we allow up to 8 columns.
 	@include break-small {
-		@for $i from 3 through 8 {
-			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
+		@for $i from 1 through 8 {
+			&.columns-#{ $i } {
+				grid-template-columns: repeat($i, 1fr);
 
 			}
 		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
-			figure.wp-block-image:not(#individual-image) {
-
-				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
-			}
-			// If only 2 child images use 2 columns.
-			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
-			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
-				width: calc(50% - (var(--gallery-block--gutter-size, 16px) * 0.5));
-			}
-			// For a single image set to 100%.
-			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {
-				width: 100%;
-			}
+			grid-template-columns: repeat(3, 1fr);
 		}
 	}
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -6,7 +6,7 @@
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
+		width: calc(50% - (var(--wp--style--scoped-block-gap, #{$grid-unit-20}) / 2));
 	}
 
 	figure.wp-block-image {
@@ -85,11 +85,11 @@
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
-				margin-bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				margin-bottom: var(--wp--style--scoped-block-gap, #{$grid-unit-20});
 			}
 
 			figcaption {
-				bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				bottom: var(--wp--style--scoped-block-gap, #{$grid-unit-20});
 			}
 		}
 	}
@@ -119,7 +119,7 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
+				width: calc(#{math.div(100%, $i)} - (var(--wp--style--scoped-block-gap, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
 
 			}
 		}
@@ -127,12 +127,12 @@
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
 
-				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
+				width: calc(33.33% - (var(--wp--style--scoped-block-gap, 16px) * #{math.div(2, 3)}));
 			}
 			// If only 2 child images use 2 columns.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
-				width: calc(50% - (var(--gallery-block--gutter-size, 16px) * 0.5));
+				width: calc(50% - (var(--wp--style--scoped-block-gap, 16px) * 0.5));
 			}
 			// For a single image set to 100%.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,6 +1,11 @@
 // Import styles for rendering the static content of deprecated gallery versions.
 @import "./deprecated.scss";
 
+// The following is a temporary override until flex layout supports
+// an align items setting of normal.
+figure.wp-block-gallery.has-nested-images {
+	align-items: normal;
+}
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
 	// Need bogus :not(#individual-image) to override long :not()
@@ -14,8 +19,6 @@
 		flex-grow: 1;
 		justify-content: center;
 		position: relative;
-		margin-top: auto;
-		margin-bottom: auto;
 		flex-direction: column;
 
 		> div,

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -3,17 +3,15 @@
 
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	display: grid;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		width: 100%;
-    	height: 100%;
-    	object-fit: cover
+		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
 	}
 
 	figure.wp-block-image {
 		display: flex;
+		flex-grow: 1;
 		justify-content: center;
 		position: relative;
 		margin-top: auto;
@@ -82,10 +80,8 @@
 
 	// Non cropped images.
 	&:not(.is-cropped) {
+
 		figure.wp-block-image:not(#individual-image) {
-			width: 100%;
-			height: initial;
-			object-fit: initial;
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
@@ -115,17 +111,33 @@
 		}
 	}
 
+	&.columns-1 figure.wp-block-image:not(#individual-image) {
+		width: 100%;
+	}
+
 	// Beyond mobile viewports, we allow up to 8 columns.
 	@include break-small {
-		@for $i from 1 through 8 {
-			&.columns-#{ $i } {
-				grid-template-columns: repeat($i, 1fr);
+		@for $i from 3 through 8 {
+			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
+				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
 
 			}
 		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
-			grid-template-columns: repeat(3, 1fr);
+			figure.wp-block-image:not(#individual-image) {
+
+				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
+			}
+			// If only 2 child images use 2 columns.
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
+				width: calc(50% - (var(--gallery-block--gutter-size, 16px) * 0.5));
+			}
+			// For a single image set to 100%.
+			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {
+				width: 100%;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #20705

## Description
Adds block gap support to the Gallery block. 

This PR makes use of the gap layout setting added in #37360, but required the addition of a new scoped css var `--wp--style--scoped-block-gap` as the Gallery needs to have access to the current gap setting in css in order to recalculate the width of the images when the gap size changes. 

If this css var is not added, because flex layout is used the number of columns reduces as the gap size increases. 

I investigated using css grid instead of flex, and this works without the use of this var as the number of columns can be fixed and images automatically resize ... but, there is no way to easily make orphaned images in the last row span empty rows, eg. if 3 columns set, and only 5 images, the images on the last row should expand to fill 50% each instead of 33%. There are some css hacks to make this work, but accounting for all the permutations of last row % splits when you have 8 columns is practically impossible.

Flex is designed to handle this sort of layout, so adding the new css var in order to allow the gap support to work seems like the best option, but I am open to suggestions on alternative approaches.

## How has this been tested?

- Add a Gallery block and add a number of images
- Test that the block gap can be adjusted and displays as expected in editor and frontend in both block and non-block themes

## Screenshots 
![gallery-gap](https://user-images.githubusercontent.com/3629020/149414227-4d72c224-0cd1-40e1-a34d-cd19b50cfb75.gif)

