### PR TITLE
Spacer: No need to use withDispatch HOC

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -6,13 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { useBlockProps } from '@wordpress/block-editor';
 import { ResizableBox } from '@wordpress/components';
-import { compose, withInstanceId } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
 import { useState, useEffect } from '@wordpress/element';
 import { View } from '@wordpress/primitives';
 
@@ -86,8 +81,7 @@ const SpacerEdit = ( {
 	attributes,
 	isSelected,
 	setAttributes,
-	onResizeStart,
-	onResizeStop,
+	toggleSelection,
 	context,
 } ) => {
 	const { orientation } = context;
@@ -96,6 +90,9 @@ const SpacerEdit = ( {
 	const [ isResizing, setIsResizing ] = useState( false );
 	const [ temporaryHeight, setTemporaryHeight ] = useState( null );
 	const [ temporaryWidth, setTemporaryWidth ] = useState( null );
+
+	const onResizeStart = () => toggleSelection( false );
+	const onResizeStop = () => toggleSelection( true );
 
 	const handleOnVerticalResizeStop = ( newHeight ) => {
 		onResizeStop();
@@ -197,14 +194,4 @@ const SpacerEdit = ( {
 	);
 };
 
-export default compose( [
-	withDispatch( ( dispatch ) => {
-		const { toggleSelection } = dispatch( blockEditorStore );
-
-		return {
-			onResizeStart: () => toggleSelection( false ),
-			onResizeStop: () => toggleSelection( true ),
-		};
-	} ),
-	withInstanceId,
-] )( SpacerEdit );
+export default SpacerEdit;


### PR DESCRIPTION
## Description
PR removes `withDispatch` HOC which was used to toggle multi-block selection and uses `toggleSelection` from block props instead.

I've also removed `withInstanceId` since it's wasn't used by the Edit component.

## Testing Instructions
1. Add Spacer block to a post.
2. Resize it using Resizable box handles.
3. This shouldn't work and not trigger any errors.

## Types of changes
Core Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
