### PR TITLE
Update templates to standarize naming and imports usage.

### DIFF
--- a/packages/create-block-tutorial-template/templates/src/edit.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/edit.js.mustache
@@ -25,7 +25,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @return {WPElement} Element to render.
  */
-export default function Edit( { attributes, setAttributes } ) {
+export default function edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>

--- a/packages/create-block-tutorial-template/templates/src/edit.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/edit.js.mustache
@@ -17,6 +17,9 @@ import { useBlockProps } from '@wordpress/block-editor';
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
+ * When using React hooks, we need to create a React component so that we adhere
+ * to the rules of hooks @see https://reactjs.org/docs/hooks-rules.html
+ *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
  *
  * @param {Object}   props               Properties passed to the function.

--- a/packages/create-block-tutorial-template/templates/src/edit.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/edit.js.mustache
@@ -28,7 +28,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  *
  * @return {WPElement} Element to render.
  */
-export default function edit( { attributes, setAttributes } ) {
+export default function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>

--- a/packages/create-block-tutorial-template/templates/src/index.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/index.js.mustache
@@ -19,7 +19,7 @@ import './editor.scss';
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import edit from './edit';
 import save from './save';
 
 /**
@@ -37,10 +37,11 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 		},
 	},
 
+    // The edit and save properties below are using object property shorthand. See https://alligator.io/js/object-property-shorthand-es6/
 	/**
 	 * @see ./edit.js
 	 */
-	edit: Edit,
+	edit,
 
 	/**
 	 * @see ./save.js

--- a/packages/create-block-tutorial-template/templates/src/save.js.mustache
+++ b/packages/create-block-tutorial-template/templates/src/save.js.mustache
@@ -11,13 +11,16 @@ import { useBlockProps } from '@wordpress/block-editor';
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
  *
+ * When using React hooks, we need to create a React component so that we adhere
+ * to the rules of hooks @see https://reactjs.org/docs/hooks-rules.html
+
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
  *
  * @param {Object} props            Properties passed to the function.
  * @param {Object} props.attributes Available block attributes.
  * @return {WPElement} Element to render.
  */
-export default function save( { attributes } ) {
+export default function Save( { attributes } ) {
 	const blockProps = useBlockProps.save();
 	return <div { ...blockProps }>{ attributes.message }</div>;
 }

--- a/packages/create-block/lib/templates/esnext/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/edit.js.mustache
@@ -29,7 +29,7 @@ import './editor.scss';
  *
  * @return {WPElement} Element to render.
  */
-export default function Edit() {
+export default function edit() {
 	return (
 		<p { ...useBlockProps() }>
 			{ __( '{{title}} – hello from the editor!', '{{textdomain}}' ) }

--- a/packages/create-block/lib/templates/esnext/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/edit.js.mustache
@@ -24,6 +24,9 @@ import './editor.scss';
 /**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
+*
+ * When using React hooks, we need to create a React component so that we adhere
+ * to the rules of hooks @see https://reactjs.org/docs/hooks-rules.html
  *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit
  *

--- a/packages/create-block/lib/templates/esnext/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/edit.js.mustache
@@ -32,7 +32,7 @@ import './editor.scss';
  *
  * @return {WPElement} Element to render.
  */
-export default function edit() {
+export default function Edit() {
 	return (
 		<p { ...useBlockProps() }>
 			{ __( '{{title}} – hello from the editor!', '{{textdomain}}' ) }

--- a/packages/create-block/lib/templates/esnext/block/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/index.js.mustache
@@ -17,7 +17,7 @@ import './style.scss';
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import edit from './edit';
 import save from './save';
 
 /**
@@ -26,10 +26,12 @@ import save from './save';
  * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-registration/
  */
 registerBlockType( '{{namespace}}/{{slug}}', {
+
+	// The edit and save properties below are using object property shorthand. See https://alligator.io/js/object-property-shorthand-es6/
 	/**
 	 * @see ./edit.js
 	 */
-	edit: Edit,
+	edit: edit,
 
 	/**
 	 * @see ./save.js

--- a/packages/create-block/lib/templates/esnext/block/index.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/index.js.mustache
@@ -31,7 +31,7 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
 	 * @see ./edit.js
 	 */
-	edit: edit,
+	edit,
 
 	/**
 	 * @see ./save.js

--- a/packages/create-block/lib/templates/esnext/block/save.js.mustache
+++ b/packages/create-block/lib/templates/esnext/block/save.js.mustache
@@ -14,15 +14,18 @@ import { __ } from '@wordpress/i18n';
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
- * The save function defines the way in which the different attributes should
+ * The Save React component defines the way in which the different attributes should
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
+ *
+ * When using React hooks, we need to create a React component so that we adhere
+ * to the rules of hooks @see https://reactjs.org/docs/hooks-rules.html
  *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#save
  *
  * @return {WPElement} Element to render.
  */
-export default function save() {
+export default function Save() {
 	return (
 		<p { ...useBlockProps.save() }>
 			{ __(


### PR DESCRIPTION
## Description
Updates to create-block templates as outined in #38138

## How has this been tested?
Ran `npx @wordpress/create-block gb-test --template=../create-block-tutorial-template`

## Screenshots <!-- if applicable -->

## Types of changes
Template changes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
