### PR TITLE
Fix pattern preview expanding height and scrollbar issues

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -69,8 +69,13 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 						position: 'absolute',
 						width: viewportWidth,
 						height: contentHeight,
-						maxHeight: '100vh',
 						pointerEvents: 'none',
+						// This is a catch-all max-height for patterns.
+						// VH units are as tall as your current viewport, and when used inside a scaled iframe
+						// the math to convert an inherited VH unit appears to cause it to keep growing endlessly.
+						// By applying a max-height, at least it will stop growing.
+						// A longer term fix would be to disallow the thumbnail from growing after initial load.
+						maxHeight: '1800px',
 					} }
 				>
 					{ contentResizeListener }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -33,6 +33,11 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 		};
 	}, [] );
 
+	// Avoid scrollbars for pattern previews.
+	if ( styles ) {
+		styles.push( { css: 'body{overflow:hidden;}' } );
+	}
+
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
 

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -4,6 +4,7 @@
 import { Disabled } from '@wordpress/components';
 import { useResizeObserver, pure, useRefEffect } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,9 +35,16 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	}, [] );
 
 	// Avoid scrollbars for pattern previews.
-	if ( styles ) {
-		styles.push( { css: 'body{overflow:hidden;}' } );
-	}
+	const editorStyles = useMemo( () => {
+		if ( styles ) {
+			return [
+				...styles,
+				{ css: 'body{overflow:hidden;}', __unstableType: 'presets' },
+			];
+		}
+
+		return styles;
+	}, [ styles ] );
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
@@ -54,7 +62,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				} }
 			>
 				<Iframe
-					head={ <EditorStyles styles={ styles } /> }
+					head={ <EditorStyles styles={ editorStyles } /> }
 					assets={ assets }
 					contentRef={ useRefEffect( ( bodyElement ) => {
 						const {

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -69,6 +69,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 						position: 'absolute',
 						width: viewportWidth,
 						height: contentHeight,
+						maxHeight: '99vh',
 						pointerEvents: 'none',
 					} }
 				>

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -39,7 +39,10 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 		if ( styles ) {
 			return [
 				...styles,
-				{ css: 'body{overflow:hidden;}', __unstableType: 'presets' },
+				{
+					css: 'body{height:unset;overflow:hidden;}',
+					__unstableType: 'presets',
+				},
 			];
 		}
 

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -69,7 +69,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 						position: 'absolute',
 						width: viewportWidth,
 						height: contentHeight,
-						maxHeight: '99vh',
+						maxHeight: '100vh',
 						pointerEvents: 'none',
 					} }
 				>

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -17,6 +17,8 @@ import { store } from '../../store';
 // This is used to avoid rendering the block list if the sizes change.
 let MemoizedBlockList;
 
+const MAX_HEIGHT = 1800;
+
 function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	const [
 		containerResizeListener,
@@ -40,7 +42,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 			return [
 				...styles,
 				{
-					css: 'body{height:unset;overflow:hidden;}',
+					css: 'body{height:auto;overflow:hidden;}',
 					__unstableType: 'presets',
 				},
 			];
@@ -62,6 +64,10 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				style={ {
 					transform: `scale(${ scale })`,
 					height: contentHeight * scale,
+					maxHeight:
+						contentHeight > MAX_HEIGHT
+							? MAX_HEIGHT * scale
+							: undefined,
 				} }
 			>
 				<Iframe
@@ -87,11 +93,8 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 						height: contentHeight,
 						pointerEvents: 'none',
 						// This is a catch-all max-height for patterns.
-						// VH units are as tall as your current viewport, and when used inside a scaled iframe
-						// the math to convert an inherited VH unit appears to cause it to keep growing endlessly.
-						// By applying a max-height, at least it will stop growing.
-						// A longer term fix would be to disallow the thumbnail from growing after initial load.
-						maxHeight: '1800px',
+						// See: https://github.com/WordPress/gutenberg/pull/38175.
+						maxHeight: MAX_HEIGHT,
 					} }
 				>
 					{ contentResizeListener }

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -17,7 +17,7 @@ import { store } from '../../store';
 // This is used to avoid rendering the block list if the sizes change.
 let MemoizedBlockList;
 
-const MAX_HEIGHT = 1800;
+const MAX_HEIGHT = 2000;
 
 function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	const [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -235,7 +235,7 @@ function Iframe(
 
 	head = (
 		<>
-			<style>{ 'body{margin:0}' }</style>
+			<style>{ 'body{margin:0;overflow: hidden}' }</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -235,7 +235,7 @@ function Iframe(
 
 	head = (
 		<>
-			<style>{ 'body{margin:0;}' }</style>
+			<style>{ 'body{margin:0}' }</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -235,7 +235,7 @@ function Iframe(
 
 	head = (
 		<>
-			<style>{ 'body{margin:0;overflow: hidden}' }</style>
+			<style>{ 'body{margin:0;}' }</style>
 			{ styles.map(
 				( { tagName, href, id, rel, media, textContent } ) => {
 					const TagName = tagName.toLowerCase();


### PR DESCRIPTION
## Description
Resolves #34729
Resolves #37573.

Description by @jasmussen

This PR fixes the scrollbar shown inside thumbnails and applies a bandaid to stop `vh` based patterns from endlessly expanding.
In testing, it became clear that 100vh equals the height of your browser. Inside an iframe, things are different. This [StackOverflow question](https://stackoverflow.com/questions/34057239/css-vh-units-inside-an-iframe) led me to [this spec note](https://www.w3.org/TR/css-values/#viewport-relative-lengths):

>The viewport-percentage lengths are relative to the size of the initial containing block. When the height or width of the initial containing block is changed, they are scaled accordingly.

That seems to suggest it’s very easy to create a race condition, as “initial containing block” can’t be properly sized until content inside is loaded.
Because of that, this PR applies a pixel based max-height. A tall one, and one that will let the VH based pattern scale until it reaches that max-limit, but nevertheless it should mitigate the issue.
As noted in comments in the code, a better fix might be apply a max-height based on the initial-content height. But due to the iframe scaling behavior, this seems nontrivial

## How has this been tested?
I tested with TT2, Blockbase, and Blank Canvas themes. The "vertically expanding" issue was most visible with Blank Canvas.

## Screenshots <!-- if applicable -->
1. Using "Blank Canvas" open the Inserter > Patterns tab.
2. Try switching between categories "Featured," "Blank Canvas" and "Links in Bio".
3. Confirm that pattern previews don't expect vertically and that they don't have visible scrollbars.

Try similar testing method with different Classic and Block themes.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
