### PR TITLE
`ComboBox`: fix `reset` button's height

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   Components: Fix `Slot`/`Fill` Emotion `StyleProvider` ([#38237](https://github.com/WordPress/gutenberg/pull/38237))
+-   Reduce height and min-width of the reset button on `ComboBoxControl` for consistency. ([#38020](https://github.com/WordPress/gutenberg/pull/38020))
 
 ## 19.3.0 (2022-01-27)
 

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -8,11 +8,6 @@ import { useState } from '@wordpress/element';
  */
 import ComboboxControl from '../';
 
-/**
- * External dependencies
- */
-import { boolean } from '@storybook/addon-knobs';
-
 const countries = [
 	{ name: 'Afghanistan', code: 'AF' },
 	{ name: 'Åland Islands', code: 'AX' },
@@ -262,9 +257,6 @@ const countries = [
 export default {
 	title: 'Components/ComboboxControl',
 	component: ComboboxControl,
-	parameters: {
-		knobs: { disable: false },
-	},
 };
 
 const mapCountryOption = ( country ) => ( {
@@ -274,7 +266,7 @@ const mapCountryOption = ( country ) => ( {
 
 const countryOptions = countries.map( mapCountryOption );
 
-function CountryCodeComboboxControl() {
+function CountryCodeComboboxControl( { allowReset } ) {
 	const [ value, setValue ] = useState( null );
 
 	return (
@@ -284,10 +276,13 @@ function CountryCodeComboboxControl() {
 				onChange={ setValue }
 				label="Select a country"
 				options={ countryOptions }
-				allowReset={ boolean( 'allowReset', false ) }
+				allowReset={ allowReset }
 			/>
 			<p>Value: { value }</p>
 		</>
 	);
 }
-export const _default = () => <CountryCodeComboboxControl />;
+export const _default = CountryCodeComboboxControl.bind( {} );
+_default.args = {
+	allowReset: false,
+};

--- a/packages/components/src/combobox-control/stories/index.js
+++ b/packages/components/src/combobox-control/stories/index.js
@@ -8,6 +8,11 @@ import { useState } from '@wordpress/element';
  */
 import ComboboxControl from '../';
 
+/**
+ * External dependencies
+ */
+import { boolean } from '@storybook/addon-knobs';
+
 const countries = [
 	{ name: 'Afghanistan', code: 'AF' },
 	{ name: 'Åland Islands', code: 'AX' },
@@ -257,6 +262,9 @@ const countries = [
 export default {
 	title: 'Components/ComboboxControl',
 	component: ComboboxControl,
+	parameters: {
+		knobs: { disable: false },
+	},
 };
 
 const mapCountryOption = ( country ) => ( {
@@ -276,6 +284,7 @@ function CountryCodeComboboxControl() {
 				onChange={ setValue }
 				label="Select a country"
 				options={ countryOptions }
+				allowReset={ boolean( 'allowReset', false ) }
 			/>
 			<p>Value: { value }</p>
 		</>

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -40,7 +40,7 @@ input.components-combobox-control__input[type="text"] {
 
 .components-combobox-control__reset.components-button {
 	display: flex;
-	height: $grid-unit-30;
-	min-width: $grid-unit-30;
+	height: $grid-unit-20;
+	min-width: $grid-unit-20;
 	padding: 0;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Reduces the height of the reset button icon so that it doesn't expand the textbox height that contains it.

This expanded height was noticed when we placed it next to a text input we expected would have a matching height ([example](https://user-images.githubusercontent.com/811776/149080697-08f06b1a-ce07-481a-bdad-491c18c14a43.png), it's off by 2px). 

## How has this been tested?

Manually checking in storybook docs

```
npm run storybook:dev
```

## Screenshots <!-- if applicable -->

Before

https://user-images.githubusercontent.com/811776/149721079-7aac8010-8ae1-430e-8785-6ab6f7da1233.mp4

After

https://user-images.githubusercontent.com/811776/149721090-ac1a07f1-02ec-41b4-8081-f0cceeeb5fe9.mp4


## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
