### PR TITLE
Add tools slot on the navigation and widgets page settings menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16617,6 +16617,7 @@
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/media-utils": "file:packages/media-utils",
 				"@wordpress/notices": "file:packages/notices",
+				"@wordpress/plugins": "file:packages/plugins",
 				"@wordpress/url": "file:packages/url",
 				"classnames": "^2.3.1",
 				"lodash": "^4.17.21",

--- a/packages/edit-navigation/package.json
+++ b/packages/edit-navigation/package.json
@@ -48,6 +48,7 @@
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/media-utils": "file:../media-utils",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/plugins": "file:../plugins",
 		"@wordpress/url": "file:../url",
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",

--- a/packages/edit-navigation/src/components/header/more-menu.js
+++ b/packages/edit-navigation/src/components/header/more-menu.js
@@ -6,10 +6,15 @@ import { external } from '@wordpress/icons';
 import { MoreMenuDropdown } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import ToolsMoreMenuGroup from './tools-more-menu-group';
+
 export default function MoreMenu() {
 	return (
 		<MoreMenuDropdown>
-			{ () => (
+			{ ( onClose ) => (
 				<MenuGroup label={ __( 'Tools' ) }>
 					<MenuItem
 						role="menuitem"
@@ -26,6 +31,7 @@ export default function MoreMenu() {
 							}
 						</VisuallyHidden>
 					</MenuItem>
+					<ToolsMoreMenuGroup.Slot fillProps={ { onClose } } />
 				</MenuGroup>
 			) }
 		</MoreMenuDropdown>

--- a/packages/edit-navigation/src/components/header/tools-more-menu-group.js
+++ b/packages/edit-navigation/src/components/header/tools-more-menu-group.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
+	'EditNavigationToolsMoreMenuGroup'
+);
+
+ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
+	<Slot fillProps={ fillProps }>{ ( fills ) => fills }</Slot>
+);
+
+export default ToolsMoreMenuGroup;

--- a/packages/edit-navigation/src/components/layout/index.js
+++ b/packages/edit-navigation/src/components/layout/index.js
@@ -18,6 +18,7 @@ import {
 } from '@wordpress/interface';
 import { __ } from '@wordpress/i18n';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
+import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -200,6 +201,7 @@ export default function Layout( { blockEditorSettings } ) {
 						<UnsavedChangesWarning />
 					</BlockEditorProvider>
 					<Popover.Slot />
+					<PluginArea />
 				</SlotFillProvider>
 			</ShortcutProvider>
 		</ErrorBoundary>

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -14,6 +14,7 @@ import { useViewportMatch } from '@wordpress/compose';
  * Internal dependencies
  */
 import KeyboardShortcutHelpModal from '../keyboard-shortcut-help-modal';
+import ToolsMoreMenuGroup from './tools-more-menu-group';
 
 export default function MoreMenu() {
 	const [
@@ -33,7 +34,7 @@ export default function MoreMenu() {
 	return (
 		<>
 			<MoreMenuDropdown>
-				{ () => (
+				{ ( onClose ) => (
 					<>
 						{ isLargeViewport && (
 							<MenuGroup label={ _x( 'View', 'noun' ) }>
@@ -84,6 +85,9 @@ export default function MoreMenu() {
 									}
 								</VisuallyHidden>
 							</MenuItem>
+							<ToolsMoreMenuGroup.Slot
+								fillProps={ { onClose } }
+							/>
 						</MenuGroup>
 						<MenuGroup label={ __( 'Preferences' ) }>
 							<MoreMenuFeatureToggle

--- a/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.js
+++ b/packages/edit-widgets/src/components/more-menu/tools-more-menu-group.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill } from '@wordpress/components';
+
+const { Fill: ToolsMoreMenuGroup, Slot } = createSlotFill(
+	'EditWidgetsToolsMoreMenuGroup'
+);
+
+ToolsMoreMenuGroup.Slot = ( { fillProps } ) => (
+	<Slot fillProps={ fillProps }>
+		{ ( fills ) => ! isEmpty( fills ) && fills }
+	</Slot>
+);
+
+export default ToolsMoreMenuGroup;


### PR DESCRIPTION
## Description

This PR adds a slot on the `edit-navigation` and `edit-widgets` page's settings menu so one can extend the menu as needed.

## How to test this PR

### Widgets page

- Activate a classic theme;
- Go to `Appearance > Widgets`;
- Open the developer console and input the following snippet:

```js
var el = wp.element.createElement;
var Fill = wp.components.Fill;
var registerPlugin = wp.plugins.registerPlugin;

registerPlugin( 'more-menu-items', {
  render: function() {
    return el(
      Fill,
      { name: 'EditWidgetsToolsMoreMenuGroup' },
      el('span', {}, 'hello, world')
    );
  }
} );
```

You should see the "hello, world" string rendered inside the settings menu:

![image](https://user-images.githubusercontent.com/26530524/149223200-c298ef2e-88dc-42a1-9c16-fec1ac283796.png)

### Navigation page

- Enable the Navigation screen inside `Gutenberg > Experiments`;
- Go to `Gutenberg > Navigation (Beta)`;
- Open the developer console and input the following snippet:

```js
var el = wp.element.createElement;
var Fill = wp.components.Fill;
var registerPlugin = wp.plugins.registerPlugin;

registerPlugin( 'more-menu-items', {
  render: function() {
    return el(
      Fill,
      { name: 'EditNavigationToolsMoreMenuGroup' },
      el('span', {}, 'hello, world')
    );
  }
} );
```

You should see the "hello, world" string rendered inside the settings menu:

![image](https://user-images.githubusercontent.com/26530524/149223523-12918dc6-ea1e-4fc6-bd32-2a253710e1f6.png)

## Types of changes

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
