### PR TITLE
CustomSelectControl: Add hints example to storybook

### DIFF
--- a/packages/components/src/custom-select-control/stories/index.js
+++ b/packages/components/src/custom-select-control/stories/index.js
@@ -57,3 +57,30 @@ export const longLabels = () => (
 		options={ longLabelOptions }
 	/>
 );
+
+const withHintsOptions = [
+	{
+		key: 'thumbnail',
+		name: 'Thumbnail',
+		__experimentalHint: '150x150',
+	},
+	{
+		key: 'medium',
+		name: 'Medium',
+		__experimentalHint: '250x250',
+	},
+	{
+		key: 'large',
+		name: 'Large',
+		__experimentalHint: '1024x1024',
+	},
+	{
+		key: 'full',
+		name: 'Full Size',
+		__experimentalHint: '1600x1600',
+	},
+];
+
+export const hints = () => (
+	<CustomSelectControl label="Testing hints" options={ withHintsOptions } />
+);


### PR DESCRIPTION
## Description
PR adds CustomSelectControl example with `CustomSelectControl` to the storybook.

## How has this been tested?
Locally using `npm run storybook:dev`

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-18 at 21 48 58](https://user-images.githubusercontent.com/240569/149991587-3c799bc8-31ac-4e99-a312-4e21d20fcfad.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
