### PR TITLE
Show menus selection in placeholder only if available

### DIFF
--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -25,7 +25,7 @@ import useNavigationMenu from '../../use-navigation-menu';
 import useCreateNavigationMenu from '../use-create-navigation-menu';
 
 const ExistingMenusDropdown = ( {
-	canSwitchNavigationMenu,
+	showNavigationMenus,
 	navigationMenus,
 	setSelectedMenu,
 	onFinish,
@@ -51,7 +51,7 @@ const ExistingMenusDropdown = ( {
 		>
 			{ ( { onClose } ) => (
 				<>
-					{ canSwitchNavigationMenu && hasNavigationMenus && (
+					{ showNavigationMenus && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
 							{ navigationMenus.map( ( menu ) => {
 								return (
@@ -201,7 +201,7 @@ export default function NavigationPlaceholder( {
 							{ showSelectMenus ? (
 								<>
 									<ExistingMenusDropdown
-										canSwitchNavigationMenu={
+										showNavigationMenus={
 											canSwitchNavigationMenu
 										}
 										navigationMenus={ navigationMenus }

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -38,6 +38,7 @@ const ExistingMenusDropdown = ( {
 		iconPosition: 'right',
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
+
 	return (
 		<DropdownMenu
 			text={ __( 'Select menu' ) }
@@ -47,27 +48,26 @@ const ExistingMenusDropdown = ( {
 		>
 			{ ( { onClose } ) => (
 				<>
-					{ canSwitchNavigationMenu &&
-						navigationMenus?.length(
-							<MenuGroup label={ __( 'Menus' ) }>
-								{ navigationMenus.map( ( menu ) => {
-									return (
-										<MenuItem
-											onClick={ () => {
-												setSelectedMenu( menu.id );
-												onFinish( menu );
-											} }
-											onClose={ onClose }
-											key={ menu.id }
-										>
-											{ decodeEntities(
-												menu.title.rendered
-											) }
-										</MenuItem>
-									);
-								} ) }
-							</MenuGroup>
-						) }
+					{ canSwitchNavigationMenu && navigationMenus?.length && (
+						<MenuGroup label={ __( 'Menus' ) }>
+							{ navigationMenus.map( ( menu ) => {
+								return (
+									<MenuItem
+										onClick={ () => {
+											setSelectedMenu( menu.id );
+											onFinish( menu );
+										} }
+										onClose={ onClose }
+										key={ menu.id }
+									>
+										{ decodeEntities(
+											menu.title.rendered
+										) }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
 					{ showClassicMenus && menus?.length && (
 						<MenuGroup label={ __( 'Classic Menus' ) }>
 							{ menus.map( ( menu ) => {

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -175,6 +175,12 @@ export default function NavigationPlaceholder( {
 
 	const { navigationMenus } = useNavigationMenu();
 
+	const hasNavigationMenus = !! navigationMenus?.length;
+
+	const showSelectMenus =
+		( canSwitchNavigationMenu || canUserCreateNavigation ) &&
+		( hasNavigationMenus || hasMenus );
+
 	return (
 		<>
 			{ ( ! hasResolvedNavigationMenus || isStillLoading ) && (
@@ -192,7 +198,7 @@ export default function NavigationPlaceholder( {
 
 							<hr />
 
-							{ hasMenus || navigationMenus?.length ? (
+							{ showSelectMenus ? (
 								<>
 									<ExistingMenusDropdown
 										canSwitchNavigationMenu={

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -39,6 +39,9 @@ const ExistingMenusDropdown = ( {
 		className: 'wp-block-navigation-placeholder__actions__dropdown',
 	};
 
+	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasClassicMenus = !! menus?.length;
+
 	return (
 		<DropdownMenu
 			text={ __( 'Select menu' ) }
@@ -48,7 +51,7 @@ const ExistingMenusDropdown = ( {
 		>
 			{ ( { onClose } ) => (
 				<>
-					{ canSwitchNavigationMenu && navigationMenus?.length && (
+					{ canSwitchNavigationMenu && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
 							{ navigationMenus.map( ( menu ) => {
 								return (
@@ -68,7 +71,7 @@ const ExistingMenusDropdown = ( {
 							} ) }
 						</MenuGroup>
 					) }
-					{ showClassicMenus && menus?.length && (
+					{ showClassicMenus && hasClassicMenus && (
 						<MenuGroup label={ __( 'Classic Menus' ) }>
 							{ menus.map( ( menu ) => {
 								return (

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -47,28 +47,30 @@ const ExistingMenusDropdown = ( {
 		>
 			{ ( { onClose } ) => (
 				<>
-					<MenuGroup label={ __( 'Menus' ) }>
-						{ canSwitchNavigationMenu &&
-							navigationMenus?.map( ( menu ) => {
-								return (
-									<MenuItem
-										onClick={ () => {
-											setSelectedMenu( menu.id );
-											onFinish( menu );
-										} }
-										onClose={ onClose }
-										key={ menu.id }
-									>
-										{ decodeEntities(
-											menu.title.rendered
-										) }
-									</MenuItem>
-								);
-							} ) }
-					</MenuGroup>
-					{ showClassicMenus && (
+					{ canSwitchNavigationMenu &&
+						navigationMenus?.length(
+							<MenuGroup label={ __( 'Menus' ) }>
+								{ navigationMenus.map( ( menu ) => {
+									return (
+										<MenuItem
+											onClick={ () => {
+												setSelectedMenu( menu.id );
+												onFinish( menu );
+											} }
+											onClose={ onClose }
+											key={ menu.id }
+										>
+											{ decodeEntities(
+												menu.title.rendered
+											) }
+										</MenuItem>
+									);
+								} ) }
+							</MenuGroup>
+						) }
+					{ showClassicMenus && menus?.length && (
 						<MenuGroup label={ __( 'Classic Menus' ) }>
-							{ menus?.map( ( menu ) => {
+							{ menus.map( ( menu ) => {
 								return (
 									<MenuItem
 										onClick={ () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In https://github.com/WordPress/gutenberg/pull/37884#issuecomment-1010202943 @spacedmonkey noticed that the `Select menu` dropdown will render even if there no menus or no classic menus.

This PR improves the conditionals to ensure that the correct pieces only render if they are needed.

## How has this been tested?

1. Delete all Navigation Menus and all Classic Menus.
2. New Post -> Add Nav block.
3. The placeholder should not show the `Select menu` option.
4. Create a Navigation and save so as to create a Navigation Post.
5. Add a new Nav block. You should now see the `Select menu` dropdown. It should only contain the `Menus` section and not the `Classic Menus` section.
6. Switch to Classic Theme and add a Menu via `Appearance -> Menus`.
7. Switch back to block Theme.
8. Go back to your previous post (the one where you added the Nav blocks).
9. Add a new Nav block. You should see the `Select menu` option. Within the dropdown you should see sections for both `Menus` and `Classic Menus`.
10. Within the `Select menu` dropdown go to `Manage Menus` and delete your Navigation posts.
11. Return to the original Post and add a new Nav block. You should see the `Select menu` option. Within the dropdown you should only see the `Classic Menus` section and not the `Menus` section.

Now test as a lower permission user:

- Create both Navigation post and Classic Menu again.
- Switch to a contributor user. 
- Create new Post and add a new Nav block.
- You should see the `Select menu` option. Within the dropdown you should only see the `Menus` section and not the `Classic Menus` section. This is because the user is allowed to switch to an existing Menu but they are not allowed to _create_ a new menu from a Classic Menu.


## Screenshots <!-- if applicable -->

When there are no Menus or Classic Menus the `Select menu` option is not displayed:

<img width="791" alt="Screen Shot 2022-01-14 at 11 40 06" src="https://user-images.githubusercontent.com/444434/149509843-2e8c3764-e901-43fa-85ac-affe016af674.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
