### PR TITLE
Update `micromodal` to 0.4.10 to fix navigation close button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46275,9 +46275,9 @@
 			}
 		},
 		"micromodal": {
-			"version": "0.4.9",
-			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.9.tgz",
-			"integrity": "sha512-6sWcdAhzUOiu88LRz+HgGM2cfvwQjrOBXx+3BilqWg3Lr+bTNEgCUMME5OqgeoWckRk2klDkT0sPqjJzDB1ffw=="
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+			"integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16404,7 +16404,7 @@
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"micromodal": "^0.4.9",
+				"micromodal": "^0.4.10",
 				"moment": "^2.22.1"
 			},
 			"dependencies": {

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -66,7 +66,7 @@
 		"fast-average-color": "4.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"micromodal": "^0.4.9",
+		"micromodal": "^0.4.10",
 		"moment": "^2.22.1"
 	},
 	"publishConfig": {


### PR DESCRIPTION
## Description
Update the version of `micromodal` library to `0.4.10` to bring in a fix that allows `preventDefault` again, fixing the click-through behavior in browsers that emulate click events on touch events. See https://github.com/ghosh/Micromodal/pull/488.

Fixes #37996.

## How has this been tested?

- Using either an android phone or Firefox's responsive mode with touch simulation
- Open the navigation menu with the hamburger button
- Close the menu with the ✖️  button
- It should close and stay closed
- If you have the admin bar visible, it should not take you to your profile

## Types of changes

Bug fix (non-breaking change which fixes an issue)
