### PR TITLE
Tools Panel: only show header ➕ icon when all items are optional

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   Refine `ExternalLink` to be same size as the text, to appear more as a glyph than an icon. ([#37859](https://github.com/WordPress/gutenberg/pull/37859))
+-   Updated `ToolsPanel` header icon to only show "plus" icon when all items are optional and all are currently hidden ([#38262](https://github.com/WordPress/gutenberg/pull/38262))
 
 ### Bug Fix
 

--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
+import { boolean } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -23,6 +24,9 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 export default {
 	title: 'Components (Experimental)/ToolsPanel',
 	component: ToolsPanel,
+	parameters: {
+		knobs: { disable: false },
+	},
 };
 
 export const _default = () => {
@@ -138,11 +142,15 @@ export const WithNonToolsPanelItems = () => {
 export const WithOptionalItemsPlusIcon = () => {
 	const [ height, setHeight ] = useState();
 	const [ width, setWidth ] = useState();
+	const [ minWidth, setMinWidth ] = useState();
 
 	const resetAll = () => {
 		setHeight( undefined );
 		setWidth( undefined );
+		setMinWidth( undefined );
 	};
+
+	const includeDefaultControls = boolean( 'includeDefaultControls', false );
 
 	return (
 		<PanelWrapperView>
@@ -150,7 +158,20 @@ export const WithOptionalItemsPlusIcon = () => {
 				<ToolsPanel
 					label="Tools Panel (optional items only)"
 					resetAll={ resetAll }
+					key={ includeDefaultControls }
 				>
+					<SingleColumnItem
+						hasValue={ () => !! minWidth }
+						label="Minimum width"
+						onDeselect={ () => setMinWidth( undefined ) }
+						isShownByDefault={ includeDefaultControls }
+					>
+						<UnitControl
+							label="Minimum width"
+							value={ minWidth }
+							onChange={ ( next ) => setMinWidth( next ) }
+						/>
+					</SingleColumnItem>
 					<SingleColumnItem
 						hasValue={ () => !! width }
 						label="Width"

--- a/packages/components/src/tools-panel/test/index.js
+++ b/packages/components/src/tools-panel/test/index.js
@@ -942,6 +942,17 @@ describe( 'ToolsPanel', () => {
 	} );
 
 	describe( 'panel header icon toggle', () => {
+		const defaultControls = {
+			attributes: { value: false },
+			hasValue: jest.fn().mockImplementation( () => {
+				return !! defaultControls.attributes.value;
+			} ),
+			label: 'Default',
+			onDeselect: jest.fn(),
+			onSelect: jest.fn(),
+			isShownByDefault: true,
+		};
+
 		const optionalControls = {
 			attributes: { value: false },
 			hasValue: jest.fn().mockImplementation( () => {
@@ -953,7 +964,26 @@ describe( 'ToolsPanel', () => {
 			isShownByDefault: false,
 		};
 
-		it( 'should render appropriate icons for the dropdown menu', async () => {
+		it( 'should render appropriate icon for the dropdown menu where there are default controls', async () => {
+			render(
+				<ToolsPanel { ...defaultProps }>
+					<ToolsPanelItem { ...defaultControls }>
+						<div>Default control</div>
+					</ToolsPanelItem>
+					<ToolsPanelItem { ...optionalControls }>
+						<div>Optional control</div>
+					</ToolsPanelItem>
+				</ToolsPanel>
+			);
+
+			const optionsDisplayedIcon = screen.getByRole( 'button', {
+				name: 'View options',
+			} );
+
+			expect( optionsDisplayedIcon ).toBeInTheDocument();
+		} );
+
+		it( 'should render appropriate icons for the dropdown menu where there are no default controls', async () => {
 			render(
 				<ToolsPanel { ...defaultProps }>
 					<ToolsPanelItem { ...optionalControls }>

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -49,7 +49,7 @@ const generateMenuItems = ( {
 };
 
 const isMenuItemTypeEmpty = (
-	obj: ToolsPanelMenuItems[ ToolsPanelMenuItemKey ]
+	obj?: ToolsPanelMenuItems[ ToolsPanelMenuItemKey ]
 ) => obj && Object.keys( obj ).length === 0;
 
 export function useToolsPanel(

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -191,7 +191,7 @@ export function useToolsPanel(
 			hasInnerWrapper &&
 			styles.ToolsPanelWithInnerWrapper( DEFAULT_COLUMNS );
 		const emptyStyle =
-			! isMenuItemTypeEmpty( menuItems?.default ) &&
+			isMenuItemTypeEmpty( menuItems?.default ) &&
 			areAllOptionalControlsHidden &&
 			styles.ToolsPanelHiddenInnerWrapper;
 

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -48,6 +48,13 @@ const generateMenuItems = ( {
 	return menuItems;
 };
 
+const isMenuItemTypeEmpty = (
+	obj: ToolsPanelMenuItems[ ToolsPanelMenuItemKey ]
+) =>
+	obj &&
+	Object.keys( obj ).length === 0 &&
+	Object.getPrototypeOf( obj ) === Object.prototype;
+
 export function useToolsPanel(
 	props: WordPressComponentProps< ToolsPanelProps, 'div' >
 ) {
@@ -167,24 +174,24 @@ export function useToolsPanel(
 	] = useState( false );
 
 	useEffect( () => {
-		if ( menuItems.optional ) {
-			const optionalItems = Object.entries( menuItems.optional );
-			const allControlsHidden =
-				optionalItems.length > 0 &&
-				! optionalItems.some( ( [ , isSelected ] ) => isSelected );
+		if (
+			isMenuItemTypeEmpty( menuItems?.default ) &&
+			! isMenuItemTypeEmpty( menuItems?.optional )
+		) {
+			const allControlsHidden = ! Object.entries(
+				menuItems.optional
+			).some( ( [ , isSelected ] ) => isSelected );
 			setAreAllOptionalControlsHidden( allControlsHidden );
 		}
 	}, [ menuItems.optional, setAreAllOptionalControlsHidden ] );
 
 	const cx = useCx();
 	const classes = useMemo( () => {
-		const hasDefaultMenuItems =
-			menuItems?.default && !! Object.keys( menuItems?.default ).length;
 		const wrapperStyle =
 			hasInnerWrapper &&
 			styles.ToolsPanelWithInnerWrapper( DEFAULT_COLUMNS );
 		const emptyStyle =
-			! hasDefaultMenuItems &&
+			! isMenuItemTypeEmpty( menuItems?.default ) &&
 			areAllOptionalControlsHidden &&
 			styles.ToolsPanelHiddenInnerWrapper;
 

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -50,10 +50,7 @@ const generateMenuItems = ( {
 
 const isMenuItemTypeEmpty = (
 	obj: ToolsPanelMenuItems[ ToolsPanelMenuItemKey ]
-) =>
-	obj &&
-	Object.keys( obj ).length === 0 &&
-	Object.getPrototypeOf( obj ) === Object.prototype;
+) => obj && Object.keys( obj ).length === 0;
 
 export function useToolsPanel(
 	props: WordPressComponentProps< ToolsPanelProps, 'div' >
@@ -183,7 +180,7 @@ export function useToolsPanel(
 			).some( ( [ , isSelected ] ) => isSelected );
 			setAreAllOptionalControlsHidden( allControlsHidden );
 		}
-	}, [ menuItems.optional, setAreAllOptionalControlsHidden ] );
+	}, [ menuItems, setAreAllOptionalControlsHidden ] );
 
 	const cx = useCx();
 	const classes = useMemo( () => {


### PR DESCRIPTION
## Description

➕ ➕ ➕ ➕ ➕ ➕ ➕ ➕ 

This change checks for default ToolsPanel items and, where they exist, disables the plus icon.

The plus icon should only appear where there are optional menu items only, and only when no optional item is selected.

The argument to limit the plus icon in this way is that there is the potential for it to cause confusion as to its purpose, particularly in the presence of a minus sign (where the control has a value).

<img width="267" alt="Screen Shot 2022-01-27 at 1 20 59 pm" src="https://user-images.githubusercontent.com/6458278/151280333-e8182b74-c198-4667-9171-116f8368d7c9.png">

See discussion over at https://github.com/WordPress/gutenberg/issues/38219#issuecomment-1022751087 for context

➕ ➕ ➕ ➕ ➕ ➕ ➕ ➕ 

## Testing Instructions

Pick a block that has some form of block supports with default entries for example the List Block `block.json` has Typography support.

Fire up the editor and check that the ellipses icon for the corresponding panel is always, regardless of which item you select or deselect. 

<img width="400" alt="Screen Shot 2022-01-27 at 12 52 23 pm" src="https://user-images.githubusercontent.com/6458278/151278574-c78d3d96-4518-4836-a185-9f8ad68b9075.png">

Now, remove the `"__experimentalDefaultControls"` object:

```js
	"supports": {
		"anchor": true,
		"className": false,
		"typography": {
			"fontSize": true,
			"__experimentalFontFamily": true,
			"lineHeight": true,
			"__experimentalFontStyle": true,
			"__experimentalFontWeight": true,
			"__experimentalLetterSpacing": true,
			"__experimentalTextTransform": true,
			"__experimentalDefaultControls": {    // <-- Remove this object
				"fontSize": true
			}
		},
```

Check that the plus icon is displayed when there are no optional controls selected.

<img width="400" alt="Screen Shot 2022-01-27 at 12 55 09 pm" src="https://user-images.githubusercontent.com/6458278/151278591-e722ffec-15f8-44d5-a2ce-c8eff3771de6.png">

Blocks that inject controls into the ToolsPanel, e.g., minimum height for the Cover Block, or drop cap for the Paragraph block should work similarly depending on whether the ToolsPanel Item `isShownByDefault` prop is true or false.

So if it's `true` the plus icon will not show since there's a default. If it's `false` it means the fill is optional, so, if there are no other defaults, a plus icon will display.

<img width="286" alt="Screen Shot 2022-01-27 at 1 16 13 pm" src="https://user-images.githubusercontent.com/6458278/151279920-6acea400-f724-4b3b-bdec-439ecf73e8c6.png">

Tests shall pass! 

`npm run test-unit packages/components/src/tools-panel/test/index.js`

Ensure the relevant story is still... relevant. 

` npm run storybook:dev`


## Types of changes
Design tool icon change.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
