### PR TITLE
Block API Reference: Fix 'isSelected' property type

### DIFF
--- a/docs/reference-guides/block-api/block-edit-save.md
+++ b/docs/reference-guides/block-api/block-edit-save.md
@@ -131,7 +131,7 @@ The value of `attributes.content` will be displayed inside the `div` when insert
 
 ### isSelected
 
-The isSelected property is an object that communicates whether the block is currently selected.
+The isSelected property is an boolean that communicates whether the block is currently selected.
 
 {% codetabs %}
 {% JSX %}


### PR DESCRIPTION
## Description
I noticed that this documentation referenced the `isSelected` property as an object instead of a boolean.

## Types of changes
Documentation
