### PR TITLE
Social Icons: Fix styling when oriented vertically

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,4 +1,6 @@
 .wp-block-social-links {
+	// Required for when social icons are oriented vertically.
+	align-items: flex-start;
 	padding-left: 0;
 	padding-right: 0;
 	// Some themes set text-indent on all <ul>


### PR DESCRIPTION
## Description
When the Social Icons block is oriented vertically, the individual links span the entire width of the content area and do not maintain their correct width. This issue appears to be a regression in the latest version of Gutenberg since the issue is not present in WordPress 5.9 RC2.

What's strange is that the CSS provided by the Social Icons block has not changed in recent months, so this issue must be caused by something else. I have not been able to isolate it. The root of the issue is that in the editor, `align-items: flex-start;` is added to the block. On the frontend, this CSS does not exist. This PR simply adds it back. 

## How has this been tested?
1. Use Twenty Twenty-Two with Gutenberg 12.4 RC1 and WordPress 5.9 RC2
2. Add the Social Icons block with a couple Social Icons
3. Orient the block vertically. See that it displays correctly in the Editor
4. Switch to the Frontend and see that with this PR the icons display correctly as well, without this PR they render like the screenshots below

## Screenshots
Without the fix in this PR with Gutenberg 12.4 RC1 active in the TT2 theme:
![image](https://user-images.githubusercontent.com/4832319/149552865-7d8cc887-120c-45bd-a1c0-b40d60e4a286.png)

With the fix, the icons display correctly:
![image](https://user-images.githubusercontent.com/4832319/149552773-cfafa976-093a-46fd-98ad-8a164b7ab720.png)

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
