### PR TITLE
Backport #38032 for WP 5.9 RC3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18734,7 +18734,7 @@
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
-				"micromodal": "^0.4.9",
+				"micromodal": "^0.4.10",
 				"moment": "^2.22.1"
 			},
 			"dependencies": {
@@ -47494,9 +47494,9 @@
 			}
 		},
 		"micromodal": {
-			"version": "0.4.9",
-			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.9.tgz",
-			"integrity": "sha512-6sWcdAhzUOiu88LRz+HgGM2cfvwQjrOBXx+3BilqWg3Lr+bTNEgCUMME5OqgeoWckRk2klDkT0sPqjJzDB1ffw=="
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/micromodal/-/micromodal-0.4.10.tgz",
+			"integrity": "sha512-BUrEnzMPFBwK8nOE4xUDYHLrlGlLULQVjpja99tpJQPSUEWgw3kTLp1n1qv0HmKU29AiHE7Y7sMLiRziDK4ghQ=="
 		},
 		"miller-rabin": {
 			"version": "4.0.1",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -67,7 +67,7 @@
 		"fast-average-color": "4.3.0",
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
-		"micromodal": "^0.4.9",
+		"micromodal": "^0.4.10",
 		"moment": "^2.22.1"
 	},
 	"publishConfig": {


### PR DESCRIPTION
This backports #38032 to the `wp/trunk` branch for inclusion in WP 5.9 RC3.