### PR TITLE
Block Templates API: Add rest_insert hook

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -268,9 +268,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a single item is created or updated via the REST API.
 		 *
-		 * @param Gutenberg_Block_Template	$template	Inserted or updated block template object.
-		 * @param WP_REST_Request			$request	Request object.
-		 * @param boolean					$creating	True when creating item, false when updating.
+		 * @param Gutenberg_Block_Template $template Inserted or updated block template object.
+		 * @param WP_REST_Request $request Request object.
+		 * @param boolean $creating True when creating item, false when updating.
 		 */
 		do_action( "rest_insert_{$this->post_type}", $template, $request, ! $is_customized_template );
 
@@ -323,9 +323,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		/**
 		 * Fires after a single item is created via the REST API.
 		 *
-		 * @param Gutenberg_Block_Template	$template	Newly created block template object.
-		 * @param WP_REST_Request			$request	Request object.
-		 * @param boolean					$creating	True when creating item, false when updating.
+		 * @param Gutenberg_Block_Template $template Newly created block template object.
+		 * @param WP_REST_Request $request Request object.
+		 * @param boolean $creating True when creating item, false when updating.
 		 */
 		do_action( "rest_insert_{$this->post_type}", $template, $request, true );
 

--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -252,7 +252,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			return $changes;
 		}
 
-		if ( 'custom' === $template->source ) {
+		$is_customized_template = 'custom' === $template->source;
+
+		if ( $is_customized_template ) {
 			$result = wp_update_post( wp_slash( (array) $changes ), true );
 		} else {
 			$result = wp_insert_post( wp_slash( (array) $changes ), true );
@@ -262,6 +264,16 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		$template      = gutenberg_get_block_template( $request['id'], $this->post_type );
+
+		/**
+		 * Fires after a single item is created or updated via the REST API.
+		 *
+		 * @param Gutenberg_Block_Template	$template	Inserted or updated block template object.
+		 * @param WP_REST_Request			$request	Request object.
+		 * @param boolean					$creating	True when creating item, false when updating.
+		 */
+		do_action( "rest_insert_{$this->post_type}", $template, $request, ! $is_customized_template );
+
 		$fields_update = $this->update_additional_fields_for_object( $template, $request );
 		if ( is_wp_error( $fields_update ) ) {
 			return $fields_update;
@@ -307,6 +319,16 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		}
 		$id            = $posts[0]->id;
 		$template      = gutenberg_get_block_template( $id, $this->post_type );
+
+		/**
+		 * Fires after a single item is created via the REST API.
+		 *
+		 * @param Gutenberg_Block_Template	$template	Newly created block template object.
+		 * @param WP_REST_Request			$request	Request object.
+		 * @param boolean					$creating	True when creating item, false when updating.
+		 */
+		do_action( "rest_insert_{$this->post_type}", $template, $request, true );
+
 		$fields_update = $this->update_additional_fields_for_object( $template, $request );
 		if ( is_wp_error( $fields_update ) ) {
 			return $fields_update;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR adds the `rest_insert_{$post_type}` action into the Gutenberg Block Templates rest API. This would allow users to hook into block template creation and updates. A concrete use case might be users wanting to communicate with third party APIs when a template part or template has been saved. 

This is almost identical to the implementation in [class-wp-rest-menu-items-controller](https://github.com/WordPress/gutenberg/blob/trunk/lib/class-wp-rest-menu-items-controller.php#L201-L211)

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
TBD

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
New feature

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
