### PR TITLE
Gallery block: add gap support / block spacing

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -248,7 +248,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Supports:** align, anchor, ~~html~~
+-	**Supports:** align, anchor, spacing (blockGap), units (em, px, rem, vh, vw), ~~html~~
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -117,7 +117,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 		$style .= '}';
 
-		$style .= ":where($selector > *) { margin: 0; }";
+		$style .= "$selector > * { margin: 0; }";
 	}
 
 	return $style;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -117,7 +117,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		}
 		$style .= '}';
 
-		$style .= "$selector > * { margin: 0; }";
+		$style .= ":where($selector > *) { margin: 0; }";
 	}
 
 	return $style;

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -107,7 +107,22 @@
 	"supports": {
 		"anchor": true,
 		"align": true,
-		"html": false
+		"html": false,
+		"units": [ "px", "em", "rem", "vh", "vw" ],
+		"spacing": {
+			"blockGap": true,
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
+		},
+		"__experimentalLayout": {
+			"allowSwitching": false,
+			"allowInheriting": false,
+			"allowEditing": false,
+			"default": {
+				"type": "flex"
+			}
+		}
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"

--- a/packages/block-library/src/gallery/deprecated.scss
+++ b/packages/block-library/src/gallery/deprecated.scss
@@ -1,6 +1,6 @@
 // Deprecated gallery styles pre refactoring to use nested image blocks.
 // https://github.com/WordPress/gutenberg/pull/25940.
-.wp-block-gallery,
+.wp-block-gallery:not(.has-nested-images),
 .blocks-gallery-grid {
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/block-library/src/gallery/deprecated.scss
+++ b/packages/block-library/src/gallery/deprecated.scss
@@ -1,7 +1,7 @@
 // Deprecated gallery styles pre refactoring to use nested image blocks.
 // https://github.com/WordPress/gutenberg/pull/25940.
 .wp-block-gallery:not(.has-nested-images),
-.blocks-gallery-grid {
+.blocks-gallery-grid:not(.has-nested-images) {
 	display: flex;
 	flex-wrap: wrap;
 	list-style-type: none;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -121,7 +121,10 @@ function GalleryEdit( props ) {
 		};
 	}, [] );
 
-	const styleElement = useContext( BlockList.__unstableElementContext );
+	const styleElement = Platform.isWeb
+		? // eslint-disable-next-line react-hooks/rules-of-hooks
+		  useContext( BlockList.__unstableElementContext )
+		: undefined;
 
 	const innerBlockImages = useSelect(
 		( select ) => {

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -485,7 +485,7 @@ function GalleryEdit( props ) {
 
 	const gap = attributes.style?.spacing?.blockGap
 		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap ) }`;
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -565,7 +565,8 @@ function GalleryEdit( props ) {
 				/>
 			</BlockControls>
 			{ noticeUI }
-			{ gap &&
+			{ Platform.isWeb &&
+				gap &&
 				styleElement &&
 				createPortal( <GapStyle />, styleElement ) }
 			<Gallery

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -24,15 +24,8 @@ import {
 	useBlockProps,
 	BlockControls,
 	MediaReplaceFlow,
-	BlockList,
 } from '@wordpress/block-editor';
-import {
-	Platform,
-	useEffect,
-	useMemo,
-	createPortal,
-	useContext,
-} from '@wordpress/element';
+import { Platform, useEffect, useMemo } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -61,6 +54,7 @@ import useImageSizes from './use-image-sizes';
 import useShortCodeTransform from './use-short-code-transform';
 import useGetNewImages from './use-get-new-images';
 import useGetMedia from './use-get-media';
+import GapStyles from './gap-styles';
 
 const MAX_COLUMNS = 8;
 const linkOptions = [
@@ -120,11 +114,6 @@ function GalleryEdit( props ) {
 			preferredStyle: preferredStyleVariations?.value?.[ 'core/image' ],
 		};
 	}, [] );
-
-	const styleElement = Platform.isWeb
-		? // eslint-disable-next-line react-hooks/rules-of-hooks
-		  useContext( BlockList.__unstableElementContext )
-		: undefined;
 
 	const innerBlockImages = useSelect(
 		( select ) => {
@@ -486,14 +475,6 @@ function GalleryEdit( props ) {
 
 	const hasLinkTo = linkTo && linkTo !== 'none';
 
-	const gap = attributes.style?.spacing?.blockGap
-		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
-
-	const GapStyle = () => {
-		return <style>{ gap }</style>;
-	};
-
 	return (
 		<>
 			<InspectorControls>
@@ -568,10 +549,12 @@ function GalleryEdit( props ) {
 				/>
 			</BlockControls>
 			{ noticeUI }
-			{ Platform.isWeb &&
-				gap &&
-				styleElement &&
-				createPortal( <GapStyle />, styleElement ) }
+			{ Platform.isWeb && (
+				<GapStyles
+					blockGap={ attributes.style?.spacing?.blockGap }
+					clientId={ clientId }
+				/>
+			) }
 			<Gallery
 				{ ...props }
 				images={ images }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -565,7 +565,9 @@ function GalleryEdit( props ) {
 				/>
 			</BlockControls>
 			{ noticeUI }
-			{ gap && createPortal( <GapStyle />, styleElement ) }
+			{ gap &&
+				styleElement &&
+				createPortal( <GapStyle />, styleElement ) }
 			<Gallery
 				{ ...props }
 				images={ images }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -7,7 +7,7 @@ import { concat, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { compose, useInstanceId } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import {
 	BaseControl,
 	PanelBody,
@@ -121,7 +121,6 @@ function GalleryEdit( props ) {
 		};
 	}, [] );
 
-	const id = useInstanceId( getBlock( clientId ) );
 	const styleElement = useContext( BlockList.__unstableElementContext );
 
 	const innerBlockImages = useSelect(
@@ -485,8 +484,8 @@ function GalleryEdit( props ) {
 	const hasLinkTo = linkTo && linkTo !== 'none';
 
 	const gap = attributes.style?.spacing?.blockGap
-		? `.wp-container-${ id } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
-		: undefined;
+		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap ) }`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -473,7 +473,9 @@ function GalleryEdit( props ) {
 	}
 
 	const hasLinkTo = linkTo && linkTo !== 'none';
-
+	const style = attributes.style?.spacing?.blockGap
+		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
+		: undefined;
 	return (
 		<>
 			<InspectorControls>
@@ -548,6 +550,7 @@ function GalleryEdit( props ) {
 				/>
 			</BlockControls>
 			{ noticeUI }
+			<style>{ style }</style>
 			<Gallery
 				{ ...props }
 				images={ images }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -7,7 +7,7 @@ import { concat, find } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
+import { compose, useInstanceId } from '@wordpress/compose';
 import {
 	BaseControl,
 	PanelBody,
@@ -24,8 +24,15 @@ import {
 	useBlockProps,
 	BlockControls,
 	MediaReplaceFlow,
+	BlockList,
 } from '@wordpress/block-editor';
-import { Platform, useEffect, useMemo } from '@wordpress/element';
+import {
+	Platform,
+	useEffect,
+	useMemo,
+	createPortal,
+	useContext,
+} from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -113,6 +120,9 @@ function GalleryEdit( props ) {
 			preferredStyle: preferredStyleVariations?.value?.[ 'core/image' ],
 		};
 	}, [] );
+
+	const id = useInstanceId( getBlock( clientId ) );
+	const styleElement = useContext( BlockList.__unstableElementContext );
 
 	const innerBlockImages = useSelect(
 		( select ) => {
@@ -473,9 +483,15 @@ function GalleryEdit( props ) {
 	}
 
 	const hasLinkTo = linkTo && linkTo !== 'none';
-	const style = attributes.style?.spacing?.blockGap
-		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
+
+	const gap = attributes.style?.spacing?.blockGap
+		? `.wp-container-${ id } { --wp--style--unstable-gallery-gap: ${ attributes.style.spacing.blockGap } }`
 		: undefined;
+
+	const GapStyle = () => {
+		return <style>{ gap }</style>;
+	};
+
 	return (
 		<>
 			<InspectorControls>
@@ -550,7 +566,7 @@ function GalleryEdit( props ) {
 				/>
 			</BlockControls>
 			{ noticeUI }
-			<style>{ style }</style>
+			{ gap && createPortal( <GapStyle />, styleElement ) }
 			<Gallery
 				{ ...props }
 				images={ images }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -4,7 +4,6 @@ figure.wp-block-gallery {
 	// See https://github.com/WordPress/gutenberg/pull/10358
 
 	display: block;
-	margin: 0;
 	&.has-nested-images {
 		.components-drop-zone {
 			display: none;

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -69,13 +69,14 @@ export const Gallery = ( props ) => {
 			) }
 		>
 			{ children }
-
-			<View
-				className="blocks-gallery-media-placeholder-wrapper"
-				onClick={ removeCaptionFocus }
-			>
-				{ mediaPlaceholder }
-			</View>
+			{ isSelected && ! children && (
+				<View
+					className="blocks-gallery-media-placeholder-wrapper"
+					onClick={ removeCaptionFocus }
+				>
+					{ mediaPlaceholder }
+				</View>
+			) }
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -15,5 +15,7 @@ export default function GapStyles( { blockGap, clientId } ) {
 		return <style>{ gap }</style>;
 	};
 
-	return gap && styleElement && createPortal( <GapStyle />, styleElement );
+	return gap && styleElement
+		? createPortal( <GapStyle />, styleElement )
+		: null;
 }

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockList } from '@wordpress/block-editor';
+import { useContext, createPortal } from '@wordpress/element';
+
+export default function GapStyles( { blockGap, clientId } ) {
+	const styleElement = useContext( BlockList.__unstableElementContext );
+
+	const gap = blockGap
+		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ blockGap } }`
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
+
+	const GapStyle = () => {
+		return <style>{ gap }</style>;
+	};
+
+	return gap && styleElement && createPortal( <GapStyle />, styleElement );
+}

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -9,7 +9,7 @@ export default function GapStyles( { blockGap, clientId } ) {
 
 	const gap = blockGap
 		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 16px ) }`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -9,7 +9,7 @@ export default function GapStyles( { blockGap, clientId } ) {
 
 	const gap = blockGap
 		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 16px ) }`;
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -57,7 +57,7 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
-	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 0.5em )';
+	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 16px )';
 	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -75,7 +75,10 @@ function block_core_gallery_render( $attributes, $content ) {
  */
 function register_block_core_gallery() {
 	register_block_type_from_metadata(
-		__DIR__ . '/gallery'
+		__DIR__ . '/gallery',
+		array(
+			'render_callback' => 'block_core_gallery_render',
+		)
 	);
 }
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -44,11 +44,11 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  * @return string The content of the block being rendered.
  */
 function block_core_gallery_render( $attributes, $content ) {
-	$gap_value = _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) );
+	$gap = _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.
-	$gap_value = preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+	$gap = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 	$id        = uniqid();
 	$class     = 'wp-block-gallery-' . $id;
 	$content   = preg_replace(
@@ -57,6 +57,7 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
+	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 0.5em )';
 	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -48,7 +48,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.
