### PR TITLE
Fix draft previews

### DIFF
--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -204,7 +204,7 @@ describe( 'Preview', () => {
 	it( 'should not revert title during a preview right after a save draft', async () => {
 		const editorPage = page;
 
-		// Type aaaaa in the title filed.
+		// Type aaaaa in the title field.
 		await editorPage.type( '.editor-post-title__input', 'aaaaa' );
 		await editorPage.keyboard.press( 'Tab' );
 
@@ -245,6 +245,70 @@ describe( 'Preview', () => {
 			( node ) => node.textContent
 		);
 		expect( previewTitle ).toBe( 'aaaaabbbbb' );
+
+		await previewPage.close();
+	} );
+
+	it( 'should not revert title during a preview right after switching from published to draft', async () => {
+		const editorPage = page;
+
+		// Type Lorem in the title field.
+		await editorPage.type( '.editor-post-title__input', 'Lorem' );
+
+		// Open the preview page.
+		const previewPage = await openPreviewPage( editorPage );
+		await previewPage.waitForSelector( '.entry-title' );
+
+		// Title in preview should match input.
+		let previewTitle = await previewPage.$eval(
+			'.entry-title',
+			( node ) => node.textContent
+		);
+		expect( previewTitle ).toBe( 'Lorem' );
+
+		// Return to editor and publish post.
+		await editorPage.bringToFront();
+		await publishPost();
+
+		// Close the panel.
+		await page.waitForSelector( '.editor-post-publish-panel' );
+		await page.click( '.editor-post-publish-panel__header button' );
+
+		// Change the title and preview again.
+		await editorPage.type( '.editor-post-title__input', ' Ipsum' );
+		await editorPage.keyboard.press( 'Tab' );
+		await waitForPreviewDropdownOpen( editorPage );
+		await waitForPreviewNavigation( previewPage );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval(
+			'.entry-title',
+			( node ) => node.textContent
+		);
+
+		expect( previewTitle ).toBe( 'Lorem Ipsum' );
+
+		// Return to editor and switch to Draft.
+		await editorPage.bringToFront();
+		await editorPage.waitForSelector( '.editor-post-switch-to-draft' );
+		await editorPage.click( '.editor-post-switch-to-draft' );
+		await page.keyboard.press( 'Enter' );
+
+		// Change the title.
+		await editorPage.type( '.editor-post-title__input', 'Draft ' );
+		await editorPage.keyboard.press( 'Tab' );
+
+		// Open the preview page.
+		await waitForPreviewDropdownOpen( editorPage );
+		await waitForPreviewNavigation( previewPage );
+
+		// Title in preview should match updated input.
+		previewTitle = await previewPage.$eval(
+			'.entry-title',
+			( node ) => node.textContent
+		);
+
+		expect( previewTitle ).toBe( 'Draft Lorem Ipsum' );
 
 		await previewPage.close();
 	} );

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -249,11 +249,12 @@ describe( 'Preview', () => {
 		await previewPage.close();
 	} );
 
-	it( 'should not revert title during a preview right after switching from published to draft', async () => {
+	// Verify correct preview. See: https://github.com/WordPress/gutenberg/issues/33616
+	it( 'should display the correct preview when switching between published and draft statuses', async () => {
 		const editorPage = page;
 
 		// Type Lorem in the title field.
-		await editorPage.type( '.editor-post-title__input', 'Lorem' );
+		await editorPage.type( '[aria-label="Add title"]', 'Lorem' );
 
 		// Open the preview page.
 		const previewPage = await openPreviewPage( editorPage );
@@ -275,7 +276,7 @@ describe( 'Preview', () => {
 		await page.click( '.editor-post-publish-panel__header button' );
 
 		// Change the title and preview again.
-		await editorPage.type( '.editor-post-title__input', ' Ipsum' );
+		await editorPage.type( '[aria-label="Add title"]', ' Ipsum' );
 		await editorPage.keyboard.press( 'Tab' );
 		await waitForPreviewDropdownOpen( editorPage );
 		await waitForPreviewNavigation( previewPage );
@@ -295,7 +296,7 @@ describe( 'Preview', () => {
 		await page.keyboard.press( 'Enter' );
 
 		// Change the title.
-		await editorPage.type( '.editor-post-title__input', 'Draft ' );
+		await editorPage.type( '[aria-label="Add title"]', 'Draft ' );
 		await editorPage.keyboard.press( 'Tab' );
 
 		// Open the preview page.

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -839,6 +839,11 @@ export function getEditedPostPreviewLink( state ) {
 	}
 
 	let previewLink = getAutosaveAttribute( state, 'preview_link' );
+	// Fix for issue: https://github.com/WordPress/gutenberg/issues/33616
+	// If the post is draft, ignore the preview link from the autosave record,
+	// because the preview could be a stale autosave if the post was switched from
+	// published to draft.
+	// See: https://github.com/Automattic/gutenberg/pull/1
 	if ( ! previewLink || 'draft' === getCurrentPost( state ).status ) {
 		previewLink = getEditedPostAttribute( state, 'link' );
 		if ( previewLink ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -843,7 +843,6 @@ export function getEditedPostPreviewLink( state ) {
 	// If the post is draft, ignore the preview link from the autosave record,
 	// because the preview could be a stale autosave if the post was switched from
 	// published to draft.
-	// See: https://github.com/Automattic/gutenberg/pull/1
 	if ( ! previewLink || 'draft' === getCurrentPost( state ).status ) {
 		previewLink = getEditedPostAttribute( state, 'link' );
 		if ( previewLink ) {

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -839,7 +839,7 @@ export function getEditedPostPreviewLink( state ) {
 	}
 
 	let previewLink = getAutosaveAttribute( state, 'preview_link' );
-	if ( ! previewLink ) {
+	if ( ! previewLink || 'draft' === getCurrentPost( state ).status ) {
 		previewLink = getEditedPostAttribute( state, 'link' );
 		if ( previewLink ) {
 			previewLink = addQueryArgs( previewLink, { preview: true } );

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -843,6 +843,7 @@ export function getEditedPostPreviewLink( state ) {
 	// If the post is draft, ignore the preview link from the autosave record,
 	// because the preview could be a stale autosave if the post was switched from
 	// published to draft.
+	// See: https://github.com/WordPress/gutenberg/pull/37952
 	if ( ! previewLink || 'draft' === getCurrentPost( state ).status ) {
 		previewLink = getEditedPostAttribute( state, 'link' );
 		if ( previewLink ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fixes [#33616](https://github.com/WordPress/gutenberg/issues/33616): Draft post not previewable if the draft was previously published.

When the post gets published, an autosave record is generated. Then, if the post is switched to Draft, the generated autosave record becomes stale. Subsequent edits to the post will reflect in the parent record, but not in the autosave record. This condition causes the preview to display the outdated content from the autosave record, which is not up to date with more recent edits. To solve this, the status of the post will be checked during preview link creation and if it's a draft, the autosave record will be ignored.

## How has this been tested?
1. Open the edit page for a brand new post
2. Add a title and body and hit preview in a new tab
3. Notice the preview works great
4. Publish the post
5. Update the title and body and preview a couple times
6. Notice preview still works great
7. Switch the post to a draft
8. Update the title and content and hit preview
9. Confirmed that the title and body in the preview match the content from the Editor.
10. Published the article again and confirmed that the preview still works great.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
