### PR TITLE
Fix hiding the bottom of tablet/mobile preview in Site Editor

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -24,6 +24,12 @@
 		.edit-site-visual-editor__editor-canvas {
 			border-radius: $radius-block-ui;
 		}
+
+		// To hide the horizontal scrollbar and show the drag handle on the
+		// left and right of the container.
+		.components-resizable-box__container {
+			overflow: visible;
+		}
 	}
 }
 
@@ -42,6 +48,8 @@
 
 .components-resizable-box__container {
 	margin: 0 auto;
+	// Removing this will cancel the bottom margins in the iframe.
+	overflow: auto;
 }
 
 .resizable-editor__drag-handle {

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -32,7 +32,6 @@ html.wp-toolbar {
 	position: relative;
 	height: 100%;
 	display: block;
-	overflow: hidden;
 
 	iframe {
 		display: block;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fix https://github.com/WordPress/gutenberg/issues/37708.

Remove `overflow: hidden` in `.edit-site-visual-editor` to fix the bottom of tablet/mobile preview being cut off in smaller viewport.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Activate a block-based theme (I'm using Seadlet)
2. Go to Appearance -> Editor
3. Switch the preview from "Desktop" to "Mobile" or "Tablet"
4. The preview shouldn't be cut off, and can be scrolled down
5. Edit a template part (Header for instance)
6. The focus mode should not have a horizontal scrollbar either

## Screenshots <!-- if applicable -->
![Screen Shot 2022-01-17 at 1 53 08 PM](https://user-images.githubusercontent.com/7753001/149715189-997e081d-70b6-463f-8ea5-a4c8c7bd6433.png)

![Screen Shot 2022-01-17 at 1 53 30 PM](https://user-images.githubusercontent.com/7753001/149715199-923083d5-5779-4e52-aca0-7a5d64efa223.png)

(_I noticed there's a vertical scrollbar in smaller viewport, probably unrelated to this change though as it's also happening on trunk._)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
