### PR TITLE
Social Icons: Add the ability to show/hide labels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -726,7 +726,7 @@ Display icons linking to your social media profiles or sites. ([Source](https://
 -	**Name:** core/social-links
 -	**Category:** widgets
 -	**Supports:** align (center, left, right), anchor, spacing (blockGap, margin, units)
--	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, size
+-	**Attributes:** customIconBackgroundColor, customIconColor, iconBackgroundColor, iconBackgroundColorValue, iconColor, iconColorValue, openInNewTab, showLabels, size
 
 ## Spacer
 

--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -20,6 +20,7 @@
 	},
 	"usesContext": [
 		"openInNewTab",
+		"showLabels",
 		"iconColorValue",
 		"iconBackgroundColorValue"
 	],

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -79,7 +79,7 @@ const SocialLinkEdit = ( {
 	const ref = useRef();
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
-	const socialLinkLabel = label ? label : socialLinkName;
+	const socialLinkLabel = label ?? socialLinkName;
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -114,7 +114,11 @@ const SocialLinkEdit = ( {
 				</PanelBody>
 			</InspectorControls>
 			<li { ...blockProps }>
-				<Button ref={ ref } onClick={ () => setPopover( true ) }>
+				<Button
+					className="wp-block-social-link-anchor"
+					ref={ ref }
+					onClick={ () => setPopover( true ) }
+				>
 					<IconComponent />
 					<span
 						className={ classNames( 'wp-block-social-link-label', {

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -117,10 +117,9 @@ const SocialLinkEdit = ( {
 				<Button ref={ ref } onClick={ () => setPopover( true ) }>
 					<IconComponent />
 					<span
-						className={ classNames(
-							'wp-block-social-link-label',
-							{ 'screen-reader-text': ! showLabels },
-						) }
+						className={ classNames( 'wp-block-social-link-label', {
+							'screen-reader-text': ! showLabels,
+						} ) }
 					>
 						{ socialLinkLabel }
 					</span>

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -116,7 +116,14 @@ const SocialLinkEdit = ( {
 			<li { ...blockProps }>
 				<Button ref={ ref } onClick={ () => setPopover( true ) }>
 					<IconComponent />
-					{ showLabels && <span>{ socialLinkLabel }</span> }
+					<span
+						className={ classNames(
+							'wp-block-social-link-label',
+							{ 'screen-reader-text': ! showLabels },
+						) }
+					>
+						{ socialLinkLabel }
+					</span>
 					{ isSelected && showURLPopover && (
 						<SocialLinkURLPopover
 							url={ url }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -70,7 +70,7 @@ const SocialLinkEdit = ( {
 	setAttributes,
 } ) => {
 	const { url, service, label } = attributes;
-	const { iconColorValue, iconBackgroundColorValue } = context;
+	const { showLabels, iconColorValue, iconBackgroundColorValue } = context;
 	const [ showURLPopover, setPopover ] = useState( false );
 	const classes = classNames( 'wp-social-link', 'wp-social-link-' + service, {
 		'wp-social-link__is-incomplete': ! url,
@@ -79,6 +79,7 @@ const SocialLinkEdit = ( {
 	const ref = useRef();
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
+	const socialLinkLabel = label ? label : socialLinkName;
 	const blockProps = useBlockProps( {
 		className: classes,
 		style: {
@@ -115,6 +116,7 @@ const SocialLinkEdit = ( {
 			<li { ...blockProps }>
 				<Button ref={ ref } onClick={ () => setPopover( true ) }>
 					<IconComponent />
+					{ showLabels && <span>{ socialLinkLabel }</span> }
 					{ isSelected && showURLPopover && (
 						<SocialLinkURLPopover
 							url={ url }

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -17,16 +17,10 @@
 function render_block_core_social_link( $attributes, $content, $block ) {
 	$open_in_new_tab = isset( $block->context['openInNewTab'] ) ? $block->context['openInNewTab'] : false;
 
-	$service = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
-	$url     = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
-	$label   = ( isset( $attributes['label'] ) ) ? $attributes['label'] : sprintf(
-		/* translators: %1$s: Social-network name. %2$s: URL. */
-		__( '%1$s: %2$s' ),
-		block_core_social_link_get_name( $service ),
-		$url
-	);
+	$service     = ( isset( $attributes['service'] ) ) ? $attributes['service'] : 'Icon';
+	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
+	$label       = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
-	$shown_label = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$class_name  = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
@@ -48,14 +42,11 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	);
 
 	$link  = '<li ' . $wrapper_attributes . '>';
-	$link .= '<a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" title="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">';
+	$link .= '<a href="' . esc_url( $url ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">';
 	$link .= $icon;
-
-	if ( $show_labels ) {
-		$link .= '<span class="wp-block-social-link-label">' . esc_html( $shown_label ) . '</span>';
-	}
-
-	$link .= '</a></li>';
+	$link .= '<span class="wp-block-social-link-label' . ( $show_labels ? '' : ' screen-reader-text' ) . '">';
+	$link .= esc_html( $label );
+	$link .= '</span></a></li>';
 
 	return $link;
 }

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -52,7 +52,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$link .= $icon;
 
 	if ( $show_labels ) {
-		$link .= '<span class="wp-block-social-link-label">' . esc_attr( $shown_label ) . '</span>';
+		$link .= '<span class="wp-block-social-link-label">' . esc_html( $shown_label ) . '</span>';
 	}
 
 	$link .= '</a></li>';

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -25,7 +25,9 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		block_core_social_link_get_name( $service ),
 		$url
 	);
-	$class_name = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
+	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
+	$shown_label = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
+	$class_name  = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
 	if ( ! $url ) {
@@ -45,7 +47,17 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 		)
 	);
 
-	return '<li ' . $wrapper_attributes . '><a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">' . $icon . '</a></li>';
+	$link  = '<li ' . $wrapper_attributes . '>';
+	$link .= '<a href="' . esc_url( $url ) . '" aria-label="' . esc_attr( $label ) . '" title="' . esc_attr( $label ) . '" ' . $rel_target_attributes . ' class="wp-block-social-link-anchor">';
+	$link .= $icon;
+
+	if ( $show_labels ) {
+		$link .= '<span class="wp-block-social-link-label">' . esc_attr( $shown_label ) . '</span>';
+	}
+
+	$link .= '</a></li>';
+
+	return $link;
 }
 
 /**

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -30,12 +30,17 @@
 			"type": "boolean",
 			"default": false
 		},
+		"showLabels": {
+			"type": "boolean",
+			"default": false
+		},
 		"size": {
 			"type": "string"
 		}
 	},
 	"providesContext": {
 		"openInNewTab": "openInNewTab",
+		"showLabels": "showLabels",
 		"iconColorValue": "iconColorValue",
 		"iconBackgroundColorValue": "iconBackgroundColorValue"
 	},

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -60,6 +60,7 @@ export function SocialLinksEdit( props ) {
 		iconBackgroundColorValue,
 		iconColorValue,
 		openInNewTab,
+		showLabels,
 		size,
 		layout,
 	} = attributes;
@@ -80,7 +81,6 @@ export function SocialLinksEdit( props ) {
 
 	const SocialPlaceholder = (
 		<li className="wp-block-social-links__social-placeholder">
-			<div className="wp-social-link"></div>
 			<div className="wp-block-social-links__social-placeholder-icons">
 				<div className="wp-social-link wp-social-link-twitter"></div>
 				<div className="wp-social-link wp-social-link-facebook"></div>
@@ -190,6 +190,13 @@ export function SocialLinksEdit( props ) {
 						checked={ openInNewTab }
 						onChange={ () =>
 							setAttributes( { openInNewTab: ! openInNewTab } )
+						}
+					/>
+					<ToggleControl
+						label={ __( 'Show labels' ) }
+						checked={ showLabels }
+						onChange={ () =>
+							setAttributes( { showLabels: ! showLabels } )
 						}
 					/>
 				</PanelBody>

--- a/packages/block-library/src/social-links/save.js
+++ b/packages/block-library/src/social-links/save.js
@@ -10,10 +10,16 @@ import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( props ) {
 	const {
-		attributes: { iconBackgroundColorValue, iconColorValue, size },
+		attributes: {
+			iconBackgroundColorValue,
+			iconColorValue,
+			showLabels,
+			size,
+		},
 	} = props;
 
 	const className = classNames( size, {
+		'has-visible-labels': showLabels,
 		'has-icon-color': iconColorValue,
 		'has-icon-background-color': iconBackgroundColorValue,
 	} );

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -28,6 +28,12 @@
 			width: 1em;
 			height: 1em;
 		}
+
+		span {
+			margin-left: 0.5em;
+			margin-right: 0.5em;
+			font-size: 0.65em;
+		}
 	}
 
 	// Icon sizes.
@@ -74,7 +80,8 @@
 	height: auto;
 
 	a {
-		display: block;
+		align-items: center;
+		display: flex;
 		line-height: 0;
 		transition: transform 0.1s ease;
 	}

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -29,7 +29,7 @@
 			height: 1em;
 		}
 
-		span {
+		span:not(.screen-reader-text) {
 			margin-left: 0.5em;
 			margin-right: 0.5em;
 			font-size: 0.65em;


### PR DESCRIPTION
## Description
The Social Links (Icons) block allows you add custom link labels. Unfortunately you are not able to display these text labels, which has been requested in #31605. This PR fixes #31605 by adding the ability to toggle on and off link labels. When enabled, service name is shown if no custom label has been specified.

## How has this been tested?
1. Test with any theme running WordPress 5.9 RC3.
2. Add a Social Icons block to a new page and add a few individual icons. 
3. In the sidebar, toggle on "Show labels", you should now see the service names.
4. On one icon, add a custom label and see that it updates the label in the Editor.
5. View on the frontend and confirm that the labels display correctly. 

## Screenshots 

![socail-icon-labels](https://user-images.githubusercontent.com/4832319/150646671-7c358746-9c37-4db0-9d87-714804f7caf0.gif)

## Types of changes
New feature

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
