### PR TITLE
Skip flaky nav permissions test until fixed

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -760,7 +760,7 @@ describe( 'Navigation', () => {
 		expect( tagCount ).toBe( 1 );
 	} );
 
-	describe( 'Permission based restrictions', () => {
+	describe.skip( 'Permission based restrictions', () => {
 		const contributorUsername = 'contributoruser';
 		let contributorPassword;
 


### PR DESCRIPTION
This is failing regularly, so I'm temporarily skipping this test until the fix in #38025 lands.