### PR TITLE
Components: Fix `Slot`/`Fill` Emotion `StyleProvider`

### DIFF
--- a/packages/components/src/slot-fill/bubbles-virtually/fill.js
+++ b/packages/components/src/slot-fill/bubbles-virtually/fill.js
@@ -8,6 +8,7 @@ import { useRef, useState, useEffect, createPortal } from '@wordpress/element';
  * Internal dependencies
  */
 import useSlot from './use-slot';
+import StyleProvider from '../../style-provider';
 
 function useForceUpdate() {
 	const [ , setState ] = useState( {} );
@@ -48,5 +49,15 @@ export default function Fill( { name, children } ) {
 		children = children( slot.fillProps );
 	}
 
-	return createPortal( children, slot.ref.current );
+	// When using a `Fill`, the `children` will be rendered in the document of the
+	// `Slot`. This means that we need to wrap the `children` in a `StyleProvider`
+	// to make sure we're referencing the right document/iframe (instead of the
+	// context of the `Fill`'s parent).
+	const wrappedChildren = (
+		<StyleProvider document={ slot.ref.current.ownerDocument }>
+			{ children }
+		</StyleProvider>
+	);
+
+	return createPortal( wrappedChildren, slot.ref.current );
 }

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -1,17 +1,22 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { useCx } from '..';
-import StyleProvider from '../../../style-provider';
+import { css } from '@emotion/react';
 
 /**
  * WordPress dependencies
  */
 import { useState, createPortal } from '@wordpress/element';
