### PR TITLE
[Block Library - Post Featured Image]: Show all the controls when inside a Query Loop

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -92,9 +92,36 @@ function PostFeaturedImageDisplay( {
 		createErrorNotice( message[ 2 ], { type: 'snackbar' } );
 	};
 
+	const controls = (
+		<>
+			<DimensionControls
+				clientId={ clientId }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+			<InspectorControls>
+				<PanelBody title={ __( 'Link settings' ) }>
+					<ToggleControl
+						label={ sprintf(
+							// translators: %s: Name of the post type e.g: "post".
+							__( 'Link to %s' ),
+							postType
+						) }
+						onChange={ () => setAttributes( { isLink: ! isLink } ) }
+						checked={ isLink }
+					/>
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
 	let image;
 	if ( ! featuredImage && isDescendentOfQueryLoop ) {
-		return <div { ...blockProps }>{ placeholderChip }</div>;
+		return (
+			<>
+				{ controls }
+				<div { ...blockProps }>{ placeholderChip }</div>
+			</>
+		);
 	}
 
 	const label = __( 'Add a featured image' );
@@ -138,24 +165,7 @@ function PostFeaturedImageDisplay( {
 
 	return (
 		<>
-			<DimensionControls
-				clientId={ clientId }
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-			/>
-			<InspectorControls>
-				<PanelBody title={ __( 'Link settings' ) }>
-					<ToggleControl
-						label={ sprintf(
-							// translators: %s: Name of the post type e.g: "post".
-							__( 'Link to %s' ),
-							postType
-						) }
-						onChange={ () => setAttributes( { isLink: ! isLink } ) }
-						checked={ isLink }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			{ controls }
 			{ !! media && ! isDescendentOfQueryLoop && (
 				<BlockControls group="other">
 					<MediaReplaceFlow


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37799

From the issue:

>When the post featured image block is placed inside a query and post template, the featured image is represented either
by a placeholder or the actual featured image.
These images have two different sets of controls, which makes it difficult to find how to change the size and scale.

>If you happen to select the placeholder, you can only change the padding and margin.
To change the size and scale, you have to find a post or page in the post list that has an actual featured image, and select that.
So if your current list of posts does not include a featured image, this is a very confusing experience, and the feature is only discoverable by chance.

This PR fixes that by adding the rest of the controls in the case of a `Query Loop` parent.

## Testing instructions
1. Add a Query Loop block and inside a Post Featured Image block.
2. Make sure that a post from the results has no featured image set
3. Select that block and observe that the rest of the controls are displayed. 