### PR TITLE
Add: End to end test for the block transforms.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Keep styles on block transforms Should keep colors during a transform 1`] = `
+"<!-- wp:paragraph {\\"textColor\\":\\"luminous-vivid-orange\\"} -->
+<p class=\\"has-luminous-vivid-orange-color has-text-color\\" id=\\"heading\\">Heading</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Keep styles on block transforms Should keep the font size during a transform from multiple blocks into a single one 1`] = `
+"<!-- wp:list {\\"fontSize\\":\\"large\\"} -->
+<ul class=\\"has-large-font-size\\"><li>Line 1 to be made large</li><li>Line 2 to be made large</li><li>Line 3 to be made large</li></ul>
+<!-- /wp:list -->"
+`;
+
+exports[`Keep styles on block transforms Should keep the font size during a transform from multiple blocks into multiple blocks 1`] = `
+"<!-- wp:heading {\\"fontSize\\":\\"large\\"} -->
+<h2 class=\\"has-large-font-size\\" id=\\"line-1-to-be-made-large\\">Line 1 to be made large</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {\\"fontSize\\":\\"large\\"} -->
+<h2 class=\\"has-large-font-size\\" id=\\"line-2-to-be-made-large\\">Line 2 to be made large</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {\\"fontSize\\":\\"large\\"} -->
+<h2 class=\\"has-large-font-size\\" id=\\"line-3-to-be-made-large\\">Line 3 to be made large</h2>
+<!-- /wp:heading -->"
+`;
+
+exports[`Keep styles on block transforms Should not include styles in the group block when grouping a block 1`] = `
+"<!-- wp:group -->
+<div class=\\"wp-block-group\\"><!-- wp:paragraph {\\"fontSize\\":\\"large\\"} -->
+<p class=\\"has-large-font-size\\">Line 1 to be made large</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/keep-styles-on-block-transforms.test.js
+++ b/packages/e2e-tests/specs/editor/various/keep-styles-on-block-transforms.test.js
@@ -1,0 +1,85 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	clickBlockAppender,
+	createNewPost,
+	pressKeyWithModifier,
+	transformBlockTo,
+	getEditedPostContent,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Keep styles on block transforms', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	it( 'Should keep colors during a transform', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '## Heading' );
+		const [ colorPanelToggle ] = await page.$x(
+			"//button[./span[contains(text(),'Color')]]"
+		);
+		await colorPanelToggle.click();
+
+		const textColorButton = await page.waitForSelector(
+			'.block-editor-panel-color-gradient-settings__item'
+		);
+		await textColorButton.click();
+
+		const colorButtonSelector = `//button[@aria-label='Color: Luminous vivid orange']`;
+		const [ colorButton ] = await page.$x( colorButtonSelector );
+		await colorButton.click();
+		await page.waitForXPath(
+			`${ colorButtonSelector }[@aria-pressed='true']`
+		);
+		await page.click( 'h2[data-type="core/heading"]' );
+		await transformBlockTo( 'Paragraph' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Should keep the font size during a transform from multiple blocks into a single one', async () => {
+		// Create a paragraph block with some content.
+		await clickBlockAppender();
+		await page.keyboard.type( 'Line 1 to be made large' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 2 to be made large' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 3 to be made large' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await page.click(
+			'[role="radiogroup"][aria-label="Font size"] [aria-label="Large"]'
+		);
+		await transformBlockTo( 'List' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Should keep the font size during a transform from multiple blocks into multiple blocks', async () => {
+		// Create a paragraph block with some content.
+		await clickBlockAppender();
+		await page.keyboard.type( 'Line 1 to be made large' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 2 to be made large' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Line 3 to be made large' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await pressKeyWithModifier( 'shift', 'ArrowUp' );
+		await page.click(
+			'[role="radiogroup"][aria-label="Font size"] [aria-label="Large"]'
+		);
+		await transformBlockTo( 'Heading' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'Should not include styles in the group block when grouping a block', async () => {
+		// Create a paragraph block with some content.
+		await clickBlockAppender();
+		await page.keyboard.type( 'Line 1 to be made large' );
+		await page.click(
+			'[role="radiogroup"][aria-label="Font size"] [aria-label="Large"]'
+		);
+		await transformBlockTo( 'Group' );
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/37596.

Adds an end-to-end test to make sure the styles (typography and color) are correctly kept during a block transform.
cc: @ntsekouras

## Testing Instructions
I verified the end-to-end tests passed.
