### PR TITLE
Gallery block: prototype managing gap changes without css var

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -93,12 +93,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
 			$style    .= "gap: $gap_style;";
-
-			/*
-			 * In some contexts a flex container's children may be need to recalculate their width
-			 * based on the current gap so this value is made available as a css var.
-			 */
-			$style .= "--wp--style--block-scoped-flex-gap: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';
 		}

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -113,9 +113,6 @@ export default {
 				${ appendSelectors( selector ) } {
 					display: flex;
 					gap: ${ hasBlockGapStylesSupport ? blockGapValue : '0.5em' };
-					--wp--style--block-scoped-flex-gap: ${
-						hasBlockGapStylesSupport ? blockGapValue : '0.5em'
-					}; 
 					flex-wrap: ${ flexWrap };
 					${ orientation === 'horizontal' ? rowOrientation : columnOrientation }
 				}

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -102,7 +102,9 @@
 	"providesContext": {
 		"allowResize": "allowResize",
 		"imageCrop": "imageCrop",
-		"fixedHeight": "fixedHeight"
+		"fixedHeight": "fixedHeight",
+		"style": "style",
+		"columns": "columns"
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -4,7 +4,13 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop", "fixedHeight" ],
+	"usesContext": [
+		"allowResize",
+		"imageCrop",
+		"fixedHeight",
+		"style",
+		"columns"
+	],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -123,6 +123,10 @@ export function ImageEdit( {
 		height,
 		sizeSlug,
 	} = attributes;
+
+	const parentGap = context?.style?.spacing?.blockGap;
+	const columns = context?.columns ? context?.columns : 3;
+
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
 	const altRef = useRef();
@@ -349,8 +353,17 @@ export function ImageEdit( {
 		className: classes,
 	} );
 
+	const newWidth =
+		columns && parentGap
+			? `calc((100% / ${ columns }) - ${ parentGap })`
+			: 'initial';
 	return (
-		<figure { ...blockProps }>
+		<figure
+			{ ...blockProps }
+			style={ {
+				width: newWidth,
+			} }
+		>
 			{ ( temporaryURL || url ) && (
 				<Image
 					temporaryURL={ temporaryURL }


### PR DESCRIPTION
## Description
For background see https://github.com/WordPress/gutenberg/pull/37903

This PR is just a PoC to look at options for managing gap changes in the Gallery block without resorting to an additional flex layout module css var.

## How has this been tested?
 Add a gallery in WP env with block theme, add images and adjust block gap.

This PR is not supposed to be 100% functional, it is just an exploration of what is and isn't possible, and it currently only works in editor, not frontend, as the context value used are not available in the save method.

I wouldn't recommend going with this approach as it has the following limitations:

- Adds additional coupling between Image block and parent gallery, and potentially extra re-renders of all images in a gallery as gap value changes 
- The context values passed from the Gallery are not available in the Image save function, so a new attributes would need to be added, and these combined with the inline style would result in the need for a new image deprecation

Even though this is not a great way forward I thought it was worth putting up in case it triggered any different approaches from others.
