### PR TITLE
Use consistent punctuation, capitalization in templateParts documentation

### DIFF
--- a/docs/how-to-guides/themes/create-block-theme.md
+++ b/docs/how-to-guides/themes/create-block-theme.md
@@ -778,9 +778,9 @@ Since the theme has custom padding enabled, you can add `padding` within the `sp
 ### Template parts
 
 In the templeParts section, assign the two template parts that you created to their template areas.
-Add three keys: -`name`, the file name of the template part file without the file extension, -`area`, the name of the template area, and `title` the visible name in the editor.
+Add three keys: `name`, the file name of the template part file without the file extension, `area`, the name of the template area, and `title`, the visible name in the editor.
 
-There are three template areas to choose from: Header, footer, and general.
+There are three template areas to choose from: header, footer, and general.
 
 ```json
 "templateParts": [


### PR DESCRIPTION
## Description

This suggests a handful of small tweaks to the documentation found at https://developer.wordpress.org/block-editor/how-to-guides/themes/create-block-theme/#template-parts

* Remove an unnecessary leading `-` from name and area.
* Add a comma after title for consistency with name and area.
* Use small case for "Header" as it is a specific value for the area property.
