### PR TITLE
Fix erroneous react-dom usage in native tests

### DIFF
--- a/packages/element/src/react-platform.native.js
+++ b/packages/element/src/react-platform.native.js
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { AppRegistry } from 'react-native';
+
+/**
+ * Registers an app root component allowing the native system to run the app.
+ *
+ * @param {string}   appKey            Unique app name identifier.
+ * @param {Function} componentProvider Function returning the app root React component.
+ */
+export const registerComponent = ( appKey, componentProvider ) => {
+	AppRegistry.registerComponent( appKey, componentProvider );
+};

--- a/packages/react-native-editor/src/index.js
+++ b/packages/react-native-editor/src/index.js
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import 'react-native-gesture-handler';
-import { AppRegistry } from 'react-native';
 
 /**
  * WordPress dependencies
  */
 import { applyFilters, doAction } from '@wordpress/hooks';
-import { Component, cloneElement } from '@wordpress/element';
+import { Component, cloneElement, registerComponent } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -77,7 +76,7 @@ const registerGutenberg = ( {
 		}
 	}
 
-	AppRegistry.registerComponent( 'gutenberg', () => Gutenberg );
+	registerComponent( 'gutenberg', () => Gutenberg );
 };
 
 export { initialHtml as initialHtmlGutenberg, registerGutenberg, setupLocale };

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { AppRegistry } from 'react-native';
+import { AppRegistry, Text } from 'react-native';
 import { render, waitFor } from 'test/helpers';
 
 /**
@@ -176,9 +176,19 @@ describe( 'Register Gutenberg', () => {
 		expect( hookCallOrder ).toBeGreaterThan( onRenderEditorCallOrder );
 	} );
 
-	it( 'initializes the editor', () => {
-		const { getByTestId } = initGutenberg();
-		const blockList = waitFor( () => getByTestId( 'block-list-wrapper' ) );
+	it( 'initializes the editor', async () => {
+		const MockEditor = () => <Text>Mock Editor</Text>;
+		jest.mock( '../setup', () => {
+			return {
+				__esModule: true,
+				default: jest.fn( () => <MockEditor /> ),
+			};
+		} );
+
+		const screen = initGutenberg();
+		const blockList = await waitFor( () =>
+			screen.getByText( 'Mock Editor' )
+		);
 		expect( blockList ).toBeDefined();
 	} );
 } );


### PR DESCRIPTION
## Description
Reinstate `react-platform.native.js` file, which was removed in https://github.com/WordPress/gutenberg/commit/b7b62d2d3db4395ce5d2ad42bd1fc0f1c3c2f12d, as it was no longer strictly necessary. However, the removal led to Jest loading the DOM-specific version of the file when mocking Gutenberg modules that depended upon `react-platform.js`. Jest would seemingly load `react-dom` when attempting to auto-mock the module, e.g. [`reusable-block-types-tab.native.js`](https://github.com/WordPress/gutenberg/blob/bea24fbd7ec829ed84c5dd30e5416052440f5171/packages/block-editor/src/components/inserter/test/reusable-blocks-tab.native.js#L19) > [`use-select/index.js`](https://github.com/WordPress/gutenberg/blob/bea24fbd7ec829ed84c5dd30e5416052440f5171/packages/data/src/components/use-select/index.js#L10) > [`@wordpress/element`](https://github.com/WordPress/gutenberg/blob/bea24fbd7ec829ed84c5dd30e5416052440f5171/packages/element/src/index.js#L3) > [`react-platform.js`](https://github.com/WordPress/gutenberg/blob/bea24fbd7ec829ed84c5dd30e5416052440f5171/packages/element/src/react-platform.js#L4-L9). Reinstating `react-platform.native.js` addresses this issue by ensuring that Jest does not encounter an import of `react-dom`.

<details><summary>react-dom Error Details</summary>

```
TypeError: Cannot use 'in' operator to search for 'WebkitAnimation' in undefined

  at getVendorPrefixedEventName (node_modules/react-dom/cjs/react-dom.development.js:5011:58)
  at node_modules/react-dom/cjs/react-dom.development.js:5019:21
  at Object.<anonymous> (node_modules/react-dom/cjs/react-dom.development.js:26261:5)
  at Object.<anonymous> (node_modules/react-dom/index.js:37:20)
```

</details>

Additionally, these changes fix a false-positive `ReactNativeEditor` test. This test failed when run in isolation. It would appear it was dependent upon the `jest.mock('../setup')` found in sibling tests.

After defining a mock for this specific test, it was discovered that the assertion did not await the asynchronous query found within the test. The assertion resulted in a false-positive as the returned query `Promise` technically matches `toBeDefined`. `async`/`await` was added to ensure the test assertion awaits the query result, as well as fixes the following related log warning.

<details><summary>Async Test Warning</summary>

```
A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.
```

</details>

## How has this been tested?
- Verified native tests pass locally.
- Verified native Demo editor launched on device without issue.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
