### PR TITLE
Latest Posts: Fix featured image alignment label position

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -299,7 +299,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								} )
 							}
 						/>
-						<BaseControl className="block-editor-image-alignment-control__row">
+						<BaseControl className="editor-latest-posts-image-alignment-control">
 							<BaseControl.VisualLabel>
 								{ __( 'Image alignment' ) }
 							</BaseControl.VisualLabel>

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -12,3 +12,13 @@
 .edit-post-visual-editor .wp-block-latest-posts.is-grid li {
 	margin-bottom: 20px;
 }
+
+.editor-latest-posts-image-alignment-control {
+	.components-base-control__label {
+		display: block;
+	}
+
+	.components-toolbar {
+		border: none;
+	}
+}

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -17,8 +17,4 @@
 	.components-base-control__label {
 		display: block;
 	}
-
-	.components-toolbar {
-		border: none;
-	}
 }

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -17,4 +17,8 @@
 	.components-base-control__label {
 		display: block;
 	}
+
+	.components-toolbar {
+		border-radius: $radius-block-ui;
+	}
 }

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -73,15 +73,3 @@
 		text-align: center;
 	}
 }
-
-.block-editor-image-alignment-control__row {
-	.components-base-control__field {
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-
-		.components-base-control__label {
-			margin-bottom: 0;
-		}
-	}
-}


### PR DESCRIPTION
## Description
PR fixes the Latest Posts block featured image alignment label position. ~~It also removes the border from controls.~~

## How has this been tested?
1. Add the Latest Posts block to a page.
2. Enable the "Display featured image" setting.
3. Check that the alignment control label is displayed above the controls.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-01-21 at 12 49 35](https://user-images.githubusercontent.com/240569/150495993-bff10a0e-9b72-4fbe-a88f-35ca4b7793e1.png)|![CleanShot 2022-01-21 at 12 45 05](https://user-images.githubusercontent.com/240569/150495518-69359a8f-bd69-4b7b-a36e-00bf8d0141dc.png)|

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
