### PR TITLE
[Block Library]: Remove font family support from 5.9 blocks

### DIFF
--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -64,7 +64,6 @@
 		},
 		"typography": {
 			"fontSize": true,
-			"__experimentalFontFamily": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -40,7 +40,6 @@
 		"className": false,
 		"typography": {
 			"fontSize": true,
-			"__experimentalFontFamily": true,
 			"lineHeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -85,7 +85,6 @@
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalTextTransform": true,
-			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -28,7 +28,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -42,7 +42,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalTextTransform": true,

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -30,7 +30,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -25,7 +25,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -40,7 +40,6 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalFontFamily": true,
 			"__experimentalTextTransform": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -28,7 +28,6 @@
 		},
 		"typography": {
 			"fontSize": true,
-			"__experimentalFontFamily": true,
 			"lineHeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/37826



From the issue:
>While testing 5.9 RC1 I found that the font family selection for paragraphs was not yet available. @carolinan and @bph mentioned the issue #37586, however, it was discussed to revert that feature as the Webfont API is not ready yet, so it got removed with PR #37815.

>While further testing I noticed that it is still in use by several blocks and to avoid unneccessary confusion in 5.9, I'd suggest to have it removed from those blocks as well:


There are nine blocks in core that have this setting.