### PR TITLE
Post Featured Image: Add size selector

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -528,7 +528,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), spacing (margin, padding), ~~html~~
--	**Attributes:** height, isLink, scale, width
+-	**Attributes:** height, isLink, scale, sizeSlug, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -20,6 +20,9 @@
 		"scale": {
 			"type": "string",
 			"default": "cover"
+		},
+		"sizeSlug": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -166,7 +166,7 @@ const DimensionControls = ( {
 						onChange={ ( nextSizeSlug ) =>
 							setAttributes( { sizeSlug: nextSizeSlug } )
 						}
-						help={ __( 'Select the image source to use.' ) }
+						help={ __( 'Select the size of the source image.' ) }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -3,6 +3,7 @@
  */
 import { __, _x } from '@wordpress/i18n';
 import {
+	SelectControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -32,6 +33,7 @@ const SCALE_OPTIONS = (
 );
 
 const DEFAULT_SCALE = 'cover';
+const DEFAULT_SIZE = 'full';
 
 const scaleHelp = {
 	cover: __(
@@ -47,8 +49,9 @@ const scaleHelp = {
 
 const DimensionControls = ( {
 	clientId,
-	attributes: { width, height, scale },
+	attributes: { width, height, scale, sizeSlug },
 	setAttributes,
+	imageSizeOptions = [],
 } ) => {
 	const defaultUnits = [ 'px', '%', 'vw', 'em', 'rem' ];
 	const units = useCustomUnits( {
@@ -113,6 +116,29 @@ const DimensionControls = ( {
 					units={ units }
 				/>
 			</ToolsPanelItem>
+			{ !! imageSizeOptions.length && (
+				<ToolsPanelItem
+					hasValue={ () => !! sizeSlug && sizeSlug !== DEFAULT_SIZE }
+					label={ __( 'Size' ) }
+					onDeselect={ () =>
+						setAttributes( { sizeSlug: undefined } )
+					}
+					resetAllFilter={ () => ( {
+						sizeSlug: undefined,
+					} ) }
+					isShownByDefault={ true }
+					panelId={ clientId }
+				>
+					<SelectControl
+						label={ __( 'Size' ) }
+						value={ sizeSlug || DEFAULT_SIZE }
+						options={ imageSizeOptions }
+						onChange={ ( nextSizeSlug ) =>
+							setAttributes( { sizeSlug: nextSizeSlug } )
+						}
+					/>
+				</ToolsPanelItem>
+			) }
 			{ !! height && (
 				<ToolsPanelItem
 					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -116,29 +116,6 @@ const DimensionControls = ( {
 					units={ units }
 				/>
 			</ToolsPanelItem>
-			{ !! imageSizeOptions.length && (
-				<ToolsPanelItem
-					hasValue={ () => !! sizeSlug && sizeSlug !== DEFAULT_SIZE }
-					label={ __( 'Size' ) }
-					onDeselect={ () =>
-						setAttributes( { sizeSlug: undefined } )
-					}
-					resetAllFilter={ () => ( {
-						sizeSlug: undefined,
-					} ) }
-					isShownByDefault={ true }
-					panelId={ clientId }
-				>
-					<SelectControl
-						label={ __( 'Size' ) }
-						value={ sizeSlug || DEFAULT_SIZE }
-						options={ imageSizeOptions }
-						onChange={ ( nextSizeSlug ) =>
-							setAttributes( { sizeSlug: nextSizeSlug } )
-						}
-					/>
-				</ToolsPanelItem>
-			) }
 			{ !! height && (
 				<ToolsPanelItem
 					hasValue={ () => !! scale && scale !== DEFAULT_SCALE }
@@ -167,6 +144,29 @@ const DimensionControls = ( {
 					>
 						{ SCALE_OPTIONS }
 					</ToggleGroupControl>
+				</ToolsPanelItem>
+			) }
+			{ !! imageSizeOptions.length && (
+				<ToolsPanelItem
+					hasValue={ () => !! sizeSlug && sizeSlug !== DEFAULT_SIZE }
+					label={ __( 'Size' ) }
+					onDeselect={ () =>
+						setAttributes( { sizeSlug: undefined } )
+					}
+					resetAllFilter={ () => ( {
+						sizeSlug: undefined,
+					} ) }
+					isShownByDefault={ false }
+					panelId={ clientId }
+				>
+					<SelectControl
+						label={ __( 'Size' ) }
+						value={ sizeSlug || DEFAULT_SIZE }
+						options={ imageSizeOptions }
+						onChange={ ( nextSizeSlug ) =>
+							setAttributes( { sizeSlug: nextSizeSlug } )
+						}
+					/>
 				</ToolsPanelItem>
 			) }
 		</InspectorControls>

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -148,8 +148,8 @@ const DimensionControls = ( {
 			) }
 			{ !! imageSizeOptions.length && (
 				<ToolsPanelItem
-					hasValue={ () => !! sizeSlug && sizeSlug !== DEFAULT_SIZE }
-					label={ __( 'Size' ) }
+					hasValue={ () => !! sizeSlug }
+					label={ __( 'Image size' ) }
 					onDeselect={ () =>
 						setAttributes( { sizeSlug: undefined } )
 					}
@@ -160,7 +160,7 @@ const DimensionControls = ( {
 					panelId={ clientId }
 				>
 					<SelectControl
-						label={ __( 'Size' ) }
+						label={ __( 'Image size' ) }
 						value={ sizeSlug || DEFAULT_SIZE }
 						options={ imageSizeOptions }
 						onChange={ ( nextSizeSlug ) =>

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -166,6 +166,7 @@ const DimensionControls = ( {
 						onChange={ ( nextSizeSlug ) =>
 							setAttributes( { sizeSlug: nextSizeSlug } )
 						}
+						help={ __( 'Select the image source to use.' ) }
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,8 +19,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$sizeSlug       = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$featured_image = get_the_post_thumbnail( $post_ID, $sizeSlug );
+	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
+	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug );
 	if ( ! $featured_image ) {
 		return '';
 	}

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -19,7 +19,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$featured_image = get_the_post_thumbnail( $post_ID );
+	$sizeSlug       = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
+	$featured_image = get_the_post_thumbnail( $post_ID, $sizeSlug );
 	if ( ! $featured_image ) {
 		return '';
 	}


### PR DESCRIPTION
## Description
Resolves #33789.

PR adds image size dropdown to the Featured Image block. This new option will be displayed in the "Dimensions" panel.

Now that I added yet another option to "Dimensions" control, I think they look a little out of place. Maybe we should go with the initial design proposed in the issue?

## How has this been tested?
1. Add a featured image block to the post.
2. The "Dimensions" should display a new size selector.
3. Changing size should display featured image in this size, both in editor and frontend.
4. Confirm same in Site Editor.

Note: Size dropdown isn't displayed if Post Featured Image has no media selected.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-18 at 17 08 17](https://user-images.githubusercontent.com/240569/149943210-4f66ef1b-b114-4bcb-885e-e8ebfd2681fa.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
