### PR TITLE
Fix iframe stylesheets cloning for Firefox

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -32,11 +32,11 @@ const BLOCK_PREFIX = 'wp-block';
  * contains the `editor-styles-wrapper`, `wp-block`, or `wp-block-*` class
  * selectors.
  *
- * Ideally, this hook should be removed in the future and styles should be added
- * explicitly as editor styles.
+ * This is a compatibility layer. Ideally, this hook should be removed in the
+ * future and styles should be added explicitly as editor styles.
  */
-const useEditorStyles = () =>
-	useRefEffect( ( node ) => {
+function useEditorStylesCompat() {
+	return useRefEffect( ( node ) => {
 		// Search the document for stylesheets targetting the editor canvas.
 		const clonedStyles = [];
 		Array.from( document.styleSheets ).forEach( ( styleSheet ) => {
@@ -106,6 +106,7 @@ const useEditorStyles = () =>
 
 		node.addEventListener( 'load', appendStyles );
 	} );
+}
 
 /**
  * Bubbles some event types (keydown, keypress, and dragover) to parent document
@@ -272,7 +273,7 @@ function Iframe(
 			{ tabIndex >= 0 && before }
 			<iframe
 				{ ...props }
-				ref={ useMergeRefs( [ ref, setRef, useEditorStyles() ] ) }
+				ref={ useMergeRefs( [ ref, setRef, useEditorStylesCompat() ] ) }
 				tabIndex={ tabIndex }
 				title={ __( 'Editor canvas' ) }
 			>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -91,6 +91,14 @@ function useEditorStylesCompat() {
 
 		const appendStyles = () => {
 			const doc = node.contentDocument;
+
+			if (
+				doc.readyState !== 'interactive' &&
+				doc.readyState !== 'complete'
+			) {
+				return false;
+			}
+
 			clonedStyles.forEach( ( style ) => {
 				if (
 					doc?.head &&
@@ -102,7 +110,13 @@ function useEditorStylesCompat() {
 					doc.head.appendChild( style );
 				}
 			} );
+
+			return true;
 		};
+
+		if ( appendStyles() ) {
+			return;
+		}
 
 		node.addEventListener( 'load', appendStyles );
 	} );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -89,7 +89,7 @@ function useEditorStylesCompat() {
 			}
 		} );
 
-		const appendStyles = () => {
+		function appendStyles() {
 			const doc = node.contentDocument;
 
 			if (
@@ -112,7 +112,7 @@ function useEditorStylesCompat() {
 			} );
 
 			return true;
-		};
+		}
 
 		if ( appendStyles() ) {
 			return;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR changes the `styleSheetsCompat()` strategy for stylesheets cloning into iframes to use `useRefEffect()` in order to fix Firefox compatibility.

Closes #37961 

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Using the sample plugin provided in #37961, compare the result of the post editors' Patterns list in Chrome and Firefox.

## Screenshots <!-- if applicable -->

| | Chrome 97.0.4692.71  | Firefox 96.0.1 |
| - | - | - |
| Current | ![image](https://user-images.githubusercontent.com/820752/149962459-5fa8c664-c75f-48ab-ab57-fd6bf8f5453f.png) | ![image](https://user-images.githubusercontent.com/820752/149962802-eb3073b4-5957-4820-be36-6945a6cd2403.png) |
| This branch | ![image](https://user-images.githubusercontent.com/820752/149964331-923c2f9c-bb67-4f7a-acd9-22e522d5cdf4.png) | ![image](https://user-images.githubusercontent.com/820752/149964241-9fff9f8c-3db2-4e09-a62a-c998cc72bbb0.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
