### PR TITLE
Add classic menus to menu switcher

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -486,12 +486,15 @@ function Navigation( {
 							>
 								{ ( { onClose } ) => (
 									<NavigationMenuSelector
+										clientId={ clientId }
 										onSelect={ ( { id } ) => {
 											setRef( id );
 											onClose();
 										} }
 										onCreateNew={ startWithEmptyMenu }
-										showCreate={ canUserCreateNavigation }
+										canUserCreateNavigation={
+											canUserCreateNavigation
+										}
 									/>
 								) }
 							</ToolbarDropdownMenu>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -45,6 +45,7 @@ import { __ } from '@wordpress/i18n';
  */
 import useListViewModal from './use-list-view-modal';
 import useNavigationMenu from '../use-navigation-menu';
+import useNavigationEntities from '../use-navigation-entities';
 import Placeholder from './placeholder';
 import PlaceholderPreview from './placeholder/placeholder-preview';
 import ResponsiveWrapper from './responsive-wrapper';
@@ -152,6 +153,10 @@ function Navigation( {
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
 		`navigationMenu/${ ref }`
 	);
+
+	// Preload classic menus, so that they don't suddenly pop-in when viewing
+	// the Select Menu dropdown.
+	useNavigationEntities();
 
 	const {
 		hasUncontrolledInnerBlocks,

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -21,7 +21,10 @@ export default function NavigationMenuSelector( {
 	onCreateNew,
 	canUserCreateNavigation = false,
 } ) {
-	const { menus: classicMenus } = useNavigationEntities();
+	const {
+		menus: classicMenus,
+		hasMenus: hasClassicMenus,
+	} = useNavigationEntities();
 	const { navigationMenus } = useNavigationMenu();
 	const ref = useEntityId( 'postType', 'wp_navigation' );
 
@@ -74,23 +77,25 @@ export default function NavigationMenuSelector( {
 			</MenuGroup>
 			{ canUserCreateNavigation && (
 				<>
-					<MenuGroup label={ __( 'Classic Menus' ) }>
-						{ classicMenus.map( ( menu ) => {
-							return (
-								<MenuItem
-									onClick={ () => {
-										convertClassicMenuToBlocks(
-											menu.id,
-											menu.name
-										);
-									} }
-									key={ menu.id }
-								>
-									{ decodeEntities( menu.name ) }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
+					{ hasClassicMenus && (
+						<MenuGroup label={ __( 'Classic Menus' ) }>
+							{ classicMenus.map( ( menu ) => {
+								return (
+									<MenuItem
+										onClick={ () => {
+											convertClassicMenuToBlocks(
+												menu.id,
+												menu.name
+											);
+										} }
+										key={ menu.id }
+									>
+										{ decodeEntities( menu.name ) }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
 					<MenuGroup label={ __( 'Tools' ) }>
 						<MenuItem onClick={ onCreateNew }>
 							{ __( 'Create new menu' ) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -11,18 +11,44 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
+import useNavigationEntities from '../use-navigation-entities';
+import useConvertClassicMenu from '../use-convert-classic-menu';
+import useCreateNavigationMenu from './use-create-navigation-menu';
 
 export default function NavigationMenuSelector( {
+	clientId,
 	onSelect,
 	onCreateNew,
-	showCreate = false,
+	canUserCreateNavigation = false,
 } ) {
+	const { menus: classicMenus } = useNavigationEntities();
 	const { navigationMenus } = useNavigationMenu();
 	const ref = useEntityId( 'postType', 'wp_navigation' );
 
+	const createNavigationMenu = useCreateNavigationMenu( clientId );
+
+	const onFinishMenuCreation = async (
+		blocks,
+		navigationMenuTitle = null
+	) => {
+		if ( ! canUserCreateNavigation ) {
+			return;
+		}
+
+		const navigationMenu = await createNavigationMenu(
+			navigationMenuTitle,
+			blocks
+		);
+		onSelect( navigationMenu );
+	};
+
+	const convertClassicMenuToBlocks = useConvertClassicMenu(
+		onFinishMenuCreation
+	);
+
 	return (
 		<>
-			<MenuGroup>
+			<MenuGroup label={ __( 'Menus' ) }>
 				<MenuItemsChoice
 					value={ ref }
 					onSelect={ ( selectedId ) =>
@@ -46,19 +72,38 @@ export default function NavigationMenuSelector( {
 					} ) }
 				/>
 			</MenuGroup>
-			{ showCreate && (
-				<MenuGroup>
-					<MenuItem onClick={ onCreateNew }>
-						{ __( 'Create new menu' ) }
-					</MenuItem>
-					<MenuItem
-						href={ addQueryArgs( 'edit.php', {
-							post_type: 'wp_navigation',
+			{ canUserCreateNavigation && (
+				<>
+					<MenuGroup label={ __( 'Classic Menus' ) }>
+						{ classicMenus.map( ( menu ) => {
+							return (
+								<MenuItem
+									onClick={ () => {
+										convertClassicMenuToBlocks(
+											menu.id,
+											menu.name
+										);
+									} }
+									key={ menu.id }
+								>
+									{ decodeEntities( menu.name ) }
+								</MenuItem>
+							);
 						} ) }
-					>
-						{ __( 'Manage menus' ) }
-					</MenuItem>
-				</MenuGroup>
+					</MenuGroup>
+					<MenuGroup label={ __( 'Tools' ) }>
+						<MenuItem onClick={ onCreateNew }>
+							{ __( 'Create new menu' ) }
+						</MenuItem>
+						<MenuItem
+							href={ addQueryArgs( 'edit.php', {
+								post_type: 'wp_navigation',
+							} ) }
+						>
+							{ __( 'Manage menus' ) }
+						</MenuItem>
+					</MenuGroup>
+				</>
 			) }
 		</>
 	);

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -9,7 +9,6 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { useCallback, useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { navigation, Icon } from '@wordpress/icons';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -20,14 +19,13 @@ import { decodeEntities } from '@wordpress/html-entities';
 
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
-import menuItemsToBlocks from '../../menu-items-to-blocks';
 import useNavigationMenu from '../../use-navigation-menu';
 import useCreateNavigationMenu from '../use-create-navigation-menu';
+import useConvertClassicMenu from '../../use-convert-classic-menu';
 
 const ExistingMenusDropdown = ( {
 	showNavigationMenus,
 	navigationMenus,
-	setSelectedMenu,
 	onFinish,
 	menus,
 	onCreateFromMenu,
@@ -57,7 +55,6 @@ const ExistingMenusDropdown = ( {
 								return (
 									<MenuItem
 										onClick={ () => {
-											setSelectedMenu( menu.id );
 											onFinish( menu );
 										} }
 										onClose={ onClose }
@@ -77,8 +74,10 @@ const ExistingMenusDropdown = ( {
 								return (
 									<MenuItem
 										onClick={ () => {
-											setSelectedMenu( menu.id );
-											onCreateFromMenu( menu.name );
+											onCreateFromMenu(
+												menu.id,
+												menu.name
+											);
 										} }
 										onClose={ onClose }
 										key={ menu.id }
@@ -102,9 +101,6 @@ export default function NavigationPlaceholder( {
 	hasResolvedNavigationMenus,
 	canUserCreateNavigation = false,
 } ) {
-	const [ selectedMenu, setSelectedMenu ] = useState();
-	const [ isCreatingFromMenu, setIsCreatingFromMenu ] = useState( false );
-	const [ menuName, setMenuName ] = useState( '' );
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
 	const onFinishMenuCreation = async (
@@ -122,38 +118,17 @@ export default function NavigationPlaceholder( {
 		onFinish( navigationMenu, blocks );
 	};
 
+	const convertClassicMenu = useConvertClassicMenu( onFinishMenuCreation );
+
 	const {
 		isResolvingPages,
 		menus,
 		isResolvingMenus,
-		menuItems,
-		hasResolvedMenuItems,
 		hasPages,
 		hasMenus,
-	} = useNavigationEntities( selectedMenu );
+	} = useNavigationEntities();
 
 	const isStillLoading = isResolvingPages || isResolvingMenus;
-
-	const createFromMenu = useCallback(
-		( name ) => {
-			const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
-			onFinishMenuCreation( blocks, name );
-		},
-		[ menuItems, menuItemsToBlocks, onFinish ]
-	);
-
-	const onCreateFromMenu = ( name ) => {
-		// If we have menu items, create the block right away.
-		if ( hasResolvedMenuItems ) {
-			createFromMenu( name );
-			return;
-		}
-
-		// Otherwise, create the block when resolution finishes.
-		setIsCreatingFromMenu( true );
-		// Store the name to use later.
-		setMenuName( name );
-	};
 
 	const onCreateEmptyMenu = () => {
 		onFinishMenuCreation( [] );
@@ -163,15 +138,6 @@ export default function NavigationPlaceholder( {
 		const block = [ createBlock( 'core/page-list' ) ];
 		onFinishMenuCreation( block );
 	};
-
-	useEffect( () => {
-		// If the user selected a menu but we had to wait for menu items to
-		// finish resolving, then create the block once resolution finishes.
-		if ( isCreatingFromMenu && hasResolvedMenuItems ) {
-			createFromMenu( menuName );
-			setIsCreatingFromMenu( false );
-		}
-	}, [ isCreatingFromMenu, hasResolvedMenuItems, menuName ] );
 
 	const { navigationMenus } = useNavigationMenu();
 
@@ -205,10 +171,9 @@ export default function NavigationPlaceholder( {
 											canSwitchNavigationMenu
 										}
 										navigationMenus={ navigationMenus }
-										setSelectedMenu={ setSelectedMenu }
 										onFinish={ onFinish }
 										menus={ menus }
-										onCreateFromMenu={ onCreateFromMenu }
+										onCreateFromMenu={ convertClassicMenu }
 										showClassicMenus={
 											canUserCreateNavigation
 										}

--- a/packages/block-library/src/navigation/use-convert-classic-menu.js
+++ b/packages/block-library/src/navigation/use-convert-classic-menu.js
@@ -38,18 +38,21 @@ export default function useConvertClassicMenu( onFinish ) {
 		}
 	}, [ isAwaitingMenuItemResolution, hasResolvedMenuItems, menuName ] );
 
-	return ( id, name ) => {
-		setSelectedMenu( id );
+	return useCallback(
+		( id, name ) => {
+			setSelectedMenu( id );
 
-		// If we have menu items, create the block right away.
-		if ( hasResolvedMenuItems ) {
-			createFromMenu( name );
-			return;
-		}
+			// If we have menu items, create the block right away.
+			if ( hasResolvedMenuItems ) {
+				createFromMenu( name );
+				return;
+			}
 
-		// Otherwise, create the block when resolution finishes.
-		setIsAwaitingMenuItemResolution( true );
-		// Store the name to use later.
-		setMenuName( name );
-	};
+			// Otherwise, create the block when resolution finishes.
+			setIsAwaitingMenuItemResolution( true );
+			// Store the name to use later.
+			setMenuName( name );
+		},
+		[ hasResolvedMenuItems, createFromMenu ]
+	);
 }

--- a/packages/block-library/src/navigation/use-convert-classic-menu.js
+++ b/packages/block-library/src/navigation/use-convert-classic-menu.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useNavigationEntities from './use-navigation-entities';
+import menuItemsToBlocks from './menu-items-to-blocks';
+
+export default function useConvertClassicMenu( onFinish ) {
+	const [ selectedMenu, setSelectedMenu ] = useState();
+	const [
+		isAwaitingMenuItemResolution,
+		setIsAwaitingMenuItemResolution,
+	] = useState( false );
+	const [ menuName, setMenuName ] = useState( '' );
+
+	const { menuItems, hasResolvedMenuItems } = useNavigationEntities(
+		selectedMenu
+	);
+
+	const createFromMenu = useCallback(
+		( name ) => {
+			const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
+			onFinish( blocks, name );
+		},
+		[ menuItems, menuItemsToBlocks, onFinish ]
+	);
+
+	useEffect( () => {
+		// If the user selected a menu but we had to wait for menu items to
+		// finish resolving, then create the block once resolution finishes.
+		if ( isAwaitingMenuItemResolution && hasResolvedMenuItems ) {
+			createFromMenu( menuName );
+			setIsAwaitingMenuItemResolution( false );
+		}
+	}, [ isAwaitingMenuItemResolution, hasResolvedMenuItems, menuName ] );
+
+	return ( id, name ) => {
+		setSelectedMenu( id );
+
+		// If we have menu items, create the block right away.
+		if ( hasResolvedMenuItems ) {
+			createFromMenu( name );
+			return;
+		}
+
+		// Otherwise, create the block when resolution finishes.
+		setIsAwaitingMenuItemResolution( true );
+		// Store the name to use later.
+		setMenuName( name );
+	};
+}


### PR DESCRIPTION
## Description
Fixes #38166

## How has this been tested?
1. Ensure you have some classic menus. If not, switch to a classic theme and create some, then switch back to a block theme.
2. Select a navigation block that has an existing menu
3. From the block toolbar, Use the 'Select Menu' option
4. Choose a classic menu

Expected: The classic menu should be converted to a block menu

## Screenshots <!-- if applicable -->
![Screen Shot 2022-01-24 at 11 26 05 am](https://user-images.githubusercontent.com/677833/150717209-aa2218a0-2aa6-40a5-ac9a-db50c0a4fe70.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
