### PR TITLE
[Block Library - Query Loop]: Reorganise inspector controls + `order` selection bug

### DIFF
--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -21,7 +21,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import QueryToolbar from './query-toolbar';
-import QueryInspectorControls from './query-inspector-controls';
+import QueryInspectorControls from './inspector-controls';
 import QueryPlaceholder from './query-placeholder';
 import { DEFAULTS_POSTS_PER_PAGE } from '../constants';
 import { getFirstQueryClientIdFromBlocks } from '../utils';

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -65,7 +65,7 @@ export function QueryContent( { attributes, setAttributes } ) {
 
 	// Changes in query property (which is an object) need to be in the same callback,
 	// because updates are batched after the render and changes in different query properties
-	// would cause to overide previous wanted changes.
+	// would cause to override previous wanted changes.
 	useEffect( () => {
 		const newQuery = {};
 		if ( ! query.perPage && postsPerPage ) {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -25,8 +25,9 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
-import { getTermsInfo, usePostTypes } from '../utils';
-import { MAX_FETCHED_TERMS } from '../constants';
+import OrderControl from './order-control';
+import { getTermsInfo, usePostTypes } from '../../utils';
+import { MAX_FETCHED_TERMS } from '../../constants';
 
 const stickyOptions = [
 	{ label: __( 'Include' ), value: '' },
@@ -217,14 +218,9 @@ export default function QueryInspectorControls( {
 					</>
 				) }
 				{ ! inherit && (
-					<QueryControls
+					<OrderControl
 						{ ...{ order, orderBy } }
-						onOrderChange={ ( value ) =>
-							setQuery( { order: value } )
-						}
-						onOrderByChange={ ( value ) =>
-							setQuery( { orderBy: value } )
-						}
+						onChange={ setQuery }
 					/>
 				) }
 				{ showSticky && (

--- a/packages/block-library/src/query/edit/inspector-controls/order-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/order-control.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const orderOptions = [
+	{
+		label: __( 'Newest to oldest' ),
+		value: 'date/desc',
+	},
+	{
+		label: __( 'Oldest to newest' ),
+		value: 'date/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in ascending order */
+		label: __( 'A → Z' ),
+		value: 'title/asc',
+	},
+	{
+		/* translators: label for ordering posts by title in descending order */
+		label: __( 'Z → A' ),
+		value: 'title/desc',
+	},
+];
+function OrderControl( { order, orderBy, onChange } ) {
+	return (
+		<SelectControl
+			label={ __( 'Order by' ) }
+			value={ `${ orderBy }/${ order }` }
+			options={ orderOptions }
+			onChange={ ( value ) => {
+				const [ newOrderBy, newOrder ] = value.split( '/' );
+				onChange( { order: newOrder, orderBy: newOrderBy } );
+			} }
+		/>
+	);
+}
+
+export default OrderControl;


### PR DESCRIPTION
The first iteration of `Query Loop` block seems to have worked well but there is so much more to be improved. I plan to create a new overview issue about the next steps for this soon.

For start I want to decouple the block from `QueryControls` component which was first implemented for `Latest Posts` block. This PR though handles only the `order/orderBy`, because I intent to also implement [multiple authors selection](https://github.com/WordPress/gutenberg/issues/26668) right after.

The change of folder structure is needed and will become more obvious with the follow up PRs.

By doing this I noticed an existing bug in `order/orderBy` when the new selection included a change in both `order` and `orderBy` attributes. In that cases we would issue two changes in the same top level `query` attribute(object) and because updates are batched after the render, changes in different query properties would cause to override previous wanted changes.

#### Before

https://user-images.githubusercontent.com/16275880/149361341-304f3939-0881-4902-ba94-6dc181f45d6e.mov



#### After

https://user-images.githubusercontent.com/16275880/149361359-ca550fb6-012e-4e8b-b28a-fec283e39efd.mov



## Testing instructions
1. Everything should work as before
2. You can also now select properly any of the available `order` options