### PR TITLE
Fix flaky classic block conversion undo test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/classic.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/classic.test.js
@@ -45,8 +45,10 @@ describe( 'Classic', () => {
 		await page.keyboard.type( 'test' );
 
 		// Click the image button.
-		await page.waitForSelector( 'div[aria-label^="Add Media"]' );
-		await page.click( 'div[aria-label^="Add Media"]' );
+		const addMediaButton = await page.waitForSelector(
+			'div[aria-label^="Add Media"]'
+		);
+		await addMediaButton.click();
 
 		await page.click( '.media-menu-item#menu-item-gallery' );
 
@@ -92,6 +94,7 @@ describe( 'Classic', () => {
 
 		// Check that you can undo back to a Classic block gallery in one step.
 		await pressKeyWithModifier( 'primary', 'z' );
+		await page.waitForSelector( 'div[aria-label="Block: Classic"]' );
 		expect( await getEditedPostContent() ).toMatch(
 			/\[gallery ids=\"\d+\"\]/
 		);


### PR DESCRIPTION
## Description
Fixes #36123. Or at least attempts to.

This test inserts a classic block with a gallery. Converts it to blocks, and then uses undo to convert it back to a classic block again.

The error happens just after the undo step, the test expects a classic block but instead the converted block content is still present:
```
    Expected pattern: /\[gallery ids=\"\d+\"\]/
    Received string:  "<!-- wp:paragraph -->
    <p>test</p>
    <!-- /wp:paragraph -->·
    <!-- wp:gallery {\"columns\":3,\"linkTo\":\"none\"} -->
    <figure class=\"wp-block-gallery has-nested-images columns-3 is-cropped\"><!-- wp:image {\"id\":308} -->
    <figure class=\"wp-block-image\"><img src=\"http://localhost:8889/wp-content/uploads/2022/01/ea61b3da-4a08-4715-9b71-b668a1a796b1.png\" alt=\"\" class=\"wp-image-308\"/></figure>
    <!-- /wp:image --></figure>
    <!-- /wp:gallery -->"
 ```

I think the test needs to wait for the `undo` to take effect, but it doesn't and the assertion is happening too quickly. I've added a `waitForSelector` that waits for the classic block to be present.