### PR TITLE
Social Icons: Fix color picker bug when set to Logos Only

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -116,6 +116,36 @@ export function SocialLinksEdit( props ) {
 		position: 'bottom right',
 	};
 
+	const colorSettings = [
+		{
+			// Use custom attribute as fallback to prevent loss of named color selection when
+			// switching themes to a new theme that does not have a matching named color.
+			value: iconColor.color || iconColorValue,
+			onChange: ( colorValue ) => {
+				setIconColor( colorValue );
+				setAttributes( { iconColorValue: colorValue } );
+			},
+			label: __( 'Icon color' ),
+		}
+	];
+
+	if ( ! logosOnly ) {
+		colorSettings.push( {
+			// Use custom attribute as fallback to prevent loss of named color selection when
+			// switching themes to a new theme that does not have a matching named color.
+			value:
+				iconBackgroundColor.color ||
+				iconBackgroundColorValue,
+			onChange: ( colorValue ) => {
+				setIconBackgroundColor( colorValue );
+				setAttributes( {
+					iconBackgroundColorValue: colorValue,
+				} );
+			},
+			label: __( 'Icon background' ),
+		} );
+	}
+
 	return (
 		<Fragment>
 			<BlockControls group="other">
@@ -169,32 +199,7 @@ export function SocialLinksEdit( props ) {
 					__experimentalHasMultipleOrigins
 					__experimentalIsRenderedInSidebar
 					title={ __( 'Color' ) }
-					colorSettings={ [
-						{
-							// Use custom attribute as fallback to prevent loss of named color selection when
-							// switching themes to a new theme that does not have a matching named color.
-							value: iconColor.color || iconColorValue,
-							onChange: ( colorValue ) => {
-								setIconColor( colorValue );
-								setAttributes( { iconColorValue: colorValue } );
-							},
-							label: __( 'Icon color' ),
-						},
-						! logosOnly && {
-							// Use custom attribute as fallback to prevent loss of named color selection when
-							// switching themes to a new theme that does not have a matching named color.
-							value:
-								iconBackgroundColor.color ||
-								iconBackgroundColorValue,
-							onChange: ( colorValue ) => {
-								setIconBackgroundColor( colorValue );
-								setAttributes( {
-									iconBackgroundColorValue: colorValue,
-								} );
-							},
-							label: __( 'Icon background' ),
-						},
-					] }
+					colorSettings={ colorSettings }
 				/>
 				{ ! logosOnly && (
 					<ContrastChecker

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -126,16 +126,14 @@ export function SocialLinksEdit( props ) {
 				setAttributes( { iconColorValue: colorValue } );
 			},
 			label: __( 'Icon color' ),
-		}
+		},
 	];
 
 	if ( ! logosOnly ) {
 		colorSettings.push( {
 			// Use custom attribute as fallback to prevent loss of named color selection when
 			// switching themes to a new theme that does not have a matching named color.
-			value:
-				iconBackgroundColor.color ||
-				iconBackgroundColorValue,
+			value: iconBackgroundColor.color || iconBackgroundColorValue,
 			onChange: ( colorValue ) => {
 				setIconBackgroundColor( colorValue );
 				setAttributes( {


### PR DESCRIPTION
## Description
When the Social Icons block is set to "Logos Only", the color picker for the Icon Background color should not be shown. Currently it is still shown but with no label and no settings. Basically just an "empty" color picker component is rendered. This PR fixes that by removing the conditional from the color settings array itself.  

## How has this been tested?
1. Use the latest version of Gutenberg and the latest version of TT2
2. Add a Social Icons block to a page and add a few Social Links. 
3. Set the Social Icons block to "Logos only", see the "empty" color picker component. 
4. Switch to this PR and now the color picker displays as it should.

## Screenshots 

Currently in trunk:
![image](https://user-images.githubusercontent.com/4832319/149625765-e17f1bd2-cd3a-4979-b1a6-2f45f384f066.png)

With this PR:
![image](https://user-images.githubusercontent.com/4832319/149625741-b808d251-3631-4ff4-acba-722c201fe7ca.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
