### PR TITLE
Block Library: Add filter for inner blocks in the Navigation block

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -455,9 +455,11 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	 * Filter navigation block $inner_blocks.
 	 * Allows modification of a navigation block menu items.
 	 *
+	 * @since 6.1.0	 
+	 *
 	 * @param \WP_Block_List $inner_blocks
 	 */
-	$inner_blocks = apply_filters( 'render_block_core_navigation_inner_blocks', $inner_blocks );
+	$inner_blocks = apply_filters( 'block_core_navigation_render_inner_blocks', $inner_blocks );
 
 	$layout_justification = array(
 		'left'          => 'items-justified-left',

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -455,7 +455,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	 * Filter navigation block $inner_blocks.
 	 * Allows modification of a navigation block menu items.
 	 *
-	 * @since 6.1.0	 
+	 * @since 6.1.0
 	 *
 	 * @param \WP_Block_List $inner_blocks
 	 */

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -449,7 +449,6 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		}
 
 		$inner_blocks = new WP_Block_List( $fallback_blocks, $attributes );
-
 	}
 
 	/**

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -452,6 +452,14 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	}
 
+	/**
+	 * Filter navigation block $inner_blocks.
+	 * Allows modification of a navigation block menu items.
+	 *
+	 * @param \WP_Block_List $inner_blocks
+	 */
+	$inner_blocks = apply_filters( 'render_block_core_navigation_inner_blocks', $inner_blocks );
+
 	$layout_justification = array(
 		'left'          => 'items-justified-left',
 		'right'         => 'items-justified-right',


### PR DESCRIPTION


## Description
Add filter to navigation.php to add ability to modify navigation block menu items.

Fixes https://github.com/WordPress/gutenberg/issues/37717

## Types of changes
New feature: filter menu items of navigation block.

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
