### PR TITLE
Gallery: Ensure last image takes up all available space

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -30,6 +30,7 @@
 		margin-top: auto;
 		margin-bottom: auto;
 		flex-direction: column;
+		max-width: 100%;
 
 		> div,
 		> a {
@@ -41,7 +42,9 @@
 		img {
 			display: block;
 			height: auto;
-			max-width: 100%;
+			// Ensure max-width is not overridden on the img when the parent gallery has
+			// wide or full alignment.
+			max-width: 100% !important;
 			width: auto;
 		}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Fixes #38156

## Description
<!-- Please describe what you have changed or added -->
In the Gallery block, if the last row contains a single image it should scale up to use all the available space. Some theme styles for the `full` and `wide` alignment options were limiting the max-width of Images and preventing this from working correctly for full/wide-aligned Galleries. This PR adds a `max-width: 100%` to override those styles.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
Tested in Twenty Twenty-One, Twenty Twenty, Twenty Nineteen, Seedlet, and TT1-blocks.

For each theme:
1. Create a gallery with three images. Set the 'Columns' setting to 2, so that the last image appears on a row by itself.
2. Verify that the last image takes up all available space in the row.
3. Change the alignment of the Gallery to "Full width" and then "Wide width" and verify the image scales appropriately.
4. Check the post on the frontend and verify the image is scaled correctly for each width.

Make sure to test Twenty Nineteen, because it has highly specific rules that target the `img` and required higher specificity to override.

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="427" alt="Screen Shot 2022-01-24 at 11 37 11 AM" src="https://user-images.githubusercontent.com/63313398/150854405-6c9ff23b-4857-4252-b01b-e769ac2c927f.png"> | <img width="433" alt="Screen Shot 2022-01-24 at 11 36 58 AM" src="https://user-images.githubusercontent.com/63313398/150854437-4be0ed5b-b5b2-494f-8e4d-66838834c7a2.png"> |


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
