### PR TITLE
Don't use WP_Query::get_posts directly

### DIFF
--- a/lib/upgrade.php
+++ b/lib/upgrade.php
@@ -37,14 +37,14 @@ function _gutenberg_migrate_database() {
  */
 function _gutenberg_migrate_remove_fse_drafts() {
 	// Delete auto-draft templates and template parts.
-	$delete_query = new WP_QUERY(
+	$delete_query = new WP_Query(
 		array(
 			'post_status'    => array( 'auto-draft' ),
 			'post_type'      => array( 'wp_template', 'wp_template_part' ),
 			'posts_per_page' => -1,
 		)
 	);
-	foreach ( $delete_query->get_posts() as $post ) {
+	foreach ( $delete_query->posts as $post ) {
 		wp_delete_post( $post->ID, true );
 	}
 


### PR DESCRIPTION
## Description
Don't call `WP_Query::get_posts` directly after passing args to `WP_Query` to avoid duplicated queries.

Similar to #32700

## How has this been tested?
All checks are passing.

## Types of changes
Performance/Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
