### PR TITLE
Scripts: Corrected "npm start:hot" in the README file

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -350,7 +350,7 @@ _Example:_
 
 This is how you execute the script with presented setup:
 
--   `npm run start` - starts the build for development.
+-   `npm start` - starts the build for development.
 -   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the code.
 -   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -350,8 +350,8 @@ _Example:_
 
 This is how you execute the script with presented setup:
 
--   `npm start` - starts the build for development.
--   `npm start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the code.
+-   `npm run start` - starts the build for development.
+-   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the code.
 -   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:


### PR DESCRIPTION
#"run" keyword was missing on these two commands.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
"run" keyword was missing on these two commands.
```
npm start
npm start:hot
```
Correct Command is

```
npm run start
npm run start:hot
```


## Types of changes
Documentation Improvement.

