### PR TITLE
Update Contributing Guidelines to reflect Dual-License

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
--   All WordPress projects are [licensed under the GPLv2+](/LICENSE.md), and all contributions to Gutenberg will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
+-   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under both the GPLv2+ and MPL licenses as stated in [Gutenberg's License](/LICENSE.md).
 
 ## Reporting Security Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
--   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under both the GPLv2+ and MPL licenses as stated in [Gutenberg's License](/LICENSE.md).
+-   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under the license stated in [Gutenberg's License](/LICENSE.md).
 
 ## Reporting Security Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
--   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under the license stated in [Gutenberg's License](/LICENSE.md).
+-   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [Gutenberg's License](/LICENSE.md).
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
## Description
Updating the Contributing Guidelines to reflect Gutenberg's Dual-License for new contributions. I missed this [when I updated the license](https://github.com/WordPress/gutenberg/pull/30383). 

Thanks to @jeffpaul for catching this. 🙇 

## Types of changes
Documentation

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [X] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [X] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [X] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
