### PR TITLE
Unset inherited backgrounds on Posts Lists.

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -11,6 +11,11 @@
 	list-style: none;
 	padding: 0;
 
+	// Unset background colors that can be inherited from Global Styles with extra specificity.
+	&.wp-block-post-template {
+		background: none;
+	}
+
 	&.is-flex-container {
 		flex-direction: row;
 		display: flex;


### PR DESCRIPTION
## Description

Makes progress on #37388, alternative to #37528, and goes well with #37940. 

If you set the List block to have a specific background color in global styles, the ul block is targetted, making that color bleed into the Posts List and Query Loop blocks:

<img width="1220" alt="before" src="https://user-images.githubusercontent.com/1204802/149297278-c20d0ed8-8255-414f-8c58-6bfadfdb7122.png">

This PR unsets any inherited colors on the `ul` element used:

<img width="887" alt="Screenshot 2022-01-13 at 09 50 00" src="https://user-images.githubusercontent.com/1204802/149297419-778fbb06-d026-424d-803d-ac5123ed3eb9.png">


## How has this been tested?
Change the background color of the List block in global styles. Then insert a Posts List or Query Loop block, they should still have a transparent background.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
