### PR TITLE
Always allow accessing edit.php?post_type=wp_navigation page

### DIFF
--- a/lib/navigation.php
+++ b/lib/navigation.php
@@ -37,8 +37,7 @@ function gutenberg_register_navigation_post_type() {
 		'description'           => __( 'Navigation menus.', 'gutenberg' ),
 		'public'                => false,
 		'has_archive'           => false,
-		// We should disable UI for non-block themes.
-		'show_ui'               => wp_is_block_theme(),
+		'show_ui'               => true,
 		'show_in_menu'          => false,
 		'show_in_admin_bar'     => false,
 		'show_in_rest'          => true,


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/38118.

The Navigation block is supported in both block themes and classic themes, so it is incorrect to only allow access to `edit.php?post_type=wp_navigation` when the current theme is a block theme.

This fixes a bug where clicking on 'Manage menus' in the toolbar of a Navigation block takes you an error page when running a classic theme.

It's the same fix as what's in https://core.trac.wordpress.org/ticket/54889 but in Gutenberg. We need to make the change in both codebases so that older versions of WP running the Gutenberg plugin don't have the issue.