### PR TITLE
Fix: PanelColorSettings renders an empty when a color setting is falsy.

### DIFF
--- a/packages/block-editor/src/components/colors-gradients/dropdown.js
+++ b/packages/block-editor/src/components/colors-gradients/dropdown.js
@@ -41,51 +41,56 @@ export default function ColorGradientSettingsDropdown( {
 			isSeparated
 			className="block-editor-panel-color-gradient-settings__item-group"
 		>
-			{ settings.map( ( setting, index ) => (
-				<Dropdown
-					key={ index }
-					position={ dropdownPosition }
-					className="block-editor-panel-color-gradient-settings__dropdown"
-					contentClassName="block-editor-panel-color-gradient-settings__dropdown-content"
-					renderToggle={ ( { isOpen, onToggle } ) => {
-						return (
-							<Item
-								onClick={ onToggle }
-								className={ classnames(
-									'block-editor-panel-color-gradient-settings__item',
-									{ 'is-open': isOpen }
-								) }
-							>
-								<HStack justify="flex-start">
-									<ColorIndicator
-										className="block-editor-panel-color-gradient-settings__color-indicator"
-										colorValue={
-											setting.gradientValue ??
-											setting.colorValue
-										}
-									/>
-									<FlexItem>{ setting.label }</FlexItem>
-								</HStack>
-							</Item>
-						);
-					} }
-					renderContent={ () => (
-						<ColorGradientControl
-							showTitle={ false }
-							{ ...{
-								colors,
-								gradients,
-								disableCustomColors,
-								disableCustomGradients,
-								__experimentalHasMultipleOrigins,
-								__experimentalIsRenderedInSidebar,
-								enableAlpha,
-								...setting,
+			{ settings.map(
+				( setting, index ) =>
+					setting && (
+						<Dropdown
+							key={ index }
+							position={ dropdownPosition }
+							className="block-editor-panel-color-gradient-settings__dropdown"
+							contentClassName="block-editor-panel-color-gradient-settings__dropdown-content"
+							renderToggle={ ( { isOpen, onToggle } ) => {
+								return (
+									<Item
+										onClick={ onToggle }
+										className={ classnames(
+											'block-editor-panel-color-gradient-settings__item',
+											{ 'is-open': isOpen }
+										) }
+									>
+										<HStack justify="flex-start">
+											<ColorIndicator
+												className="block-editor-panel-color-gradient-settings__color-indicator"
+												colorValue={
+													setting.gradientValue ??
+													setting.colorValue
+												}
+											/>
+											<FlexItem>
+												{ setting.label }
+											</FlexItem>
+										</HStack>
+									</Item>
+								);
 							} }
+							renderContent={ () => (
+								<ColorGradientControl
+									showTitle={ false }
+									{ ...{
+										colors,
+										gradients,
+										disableCustomColors,
+										disableCustomGradients,
+										__experimentalHasMultipleOrigins,
+										__experimentalIsRenderedInSidebar,
+										enableAlpha,
+										...setting,
+									} }
+								/>
+							) }
 						/>
-					) }
-				/>
-			) ) }
+					)
+			) }
 		</ItemGroup>
 	);
 }

--- a/packages/block-editor/src/components/panel-color-settings/index.js
+++ b/packages/block-editor/src/components/panel-color-settings/index.js
@@ -4,13 +4,17 @@
 import PanelColorGradientSettings from '../colors-gradients/panel-color-gradient-settings';
 
 const PanelColorSettings = ( { colorSettings, ...props } ) => {
-	const settings = colorSettings.map(
-		( { value, onChange, ...otherSettings } ) => ( {
+	const settings = colorSettings.map( ( setting ) => {
+		if ( ! setting ) {
+			return setting;
+		}
+		const { value, onChange, ...otherSettings } = setting;
+		return {
 			...otherSettings,
 			colorValue: value,
 			onColorChange: onChange,
-		} )
-	);
+		};
+	} );
 	return (
 		<PanelColorGradientSettings
 			settings={ settings }


### PR DESCRIPTION
Adds a check to the internal ColorGradientSettingsDropdown component that verifies if a setting is falsy and in that case renders nothing instead of rendering an unsable color picker.
Adds a check to PanelColorSettings to make sure we don't pass a setting with null properties when a setting is null.

## How has this been tested?
I reverted https://github.com/WordPress/gutenberg/pull/38006.
I went to to the social links block, enabled to the logo-only option, and verified the color option available was icon color and an empty option was not rendered.
