### PR TITLE
Override Site Editor URLs to use plugin page

### DIFF
--- a/lib/compat/wordpress-5.9/admin-menu.php
+++ b/lib/compat/wordpress-5.9/admin-menu.php
@@ -77,8 +77,23 @@ function gutenberg_adminbar_items( $wp_admin_bar ) {
 		);
 	}
 }
-
 add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
+
+/**
+ * Override Site Editor URLs to use plugin page.
+ *
+ * @param string $url Admin URL link with path.
+ * @param string $path Path relative to the admin URL.
+ * @return string Modified Admin URL link.
+ */
+function gutenberg_override_site_editor_urls( $url, $path ) {
+	if ( $path === 'site-editor.php' ) {
+		$url = str_replace( $path, 'themes.php?page=gutenberg-edit-site', $url );
+	}
+
+	return $url;
+}
+add_filter( 'admin_url', 'gutenberg_override_site_editor_urls', 10, 2 );
 
 /**
  * Check if any plugin, or theme features, are using the Customizer.

--- a/lib/compat/wordpress-5.9/admin-menu.php
+++ b/lib/compat/wordpress-5.9/admin-menu.php
@@ -87,7 +87,7 @@ add_action( 'admin_bar_menu', 'gutenberg_adminbar_items', 50 );
  * @return string Modified Admin URL link.
  */
 function gutenberg_override_site_editor_urls( $url, $path ) {
-	if ( $path === 'site-editor.php' ) {
+	if ( 'site-editor.php' === $path ) {
 		$url = str_replace( $path, 'themes.php?page=gutenberg-edit-site', $url );
 	}
 


### PR DESCRIPTION
## Description
PR add filter to override `wp-admin/site-editor.php` paths with `themes.php?page=gutenberg-edit-site`. It should prevent plugin users from accidentally accessing editor shipped with the core in 5.9.

## Testing Instructions
1. Go to Themes and activate any block theme.
2. Click on the "Customize" button.
3. It should take you to the `themes.php?page=gutenberg-edit-site` page.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
