### PR TITLE
Docgen/stop crashing on missing return types

### DIFF
--- a/packages/docgen/lib/get-jsdoc-from-token.js
+++ b/packages/docgen/lib/get-jsdoc-from-token.js
@@ -48,7 +48,7 @@ module.exports = ( token ) => {
 					token,
 					0
 				);
-				if ( potentialTypeAnnotation !== '' ) {
+				if ( potentialTypeAnnotation ) {
 					jsdoc.tags.push( {
 						tag: 'type',
 						type: potentialTypeAnnotation,

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -454,7 +454,7 @@ function getQualifiedObjectPatternTypeAnnotation( tag, paramType ) {
  * @param {CommentTag} tag              The documented parameter.
  * @param {ASTNode}    declarationToken The function the parameter is documented on.
  * @param {number}     paramIndex       The parameter index.
- * @return {null | string} The parameter's type annotation.
+ * @return {string?} The parameter's type annotation.
  */
 function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 	const functionToken = getFunctionToken( declarationToken );
@@ -480,59 +480,43 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 		! paramToken.typeAnnotation ||
 		! paramToken.typeAnnotation.typeAnnotation
 	) {
-		return null;
+		return;
 	}
 
 	const paramType = paramToken.typeAnnotation.typeAnnotation;
 	const isQualifiedName = tag.name.includes( '.' );
 
-	try {
-		if (
-			babelTypes.isIdentifier( paramToken ) ||
-			babelTypes.isRestElement( paramToken ) ||
-			( ( babelTypes.isArrayPattern( paramToken ) ||
-				babelTypes.isObjectPattern( paramToken ) ) &&
-				! isQualifiedName )
-		) {
-			return getTypeAnnotation( paramType );
-		} else if ( babelTypes.isArrayPattern( paramToken ) ) {
-			return getQualifiedArrayPatternTypeAnnotation( tag, paramType );
-		} else if ( babelTypes.isObjectPattern( paramToken ) ) {
-			return getQualifiedObjectPatternTypeAnnotation( tag, paramType );
-		}
-	} catch ( e ) {
-		throw new Error(
-			`Could not understand type for parameter '${
-				tag.name
-			}' in function '${ getFunctionNameForError( declarationToken ) }'.`
-		);
+	if (
+		babelTypes.isIdentifier( paramToken ) ||
+		babelTypes.isRestElement( paramToken ) ||
+		( ( babelTypes.isArrayPattern( paramToken ) ||
+			babelTypes.isObjectPattern( paramToken ) ) &&
+			! isQualifiedName )
+	) {
+		return getTypeAnnotation( paramType );
+	} else if ( babelTypes.isArrayPattern( paramToken ) ) {
+		return getQualifiedArrayPatternTypeAnnotation( tag, paramType );
+	} else if ( babelTypes.isObjectPattern( paramToken ) ) {
+		return getQualifiedObjectPatternTypeAnnotation( tag, paramType );
 	}
 }
 
 /**
  * @param {ASTNode} declarationToken A function token.
- * @return {null | string} The function's return type annotation.
+ * @return {string?} The function's return type annotation.
  */
 function getReturnTypeAnnotation( declarationToken ) {
 	const functionToken = getFunctionToken( declarationToken );
 	if ( ! functionToken.returnType ) {
-		return null;
+		return;
 	}
 
-	try {
-		return getTypeAnnotation( functionToken.returnType.typeAnnotation );
-	} catch ( e ) {
-		throw new Error(
-			`Could not understand return type for function '${ getFunctionNameForError(
-				declarationToken
-			) }'.`
-		);
-	}
+	return getTypeAnnotation( functionToken.returnType.typeAnnotation );
 }
 
 /**
  * @param {ASTNode} declarationToken
- * @return {string} The type annotation for the variable.
+ * @return {string?} The type annotation for the variable.
  */
 function getVariableTypeAnnotation( declarationToken ) {
 	let resolvedToken = declarationToken;
@@ -553,7 +537,6 @@ function getVariableTypeAnnotation( declarationToken ) {
 		return getTypeAnnotation( resolvedToken.typeAnnotation.typeAnnotation );
 	} catch ( e ) {
 		// assume it's a fully undocumented variable, there's nothing we can do about that but fail silently.
-		return '';
 	}
 }
 

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -397,7 +397,10 @@ function getFunctionToken( token ) {
 
 function getFunctionNameForError( declarationToken ) {
 	let namedFunctionToken = declarationToken;
-	if ( babelTypes.isExportNamedDeclaration( declarationToken ) ) {
+	if (
+		babelTypes.isExportNamedDeclaration( declarationToken ) ||
+		babelTypes.isExportDefaultDeclaration( declarationToken )
+	) {
 		namedFunctionToken = declarationToken.declaration;
 	}
 
@@ -502,16 +505,19 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 
 /**
  * @param {ASTNode} declarationToken A function token.
- * @return {null | string} The function's return type annoation.
+ * @return {null | string} The function's return type annotation.
  */
 function getReturnTypeAnnotation( declarationToken ) {
 	const functionToken = getFunctionToken( declarationToken );
+	if ( ! functionToken.returnType ) {
+		return 'unknown (see the source)';
+	}
 
 	try {
 		return getTypeAnnotation( functionToken.returnType.typeAnnotation );
 	} catch ( e ) {
 		throw new Error(
-			`Could not find return type for function '${ getFunctionNameForError(
+			`Could not understand return type for function '${ getFunctionNameForError(
 				declarationToken
 			) }'.`
 		);

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -472,15 +472,21 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 		);
 	}
 
+	if ( babelTypes.isAssignmentPattern( paramToken ) ) {
+		paramToken = paramToken.left;
+	}
+
+	if (
+		! paramToken.typeAnnotation ||
+		! paramToken.typeAnnotation.typeAnnotation
+	) {
+		return null;
+	}
+
+	const paramType = paramToken.typeAnnotation.typeAnnotation;
 	const isQualifiedName = tag.name.includes( '.' );
 
 	try {
-		if ( babelTypes.isAssignmentPattern( paramToken ) ) {
-			paramToken = paramToken.left;
-		}
-
-		const paramType = paramToken.typeAnnotation.typeAnnotation;
-
 		if (
 			babelTypes.isIdentifier( paramToken ) ||
 			babelTypes.isRestElement( paramToken ) ||
@@ -496,7 +502,7 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 		}
 	} catch ( e ) {
 		throw new Error(
-			`Could not find type for parameter '${
+			`Could not understand type for parameter '${
 				tag.name
 			}' in function '${ getFunctionNameForError( declarationToken ) }'.`
 		);

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -545,7 +545,7 @@ module.exports =
 	 * @param {CommentTag}    tag   A comment tag.
 	 * @param {ASTNode}       token A function token.
 	 * @param {number | null} index The index of the parameter or `null` if not a param tag.
-	 * @return {null | string} The type annotation for the given tag or null if the tag has no type annotation.
+	 * @return {[string]} The type annotation for the given tag or null if the tag has no type annotation.
 	 */
 	function ( tag, token, index ) {
 		// If the file is using JSDoc type annotations, use the JSDoc.
@@ -562,9 +562,6 @@ module.exports =
 			}
 			case 'type': {
 				return getVariableTypeAnnotation( token );
-			}
-			default: {
-				return '';
 			}
 		}
 	};

--- a/packages/docgen/lib/get-type-annotation.js
+++ b/packages/docgen/lib/get-type-annotation.js
@@ -510,7 +510,7 @@ function getParamTypeAnnotation( tag, declarationToken, paramIndex ) {
 function getReturnTypeAnnotation( declarationToken ) {
 	const functionToken = getFunctionToken( declarationToken );
 	if ( ! functionToken.returnType ) {
-		return 'unknown (see the source)';
+		return null;
 	}
 
 	try {

--- a/packages/docgen/lib/markdown/formatter.js
+++ b/packages/docgen/lib/markdown/formatter.js
@@ -60,9 +60,6 @@ const getHeading = ( index, text ) => {
 };
 
 const getTypeOutput = ( tag ) => {
-	if ( ! tag.type ) {
-		return '<abbr title="See the documentation for more complete types">*</abbr>';
-	}
 	if ( tag.optional ) {
 		return `\`[${ tag.type }]\``;
 	}
@@ -117,27 +114,27 @@ module.exports = (
 				'Type',
 				getSymbolTagsByName( symbol, 'type' ),
 				( tag ) =>
-					`\n- ${ getTypeOutput( tag ) }${ cleanSpaces(
-						` ${ tag.name } ${ tag.description }`
-					) }`,
+					`\n- ${
+						tag.type ? getTypeOutput( tag ) : ''
+					}${ cleanSpaces( ` ${ tag.name } ${ tag.description }` ) }`,
 				docs
 			);
 			formatTag(
 				'Parameters',
 				getSymbolTagsByName( symbol, 'param' ),
 				( tag ) =>
-					`\n- *${ tag.name }* ${ getTypeOutput(
-						tag
-					) }: ${ cleanSpaces( tag.description ) }`,
+					`\n- *${ tag.name }* ${
+						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
+					}${ cleanSpaces( tag.description ) }`,
 				docs
 			);
 			formatTag(
 				'Returns',
 				getSymbolTagsByName( symbol, 'return' ),
 				( tag ) => {
-					return `\n- ${ getTypeOutput( tag ) }: ${ cleanSpaces(
-						`${ tag.name } ${ tag.description }`
-					) }`;
+					return `\n- ${
+						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
+					}${ cleanSpaces( `${ tag.name } ${ tag.description }` ) }`;
 				},
 				docs
 			);
@@ -151,9 +148,9 @@ module.exports = (
 				'Properties',
 				getSymbolTagsByName( symbol, 'property' ),
 				( tag ) =>
-					`\n- *${ tag.name }* ${ getTypeOutput(
-						tag
-					) }: ${ cleanSpaces( tag.description ) }`,
+					`\n- *${ tag.name }* ${
+						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
+					}${ cleanSpaces( tag.description ) }`,
 				docs
 			);
 			docs.push( '\n' );

--- a/packages/docgen/lib/markdown/formatter.js
+++ b/packages/docgen/lib/markdown/formatter.js
@@ -60,6 +60,9 @@ const getHeading = ( index, text ) => {
 };
 
 const getTypeOutput = ( tag ) => {
+	if ( ! tag.type ) {
+		return '<abbr title="See the documentation for more complete types">*</abbr>';
+	}
 	if ( tag.optional ) {
 		return `\`[${ tag.type }]\``;
 	}

--- a/packages/docgen/lib/markdown/formatter.js
+++ b/packages/docgen/lib/markdown/formatter.js
@@ -18,7 +18,7 @@ const formatTag = ( title, tags, formatter, docs ) => {
 		docs.push( '\n' );
 		docs.push( `*${ title }*` );
 		docs.push( '\n' );
-		docs.push( ...tags.map( formatter ) );
+		docs.push( ...tags.map( ( tag ) => `\n${ formatter( tag ) }` ) );
 	}
 };
 
@@ -103,54 +103,88 @@ module.exports = (
 			formatTag(
 				'Related',
 				getSymbolTagsByName( symbol, 'see', 'link' ),
-				( tag ) =>
-					`\n- ${ tag.name.trim() }${
-						tag.description ? ' ' : ''
-					}${ tag.description.trim() }`,
+				( tag ) => {
+					const name = tag.name.trim();
+					const desc = tag.description.trim();
+
+					// prettier-ignore
+					return desc
+						? `- ${ name } ${ desc }`
+						: `- ${ name }`;
+				},
 				docs
 			);
 			formatExamples( getSymbolTagsByName( symbol, 'example' ), docs );
 			formatTag(
 				'Type',
 				getSymbolTagsByName( symbol, 'type' ),
-				( tag ) =>
-					`\n- ${
-						tag.type ? getTypeOutput( tag ) : ''
-					}${ cleanSpaces( ` ${ tag.name } ${ tag.description }` ) }`,
+				( tag ) => {
+					const type = tag.type && getTypeOutput( tag );
+					const desc = cleanSpaces(
+						`${ tag.name } ${ tag.description }`
+					);
+
+					// prettier-ignore
+					return type
+						? `- ${ type }${ desc }`
+						: `- ${ desc }`;
+				},
 				docs
 			);
 			formatTag(
 				'Parameters',
 				getSymbolTagsByName( symbol, 'param' ),
-				( tag ) =>
-					`\n- *${ tag.name }* ${
-						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
-					}${ cleanSpaces( tag.description ) }`,
+				( tag ) => {
+					const name = tag.name;
+					const type = tag.type && getTypeOutput( tag );
+					const desc = cleanSpaces( tag.description );
+
+					return type
+						? `- *${ name }* ${ type }: ${ desc }`
+						: `- *${ name }* ${ desc }`;
+				},
 				docs
 			);
 			formatTag(
 				'Returns',
 				getSymbolTagsByName( symbol, 'return' ),
 				( tag ) => {
-					return `\n- ${
-						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
-					}${ cleanSpaces( `${ tag.name } ${ tag.description }` ) }`;
+					const type = tag.type && getTypeOutput( tag );
+					const desc = cleanSpaces(
+						`${ tag.name } ${ tag.description }`
+					);
+
+					// prettier-ignore
+					return type
+						? `- ${ type }: ${ desc }`
+						: `- ${ desc }`;
 				},
 				docs
 			);
 			formatTag(
 				'Type Definition',
 				getSymbolTagsByName( symbol, 'typedef' ),
-				( tag ) => `\n- *${ tag.name }* ${ getTypeOutput( tag ) }`,
+				( tag ) => {
+					const name = tag.name;
+					const type = getTypeOutput( tag );
+
+					return `- *${ name }* ${ type }`;
+				},
 				docs
 			);
 			formatTag(
 				'Properties',
 				getSymbolTagsByName( symbol, 'property' ),
-				( tag ) =>
-					`\n- *${ tag.name }* ${
-						tag.type ? `${ getTypeOutput( tag ) }: ` : ''
-					}${ cleanSpaces( tag.description ) }`,
+				( tag ) => {
+					const name = tag.name;
+					const type = tag.type && getTypeOutput( tag );
+					const desc = cleanSpaces( tag.description );
+
+					// prettier-ignore
+					return type
+						? `- *${ name }* ${ type }: ${ desc }`
+						: `- *${ name }* ${ desc }`
+				},
 				docs
 			);
 			docs.push( '\n' );

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -85,14 +85,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -117,14 +110,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -149,14 +135,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -181,14 +160,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -213,14 +185,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -279,14 +244,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -311,14 +269,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -343,14 +294,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "firstDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			  Object {
 			    "description": "My declaration example.",
@@ -358,14 +302,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "secondDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -443,14 +380,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -467,14 +397,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -510,14 +433,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -550,14 +466,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );
@@ -590,14 +499,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			  Object {
 			    "description": "Variable declaration example.",
@@ -605,14 +507,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "variableDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			  Object {
 			    "description": "Class declaration example.",
@@ -660,14 +555,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 11,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			  Object {
 			    "description": "Class declaration example.",
@@ -699,14 +587,7 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "variableDeclaration",
 			    "path": null,
-			    "tags": Array [
-			      Object {
-			        "description": "",
-			        "name": "",
-			        "tag": "type",
-			        "type": undefined,
-			      },
-			    ],
+			    "tags": Array [],
 			  },
 			]
 		` );

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -85,7 +85,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -110,7 +117,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -135,7 +149,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -160,7 +181,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -185,7 +213,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -244,7 +279,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -269,7 +311,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -294,7 +343,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "firstDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			  Object {
 			    "description": "My declaration example.",
@@ -302,7 +358,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "secondDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -380,7 +443,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 4,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -397,7 +467,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "default",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -433,7 +510,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -466,7 +550,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 6,
 			    "name": "myDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );
@@ -499,7 +590,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			  Object {
 			    "description": "Variable declaration example.",
@@ -507,7 +605,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "variableDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			  Object {
 			    "description": "Class declaration example.",
@@ -555,7 +660,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 11,
 			    "name": "functionDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			  Object {
 			    "description": "Class declaration example.",
@@ -587,7 +699,14 @@ describe( 'Intermediate Representation', () => {
 			    "lineStart": 16,
 			    "name": "variableDeclaration",
 			    "path": null,
-			    "tags": Array [],
+			    "tags": Array [
+			      Object {
+			        "description": "",
+			        "name": "",
+			        "tag": "type",
+			        "type": undefined,
+			      },
+			    ],
 			  },
 			]
 		` );

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -36,7 +36,7 @@ describe( 'Type annotations', () => {
 		};
 		const node = {};
 		const result = getTypeAnnotation( tag, node, 0 );
-		expect( result ).toBe( '' );
+		expect( result ).toBeFalsy();
 	} );
 
 	const paramTag = {

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -196,12 +196,12 @@ describe( 'Type annotations', () => {
 	describe( 'missing types', () => {
 		const node = getMissingTypesNode();
 
-		it( 'should return null if there is no return type', () => {
-			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBeNull();
+		it( 'should return empty value if there is no return type', () => {
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBeFalsy();
 		} );
 
-		it( 'should return null if there is no param type', () => {
-			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBeNull();
+		it( 'should return empty value if there is no param type', () => {
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBeFalsy();
 		} );
 	} );
 

--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -196,16 +196,12 @@ describe( 'Type annotations', () => {
 	describe( 'missing types', () => {
 		const node = getMissingTypesNode();
 
-		it( 'should throw an error if there is no return type', () => {
-			expect( () => getTypeAnnotation( returnTag, node, 0 ) ).toThrow(
-				"Could not find return type for function 'fn'."
-			);
+		it( 'should return null if there is no return type', () => {
+			expect( getTypeAnnotation( returnTag, node, 0 ) ).toBeNull();
 		} );
 
-		it( 'should throw an error if there is no param type', () => {
-			expect( () => getTypeAnnotation( paramTag, node, 0 ) ).toThrow(
-				"Could not find type for parameter 'foo' in function 'fn'."
-			);
+		it( 'should return null if there is no param type', () => {
+			expect( getTypeAnnotation( paramTag, node, 0 ) ).toBeNull();
 		} );
 	} );
 


### PR DESCRIPTION
Resolves #37766 

## Description

The `docgen` process currently fails in a number of circumstances where it's trying to find type information, specifically return-type information, and can't find it. As highlighted in PRs converting modules to TypeScript, this introduces a mismatch in how some idiomatic code will be written and in the case where we can't find type information we should quietly accept that and remove the type information from the generated docs.

Eventually it would be nice to get better inference from TypeScript on the types it knows, but some issues around type usefulness remain. For now, this patch makes the process more lenient so that it doesn't hold up other changes and so
that we avoid pushing developers from writing value-lacking types such as `{Object}` or `{Function}` for the sake of getting past the linter.

For example, by removing the JSDoc type annotations in #37239 we find the corresponding changes to the `data` package's `README`. The JSDoc description still provides the helpful part of documenting the types and has a lower risk chance of getting out of sync with the code than it would be to annotate `Function` or `<InnerProps extends HOCProps>(Inner: ComponentType<InnerProps>) => {} extends HOCProps ? ComponentType<...> : ComponentType<...>`

```
Δ packages/data/README.md
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

──────────────────────────────────────────────────────┐
• 761: const ParentProvidingRegistry = ( props ) => { │
──────────────────────────────────────────────────────┘
761 ⋮761 │
762 ⋮762 │_Returns_
763 ⋮763 │
764 ⋮    │-   `Function`: A custom react hook exposing the registry context value.
    ⋮764 │-   A custom react hook exposing the registry context value.
765 ⋮765 │
766 ⋮766 │### useSelect
767 ⋮767 │

Δ packages/data/src/components/registry-provider/use-registry.js
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

───────────────────────────────────────────┐
• 45: import { Context } from './context'; │
───────────────────────────────────────────┘
 45 ⋮ 45 │ * };
 46 ⋮ 46 │ * ```
 47 ⋮ 47 │ *
 48 ⋮    │ * @return {Function}  A custom react hook exposing the registry context value.
    ⋮ 48 │ * @return A custom react hook exposing the registry context value.
 49 ⋮ 49 │ */
 50 ⋮ 50 │export default function useRegistry() {
 51 ⋮ 51 │    return useContext( Context );
```

## How has this been tested?

After re-building the package the reference docs were re-generated and no differences in output were found against `trunk` (given that we don't introduce any of the cases that would have broken the `docgen` in this PR we expect no changes).

## Types of changes
This changes the build pipeline, namely it relaxes the requirement that a JSDoc entry for a value that has a description also has an explicit type listed.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
