### PR TITLE
[Block Library - Query Loop]: Add support for custom taxonomies filtering

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -19,7 +19,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Standard', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
 							<!-- wp:post-template -->
 							<!-- wp:post-title {"isLink":true} /-->
@@ -37,7 +37,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Image at left', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
 							<!-- wp:post-template -->
 							<!-- wp:columns {"align":"wide"} -->
@@ -57,7 +57,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Small image and title', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
 							<!-- wp:post-template -->
 							<!-- wp:columns {"verticalAlignment":"center"} -->
@@ -76,7 +76,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'title'      => _x( 'Grid', 'Block pattern title', 'gutenberg' ),
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
-			'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
+			'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 							<div class="wp-block-query">
 							<!-- wp:post-template -->
 							<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
@@ -93,7 +93,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'blockTypes' => array( 'core/query' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"100px","right":"100px","bottom":"100px","left":"100px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->
-							<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:100px;padding-right:100px;padding-bottom:100px;padding-left:100px"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+							<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:100px;padding-right:100px;padding-bottom:100px;padding-left:100px"><!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query"><!-- wp:post-template -->
 							<!-- wp:separator {"customColor":"#ffffff","align":"wide","className":"is-style-wide"} -->
 							<hr class="wp-block-separator alignwide has-text-color has-background is-style-wide" style="background-color:#ffffff;color:#ffffff"/>
@@ -119,7 +119,7 @@ function gutenberg_register_gutenberg_patterns() {
 			'content'    => '<!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":false}} -->
 							<div class="wp-block-group" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:columns -->
 							<div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
-							<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
+							<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 							<div class="wp-block-query"><!-- wp:post-template -->
 							<!-- wp:post-featured-image /-->
 							<!-- wp:post-title /-->
@@ -131,7 +131,7 @@ function gutenberg_register_gutenberg_patterns() {
 							<!-- /wp:query --></div>
 							<!-- /wp:column -->
 							<!-- wp:column {"width":"50%"} -->
-							<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":2,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
+							<div class="wp-block-column" style="flex-basis:50%"><!-- wp:query {"query":{"perPage":2,"pages":0,"offset":2,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"list"}} -->
 							<div class="wp-block-query"><!-- wp:post-template -->
 							<!-- wp:spacer {"height":200} -->
 							<div style="height:200px" aria-hidden="true" class="wp-block-spacer"></div>

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -95,7 +95,6 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 						'taxonomy'         => $taxonomy,
 						'terms'            => $terms,
 						'include_children' => false,
-
 					);
 				}
 			}

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -79,6 +79,7 @@ export default function PostTemplateEdit( {
 			exclude,
 			sticky,
 			inherit,
+			taxQuery,
 		} = {},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
@@ -90,15 +91,37 @@ export default function PostTemplateEdit( {
 
 	const { posts, blocks } = useSelect(
 		( select ) => {
-			const { getEntityRecords } = select( coreStore );
+			const { getEntityRecords, getTaxonomies } = select( coreStore );
 			const { getBlocks } = select( blockEditorStore );
+			const taxonomies = getTaxonomies( {
+				type: postType,
+				per_page: -1,
+				context: 'view',
+			} );
 			const query = {
 				offset: perPage ? perPage * ( page - 1 ) + offset : 0,
-				categories: categoryIds,
-				tags: tagIds,
 				order,
 				orderby: orderBy,
 			};
+			if ( taxQuery ) {
+				// We have to build the tax query for the REST API and use as
+				// keys the taxonomies `rest_base` with the `term ids` as values.
+				const builtTaxQuery = Object.entries( taxQuery ).reduce(
+					( accumulator, [ taxonomySlug, terms ] ) => {
+						const taxonomy = taxonomies?.find(
+							( { slug } ) => slug === taxonomySlug
+						);
+						if ( taxonomy?.rest_base ) {
+							accumulator[ taxonomy?.rest_base ] = terms;
+						}
+						return accumulator;
+					},
+					{}
+				);
+				if ( !! Object.keys( builtTaxQuery ).length ) {
+					Object.assign( query, builtTaxQuery );
+				}
+			}
 			if ( perPage ) {
 				query.per_page = perPage;
 			}
@@ -146,6 +169,7 @@ export default function PostTemplateEdit( {
 			sticky,
 			inherit,
 			templateSlug,
+			taxQuery,
 		]
 	);
 	const blockContexts = useMemo(

--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -69,9 +69,7 @@ export default function PostTemplateEdit( {
 		query: {
 			perPage,
 			offset,
-			categoryIds = [],
 			postType,
-			tagIds = [],
 			order,
 			orderBy,
 			author,
@@ -157,8 +155,6 @@ export default function PostTemplateEdit( {
 			perPage,
 			page,
 			offset,
-			categoryIds,
-			tagIds,
 			order,
 			orderBy,
 			clientId,

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -25,7 +25,8 @@
 				"search": "",
 				"exclude": [],
 				"sticky": "",
-				"inherit": true
+				"inherit": true,
+				"taxQuery": null
 			}
 		},
 		"tagName": {

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -17,8 +17,6 @@
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
-				"categoryIds": [],
-				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
 				"author": "",

--- a/packages/block-library/src/query/deprecated.js
+++ b/packages/block-library/src/query/deprecated.js
@@ -6,9 +6,85 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { InnerBlocks } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	useInnerBlocksProps,
+	useBlockProps,
+} from '@wordpress/block-editor';
+
+const migrateToTaxQuery = ( attributes ) => {
+	const { query } = attributes;
+	const newQuery = {
+		...omit( query, [ 'categoryIds', 'tagIds' ] ),
+	};
+	if ( query.categoryIds?.length || query.tagIds?.length ) {
+		newQuery.taxQuery = {
+			category: !! query.categoryIds?.length
+				? query.categoryIds
+				: undefined,
+			post_tag: !! query.tagIds?.length ? query.tagIds : undefined,
+		};
+	}
+	return {
+		...attributes,
+		query: newQuery,
+	};
+};
 
 const deprecated = [
+	// Version with `categoryIds and tagIds`.
+	{
+		attributes: {
+			queryId: {
+				type: 'number',
+			},
+			query: {
+				type: 'object',
+				default: {
+					perPage: null,
+					pages: 0,
+					offset: 0,
+					postType: 'post',
+					categoryIds: [],
+					tagIds: [],
+					order: 'desc',
+					orderBy: 'date',
+					author: '',
+					search: '',
+					exclude: [],
+					sticky: '',
+					inherit: true,
+				},
+			},
+			tagName: {
+				type: 'string',
+				default: 'div',
+			},
+			displayLayout: {
+				type: 'object',
+				default: {
+					type: 'list',
+				},
+			},
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			html: false,
+			color: {
+				gradients: true,
+				link: true,
+			},
+			__experimentalLayout: true,
+		},
+		isEligible: ( { query: { categoryIds, tagIds } = {} } ) =>
+			categoryIds || tagIds,
+		migrate: migrateToTaxQuery,
+		save( { attributes: { tagName: Tag = 'div' } } ) {
+			const blockProps = useBlockProps.save();
+			const innerBlocksProps = useInnerBlocksProps.save( blockProps );
+			return <Tag { ...innerBlocksProps } />;
+		},
+	},
 	// Version with NO wrapper `div` element.
 	{
 		attributes: {
@@ -44,9 +120,10 @@ const deprecated = [
 			html: false,
 		},
 		migrate( attributes ) {
+			const withTaxQuery = migrateToTaxQuery( attributes );
 			return {
-				...omit( attributes, [ 'layout' ] ),
-				displayLayout: attributes.layout,
+				...omit( withTaxQuery, [ 'layout' ] ),
+				displayLayout: withTaxQuery.layout,
 			};
 		},
 		save() {

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -15,11 +15,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	InspectorControls,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
+import { InspectorControls } from '@wordpress/block-editor';
 import { useEffect, useState, useCallback } from '@wordpress/element';
 
 /**
@@ -55,26 +51,6 @@ export default function QueryInspectorControls( {
 	useEffect( () => {
 		setShowSticky( postType === 'post' );
 	}, [ postType ] );
-	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
-		blockEditorStore
-	);
-	// We need to migrate `categoryIds` and `tagIds` to `tax_query`.
-	// TODO: We could probably use the `deprecations` API but it
-	// doesn't support dynamic blocks deprecations properly.
-	useEffect( () => {
-		if ( query.categoryIds?.length || query.tagIds?.length ) {
-			const updateObj = { categoryIds: [], tagIds: [] };
-			updateObj.taxQuery = {
-				category: !! query.categoryIds?.length
-					? query.categoryIds
-					: undefined,
-				post_tag: !! query.tagIds?.length ? query.tagIds : undefined,
-				...taxQuery,
-			};
-			__unstableMarkNextChangeAsNotPersistent();
-			setQuery( updateObj );
-		}
-	}, [ query.categoryIds, query.tagIds ] );
 	const onPostTypeChange = ( newValue ) => {
 		const updateQuery = { postType: newValue };
 		// We need to dynamically update the `taxQuery` property,

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -9,53 +9,32 @@ import { debounce } from 'lodash';
 import {
 	PanelBody,
 	TextControl,
-	FormTokenField,
 	SelectControl,
 	RangeControl,
 	ToggleControl,
 	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import {
+	InspectorControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
 import { useEffect, useState, useCallback } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import OrderControl from './order-control';
 import AuthorControl from './author-control';
-import { getEntitiesInfo, usePostTypes } from '../../utils';
-import { MAX_FETCHED_TERMS } from '../../constants';
+import TaxonomyControls from './taxonomy-controls';
+import { usePostTypes } from '../../utils';
 
 const stickyOptions = [
 	{ label: __( 'Include' ), value: '' },
 	{ label: __( 'Exclude' ), value: 'exclude' },
 	{ label: __( 'Only' ), value: 'only' },
 ];
-
-// Helper function to get the term id based on user input in terms `FormTokenField`.
-const getTermIdByTermValue = ( termsMappedByName, termValue ) => {
-	// First we check for exact match by `term.id` or case sensitive `term.name` match.
-	const termId = termValue?.id || termsMappedByName[ termValue ]?.id;
-	if ( termId ) return termId;
-	/**
-	 * Here we make an extra check for entered terms in a non case sensitive way,
-	 * to match user expectations, due to `FormTokenField` behaviour that shows
-	 * suggestions which are case insensitive.
-	 *
-	 * Although WP tries to discourage users to add terms with the same name (case insensitive),
-	 * it's still possible if you manually change the name, as long as the terms have different slugs.
-	 * In this edge case we always apply the first match from the terms list.
-	 */
-	const termValueLower = termValue.toLocaleLowerCase();
-	for ( const term in termsMappedByName ) {
-		if ( term.toLocaleLowerCase() === termValueLower ) {
-			return termsMappedByName[ term ].id;
-		}
-	}
-};
 
 export default function QueryInspectorControls( {
 	attributes: { query, displayLayout },
@@ -69,64 +48,56 @@ export default function QueryInspectorControls( {
 		postType,
 		sticky,
 		inherit,
+		taxQuery,
 	} = query;
-	const [ showCategories, setShowCategories ] = useState( true );
-	const [ showTags, setShowTags ] = useState( true );
 	const [ showSticky, setShowSticky ] = useState( postType === 'post' );
 	const { postTypesTaxonomiesMap, postTypesSelectOptions } = usePostTypes();
-	const { categories, tags } = useSelect( ( select ) => {
-		const { getEntityRecords } = select( coreStore );
-		const termsQuery = { per_page: MAX_FETCHED_TERMS };
-		const _categories = getEntityRecords(
-			'taxonomy',
-			'category',
-			termsQuery
-		);
-		const _tags = getEntityRecords( 'taxonomy', 'post_tag', termsQuery );
-		return {
-			categories: getEntitiesInfo( _categories ),
-			tags: getEntitiesInfo( _tags ),
-		};
-	}, [] );
-	useEffect( () => {
-		if ( ! postTypesTaxonomiesMap ) return;
-		const postTypeTaxonomies = postTypesTaxonomiesMap[ postType ];
-		setShowCategories( postTypeTaxonomies.includes( 'category' ) );
-		setShowTags( postTypeTaxonomies.includes( 'post_tag' ) );
-	}, [ postType, postTypesTaxonomiesMap ] );
 	useEffect( () => {
 		setShowSticky( postType === 'post' );
 	}, [ postType ] );
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
+		blockEditorStore
+	);
+	// We need to migrate `categoryIds` and `tagIds` to `tax_query`.
+	// TODO: We could probably use the `deprecations` API but it
+	// doesn't support dynamic blocks deprecations properly.
+	useEffect( () => {
+		if ( query.categoryIds?.length || query.tagIds?.length ) {
+			const updateObj = { categoryIds: [], tagIds: [] };
+			updateObj.taxQuery = {
+				category: !! query.categoryIds?.length
+					? query.categoryIds
+					: undefined,
+				post_tag: !! query.tagIds?.length ? query.tagIds : undefined,
+				...taxQuery,
+			};
+			__unstableMarkNextChangeAsNotPersistent();
+			setQuery( updateObj );
+		}
+	}, [ query.categoryIds, query.tagIds ] );
 	const onPostTypeChange = ( newValue ) => {
 		const updateQuery = { postType: newValue };
-		if ( ! postTypesTaxonomiesMap[ newValue ].includes( 'category' ) ) {
-			updateQuery.categoryIds = [];
-		}
-		if ( ! postTypesTaxonomiesMap[ newValue ].includes( 'post_tag' ) ) {
-			updateQuery.tagIds = [];
-		}
+		// We need to dynamically update the `taxQuery` property,
+		// by removing any not supported taxonomy from the query.
+		const supportedTaxonomies = postTypesTaxonomiesMap[ newValue ];
+		const updatedTaxQuery = Object.entries( taxQuery || {} ).reduce(
+			( accumulator, [ taxonomySlug, terms ] ) => {
+				if ( supportedTaxonomies.includes( taxonomySlug ) ) {
+					accumulator[ taxonomySlug ] = terms;
+				}
+				return accumulator;
+			},
+			{}
+		);
+		updateQuery.taxQuery = !! Object.keys( updatedTaxQuery ).length
+			? updatedTaxQuery
+			: undefined;
+
 		if ( newValue !== 'post' ) {
 			updateQuery.sticky = '';
 		}
 		setQuery( updateQuery );
 	};
-	// Handles categories and tags changes.
-	const onTermsChange = ( terms, queryProperty ) => ( newTermValues ) => {
-		const termIds = Array.from(
-			newTermValues.reduce( ( accumulator, termValue ) => {
-				const termId = getTermIdByTermValue(
-					terms.mapByName,
-					termValue
-				);
-				if ( termId ) accumulator.add( termId );
-				return accumulator;
-			}, new Set() )
-		);
-		setQuery( { [ queryProperty ]: termIds } );
-	};
-	const onCategoriesChange = onTermsChange( categories, 'categoryIds' );
-	const onTagsChange = onTermsChange( tags, 'tagIds' );
-
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 	const onChangeDebounced = useCallback(
 		debounce( () => {
@@ -136,42 +107,10 @@ export default function QueryInspectorControls( {
 		}, 250 ),
 		[ querySearch, query.search ]
 	);
-
 	useEffect( () => {
 		onChangeDebounced();
 		return onChangeDebounced.cancel;
 	}, [ querySearch, onChangeDebounced ] );
-
-	// Returns only the existing term ids (categories/tags) in proper
-	// format to be used in `FormTokenField`. This prevents the component
-	// from crashing in the editor, when non existing term ids were provided.
-	const getExistingTermsFormTokenValue = ( taxonomy ) => {
-		const termsMapper = {
-			category: {
-				queryProp: 'categoryIds',
-				terms: categories,
-			},
-			post_tag: {
-				queryProp: 'tagIds',
-				terms: tags,
-			},
-		};
-		const requestedTerm = termsMapper[ taxonomy ];
-		return ( query[ requestedTerm.queryProp ] || [] ).reduce(
-			( accumulator, termId ) => {
-				const term = requestedTerm.terms.mapById[ termId ];
-				if ( term ) {
-					accumulator.push( {
-						id: termId,
-						value: term.name,
-					} );
-				}
-				return accumulator;
-			},
-			[]
-		);
-	};
-
 	return (
 		<InspectorControls>
 			<PanelBody title={ __( 'Settings' ) }>
@@ -234,26 +173,7 @@ export default function QueryInspectorControls( {
 			</PanelBody>
 			{ ! inherit && (
 				<PanelBody title={ __( 'Filters' ) }>
-					{ showCategories && categories?.entities?.length > 0 && (
-						<FormTokenField
-							label={ __( 'Categories' ) }
-							value={ getExistingTermsFormTokenValue(
-								'category'
-							) }
-							suggestions={ categories.names }
-							onChange={ onCategoriesChange }
-						/>
-					) }
-					{ showTags && tags?.entities?.length > 0 && (
-						<FormTokenField
-							label={ __( 'Tags' ) }
-							value={ getExistingTermsFormTokenValue(
-								'post_tag'
-							) }
-							suggestions={ tags.names }
-							onChange={ onTagsChange }
-						/>
-					) }
+					<TaxonomyControls onChange={ setQuery } query={ query } />
 					<AuthorControl value={ authorIds } onChange={ setQuery } />
 					<TextControl
 						label={ __( 'Keyword' ) }

--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -1,0 +1,118 @@
+/**
+ * WordPress dependencies
+ */
+import { FormTokenField } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { getEntitiesInfo, useTaxonomies } from '../../utils';
+import { MAX_FETCHED_TERMS } from '../../constants';
+
+// Helper function to get the term id based on user input in terms `FormTokenField`.
+const getTermIdByTermValue = ( termsMappedByName, termValue ) => {
+	// First we check for exact match by `term.id` or case sensitive `term.name` match.
+	const termId = termValue?.id || termsMappedByName[ termValue ]?.id;
+	if ( termId ) return termId;
+	/**
+	 * Here we make an extra check for entered terms in a non case sensitive way,
+	 * to match user expectations, due to `FormTokenField` behaviour that shows
+	 * suggestions which are case insensitive.
+	 *
+	 * Although WP tries to discourage users to add terms with the same name (case insensitive),
+	 * it's still possible if you manually change the name, as long as the terms have different slugs.
+	 * In this edge case we always apply the first match from the terms list.
+	 */
+	const termValueLower = termValue.toLocaleLowerCase();
+	for ( const term in termsMappedByName ) {
+		if ( term.toLocaleLowerCase() === termValueLower ) {
+			return termsMappedByName[ term ].id;
+		}
+	}
+};
+
+function TaxonomyControls( { onChange, query } ) {
+	const taxonomies = useTaxonomies( query.postType );
+	const taxonomiesInfo = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const termsQuery = { per_page: MAX_FETCHED_TERMS };
+			const _taxonomiesInfo = taxonomies?.map( ( { slug, name } ) => {
+				const _terms = getEntityRecords( 'taxonomy', slug, termsQuery );
+				return {
+					slug,
+					name,
+					terms: getEntitiesInfo( _terms ),
+				};
+			} );
+			return _taxonomiesInfo;
+		},
+		[ taxonomies ]
+	);
+	const onTermsChange = ( taxonomySlug ) => ( newTermValues ) => {
+		const taxonomyInfo = taxonomiesInfo.find(
+			( { slug } ) => slug === taxonomySlug
+		);
+		if ( ! taxonomyInfo ) return;
+		const termIds = Array.from(
+			newTermValues.reduce( ( accumulator, termValue ) => {
+				const termId = getTermIdByTermValue(
+					taxonomyInfo.terms.mapByName,
+					termValue
+				);
+				if ( termId ) accumulator.add( termId );
+				return accumulator;
+			}, new Set() )
+		);
+		const newTaxQuery = {
+			...query.taxQuery,
+			[ taxonomySlug ]: termIds,
+		};
+		onChange( { taxQuery: newTaxQuery } );
+	};
+	// Returns only the existing term ids in proper format to be
+	// used in `FormTokenField`. This prevents the component from
+	// crashing in the editor, when non existing term ids were provided.
+	const getExistingTaxQueryValue = ( taxonomySlug ) => {
+		const taxonomyInfo = taxonomiesInfo.find(
+			( { slug } ) => slug === taxonomySlug
+		);
+		if ( ! taxonomyInfo ) return [];
+		return ( query.taxQuery?.[ taxonomySlug ] || [] ).reduce(
+			( accumulator, termId ) => {
+				const term = taxonomyInfo.terms.mapById[ termId ];
+				if ( term ) {
+					accumulator.push( {
+						id: termId,
+						value: term.name,
+					} );
+				}
+				return accumulator;
+			},
+			[]
+		);
+	};
+	return (
+		<>
+			{ !! taxonomiesInfo?.length &&
+				taxonomiesInfo.map( ( { slug, name, terms } ) => {
+					if ( ! terms?.names?.length ) {
+						return null;
+					}
+					return (
+						<FormTokenField
+							key={ slug }
+							label={ name }
+							value={ getExistingTaxQueryValue( slug ) }
+							suggestions={ terms.names }
+							onChange={ onTermsChange( slug ) }
+						/>
+					);
+				} ) }
+		</>
+	);
+}
+
+export default TaxonomyControls;

--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -55,16 +55,14 @@ export const getEntitiesInfo = ( entities ) => {
  * @return {Object} The helper object related to post types.
  */
 export const usePostTypes = () => {
-	const { postTypes } = useSelect( ( select ) => {
+	const postTypes = useSelect( ( select ) => {
 		const { getPostTypes } = select( coreStore );
 		const excludedPostTypes = [ 'attachment' ];
 		const filteredPostTypes = getPostTypes( { per_page: -1 } )?.filter(
 			( { viewable, slug } ) =>
 				viewable && ! excludedPostTypes.includes( slug )
 		);
-		return {
-			postTypes: filteredPostTypes,
-		};
+		return filteredPostTypes;
 	}, [] );
 	const postTypesTaxonomiesMap = useMemo( () => {
 		if ( ! postTypes?.length ) return;
@@ -82,6 +80,28 @@ export const usePostTypes = () => {
 		[ postTypes ]
 	);
 	return { postTypesTaxonomiesMap, postTypesSelectOptions };
+};
+
+/**
+ * Hook that returns the taxonomies associated with a specific post type.
+ *
+ * @param {string} postType The post type from which to retrieve the associated taxonomies.
+ * @return {Object[]} An array of the associated taxonomies.
+ */
+export const useTaxonomies = ( postType ) => {
+	const taxonomies = useSelect(
+		( select ) => {
+			const { getTaxonomies } = select( coreStore );
+			const filteredTaxonomies = getTaxonomies( {
+				type: postType,
+				per_page: -1,
+				context: 'view',
+			} );
+			return filteredTaxonomies;
+		},
+		[ postType ]
+	);
+	return taxonomies;
 };
 
 /**

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -46,8 +46,6 @@ const variations = [
 				pages: 1,
 				offset: 0,
 				postType: 'post',
-				categoryIds: [],
-				tagIds: [],
 				order: 'desc',
 				orderBy: 'date',
 				author: '',

--- a/packages/block-library/src/query/variations.js
+++ b/packages/block-library/src/query/variations.js
@@ -20,8 +20,6 @@ const QUERY_DEFAULT_ATTRIBUTES = {
 		pages: 0,
 		offset: 0,
 		postType: 'post',
-		categoryIds: [],
-		tagIds: [],
 		order: 'desc',
 		orderBy: 'date',
 		author: '',

--- a/packages/e2e-tests/plugins/query-block.php
+++ b/packages/e2e-tests/plugins/query-block.php
@@ -16,7 +16,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Query Test 1', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:post-template -->
 						<!-- wp:post-title {"isLink":true} /-->
 						<!-- /wp:post-template -->
@@ -28,7 +28,7 @@ register_block_pattern(
 	array(
 		'title'      => __( 'Query Test 2', 'gutenberg' ),
 		'blockTypes' => array( 'core/query' ),
-		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
+		'content'    => '<!-- wp:query {"query":{"perPage":1,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
 						<!-- wp:post-template -->
 						<!-- wp:post-title {"isLink":true} /-->
 						<!-- wp:post-date /-->

--- a/test/emptytheme/block-templates/index.html
+++ b/test/emptytheme/block-templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 
-<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
 <div class="wp-block-query">
 	<!-- wp:post-template -->
 	<!-- wp:post-title {"isLink":true} /-->

--- a/test/integration/fixtures/blocks/core__query.json
+++ b/test/integration/fixtures/blocks/core__query.json
@@ -9,8 +9,6 @@
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
-				"categoryIds": [],
-				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
 				"author": "",

--- a/test/integration/fixtures/blocks/core__query.json
+++ b/test/integration/fixtures/blocks/core__query.json
@@ -17,7 +17,8 @@
 				"search": "",
 				"exclude": [],
 				"sticky": "",
-				"inherit": true
+				"inherit": true,
+				"taxQuery": null
 			},
 			"tagName": "div",
 			"displayLayout": {

--- a/test/integration/fixtures/blocks/core__query__deprecated-1.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-1.json
@@ -9,8 +9,6 @@
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",
-				"categoryIds": [],
-				"tagIds": [],
 				"order": "desc",
 				"orderBy": "date",
 				"author": "",

--- a/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
-<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"}} -->
+<!-- wp:query {"query":{"perPage":null,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list"}} -->
 <div class="wp-block-query"></div>
 <!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.html
@@ -1,0 +1,6 @@
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","categoryIds":[3,5],"tagIds":[6],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title /-->
+<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.json
@@ -1,0 +1,56 @@
+[
+	{
+		"clientId": "_clientId_0",
+		"name": "core/query",
+		"isValid": true,
+		"attributes": {
+			"queryId": 19,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false,
+				"taxQuery": {
+					"category": [ 3, 5 ],
+					"post_tag": [ 6 ]
+				}
+			},
+			"tagName": "div",
+			"displayLayout": {
+				"type": "list"
+			}
+		},
+		"innerBlocks": [
+			{
+				"clientId": "_clientId_0",
+				"name": "core/post-template",
+				"isValid": true,
+				"attributes": {},
+				"innerBlocks": [
+					{
+						"clientId": "_clientId_0",
+						"name": "core/post-title",
+						"isValid": true,
+						"attributes": {
+							"level": 2,
+							"isLink": false,
+							"rel": "",
+							"linkTarget": "_self"
+						},
+						"innerBlocks": [],
+						"originalContent": ""
+					}
+				],
+				"originalContent": ""
+			}
+		],
+		"originalContent": "<div class=\"wp-block-query\">\n</div>"
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.parsed.json
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.parsed.json
@@ -1,0 +1,46 @@
+[
+	{
+		"blockName": "core/query",
+		"attrs": {
+			"queryId": 19,
+			"query": {
+				"perPage": 3,
+				"pages": 0,
+				"offset": 0,
+				"postType": "post",
+				"categoryIds": [ 3, 5 ],
+				"tagIds": [ 6 ],
+				"order": "desc",
+				"orderBy": "date",
+				"author": "",
+				"search": "",
+				"exclude": [],
+				"sticky": "",
+				"inherit": false
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/post-template",
+				"attrs": {},
+				"innerBlocks": [
+					{
+						"blockName": "core/post-title",
+						"attrs": {},
+						"innerBlocks": [],
+						"innerHTML": "",
+						"innerContent": []
+					}
+				],
+				"innerHTML": "\n\n",
+				"innerContent": [ "\n", null, "\n" ]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-query\">\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-query\">",
+			null,
+			"\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__query__deprecated-2.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:query {"queryId":19,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{"category":[3,5],"post_tag":[6]}},"displayLayout":{"type":"list"}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/34977

This PR adds support for custom taxonomies filtering. In order to do that I had also had to change the way the block was holding information about tags and categories with explicitly defined props(`categoryIds, tagIds`).

I added a new property in the `query` attribute which is called `taxQuery` and holds the relevant information. My original plan was to split this PR in two (migrate to `taxQuery` and add custom taxonomies support), but the only difference would be to whitelist the previous supported taxonomies(`categories, tags`) so it didn't make much sense..

## Show case
#### Existing Query Loop blocks
In the below video I initially show an existing `Query Loop` block (both editor and front end) with `categories and tags` filters - I also highlight the set properties in code editor. After that I reload the pages with the new code to show the proper migration of the existing values by using the `taxQuery` property.

https://user-images.githubusercontent.com/16275880/150097649-477aeb97-e63d-4687-bd0a-581cd5b19691.mov


#### Custom taxonomies
In the following video I add some WooCommerce product categories filter:

https://user-images.githubusercontent.com/16275880/150097792-e479b313-5877-4890-9afa-dfddb8ff0d41.mov



## Testing instructions
1. Every existing `Query Loop` should work as before with no regressions
2. Insert/update `Query Loop` blocks with the new taxonomy filters (try any combination)
3. Also test by changing the `post type` filter that should show conditionally the available taxonomies' filters and reset the unavailable ones
4. Observe that everything works as expected
