### PR TITLE
Buttons: Preserve styling from adjacent button blocks when inserting a new button block

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -11,6 +11,8 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { store as blockEditorStore } from '../../store';
 import { getLayoutType } from '../../layouts';
 
+/** @typedef {import('../../selectors').WPDirectInsertBlock } WPDirectInsertBlock */
+
 /**
  * This hook is a side effect which updates the block-editor store when changes
  * happen to inner block settings. The given props are transformed into a
@@ -18,20 +20,20 @@ import { getLayoutType } from '../../layouts';
  * the block-editor store, then the store is updated with the new settings which
  * came from props.
  *
- * @param {string}            clientId                   The client ID of the block to update.
- * @param {string[]}          allowedBlocks              An array of block names which are permitted
- *                                                       in inner blocks.
- * @param {?Array}            __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
- * @param {?Function|boolean} __experimentalDirectInsert If a default block should be inserted directly by the
- *                                                       appender.
- * @param {string}            [templateLock]             The template lock specified for the inner
- *                                                       blocks component. (e.g. "all")
- * @param {boolean}           captureToolbars            Whether or children toolbars should be shown
- *                                                       in the inner blocks component rather than on
- *                                                       the child block.
- * @param {string}            orientation                The direction in which the block
- *                                                       should face.
- * @param {Object}            layout                     The layout object for the block container.
+ * @param {string}               clientId                   The client ID of the block to update.
+ * @param {string[]}             allowedBlocks              An array of block names which are permitted
+ *                                                          in inner blocks.
+ * @param {?WPDirectInsertBlock} __experimentalDefaultBlock The default block to insert: [ blockName, { blockAttributes } ].
+ * @param {?Function|boolean}    __experimentalDirectInsert If a default block should be inserted directly by the
+ *                                                          appender.
+ * @param {string}               [templateLock]             The template lock specified for the inner
+ *                                                          blocks component. (e.g. "all")
+ * @param {boolean}              captureToolbars            Whether or children toolbars should be shown
+ *                                                          in the inner blocks component rather than on
+ *                                                          the child block.
+ * @param {string}               orientation                The direction in which the block
+ *                                                          should face.
+ * @param {Object}               layout                     The layout object for the block container.
  */
 export default function useNestedSettingsUpdate(
 	clientId,

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -351,10 +351,10 @@ export default compose( [
 							}
 						}
 					);
