### PR TITLE
Post Editor: Fix template queries

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -55,6 +55,7 @@ export function TemplatePanel() {
 
 		const wpTemplates = getEntityRecords( 'postType', 'wp_template', {
 			post_type: currentPostType,
+			per_page: -1,
 		} );
 
 		const newAvailableTemplates = fromPairs(

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -394,7 +394,7 @@ export const getEditedPostTemplate = createRegistrySelector(
 		);
 		if ( currentTemplate ) {
 			const templateWithSameSlug = select( coreStore )
-				.getEntityRecords( 'postType', 'wp_template' )
+				.getEntityRecords( 'postType', 'wp_template', { per_page: -1 } )
 				?.find( ( template ) => template.slug === currentTemplate );
 			if ( ! templateWithSameSlug ) {
 				return templateWithSameSlug;


### PR DESCRIPTION
## Description
Resolves #37969.
Similar to #36761

> The problem here is that core data limits received items to ten when the per_page argument isn't provided. It is okay for most of the endpoints since they return ten items by default. But can cause unexpected results when the endpoint doesn't support pagination.

https://github.com/WordPress/gutenberg/issues/36563#issuecomment-972944085

## How has this been tested?
You can test this by installing a theme from the theme directory called ["Aino"](https://wordpress.org/themes/aino/), which has several templates.

1. Activate the block theme
2. Create a new post.
3. In the Templates section, select the following templates in the select list:

"Post with Portrait Featured image" - the Edit link is available
"Post without Comments" - the Edit link is available

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-19 at 16 27 16](https://user-images.githubusercontent.com/240569/150129345-4d2ca4b6-ca5f-475c-880b-18d67fe5612a.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
