### PR TITLE
Add allowed-plugins in composer config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,10 @@
 		"process-timeout": 0,
 		"platform": {
 			"php": "7.4"
+		},
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true,
+			"composer/installers": true
 		}
 	},
 	"require-dev": {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
As of Composer 2.2, Composer plugins need to be explicitly allowed to run. This commit adds the necessary configuration for that to prevent Composer asking every single time `composer install` or `composer update` is runned.

See
https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution
https://getcomposer.org/doc/06-config.md#allow-plugins

## How has this been tested?
Locally with composer v2.2.4
