### PR TITLE
Demo: entity hooks

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -2,22 +2,20 @@
  * WordPress dependencies
  */
 import { MenuGroup, MenuItem, MenuItemsChoice } from '@wordpress/components';
-import { useEntityId } from '@wordpress/core-data';
+import { useEntityId, useEntityRecords } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
-
-/**
- * Internal dependencies
- */
-import useNavigationMenu from '../use-navigation-menu';
 
 export default function NavigationMenuSelector( {
 	onSelect,
 	onCreateNew,
 	showCreate = false,
 } ) {
-	const { navigationMenus } = useNavigationMenu();
+	const navigationMenus = useEntityRecords( 'postType', 'wp_navigation', {
+		per_page: -1,
+		status: 'publish',
+	} );
 	const ref = useEntityId( 'postType', 'wp_navigation' );
 
 	return (
@@ -27,23 +25,25 @@ export default function NavigationMenuSelector( {
 					value={ ref }
 					onSelect={ ( selectedId ) =>
 						onSelect(
-							navigationMenus.find(
+							navigationMenus.records.find(
 								( post ) => post.id === selectedId
 							)
 						)
 					}
-					choices={ navigationMenus.map( ( { id, title } ) => {
-						const label = decodeEntities( title.rendered );
-						return {
-							value: id,
-							label,
-							'aria-label': sprintf(
-								/* translators: %s: The name of a menu. */
-								__( "Switch to '%s'" ),
-								label
-							),
-						};
-					} ) }
+					choices={ navigationMenus.records.map(
+						( { id, title } ) => {
+							const label = decodeEntities( title.rendered );
+							return {
+								value: id,
+								label,
+								'aria-label': sprintf(
+									/* translators: %s: The name of a menu. */
+									__( "Switch to '%s'" ),
+									label
+								),
+							};
+						}
+					) }
 				/>
 			</MenuGroup>
 			{ showCreate && (

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -122,29 +122,23 @@ export default function NavigationPlaceholder( {
 		onFinish( navigationMenu, blocks );
 	};
 
-	const {
-		isResolvingPages,
-		menus,
-		isResolvingMenus,
-		menuItems,
-		hasResolvedMenuItems,
-		hasPages,
-		hasMenus,
-	} = useNavigationEntities( selectedMenu );
+	const { menus, pages, menuItems } = useNavigationEntities( selectedMenu );
 
-	const isStillLoading = isResolvingPages || isResolvingMenus;
+	const isStillLoading = pages.isResolving || menus.isResolving;
 
 	const createFromMenu = useCallback(
 		( name ) => {
-			const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
+			const { innerBlocks: blocks } = menuItemsToBlocks(
+				menuItems.records
+			);
 			onFinishMenuCreation( blocks, name );
 		},
-		[ menuItems, menuItemsToBlocks, onFinish ]
+		[ menuItems.records, menuItemsToBlocks, onFinish ]
 	);
 
 	const onCreateFromMenu = ( name ) => {
 		// If we have menu items, create the block right away.
-		if ( hasResolvedMenuItems ) {
+		if ( menuItems.hasResolved ) {
 			createFromMenu( name );
 			return;
 		}
@@ -167,11 +161,11 @@ export default function NavigationPlaceholder( {
 	useEffect( () => {
 		// If the user selected a menu but we had to wait for menu items to
 		// finish resolving, then create the block once resolution finishes.
-		if ( isCreatingFromMenu && hasResolvedMenuItems ) {
+		if ( isCreatingFromMenu && menuItems.hasResolved ) {
 			createFromMenu( menuName );
 			setIsCreatingFromMenu( false );
 		}
-	}, [ isCreatingFromMenu, hasResolvedMenuItems, menuName ] );
+	}, [ isCreatingFromMenu, menuItems.hasResolved, menuName ] );
 
 	const { navigationMenus } = useNavigationMenu();
 
@@ -179,7 +173,7 @@ export default function NavigationPlaceholder( {
 
 	const showSelectMenus =
 		( canSwitchNavigationMenu || canUserCreateNavigation ) &&
-		( hasNavigationMenus || hasMenus );
+		( hasNavigationMenus || menus.hasRecords );
 
 	return (
 		<>
@@ -207,7 +201,7 @@ export default function NavigationPlaceholder( {
 										navigationMenus={ navigationMenus }
 										setSelectedMenu={ setSelectedMenu }
 										onFinish={ onFinish }
-										menus={ menus }
+										menus={ menus.records }
 										onCreateFromMenu={ onCreateFromMenu }
 										showClassicMenus={
 											canUserCreateNavigation
@@ -216,7 +210,7 @@ export default function NavigationPlaceholder( {
 									<hr />
 								</>
 							) : undefined }
-							{ canUserCreateNavigation && hasPages ? (
+							{ canUserCreateNavigation && pages.hasRecords ? (
 								<>
 									<Button
 										variant="tertiary"

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -21,8 +21,8 @@ import { decodeEntities } from '@wordpress/html-entities';
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
 import menuItemsToBlocks from '../../menu-items-to-blocks';
-import useNavigationMenu from '../../use-navigation-menu';
 import useCreateNavigationMenu from '../use-create-navigation-menu';
+import { useEntityRecords } from '@wordpress/core-data';
 
 const ExistingMenusDropdown = ( {
 	showNavigationMenus,
@@ -167,9 +167,12 @@ export default function NavigationPlaceholder( {
 		}
 	}, [ isCreatingFromMenu, menuItems.hasResolved, menuName ] );
 
-	const { navigationMenus } = useNavigationMenu();
+	const navigationMenus = useEntityRecords( 'postType', 'wp_navigation', {
+		per_page: -1,
+		status: 'publish',
+	} );
 
-	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasNavigationMenus = !! navigationMenus.records?.length;
 
 	const showSelectMenus =
 		( canSwitchNavigationMenu || canUserCreateNavigation ) &&
@@ -198,7 +201,9 @@ export default function NavigationPlaceholder( {
 										showNavigationMenus={
 											canSwitchNavigationMenu
 										}
-										navigationMenus={ navigationMenus }
+										navigationMenus={
+											navigationMenus.records
+										}
 										setSelectedMenu={ setSelectedMenu }
 										onFinish={ onFinish }
 										menus={ menus.records }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -8,14 +8,13 @@ import classnames from 'classnames';
  */
 import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { Disabled, Spinner } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import useNavigationMenu from '../use-navigation-menu';
 import useCreateNavigationMenu from './use-create-navigation-menu';
 
 const EMPTY_OBJECT = {};
@@ -70,7 +69,10 @@ export default function UnsavedInnerBlocks( {
 		[ isDisabled ]
 	);
 
-	const { hasResolvedNavigationMenus, navigationMenus } = useNavigationMenu();
+	const navigationMenus = useEntityRecords( 'postType', 'wp_navigation', {
+		per_page: -1,
+		status: 'publish',
+	} );
 
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
@@ -94,7 +96,7 @@ export default function UnsavedInnerBlocks( {
 			isSaving ||
 			savingLock.current ||
 			! hasResolvedDraftNavigationMenus ||
-			! hasResolvedNavigationMenus ||
+			! navigationMenus.hasResolved ||
 			! hasSelection
 		) {
 			return;
@@ -108,9 +110,9 @@ export default function UnsavedInnerBlocks( {
 		isDisabled,
 		isSaving,
 		hasResolvedDraftNavigationMenus,
-		hasResolvedNavigationMenus,
+		navigationMenus.hasResolved,
 		draftNavigationMenus,
-		navigationMenus,
+		navigationMenus.records,
 		hasSelection,
 		createNavigationMenu,
 		blocks,

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { serialize } from '@wordpress/blocks';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
+import { useEntityRecordCreate } from '@wordpress/core-data';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -12,7 +11,7 @@ import { useCallback } from '@wordpress/element';
 import useGenerateDefaultNavigationTitle from './use-generate-default-navigation-title';
 
 export default function useCreateNavigationMenu( clientId ) {
-	const { saveEntityRecord } = useDispatch( coreStore );
+	const { create } = useEntityRecordCreate( 'postType', 'wp_navigation' );
 	const generateDefaultTitle = useGenerateDefaultNavigationTitle( clientId );
 
 	// This callback uses data from the two placeholder steps and only creates
@@ -22,18 +21,13 @@ export default function useCreateNavigationMenu( clientId ) {
 			if ( ! title ) {
 				title = await generateDefaultTitle();
 			}
-			const record = {
+
+			return await create( {
 				title,
 				content: serialize( blocks ),
 				status: 'publish',
-			};
-
-			return await saveEntityRecord(
-				'postType',
-				'wp_navigation',
-				record
-			);
+			} );
 		},
-		[ serialize, saveEntityRecord ]
+		[ serialize, create ]
 	);
 }

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -39,12 +39,3 @@ export default function useNavigationEntities( menuId ) {
 		menuItems,
 	};
 }
-
-async function test() {
-	try {
-		const newRecord = await save();
-		// save worked 100%
-	} catch(e) {
-		// access to error
-	}
-}

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -39,3 +39,12 @@ export default function useNavigationEntities( menuId ) {
 		menuItems,
 	};
 }
+
+async function test() {
+	try {
+		const newRecord = await save();
+		// save worked 100%
+	} catch(e) {
+		// access to error
+	}
+}

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -1,144 +1,41 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-
-/**
- * @typedef {Object} NavigationEntitiesData
- * @property {Array|undefined} pages                - a collection of WP Post entity objects of post type "Page".
- * @property {boolean}         isResolvingPages     - indicates whether the request to fetch pages is currently resolving.
- * @property {boolean}         hasResolvedPages     - indicates whether the request to fetch pages has finished resolving.
- * @property {Array|undefined} menus                - a collection of Menu entity objects.
- * @property {boolean}         isResolvingMenus     - indicates whether the request to fetch menus is currently resolving.
- * @property {boolean}         hasResolvedMenus     - indicates whether the request to fetch menus has finished resolving.
- * @property {Array|undefined} menusItems           - a collection of Menu Item entity objects for the current menuId.
- * @property {boolean}         hasResolvedMenuItems - indicates whether the request to fetch menuItems has finished resolving.
- * @property {boolean}         hasPages             - indicates whether there is currently any data for pages.
- * @property {boolean}         hasMenus             - indicates whether there is currently any data for menus.
- */
+import { useEntityRecords } from '@wordpress/core-data';
 
 /**
  * Manages fetching and resolution state for all entities required
  * for the Navigation block.
  *
  * @param {number} menuId the menu for which to retrieve menuItem data.
- * @return { NavigationEntitiesData } the entity data.
+ * @return { Object } the entity data.
  */
 export default function useNavigationEntities( menuId ) {
-	return {
-		...usePageEntities(),
-		...useMenuEntities(),
-		...useMenuItemEntities( menuId ),
-	};
-}
-
-function useMenuEntities() {
-	const { menus, isResolvingMenus, hasResolvedMenus } = useSelect(
-		( select ) => {
-			const { getMenus, isResolving, hasFinishedResolution } = select(
-				coreStore
-			);
-
-			const menusParameters = [ { per_page: -1, context: 'view' } ];
-
-			return {
-				menus: getMenus( ...menusParameters ),
-				isResolvingMenus: isResolving( 'getMenus', menusParameters ),
-				hasResolvedMenus: hasFinishedResolution(
-					'getMenus',
-					menusParameters
-				),
-			};
+	const menus = useEntityRecords( 'root', 'menu', {
+		per_page: -1,
+		context: 'view',
+	} );
+	const pages = useEntityRecords( 'postType', 'page', {
+		parent: 0,
+		order: 'asc',
+		orderby: 'id',
+		per_page: -1,
+		context: 'view',
+	} );
+	const menuItems = useEntityRecords(
+		'root',
+		'menuItem',
+		{
+			menus: menuId,
+			per_page: -1,
+			context: 'view',
 		},
-		[]
+		{ runIf: menuId !== undefined }
 	);
 
 	return {
 		menus,
-		isResolvingMenus,
-		hasResolvedMenus,
-		hasMenus: !! ( hasResolvedMenus && menus?.length ),
-	};
-}
-
-function useMenuItemEntities( menuId ) {
-	const { menuItems, hasResolvedMenuItems } = useSelect(
-		( select ) => {
-			const { getMenuItems, hasFinishedResolution } = select( coreStore );
-
-			const hasSelectedMenu = menuId !== undefined;
-			const menuItemsParameters = hasSelectedMenu
-				? [
-						{
-							menus: menuId,
-							per_page: -1,
-							context: 'view',
-						},
-				  ]
-				: undefined;
-
-			return {
-				menuItems: hasSelectedMenu
-					? getMenuItems( ...menuItemsParameters )
-					: undefined,
-				hasResolvedMenuItems: hasSelectedMenu
-					? hasFinishedResolution(
-							'getMenuItems',
-							menuItemsParameters
-					  )
-					: false,
-			};
-		},
-		[ menuId ]
-	);
-
-	return {
-		menuItems,
-		hasResolvedMenuItems,
-	};
-}
-
-function usePageEntities() {
-	const { pages, isResolvingPages, hasResolvedPages } = useSelect(
-		( select ) => {
-			const {
-				getEntityRecords,
-				isResolving,
-				hasFinishedResolution,
-			} = select( coreStore );
-
-			const pagesParameters = [
-				'postType',
-				'page',
-				{
-					parent: 0,
-					order: 'asc',
-					orderby: 'id',
-					per_page: -1,
-					context: 'view',
-				},
-			];
-
-			return {
-				pages: getEntityRecords( ...pagesParameters ) || null,
-				isResolvingPages: isResolving(
-					'getEntityRecords',
-					pagesParameters
-				),
-				hasResolvedPages: hasFinishedResolution(
-					'getEntityRecords',
-					pagesParameters
-				),
-			};
-		},
-		[]
-	);
-
-	return {
 		pages,
-		isResolvingPages,
-		hasResolvedPages,
-		hasPages: !! ( hasResolvedPages && pages?.length ),
+		menuItems,
 	};
 }

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -1,91 +1,16 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useEntityRecord } from '@wordpress/core-data';
 
 export default function useNavigationMenu( ref ) {
-	return useSelect(
-		( select ) => {
-			const {
-				getEntityRecord,
-				getEditedEntityRecord,
-				getEntityRecords,
-				hasFinishedResolution,
-				canUser,
-			} = select( coreStore );
+	const navigationMenu = useEntityRecord( 'postType', 'wp_navigation', ref );
 
-			const navigationMenuSingleArgs = [
-				'postType',
-				'wp_navigation',
-				ref,
-			];
-			const rawNavigationMenu = ref
-				? getEntityRecord( ...navigationMenuSingleArgs )
-				: null;
-			let navigationMenu = ref
-				? getEditedEntityRecord( ...navigationMenuSingleArgs )
-				: null;
-
-			// getEditedEntityRecord will return the post regardless of status.
-			// Therefore if the found post is not published then we should ignore it.
-			if ( navigationMenu?.status !== 'publish' ) {
-				navigationMenu = null;
-			}
-
-			const hasResolvedNavigationMenu = ref
-				? hasFinishedResolution(
-						'getEditedEntityRecord',
-						navigationMenuSingleArgs
-				  )
-				: false;
-
-			const navigationMenuMultipleArgs = [
-				'postType',
-				'wp_navigation',
-				{ per_page: -1, status: 'publish' },
-			];
-			const navigationMenus = getEntityRecords(
-				...navigationMenuMultipleArgs
-			);
-
-			const canSwitchNavigationMenu = ref
-				? navigationMenus?.length > 1
-				: navigationMenus?.length > 0;
-
-			return {
-				isNavigationMenuResolved: hasResolvedNavigationMenu,
-				isNavigationMenuMissing:
-					! ref ||
-					( hasResolvedNavigationMenu && ! rawNavigationMenu ),
-				canSwitchNavigationMenu,
-				hasResolvedNavigationMenus: hasFinishedResolution(
-					'getEntityRecords',
-					navigationMenuMultipleArgs
-				),
-				navigationMenu,
-				navigationMenus,
-				canUserUpdateNavigationEntity: ref
-					? canUser( 'update', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserUpdateNavigationEntity: hasFinishedResolution(
-					'canUser',
-					[ 'update', 'navigation', ref ]
-				),
-				canUserDeleteNavigationEntity: ref
-					? canUser( 'delete', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserDeleteNavigationEntity: hasFinishedResolution(
-					'canUser',
-					[ 'delete', 'navigation', ref ]
-				),
-				canUserCreateNavigation: canUser( 'create', 'navigation' ),
-				hasResolvedCanUserCreateNavigation: hasFinishedResolution(
-					'canUser',
-					[ 'create', 'navigation' ]
-				),
-			};
-		},
-		[ ref ]
-	);
+	return {
+		isNavigationMenuMissing: navigationMenu.isMissing,
+		navigationMenu:
+			navigationMenu.record?.status !== 'publish'
+				? null
+				: navigationMenu.record,
+	};
 }


### PR DESCRIPTION
DO NOT MERGE

This PR showcases how https://github.com/WordPress/gutenberg/pull/38135/files and https://github.com/WordPress/gutenberg/pull/38134 enable more succinct code.

The key part are changes in:
* `packages/block-library/src/navigation/use-navigation-entities.js`
* `packages/block-library/src/navigation/use-navigation-menu.js`