### PR TITLE
Site Editor: Fix resizable box scrollbars in blocks

### DIFF
--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -31,6 +31,12 @@
 			overflow: visible;
 		}
 	}
+
+	> .components-resizable-box__container {
+		margin: 0 auto;
+		// Removing this will cancel the bottom margins in the iframe.
+		overflow: auto;
+	}
 }
 
 .edit-site-visual-editor__back-button {
@@ -44,12 +50,6 @@
 	&:hover {
 		color: $gray-100;
 	}
-}
-
-.components-resizable-box__container {
-	margin: 0 auto;
-	// Removing this will cancel the bottom margins in the iframe.
-	overflow: auto;
 }
 
 .resizable-editor__drag-handle {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -32,7 +32,7 @@
 		}
 	}
 
-	> .components-resizable-box__container {
+	.components-resizable-box__container {
 		margin: 0 auto;
 		// Removing this will cancel the bottom margins in the iframe.
 		overflow: auto;


### PR DESCRIPTION
## Description
Fixes #38086.

It looks like the `.components-resizable-box__container` styles introduced in #38019 were leaking inside the iframe when the WP core loads concatenated CSS files using `load-styles.php.` It causes all `ResizableBox` on canvas to have scrollbars.

RR fixes this issue by increasing the specificity of the new styles and only targeting direct children of `.edit-site-visual-editor.`

## How has this been tested?
Unfortunately, plugin CSS assets aren't loaded via `load-styles.php`, so it's hard to test this fix. So instead, test that this doesn't introduce regression to the #38019.

1. Activate a block-based theme - TT2
2. Go to Appearance -> Editor
3. Switch the preview from "Desktop" to "Mobile" or "Tablet."
4. The preview shouldn't be cut off and can be scrolled down
5. Edit a template part (Header for instance)
6. The focus mode should not have a horizontal scrollbar either

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
