### PR TITLE
Fixes pasting plaintext with HTML tags does not display them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16953,6 +16953,7 @@
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
+				"@wordpress/escape-html": "file:packages/escape-html",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",
 				"@wordpress/i18n": "file:packages/i18n",
@@ -30476,7 +30477,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -41037,7 +41038,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
+		"@wordpress/escape-html": "file:../escape-html",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",

--- a/packages/blocks/src/api/raw-handling/paste-handler.js
+++ b/packages/blocks/src/api/raw-handling/paste-handler.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { getPhrasingContentSchema, removeInvalidHTML } from '@wordpress/dom';
+import { escapeHTML } from '@wordpress/escape-html';
 
 /**
  * Internal dependencies
@@ -125,7 +126,7 @@ export function pasteHandler( {
 	// * There is a plain text version.
 	// * There is no HTML version, or it has no formatting.
 	if ( plainText && ( ! HTML || isPlain( HTML ) ) ) {
-		HTML = plainText;
+		HTML = escapeHTML( plainText );
 
 		// The markdown converter (Showdown) trims whitespace.
 		if ( ! /^\s+$/.test( plainText ) ) {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/rich-text.test.js.snap
@@ -24,6 +24,12 @@ exports[`RichText should apply multiple formats when selection is collapsed 1`] 
 <!-- /wp:paragraph -->"
 `;
 
+exports[`RichText should escape HTML on paste 1`] = `
+"<!-- wp:paragraph -->
+<p>Test &lt;img> tag</p>
+<!-- /wp:paragraph -->"
+`;
+
 exports[`RichText should handle Home and End keys 1`] = `
 "<!-- wp:paragraph -->
 <p>-<strong>12</strong>+</p>
@@ -159,6 +165,16 @@ exports[`RichText should return focus when pressing formatting button 1`] = `
 exports[`RichText should run input rules after composition end 1`] = `
 "<!-- wp:paragraph -->
 <p><code>a</code></p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`RichText should split rich text and escape HTML on paste 1`] = `
+"<!-- wp:paragraph -->
+<p>First line &lt;img&gt;</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second line &lt;img&gt;.</p>
 <!-- /wp:paragraph -->"
 `;
 

--- a/packages/e2e-tests/specs/editor/various/rich-text.test.js
+++ b/packages/e2e-tests/specs/editor/various/rich-text.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	showBlockToolbar,
 	clickBlockToolbarButton,
+	setClipboardData,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'RichText', () => {
@@ -553,6 +554,30 @@ describe( 'RichText', () => {
 		await page.keyboard.type( '-' );
 
 		// Expect: <strong>1</strong>-<em>2</em>
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should escape HTML on paste', async () => {
+		await clickBlockAppender();
+
+		// Test to see if HTML is kept.
+		await setClipboardData( { plainText: 'Test <img> tag\n' } );
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'should split rich text and escape HTML on paste', async () => {
+		await clickBlockAppender();
+
+		// Test to see if HTML is kept and block is split.
+		await setClipboardData( {
+			plainText: 'First line <img>\n\nSecond line <img>.',
+		} );
+
+		await pressKeyWithModifier( 'primary', 'v' );
+
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
Fixes #38064 

## Description
The issue was happening because the pasted text was treated as HTML [here](https://github.com/WordPress/gutenberg/blob/6829e2363f925405283f02b4eb5018e7e009c1da/packages/block-editor/src/components/rich-text/use-paste-handler.js#L219). I fixed it detecting if it's plaintext and then treating it accordingly. 

## How has this been tested?

The code fix is simple, so I tested it in my local dev environment. I repeated the same steps as described in the linked issue and then verified it was working. I also ran `npm run test` to verify all tests passed. Here is how to test this PR:

### Reproducing the Issue
Before merging PR in local, run following steps:
1. Copy the below text and paste as plaintext(`cnrtl-shift-v`) in Gutenberg:
```
Add width and height attributes to <img> elements
```
2. The rendered text will be:
```
Add width and height attributes to  elements
```

![Screenshot](https://user-images.githubusercontent.com/8456197/150100761-e52bcb51-a896-4bae-9a18-1cdae6804ed7.png)
Here is what comes in console:
![Screenshot from 2022-01-19 13-58-13](https://user-images.githubusercontent.com/8456197/150101389-b23eadad-b314-4013-9338-ebfb12bd4b89.png)

### Testing the PR

After merging this PR, run the following steps:
1. Copy the below text and paste as plaintext(`cnrtl-shift-v`) in Gutenberg:
```
Add width and height attributes to <img> elements
```
2. The rendered text will be:
```
Add width and height attributes to <img> elements
```
Please note that Gutenberg is now correctly rendering the `<img>` tag.

![Screenshot from 2022-02-07 17-32-26](https://user-images.githubusercontent.com/8456197/152784711-6f3b4302-8766-4497-ac55-525753b111b1.png)

## Types of changes
Very simple one-line code fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
