### PR TITLE
Fix/expanding thumbnails

### DIFF
--- a/packages/edit-post/src/classic.scss
+++ b/packages/edit-post/src/classic.scss
@@ -18,6 +18,20 @@ html :where(.editor-styles-wrapper) {
 	}
 }
 
+.block-editor-block-preview__content-iframe {
+	.block-editor-block-list__layout.is-root-container > .wp-block {
+		// Prevent full-height blocks expanding height endlessly in pattern preview.
+		margin-top: 0;
+		margin-bottom: 0;
+
+		// Remove the compensating margin of full-wide blocks in pattern preview to prevent horizontal scrollbars.
+		&[data-align="full"] {
+			margin-left: 0;
+			margin-right: 0;
+		}
+	}
+}
+
 // Deprecated style needed for the block widths and alignments.
 // for themes that don't support the new layout (theme.json).
 html :where(.wp-block) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Resolves #34729.

## How has this been tested?

Tested with TT2 and TT1.

## Screenshots

![スクリーンショット 2022-01-24 22 51 40](https://user-images.githubusercontent.com/5457539/150795013-c7183b8e-4f12-427c-9776-3b565e8a4545.png)

## Types of changes

Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
