### PR TITLE
ToolsPanel: Memoize callbacks and context to prevent unnecessary rerenders

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -3,6 +3,7 @@
  */
 import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,74 +12,52 @@ import { store as blockEditorStore } from '../../store';
 import { cleanEmptyObject } from '../../hooks/utils';
 
 export default function BlockSupportToolsPanel( { children, group, label } ) {
-	const { attributes, clientIds, panelId } = useSelect( ( select ) => {
-		const {
-			getBlockAttributes,
-			getMultiSelectedBlockClientIds,
-			getSelectedBlockClientId,
-			hasMultiSelection,
-		} = select( blockEditorStore );
-
-		// When we currently have a multi-selection, the value returned from
-		// `getSelectedBlockClientId()` is `null`. When a `null` value is used
-		// for the `panelId`, a `ToolsPanel` will still allow panel items to
-		// register themselves despite their panelIds not matching.
-		const selectedBlockClientId = getSelectedBlockClientId();
-
-		if ( hasMultiSelection() ) {
-			const selectedBlockClientIds = getMultiSelectedBlockClientIds();
-			const selectedBlockAttributes = selectedBlockClientIds.reduce(
-				( blockAttributes, blockId ) => {
-					blockAttributes[ blockId ] = getBlockAttributes( blockId );
-					return blockAttributes;
-				},
-				{}
-			);
-
-			return {
-				panelId: selectedBlockClientId,
-				clientIds: selectedBlockClientIds,
-				attributes: selectedBlockAttributes,
-			};
-		}
-
-		return {
-			panelId: selectedBlockClientId,
-			clientIds: [ selectedBlockClientId ],
-			attributes: {
-				[ selectedBlockClientId ]: getBlockAttributes(
-					selectedBlockClientId
-				),
-			},
-		};
-	}, [] );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const {
+		getBlockAttributes,
+		getMultiSelectedBlockClientIds,
+		getSelectedBlockClientId,
+		hasMultiSelection,
+	} = useSelect( blockEditorStore );
 
-	const resetAll = ( resetFilters = [] ) => {
-		const newAttributes = {};
+	const panelId = getSelectedBlockClientId();
+	const resetAll = useCallback(
+		( resetFilters = [] ) => {
+			const newAttributes = {};
 
-		clientIds.forEach( ( clientId ) => {
-			const { style } = attributes[ clientId ];
-			let newBlockAttributes = { style };
+			const clientIds = hasMultiSelection()
+				? getMultiSelectedBlockClientIds()
+				: [ panelId ];
 
-			resetFilters.forEach( ( resetFilter ) => {
+			clientIds.forEach( ( clientId ) => {
+				const { style } = getBlockAttributes( clientId );
+				let newBlockAttributes = { style };
+
+				resetFilters.forEach( ( resetFilter ) => {
+					newBlockAttributes = {
+						...newBlockAttributes,
+						...resetFilter( newBlockAttributes ),
+					};
+				} );
+
+				// Enforce a cleaned style object.
 				newBlockAttributes = {
 					...newBlockAttributes,
-					...resetFilter( newBlockAttributes ),
+					style: cleanEmptyObject( newBlockAttributes.style ),
 				};
+
+				newAttributes[ clientId ] = newBlockAttributes;
 			} );
 
-			// Enforce a cleaned style object.
-			newBlockAttributes = {
-				...newBlockAttributes,
-				style: cleanEmptyObject( newBlockAttributes.style ),
-			};
-
-			newAttributes[ clientId ] = newBlockAttributes;
-		} );
-
-		updateBlockAttributes( clientIds, newAttributes, true );
-	};
+			updateBlockAttributes( clientIds, newAttributes, true );
+		},
+		[
+			hasMultiSelection,
+			getMultiSelectedBlockClientIds,
+			panelId,
+			getBlockAttributes,
+		]
+	);
 
 	return (
 		<ToolsPanel

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -52,10 +52,12 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 			updateBlockAttributes( clientIds, newAttributes, true );
 		},
 		[
-			hasMultiSelection,
-			getMultiSelectedBlockClientIds,
-			panelId,
+			cleanEmptyObject,
 			getBlockAttributes,
+			getMultiSelectedBlockClientIds,
+			hasMultiSelection,
+			panelId,
+			updateBlockAttributes,
 		]
 	);
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,7 @@
 -   Add missing styles to the `BaseControl.VisualLabel` component. ([#37747](https://github.com/WordPress/gutenberg/pull/37747))
 -   Prevent keyDown events from propagating up in `CustomSelectControl` ([#30557](https://github.com/WordPress/gutenberg/pull/30557))
 -   Mark `children` prop as optional in `SelectControl` ([#37872](https://github.com/WordPress/gutenberg/pull/37872))
+-   Add memoization of callbacks and context to prevent unnecessary rerenders of the `ToolsPanel` ([#38037](https://github.com/WordPress/gutenberg/pull/38037))
 
 ## 19.2.0 (2022-01-04)
 


### PR DESCRIPTION
Raised in https://github.com/WordPress/gutenberg/pull/32392#issuecomment-1010786016

## Description

This PR adds memoization to the callbacks and context used by the `ToolsPanel` and `BlockSupportsToolsPanel` to prevent unnecessary rerenders.


## How has this been tested?

1. Run `ToolsPanel` unit tests: `npm run test-unit packages/components/src/tools-panel/test`
2. Test all the [`ToolsPanel` storybook examples](http://localhost:50240/?path=/story/components-experimental-toolspanel--default) still function as expected: `npm run storybook:dev`
3. Confirm the `ToolsPanel` functions as expected for block supports within the block/site editors.
4. Ensure typography block support panel still functions for multi-selections in block editor.
5. Confirm the `ToolsPanel` is not excessively rerendering.

#### Testing of rerendering fix

1. Checkout `trunk` and open block editor
2. Create a post and add multiple paragraphs with text and save the post
3. Enable React Dev Tools if not already running, ensure you have "Highlight updates when components render" on under General settings
4. Reload the page, then select a paragraph block
5. Now hover over different blocks and you should see the Typography `ToolsPanel` rerendering
6. Checkout this PR branch and rebuild
7. Repeat steps 4 & 5 except this time the Typography panel should not be rerendering

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![ToolsPanelRerenderingBefore](https://user-images.githubusercontent.com/60436221/149853664-a2a20a4e-a84f-40e9-924e-c9cd674e6343.gif) | ![ToolsPanelRerenderingAfter](https://user-images.githubusercontent.com/60436221/149853688-b227e1af-45a6-40b3-858c-f50c9bc7365b.gif) |

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
