### PR TITLE
Navigation: Try fixing issue with submenu button in dark contexts.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -100,6 +100,18 @@
 	display: block;
 	position: static;
 	width: 100%;
+
+	// Colors need to work in both dark themes, and dark dropdown colors.
+	// This customization would be nice to retire in a refactor of the canvas appender button.
+	.block-editor-button-block-appender {
+		color: $white;
+		background: $gray-900;
+		padding: 0;
+		width: $button-size-small;
+		border-radius: $radius-block-ui;
+		margin-right: 0;
+		margin-left: auto;
+	}
 }
 
 // Hide when hovering.


### PR DESCRIPTION
## Description

When a dark background is detected in the theme, a `is-dark-theme` color is added to the body class so the user interface can be inverted. That can make the button invisible:
<img width="739" alt="Screenshot 2022-01-27 at 08 40 51" src="https://user-images.githubusercontent.com/1204802/151314592-a11f5b9e-d6f6-453a-832f-56f4df61b37b.png">

This doesn't work for the navigation block submenu appender, for two reasons:

1. The submenu itself can have a dark background, so the default dark button blends in regardless.
2. The submenu appender is custom specifically so it can be visible even when an adjacent button is selected, for easier menu building. See #36720.

This PR tweaks the visuals to make the button work in any context:
<img width="645" alt="Screenshot 2022-01-27 at 08 47 42" src="https://user-images.githubusercontent.com/1204802/151314867-0f46b6e3-0ab1-4206-9afb-2273197c255c.png">

<img width="658" alt="Screenshot 2022-01-27 at 08 47 48" src="https://user-images.githubusercontent.com/1204802/151314870-31192e18-a4be-41c7-b076-afd52b0fe18c.png">


## Testing Instructions

Build a navigation menu with submenus, try dark and light submenu background colors, ensure the plus is always visible.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
