### PR TITLE
Wrap long cell labels on Android

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/cell.native.js
+++ b/packages/components/src/mobile/bottom-sheet/cell.native.js
@@ -356,7 +356,12 @@ class BottomSheetCell extends Component {
 					<View style={ rowContainerStyles }>
 						<View style={ styles.cellRowContainer }>
 							{ icon && (
-								<View style={ styles.cellRowContainer }>
+								<View
+									style={ [
+										styles.cellRowContainer,
+										styles.cellRowIcon,
+									] }
+								>
 									<Icon
 										icon={ icon }
 										size={ 24 }

--- a/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
@@ -1,6 +1,7 @@
 .titleStyle {
 	text-align: left;
 	font-weight: bold;
+	width: 100%;
 }
 
 .summaryStyle {

--- a/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/link-suggestion-styles.native.scss
@@ -16,6 +16,8 @@
 }
 
 .containerStyle {
+	flex-grow: 1;
+	flex-basis: 0;
 	align-items: flex-start;
 }
 

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -108,8 +108,6 @@
 
 .cellRowIcon {
 	flex-shrink: 0;
-	flex-basis: auto;
-	flex-grow: 0;
 }
 
 .cellLabel {

--- a/packages/components/src/mobile/bottom-sheet/styles.native.scss
+++ b/packages/components/src/mobile/bottom-sheet/styles.native.scss
@@ -103,7 +103,13 @@
 .cellRowContainer {
 	flex-direction: row;
 	align-items: center;
+	flex-shrink: 1;
+}
+
+.cellRowIcon {
 	flex-shrink: 0;
+	flex-basis: auto;
+	flex-grow: 0;
 }
 
 .cellLabel {

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -16,6 +16,7 @@ For each user feature we should also add a importance categorization label  to i
 -   [*] Add contrast checker to text-based blocks [#34902]
 
 -   [*] [Image block] Fix missing translations [#37956]
+-   [*] Fix cut-off setting labels by properly wrapping the text [#37993]
 
 ## 1.69.0
 


### PR DESCRIPTION
## Related PRs

- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4475

## Description
Fixes #37858. Prior to this change, the cell label container was disallowed from shrinking to accommodate its siblings. This caused longer labels to force the sibling elements out of the viewport causing them to be invisible or cut-off.

Additional changes were applied to the link suggestion styles to ensure the sibling of cell icons do not encroach upon the now static width icon.

Lastly, https://github.com/WordPress/gutenberg/issues/37995 was created to capture an existing, unrelated issue identified while testing this work. 

## How has this been tested?
<details><summary>Case 1: Long Label Wraps</summary>

1. Change the device's language to one that generally requires more space than
   English, e.g. Spanish.
1. Open the block editor.
1. Add an Embed block.
1. Set a valid YouTube URL.
1. Open the Embed block settings.
1. ℹ️ Verify the _Resize for smaller devices_ toggle is visible.

</details>

<details><summary>Case 2: Scaled Text Controls Remain Accessible</summary> 

1. Set the device's OS text size to the largest available.
1. Open the block editor.
1. Add a Cover block.
1. Set an image for the Cover block.
1. Open the Cover block settings.
1. ℹ️ Verify the _Opacity_ slider displays and remains accessible. See https://github.com/WordPress/gutenberg/pull/20768#pullrequestreview-372353894 for additional details. 

</details>

<details><summary>Case 3: Link Picker Aligned Correctly</summary>

1. Copy a URL to the device clipboard.
1. Open the block editor.
1. Add a Paragraph block.
1. Add a link to the paragraph.
1. ℹ️ Verify the link suggestion is correctly aligned, i.e. the proper space is displayed between the left-side icon and right-side text, the link suggestion aligns with the search field above it.

</details>

<details><summary>Case 4: Android Media Options Aligned Correctly</summary>

1. Open the block editor on Android. 
1. Add an Image block. 
1. Tap the block to set media. 
1. ℹ️ Verify the listed options are correctly aligned, both the icons and label text. See https://github.com/WordPress/gutenberg/pull/20768 for additional details. 

</details>

## Screenshots <!-- if applicable -->

<details><summary>Long Label Wraps</summary>

| Android | iOS |
| - | - |
| ![Android cell label wraps](https://user-images.githubusercontent.com/438664/149593494-27a101cb-cb9f-4fda-a412-cc39c8bb9e76.jpg) | ![iOS cell label wraps](https://user-images.githubusercontent.com/438664/149593523-0cd81261-61dc-4612-b078-20c0ed77725d.PNG) |

</details>

<details><summary>Scaled Text Controls Remain Accessible</summary>

| Android | iOS |
| - | - |
| ![Android slider large text renders accessibly](https://user-images.githubusercontent.com/438664/149593598-f9b6e632-953e-46e0-a940-09ac9a0ffee5.jpg) | ![iOS slider text render accessibly](https://user-images.githubusercontent.com/438664/149593632-7086e32f-8697-4358-a00a-a00413698dbe.PNG) |

</details>

<details><summary>Link Picker Suggestion Aligned Correctly</summary>

| Before | After |
| - | - |
| ![Link suggestion misaligned before changes](https://user-images.githubusercontent.com/438664/149592954-4f6acff7-768d-4734-b52f-e0b986976932.jpg) | ![Link suggestion correctly aligned after changes](https://user-images.githubusercontent.com/438664/149592972-04b1f00e-027b-4e40-9538-10280a4ee340.jpg) |

</details>

<details><summary>Media Options Aligned Correctly</summary>

![Android media options are aligned correctly.](https://user-images.githubusercontent.com/438664/149594875-94742eb4-7e6e-4668-b16e-8a1959fe2daa.jpg)

</details>

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
