### PR TITLE
Submenu: Add revert button.

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -554,7 +554,7 @@ export default function NavigationSubmenuEdit( {
 					<ToolbarButton
 						name="revert"
 						icon={ keyboardReturn }
-						title={ __( 'Revert to Link' ) }
+						title={ __( 'Convert to Link' ) }
 						onClick={ transformToLink }
 						className="wp-block-navigation__submenu__revert"
 					/>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -38,7 +38,7 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { link as linkIcon, undo } from '@wordpress/icons';
+import { link as linkIcon, removeSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -541,17 +541,6 @@ export default function NavigationSubmenuEdit( {
 		<Fragment>
 			<BlockControls>
 				<ToolbarGroup>
-					{ ! selectedBlockHasDescendants && (
-						<ToolbarButton
-							name="revert"
-							icon={ undo }
-							title={ __( 'Convert to Link' ) }
-							onClick={ transformToLink }
-							className="wp-block-navigation__submenu__revert"
-						/>
-					) }
-				</ToolbarGroup>
-				<ToolbarGroup>
 					{ ! openSubmenusOnClick && (
 						<ToolbarButton
 							name="link"
@@ -559,6 +548,15 @@ export default function NavigationSubmenuEdit( {
 							title={ __( 'Link' ) }
 							shortcut={ displayShortcut.primary( 'k' ) }
 							onClick={ () => setIsLinkOpen( true ) }
+						/>
+					) }
+					{ ! selectedBlockHasDescendants && (
+						<ToolbarButton
+							name="revert"
+							icon={ removeSubmenu }
+							title={ __( 'Convert to Link' ) }
+							onClick={ transformToLink }
+							className="wp-block-navigation__submenu__revert"
 						/>
 					) }
 				</ToolbarGroup>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -555,6 +555,9 @@ export default function NavigationSubmenuEdit( {
 		replaceBlock( clientId, newLinkBlock );
 	}
 
+	const canConvertToLink =
+		! selectedBlockHasDescendants || onlyDescendantIsEmptyLink;
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -568,16 +571,15 @@ export default function NavigationSubmenuEdit( {
 							onClick={ () => setIsLinkOpen( true ) }
 						/>
 					) }
-					{ ( ! selectedBlockHasDescendants ||
-						onlyDescendantIsEmptyLink ) && (
-						<ToolbarButton
-							name="revert"
-							icon={ removeSubmenu }
-							title={ __( 'Convert to Link' ) }
-							onClick={ transformToLink }
-							className="wp-block-navigation__submenu__revert"
-						/>
-					) }
+
+					<ToolbarButton
+						name="revert"
+						icon={ removeSubmenu }
+						title={ __( 'Convert to Link' ) }
+						onClick={ transformToLink }
+						className="wp-block-navigation__submenu__revert"
+						isDisabled={ ! canConvertToLink }
+					/>
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -541,16 +541,6 @@ export default function NavigationSubmenuEdit( {
 		<Fragment>
 			<BlockControls>
 				<ToolbarGroup>
-					{ ! openSubmenusOnClick && (
-						<ToolbarButton
-							name="link"
-							icon={ linkIcon }
-							title={ __( 'Link' ) }
-							shortcut={ displayShortcut.primary( 'k' ) }
-							onClick={ () => setIsLinkOpen( true ) }
-						/>
-					) }
-
 					{ ! selectedBlockHasDescendants && (
 						<ToolbarButton
 							name="revert"
@@ -558,6 +548,17 @@ export default function NavigationSubmenuEdit( {
 							title={ __( 'Convert to Link' ) }
 							onClick={ transformToLink }
 							className="wp-block-navigation__submenu__revert"
+						/>
+					) }
+				</ToolbarGroup>
+				<ToolbarGroup>
+					{ ! openSubmenusOnClick && (
+						<ToolbarButton
+							name="link"
+							icon={ linkIcon }
+							title={ __( 'Link' ) }
+							shortcut={ displayShortcut.primary( 'k' ) }
+							onClick={ () => setIsLinkOpen( true ) }
 						/>
 					) }
 				</ToolbarGroup>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -338,14 +338,14 @@ export default function NavigationSubmenuEdit( {
 			] );
 
 			// Check for a single descendant in the submenu. If that block
-			// is a link block in a "placeholder" state with no URL then
+			// is a link block in a "placeholder" state with no label then
 			// we can consider as an "empty" link.
 			if ( selectedBlockDescendants?.length === 1 ) {
 				const singleBlock = getBlock( selectedBlockDescendants[ 0 ] );
 
 				_onlyDescendantIsEmptyLink =
 					singleBlock?.name === 'core/navigation-link' &&
-					! singleBlock?.attributes?.url;
+					! singleBlock?.attributes?.label;
 			}
 
 			return {

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -551,13 +551,15 @@ export default function NavigationSubmenuEdit( {
 						/>
 					) }
 
-					<ToolbarButton
-						name="revert"
-						icon={ keyboardReturn }
-						title={ __( 'Convert to Link' ) }
-						onClick={ transformToLink }
-						className="wp-block-navigation__submenu__revert"
-					/>
+					{ ! selectedBlockHasDescendants && (
+						<ToolbarButton
+							name="revert"
+							icon={ keyboardReturn }
+							title={ __( 'Convert to Link' ) }
+							onClick={ transformToLink }
+							className="wp-block-navigation__submenu__revert"
+						/>
+					) }
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -38,9 +38,10 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { link as linkIcon } from '@wordpress/icons';
+import { link as linkIcon, keyboardReturn } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -294,9 +295,11 @@ export default function NavigationSubmenuEdit( {
 	};
 	const { showSubmenuIcon, openSubmenusOnClick } = context;
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
-		blockEditorStore
-	);
+
+	const {
+		__unstableMarkNextChangeAsNotPersistent,
+		replaceBlock,
+	} = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const listItemRef = useRef( null );
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
@@ -529,6 +532,11 @@ export default function NavigationSubmenuEdit( {
 
 	const ParentElement = openSubmenusOnClick ? 'button' : 'a';
 
+	function transformToLink() {
+		const newLinkBlock = createBlock( 'core/navigation-link', attributes );
+		replaceBlock( clientId, newLinkBlock );
+	}
+
 	return (
 		<Fragment>
 			<BlockControls>
@@ -542,6 +550,14 @@ export default function NavigationSubmenuEdit( {
 							onClick={ () => setIsLinkOpen( true ) }
 						/>
 					) }
+
+					<ToolbarButton
+						name="revert"
+						icon={ keyboardReturn }
+						title={ __( 'Revert to Link' ) }
+						onClick={ transformToLink }
+						className="wp-block-navigation__submenu__revert"
+					/>
 				</ToolbarGroup>
 			</BlockControls>
 			<InspectorControls>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -38,7 +38,7 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
-import { link as linkIcon, keyboardReturn } from '@wordpress/icons';
+import { link as linkIcon, undo } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { speak } from '@wordpress/a11y';
 import { createBlock } from '@wordpress/blocks';
@@ -544,7 +544,7 @@ export default function NavigationSubmenuEdit( {
 					{ ! selectedBlockHasDescendants && (
 						<ToolbarButton
 							name="revert"
-							icon={ keyboardReturn }
+							icon={ undo }
 							title={ __( 'Convert to Link' ) }
 							onClick={ transformToLink }
 							className="wp-block-navigation__submenu__revert"

--- a/packages/block-library/src/navigation-submenu/editor.scss
+++ b/packages/block-library/src/navigation-submenu/editor.scss
@@ -39,4 +39,8 @@
 			}
 		}
 	}
+
+	.wp-block-navigation__submenu__revert {
+		transform: rotate(-270deg);
+	}
 }

--- a/packages/block-library/src/navigation-submenu/editor.scss
+++ b/packages/block-library/src/navigation-submenu/editor.scss
@@ -39,8 +39,4 @@
 			}
 		}
 	}
-
-	.wp-block-navigation__submenu__revert {
-		transform: rotate(-270deg);
-	}
 }

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -739,8 +739,7 @@ describe( 'Navigation', () => {
 		expect( tagCount ).toBe( 1 );
 	} );
 
-	// eslint-disable-next-line jest/no-focused-tests
-	describe.only( 'Submenus', () => {
+	describe( 'Submenus', () => {
 		it( 'shows button which converts submenu to link when submenu is not-populated (empty)', async () => {
 			const navSubmenuSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]`;
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -208,6 +208,13 @@ async function getNavigationMenuRawContent() {
 	return stripPageIds( response.content.raw );
 }
 
+async function waitForBlock( blockName ) {
+	const blockSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: ${ blockName }"]`;
+
+	// Wait for a Submenu block before making assertion.
+	return await page.waitForSelector( blockSelector );
+}
+
 // Disable reason - these tests are to be re-written.
 // eslint-disable-next-line jest/no-disabled-tests
 describe( 'Navigation', () => {
@@ -731,8 +738,11 @@ describe( 'Navigation', () => {
 		expect( tagCount ).toBe( 1 );
 	} );
 
-	describe( 'Submenus', () => {
+	// eslint-disable-next-line jest/no-focused-tests
+	describe.only( 'Submenus', () => {
 		it( 'shows button to convert submenu to link when empty', async () => {
+			const navSubmenuSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]`;
+
 			await createNewPost();
 			await insertBlock( 'Navigation' );
 
@@ -748,11 +758,7 @@ describe( 'Navigation', () => {
 
 			await page.click( 'button[aria-label="Add submenu"]' );
 
-			const navSubmenuSelector =
-				'[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]';
-
-			// Wait for a Submenu block before making assertion.
-			await page.waitForSelector( navSubmenuSelector );
+			await waitForBlock( 'Submenu' );
 
 			await showBlockToolbar();
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -121,20 +121,18 @@ async function selectClassicMenu( optionText ) {
 	await theOption.click();
 }
 
-async function populateNavWithOneItem( item ) {
-	item = item || {
-		url: 'https://wordpress.org',
-		label: 'WP',
-		type: 'url',
-	};
-
+async function populateNavWithOneItem() {
 	// Add a Link block first.
 	const appender = await page.waitForSelector(
 		'.wp-block-navigation .block-list-appender'
 	);
 	await appender.click();
 	// Add a link to the Link block.
-	await updateActiveNavigationLink( item );
+	await updateActiveNavigationLink( {
+		url: 'https://wordpress.org',
+		label: 'WP',
+		type: 'url',
+	} );
 }
 
 const PLACEHOLDER_ACTIONS_CLASS = 'wp-block-navigation-placeholder__actions';

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -26,6 +26,7 @@ import {
 	loginUser,
 	deleteUser,
 	switchUserToAdmin,
+	clickBlockToolbarButton,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -213,16 +214,6 @@ async function waitForBlock( blockName ) {
 
 	// Wait for a Submenu block before making assertion.
 	return page.waitForSelector( blockSelector );
-}
-
-async function clickBlockToolbarButton( label ) {
-	await showBlockToolbar();
-
-	const btn = await page.waitForSelector(
-		`[aria-label="Editor content"][role="region"] [aria-label="Block tools"] [aria-label="${ label }"]`
-	);
-
-	return btn.click();
 }
 
 // Disable reason - these tests are to be re-written.
@@ -749,7 +740,7 @@ describe( 'Navigation', () => {
 	} );
 
 	// eslint-disable-next-line jest/no-focused-tests
-	describe( 'Submenus', () => {
+	describe.only( 'Submenus', () => {
 		it( 'shows button which converts submenu to link when submenu is not-populated (empty)', async () => {
 			const navSubmenuSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]`;
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -221,7 +221,7 @@ async function clickBlockToolbarButton( label ) {
 	await showBlockToolbar();
 
 	const btn = await page.waitForSelector(
-		`[aria-label="Block tools"] [aria-label="${ label }"]`
+		`[aria-label="Editor content"][role="region"] [aria-label="Block tools"] [aria-label="${ label }"]`
 	);
 
 	return btn.click();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -762,7 +762,7 @@ describe( 'Navigation', () => {
 			// Revert the Submenu back to a Navigation Link block.
 			await clickBlockToolbarButton( 'Convert to Link' );
 
-			// Check the Submenu block is no long present.
+			// Check the Submenu block is no longer present.
 			const convertToLinkButton = await page.$( navSubmenuSelector );
 
 			expect( convertToLinkButton ).toBeFalsy();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -762,12 +762,12 @@ describe( 'Navigation', () => {
 			await clickBlockToolbarButton( 'Convert to Link' );
 
 			// Check the Submenu block is no longer present.
-			const convertToLinkButton = await page.$( navSubmenuSelector );
+			const submenuBlock = await page.$( navSubmenuSelector );
 
-			expect( convertToLinkButton ).toBeFalsy();
+			expect( submenuBlock ).toBeFalsy();
 		} );
 
-		it( 'does not show button to convert submenu to link when submenu is populated', async () => {
+		it( 'shows button to convert submenu to link in disabled state when submenu is populated', async () => {
 			await createNewPost();
 			await insertBlock( 'Navigation' );
 
@@ -798,11 +798,12 @@ describe( 'Navigation', () => {
 
 			await clickBlockToolbarButton( 'Select Submenu' );
 
-			const convertToLinkButton = await page.$(
-				'[aria-label="Block tools"] [aria-label="Convert to Link"]'
+			// Check button exists but is in disabled state.
+			const disabledConvertToLinkButton = await page.$(
+				'[aria-label="Block tools"] [aria-label="Convert to Link"][disabled]'
 			);
 
-			expect( convertToLinkButton ).toBeFalsy();
+			expect( disabledConvertToLinkButton ).toBeTruthy();
 		} );
 
 		it( 'shows button to convert submenu to link when submenu is populated with a single incomplete link item', async () => {
@@ -836,8 +837,9 @@ describe( 'Navigation', () => {
 			// no URL of label and can be considered unpopulated.
 			await clickBlockToolbarButton( 'Select Submenu' );
 
+			// Check for non-disabled Convert to Link button
 			const convertToLinkButton = await page.$(
-				'[aria-label="Block tools"] [aria-label="Convert to Link"]'
+				'[aria-label="Block tools"] [aria-label="Convert to Link"]:not([disabled])'
 			);
 
 			expect( convertToLinkButton ).toBeTruthy();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -749,7 +749,7 @@ describe( 'Navigation', () => {
 	} );
 
 	// eslint-disable-next-line jest/no-focused-tests
-	describe.only( 'Submenus', () => {
+	describe( 'Submenus', () => {
 		it( 'shows button which converts submenu to link when submenu is not-populated (empty)', async () => {
 			const navSubmenuSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]`;
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -217,6 +217,16 @@ async function waitForBlock( blockName ) {
 	return page.waitForSelector( blockSelector );
 }
 
+async function clickBlockToolbarButton( label ) {
+	await showBlockToolbar();
+
+	const btn = await page.waitForSelector(
+		`[aria-label="Block tools"] [aria-label="${ label }"]`
+	);
+
+	return btn.click();
+}
+
 // Disable reason - these tests are to be re-written.
 // eslint-disable-next-line jest/no-disabled-tests
 describe( 'Navigation', () => {
@@ -741,7 +751,7 @@ describe( 'Navigation', () => {
 	} );
 
 	// eslint-disable-next-line jest/no-focused-tests
-	describe( 'Submenus', () => {
+	describe.only( 'Submenus', () => {
 		it( 'shows button to convert submenu to link when empty', async () => {
 			const navSubmenuSelector = `[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]`;
 
@@ -756,16 +766,12 @@ describe( 'Navigation', () => {
 
 			await populateNavWithOneItem();
 
-			await showBlockToolbar();
-
-			await page.click( 'button[aria-label="Add submenu"]' );
+			await clickBlockToolbarButton( 'Add submenu' );
 
 			await waitForBlock( 'Submenu' );
 
-			await showBlockToolbar();
-
 			// Revert the Submenu back to a Navigation Link block.
-			await page.click( 'button[aria-label="Convert to Link"]' );
+			await clickBlockToolbarButton( 'Convert to Link' );
 
 			// Check the Submenu block is no long present.
 			const navSubmenusLength = await page.$$eval(
@@ -793,9 +799,7 @@ describe( 'Navigation', () => {
 				type: 'url',
 			} );
 
-			await showBlockToolbar();
-
-			await page.click( 'button[aria-label="Add submenu"]' );
+			await clickBlockToolbarButton( 'Add submenu' );
 
 			await waitForBlock( 'Submenu' );
 
@@ -812,13 +816,7 @@ describe( 'Navigation', () => {
 				type: 'url',
 			} );
 
-			await showBlockToolbar();
-
-			const switchToParentBlockButton = await page.waitForSelector(
-				'[aria-label="Block tools"] [aria-label="Select Submenu"]'
-			);
-
-			await switchToParentBlockButton.click();
+			await clickBlockToolbarButton( 'Select Submenu' );
 
 			const convertToLinkButton = await page.$(
 				'[aria-label="Block tools"] [aria-label="Convert to Link"]'

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -179,6 +179,7 @@ export { default as quote } from './library/quote';
 export { default as receipt } from './library/receipt';
 export { default as redo } from './library/redo';
 export { default as removeBug } from './library/remove-bug';
+export { default as removeSubmenu } from './library/remove-submenu';
 export { default as replace } from './library/replace';
 export { default as reset } from './library/reset';
 export { default as resizeCornerNE } from './library/resize-corner-n-e';

--- a/packages/icons/src/library/remove-submenu.js
+++ b/packages/icons/src/library/remove-submenu.js
@@ -6,8 +6,8 @@ import { SVG, Path } from '@wordpress/primitives';
 const removeSubmenu = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
-			fill-rule="evenodd"
-			clip-rule="evenodd"
+			fillRule="evenodd"
+			clipRule="evenodd"
 			d="m13.955 20.748 8-17.5-.91-.416L19.597 6H13.5v1.5h5.411l-1.6 3.5H13.5v1.5h3.126l-1.6 3.5H13.5l.028 1.5h.812l-1.295 2.832.91.416ZM17.675 16l-.686 1.5h4.539L21.5 16h-3.825Zm2.286-5-.686 1.5H21.5V11h-1.54ZM2 12c0 3.58 2.42 5.5 6 5.5h.5V19l3-2.5-3-2.5v2H8c-2.48 0-4.5-1.52-4.5-4S5.52 7.5 8 7.5h3.5V6H8c-3.58 0-6 2.42-6 6Z"
 		/>
 	</SVG>

--- a/packages/icons/src/library/remove-submenu.js
+++ b/packages/icons/src/library/remove-submenu.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const removeSubmenu = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="m13.955 20.748 8-17.5-.91-.416L19.597 6H13.5v1.5h5.411l-1.6 3.5H13.5v1.5h3.126l-1.6 3.5H13.5l.028 1.5h.812l-1.295 2.832.91.416ZM17.675 16l-.686 1.5h4.539L21.5 16h-3.825Zm2.286-5-.686 1.5H21.5V11h-1.54ZM2 12c0 3.58 2.42 5.5 6 5.5h.5V19l3-2.5-3-2.5v2H8c-2.48 0-4.5-1.52-4.5-4S5.52 7.5 8 7.5h3.5V6H8c-3.58 0-6 2.42-6 6Z"
+		/>
+	</SVG>
+);
+
+export default removeSubmenu;


### PR DESCRIPTION

<img width="657" alt="Screen Shot 2022-02-01 at 10 47 41" src="https://user-images.githubusercontent.com/444434/151955187-810d1780-5e1c-4cc9-ab93-45a46d8ea879.png">



## Description
In https://github.com/WordPress/gutenberg/issues/36977#issuecomment-1020225327 we learnt that some users want to be able to revert the submenu block to a standard link. The expectation was/is that deleting the submenu would restore the link but of course as the block is in fact a submenu block this just removes the entire block.

This PR seeks to implement one possible solution which is to show an explicit "Revert to Link" button in the block toolbar. This effectively just does the same thing as the block's built-in "Transform" option, but it makes it more explicit for this specific use case.

I'm no designer so this is just one idea for solving this case and we will also no doubt need a better icon choice. 

Curious to hear from those more experienced with this block as well.

Also would love feedback from @courtneyr-dev who originally noticed the quirk and requested the change.

## How has this been tested?

1. Add Nav block.
2. Create items.
3. Add a submenu to one of the items and add some sub items.
4. On the parent submenu item, click the toolbar button to revert to a standard link.
5. The link details should all be retained except from any child blocks which will be disguarded.

⚠️ As noted above, any children of the submenu block being revert will be lost. Is that the behaviour we want? If not then what should happen?

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/151781990-ab0a4c1b-2a37-4b36-b977-9210796746b8.mp4



## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
