### PR TITLE
[RNMobile] Remove trailing whitespace from strings

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -490,7 +490,7 @@ export class ImageEdit extends Component {
 				footerNote={
 					<>
 						{ __(
-							'Describe the purpose of the image. Leave empty if the image is purely decorative. '
+							'Describe the purpose of the image. Leave empty if the image is purely decorative.'
 						) }
 						<FooterMessageLink
 							href={

--- a/packages/editor/src/components/editor-help/add-blocks.native.js
+++ b/packages/editor/src/components/editor-help/add-blocks.native.js
@@ -24,7 +24,7 @@ const AddBlocks = () => {
 			<View style={ styles.helpDetailContainer }>
 				<HelpDetailBodyText
 					text={ __(
-						'Add a new block at any time by tapping on the + icon in the toolbar on the bottom left. '
+						'Add a new block at any time by tapping on the + icon in the toolbar on the bottom left.'
 					) }
 				/>
 				<HelpDetailBodyText


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

On Android, translations of strings with trailing whitespace are not being properly retrieved. For this reason, the trailing whitespace has been removed strings that are only referenced in the native version.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

**Preparation:**
1. Change the device's locale to non-English.
1. Open the editor in the Android app.

### String `Describe the purpose of the image. Leave empty if the image is purely decorative.`
1. Add an Image block and select an image.
1. Open the block settings by tapping on the gear icon button.
1. Tap on "Alt Text".
1. Observe that the string `Describe the purpose of the image. Leave empty if the image is purely decorative.` is translated.

### String `Add a new block at any time by tapping on the + icon in the toolbar on the bottom left.`
1. Open post settings by tapping on the three dots button.
1. Tap on "Help & Support" option.
1. Navigate to "Add blocks".
1. Observe that the string `Add a new block at any time by tapping on the + icon in the toolbar on the bottom left.` is translated.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
