### PR TITLE
Add storage state to rest in e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ node_modules
 gutenberg.zip
 coverage
 *-performance-results.json
-/test/integration/storage-state
+/test/storage-state
 
 # Directories/files that may appear in your environment
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 gutenberg.zip
 coverage
 *-performance-results.json
+/test/integration/storage-state
 
 # Directories/files that may appear in your environment
 *.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -16741,7 +16741,6 @@
 				"@wordpress/api-fetch": "file:packages/api-fetch",
 				"@wordpress/keycodes": "file:packages/keycodes",
 				"@wordpress/url": "file:packages/url",
-				"form-data": "^4.0.0",
 				"lodash": "^4.17.21",
 				"node-fetch": "^2.6.0"
 			}
@@ -34847,28 +34846,6 @@
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
 					"dev": true
-				}
-			}
-		},
-		"form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dev": true,
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"dependencies": {
-				"combined-stream": {
-					"version": "1.0.8",
-					"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-					"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-					"dev": true,
-					"requires": {
-						"delayed-stream": "~1.0.0"
-					}
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
 		"publish:latest": "lerna publish",
 		"test": "npm run lint && npm run test-unit",
 		"test:create-block": "./bin/test-create-block.sh",
-		"test-e2e": "ADMIN_STORAGE_STATE_PATH=./test/integration/storage-state/admin.json wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
+		"test-e2e": "ADMIN_STORAGE_STATE_PATH=./test/storage-state/admin.json wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
 		"publish:latest": "lerna publish",
 		"test": "npm run lint && npm run test-unit",
 		"test:create-block": "./bin/test-create-block.sh",
-		"test-e2e": "ADMIN_STORAGE_STATE_PATH=./test/storage-state/admin.json wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
+		"test-e2e": "cross-env ADMIN_STORAGE_STATE_PATH=./test/storage-state/admin.json wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",

--- a/package.json
+++ b/package.json
@@ -269,7 +269,7 @@
 		"publish:latest": "lerna publish",
 		"test": "npm run lint && npm run test-unit",
 		"test:create-block": "./bin/test-create-block.sh",
-		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
+		"test-e2e": "ADMIN_STORAGE_STATE_PATH=./test/integration/storage-state/admin.json wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",
 		"test-performance": "wp-scripts test-e2e --config packages/e2e-tests/jest.performance.config.js",

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -24,10 +24,12 @@
 	},
 	"files": [
 		"build",
-		"build-module"
+		"build-module",
+		"build-types"
 	],
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"types": "build-types",
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -35,7 +35,6 @@
 		"@wordpress/api-fetch": "file:../api-fetch",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/url": "file:../url",
-		"form-data": "^4.0.0",
 		"lodash": "^4.17.21",
 		"node-fetch": "^2.6.0"
 	},

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -94,6 +94,7 @@ export { openPreviewPage } from './preview';
 export { wpDataSelect } from './wp-data-select';
 export { deleteAllWidgets } from './widgets';
 export {
+	setupRest as __experimentalSetupRest,
 	rest as __experimentalRest,
 	batch as __experimentalBatch,
 } from './rest-api';

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -1,6 +1,8 @@
 /**
  * External dependencies
  */
+import fs from 'fs/promises';
+import path from 'path';
 import fetch from 'node-fetch';
 import FormData from 'form-data';
 
@@ -12,14 +14,110 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { WP_BASE_URL } from './shared/config';
+import { WP_BASE_URL, WP_ADMIN_USER } from './shared/config';
 import { createURL } from './create-url';
+
+/**
+ * @typedef {Object} StorageState
+ * @property {string} cookie  The login cookie.
+ * @property {string} nonce   The login nonce.
+ * @property {string} rootURL The REST API root url.
+ */
 
 // `apiFetch` expects `window.fetch` to be available in its default handler.
 global.window = global.window || {};
 global.window.fetch = fetch;
 
