### PR TITLE
ToolsPanel StoryBook: removing knobs in favour of controls

### DIFF
--- a/packages/components/src/tools-panel/stories/index.js
+++ b/packages/components/src/tools-panel/stories/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
-import { boolean } from '@storybook/addon-knobs';
 
 /**
  * WordPress dependencies
@@ -24,9 +23,6 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 export default {
 	title: 'Components (Experimental)/ToolsPanel',
 	component: ToolsPanel,
-	parameters: {
-		knobs: { disable: false },
-	},
 };
 
 export const _default = () => {
@@ -139,7 +135,7 @@ export const WithNonToolsPanelItems = () => {
 	);
 };
 
-export const WithOptionalItemsPlusIcon = () => {
+export const WithOptionalItemsPlusIcon = ( { isShownByDefault } ) => {
 	const [ height, setHeight ] = useState();
 	const [ width, setWidth ] = useState();
 	const [ minWidth, setMinWidth ] = useState();
@@ -150,21 +146,19 @@ export const WithOptionalItemsPlusIcon = () => {
 		setMinWidth( undefined );
 	};
 
-	const includeDefaultControls = boolean( 'includeDefaultControls', false );
-
 	return (
 		<PanelWrapperView>
 			<Panel>
 				<ToolsPanel
 					label="Tools Panel (optional items only)"
 					resetAll={ resetAll }
-					key={ includeDefaultControls }
+					key={ isShownByDefault }
 				>
 					<SingleColumnItem
 						hasValue={ () => !! minWidth }
 						label="Minimum width"
 						onDeselect={ () => setMinWidth( undefined ) }
-						isShownByDefault={ includeDefaultControls }
+						isShownByDefault={ isShownByDefault }
 					>
 						<UnitControl
 							label="Minimum width"
@@ -200,6 +194,10 @@ export const WithOptionalItemsPlusIcon = () => {
 			</Panel>
 		</PanelWrapperView>
 	);
+};
+
+WithOptionalItemsPlusIcon.args = {
+	isShownByDefault: false,
 };
 
 const { Fill: ToolsPanelItems, Slot } = createSlotFill( 'ToolsPanelSlot' );


### PR DESCRIPTION
## Description

Over in https://github.com/WordPress/gutenberg/pull/38262#pullrequestreview-864593104 @ciampo pointed out that the knobs addon for Storybook is deprecated. 

This PR updates the changes in #38262 to use controls instead.

## Testing Instructions

```bash
npm run storybook:dev
```

Then head to http://localhost:50240/?path=/story/components-experimental-toolspanel--with-optional-items-plus-icon

The control should toggle a default control on and off. On and off. On and off.

## Screenshots <!-- if applicable -->

![Jan-28-2022 10-57-12](https://user-images.githubusercontent.com/6458278/151463151-ea5d53d0-a8e0-4f6f-bdb4-ec5e83aa8fec.gif)


## Types of changes
Janitorial

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
