### PR TITLE
WIP: Support dynamic CSS values in the UI

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -7,7 +7,7 @@ import {
 	BaseControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalUnitControl as UnitControl,
+	__experimentalCustomUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { useState } from '@wordpress/element';

--- a/packages/components/src/custom-unit-control/index.js
+++ b/packages/components/src/custom-unit-control/index.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import BaseUnitControl from '../unit-control';
+import Button from '../button';
+import TextControl from '../text-control';
+import { FlexItem, Flex } from '../flex';
+import {
+	ALL_CSS_UNITS,
+	CSS_UNITS,
+	hasUnits,
+	getUnitsWithCurrentUnit,
+} from '../unit-control/utils';
+
+function hasCustomValue( initialValue, units = ALL_CSS_UNITS ) {
+	const value = String( initialValue ).trim();
+
+	const num = parseFloat( value );
+	if ( isNaN( num ) ) {
+		// If no value can be parsed, this is a custom value.
+		return true;
+	}
+
+	const unitMatch = value.match( /[\d.\-\+]*\s*(.*)/ );
+	let unit = unitMatch?.[ 1 ] !== undefined ? unitMatch[ 1 ] : '';
+	unit = unit.toLowerCase();
+
+	if ( hasUnits( units ) && units !== false ) {
+		const match = units.find( ( item ) => item.value === unit );
+		// If not using an accepted unit, this is a custom value
+		return match?.value === undefined;
+	}
+
+	return true;
+}
+
+export const Layout = styled( Flex )`
+	min-height: 30px;
+	gap: 0;
+	align-items: start;
+`;
+
+export default function CustomUnitControl( props ) {
+	const {
+		label,
+		unit,
+		units: unitsProp = CSS_UNITS,
+		value,
+		onChange,
+	} = props;
+
+	const units = useMemo(
+		() => getUnitsWithCurrentUnit( value, unit, unitsProp ),
+		[ value, unit, unitsProp ]
+	);
+	const [ isCustomValue, setIsCustomValue ] = useState(
+		!! value && hasCustomValue( value, units )
+	);
+
+	return (
+		<Layout>
+			{ isCustomValue && (
+				<FlexItem>
+					<TextControl
+						autoComplete="off"
+						value={ value || '' }
+						onChange={ ( nextValue ) => {
+							onChange( nextValue );
+						} }
+						help={ __( 'Enter custom CSS.' ) }
+					/>
+				</FlexItem>
+			) }
+			{ ! isCustomValue && (
+				<FlexItem>
+					<BaseUnitControl
+						aria-label={ label }
+						className="component-custom-unit-control__unit-control"
+						isResetValueOnUnitChange={ false }
+						{ ...props }
+					/>
+				</FlexItem>
+			) }
+			<FlexItem>
+				<Button
+					className="component-box-control__reset-button"
+					isSecondary
+					isSmall
+					onClick={ () => setIsCustomValue( ! isCustomValue ) }
+				>
+					{ isCustomValue ? __( 'Select' ) : __( 'Custom' ) }
+				</Button>
+			</FlexItem>
+		</Layout>
+	);
+}

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -49,6 +49,7 @@ export {
 } from './composite';
 export { ConfirmDialog as __experimentalConfirmDialog } from './confirm-dialog';
 export { default as CustomSelectControl } from './custom-select-control';
+export { default as __experimentalCustomUnitControl } from './custom-unit-control';
 export { default as Dashicon } from './dashicon';
 export { default as DateTimePicker, DatePicker, TimePicker } from './date-time';
 export { default as __experimentalDimensionControl } from './dimension-control';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
🚧 Extremely early WIP 🚧

At the moment I'm just using this branch to play around with various approaches for a CustomUnitControl, using the Spacer block to test it out. The purpose is to add support in the UI for complex use cases like the one described [here](https://github.com/WordPress/gutenberg/pull/36186#issuecomment-987954235):

> The main use case I have in mind is this space beneath the header in Twenty Twenty-Two. I'd love to use a spacer to replace that, but to keep it in sync with other areas of the theme we currently use a max(1.25rem, 5vw) value so that the space isn't too large on small screens.

Values that accept custom units (like `padding`, `margin`, and the Spacer block's `height` as referenced in that example) can technically support dynamic values, but the UI doesn't provide a way to see or edit those values. (You can manually edit the attribute in the Code editor, for example).

ToDo:
* Play around with adding custom value support to the existing UnitControl instead, toggled on via a prop, so that it can potentially be used in the BoxControl as well
* Handling of invalid custom css
* Edge cases, for example if you type "100" in the Custom input, because this is a string it will not automatically be interpreted as `100px`


https://user-images.githubusercontent.com/63313398/150242030-052e9e86-0c63-4ec8-a0fd-ef3a275a3c75.mov



## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
