### PR TITLE
Inspector Controls: add custom slot group after core slot

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -79,6 +79,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 					__experimentalGroup="border"
 					label={ __( 'Border' ) }
 				/>
+				<InspectorControls.Slot __experimentalGroup="bottom" />
 			</div>
 		);
 	}
@@ -151,6 +152,7 @@ const BlockInspectorSingleBlock = ( {
 				__experimentalGroup="border"
 				label={ __( 'Border' ) }
 			/>
+			<InspectorControls.Slot __experimentalGroup="bottom" />
 			<div>
 				<AdvancedControls />
 			</div>

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -12,6 +12,7 @@ const InspectorControlsDimensions = createSlotFill(
 const InspectorControlsTypography = createSlotFill(
 	'InspectorControlsTypography'
 );
+const InspectorControlsBottom = createSlotFill( 'InspectorControlsBottom' );
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -19,6 +20,7 @@ const groups = {
 	border: InspectorControlsBorder,
 	dimensions: InspectorControlsDimensions,
 	typography: InspectorControlsTypography,
+	bottom: InspectorControlsBottom,
 };
 
 export default groups;

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -25,8 +25,8 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  * Given a function mapping a component to an enhanced component and modifier
  * name, returns the enhanced component augmented with a generated displayName.
  *
- * @param mapComponent Function mapping component to enhanced component.
- * @param modifierName Seed name from which to generated display name.
+ * @param  mapComponent Function mapping component to enhanced component.
+ * @param  modifierName Seed name from which to generated display name.
  *
  * @return Component class with generated display name assigned.
  */


### PR DESCRIPTION
See: https://github.com/WordPress/gutenberg/issues/37845

This pull request will provide a **new group** to the `InspectorControls` slot, allowing controls to be added after the typography / dimensions /border.

Currently, it is possible to inject any `InspectorControls` using the `editor.BlockEdit` filter.
However, the injected position is fixed to before typegraphy slot.

So if you inject an InspectorControl in custom block with multiple supports, the control will be inserted between the Color panel and the Typography panel.

**I think that it is unnatural for a custom control to be interrupted between the panels provided by the core.**

I think there needs to be a receptacle at the end of all the core controls, just before the advanced controls, where any `InspectorControls` can be injected.

The name of the group I added is "**bottom**", but there may be a better name.

Please let me know what you think about this pull request.

