### PR TITLE
[docgen] Refactor code to use require() instead of JSON.parse(fs.readFileSync())

### DIFF
--- a/packages/docgen/test/get-export-entries.js
+++ b/packages/docgen/test/get-export-entries.js
@@ -1,24 +1,12 @@
 /**
- * External dependencies
- */
-const fs = require( 'fs' );
-const path = require( 'path' );
-
-/**
  * Internal dependencies
  */
 const getExportEntries = require( '../lib/get-export-entries' );
 
 describe( 'Export entries', () => {
 	it( 'default class (anonymous)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-class-anonymous/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-class-anonymous/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: '*default*',
@@ -30,14 +18,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default class (named)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-class-named/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-class-named/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'ClassDeclaration',
@@ -49,14 +31,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default function (anonymous)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-function-anonymous/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-function-anonymous/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: '*default*',
@@ -68,14 +44,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default function (named)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-function-named/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-function-named/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'myDeclaration',
@@ -87,14 +57,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default identifier', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-identifier/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-identifier/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'ClassDeclaration',
@@ -106,14 +70,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default import (named)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-import-named/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-import-named/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'fnDeclaration',
@@ -125,14 +83,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default import (default)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-import-default/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-import-default/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'fnDeclaration',
@@ -144,14 +96,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default named export', () => {
-		const tokens = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/default-named-export/exports.json'
-			),
-			'utf-8'
-		);
-		const namedExport = getExportEntries( JSON.parse( tokens )[ 0 ] );
+		const tokens = require( './fixtures/default-named-export/exports.json' );
+		const namedExport = getExportEntries( tokens[ 0 ] );
 		expect( namedExport ).toHaveLength( 1 );
 		expect( namedExport[ 0 ] ).toEqual( {
 			localName: 'functionDeclaration',
@@ -160,7 +106,7 @@ describe( 'Export entries', () => {
 			lineStart: 4,
 			lineEnd: 4,
 		} );
-		const defaultExport = getExportEntries( JSON.parse( tokens )[ 1 ] );
+		const defaultExport = getExportEntries( tokens[ 1 ] );
 		expect( defaultExport ).toHaveLength( 1 );
 		expect( defaultExport[ 0 ] ).toEqual( {
 			localName: 'functionDeclaration',
@@ -172,11 +118,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'default variable', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/default-variable/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/default-variable/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: '*default*',
@@ -188,11 +131,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named class', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-class/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-class/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'MyDeclaration',
@@ -204,11 +144,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named default', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-default/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-default/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'default',
@@ -220,14 +157,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named default (exported)', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/named-default-exported/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-default-exported/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'default',
@@ -239,11 +170,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named function', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-function/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-function/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'myDeclaration',
@@ -255,11 +183,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named identifier', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-identifier/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-identifier/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'myDeclaration',
@@ -268,14 +193,8 @@ describe( 'Export entries', () => {
 			lineStart: 6,
 			lineEnd: 6,
 		} );
-		const tokenObject = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/named-identifier-destructuring/exports.json'
-			),
-			'utf-8'
-		);
-		const nameObject = getExportEntries( JSON.parse( tokenObject ) );
+		const tokenObject = require( './fixtures/named-identifier-destructuring/exports.json' );
+		const nameObject = getExportEntries( tokenObject );
 		expect( nameObject ).toHaveLength( 1 );
 		expect( nameObject[ 0 ] ).toEqual( {
 			localName: 'someDeclaration',
@@ -287,11 +206,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named identifiers', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-identifiers/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-identifiers/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 3 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'functionDeclaration',
@@ -314,16 +230,8 @@ describe( 'Export entries', () => {
 			lineStart: 16,
 			lineEnd: 16,
 		} );
-		const tokenIdentifiersAndInline = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/named-identifiers-and-inline/exports.json'
-			),
-			'utf-8'
-		);
-		const nameInline0 = getExportEntries(
-			JSON.parse( tokenIdentifiersAndInline )[ 0 ]
-		);
+		const tokenIdentifiersAndInline = require( './fixtures/named-identifiers-and-inline/exports.json' );
+		const nameInline0 = getExportEntries( tokenIdentifiersAndInline[ 0 ] );
 		expect( nameInline0 ).toHaveLength( 2 );
 		expect( nameInline0[ 0 ] ).toEqual( {
 			localName: 'functionDeclaration',
@@ -339,9 +247,7 @@ describe( 'Export entries', () => {
 			lineStart: 11,
 			lineEnd: 11,
 		} );
-		const nameInline1 = getExportEntries(
-			JSON.parse( tokenIdentifiersAndInline )[ 1 ]
-		);
+		const nameInline1 = getExportEntries( tokenIdentifiersAndInline[ 1 ] );
 		expect( nameInline1 ).toHaveLength( 1 );
 		expect( nameInline1[ 0 ] ).toEqual( {
 			localName: 'variableDeclaration',
@@ -353,14 +259,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named import namespace', () => {
-		const token = fs.readFileSync(
-			path.join(
-				__dirname,
-				'./fixtures/named-import-namespace/exports.json'
-			),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-import-namespace/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'variables',
@@ -372,11 +272,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named variable', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-variable/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-variable/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'myDeclaration',
@@ -388,11 +285,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'named variables', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/named-variables/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/named-variables/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 2 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: 'firstDeclaration',
@@ -411,11 +305,8 @@ describe( 'Export entries', () => {
 	} );
 
 	it( 'namespace (*)', () => {
-		const token = fs.readFileSync(
-			path.join( __dirname, './fixtures/namespace/exports.json' ),
-			'utf-8'
-		);
-		const name = getExportEntries( JSON.parse( token ) );
+		const token = require( './fixtures/namespace/exports.json' );
+		const name = getExportEntries( token );
 		expect( name ).toHaveLength( 1 );
 		expect( name[ 0 ] ).toEqual( {
 			localName: '*',

--- a/packages/docgen/test/get-intermediate-representation.js
+++ b/packages/docgen/test/get-intermediate-representation.js
@@ -1,10 +1,4 @@
 /**
- * External dependencies
- */
-const fs = require( 'fs' );
-const path = require( 'path' );
-
-/**
  * Internal dependencies
  */
 const getIntermediateRepresentation = require( '../lib/get-intermediate-representation' );
@@ -12,16 +6,9 @@ const getIntermediateRepresentation = require( '../lib/get-intermediate-represen
 describe( 'Intermediate Representation', () => {
 	describe( 'undocumented code', () => {
 		it( 'default export on multiple lines', () => {
-			const token = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-undocumented-nocomments/exports.json'
-				),
-				'utf-8'
-			);
 			const ir = getIntermediateRepresentation(
 				null,
-				JSON.parse( token )
+				require( './fixtures/default-undocumented-nocomments/exports.json' )
 			);
 			expect( ir ).toMatchInlineSnapshot( `
 			Array [
@@ -37,16 +24,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 		} );
 		it( 'default export on one line', () => {
-			const tokenOneliner = fs.readFileSync(
-				path.join(
-					__dirname,
-					'./fixtures/default-undocumented-oneliner/exports.json'
-				),
-				'utf-8'
-			);
 			const irOneliner = getIntermediateRepresentation(
 				null,
-				JSON.parse( tokenOneliner )
+				require( './fixtures/default-undocumented-oneliner/exports.json' )
 			);
 			expect( irOneliner ).toMatchInlineSnapshot( `
 			Array [
@@ -66,16 +46,9 @@ describe( 'Intermediate Representation', () => {
 	describe( 'JSDoc in export statement', () => {
 		describe( 'default export', () => {
 			it( 'anonymous class', () => {
-				const tokenClassAnonymous = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-class-anonymous/exports.json'
-					),
-					'utf-8'
-				);
 				const irClassAnonymous = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenClassAnonymous )
+					require( './fixtures/default-class-anonymous/exports.json' )
 				);
 				expect( irClassAnonymous ).toMatchInlineSnapshot( `
 			Array [
@@ -91,16 +64,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named class', () => {
-				const tokenClassNamed = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-class-named/exports.json'
-					),
-					'utf-8'
-				);
 				const irClassNamed = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenClassNamed )
+					require( './fixtures/default-class-named/exports.json' )
 				);
 				expect( irClassNamed ).toMatchInlineSnapshot( `
 			Array [
@@ -116,16 +82,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'anonymous function', () => {
-				const tokenFnAnonymous = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-function-anonymous/exports.json'
-					),
-					'utf-8'
-				);
 				const irFnAnonymous = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenFnAnonymous )
+					require( './fixtures/default-function-anonymous/exports.json' )
 				);
 				expect( irFnAnonymous ).toMatchInlineSnapshot( `
 			Array [
@@ -141,16 +100,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named function', () => {
-				const tokenFnNamed = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-function-named/exports.json'
-					),
-					'utf-8'
-				);
 				const irFnNamed = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenFnNamed )
+					require( './fixtures/default-function-named/exports.json' )
 				);
 				expect( irFnNamed ).toMatchInlineSnapshot( `
 			Array [
@@ -166,16 +118,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'variable', () => {
-				const tokenVariable = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-variable/exports.json'
-					),
-					'utf-8'
-				);
 				const irVar = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenVariable )
+					require( './fixtures/default-variable/exports.json' )
 				);
 				expect( irVar ).toMatchInlineSnapshot( `
 			Array [
@@ -193,16 +138,9 @@ describe( 'Intermediate Representation', () => {
 		} );
 		describe( 'named export', () => {
 			it( 'named class', () => {
-				const tokenClass = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-class/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedClass = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenClass )
+					require( './fixtures/named-class/exports.json' )
 				);
 				expect( irNamedClass ).toMatchInlineSnapshot( `
 			Array [
@@ -225,16 +163,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named function', () => {
-				const tokenFn = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-function/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedFn = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenFn )
+					require( './fixtures/named-function/exports.json' )
 				);
 				expect( irNamedFn ).toMatchInlineSnapshot( `
 			Array [
@@ -250,16 +181,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named variable', () => {
-				const tokenVariable = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-variable/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedVar = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenVariable )
+					require( './fixtures/named-variable/exports.json' )
 				);
 				expect( irNamedVar ).toMatchInlineSnapshot( `
 			Array [
@@ -275,16 +199,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named variables', () => {
-				const tokenVariables = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-variables/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedVars = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenVariables )
+					require( './fixtures/named-variables/exports.json' )
 				);
 				expect( irNamedVars ).toMatchInlineSnapshot( `
 			Array [
@@ -313,24 +230,10 @@ describe( 'Intermediate Representation', () => {
 	describe( 'JSDoc in same file', () => {
 		describe( 'default export', () => {
 			it( 'named class', () => {
-				const token = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-identifier/exports.json'
-					),
-					'utf-8'
-				);
-				const ast = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-identifier/ast.json'
-					),
-					'utf-8'
-				);
 				const irDefaultId = getIntermediateRepresentation(
 					null,
-					JSON.parse( token ),
-					JSON.parse( ast )
+					require( './fixtures/default-identifier/exports.json' ),
+					require( './fixtures/default-identifier/ast.json' )
 				);
 				expect( irDefaultId ).toMatchInlineSnapshot( `
 			Array [
@@ -353,24 +256,12 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named function', () => {
-				const namedExport = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-named-export/exports.json'
-					),
-					'utf-8'
-				);
-				const namedExportAST = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-named-export/ast.json'
-					),
-					'utf-8'
-				);
+				const namedExport = require( './fixtures/default-named-export/exports.json' );
+				const namedExportAST = require( './fixtures/default-named-export/ast.json' );
 				const irDefaultNamed0 = getIntermediateRepresentation(
 					null,
-					JSON.parse( namedExport )[ 0 ],
-					JSON.parse( namedExportAST )
+					namedExport[ 0 ],
+					namedExportAST
 				);
 				expect( irDefaultNamed0 ).toMatchInlineSnapshot( `
 			Array [
@@ -386,8 +277,8 @@ describe( 'Intermediate Representation', () => {
 		` );
 				const irDefaultNamed1 = getIntermediateRepresentation(
 					null,
-					JSON.parse( namedExport )[ 1 ],
-					JSON.parse( namedExportAST )
+					namedExport[ 1 ],
+					namedExportAST
 				);
 				expect( irDefaultNamed1 ).toMatchInlineSnapshot( `
 			Array [
@@ -406,24 +297,10 @@ describe( 'Intermediate Representation', () => {
 
 		describe( 'named export', () => {
 			it( 'named identifier', () => {
-				const token = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifier/exports.json'
-					),
-					'utf-8'
-				);
-				const ast = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifier/ast.json'
-					),
-					'utf-8'
-				);
 				const irNamedId = getIntermediateRepresentation(
 					null,
-					JSON.parse( token ),
-					JSON.parse( ast )
+					require( './fixtures/named-identifier/exports.json' ),
+					require( './fixtures/named-identifier/ast.json' )
 				);
 				expect( irNamedId ).toMatchInlineSnapshot( `
 			Array [
@@ -439,24 +316,10 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named identifier with destructuring', () => {
-				const tokenObject = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifier-destructuring/exports.json'
-					),
-					'utf-8'
-				);
-				const astObject = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifier-destructuring/ast.json'
-					),
-					'utf-8'
-				);
 				const irNamedIdDestructuring = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenObject ),
-					JSON.parse( astObject )
+					require( './fixtures/named-identifier-destructuring/exports.json' ),
+					require( './fixtures/named-identifier-destructuring/ast.json' )
 				);
 				expect( irNamedIdDestructuring ).toMatchInlineSnapshot( `
 			Array [
@@ -472,24 +335,10 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named identifiers', () => {
-				const tokens = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifiers/exports.json'
-					),
-					'utf-8'
-				);
-				const asts = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifiers/ast.json'
-					),
-					'utf-8'
-				);
 				const irIds = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokens ),
-					JSON.parse( asts )
+					require( './fixtures/named-identifiers/exports.json' ),
+					require( './fixtures/named-identifiers/ast.json' )
 				);
 				expect( irIds ).toMatchInlineSnapshot( `
 			Array [
@@ -528,24 +377,12 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named identifiers and inline', () => {
-				const foo = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifiers-and-inline/exports.json'
-					),
-					'utf-8'
-				);
-				const bar = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-identifiers-and-inline/ast.json'
-					),
-					'utf-8'
-				);
+				const foo = require( './fixtures/named-identifiers-and-inline/exports.json' );
+				const bar = require( './fixtures/named-identifiers-and-inline/ast.json' );
 				const irIdInline0 = getIntermediateRepresentation(
 					null,
-					JSON.parse( foo )[ 0 ],
-					JSON.parse( bar )
+					foo[ 0 ],
+					bar
 				);
 				expect( irIdInline0 ).toMatchInlineSnapshot( `
 			Array [
@@ -576,8 +413,8 @@ describe( 'Intermediate Representation', () => {
 		` );
 				const irIdInline1 = getIntermediateRepresentation(
 					null,
-					JSON.parse( foo )[ 1 ],
-					JSON.parse( bar )
+					foo[ 1 ],
+					bar
 				);
 				expect( irIdInline1 ).toMatchInlineSnapshot( `
 			Array [
@@ -598,28 +435,11 @@ describe( 'Intermediate Representation', () => {
 	describe( 'JSDoc in module dependency', () => {
 		describe( 'named export', () => {
 			it( 'named import', () => {
-				const tokenImportNamed = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-import-named/exports.json'
-					),
-					'utf-8'
-				);
-				const getModuleImportNamed = () =>
-					JSON.parse(
-						fs.readFileSync(
-							path.join(
-								__dirname,
-								'./fixtures/named-identifiers/ir.json'
-							),
-							'utf-8'
-						)
-					);
 				const ir = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenImportNamed ),
+					require( './fixtures/named-import-named/exports.json' ),
 					{ body: [] },
-					getModuleImportNamed
+					() => require( './fixtures/named-identifiers/ir.json' )
 				);
 				expect( ir ).toMatchInlineSnapshot( `
 			Array [
@@ -653,29 +473,12 @@ describe( 'Intermediate Representation', () => {
 		} );
 
 		describe( 'named default export', () => {
-			const getModule = () =>
-				JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/named-default/module-ir.json'
-						),
-						'utf-8'
-					)
-				);
 			it( 'default', () => {
-				const tokenDefault = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-default/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedDefault = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenDefault ),
+					require( './fixtures/named-default/exports.json' ),
 					{ body: [] },
-					getModule
+					() => require( './fixtures/named-default/module-ir.json' )
 				);
 				expect( irNamedDefault ).toMatchInlineSnapshot( `
 			Array [
@@ -691,18 +494,11 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'renamed', () => {
-				const tokenDefaultExported = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-default-exported/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamedDefaultExported = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenDefaultExported ),
+					require( './fixtures/named-default-exported/exports.json' ),
 					{ body: [] },
-					getModule
+					() => require( './fixtures/named-default/module-ir.json' )
 				);
 				expect( irNamedDefaultExported ).toMatchInlineSnapshot( `
 			Array [
@@ -721,23 +517,11 @@ describe( 'Intermediate Representation', () => {
 
 		describe( 'namespace export', () => {
 			const getModule = () =>
-				JSON.parse(
-					fs.readFileSync(
-						path.join(
-							__dirname,
-							'./fixtures/namespace/module-ir.json'
-						),
-						'utf-8'
-					)
-				);
+				require( './fixtures/namespace/module-ir.json' );
 			it( 'exports', () => {
-				const token = fs.readFileSync(
-					path.join( __dirname, './fixtures/namespace/exports.json' ),
-					'utf-8'
-				);
 				const irNamespace = getIntermediateRepresentation(
 					null,
-					JSON.parse( token ),
+					require( './fixtures/namespace/exports.json' ),
 					{ body: [] },
 					getModule
 				);
@@ -771,16 +555,9 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'exports with comment', () => {
-				const tokenCommented = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/namespace-commented/exports.json'
-					),
-					'utf-8'
-				);
 				const irNamespaceCommented = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenCommented ),
+					require( './fixtures/namespace-commented/exports.json' ),
 					{ body: [] },
 					getModule
 				);
@@ -819,35 +596,12 @@ describe( 'Intermediate Representation', () => {
 	describe( 'JSDoc in module dependency through import', () => {
 		describe( 'default export', () => {
 			it( 'default import', () => {
-				const tokenDefault = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-import-default/exports.json'
-					),
-					'utf-8'
-				);
-				const astDefault = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-import-default/ast.json'
-					),
-					'utf-8'
-				);
-				const getModuleDefault = () =>
-					JSON.parse(
-						fs.readFileSync(
-							path.join(
-								__dirname,
-								'./fixtures/default-import-default/module-ir.json'
-							),
-							'utf-8'
-						)
-					);
 				const irDefault = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenDefault ),
-					JSON.parse( astDefault ),
-					getModuleDefault
+					require( './fixtures/default-import-default/exports.json' ),
+					require( './fixtures/default-import-default/ast.json' ),
+					() =>
+						require( './fixtures/default-import-default/module-ir.json' )
 				);
 				expect( irDefault ).toMatchInlineSnapshot( `
 			Array [
@@ -863,35 +617,12 @@ describe( 'Intermediate Representation', () => {
 		` );
 			} );
 			it( 'named import', () => {
-				const tokenNamed = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-import-named/exports.json'
-					),
-					'utf-8'
-				);
-				const astNamed = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/default-import-named/ast.json'
-					),
-					'utf-8'
-				);
-				const getModuleNamed = () =>
-					JSON.parse(
-						fs.readFileSync(
-							path.join(
-								__dirname,
-								'./fixtures/default-import-named/module-ir.json'
-							),
-							'utf-8'
-						)
-					);
 				const irNamed = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenNamed ),
-					JSON.parse( astNamed ),
-					getModuleNamed
+					require( './fixtures/default-import-named/exports.json' ),
+					require( './fixtures/default-import-named/ast.json' ),
+					() =>
+						require( './fixtures/default-import-named/module-ir.json' )
 				);
 				expect( irNamed ).toMatchInlineSnapshot( `
 			Array [
@@ -910,46 +641,16 @@ describe( 'Intermediate Representation', () => {
 
 		describe( 'named export', () => {
 			it( 'namespace import', () => {
-				const tokenImportNamespace = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-import-namespace/exports.json'
-					),
-					'utf-8'
-				);
-				const astImportNamespace = fs.readFileSync(
-					path.join(
-						__dirname,
-						'./fixtures/named-import-namespace/ast.json'
-					),
-					'utf-8'
-				);
 				const getModuleImportNamespace = ( filePath ) => {
 					if ( filePath === './named-import-namespace-module' ) {
-						return JSON.parse(
-							fs.readFileSync(
-								path.join(
-									__dirname,
-									'./fixtures/named-import-namespace/module-ir.json'
-								),
-								'utf-8'
-							)
-						);
+						return require( './fixtures/named-import-namespace/module-ir.json' );
 					}
-					return JSON.parse(
-						fs.readFileSync(
-							path.join(
-								__dirname,
-								'./fixtures/default-function/ir.json'
-							),
-							'utf-8'
-						)
-					);
+					return require( './fixtures/default-function/ir.json' );
 				};
 				const ir = getIntermediateRepresentation(
 					null,
-					JSON.parse( tokenImportNamespace ),
-					JSON.parse( astImportNamespace ),
+					require( './fixtures/named-import-namespace/exports.json' ),
+					require( './fixtures/named-import-namespace/ast.json' ),
 					getModuleImportNamespace
 				);
 				expect( ir ).toMatchInlineSnapshot( `


### PR DESCRIPTION
## Description

While working through #37929 I noticed that the tests in the `docgen` package
read fixture data manually by chaining `JSON.parse()` and `fs.readFileSync()`,
often at times separated by a number of lines.

In this patch we're replacing those with the more natural `require()` statement
which removes noise from the test modules and hopefully will also remove a point
of confusion for those coming in to modify it. We shouldn't have to ask, "why is
this code doing something that looks normal but is doing it in a notably different
manner?"

After reviewing the history of the work, initially introduced in #13329, I could
find no explanation for the approach and found no discussion about it in the PR.

## How has this been tested?
Ran the test suite and `yarn api-docs:ref` and `yarn api-docs:blocks` and `yarn api-docs:theme-ref` and compared output to ensure no changes appeared.

## Types of changes
Refactor to remove some complexity in an already-confusing test module and run with an idiomatic solution.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