+
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { css } from '@emotion/react';
+import { useCx } from '..';
+import StyleProvider from '../../../style-provider';
+import {
+	createSlotFill,
+	Provider as SlotFillProvider,
+} from '../../../slot-fill';
 
 export default {
 	title: 'Components (Experimental)/useCx',
@@ -63,6 +68,50 @@ const Example = ( { args, children } ) => {
 	const cx = useCx();
 	const classes = cx( ...args );
 	return <span className={ classes }>{ children }</span>;
+};
+
+export const _slotfill = () => {
+	const { Fill, Slot } = createSlotFill( 'ToolsPanelSlot' );
+
+	const redText = css`
+		color: red;
+	`;
+	const blueText = css`
+		color: blue;
+	`;
+	const greenText = css`
+		color: green;
+	`;
+
+	return (
+		<SlotFillProvider>
+			<StyleProvider document={ document }>
+				<IFrame>
+					<IFrame>
+						<Example args={ [ redText ] }>
+							This text is inside an iframe and should be red
+						</Example>
+						<Fill name="test-slot">
+							<Example args={ [ blueText ] }>
+								This text is also inside the iframe, but is
+								relocated by a slot/fill and should be blue
+							</Example>
+						</Fill>
+						<Fill name="outside-frame">
+							<Example args={ [ greenText ] }>
+								This text is also inside the iframe, but is
+								relocated by a slot/fill and should be green
+							</Example>
+						</Fill>
+					</IFrame>
+					<StyleProvider document={ document }>
+						<Slot name="test-slot" />
+					</StyleProvider>
+				</IFrame>
+				<Slot name="outside-frame" />
+			</StyleProvider>
+		</SlotFillProvider>
+	);
 };
 
 export const _default = () => {

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -28,7 +28,7 @@ const Example = ( { args, children } ) => {
 	return <span className={ classes }>{ children }</span>;
 };
 
-export const _slotfill = () => {
+export const _slotFill = () => {
 	const { Fill, Slot } = createSlotFill( 'UseCxExampleSlot' );
 
 	const redText = css`
@@ -68,6 +68,27 @@ export const _slotfill = () => {
 				</Iframe>
 				<Slot bubblesVirtually name="outside-frame" />
 			</StyleProvider>
+		</SlotFillProvider>
+	);
+};
+
+export const _slotFillSimple = () => {
+	const { Fill, Slot } = createSlotFill( 'UseCxExampleSlotTwo' );
+
+	const redText = css`
+		color: red;
+	`;
+
+	return (
+		<SlotFillProvider>
+			<Iframe>
+				<Fill name="test-slot">
+					<Example args={ [ redText ] }>
+						This text should be red
+					</Example>
+				</Fill>
+			</Iframe>
+			<Slot bubblesVirtually name="test-slot" />
 		</SlotFillProvider>
 	);
 };

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -6,7 +6,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { useState, createPortal } from '@wordpress/element';
+import { __unstableIframe as Iframe } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -20,48 +20,6 @@ import {
 
 export default {
 	title: 'Components (Experimental)/useCx',
-};
-
-const IFrame = ( { children } ) => {
-	const [ iframeDocument, setIframeDocument ] = useState();
-
-	const handleRef = ( node ) => {
-		if ( ! node ) {
-			return null;
-		}
-
-		function setIfReady() {
-			const { contentDocument } = node;
-			const { readyState } = contentDocument;
-
-			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
-				return false;
-			}
-
-			setIframeDocument( contentDocument );
-		}
-
-		if ( setIfReady() ) {
-			return;
-		}
-
-		node.addEventListener( 'load', () => {
-			// iframe isn't immediately ready in Firefox
-			setIfReady();
-		} );
-	};
-
-	return (
-		<iframe ref={ handleRef } title="use-cx-test-frame">
-			{ iframeDocument &&
-				createPortal(
-					<StyleProvider document={ iframeDocument }>
-						{ children }
-					</StyleProvider>,
-					iframeDocument.body
-				) }
-		</iframe>
-	);
 };
 
 const Example = ( { args, children } ) => {
@@ -86,8 +44,8 @@ export const _slotfill = () => {
 	return (
 		<SlotFillProvider>
 			<StyleProvider document={ document }>
-				<IFrame>
-					<IFrame>
+				<Iframe>
+					<Iframe>
 						<Example args={ [ redText ] }>
 							This text is inside an iframe and should be red
 						</Example>
@@ -103,12 +61,12 @@ export const _slotfill = () => {
 								relocated by a slot/fill and should be green
 							</Example>
 						</Fill>
-					</IFrame>
+					</Iframe>
 					<StyleProvider document={ document }>
-						<Slot name="test-slot" />
+						<Slot bubblesVirtually name="test-slot" />
 					</StyleProvider>
-				</IFrame>
-				<Slot name="outside-frame" />
+				</Iframe>
+				<Slot bubblesVirtually name="outside-frame" />
 			</StyleProvider>
 		</SlotFillProvider>
 	);
@@ -119,10 +77,10 @@ export const _default = () => {
 		color: red;
 	`;
 	return (
-		<IFrame>
+		<Iframe>
 			<Example args={ [ redText ] }>
 				This text is inside an iframe and is red!
 			</Example>
-		</IFrame>
+		</Iframe>
 	);
 };

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -29,7 +29,7 @@ const Example = ( { args, children } ) => {
 };
 
 export const _slotfill = () => {
-	const { Fill, Slot } = createSlotFill( 'ToolsPanelSlot' );
+	const { Fill, Slot } = createSlotFill( 'UseCxExampleSlot' );
 
 	const redText = css`
 		color: red;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This PR contains a fix proposed by @youknowriad  in https://github.com/WordPress/gutenberg/pull/37551#issuecomment-1021975962 which fixes an issue related to Emotion's `StyleProvider` when used in combination with `Slot`/`Fill`. In Riad's words:

> The idea is that when you use a `Fill`, the `children` will be rendered in the document of the `Slot` meaning we need to wrap in another `StyleProvider` otherwise we'll be using the context of the parent of the `Fill` which can be any `document`/`iframe` and not necessarily the right one.

This PR also updated the `useCx` Storybook examples to include a couple of examples that wouldn't work before the fix in this PR. The main thing there was to use the `IFrame` element from `@wordpress/block-editor`, instead of a local replica.

We also tried to add a unit test but didn't manage due to the complexity introduced of the aforementioned `IFrame` component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- N/A I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
