### PR TITLE
Fix duotone render in non-fse themes

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -461,27 +461,27 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	add_action(
 		is_admin() ? 'admin_footer' : 'wp_footer',
-		function () use ( $filter_svg, $filter_id, $selector ) {
+		function () use ( $filter_svg ) {
 			echo $filter_svg;
-
-			// Safari renders elements incorrectly on first paint when the SVG
-			// filter comes after the content that it is filtering, so we force
-			// a repaint by resetting the display style which solves the issue.
-			global $is_safari;
-			if ( $is_safari ) {
-				wp_register_script( $filter_id, false, array(), null, true );
-				wp_enqueue_script( $filter_id );
-				wp_add_inline_script(
-					$filter_id,
-					sprintf(
-						'( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; setTimeout( function() { el.style.display = display; } ); } )();',
-						wp_json_encode( $selector )
-					),
-					'after'
-				);
-			}
 		}
 	);
+
+	// Safari renders elements incorrectly on first paint when the SVG
+	// filter comes after the content that it is filtering, so we force
+	// a repaint by resetting the display style which solves the issue.
+	global $is_safari;
+	if ( $is_safari ) {
+		wp_register_script( $filter_id, false, array(), null, true );
+		wp_enqueue_script( $filter_id );
+		wp_add_inline_script(
+			$filter_id,
+			sprintf(
+				'( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; setTimeout( function() { el.style.display = display; } ); } )();',
+				wp_json_encode( $selector )
+			),
+			'after'
+		);
+	}
 
 	// Like the layout hook, this assumes the hook only applies to blocks with a single wrapper.
 	return preg_replace(

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -468,7 +468,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 
 	// Safari renders elements incorrectly on first paint when the SVG
 	// filter comes after the content that it is filtering, so we force
-	// a repaint by resetting the display style which solves the issue.
+	// a repaint with a WebKit hack which solves the issue.
 	global $is_safari;
 	if ( $is_safari ) {
 		wp_register_script( $filter_id, false, array(), null, true );
@@ -476,7 +476,9 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		wp_add_inline_script(
 			$filter_id,
 			sprintf(
-				'( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; setTimeout( function() { el.style.display = display; } ); } )();',
+				// Simply accessing el.offsetHeight flushes layout and style
+				// changes in WebKit without having to wait for setTimeout.
+				'( function() { var el = document.querySelector( %s ); var display = el.style.display; el.style.display = "none"; el.offsetHeight; el.style.display = display; } )();',
 				wp_json_encode( $selector )
 			),
 			'after'

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -460,7 +460,7 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 	wp_enqueue_style( $filter_id );
 
 	add_action(
-		is_admin() ? 'admin_footer' : 'wp_footer',
+		'wp_footer',
 		function () use ( $filter_svg ) {
 			echo $filter_svg;
 		}

--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -467,7 +467,10 @@ function gutenberg_render_duotone_support( $block_content, $block ) {
 		// 2. Filters display incorrectly when the SVG is defined after
 		// where the filter is used in the document, so the footer does
 		// not work.
-		'wp_body_open',
+		// Additionally, some non-fse themes call the render_block filter
+		// after the wp_body_open hook, so instead we use the wp_footer hook
+		// in that case even though it won't render 100% correctly in Safari.
+		did_action( 'wp_body_open' ) === 0 ? 'wp_body_open' : 'wp_footer',
 		function () use ( $filter_svg ) {
 			echo $filter_svg;
 		}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #37598 

It seems that the `render_block` filter is being called after the `wp_body_open` hook in non-fse themes, so this change will fall back on `wp_footer` if it has already been called.

We switched from `wp_footer` to `wp_body_open` in #36754 because Safari renders blocks incorrectly when the SVG filter comes after the content that it is filtering. Switching back unfortunately means that duotone rendering will be incorrect for non-fse themes when viewed from Safari.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

1. Activate a non-fse theme like Blank Canvas.
2. In a post, add an image with a duotone filter.
3. Publish and view the post to see the filter applied.

## Screenshots <!-- if applicable -->

Using the Blank Canvas theme using the one of the default duotone filters applied to the block

Before:
![image does not render at all](https://user-images.githubusercontent.com/5129775/149380932-e3e94115-2a76-40b2-9a0e-15824769e0e8.png)

After:
![duotone filter is correctly applied to the image](https://user-images.githubusercontent.com/5129775/149380941-8de9de92-14ea-4498-be29-481774edde3b.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug Fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
