### PR TITLE
Avoid unnecessary Template panel re-renders

### DIFF
--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -53,24 +53,17 @@ export function TemplatePanel() {
 			select( editorStore ).getEditorSettings().supportsTemplateMode &&
 			_isViewable;
 
-		const wpTemplates = getEntityRecords( 'postType', 'wp_template', {
+		const templateRecords = getEntityRecords( 'postType', 'wp_template', {
 			post_type: currentPostType,
 			per_page: -1,
 		} );
-
-		const newAvailableTemplates = fromPairs(
-			( wpTemplates || [] ).map( ( { slug, title } ) => [
-				slug,
-				title.rendered,
-			] )
-		);
 
 		return {
 			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
 			selectedTemplate: getEditedPostAttribute( 'template' ),
 			availableTemplates: getEditorSettings().availableTemplates,
-			fetchedTemplates: newAvailableTemplates,
+			fetchedTemplates: templateRecords,
 			template: _supportsTemplateMode && getEditedPostTemplate(),
 			isViewable: _isViewable,
 			supportsTemplateMode: _supportsTemplateMode,
@@ -81,7 +74,12 @@ export function TemplatePanel() {
 	const templates = useMemo( () => {
 		return {
 			...availableTemplates,
-			...fetchedTemplates,
+			...fromPairs(
+				( fetchedTemplates ?? [] ).map( ( { slug, title } ) => [
+					slug,
+					title.rendered,
+				] )
+			),
 		};
 	}, [ availableTemplates, fetchedTemplates ] );
 


### PR DESCRIPTION
## Description
Another small perf tweak. Similar to #38285.

The TemplatePanel was re-rendering when typing in the editor. We should avoid mapping/filtering objects inside the `useSelect` hook.

## Testing Instructions
1. Enable "Highlight updates when components render" in React DevTools.
2. In the post open the document sidebar and start typing.
3. Check that the "Template" panel doesn't re-render.

## Types of changes
Performance

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
