### PR TITLE
Update template home, front-page, and search template descriptions

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -114,11 +114,11 @@ if ( ! function_exists( 'get_default_block_template_types' ) ) {
 			),
 			'home'           => array(
 				'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays as the site\'s home page, or as the Posts page when a static home page isn\'t set.', 'gutenberg' ),
+				'description' => __( 'Displays posts on the site homepage, or on the Posts page if a static homepage is set.', 'gutenberg' ),
 			),
 			'front-page'     => array(
 				'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays as the site\'s home page.', 'gutenberg' ),
+				'description' => __( 'Displays as the site\'s homepage.', 'gutenberg' ),
 			),
 			'singular'       => array(
 				'title'       => _x( 'Singular', 'Template name', 'gutenberg' ),
@@ -162,7 +162,7 @@ if ( ! function_exists( 'get_default_block_template_types' ) ) {
 			),
 			'search'         => array(
 				'title'       => _x( 'Search', 'Template name', 'gutenberg' ),
-				'description' => __( 'Template used to display search results.', 'gutenberg' ),
+				'description' => __( 'Displays search results.', 'gutenberg' ),
 			),
 			'privacy-policy' => array(
 				'title'       => __( 'Privacy Policy', 'gutenberg' ),

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -114,11 +114,11 @@ if ( ! function_exists( 'get_default_block_template_types' ) ) {
 			),
 			'home'           => array(
 				'title'       => _x( 'Home', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays posts on the site homepage, or on the Posts page if a static homepage is set.', 'gutenberg' ),
+				'description' => __( 'Displays posts on the homepage, or on the Posts page if a static homepage is set.', 'gutenberg' ),
 			),
 			'front-page'     => array(
 				'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays the site\'s homepage.', 'gutenberg' ),
+				'description' => __( 'Displays the homepage.', 'gutenberg' ),
 			),
 			'singular'       => array(
 				'title'       => _x( 'Singular', 'Template name', 'gutenberg' ),

--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -118,7 +118,7 @@ if ( ! function_exists( 'get_default_block_template_types' ) ) {
 			),
 			'front-page'     => array(
 				'title'       => _x( 'Front Page', 'Template name', 'gutenberg' ),
-				'description' => __( 'Displays as the site\'s homepage.', 'gutenberg' ),
+				'description' => __( 'Displays the site\'s homepage.', 'gutenberg' ),
 			),
 			'singular'       => array(
 				'title'       => _x( 'Singular', 'Template name', 'gutenberg' ),


### PR DESCRIPTION
### Home
Before: "Displays as the site\'s home page, or as the Posts page when a static home page isn\'t set." 
After: "Displays posts on the homepage, or on the Posts page if a static homepage is set.".

Fixed a couple of small typos and hopefully made the description a little clearer.

### Front-page
Before: "Displays as the site's home page."
After: "Displays the homepage."

Reading settings use "homepage" rather than "home page". This is just a consistency tweak.

### Search
Before: "Template used to display search results."
After: "Displays search results."

Similarly, this is a consistency adjustment. All other descriptions read "Displays..." rather than "Template used to display...".