### PR TITLE
Increase ConfirmDialog overlay's z-index to render above popovers

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -146,6 +146,9 @@ $z-layers: (
 	".reusable-blocks-menu-items__convert-modal": 1000001,
 	".edit-site-create-template-part-modal": 1000001,
 
+	// Note: The ConfirmDialog component's z-index is being set to 1000001 in packages/components/src/confirm-dialog/styles.ts
+	// because it uses emotion and not sass. We need it to render on top its parent popover.
+
 	// ...Except for popovers immediately beneath wp-admin menu on large breakpoints
 	".components-popover.block-editor-inserter__popover": 99999,
 	".components-popover.table-of-contents__popover": 99998,

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Mark `children` prop as optional in `SelectControl` ([#37872](https://github.com/WordPress/gutenberg/pull/37872))
 -   Add memoization of callbacks and context to prevent unnecessary rerenders of the `ToolsPanel` ([#38037](https://github.com/WordPress/gutenberg/pull/38037))
 -   Fix space between icons and rail `RangeControl` ([#36935](https://github.com/WordPress/gutenberg/pull/36935))
+-   Increase z-index of `ConfirmDialog` to render on top of parent `Popover` components ([#37959](https://github.com/WordPress/gutenberg/pull/37959))
 
 ### Experimental
 

--- a/packages/components/src/confirm-dialog/component.tsx
+++ b/packages/components/src/confirm-dialog/component.tsx
@@ -23,6 +23,8 @@ import { Flex } from '../flex';
 import Button from '../button';
 import { Text } from '../text';
 import { VStack } from '../v-stack';
+import * as styles from './styles';
+import { useCx } from '../utils/hooks/use-cx';
 
 function ConfirmDialog(
 	props: WordPressComponentProps< OwnProps, 'div', false >,
@@ -35,6 +37,9 @@ function ConfirmDialog(
 		children,
 		...otherProps
 	} = useContextSystem( props, 'ConfirmDialog' );
+
+	const cx = useCx();
+	const wrapperClassName = cx( styles.wrapper );
 
 	const [ isOpen, setIsOpen ] = useState< boolean >();
 	const [ shouldSelfClose, setShouldSelfClose ] = useState< boolean >();
@@ -82,6 +87,7 @@ function ConfirmDialog(
 					closeButtonLabel={ cancelLabel }
 					isDismissible={ true }
 					ref={ forwardedRef }
+					overlayClassName={ wrapperClassName }
 					__experimentalHideHeader
 					{ ...otherProps }
 				>

--- a/packages/components/src/confirm-dialog/styles.ts
+++ b/packages/components/src/confirm-dialog/styles.ts
@@ -12,5 +12,7 @@ import { css } from '@emotion/react';
  * any parent Popover component.
  */
 export const wrapper = css`
-	z-index: 1000001;
+	&& {
+		z-index: 1000001;
+	}
 `;

--- a/packages/components/src/confirm-dialog/styles.ts
+++ b/packages/components/src/confirm-dialog/styles.ts
@@ -1,0 +1,16 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+
+/**
+ * The z-index for ConfirmDialog is being set here instead of in
+ * packages/base-styles/_z-index.scss, because this component uses
+ * emotion instead of sass.
+ *
+ * ConfirmDialog needs this higher z-index to ensure it renders on top of
+ * any parent Popover component.
+ */
+export const wrapper = css`
+	z-index: 1000001;
+`;


### PR DESCRIPTION
## Description
This PR increases the z-index value for the new `ConfirmDialog` component so it will render above any Popovers.

By default, Popovers render above everything, with some limited exceptions. In the case of `ConfirmDialog`, this means that if the dialog is the child component of such a `Popover`, the parent component renders above the confirmation dialog.

## How has this been tested?
To test, we first need an active example of `ConfirmDialog`, which is still being implemented.

1. Check out https://github.com/WordPress/gutenberg/pull/37602
2. Next, cherry-pick the commit(s) on this PR to include the new CSS in your working copy
3. Create a new post in Gutenberg, and publish it
4. In the editor, click on the posts "Public" visibility
5. In the `PostVisibility` component that renders, select **Private**
6. Confirm that when the confirmation dialog opens, it renders above the `PostVisibility` popover (the popover should appear below the scrim along with the rest of the elements on the page)

Tested in latest Chrome with GB 6.0-alpha-52573 via wp-env.

## Checklist:
- [ x ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ x ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
