### PR TITLE
Site Editor: Fix Inserter classes

### DIFF
--- a/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/inserter-sidebar.js
@@ -42,14 +42,14 @@ export default function InserterSidebar() {
 			{ ...inserterDialogProps }
 			className="edit-site-editor__inserter-panel"
 		>
-			<TagName className="edit-post-editor__inserter-panel-header">
+			<TagName className="edit-site-editor__inserter-panel-header">
 				<Button
 					icon={ close }
 					label={ __( 'Close block inserter' ) }
 					onClick={ () => setIsInserterOpened( false ) }
 				/>
 			</TagName>
-			<div className="edit-post-editor__inserter-panel-content">
+			<div className="edit-site-editor__inserter-panel-content">
 				<Library
 					showInserterHelpPanel
 					shouldFocusBlock={ isMobile }


### PR DESCRIPTION
## Description
Resolves #38098.

PR fixes missing Inserter scrollbar issue. It looks like we were using the wrong classes.

## How has this been tested?
1. Open Block Inserter in the Site Editor.
2. Confirm that the inserter has a scrollbar.

## Screenshots <!-- if applicable -->
![CleanShot 2022-01-20 at 17 15 52](https://user-images.githubusercontent.com/240569/150346149-0d890e48-7639-4711-8aab-e7a3b62d52b7.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
