### PR TITLE
Unset inherited backgrounds on social icons.

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -4,6 +4,13 @@
 		display: inline-block;
 		margin-left: $grid-unit-10;
 	}
+
+	// Unset background colors that can be inherited from Global Styles.
+	// This is a duplicate of a rule in style.scss, as it needs higher specificity in the editor.
+	// The rule can be removed if editor styles get lowered in specificity.
+	&.wp-block-social-links {
+		background: none;
+	}
 }
 
 // Prevent toolbar from jumping when selecting / hovering a link.

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -6,6 +6,11 @@
 	// Some themes give all <ul> default margin instead of padding.
 	margin-left: 0;
 
+	// Unset background colors that can be inherited from Global Styles with extra specificity.
+	&.wp-block-social-links {
+		background: none;
+	}
+
 	// Some themes add underlines, false underlines (via shadows), and borders to <a>.
 	.wp-social-link a,
 	.wp-social-link a:hover {

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -6,10 +6,8 @@
 	// Some themes give all <ul> default margin instead of padding.
 	margin-left: 0;
 
-	// Unset background colors that can be inherited from Global Styles with extra specificity.
-	&.wp-block-social-links {
-		background: none;
-	}
+	// Unset background colors that can be inherited from Global Styles.
+	background: none;
 
 	// Some themes add underlines, false underlines (via shadows), and borders to <a>.
 	.wp-social-link a,


### PR DESCRIPTION
## Description

If you set the List block to have a specific background color in global styles, the `ul` block is targetted, making that color bleed into the Social Icons block:

<img width="800" alt="Screenshot 2022-01-13 at 09 39 03" src="https://user-images.githubusercontent.com/1204802/149296351-76de2249-c5f6-4435-8699-04163b50cea9.png">

As an alternative approach to #37528, this PR unsets any inherited background colors in the social icons block, stopping the cascade:

<img width="734" alt="Screenshot 2022-01-13 at 09 44 14" src="https://user-images.githubusercontent.com/1204802/149296405-c6b949f8-1fc5-459f-a297-6fa4fd793af1.png">


## How has this been tested?

Change the background color of the List block in global styles. Then insert a Social Icons block, it should still have a transparent background.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
