### PR TITLE
Editor: Fix post lock data inconsistency

### DIFF
--- a/lib/compat/wordpress-6.0/post-lock.php
+++ b/lib/compat/wordpress-6.0/post-lock.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Post Lock data filters.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Update post lock error and add user display nama.
+ *
+ * @param array $response  The Heartbeat response.
+ * @param array $data      The $_POST data sent.
+ * @return array The Heartbeat response.
+ */
+function gutenberg_refresh_post_lock( $response, $data ) {
+	if ( ! isset( $response['wp-refresh-post-lock']['lock_error'] ) ) {
+		return $response;
+	}
+
+	if ( array_key_exists( 'wp-refresh-post-lock', $data ) ) {
+		$received = $data['wp-refresh-post-lock'];
+
+		$post_id = absint( $received['post_id'] );
+		if ( ! $post_id ) {
+			return $response;
+		}
+
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return $response;
+		}
+
+		$user_id = wp_check_post_lock( $post_id );
+		$user    = get_userdata( $user_id );
+		if ( $user ) {
+			$response['wp-refresh-post-lock']['lock_error']['name'] = $user->display_name;
+		}
+	}
+
+	return $response;
+}
+add_filter( 'heartbeat_received', 'gutenberg_refresh_post_lock', 20, 2 );
+
+/**
+ * Updates post editor settings and adds avatar to the `postLock` user details.
+ *
+ * @param array                   $settings             Default editor settings.
+ * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_update_post_lock_details( $settings, $block_editor_context ) {
+	if ( empty( $block_editor_context->post ) ) {
+		return $settings;
+	}
+
+	if ( ! isset( $settings['postLock']['user'] ) ) {
+		return $settings;
+	}
+
+	$user_id = wp_check_post_lock( $block_editor_context->post->ID );
+	if ( $user_id ) {
+		$settings['postLock']['user']['avatar'] = get_avatar_url( $user_id, array( 'size' => 64 ) );
+	}
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_update_post_lock_details', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,6 +126,7 @@ require __DIR__ . '/compat/wordpress-5.9/default-theme-supports.php';
 require __DIR__ . '/compat/wordpress-5.9/class-gutenberg-rest-global-styles-controller.php';
 require __DIR__ . '/compat/wordpress-5.9/rest-active-global-styles.php';
 require __DIR__ . '/compat/wordpress-5.9/move-theme-editor-menu-item.php';
+require __DIR__ . '/compat/wordpress-6.0/post-lock.php';
 require __DIR__ . '/compat/experimental/blocks.php';
 
 require __DIR__ . '/blocks.php';

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -102,6 +102,7 @@ export default function PostLockedModal() {
 					isLocked: true,
 					isTakeover: true,
 					user: {
+						name: received.lock_error.name,
 						avatar: received.lock_error.avatar_src,
 					},
 				} );


### PR DESCRIPTION
## Description
Part of #37725.

PR fixed post lock data inconsistency between editor settings and heartbeat response. The editor settings were missing the user avatar and heartbeat user display name.

P.S. I will try to create a core patch later this week.

## How has this been tested?
Create two admin user accounts. Save a post as one user, then log in as the other user in an incognito mode and load the same post.

* Modal should display user avatar.
* Switch back to the initial browser window and for a heartbeat to update post lock, which might take little time.
* Confirm that message includes user display name.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-12 at 14 53 57](https://user-images.githubusercontent.com/240569/149128699-6eacde10-032f-43cf-99b8-e42b0ac4db90.png)
![CleanShot 2022-01-12 at 14 54 28](https://user-images.githubusercontent.com/240569/149128705-606e0bef-96e3-46d7-8ca5-fc01c03acfce.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
