### PR TITLE
Avoid unnecessary Post Formats re-renders

### DIFF
--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -64,6 +64,8 @@ export default function PostFormat() {
 	);
 
 	const formats = POST_FORMATS.filter( ( format ) => {
+		// Ensure current format is always in the set.
+		// The current format may not be a format supported by the theme.
 		return (
 			includes( supportedFormats, format.id ) || postFormat === format.id
 		);

--- a/packages/editor/src/components/post-format/index.js
+++ b/packages/editor/src/components/post-format/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, get, includes, union } from 'lodash';
+import { find, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -57,20 +57,17 @@ export default function PostFormat() {
 			return {
 				postFormat: _postFormat ?? 'standard',
 				suggestedFormat: getSuggestedPostFormat(),
-				// Ensure current format is always in the set.
-				// The current format may not be a format supported by the theme.
-				supportedFormats: union(
-					[ _postFormat ],
-					get( themeSupports, [ 'formats' ], [] )
-				),
+				supportedFormats: themeSupports.formats,
 			};
 		},
 		[]
 	);
 
-	const formats = POST_FORMATS.filter( ( format ) =>
-		includes( supportedFormats, format.id )
-	);
+	const formats = POST_FORMATS.filter( ( format ) => {
+		return (
+			includes( supportedFormats, format.id ) || postFormat === format.id
+		);
+	} );
 	const suggestion = find(
 		formats,
 		( format ) => format.id === suggestedFormat


### PR DESCRIPTION
## Description
A small performance tweak.

I noticed that Post Format select component was always rerendering when typing in the editor. The `supportedFormats` returned a new array even though its value rarely changes.

## Testing Instructions
1. Enable "Highlight updates when components render" in React DevTools.
2. In post open document sidebar and start typing.
3. Check that the "Post Format" component doesn't re-render.

## Screenshots <!-- if applicable -->

## Types of changes
Performance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
