### PR TITLE
Update BlockPreview component readme

### DIFF
--- a/packages/block-editor/src/components/block-preview/README.md
+++ b/packages/block-editor/src/components/block-preview/README.md
@@ -28,35 +28,23 @@ Width of the preview container in pixels. Controls at what size the blocks will 
 
 `viewportWidth` can be used to simulate how blocks look on different device sizes or to make sure make sure multiple previews will be rendered with the same scale, regardless of their content.
 
-### \_\_experimentalScalingDelay
+### `__experimentalPadding`
 
 -   **Type** `Int`
--   **Default** `100ms`
+-   **Default** `undefined`
 
-Defines a delay to be applied before calculating the scale factor and position of the preview block.
+Padding for the preview container body.
 
-### `__experimentalOnReady`
+### `__experimentalLive`
+
+-   **Type** `Boolean`
+-   **Default:** `false`
+
+Enables displaying previews without an iframe container.
+
+### `__experimentalOnClick`
 
 -   **Type** `Function`
--   **Default:** `noop`
+-   **Default:** `undefined`
 
-Use this callback as an opportunity to know when the preview is ready. The callback will pass, if available:
-
--   `scale`: the scale factor
--   `position`: offsets position (x, y)
--   `previewContainerRef`: DOM element reference
--   `inlineStyles`: Inline styles applied to the preview container
-
-Eg:
-
-```es6
-<BlockPreview
-	blocks={ blocks }
-	__experimentalOnReady={ ( { scale, previewContainerRef, position } ) => {
-		console.log(
-			`scale ${ scale } applied to the <${ previewContainerRef.current.tagName }> element.`
-		);
-		console.log( `at x: ${ position.x }, y: ${ position.y } position.` );
-	} }
-/>
-```
+Use this callback in combination with `__experimentalLive`. The callback is attached to the preview container element.


### PR DESCRIPTION
## Description
The documentation was a little outdated. Missing new parameters and still displaying ones that were removed.

## Types of changes
Documentation