### PR TITLE
Gallery block: fix bug with link destination default option not being set

### DIFF
--- a/packages/block-library/src/gallery/constants.js
+++ b/packages/block-library/src/gallery/constants.js
@@ -1,3 +1,5 @@
 export const LINK_DESTINATION_NONE = 'none';
 export const LINK_DESTINATION_MEDIA = 'media';
 export const LINK_DESTINATION_ATTACHMENT = 'attachment';
+export const LINK_DESTINATION_MEDIA_WP_CORE = 'file';
+export const LINK_DESTINATION_ATTACHMENT_WP_CORE = 'post';

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -5,6 +5,8 @@ import {
 	LINK_DESTINATION_ATTACHMENT,
 	LINK_DESTINATION_MEDIA,
 	LINK_DESTINATION_NONE,
+	LINK_DESTINATION_MEDIA_WP_CORE,
+	LINK_DESTINATION_ATTACHMENT_WP_CORE,
 } from './constants';
 import {
 	LINK_DESTINATION_ATTACHMENT as IMAGE_LINK_DESTINATION_ATTACHMENT,
@@ -21,24 +23,17 @@ import {
  * @return {Object}            New attributes to assign to image block.
  */
 export function getHrefAndDestination( image, destination ) {
-	// Need to determine the URL that the selected destination maps to.
 	// Gutenberg and WordPress use different constants so if image_default_link_type
-	// option is set we need to map file -> media and post -> attachment
-	switch ( destination ) {
-		case 'file':
-			destination = LINK_DESTINATION_MEDIA;
-			break;
-		case 'post':
-			destination = LINK_DESTINATION_ATTACHMENT;
-			break;
-	}
+	// option is set we need to map from the WP Core values.
 
 	switch ( destination ) {
+		case LINK_DESTINATION_MEDIA_WP_CORE:
 		case LINK_DESTINATION_MEDIA:
 			return {
 				href: image?.source_url || image?.url, // eslint-disable-line camelcase
 				linkDestination: IMAGE_LINK_DESTINATION_MEDIA,
 			};
+		case LINK_DESTINATION_ATTACHMENT_WP_CORE:
 		case LINK_DESTINATION_ATTACHMENT:
 			return {
 				href: image?.link,

--- a/packages/block-library/src/gallery/utils.js
+++ b/packages/block-library/src/gallery/utils.js
@@ -22,8 +22,17 @@ import {
  */
 export function getHrefAndDestination( image, destination ) {
 	// Need to determine the URL that the selected destination maps to.
-	// Gutenberg and WordPress use different constants so the new link
-	// destination also needs to be tweaked.
+	// Gutenberg and WordPress use different constants so if image_default_link_type
+	// option is set we need to map file -> media and post -> attachment
+	switch ( destination ) {
+		case 'file':
+			destination = LINK_DESTINATION_MEDIA;
+			break;
+		case 'post':
+			destination = LINK_DESTINATION_ATTACHMENT;
+			break;
+	}
+
 	switch ( destination ) {
 		case LINK_DESTINATION_MEDIA:
 			return {


### PR DESCRIPTION
## Description
Fixes:  #38302

With the refactored Gallery block the `image_default_link_type` option is not being applied to new Images.

## Testing Instructions

- On test site go to `/wp-admin/options.php` and set `image_default_link_type` to `file`
- Add a new Gallery and add an image to it and make sure the Image is linked to `Media`
- On test site go to `/wp-admin/options.php` and set `image_default_link_type` to `post`
- Add a new Gallery and add an image to it and make sure the Image is linked to `Attachment`
- On test site go to `/wp-admin/options.php` and clear the `image_default_link_type` setting
- Add a new Gallery and add an image to it and make sure the Image does not have a link set

## Screenshots 
Before:
![gallery-link-before](https://user-images.githubusercontent.com/3629020/151474619-5bf80974-ba00-47d8-bc65-a5e13e64b1a4.gif)

After:
![gallery-link-after](https://user-images.githubusercontent.com/3629020/151474695-997fcd15-a73e-4544-bbe0-ece6b4bb4822.gif)

