### PR TITLE
Gutenberg Release Workflow: Fix no unreleased pull requests error

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -193,7 +193,7 @@ jobs:
               run: |
                   IFS='.' read -r -a VERSION_ARRAY <<< "${VERSION}"
                   MILESTONE="Gutenberg ${VERSION_ARRAY[0]}.${VERSION_ARRAY[1]}"
-                  npm run changelog -- --milestone="$MILESTONE" --unreleased > release-notes.txt
+                  npm run changelog -- --milestone="$MILESTONE" --unreleased --version="${{ github.event.inputs.version }}" > release-notes.txt
                   sed -ie '1,6d' release-notes.txt
                   if [[ ${{ needs.bump-version.outputs.new_version }} != *"rc"* ]]; then
                     # Include previous RCs' release notes, if any

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -57,6 +57,11 @@ program
 	.option( '-m, --milestone <milestone>', 'Milestone' )
 	.option( '-t, --token <token>', 'Github token' )
 	.option(
+		'--version <version>',
+		'The version to be released. Either "rc" or "stable"',
+		'rc'
+	)
+	.option(
 		'-u, --unreleased',
 		"Only include PRs that haven't been included in a release yet"
 	)

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -31,6 +31,7 @@ const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
  *
  * @property {string=}  milestone  Optional Milestone title.
  * @property {string=}  token      Optional personal access token.
+ * @property {string=}  version    Optional "rc" or "stable" version. Defaults to "rc".
  * @property {boolean=} unreleased Optional flag to only include issues that haven't been part of a release yet.
  */
 
@@ -40,6 +41,7 @@ const UNKNOWN_FEATURE_FALLBACK_NAME = 'Uncategorized';
  * @property {string}   owner      Repository owner.
  * @property {string}   repo       Repository name.
  * @property {string=}  token      Optional personal access token.
+ * @property {string}  version     Optional "rc" or "stable" version.
  * @property {string}   milestone  Milestone title.
  * @property {boolean=} unreleased Only include issues that have been closed since the milestone's latest release.
  */
@@ -645,6 +647,13 @@ async function getChangelog( settings ) {
 
 	const pullRequests = await fetchAllPullRequests( octokit, settings );
 	if ( ! pullRequests.length ) {
+		if ( settings.version === 'stable' ) {
+			// No need to return an error for this case.
+			return (
+				'There are no additional pull requests associated with this milestone. ' +
+				'You can delete this line.\n'
+			);
+		}
 		if ( settings.unreleased ) {
 			throw new Error(
 				'There are no unreleased pull requests associated with the milestone.'
@@ -791,6 +800,7 @@ async function getReleaseChangelog( options ) {
 		owner: config.githubRepositoryOwner,
 		repo: config.githubRepositoryName,
 		token: options.token,
+		version: options.version || 'rc',
 		milestone:
 			options.milestone === undefined
 				? // Disable reason: valid-sprintf applies to `@wordpress/i18n` where


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### What

I've modified the release workflow to avoid throwing an error when no additional pull requests have been added to the milestone after the release candidates.

### Why

Because even if the message is correct, showing the word `Error` along with the stack trace gives the impression that something went wrong when it actually didn't.

[I bumped into that error](https://wordpress.slack.com/archives/C02QB2JS7/p1641377484274900?thread_ts=1641374819.273300&cid=C02QB2JS7) when I did the 12.3 release. [It happened](https://wordpress.slack.com/archives/C02QB2JS7/p1637771006080000?thread_ts=1637769197.079100&cid=C02QB2JS7) to @ryanwelcher in the 12.0 release as well.

### How

I've modified the workflow to pass down the version (either `rc` or `stable`) to the function and used it to determine if it should throw an error or just print a line.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

I've tested it manually in my own fork.

<a href="https://www.loom.com/share/b7dffbd217064a1e88a0fc332513bf63">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/b7dffbd217064a1e88a0fc332513bf63-with-play.gif">
  </a>

https://www.loom.com/share/b7dffbd217064a1e88a0fc332513bf63

## Checklist:
- [x] My code is manually tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
