### PR TITLE
Site Logo: Avoid unnecessary re-renders

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -396,11 +396,7 @@ export default function LogoEdit( {
 			siteLogoId: _siteLogoId,
 			canUserEdit: _canUserEdit,
 			url: siteData?.url,
-			mediaItemData: mediaItem && {
-				id: mediaItem.id,
-				url: mediaItem.source_url,
-				alt: mediaItem.alt_text,
-			},
+			mediaItemData: mediaItem,
 			isRequestingMediaItem: _isRequestingMediaItem,
 			siteIconId: _siteIconId,
 		};
@@ -427,9 +423,9 @@ export default function LogoEdit( {
 
 	let alt = null;
 	if ( mediaItemData ) {
-		alt = mediaItemData.alt;
-		if ( logoUrl !== mediaItemData.url ) {
-			setLogoUrl( mediaItemData.url );
+		alt = mediaItemData.alt_text;
+		if ( logoUrl !== mediaItemData.source_url ) {
+			setLogoUrl( mediaItemData.source_url );
 		}
 	}
 


### PR DESCRIPTION
## Description
Another small performance tweak.
Similar to #38285 and #38292.

The Site Logo block was re-rendering when typing in the editor since returned `mediaItemData` was a new object every time.

## Testing Instructions
1. Enable "Highlight updates when components render" in React DevTools.
2. Add Site Logo and Paragraph block to the post editor.
3. Start typing in paragraph check that Site Logo doesn't re-render as we type.

## Types of changes
Performance

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
