### PR TITLE
Comment Template: Improve UX of inner block selection

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -53,15 +53,22 @@ function CommentTemplateInnerBlocks( {
 	);
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment === ( activeComment || firstComment ) ? (
-				children
-			) : (
-				<MemoizedCommentTemplatePreview
-					blocks={ blocks }
-					comment={ comment }
-					setActiveComment={ setActiveComment }
-				/>
-			) }
+			{ comment === ( activeComment || firstComment ) ? children : null }
+
+			{ /* To avoid flicker when switching active block contexts, a preview
+			is ALWAYS rendered and the preview for the active block is hidden. 
+			This ensures that when switching the active block, the component is not 
+			mounted again but rather it only toggles the `isHidden` prop.
+			
+			The same strategy is used for preventing the flicker in the Post Template
+			block. */ }
+			<MemoizedCommentTemplatePreview
+				blocks={ blocks }
+				comment={ comment }
+				setActiveComment={ setActiveComment }
+				isHidden={ comment === ( activeComment || firstComment ) }
+			/>
+
 			{ comment?.children?.length > 0 ? (
 				<CommentsList
 					comments={ comment.children }
@@ -74,7 +81,12 @@ function CommentTemplateInnerBlocks( {
 	);
 }
 
-const CommentTemplatePreview = ( { blocks, comment, setActiveComment } ) => {
+const CommentTemplatePreview = ( {
+	blocks,
+	comment,
+	setActiveComment,
+	isHidden,
+} ) => {
 	const blockPreviewProps = useBlockPreview( {
 		blocks,
 	} );
@@ -83,12 +95,22 @@ const CommentTemplatePreview = ( { blocks, comment, setActiveComment } ) => {
 		setActiveComment( comment );
 	};
 
+	// We have to hide the preview block if the `comment` props points to
+	// the curently active block!
+
+	// Or, to put it differently, every preview block is visible unless it is the
+	// currently active block - in this case we render its inner blocks.
+	const style = {
+		display: isHidden ? 'none' : undefined,
+	};
+
 	return (
 		<div
 			{ ...blockPreviewProps }
 			tabIndex={ 0 }
-			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 			role="button"
+			style={ style }
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
 			onClick={ handleOnClick }
 			onKeyPress={ handleOnClick }
 		/>

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -35,7 +35,7 @@ const TEMPLATE = [
  * @param {Array}  [props.comment]          - A comment object.
  * @param {Array}  [props.activeComment]    - The block that is currently active.
  * @param {Array}  [props.setActiveComment] - The setter for activeComment.
- * @param {Array}  [props.firstBlock]       - First comment in the array.
+ * @param {Array}  [props.firstComment]     - First comment in the array.
  * @param {Array}  [props.blocks]           - Array of blocks returned from
  *                                          getBlocks() in parent .
  * @return {WPElement}                 		Inner blocks of the Comment Template
@@ -44,7 +44,7 @@ function CommentTemplateInnerBlocks( {
 	comment,
 	activeComment,
 	setActiveComment,
-	firstBlock,
+	firstComment,
 	blocks,
 } ) {
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(
@@ -53,7 +53,7 @@ function CommentTemplateInnerBlocks( {
 	);
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment === ( activeComment || firstBlock ) ? (
+			{ comment === ( activeComment || firstComment ) ? (
 				children
 			) : (
 				<BlockPreview
@@ -105,7 +105,7 @@ const CommentsList = ( {
 						activeComment={ activeComment }
 						setActiveComment={ setActiveComment }
 						blocks={ blocks }
-						firstBlock={ comments[ 0 ] }
+						firstComment={ comments[ 0 ] }
 					/>
 				</BlockContextProvider>
 			) ) }

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -1,15 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockContextProvider,
-	BlockPreview,
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
+	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
@@ -56,10 +56,10 @@ function CommentTemplateInnerBlocks( {
 			{ comment === ( activeComment || firstComment ) ? (
 				children
 			) : (
-				<BlockPreview
+				<MemoizedCommentTemplatePreview
 					blocks={ blocks }
-					__experimentalLive
-					__experimentalOnClick={ () => setActiveComment( comment ) }
+					comment={ comment }
+					setActiveComment={ setActiveComment }
 				/>
 			) }
 			{ comment?.children?.length > 0 ? (
@@ -73,6 +73,29 @@ function CommentTemplateInnerBlocks( {
 		</li>
 	);
 }
+
+const CommentTemplatePreview = ( { blocks, comment, setActiveComment } ) => {
+	const blockPreviewProps = useBlockPreview( {
+		blocks,
+	} );
+
+	const handleOnClick = () => {
+		setActiveComment( comment );
+	};
+
+	return (
+		<div
+			{ ...blockPreviewProps }
+			tabIndex={ 0 }
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+			role="button"
+			onClick={ handleOnClick }
+			onKeyPress={ handleOnClick }
+		/>
+	);
+};
+
+const MemoizedCommentTemplatePreview = memo( CommentTemplatePreview );
 
 /**
  * Component that renders a list of (nested) comments. It is called recursively.


### PR DESCRIPTION


https://user-images.githubusercontent.com/5417266/151283278-6312a36a-3d84-4e8d-947d-a22ae643cb43.mov

Fixes https://github.com/WordPress/gutenberg/issues/37154 using the same technique as used in https://github.com/WordPress/gutenberg/pull/36431. 

Instead of using the `BlockPreview` component, the Comment Template block is now using the `useBlockPreview` hook. The part that seems to improve the UX is NOT rendering the inserters after each of the blocks inside of the Comment Template.

Also renamed `firstBlock` prop to `firstComment` for clarity.

The UX seems a lot better now. Two outstanding issues that I ll tackle in following PRs:
- There is still a small flicker when deselecting the Comments Query Loop when it switches from the editor view to preview.
- Sometimes the whole Comment Template is selected instead of the individual comment.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->