### PR TITLE
Hide the block toolbar after some seconds of mouse inactivity

### DIFF
--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -84,7 +84,7 @@ export function useMouseMoveTypingReset() {
 				lastClientY &&
 				( lastClientX !== clientX || lastClientY !== clientY );
 
-			if ( isTyping() && didMove ) {
+			if ( didMove && isTyping() ) {
 				stopTyping();
 			}
 


### PR DESCRIPTION
This PR tries to improve the writing flow feeling a bit. 

Right now, when you mouse the mouse around, the block toolbar is shown but if you stop moving the mouse, it stays there forever, the idea of this PR is to hide it again after some seconds of inactivity.

**Notes**

 - The difficulty here is to not hide the toolbar while we're in need for it. For instance, once I'm interacting with a Link popover opened from the toolbar itself... So for now, I'm only hiding it if the active element is in the canvas of the editor to avoid surprises.