### PR TITLE
Add transform between core/site-logo and core/site-title blocks

### DIFF
--- a/packages/block-library/src/site-logo/index.js
+++ b/packages/block-library/src/site-logo/index.js
@@ -8,6 +8,7 @@ import { siteLogo as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -15,4 +16,5 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	transforms,
 };

--- a/packages/block-library/src/site-logo/transforms.js
+++ b/packages/block-library/src/site-logo/transforms.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/site-title' ],
+			transform: ( { isLink, linkTarget } ) => {
+				return createBlock( 'core/site-title', {
+					isLink,
+					linkTarget,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/site-title/index.js
+++ b/packages/block-library/src/site-title/index.js
@@ -9,6 +9,7 @@ import { mapMarker as icon } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 import deprecated from './deprecated';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
@@ -16,5 +17,6 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	transforms,
 	deprecated,
 };

--- a/packages/block-library/src/site-title/transforms.js
+++ b/packages/block-library/src/site-title/transforms.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/site-logo' ],
+			transform: ( { isLink, linkTarget } ) => {
+				return createBlock( 'core/site-logo', {
+					isLink,
+					linkTarget,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
Closes #37919 by adding a transform between the site logo and site title blocks. 

## Description
Added block transforms between the `core/site-logo` and `core/site-title` blocks. 

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/1813435/149186019-8d167b1c-6d52-4ccc-9777-88edd45cd1cf.mp4

## Types of changes
Add block transforms between the site-logo and site-title blocks.
