### PR TITLE
Audio: Avoid error when locked

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -89,7 +89,7 @@ function AudioEdit( {
 			const embedBlock = createUpgradedEmbedBlock( {
 				attributes: { url: newSrc },
 			} );
-			if ( undefined !== embedBlock ) {
+			if ( undefined !== embedBlock && onReplace ) {
 				onReplace( embedBlock );
 				return;
 			}


### PR DESCRIPTION
## Description
The `onReplace` prop is undefined when the block is locked, this can cause an error if a user tried to replace the URL with an embeddable audio service provider.

## Testing Instructions
1. Add locked Audio from the example below to the post.
2. Use "Replace" and change to URL to Spotify or any embeddable audio service.
3. On the trunk, this will produce an error - "onReplace is not a function"
4. Build this branch and repeat an action. Replacement shouldn't produce an error.

```
<!-- wp:audio {"lock":{"remove":true,"move":true}} -->
<figure class="wp-block-audio"><audio controls src="https://freesound.org/data/previews/400/400861_6305509-hq.mp3"></audio><figcaption>"Ocean_Hitting_Rocks_Mendocino_01.aif"&nbsp;by&nbsp;<a rel="noreferrer noopener" href="https://freesound.org/people/bobv2" target="_blank">bobv2</a>&nbsp;is licensed under&nbsp;<a rel="noreferrer noopener" href="https://creativecommons.org/publicdomain/zero/1.0/?ref=openverse" target="_blank">CC0 1.0</a></figcaption></figure>
<!-- /wp:audio -->
```

## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
