### PR TITLE
Add missing props mediaPreview in the ReadMe

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -144,7 +144,7 @@ Whether to allow multiple selection of files or not.
 
 React Element to render as preview in placeholder
 
--   Type: `Object`
+-   Type: `Component`
 -   Required: No
 -   Platform: Web
 

--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -140,6 +140,14 @@ Whether to allow multiple selection of files or not.
 -   Default: `false`
 -   Platform: Web
 
+### mediaPreview
+
+React Element to render as preview in placeholder
+
+-   Type: `Object`
+-   Required: No
+-   Platform: Web
+
 ### onError
 
 Callback called when an upload error happens.

--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -142,7 +142,7 @@ Whether to allow multiple selection of files or not.
 
 ### mediaPreview
 
-React Element to render as preview in placeholder
+The component is rendered as a preview in the placeholder.
 
 -   Type: `Component`
 -   Required: No


### PR DESCRIPTION
<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Add missing props mediaPreview in the ReadMe for Media Placeholder Component

## How has this been tested?
N/A

## Types of changes
Documentation 

## Checklist:
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->

