### PR TITLE
Fix act warnings from store resolvers with fake timers

### DIFF
--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -3,6 +3,7 @@
  */
 import { act, fireEvent, initializeEditor, getEditorHtml } from 'test/helpers';
 import { Image } from 'react-native';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 /**
  * WordPress dependencies
@@ -35,6 +36,9 @@ jest.mock( 'lodash', () => {
 
 const apiFetchPromise = Promise.resolve( {} );
 apiFetch.mockImplementation( () => apiFetchPromise );
+
+const clipboardPromise = Promise.resolve( '' );
+Clipboard.getString.mockImplementation( () => clipboardPromise );
 
 beforeAll( () => {
 	registerCoreBlocks();
@@ -127,6 +131,8 @@ describe( 'Image Block', () => {
 		);
 		fireEvent.press( screen.getByText( 'None' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.changeText(
 			screen.getByPlaceholderText( 'Search or type URL' ),
 			'wordpress.org'
@@ -159,12 +165,16 @@ describe( 'Image Block', () => {
 		fireEvent.press( screen.getByText( 'None' ) );
 		fireEvent.press( screen.getByText( 'Media File' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.changeText(
 			screen.getByPlaceholderText( 'Search or type URL' ),
 			'wordpress.org'
 		);
 		fireEvent.press( screen.getByA11yLabel( 'Apply' ) );
 		fireEvent.press( screen.getByText( 'Custom URL' ) );
+		// Await asynchronous fetch of clipboard
+		await act( () => clipboardPromise );
 		fireEvent.press( screen.getByText( 'Media File' ) );
 
 		const expectedHtml = `<!-- wp:image {"id":1,"sizeSlug":"large","linkDestination":"media","className":"is-style-default"} -->

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -63,7 +63,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -89,7 +89,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -115,7 +115,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -146,7 +146,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -182,7 +182,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -206,7 +206,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -237,7 +237,7 @@ describe( 'Image Block', () => {
 			<figcaption>Mountain</figcaption>
 		</figure>
 		<!-- /wp:image -->`;
-		const screen = await initializeEditor( { initialHtml } );
+		const screen = initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 

--- a/packages/block-library/src/missing/test/edit-integration.native.js
+++ b/packages/block-library/src/missing/test/edit-integration.native.js
@@ -40,7 +40,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 			 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 			 <!-- /wp:table -->`;
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml,
 		} );
 
@@ -59,7 +59,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 		 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 		 <!-- /wp:table -->`;
-		const { getByA11yLabel, getByText } = await initializeEditor( {
+		const { getByA11yLabel, getByText } = initializeEditor( {
 			initialHtml,
 		} );
 

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -72,7 +72,7 @@ describe.each( [
 	it( 'should display the LINK SETTINGS with an EMPTY LINK TO field.', async () => {
 		// Arrange
 		const url = 'https://tonytahmouchtest.files.wordpress.com';
-		const subject = await initializeEditor( { initialHtml } );
+		const subject = initializeEditor( { initialHtml } );
 		Clipboard.getString.mockReturnValue( url );
 
 		// Act
@@ -109,7 +109,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'tonytahmouchtest.files.wordpress.com';
-				const subject = await initializeEditor( { initialHtml } );
+				const subject = initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -162,7 +162,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'https://tonytahmouchtest.files.wordpress.com';
-				const subject = await initializeEditor( { initialHtml } );
+				const subject = initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -241,7 +241,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = await initializeEditor( { initialHtml } );
+					const subject = initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act
@@ -308,7 +308,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = await initializeEditor( { initialHtml } );
+					const subject = initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -32,7 +32,7 @@ afterAll( () => {
 
 describe( 'Text color', () => {
 	it( 'shows the text color formatting button in the toolbar', async () => {
-		const { getByA11yLabel } = await initializeEditor();
+		const { getByA11yLabel } = initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -59,7 +59,7 @@ describe( 'Text color', () => {
 			getByA11yLabel,
 			getByTestId,
 			getByA11yHint,
-		} = await initializeEditor();
+		} = initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -101,7 +101,7 @@ describe( 'Text color', () => {
 			getByTestId,
 			getByPlaceholderText,
 			getByA11yHint,
-		} = await initializeEditor();
+		} = initializeEditor();
 		const text = 'Hello this is a test';
 
 		// Wait for the editor placeholder
@@ -149,7 +149,7 @@ describe( 'Text color', () => {
 	} );
 
 	it( 'creates a paragraph block with the text color format', async () => {
-		const { getByA11yLabel } = await initializeEditor( {
+		const { getByA11yLabel } = initializeEditor( {
 			initialHtml: TEXT_WITH_COLOR,
 		} );
 

--- a/packages/rich-text/src/test/index.native.js
+++ b/packages/rich-text/src/test/index.native.js
@@ -225,16 +225,15 @@ describe( '<RichText/>', () => {
 			expect( screen.toJSON() ).toMatchSnapshot();
 		} );
 
-		it( 'renders component with style and font size', async () => {
+		it( 'renders component with style and font size', () => {
 			// Arrange
 			const initialHtml = `<!-- wp:paragraph {"style":{"color":{"text":"#fcb900"},"typography":{"fontSize":35.56}}} -->
 					<p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 					<!-- /wp:paragraph -->`;
 			// Act
-			const { unmount } = await initializeEditor( { initialHtml } );
+			initializeEditor( { initialHtml } );
 			// Assert
 			expect( getEditorHtml() ).toMatchSnapshot();
-			unmount();
 		} );
 
 		it( 'should update the font size with decimals when style prop with font size property is provided', () => {


### PR DESCRIPTION
## Description
During editor initialization, asynchronous store resolvers rely upon `setTimeout` to run at the end of the current JavaScript block execution. In order to prevent "act" warnings triggered by updates to the React tree, we leverage fake timers to manually tick and await the resolution of the current block execution before proceeding.

Additionally, usage of `initializeEditor` has been refactored to avoid unnecessary `await` now that `initializeEditor` is no longer asynchronous.

Lastly, an explicit `act` was applied for the asynchronous work of retrieving text from the clipboard. Retrieving text from the clipboard is an asynchronous action. The component updated React state once the clipboard resolved. This resulted in a state update triggering an `act` warning. Because there is no visible change to the rendered output, e.g. updated text or UI, we must await the resolution of the clipboard promise itself.

## How has this been tested?
1. Run tests with `npm run native test`
1. Observe all tests pass and no `act` errors log related to `EditorProvider` or
   `Clipboard`.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Chore

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
