### PR TITLE
[RNMobile] Fix `act` warnings that might be triggered after test finishes

### DIFF
--- a/docs/contributors/code/react-native/integration-test-guide.md
+++ b/docs/contributors/code/react-native/integration-test-guide.md
@@ -89,7 +89,7 @@ const initialHtml = `<!-- wp:buttons -->
 <div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->`;
-const { getByA11yLabel } = await initializeEditor( {
+const { getByA11yLabel } = initializeEditor( {
 	initialHtml,
 } );
 ```

--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -74,11 +74,7 @@ describe( 'Reusable block', () => {
 			return Promise.resolve( response );
 		} );
 
-		const {
-			getByA11yLabel,
-			getByTestId,
-			getByText,
-		} = await initializeEditor( {
+		const { getByA11yLabel, getByTestId, getByText } = initializeEditor( {
 			initialHtml: '',
 			capabilities: { reusableBlock: true },
 		} );
@@ -87,7 +83,7 @@ describe( 'Reusable block', () => {
 		fireEvent.press( await waitFor( () => getByA11yLabel( 'Add block' ) ) );
 
 		// Navigate to reusable tab
-		const reusableSegment = getByText( 'Reusable' );
+		const reusableSegment = await waitFor( () => getByText( 'Reusable' ) );
 		// onLayout event is required by Segment component
 		fireEvent( reusableSegment, 'layout', {
 			nativeEvent: {
@@ -127,7 +123,7 @@ describe( 'Reusable block', () => {
 		const id = 3;
 		const initialHtml = `<!-- wp:block {"ref":${ id }} /-->`;
 
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml,
 		} );
 
@@ -162,7 +158,7 @@ describe( 'Reusable block', () => {
 			return Promise.resolve( response );
 		} );
 
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml,
 		} );
 

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -35,7 +35,7 @@ describe( 'Buttons block', () => {
 			<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
 			<!-- /wp:button --></div>
 			<!-- /wp:buttons -->`;
-			const { getByA11yLabel } = await initializeEditor( {
+			const { getByA11yLabel } = initializeEditor( {
 				initialHtml,
 			} );
 
@@ -90,7 +90,7 @@ describe( 'Buttons block', () => {
 				const initialHtml = `<!-- wp:buttons -->
 				<div class="wp-block-buttons"><!-- wp:button /--></div>
 				<!-- /wp:buttons -->`;
-				const { getByA11yLabel, getByText } = await initializeEditor( {
+				const { getByA11yLabel, getByText } = initializeEditor( {
 					initialHtml,
 				} );
 

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -295,7 +295,7 @@ describe( 'when an image is attached', () => {
 
 describe( 'color settings', () => {
 	it( 'sets a color for the overlay background when the placeholder is visible', async () => {
-		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+		const { getByTestId, getByA11yLabel } = initializeEditor( {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
@@ -350,7 +350,7 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'sets a gradient overlay background when a solid background was already selected', async () => {
-		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+		const { getByTestId, getByA11yLabel } = initializeEditor( {
 			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
 		} );
 
@@ -407,7 +407,7 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'toggles between solid colors and gradients', async () => {
-		const { getByTestId, getByA11yLabel } = await initializeEditor( {
+		const { getByTestId, getByA11yLabel } = initializeEditor( {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
@@ -493,11 +493,7 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'clears the selected overlay color and mantains the inner blocks', async () => {
-		const {
-			getByTestId,
-			getByA11yLabel,
-			getByText,
-		} = await initializeEditor( {
+		const { getByTestId, getByA11yLabel, getByText } = initializeEditor( {
 			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
 		} );
 

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -142,7 +142,7 @@ const mockEmbedResponses = ( mockedResponses ) => {
 };
 
 const insertEmbedBlock = async ( blockTitle = 'Embed' ) => {
-	const editor = await initializeEditor( {
+	const editor = initializeEditor( {
 		initialHtml: '',
 	} );
 	const { getByA11yLabel, getByText } = editor;
@@ -162,7 +162,7 @@ const insertEmbedBlock = async ( blockTitle = 'Embed' ) => {
 };
 
 const initializeWithEmbedBlock = async ( initialHtml, selectBlock = true ) => {
-	const editor = await initializeEditor( { initialHtml } );
+	const editor = initializeEditor( { initialHtml } );
 	const { getByA11yLabel } = editor;
 
 	const block = await waitFor( () =>
@@ -871,7 +871,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByTestId,
 				getByText,
-			} = await initializeEditor( {
+			} = initializeEditor( {
 				initialHtml: EMPTY_PARAGRAPH_HTML,
 			} );
 
@@ -914,7 +914,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByTestId,
 				getByText,
-			} = await initializeEditor( {
+			} = initializeEditor( {
 				initialHtml: EMPTY_PARAGRAPH_HTML,
 			} );
 
@@ -959,7 +959,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByA11yLabel,
 				getByText,
-			} = await initializeEditor( { initialHtml: EMPTY_PARAGRAPH_HTML } );
+			} = initializeEditor( { initialHtml: EMPTY_PARAGRAPH_HTML } );
 
 			const paragraphText = getByPlaceholderText( 'Start writing…' );
 			fireEvent( paragraphText, 'focus' );
@@ -1001,7 +1001,7 @@ describe( 'Embed block', () => {
 					getByPlaceholderText,
 					getByA11yLabel,
 					getByText,
-				} = await initializeEditor( {
+				} = initializeEditor( {
 					initialHtml: EMPTY_PARAGRAPH_HTML,
 				} );
 

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -3,6 +3,7 @@
  */
 import { act, fireEvent, initializeEditor, getEditorHtml } from 'test/helpers';
 import { Image } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
  * WordPress dependencies
@@ -36,6 +37,9 @@ jest.mock( 'lodash', () => {
 const apiFetchPromise = Promise.resolve( {} );
 apiFetch.mockImplementation( () => apiFetchPromise );
 
+const clipboardPromise = Promise.resolve( '' );
+Clipboard.getString.mockImplementation( () => clipboardPromise );
+
 beforeAll( () => {
 	registerCoreBlocks();
 
@@ -63,7 +67,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -89,7 +93,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -115,7 +119,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -127,6 +131,8 @@ describe( 'Image Block', () => {
 		);
 		fireEvent.press( screen.getByText( 'None' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.changeText(
 			screen.getByPlaceholderText( 'Search or type URL' ),
 			'wordpress.org'
@@ -146,7 +152,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -159,12 +165,16 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'None' ) );
 		fireEvent.press( screen.getByText( 'Media File' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.changeText(
 			screen.getByPlaceholderText( 'Search or type URL' ),
 			'wordpress.org'
 		);
 		fireEvent.press( screen.getByA11yLabel( 'Apply' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.press( screen.getByText( 'Media File' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->
@@ -182,7 +192,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -206,7 +216,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -237,7 +247,7 @@ describe( 'Image Block', () => {
 			<figcaption>Mountain</figcaption>
 		</figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 

--- a/packages/block-library/src/missing/test/edit-integration.native.js
+++ b/packages/block-library/src/missing/test/edit-integration.native.js
@@ -40,7 +40,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 			 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 			 <!-- /wp:table -->`;
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml,
 		} );
 
@@ -59,7 +59,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 		 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 		 <!-- /wp:table -->`;
-		const { getByA11yLabel, getByText } = await initializeEditor( {
+		const { getByA11yLabel, getByText } = initializeEditor( {
 			initialHtml,
 		} );
 

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -72,7 +72,7 @@ describe.each( [
 	it( 'should display the LINK SETTINGS with an EMPTY LINK TO field.', async () => {
 		// Arrange
 		const url = 'https://tonytahmouchtest.files.wordpress.com';
-		const subject = await initializeEditor( { initialHtml } );
+		const subject = initializeEditor( { initialHtml } );
 		Clipboard.getString.mockReturnValue( url );
 
 		// Act
@@ -109,7 +109,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'tonytahmouchtest.files.wordpress.com';
-				const subject = await initializeEditor( { initialHtml } );
+				const subject = initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -162,7 +162,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'https://tonytahmouchtest.files.wordpress.com';
-				const subject = await initializeEditor( { initialHtml } );
+				const subject = initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -241,7 +241,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = await initializeEditor( { initialHtml } );
+					const subject = initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act
@@ -308,7 +308,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = await initializeEditor( { initialHtml } );
+					const subject = initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -32,7 +32,7 @@ afterAll( () => {
 
 describe( 'Text color', () => {
 	it( 'shows the text color formatting button in the toolbar', async () => {
-		const { getByA11yLabel } = await initializeEditor();
+		const { getByA11yLabel } = initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -59,7 +59,7 @@ describe( 'Text color', () => {
 			getByA11yLabel,
 			getByTestId,
 			getByA11yHint,
-		} = await initializeEditor();
+		} = initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -101,7 +101,7 @@ describe( 'Text color', () => {
 			getByTestId,
 			getByPlaceholderText,
 			getByA11yHint,
-		} = await initializeEditor();
+		} = initializeEditor();
 		const text = 'Hello this is a test';
 
 		// Wait for the editor placeholder
@@ -149,7 +149,7 @@ describe( 'Text color', () => {
 	} );
 
 	it( 'creates a paragraph block with the text color format', async () => {
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml: TEXT_WITH_COLOR,
 		} );
 

--- a/packages/rich-text/src/test/index.native.js
+++ b/packages/rich-text/src/test/index.native.js
@@ -231,9 +231,10 @@ describe( '<RichText/>', () => {
 					<p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 					<!-- /wp:paragraph -->`;
 			// Act
-			await initializeEditor( { initialHtml } );
+			const { unmount } = await initializeEditor( { initialHtml } );
 			// Assert
 			expect( getEditorHtml() ).toMatchSnapshot();
+			unmount();
 		} );
 
 		it( 'should update the font size with decimals when style prop with font size property is provided', () => {

--- a/packages/rich-text/src/test/index.native.js
+++ b/packages/rich-text/src/test/index.native.js
@@ -225,16 +225,15 @@ describe( '<RichText/>', () => {
 			expect( screen.toJSON() ).toMatchSnapshot();
 		} );
 
-		it( 'renders component with style and font size', async () => {
+		it( 'renders component with style and font size', () => {
 			// Arrange
 			const initialHtml = `<!-- wp:paragraph {"style":{"color":{"text":"#fcb900"},"typography":{"fontSize":35.56}}} -->
 					<p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 					<!-- /wp:paragraph -->`;
 			// Act
-			const { unmount } = await initializeEditor( { initialHtml } );
+			initializeEditor( { initialHtml } );
 			// Assert
 			expect( getEditorHtml() ).toMatchSnapshot();
-			unmount();
 		} );
 
 		it( 'should update the font size with decimals when style prop with font size property is provided', () => {

--- a/test/native/helpers.js
+++ b/test/native/helpers.js
@@ -45,30 +45,17 @@ export function initializeEditor( props ) {
 	);
 	const { getByTestId } = screen;
 
-	// A promise is used here, instead of making the function async, to prevent
-	// the React Native testing library from warning of potential undesired React state updates
-	// that can be covered in the integration tests.
-	// Reference: https://git.io/JPHn6
-	return new Promise( ( resolve ) => {
-		// Some of the store updates that happen upon editor initialization are executed at the end of the current
-		// Javascript block execution and after the test is finished. In order to prevent "act" warnings due to
-		// this behavior, we wait for the execution block to be finished before acting on the test.
-		act(
-			() => new Promise( ( actResolve ) => setImmediate( actResolve ) )
-		).then( () => {
-			// onLayout event has to be explicitly dispatched in BlockList component,
-			// otherwise the inner blocks are not rendered.
-			fireEvent( getByTestId( 'block-list-wrapper' ), 'layout', {
-				nativeEvent: {
-					layout: {
-						width: 100,
-					},
-				},
-			} );
-
-			resolve( screen );
-		} );
+	// onLayout event has to be explicitly dispatched in BlockList component,
+	// otherwise the inner blocks are not rendered.
+	fireEvent( getByTestId( 'block-list-wrapper' ), 'layout', {
+		nativeEvent: {
+			layout: {
+				width: 100,
+			},
+		},
 	} );
+
+	return screen;
 }
 
 export * from '@testing-library/react-native';

--- a/test/native/helpers.js
+++ b/test/native/helpers.js
@@ -50,9 +50,10 @@ export function initializeEditor( props ) {
 	// that can be covered in the integration tests.
 	// Reference: https://git.io/JPHn6
 	return new Promise( ( resolve ) => {
-		// Some of the store updates that happen upon editor initialization are executed at the end of the current
-		// Javascript block execution and after the test is finished. In order to prevent "act" warnings due to
-		// this behavior, we wait for the execution block to be finished before acting on the test.
+		// During editor initialization, asynchronous store resolvers rely upon `setTimeout` to run at the end
+		// of the current JavaScript block execution. In order to prevent "act" warnings triggered by updates
+		// to the React tree, we leverage `setImmediate` to await the resolution of the current block execution
+		// before proceeding.
 		act(
 			() => new Promise( ( actResolve ) => setImmediate( actResolve ) )
 		).then( () => {


### PR DESCRIPTION
**Related to https://github.com/WordPress/gutenberg/pull/33287#issuecomment-1015399942.**

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The approach for addressing the `act` warnings in this PR is simply to wait for the Javascript block execution to finish when the editor is initialized. This way we assure that no store updates, at least the ones related to the editor initialization, are executed after the test finish potentially leading to log `act` warnings and making tests fail when using `@wordpress/jest-console` package.

## Context

When the editor is initialized, specifically [the `EditorProvider` component](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/provider/index.native.js), a set of selectors are called via `withSelect` ([example](https://github.com/WordPress/gutenberg/blob/e1978ea1bb20e99be9f64a189ac5f898a7cee594/packages/editor/src/components/provider/index.native.js#L370)). Some of these selectors, like the referenced on in the example `getEditorBlocks`, require to be resolved which is done asynchronously, but due to the fact that the API requests are mocked, this results on being executed at the end of execution block because it uses a `setTimeout` function with 0 duration.

As part of the resolution process, two actions [`startResolution`](https://github.com/WordPress/gutenberg/blob/e1978ea1bb20e99be9f64a189ac5f898a7cee594/packages/data/src/redux-store/index.js#L416-L418) and [`finishResolution`](https://github.com/WordPress/gutenberg/blob/e1978ea1bb20e99be9f64a189ac5f898a7cee594/packages/data/src/redux-store/index.js#L425-L427) are dispatched, which updates the store. Due to this behavior, and since they happen after the test finishes, it leads to the `act` warnings that we often identify in the output.

I added a breakpoint in the logic in charge of creating and executing the resolvers ([reference](https://github.com/WordPress/gutenberg/blob/e1978ea1bb20e99be9f64a189ac5f898a7cee594/packages/data/src/redux-store/index.js#L415)), in order to provide a step by step explanation within the stack trace:

<details><summary>Click here to display screenshots</summary>

![Step 1](https://user-images.githubusercontent.com/14905380/149989122-7a12f6cb-c803-46fa-805e-6412ed2783ae.png)
![Step 2](https://user-images.githubusercontent.com/14905380/149989132-2e5e724f-450c-4016-a5f1-6e54865fcd31.png)
![Step 3](https://user-images.githubusercontent.com/14905380/149989138-3b92c5b1-0247-4b88-a4be-c4c60492ef7f.png)
![Step 4](https://user-images.githubusercontent.com/14905380/149989143-5dcdb3dd-26fe-4a8b-a481-d70514658a00.png)

</details>

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
1. Run command `npm run native test`
2. Observe that all tests pass.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
