### PR TITLE
Post Lock Modal: Update avatar size

### DIFF
--- a/lib/compat/wordpress-6.0/post-lock.php
+++ b/lib/compat/wordpress-6.0/post-lock.php
@@ -59,7 +59,7 @@ function gutenberg_update_post_lock_details( $settings, $block_editor_context ) 
 
 	$user_id = wp_check_post_lock( $block_editor_context->post->ID );
 	if ( $user_id ) {
-		$settings['postLock']['user']['avatar'] = get_avatar_url( $user_id, array( 'size' => 64 ) );
+		$settings['postLock']['user']['avatar'] = get_avatar_url( $user_id, array( 'size' => 128 ) );
 	}
 
 	return $settings;

--- a/packages/editor/src/components/post-locked-modal/index.js
+++ b/packages/editor/src/components/post-locked-modal/index.js
@@ -103,7 +103,7 @@ export default function PostLockedModal() {
 					isTakeover: true,
 					user: {
 						name: received.lock_error.name,
-						avatar: received.lock_error.avatar_src,
+						avatar: received.lock_error.avatar_src_2x,
 					},
 				} );
 			} else if ( received.new_lock ) {


### PR DESCRIPTION
## Description
PR updates post lock modal avatar size to 128px (2x).

## How has this been tested?
Post Lock Modal: Update avatar size

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-18 at 11 41 20](https://user-images.githubusercontent.com/240569/149892624-920762f4-b614-4485-86b2-4b1e0584bae1.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
