### PR TITLE
Add ability to make entire Post Template clickable and therefore enhance accessibility of Post Template Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -546,7 +546,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Name:** core/post-template
 -	**Category:** theme
 -	**Supports:** align, ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:** makeEntirePostClickable
 
 ## Post Terms
 

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -18,7 +18,7 @@
 			"default": false
 		}
 	},
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId", "isPostOneLink" ],
 	"supports": {
 		"html": false,
 		"color": {

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -161,7 +161,7 @@ export default function PostDateEdit( {
 						help={
 							isPostOneLink
 								? __(
-										'The Post Template block marks that the entire Post should be one link.'
+										'The Post Template block marks that the entire post should be one link.'
 								  )
 								: null
 						}

--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { __experimentalGetSettings, dateI18n } from '@wordpress/date';
 import {
 	AlignmentControl,
@@ -30,7 +30,7 @@ import { DOWN } from '@wordpress/keycodes';
 
 export default function PostDateEdit( {
 	attributes: { textAlign, format, isLink },
-	context: { postId, postType, queryId },
+	context: { postId, postType, queryId, isPostOneLink },
 	setAttributes,
 } ) {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
@@ -64,6 +64,11 @@ export default function PostDateEdit( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
+
+	// ensure that the post date is not a link when the post template marks the entire post a link
+	useEffect( () => {
+		if ( isPostOneLink ) setAttributes( { isLink: false } );
+	}, [ isPostOneLink ] );
 
 	const timeRef = useRef();
 
@@ -152,6 +157,14 @@ export default function PostDateEdit( {
 						) }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 						checked={ isLink }
+						disabled={ isPostOneLink }
+						help={
+							isPostOneLink
+								? __(
+										'The Post Template block marks that the entire Post should be one link.'
+								  )
+								: null
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -18,7 +18,7 @@
 			"default": true
 		}
 	},
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId", "isPostOneLink" ],
 	"supports": {
 		"html": false,
 		"color": {

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -28,7 +28,7 @@ export default function PostExcerptEditor( {
 	attributes: { textAlign, moreText, showMoreOnNewLine },
 	setAttributes,
 	isSelected,
-	context: { postId, postType, queryId },
+	context: { postId, postType, queryId, isPostOneLink },
 } ) {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useCanEditEntity( 'postType', postType, postId );
@@ -73,7 +73,7 @@ export default function PostExcerptEditor( {
 	const readMoreLink = (
 		<RichText
 			className="wp-block-post-excerpt__more-link"
-			tagName="a"
+			tagName={ isPostOneLink ? 'span' : 'a' }
 			aria-label={ __( '"Read more" link text' ) }
 			placeholder={ __( 'Add "read more" link text' ) }
 			value={ moreText }

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -18,13 +18,20 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$is_post_one_link = $block->context['isPostOneLink'];
+
 	$excerpt = get_the_excerpt();
 
 	if ( empty( $excerpt ) ) {
 		return '';
 	}
 
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . esc_html( $attributes['moreText'] ) . '</a>' : '';
+	$more_text  = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . esc_html( $attributes['moreText'] ) . '</a>' : '';
+
+	if ( $is_post_one_link ) {
+		$more_text = ! empty( $attributes['moreText'] ) ? '<span class="wp-block-post-excerpt__more-link">' . esc_html( $attributes['moreText'] ) . '</span>' : '';
+	}
+
 	$filter_excerpt_more = function( $more ) use ( $more_text ) {
 		return empty( $more_text ) ? $more : '';
 	};

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -22,7 +22,7 @@
 			"default": "cover"
 		}
 	},
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId", "isPostOneLink" ],
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"color": {

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -21,6 +21,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { upload } from '@wordpress/icons';
 import { SVG, Path } from '@wordpress/primitives';
 import { store as noticesStore } from '@wordpress/notices';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -50,7 +51,7 @@ function PostFeaturedImageDisplay( {
 	clientId,
 	attributes,
 	setAttributes,
-	context: { postId, postType, queryId },
+	context: { postId, postType, queryId, isPostOneLink },
 } ) {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const { isLink, height, width, scale } = attributes;
@@ -60,6 +61,11 @@ function PostFeaturedImageDisplay( {
 		'featured_media',
 		postId
 	);
+
+	// ensure that the post featured image is not a link when the post template marks the entire post a link
+	useEffect( () => {
+		if ( isPostOneLink ) setAttributes( { isLink: false } );
+	}, [ isPostOneLink ] );
 
 	const media = useSelect(
 		( select ) =>
@@ -109,6 +115,14 @@ function PostFeaturedImageDisplay( {
 						) }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 						checked={ isLink }
+						disabled={ isPostOneLink }
+						help={
+							isPostOneLink
+								? __(
+										'The Post Template block marks that the entire Post should be one link.'
+								  )
+								: null
+						}
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -119,7 +119,7 @@ function PostFeaturedImageDisplay( {
 						help={
 							isPostOneLink
 								? __(
-										'The Post Template block marks that the entire Post should be one link.'
+										'The Post Template block marks that the entire post should be one link.'
 								  )
 								: null
 						}

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -14,6 +14,9 @@
 		"displayLayout",
 		"templateSlug"
 	],
+	"providesContext": {
+		"isPostOneLink": "makeEntirePostClickable"
+	},
 	"supports": {
 		"reusable": false,
 		"html": false,
@@ -22,6 +25,13 @@
 			"allowEditing": false
 		}
 	},
+	"attributes": {
+		"makeEntirePostClickable": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"style": "wp-block-post-template",
-	"editorStyle": "wp-block-post-template-editor"
+	"editorStyle": "wp-block-post-template-editor",
+	"viewScript": "file:./view.min.js"
 }

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -18,6 +18,10 @@ import {
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
+/**
+ * Internal dependencies
+ */
+import { BlockInspector } from './inspector';
 
 const TEMPLATE = [
 	[ 'core/post-title' ],
@@ -65,6 +69,8 @@ const MemoizedPostTemplateBlockPreview = memo( PostTemplateBlockPreview );
 
 export default function PostTemplateEdit( {
 	clientId,
+	attributes,
+	setAttributes,
 	context: {
 		query: {
 			perPage,
@@ -166,14 +172,28 @@ export default function PostTemplateEdit( {
 
 	if ( ! posts ) {
 		return (
-			<p { ...blockProps }>
-				<Spinner />
-			</p>
+			<>
+				<BlockInspector
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+				/>
+				<p { ...blockProps }>
+					<Spinner />
+				</p>
+			</>
 		);
 	}
 
 	if ( ! posts.length ) {
-		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
+		return (
+			<>
+				<BlockInspector
+					attributes={ attributes }
+					setAttributes={ setAttributes }
+				/>
+				<p { ...blockProps }> { __( 'No results found.' ) }</p>
+			</>
+		);
 	}
 
 	// To avoid flicker when switching active block contexts, a preview is rendered
@@ -181,30 +201,38 @@ export default function PostTemplateEdit( {
 	// This ensures that when it is displayed again, the cached rendering of the
 	// block preview is used, instead of having to re-render the preview from scratch.
 	return (
-		<ul { ...blockProps }>
-			{ blockContexts &&
-				blockContexts.map( ( blockContext ) => (
-					<BlockContextProvider
-						key={ blockContext.postId }
-						value={ blockContext }
-					>
-						{ blockContext.postId ===
-						( activeBlockContextId ||
-							blockContexts[ 0 ]?.postId ) ? (
-							<PostTemplateInnerBlocks />
-						) : null }
-						<MemoizedPostTemplateBlockPreview
-							blocks={ blocks }
-							blockContextId={ blockContext.postId }
-							setActiveBlockContextId={ setActiveBlockContextId }
-							isHidden={
-								blockContext.postId ===
-								( activeBlockContextId ||
-									blockContexts[ 0 ]?.postId )
-							}
-						/>
-					</BlockContextProvider>
-				) ) }
-		</ul>
+		<>
+			<BlockInspector
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+			/>
+			<ul { ...blockProps }>
+				{ blockContexts &&
+					blockContexts.map( ( blockContext ) => (
+						<BlockContextProvider
+							key={ blockContext.postId }
+							value={ blockContext }
+						>
+							{ blockContext.postId ===
+							( activeBlockContextId ||
+								blockContexts[ 0 ]?.postId ) ? (
+								<PostTemplateInnerBlocks />
+							) : null }
+							<MemoizedPostTemplateBlockPreview
+								blocks={ blocks }
+								blockContextId={ blockContext.postId }
+								setActiveBlockContextId={
+									setActiveBlockContextId
+								}
+								isHidden={
+									blockContext.postId ===
+									( activeBlockContextId ||
+										blockContexts[ 0 ]?.postId )
+								}
+							/>
+						</BlockContextProvider>
+					) ) }
+			</ul>
+		</>
 	);
 }

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -67,6 +67,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 	wp_reset_postdata();
 
+	if ( $attributes['makeEntirePostClickable'] ) {
+		wp_enqueue_script( 'wp-block-post-template-view' );
+	}
+
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',
 		$wrapper_attributes,

--- a/packages/block-library/src/post-template/inspector.js
+++ b/packages/block-library/src/post-template/inspector.js
@@ -18,7 +18,7 @@ export function BlockInspector( props ) {
 				<ToggleControl
 					checked={ makeEntirePostClickable }
 					onChange={ setMakeEntirePostClickable }
-					label={ __( 'Make entire Post Clickable' ) }
+					label={ __( 'Make entire Post clickable' ) }
 					help={ __(
 						'When enabled the entire post will be clickable and direct the user to the post page.'
 					) }

--- a/packages/block-library/src/post-template/inspector.js
+++ b/packages/block-library/src/post-template/inspector.js
@@ -18,7 +18,7 @@ export function BlockInspector( props ) {
 				<ToggleControl
 					checked={ makeEntirePostClickable }
 					onChange={ setMakeEntirePostClickable }
-					label={ __( 'Make entire Post clickable' ) }
+					label={ __( 'Make entire post clickable' ) }
 					help={ __(
 						'When enabled the entire post will be clickable and direct the user to the post page.'
 					) }

--- a/packages/block-library/src/post-template/inspector.js
+++ b/packages/block-library/src/post-template/inspector.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export function BlockInspector( props ) {
+	const { attributes, setAttributes } = props;
+	const { makeEntirePostClickable } = attributes;
+
+	const setMakeEntirePostClickable = ( newValue ) =>
+		setAttributes( { makeEntirePostClickable: newValue } );
+
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( '' ) }>
+				<ToggleControl
+					checked={ makeEntirePostClickable }
+					onChange={ setMakeEntirePostClickable }
+					label={ __( 'Make entire Post Clickable' ) }
+					help={ __(
+						'When enabled the entire post will be clickable and direct the user to the post page.'
+					) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -30,4 +30,8 @@
 			}
 		}
 	}
+
+	& .wp-block-post.is-clickable {
+		cursor: pointer;
+	}
 }

--- a/packages/block-library/src/post-template/view.js
+++ b/packages/block-library/src/post-template/view.js
@@ -1,0 +1,17 @@
+// Necessary for some themes such as TT1 Blocks, where
+// scripts could be loaded before the body.
+window.addEventListener( 'load', () => {
+	const postBlocks = document.querySelectorAll(
+		'.wp-block-post-template .wp-block-post'
+	);
+
+	postBlocks.forEach( ( postCard ) => {
+		const link = postCard.querySelector( '.wp-block-post-title a' );
+		if ( link ) {
+			postCard.addEventListener( 'click', () => {
+				link.click();
+			} );
+			postCard.classList.add( 'is-clickable' );
+		}
+	} );
+} );

--- a/packages/block-library/src/post-template/view.js
+++ b/packages/block-library/src/post-template/view.js
@@ -5,13 +5,13 @@ window.addEventListener( 'load', () => {
 		'.wp-block-post-template .wp-block-post'
 	);
 
-	postBlocks.forEach( ( postCard ) => {
-		const link = postCard.querySelector( '.wp-block-post-title a' );
+	postBlocks.forEach( ( postBlockElement ) => {
+		const link = postBlockElement.querySelector( '.wp-block-post-title a' );
 		if ( link ) {
-			postCard.addEventListener( 'click', () => {
+			postBlockElement.addEventListener( 'click', () => {
 				link.click();
 			} );
-			postCard.classList.add( 'is-clickable' );
+			postBlockElement.classList.add( 'is-clickable' );
 		}
 	} );
 } );

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -6,7 +6,7 @@
 	"category": "theme",
 	"description": "Displays the title of a post, page, or any other content-type.",
 	"textdomain": "default",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [ "postId", "postType", "queryId", "isPostOneLink" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -128,7 +128,7 @@ export default function PostTitleEdit( {
 						disabled={ isPostOneLink }
 						help={
 							isPostOneLink
-								? 'The Post Template block marks that the entire Post should be one link. Therefore the link in the title is needed.'
+								? 'The Post Template block marks that the entire post should be one link. Therefore the link in the title is needed.'
 								: null
 						}
 					/>

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -13,7 +13,7 @@ import {
 	useBlockProps,
 	PlainText,
 } from '@wordpress/block-editor';
-import { RawHTML } from '@wordpress/element';
+import { RawHTML, useEffect } from '@wordpress/element';
 import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
@@ -27,7 +27,7 @@ import { useCanEditEntity } from '../utils/hooks';
 export default function PostTitleEdit( {
 	attributes: { level, textAlign, isLink, rel, linkTarget },
 	setAttributes,
-	context: { postType, postId, queryId },
+	context: { postType, postId, queryId, isPostOneLink },
 } ) {
 	const TagName = 0 === level ? 'p' : 'h' + level;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
@@ -44,6 +44,11 @@ export default function PostTitleEdit( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
+
+	// ensure that the post title is a link when the post template marks the entire post a link
+	useEffect( () => {
+		if ( isPostOneLink ) setAttributes( { isLink: true } );
+	}, [ isPostOneLink ] );
 
 	let titleElement = (
 		<TagName { ...blockProps }>{ __( 'Post Title' ) }</TagName>
@@ -120,6 +125,12 @@ export default function PostTitleEdit( {
 						label={ __( 'Make title a link' ) }
 						onChange={ () => setAttributes( { isLink: ! isLink } ) }
 						checked={ isLink }
+						disabled={ isPostOneLink }
+						help={
+							isPostOneLink
+								? 'The Post Template block marks that the entire Post should be one link. Therefore the link in the title is needed.'
+								: null
+						}
 					/>
 					{ isLink && (
 						<>

--- a/test/integration/fixtures/blocks/core__post-template.json
+++ b/test/integration/fixtures/blocks/core__post-template.json
@@ -3,7 +3,9 @@
 		"clientId": "_clientId_0",
 		"name": "core/post-template",
 		"isValid": true,
-		"attributes": {},
+		"attributes": {
+			"makeEntirePostClickable": false
+		},
 		"innerBlocks": [],
 		"originalContent": ""
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The Post Template Block currently only allows you to link to the post via the individual blocks that are used within the template. So if you want your entire card to be clickable you would have to make your post title, post featured image and post date links. The issue with this is that you now have the same link present on the page 3 times. Which is rather unpleasant for users that use a screenreader. If you look at the rotor you get the same link shown 3 times for each post in your query. 

Semantically the main linkable element should be the posts heading since that gives you the most information about the links target. 

This PR introduces a new setting that editors to check that the entire post should be clickable. When you enable that toggle all the child blocks will automatically turn off their `isLink` setting except for the post title block which will turn the `isLink` setting on. All of the blocks also disable the toggle to change whether they are a link or not and add some help text underneath the control about why the toggle is disabled. 

Additionally a view script is added to the post template which will only get loaded on the site if the setting is enabled. This script adds an click event listener to the entire card which intern triggers a click on the pos title.

Closes #38014 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature: Add option to Post Template to make entire post clickable

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
