### PR TITLE
Block Editor: Use 'noop' for conditional callbacks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { omit } from 'lodash';
+import { noop, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -99,10 +99,10 @@ function BlockListBlock( {
 			isSelected={ isSelected }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
-			insertBlocksAfter={ isLocked ? undefined : onInsertBlocksAfter }
-			onReplace={ canRemove ? onReplace : undefined }
-			onRemove={ canRemove ? onRemove : undefined }
-			mergeBlocks={ canRemove ? onMerge : undefined }
+			insertBlocksAfter={ isLocked ? noop : onInsertBlocksAfter }
+			onReplace={ canRemove ? onReplace : noop }
+			onRemove={ canRemove ? onRemove : noop }
+			mergeBlocks={ canRemove ? onMerge : noop }
 			clientId={ clientId }
 			isSelectionEnabled={ isSelectionEnabled }
 			toggleSelection={ toggleSelection }


### PR DESCRIPTION
## Description
Block's edit component might receive some functions as `undefined` depending on lock status. This can cause an error when the block calls these functions without checking their existence.

PR update logic to use `lodash.noop` instead of `undefined`.

## How has this been tested?
1. Add locked Audio from the example below to the post.
2. Use "Replace" and change to URL to Spotify or any embeddable audio service.
3. On the trunk, this will produce an error - `onReplace is not a function`.
4. Build this branch and repeat an action. Replacement shouldn't produce an error.

```
<!-- wp:audio {"lock":{"remove":true,"move":true}} -->
<figure class="wp-block-audio"><audio controls src="https://freesound.org/data/previews/400/400861_6305509-hq.mp3"></audio><figcaption>"Ocean_Hitting_Rocks_Mendocino_01.aif"&nbsp;by&nbsp;<a rel="noreferrer noopener" href="https://freesound.org/people/bobv2" target="_blank">bobv2</a>&nbsp;is licensed under&nbsp;<a rel="noreferrer noopener" href="https://creativecommons.org/publicdomain/zero/1.0/?ref=openverse" target="_blank">CC0 1.0</a></figcaption></figure>
<!-- /wp:audio -->
```

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
