### PR TITLE
Post Lock: Adjust avatar design and update message

### DIFF
--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -185,6 +185,8 @@ export default function PostLockedModal() {
 					src={ userAvatar }
 					alt={ __( 'Avatar' ) }
 					className="editor-post-locked-modal__avatar"
+					width={ 64 }
+					height={ 64 }
 				/>
 			) }
 			<div>
@@ -214,29 +216,36 @@ export default function PostLockedModal() {
 					</p>
 				) }
 				{ ! isTakeover && (
-					<p>
-						{ createInterpolateElement(
-							userDisplayName
-								? sprintf(
-										/* translators: %s: user's display name */
-										__(
-											'<strong>%s</strong> is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
-										),
-										userDisplayName
-								  )
-								: __(
-										'Another user is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
-								  ),
-							{
-								strong: <strong />,
-								PreviewLink: (
-									<ExternalLink href={ previewLink }>
-										{ __( 'preview' ) }
-									</ExternalLink>
-								),
-							}
-						) }
-					</p>
+					<>
+						<p>
+							{ createInterpolateElement(
+								userDisplayName
+									? sprintf(
+											/* translators: %s: user's display name */
+											__(
+												'<strong>%s</strong> is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+											),
+											userDisplayName
+									  )
+									: __(
+											'Another user is currently working on this post (<PreviewLink />), which means you cannot make changes, unless you take over.'
+									  ),
+								{
+									strong: <strong />,
+									PreviewLink: (
+										<ExternalLink href={ previewLink }>
+											{ __( 'preview' ) }
+										</ExternalLink>
+									),
+								}
+							) }
+						</p>
+						<p>
+							{ __(
+								'If you take over, the other user will lose editing control to the post, but their changes will be saved.'
+							) }
+						</p>
+					</>
 				) }
 
 				<Flex

--- a/packages/editor/src/components/post-locked-modal/style.scss
+++ b/packages/editor/src/components/post-locked-modal/style.scss
@@ -2,6 +2,10 @@
 	@include break-small() {
 		max-width: $break-mobile;
 	}
+
+	.components-modal__content {
+		display: flex;
+	}
 }
 
 .editor-post-locked-modal__buttons {
@@ -9,7 +13,7 @@
 }
 
 .editor-post-locked-modal__avatar {
-	float: left;
-	margin: $grid-unit-10;
-	margin-right: $grid-unit-15;
+	border-radius: $radius-block-ui;
+	margin-top: $grid-unit-20;
+	margin-right: $grid-unit-30;
 }


### PR DESCRIPTION
## Description
PR updates avatar design in takeover modal and adds explanatory text.

Resolves #37725.

## How has this been tested?
Add snippet below to the theme functions.php and emulate post lock state.

<details>
<summary>Snippet</summary>

```php
add_filter( 'block_editor_settings_all', function( $settings, $block_editor_context ) {
	if ( empty( $block_editor_context->post ) ) {
		return $settings;
	}

	if ( isset( $settings['postLock']['user'] ) ) {
		return $settings;
	}

	$user = wp_get_current_user();
	if ( ! isset( $user->ID ) ) {
		return $settings;
	}

	$settings['postLock'] = [
		'isLocked' => true,
		'user'     => [
			'name'   => $user->display_name,
			'avatar' => get_avatar_url( $user->ID, array( 'size' => 64 ) ),
		],
	];

	return $settings;
}, 10, 2 );
```
</details>

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-14 at 15 17 56](https://user-images.githubusercontent.com/240569/149509165-e8ba261b-1bab-4066-bd77-431d3cdd4b96.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
-  My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