-	$gap = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+	$gap       = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 	$id        = uniqid();
 	$class     = 'wp-block-gallery-' . $id;
 	$content   = preg_replace(

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -32,6 +32,17 @@ function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
 
 add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
 
+/**
+ * Adds a style tag for the --wp--style--unstable-gallery-gap var.
+ *
+ * The Gallery block needs to recalculate Image block width based on
+ * the current gap setting in order to maintain the number of flex columns
+ * so a css var is added to allow this.
+ *
+ * @param array  $attributes Attributes of the block being rendered.
+ * @param string $content Content of the block being rendered.
+ * @return string The content of the block being rendered.
+ */
 function block_core_gallery_render( $attributes, $content ) {
 	$gap_value = _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -57,7 +57,7 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
-	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 16px )';
+	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 0.5em )';
 	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -32,6 +32,32 @@ function block_core_gallery_data_id_backcompatibility( $parsed_block ) {
 
 add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' );
 
+function block_core_gallery_render( $attributes, $content ) {
+	$gap_value = _wp_array_get( $attributes, array( 'style', 'spacing', 'blockGap' ) );
+	// Skip if gap value contains unsupported characters.
+	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
+	// because we only want to match against the value, not the CSS attribute.
+	$gap_value = preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+	$id        = uniqid();
+	$class     = 'wp-block-gallery-' . $id;
+	$content   = preg_replace(
+		'/' . preg_quote( 'class="', '/' ) . '/',
+		'class="' . $class . ' ',
+		$content,
+		1
+	);
+	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
+	// Ideally styles should be loaded in the head, but blocks may be parsed
+	// after that, so loading in the footer for now.
+	// See https://core.trac.wordpress.org/ticket/53494.
+	add_action(
+		'wp_footer',
+		function () use ( $style ) {
+			echo '<style> ' . $style . '</style>';
+		}
+	);
+	return $content;
+}
 /**
  * Registers the `core/gallery` block on server.
  */

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -86,17 +86,9 @@ figure.wp-block-gallery.has-nested-images {
 
 	// Non cropped images.
 	&:not(.is-cropped) {
-
 		figure.wp-block-image:not(#individual-image) {
 			margin-top: 0;
 			margin-bottom: auto;
-			img {
-				margin-bottom: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
-			}
-
-			figcaption {
-				bottom: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
-			}
 		}
 	}
 

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -8,6 +8,8 @@ figure.wp-block-gallery.has-nested-images {
 }
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
+	margin-top: var(--wp--style--block-gap);
+	margin-bottom: 0;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,25 +1,17 @@
 // Import styles for rendering the static content of deprecated gallery versions.
 @import "./deprecated.scss";
 
+// The following is a temporary override until flex layout supports
+// an align items setting of normal.
+figure.wp-block-gallery.has-nested-images {
+	align-items: normal;
+}
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	display: flex;
-	flex-wrap: wrap;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
-		// Add space between thumbnails, and unset right most thumbnails later.
-		margin: 0 var(--gallery-block--gutter-size, #{$grid-unit-20}) var(--gallery-block--gutter-size, #{$grid-unit-20}) 0;
-
-		&:last-of-type:not(#individual-image) {
-			margin-right: 0;
-		}
-
-		width: calc(50% - (var(--gallery-block--gutter-size, #{$grid-unit-20}) / 2));
-
-		&:nth-of-type(even) {
-			margin-right: 0;
-		}
+		width: calc(50% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) / 2));
 	}
 
 	figure.wp-block-image {
@@ -27,8 +19,6 @@
 		flex-grow: 1;
 		justify-content: center;
 		position: relative;
-		margin-top: auto;
-		margin-bottom: auto;
 		flex-direction: column;
 		max-width: 100%;
 
@@ -101,11 +91,11 @@
 			margin-top: 0;
 			margin-bottom: auto;
 			img {
-				margin-bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				margin-bottom: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
 			}
 
 			figcaption {
-				bottom: var(--gallery-block--gutter-size, #{$grid-unit-20});
+				bottom: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
 			}
 		}
 	}
@@ -128,7 +118,6 @@
 	}
 
 	&.columns-1 figure.wp-block-image:not(#individual-image) {
-		margin-right: 0;
 		width: 100%;
 	}
 
@@ -136,35 +125,20 @@
 	@include break-small {
 		@for $i from 3 through 8 {
 			&.columns-#{ $i } figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(#{math.div(100%, $i)} - (var(--gallery-block--gutter-size, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
+				width: calc(#{math.div(100%, $i)} - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) * #{math.div($i - 1, $i)}));
 
-			}
-
-			// Prevent collapsing margin while sibling is being dragged.
-			&.columns-#{$i} figure.wp-block-image:not(#individual-image).is-dragging ~ figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-			}
-		}
-		// Unset the right margin on every rightmost gallery item to ensure center balance.
-		@for $column-count from 1 through 8 {
-			&.columns-#{$column-count} figure.wp-block-image:not(#individual-image):nth-of-type(#{ $column-count }n) {
-				margin-right: 0;
 			}
 		}
 		// If number of columns not explicitly set default to 3 columns if 3 or more images.
 		&.columns-default {
 			figure.wp-block-image:not(#individual-image) {
-				margin-right: var(--gallery-block--gutter-size, #{$grid-unit-20});
-				width: calc(33.33% - (var(--gallery-block--gutter-size, 16px) * #{math.div(2, 3)}));
-			}
-			figure.wp-block-image:not(#individual-image):nth-of-type(3n+3) {
-				margin-right: 0;
+
+				width: calc(33.33% - (var(--wp--style--unstable-gallery-gap, 16px) * #{math.div(2, 3)}));
 			}
 			// If only 2 child images use 2 columns.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2),
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(2) ~ figure.wp-block-image:not(#individual-image) {
-				width: calc(50% - (var(--gallery-block--gutter-size, 16px) * 0.5));
+				width: calc(50% - (var(--wp--style--unstable-gallery-gap, 16px) * 0.5));
 			}
 			// For a single image set to 100%.
 			figure.wp-block-image:not(#individual-image):first-child:nth-last-child(1) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -12,6 +12,7 @@ figure.wp-block-gallery.has-nested-images {
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {
 		width: calc(50% - (var(--wp--style--unstable-gallery-gap, #{$grid-unit-20}) / 2));
+		margin: 0;
 	}
 
 	figure.wp-block-image {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -8,8 +8,6 @@ figure.wp-block-gallery.has-nested-images {
 }
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
-	margin-top: var(--wp--style--block-gap);
-	margin-bottom: 0;
 	// Need bogus :not(#individual-image) to override long :not()
 	// specificity chain on default image block on front end.
 	figure.wp-block-image:not(#individual-image) {

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,15 +1,11 @@
 // Import styles for rendering the static content of deprecated gallery versions.
 @import "./deprecated.scss";
 
-// The following are temporary overrides until flex layout supports
-// an align items setting of normal, and the ability to specify a
-// fallback gap setting (currently it defaults to 0.5em, but Gallery
-// default is 16px for backwards compatibility.
+// The following is a temporary override until flex layout supports
+// an align items setting of normal.
 figure.wp-block-gallery.has-nested-images {
 	align-items: normal;
-	gap: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
 }
-
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
 	// Need bogus :not(#individual-image) to override long :not()

--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -1,11 +1,15 @@
 // Import styles for rendering the static content of deprecated gallery versions.
 @import "./deprecated.scss";
 
-// The following is a temporary override until flex layout supports
-// an align items setting of normal.
+// The following are temporary overrides until flex layout supports
+// an align items setting of normal, and the ability to specify a
+// fallback gap setting (currently it defaults to 0.5em, but Gallery
+// default is 16px for backwards compatibility.
 figure.wp-block-gallery.has-nested-images {
 	align-items: normal;
+	gap: var(--wp--style--unstable-gallery-gap, #{$grid-unit-20});
 }
+
 // Styles for current version of gallery block.
 .wp-block-gallery.has-nested-images {
 	// Need bogus :not(#individual-image) to override long :not()


### PR DESCRIPTION
Fixes #20705 & #33582

## Description
Adds block gap support to the Gallery block. 

This PR makes use of the gap layout setting added in #37360, but required the addition of a new scoped css var `--wp--style--unstable-gallery-gap` as the Gallery needs to have access to the current gap setting in css in order to recalculate the width of the images when the gap size changes. 

If this css var is not added, because flex layout is used the number of columns reduces as the gap size increases. 

I investigated using css grid instead of flex, and this works without the use of this var as the number of columns can be fixed and images automatically resize ... but, there is no way to easily make orphaned images in the last row span empty rows, eg. if 3 columns set, and only 5 images, the images on the last row should expand to fill 50% each instead of 33%. There are some css hacks to make this work, but accounting for all the permutations of last row % splits when you have 8 columns is practically impossible.

Flex is designed to handle this sort of layout, so adding the new css var in order to allow the gap support to work seems like the best option, but I am open to suggestions on alternative approaches.

## How has this been tested?

- Add a Gallery block and add a number of images
- Test that the block gap can be adjusted and displays as expected in editor and frontend in both block and non-block themes

## Screenshots 
![gallery-gap](https://user-images.githubusercontent.com/3629020/149414227-4d72c224-0cd1-40e1-a34d-cd19b50cfb75.gif)

