### PR TITLE
Gallery block :Remove the empty media placeholder wrapper when there are images 

### DIFF
--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -70,12 +70,14 @@ export const Gallery = ( props ) => {
 		>
 			{ children }
 
-			<View
-				className="blocks-gallery-media-placeholder-wrapper"
-				onClick={ removeCaptionFocus }
-			>
-				{ mediaPlaceholder }
-			</View>
+			{ isSelected && ! children && (
+				<View
+					className="blocks-gallery-media-placeholder-wrapper"
+					onClick={ removeCaptionFocus }
+				>
+					{ mediaPlaceholder }
+				</View>
+			) }
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }


### PR DESCRIPTION
## Description

The gallery caption edit test seems to have become flakey, which may be due to there being an empty media placeholder div now that the add images option has moved to the toolbar - so this PR removes that empty div.

## Testing Instructions

- Make sure `specs/editor/blocks/gallery.test.js` e2e test runs locally and in CI
- Add a Gallery and make sure the media placeholder shows when empty, that it disappears when images are added and that there is no empty div between the last gallery image and the gallery caption.

