### PR TITLE
[RNMobile] Remove WordPress-Mobile-Utils dep from the demo app

### DIFF
--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -178,9 +178,6 @@ dependencies {
     implementation("org.wordpress-mobile.gutenberg-mobile:react-native-bridge", {
         exclude group: 'org.wordpress', module: 'utils'
     })
-    implementation("org.wordpress:utils:$wordpressUtilsVersion", {
-        exclude group: 'com.android.support'
-    })
     implementation 'androidx.appcompat:appcompat:1.2.0'
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         supportLibVersion = '28.0.0'
-        wordpressUtilsVersion = '1.40.0'
         ndkVersion = "21.4.7075529"
     }
     repositories {

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         compileSdkVersion = 30
         targetSdkVersion = 30
         supportLibVersion = '28.0.0'
-        wordpressUtilsVersion = '1.22'
+        wordpressUtilsVersion = '1.40.0'
         ndkVersion = "21.4.7075529"
     }
     repositories {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The wp-mobile-utils library is not really used directly in the demo mobile app so, removing its definition.

This change was initiated by [build failures in the gutenberg-mobile repo](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/15845/workflows/fa3fc0cf-f660-4a53-b7d6-5c076afcb21e/jobs/86074?invite=true#step-110-128), although that was probably due to JCenter issues.

Nevertheless, better to remove the dependency when not needed.

**Note:** The dependency is still there in the react-native-aztec wrapper (used for `AppLog` [in ReactNativeText](https://github.com/WordPress/gutenberg/blob/154918b5770ac07c851169eaa35961c636eac5ba/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecText.java#L209)). We can try refactoring that out in a separate PR.

### Related PRs

* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4480
* https://github.com/wordpress-mobile/WordPress-Android/pull/15824

## How has this been tested?
1. By building and smoke-testing the demo app (works OK)
2. By triggering all the E2E tests [in gutenberg-mobile](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4480) and in [WPAndroid](https://github.com/wordpress-mobile/WordPress-Android/pull/15824)
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
1. Removal of the WordPress-Mobile-Utils Android dep
2. Removal of the `wordpressUtilsVersion` gradle variable

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
