### PR TITLE
Docblock typos

### DIFF
--- a/lib/compat/wordpress-5.9/block-patterns.php
+++ b/lib/compat/wordpress-5.9/block-patterns.php
@@ -36,7 +36,7 @@ if ( ! function_exists( '_load_remote_featured_patterns' ) ) {
 		foreach ( $patterns as $pattern ) {
 			$pattern_name = sanitize_title( $pattern['title'] );
 			$registry     = WP_Block_Patterns_Registry::get_instance();
-			// Some patterns might be already registerd as `core patterns with the `core` prefix.
+			// Some patterns might be already registered as `core patterns with the `core` prefix.
 			$is_registered = $registry->is_registered( $pattern_name ) || $registry->is_registered( "core/$pattern_name" );
 			if ( ! $is_registered ) {
 				register_block_pattern( $pattern_name, (array) $pattern );

--- a/lib/compat/wordpress-5.9/block-template.php
+++ b/lib/compat/wordpress-5.9/block-template.php
@@ -56,7 +56,7 @@ function gutenberg_locate_block_template( $template, $type, array $templates ) {
 		);
 		$index                  = array_search( $relative_template_path, $templates, true );
 
-		// If the template hiearchy algorithm has successfully located a PHP template file,
+		// If the template hierarchy algorithm has successfully located a PHP template file,
 		// we will only consider block templates with higher or equal specificity.
 		$templates = array_slice( $templates, 0, $index + 1 );
 	}

--- a/lib/compat/wordpress-5.9/blocks.php
+++ b/lib/compat/wordpress-5.9/blocks.php
@@ -16,7 +16,7 @@ if ( ! function_exists( 'get_query_pagination_arrow' ) ) {
 	 * It's used in QueryPaginationNext and QueryPaginationPrevious blocks.
 	 *
 	 * @param WP_Block $block   Block instance.
-	 * @param boolean  $is_next Flag for hanlding `next/previous` blocks.
+	 * @param boolean  $is_next Flag for handling `next/previous` blocks.
 	 *
 	 * @return string|null Returns the constructed WP_Query arguments.
 	 */

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -132,7 +132,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * Data from theme.json will be backfilled from existing
 	 * theme supports, if any. Note that if the same data
 	 * is present in theme.json and in theme supports,
-	 * the theme.json takes precendence.
+	 * the theme.json takes precedence.
 	 *
 	 * @param array $deprecated Deprecated argument.
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->


## Types of changes
Fixing some small spelling misstakes.
