### PR TITLE
Update versions for 5.8.2 and 5.8.3

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -7,6 +7,8 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
 | 10.8-11.9          | 5.9               |
+| 10.0-10.7          | 5.8.3             |
+| 10.0-10.7          | 5.8.2             |
 | 10.0-10.7          | 5.8.1             |
 | 10.0-10.7          | 5.8               |
 | 9.3-9.9            | 5.7.1             |


### PR DESCRIPTION
Accidentally got a bit behind on keeping the "Versions in WordPress" doc up to date for the 5.8.* point releases. This catches us up :)
