### PR TITLE
Add: Hover and Selected states to the palette editor.

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -39,6 +39,7 @@ import {
 import { NavigableMenu } from '../navigable-container';
 import { DEFAULT_GRADIENT } from '../custom-gradient-picker/constants';
 import CustomGradientPicker from '../custom-gradient-picker';
+import { COLORS } from '../utils';
 
 const DEFAULT_COLOR = '#000';
 
@@ -79,7 +80,14 @@ function Option( {
 		<PaletteItem
 			as="div"
 			onClick={ onStartEditing }
-			{ ...( isEditing ? focusOutsideProps : {} ) }
+			{ ...( isEditing
+				? {
+						...focusOutsideProps,
+						style: {
+							border: `1px solid ${ COLORS.blue.wordpress[ 700 ] }`,
+						},
+				  }
+				: { style: { cursor: 'pointer' } } ) }
 		>
 			<HStack justify="flex-start">
 				<FlexItem>

--- a/packages/components/src/palette-edit/styles.js
+++ b/packages/components/src/palette-edit/styles.js
@@ -30,7 +30,7 @@ export const IndicatorStyled = styled( CircularOptionPicker.Option )`
 export const NameInputControl = styled( InputControl )`
 	${ InputControlContainer } {
 		background: ${ COLORS.gray[ 100 ] };
-		border-radius: 2px;
+		border-radius: ${ CONFIG.controlBorderRadius }};
 		${ Input }${ Input }${ Input }${ Input } {
 			height: ${ space( 8 ) };
 		}
@@ -52,6 +52,9 @@ export const NameContainer = styled.div`
 	margin-right: ${ space( 2 ) };
 	white-space: nowrap;
 	overflow: hidden;
+	${ PaletteItem }:hover & {
+		color: var( --wp-admin-theme-color, ${ COLORS.blue.wordpress[ 700 ] } );
+	}
 `;
 
 export const PaletteHeading = styled( Heading )`


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37832
Adds the hoover and selected states following the proposed design.


## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/149422879-6e488bc2-69e8-4216-b29b-b77529007a5c.png)
![image](https://user-images.githubusercontent.com/11271197/149422889-d8b7ca14-1271-419a-82b0-d65f16ab12a6.png)
