### PR TITLE
Fix missing default `align-items` when items are oriented vertically in `flex` layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -111,6 +111,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= 'flex-direction: column;';
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$style .= "align-items: {$justify_content_options[ $layout['justifyContent'] ]};";
+			} else {
+				$style .= "align-items: flex-start;";
 			}
 		}
 		$style .= '}';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -112,7 +112,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( ! empty( $layout['justifyContent'] ) && array_key_exists( $layout['justifyContent'], $justify_content_options ) ) {
 				$style .= "align-items: {$justify_content_options[ $layout['justifyContent'] ]};";
 			} else {
-				$style .= "align-items: flex-start;";
+				$style .= 'align-items: flex-start;';
 			}
 		}
 		$style .= '}';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR is an alternative approach to #37986, which actually fixes the root issue. Thanks @ntsekouras for spotting this! 

For blocks that support the ability to orient items vertically, by default there is no `justifyContent` attribute applied. In the Editor, when there is no attribute we are applying `align-items: flex-start` as a default. On the frontend however, there is no default which leads to some rendering errors, particularly with the Social Icons block. This PR adds `align-items: flex-start` to the frontend when there is no `justifyContent` attribute and the block is meant to be oriented vertically.

## How has this been tested?
1. Use Twenty Twenty-Two with Gutenberg 12.4 RC1 and WordPress 5.9 RC3
2. Add the Social Icons block with a couple Social Icons
3. Orient the block vertically. See that it displays correctly in the Editor
4. Switch to the Frontend and see that with this PR the icons display correctly as well, without this PR they render like the screenshots below

## Screenshots 

Without this PR
![image](https://user-images.githubusercontent.com/4832319/150124426-7e9a063d-403d-471e-8f50-bac30f468bae.png)

With this PR
![image](https://user-images.githubusercontent.com/4832319/150124374-12b96d40-1ef9-4c2a-9a11-7a54b230cc52.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