-const setAPIRootURL = ( async () => {
+const REST_NONCE_ENDPOINT = createURL(
+	'wp-admin/admin-ajax.php',
+	'action=rest-nonce'
+);
+
+class AdminStorageState {
+	/**
+	 * Initialize the admin storage state from disk.
+	 *
+	 * @param {string} [storageStatePath] The storage state path.
+	 * @return {Promise<AdminStorageState>} The AdminStorageState instance.
+	 */
+	static async init( storageStatePath ) {
+		/** @type {Partial<StorageState>} */
+		let initialStorageState = {};
+
+		if ( storageStatePath ) {
+			try {
+				initialStorageState = JSON.parse(
+					await fs.readFile( storageStatePath, 'utf-8' )
+				);
+			} catch ( error ) {
+				// Ignore errors if the state is not found or invalid.
+			}
+		}
+
+		return new AdminStorageState( initialStorageState, storageStatePath );
+	}
+
+	/**
+	 * The class to update and save the admin storage state.
+	 *
+	 * @param {Partial<StorageState>} initialStorageState The initial storage state.
+	 * @param {string}                [storageStatePath]  The optional storage state path.
+	 */
+	constructor( initialStorageState, storageStatePath ) {
+		/**
+		 * @private
+		 * @type {Partial<StorageState>}
+		 */
+		this._storageState = initialStorageState;
+		/**
+		 * @private
+		 * @type {string | undefined}
+		 */
+		this._storageStatePath = storageStatePath;
+		/**
+		 * @private
+		 * @type {boolean}
+		 */
+		this._hasUpdated = false;
+	}
+
+	get value() {
+		return this._storageState;
+	}
+
+	set value( storageState ) {
+		this._storageState = storageState;
+		this._hasUpdated = true;
+	}
+
+	/**
+	 * Save the admin storage state to disk.
+	 *
+	 * @return {Promise<void>}
+	 */
+	async save() {
+		if ( this._storageStatePath && this._hasUpdated ) {
+			await fs.mkdir( path.dirname( this._storageStatePath ), {
+				recursive: true,
+			} );
+
+			await fs.writeFile(
+				this._storageStatePath,
+				JSON.stringify( this._storageState ),
+				'utf-8'
+			);
+
+			this._hasUpdated = false;
+		}
+	}
+}
+
+/**
+ * Get the API root url.
+ *
+ * @return {Promise<string>} The API root url.
+ */
+async function getAPIRootURL() {
 	// Discover the API root url using link header.
 	// See https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/#link-header
 	const res = await fetch( WP_BASE_URL, { method: 'HEAD' } );
@@ -32,13 +130,19 @@ Link header: ${ links }` );
 	}
 
 	const [ , rootURL ] = restLink;
-	apiFetch.use( apiFetch.createRootURLMiddleware( rootURL ) );
-} )();
 
-async function login( retries = 3 ) {
+	return rootURL;
+}
+
+/**
+ * Login as admin's username and password and return the login cookie.
+ *
+ * @return {Promise<string>} The login cookie.
+ */
+async function loginAsAdmin() {
 	const formData = new FormData();
-	formData.append( 'log', 'admin' );
-	formData.append( 'pwd', 'password' );
+	formData.append( 'log', WP_ADMIN_USER.username );
+	formData.append( 'pwd', WP_ADMIN_USER.password );
 
 	// Login to admin using fetch.
 	const loginResponse = await fetch( createURL( 'wp-login.php' ), {
@@ -49,48 +153,75 @@ async function login( retries = 3 ) {
 	} );
 
 	// Retrieve the cookies.
-	const cookies = loginResponse.headers.get( 'set-cookie' );
+	const cookies = loginResponse.headers.raw()[ 'set-cookie' ];
 	const cookie = cookies
-		.split( ',' )
+		// Only retrieve the cookie value.
 		.map( ( setCookie ) => setCookie.split( ';' )[ 0 ] )
 		.join( ';' );
 
-	apiFetch.nonceEndpoint = createURL(
-		'wp-admin/admin-ajax.php',
-		'action=rest-nonce'
-	);
+	return cookie;
+}
 
-	// Get the initial nonce.
-	const response = await fetch( apiFetch.nonceEndpoint, {
+/**
+ * Get the nonce.
+ *
+ * @param {string} cookie The login cookie.
+ * @return {Promise<string>} The nonce.
+ */
+async function getNonce( cookie ) {
+	const response = await fetch( REST_NONCE_ENDPOINT, {
 		headers: { cookie },
 	} );
 
-	if ( response.status === 200 ) {
-		return {
-			response,
-			cookie,
-		};
+	if ( response.status !== 200 ) {
+		throw response;
 	}
 
-	// Sometimes the nonce call will fail if a test has forced a new login
-	// and invalidated the cookie, so retry the login in these instances.
-	if ( retries > 0 ) {
-		return login( retries - 1 );
-	}
+	const nonce = await response.text();
 
-	throw new Error(
-		`Fetch api call failed for ${ apiFetch.nonceEndpoint }: ${ response.status }`
-	);
+	return nonce;
 }
 
-const setNonce = ( async () => {
-	// Get the initial nonce.
-	const loginRequest = await login();
+/**
+ * Setup the rest API client.
+ *
+ * @param {string} [storageStatePath] Optional storage state path to save.
+ * @return {Promise<StorageState>} The admin storage state.
+ */
+async function setupRest( storageStatePath ) {
+	const adminStorageState = await AdminStorageState.init( storageStatePath );
 
-	const nonce = await loginRequest.response.text();
+	if ( ! adminStorageState.value.cookie ) {
+		adminStorageState.value.cookie = await loginAsAdmin();
+	}
+
+	if ( ! adminStorageState.value.nonce ) {
+		adminStorageState.value.nonce = await getNonce(
+			adminStorageState.value.cookie
+		);
+	}
+
+	if ( ! adminStorageState.value.rootURL ) {
+		adminStorageState.value.rootURL = await getAPIRootURL();
+	}
+
+	await adminStorageState.save();
+
+	// Register nonce endpoint.
+	apiFetch.nonceEndpoint = REST_NONCE_ENDPOINT;
+
+	// Create the nonce middleware and set the initial nonce as an empty string.
+	apiFetch.nonceMiddleware = apiFetch.createNonceMiddleware(
+		adminStorageState.value.nonce
+	);
 
 	// Register the nonce middleware.
-	apiFetch.use( apiFetch.createNonceMiddleware( nonce ) );
+	apiFetch.use( apiFetch.nonceMiddleware );
+
+	// Register root url middleware.
+	apiFetch.use(
+		apiFetch.createRootURLMiddleware( adminStorageState.value.rootURL )
+	);
 
 	// For the nonce to work we have to also pass the cookies.
 	apiFetch.use( function setCookieMiddleware( request, next ) {
@@ -98,23 +229,62 @@ const setNonce = ( async () => {
 			...request,
 			headers: {
 				...request.headers,
-				cookie: loginRequest.cookie,
+				cookie: adminStorageState.value.cookie,
 			},
+		} ).catch( async ( error ) => {
+			// The default nonce handler from `apiFetch` won't pass server-side cookies
+			// automatically, so we handle it here manually in a middleware.
+			if ( error.code !== 'rest_cookie_invalid_nonce' ) {
+				throw error;
+			}
+
+			/**
+			 * We can't be sure either the cookie or the nonce is invalid,
+			 * hence updating them both.
+			 */
+
+			// Renew the cookies.
+			const cookie = await loginAsAdmin();
+			adminStorageState.value.cookie = cookie;
+
+			// Renew the nonce.
+			const nonce = await getNonce( cookie );
+			adminStorageState.value.nonce = nonce;
+			apiFetch.nonceMiddleware.nonce = nonce;
+
+			await adminStorageState.save();
+
+			return apiFetch( request );
 		} );
 	} );
-} )();
+
+	/** @type {StorageState} */
+	return adminStorageState.value;
+}
 
 /**
  * Call REST API using `apiFetch` to build and clear test states.
  *
- * @param {Object} options `apiFetch` options.
+ * @param {Object} [options] `apiFetch` options.
  * @return {Promise<any>} The response value.
  */
 async function rest( options = {} ) {
-	// Only need to set them once but before any requests.
-	await Promise.all( [ setAPIRootURL, setNonce ] );
-
 	return await apiFetch( options );
+}
+
+/** @type {number} */
+let cacheMaxBatchSize;
+async function getMaxBatchSize() {
+	if ( cacheMaxBatchSize ) {
+		return cacheMaxBatchSize;
+	}
+
+	const response = await rest( {
+		method: 'OPTIONS',
+		path: '/batch/v1',
+	} );
+	cacheMaxBatchSize = response.endpoints[ 0 ].args.requests.maxItems;
+	return cacheMaxBatchSize;
 }
 
 /**
@@ -126,6 +296,14 @@ async function rest( options = {} ) {
  * @return {Promise<any>} The response value.
  */
 async function batch( requests ) {
+	const maxBatchSize = await getMaxBatchSize();
+
+	if ( requests.length > maxBatchSize ) {
+		throw new Error(
+			`Batch requests size is over the limit of ${ maxBatchSize }`
+		);
+	}
+
 	return await rest( {
 		method: 'POST',
 		path: '/batch/v1',
@@ -136,4 +314,4 @@ async function batch( requests ) {
 	} );
 }
 
-export { rest, batch };
+export { setupRest, rest, batch };

--- a/packages/e2e-test-utils/src/rest-api.js
+++ b/packages/e2e-test-utils/src/rest-api.js
@@ -183,7 +183,7 @@ async function getNonce( cookie ) {
 	if ( response.status !== 200 ) {
 		try {
 			// If there's a json error from the API, throw it.
-			const errorBody = await response.json();
+			const errorBody = await response.clone().json();
 			throw errorBody;
 		} catch ( error ) {
 			// Otherwise, fallback to throwing the response object.

--- a/packages/e2e-test-utils/src/widgets.js
+++ b/packages/e2e-test-utils/src/widgets.js
@@ -7,6 +7,7 @@ import { rest, batch } from './rest-api';
  * Delete all the widgets in the widgets screen.
  */
 export async function deleteAllWidgets() {
+	// Calling GET requests in batch is not supported.
 	const [ widgets, sidebars ] = await Promise.all( [
 		rest( { path: '/wp/v2/widgets' } ),
 		rest( { path: '/wp/v2/sidebars' } ),

--- a/packages/e2e-test-utils/tsconfig.json
+++ b/packages/e2e-test-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"declarationDir": "build-types",
+		"allowJs": true,
+		"checkJs": false
+	},
+	"include": [
+		"src/**/*"
+	]
+}

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -253,7 +253,7 @@ expect.extend( {
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
-	await setupRest( adminStorageStatePath );
+	await setupRest( browser, adminStorageStatePath );
 
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();

--- a/packages/e2e-tests/config/setup-test-framework.js
+++ b/packages/e2e-tests/config/setup-test-framework.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import path from 'path';
 import { get } from 'lodash';
 import { toMatchInlineSnapshot, toMatchSnapshot } from 'jest-snapshot';
 
@@ -15,6 +16,7 @@ import {
 	isOfflineMode,
 	setBrowserViewport,
 	trashAllPosts,
+	__experimentalSetupRest as setupRest,
 } from '@wordpress/e2e-test-utils';
 
 /**
@@ -37,6 +39,19 @@ const THROTTLE_CPU = process.env.THROTTLE_CPU;
  * @type {string|undefined}
  */
 const SLOW_NETWORK = process.env.SLOW_NETWORK;
+
+/**
+ * Admin storage state path.
+ *
+ * @type {string|undefined}
+ */
+let adminStorageStatePath = process.env.ADMIN_STORAGE_STATE_PATH;
+if ( adminStorageStatePath && ! path.isAbsolute( adminStorageStatePath ) ) {
+	adminStorageStatePath = path.resolve(
+		process.cwd(),
+		adminStorageStatePath
+	);
+}
 
 /**
  * Emulate no internet connection.
@@ -238,6 +253,8 @@ expect.extend( {
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
+	await setupRest( adminStorageStatePath );
+
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
 	observeConsoleLogging();

--- a/packages/scripts/config/jest-environment-puppeteer/global.js
+++ b/packages/scripts/config/jest-environment-puppeteer/global.js
@@ -93,7 +93,7 @@ async function setup( jestConfig = {} ) {
 		);
 	}
 
-	await setupRest( adminStorageStatePath );
+	await setupRest( browser, adminStorageStatePath );
 }
 
 async function teardown( jestConfig = {} ) {

--- a/packages/scripts/config/jest-environment-puppeteer/global.js
+++ b/packages/scripts/config/jest-environment-puppeteer/global.js
@@ -16,6 +16,7 @@
 /**
  * External dependencies
  */
+const path = require( 'path' );
 const {
 	setup: setupServer,
 	teardown: teardownServer,
@@ -28,6 +29,12 @@ const chalk = require( 'chalk' );
  * Internal dependencies
  */
 const { readConfig, getPuppeteer } = require( './config' );
+
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalSetupRest as setupRest } from '@wordpress/e2e-test-utils';
 
 let browser;
 
@@ -77,6 +84,16 @@ async function setup( jestConfig = {} ) {
 			throw error;
 		}
 	}
+
+	let adminStorageStatePath = process.env.ADMIN_STORAGE_STATE_PATH;
+	if ( adminStorageStatePath && ! path.isAbsolute( adminStorageStatePath ) ) {
+		adminStorageStatePath = path.resolve(
+			process.cwd(),
+			adminStorageStatePath
+		);
+	}
+
+	await setupRest( adminStorageStatePath );
 }
 
 async function teardown( jestConfig = {} ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 		{ "path": "packages/deprecated" },
 		{ "path": "packages/docgen" },
 		{ "path": "packages/dom" },
+		{ "path": "packages/e2e-test-utils" },
 		{ "path": "packages/element" },
 		{ "path": "packages/dom-ready" },
 		{ "path": "packages/escape-html" },


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Inspired by the `storageState` API in [Playwright](https://playwright.dev/docs/api/class-browsercontext#browser-context-storage-state), This PR refactors the usage of the `rest` API in e2e tests.

`rest` and `batch` are experimental APIs in `e2e-test-utils` to do server-side fetching to speed up the performance of cleaning and setting test states in e2e testing. They have already been used in navigation and widgets tests. Simply said, `rest` calls the WordPress REST API via `apiFetch` on the server-side. To do this, it has to first authenticate using the admin user permission to perform most of the operations. However, every test suite in Jest is a separated context, so before this PR, we have to authenticate again in every test suite.

This PR authenticates once during [`globalSetup`](https://jestjs.io/docs/configuration#globalsetup-string) and saves the login state (cookie, nonce, etc) to disk. Then, each test suite can just grab the state from disk without sending the network request. This process is heavily inspired by the similar approach in [Playwright](https://playwright.dev/docs/test-auth#sign-in-via-api-request).

This PR also refactors the implementation to better handle some edge cases (auto re-authentication, getting max batch size, etc).

I can't decide where to put the state file though. Currently, it's placed at `test/integration/storage-state/admin.json`, I doubt that it's the best place to store that though.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Running `npm run test-e2e` should generate a file at `test/integration/storage-path/admin.json` to store the test state (`cookie`, `nonce`, `rootURL`).

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