-					blockToInsert = createBlock(
-						directInsertBlock.name,
-						newAttributes
-					);
+					blockToInsert = createBlock( directInsertBlock.name, {
+						...newAttributes,
+						...( directInsertBlock.attributes || {} ),
+					} );
 				} else {
 					blockToInsert = createBlock( allowedBlockType.name );
 				}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -353,8 +353,8 @@ export default compose( [
 					);
 
 					blockToInsert = createBlock( directInsertBlock.name, {
-						...newAttributes,
 						...( directInsertBlock.attributes || {} ),
+						...newAttributes,
 					} );
 				} else {
 					blockToInsert = createBlock( allowedBlockType.name );

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -303,15 +303,12 @@ export default compose( [
 					}
 
 					// Copy over only those attributes flagged to be copied.
-					for ( const attribute in attributesToCopy ) {
-						if (
-							attributesToCopy[ attribute ] &&
-							adjacentAttributes.hasOwnProperty( attribute )
-						) {
+					attributesToCopy.forEach( ( attribute ) => {
+						if ( adjacentAttributes.hasOwnProperty( attribute ) ) {
 							result[ attribute ] =
 								adjacentAttributes[ attribute ];
 						}
-					}
+					} );
 
 					return result;
 				}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -176,7 +176,7 @@ class Inserter extends Component {
 			onSelectOrClose,
 		} = this.props;
 
-		if ( hasSingleBlockType || directInsertBlock?.length ) {
+		if ( hasSingleBlockType || directInsertBlock ) {
 			return this.renderToggle( { onToggle: insertOnlyAllowedBlock } );
 		}
 
@@ -351,6 +351,7 @@ export default compose( [
 							}
 						}
 					);
+
 					blockToInsert = createBlock( directInsertBlock.name, {
 						...newAttributes,
 						...( directInsertBlock.attributes || {} ),

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -353,8 +353,7 @@ export default compose( [
 					);
 					blockToInsert = createBlock(
 						directInsertBlock.name,
-						newAttributes,
-						directInsertBlock.innerBlocks
+						newAttributes
 					);
 				} else {
 					blockToInsert = createBlock( allowedBlockType.name );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1844,10 +1844,15 @@ export const __experimentalGetAllowedBlocks = createSelector(
 /**
  * Returns the block to be directly inserted by the block appender.
  *
- * @param {Object}  state        Editor state.
- * @param {?string} rootClientId Optional root client ID of block list.
+ * @param    {Object}  state            Editor state.
+ * @param    {?string} rootClientId     Optional root client ID of block list.
  *
- * @return {?Array} The block type to be directly inserted.
+ * @return {?WPDirectInsertBlock}       The block type to be directly inserted.
+ *
+ * @typedef {Object} WPDirectInsertBlock
+ * @property {string}  name             The type of block.
+ * @property {?Object} attributes       Attributes to pass to the newly created block.
+ * @property {?Object} attributesToCopy Attributes to be copied from adjecent blocks when inserted.
  */
 export const __experimentalGetDirectInsertBlock = createSelector(
 	( state, rootClientId = null ) => {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1844,15 +1844,15 @@ export const __experimentalGetAllowedBlocks = createSelector(
 /**
  * Returns the block to be directly inserted by the block appender.
  *
- * @param    {Object}  state            Editor state.
- * @param    {?string} rootClientId     Optional root client ID of block list.
+ * @param    {Object}         state            Editor state.
+ * @param    {?string}        rootClientId     Optional root client ID of block list.
  *
- * @return {?WPDirectInsertBlock}       The block type to be directly inserted.
+ * @return {?WPDirectInsertBlock}              The block type to be directly inserted.
  *
  * @typedef {Object} WPDirectInsertBlock
- * @property {string}  name             The type of block.
- * @property {?Object} attributes       Attributes to pass to the newly created block.
- * @property {?Object} attributesToCopy Attributes to be copied from adjecent blocks when inserted.
+ * @property {string}         name             The type of block.
+ * @property {?Object}        attributes       Attributes to pass to the newly created block.
+ * @property {?Array<string>} attributesToCopy Attributes to be copied from adjecent blocks when inserted.
  */
 export const __experimentalGetDirectInsertBlock = createSelector(
 	( state, rootClientId = null ) => {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -19,8 +19,12 @@ const DEFAULT_BLOCK = {
 	name: buttonBlockName,
 	attributesToCopy: {
 		backgroundColor: true,
+		border: true,
 		className: true,
+		fontSize: true,
+		fontFamily: true,
 		gradient: true,
+		style: true,
 		textColor: true,
 		width: true,
 	},

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -15,15 +15,16 @@ import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 
-// The undefined attributes below ensure that text and url attributes are cleared
-// when a new button block is inserted adjacent to existing button blocks.
-const DEFAULT_BLOCK = [
-	buttonBlockName,
-	{
-		text: undefined,
-		url: undefined,
+const DEFAULT_BLOCK = {
+	name: buttonBlockName,
+	attributesToCopy: {
+		backgroundColor: true,
+		className: true,
+		gradient: true,
+		textColor: true,
+		width: true,
 	},
-];
+};
 
 function ButtonsEdit( { attributes: { layout = {} } } ) {
 	const blockProps = useBlockProps();

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -15,6 +15,16 @@ import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 
+// The undefined attributes below ensure that text and url attributes are cleared
+// when a new button block is inserted adjacent to existing button blocks.
+const DEFAULT_BLOCK = [
+	buttonBlockName,
+	{
+		text: undefined,
+		url: undefined,
+	},
+];
+
 function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
 	const blockProps = useBlockProps();
 	const preferredStyle = useSelect( ( select ) => {
@@ -41,12 +51,7 @@ function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
-		__experimentalDefaultBlock: [
-			buttonBlockName,
-			{
-				...defaultAttributes,
-			},
-		],
+		__experimentalDefaultBlock: DEFAULT_BLOCK,
 		__experimentalDirectInsert: true,
 		template: [
 			[

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -17,17 +17,17 @@ const ALLOWED_BLOCKS = [ buttonBlockName ];
 
 const DEFAULT_BLOCK = {
 	name: buttonBlockName,
-	attributesToCopy: {
-		backgroundColor: true,
-		border: true,
-		className: true,
-		fontSize: true,
-		fontFamily: true,
-		gradient: true,
-		style: true,
-		textColor: true,
-		width: true,
-	},
+	attributesToCopy: [
+		'backgroundColor',
+		'border',
+		'className',
+		'fontFamily',
+		'fontSize',
+		'gradient',
+		'style',
+		'textColor',
+		'width',
+	],
 };
 
 function ButtonsEdit( { attributes: { layout = {} } } ) {

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -25,7 +25,7 @@ const DEFAULT_BLOCK = [
 	},
 ];
 
-function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
+function ButtonsEdit( { attributes: { layout = {} } } ) {
 	const blockProps = useBlockProps();
 	const preferredStyle = useSelect( ( select ) => {
 		const preferredStyleVariations = select(
@@ -33,21 +33,6 @@ function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
 		).getSettings().__experimentalPreferredStyleVariations;
 		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
-
-	const innerBlocks = useSelect(
-		( select ) => {
-			return select( blockEditorStore ).getBlock( clientId )?.innerBlocks;
-		},
-		[ clientId ]
-	);
-
-	let defaultAttributes = {};
-
-	if ( innerBlocks?.length ) {
-		defaultAttributes = { ...innerBlocks[ 0 ].attributes };
-		defaultAttributes.text = undefined;
-		defaultAttributes.url = undefined;
-	}
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -15,7 +15,7 @@ import { name as buttonBlockName } from '../button';
 
 const ALLOWED_BLOCKS = [ buttonBlockName ];
 
-function ButtonsEdit( { attributes: { layout = {} } } ) {
+function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
 	const blockProps = useBlockProps();
 	const preferredStyle = useSelect( ( select ) => {
 		const preferredStyleVariations = select(
@@ -24,8 +24,30 @@ function ButtonsEdit( { attributes: { layout = {} } } ) {
 		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
+	const innerBlocks = useSelect(
+		( select ) => {
+			return select( blockEditorStore ).getBlock( clientId )?.innerBlocks;
+		},
+		[ clientId ]
+	);
+
+	let defaultAttributes = {};
+
+	if ( innerBlocks?.length ) {
+		defaultAttributes = { ...innerBlocks[ 0 ].attributes };
+		defaultAttributes.text = undefined;
+		defaultAttributes.url = undefined;
+	}
+
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
+		__experimentalDefaultBlock: [
+			buttonBlockName,
+			{
+				...defaultAttributes,
+			},
+		],
+		__experimentalDirectInsert: true,
 		template: [
 			[
 				buttonBlockName,

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -47,10 +47,25 @@ import { speak } from '@wordpress/a11y';
  */
 import { ItemSubmenuIcon } from './icons';
 import { name } from './block.json';
+import navigationLinkMetadata from '../navigation-link/block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
-const DEFAULT_BLOCK = [ 'core/navigation-link' ];
+const DEFAULT_BLOCK = [
+	'core/navigation-link',
+	{
+		...Object.entries( navigationLinkMetadata.attributes ).reduce(
+			( acc, attribute ) => ( {
+				...acc,
+				[ attribute[ 0 ] ]:
+					attribute[ 1 ].default !== undefined
+						? attribute[ 1 ].default
+						: undefined,
+			} ),
+			{}
+		),
+	},
+];
 
 const MAX_NESTING = 5;
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -51,6 +51,7 @@ import navigationLinkMetadata from '../navigation-link/block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
+// Set default block to use default or undefined attribute values when inserted.
 const DEFAULT_BLOCK = [
 	'core/navigation-link',
 	{

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -47,26 +47,12 @@ import { speak } from '@wordpress/a11y';
  */
 import { ItemSubmenuIcon } from './icons';
 import { name } from './block.json';
-import navigationLinkMetadata from '../navigation-link/block.json';
 
 const ALLOWED_BLOCKS = [ 'core/navigation-link', 'core/navigation-submenu' ];
 
-// Set default block to use default or undefined attribute values when inserted.
-const DEFAULT_BLOCK = [
-	'core/navigation-link',
-	{
-		...Object.entries( navigationLinkMetadata.attributes ).reduce(
-			( acc, attribute ) => ( {
-				...acc,
-				[ attribute[ 0 ] ]:
-					attribute[ 1 ].default !== undefined
-						? attribute[ 1 ].default
-						: undefined,
-			} ),
-			{}
-		),
-	},
-];
+const DEFAULT_BLOCK = {
+	name: 'core/navigation-link',
+};
 
 const MAX_NESTING = 5;
 

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,7 +14,6 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-import navigationLinkMetadata from '../../navigation-link/block.json';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
@@ -28,22 +27,9 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
-// Set default block to use default or undefined attribute values when inserted.
-const DEFAULT_BLOCK = [
-	'core/navigation-link',
-	{
-		...Object.entries( navigationLinkMetadata.attributes ).reduce(
-			( acc, attribute ) => ( {
-				...acc,
-				[ attribute[ 0 ] ]:
-					attribute[ 1 ].default !== undefined
-						? attribute[ 1 ].default
-						: undefined,
-			} ),
-			{}
-		),
-	},
-];
+const DEFAULT_BLOCK = {
+	name: 'core/navigation-link',
+};
 
 const LAYOUT = {
 	type: 'default',

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -14,6 +14,7 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
+import navigationLinkMetadata from '../../navigation-link/block.json';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
@@ -27,7 +28,22 @@ const ALLOWED_BLOCKS = [
 	'core/navigation-submenu',
 ];
 
-const DEFAULT_BLOCK = [ 'core/navigation-link' ];
+// Set default block to use default or undefined attribute values when inserted.
+const DEFAULT_BLOCK = [
+	'core/navigation-link',
+	{
+		...Object.entries( navigationLinkMetadata.attributes ).reduce(
+			( acc, attribute ) => ( {
+				...acc,
+				[ attribute[ 0 ] ]:
+					attribute[ 1 ].default !== undefined
+						? attribute[ 1 ].default
+						: undefined,
+			} ),
+			{}
+		),
+	},
+];
 
 const LAYOUT = {
 	type: 'default',


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #37904

This PR updates the Inserter logic for the `defaultBlock` to attempt to use attributes from an adjacent similar block when inserting a new block directly between two blocks. The use case is primarily for the Buttons block, where clicking between two individual Button blocks inserts a new button. For layouts or patterns that use full-width buttons (e.g. a Link in Bio pattern), or buttons with particular styling, it might make it smoother for users if in the inserted button we use those existing attributes.

I'd love feedback on whether or not this is universal enough to be added to the `defaultBlock` logic added by @tellthemachines in #34899.

The logic in this PR includes:

* In the inserter, when a block is being directly inserted via the inserter, attempt to get the attributes from the previous block if it is of the same block type, and the `directInsertBlock` has an `attributesToCopy` array with matching attribute names.
* If that isn't possible (e.g. you're clicking the last inserter in the Buttons block) then attempt to get the attributes from the last of the inner blocks.
* I've refactored the `directInsertBlock` to be an object instead of an array (to allow for the `attributesToCopy` prop) and added a typedef

For a precedent surrounding the suggested behaviour when inserting the button block, currently if you hit "enter" on a button block to fire the `onSplit` function, it [uses the existing attributes](https://github.com/wordpress/gutenberg/blob/8f4726f339332f4008e32e9906c93ee72a1f791b/packages/block-library/src/button/edit.js#L186) when creating the new button block.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Insert a Buttons block and add a few buttons. Set them to 100% width and / or some color styles.
2. Hover between the blocks and click the inserter to add a Button block. The styling of the previous Button block should be preserved.
3. Select the parent Buttons block and click the inserter at the end of the list of Button blocks. The newly inserted Button block should preserve the styling/attributes of the last block in the list.
4. Ensure that link / text is not preserved in the inserted block.
5. Double-check that this change doesn't introduce regressions for those blocks that already use the `__experimentalDefaultBlock` option when registering the block (e.g. Navigation and Navigation Submenu blocks)

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/14988353/149276720-6f213efb-4c8d-4c8f-899c-d3308c4f265d.mp4

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Somewhere between a bug fix and an enhancement (I'd argue it's an enhancement but it will likely feel like a bug fix to some users)

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
