### PR TITLE
Gallery block: fix bug with uploaded images being replaced with same image during selection phase

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -155,6 +155,14 @@ function GalleryEdit( props ) {
 				align: undefined,
 			} );
 		} );
+
+		// If new blocks added select the first of these so they scroll into view.
+		if ( newImages?.length ) {
+			multiSelect(
+				newImages[ 0 ].clientId,
+				newImages[ newImages?.length - 1 ].clientId
+			);
+		}
 	}, [ newImages ] );
 
 	const shortCodeImages = useShortCodeTransform( shortCodeTransforms );
@@ -296,14 +304,6 @@ function GalleryEdit( props ) {
 					newOrderMap[ b.attributes.id ]
 			)
 		);
-
-		// If new blocks added select the first of these so they scroll into view.
-		if ( newBlocks?.length && existingImageBlocks?.length ) {
-			multiSelect(
-				newBlocks[ 0 ].clientId,
-				newBlocks[ newBlocks.length - 1 ].clientId
-			);
-		}
 	}
 
 	function onUploadError( message ) {


### PR DESCRIPTION
## Description
An issue with the new Add button and uploading images was [identified here](https://github.com/WordPress/gutenberg/pull/38036#issuecomment-1022138717). This was cause by images with temp blob urls and no id being selected.

## Testing Instructions

- Add a gallery and select one image from media library. 
- Then use the Add button in the block tool bar and select Upload and upload several new images
- Check that the images are uploaded and selected correctly

## Screenshots 

Before:
![gallery2](https://user-images.githubusercontent.com/3629020/151272723-ba23bcc9-8609-40d6-be6d-8110454b8a12.gif)

After:
![gallery-one](https://user-images.githubusercontent.com/3629020/151272752-549950f9-1c64-40d7-a26c-8b1e87e1b20d.gif)

