### PR TITLE
Script: Ensure that `start` works when React Fast Refresh scripts missing

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Ensure that React Fast Refresh is not wired when it isn't explicitly enabled with `--hot` CLI argument when running the `start` command.
+
 ## 20.0.0 (2022-01-27)
 
 ### Breaking Changes
@@ -17,7 +21,7 @@
 ### New Features
 
 -   Added a new `plugin-zip` command to create a zip file for a WordPress plugin ([#37687](https://github.com/WordPress/gutenberg/pull/37687)).
--   Added optional support for React Fast Refresh in the `start` command. It can be activated with `--hot` CLI argument ([#28273](https://github.com/WordPress/gutenberg/pull/28273)).
+-   Added optional support for React Fast Refresh in the `start` command. It can be activated with `--hot` CLI argument ([#28273](https://github.com/WordPress/gutenberg/pull/28273)). For now, it requires that WordPress has the [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed.
 -   Automatically copy `block.json` files located in the `src` folder and its subfolders to the output folder (`build` by default) ([#37612](https://github.com/WordPress/gutenberg/pull/37612)).
 -   Scan the `src` directory for `block.json` files to detect defined scripts to use them as entry points with the `start` and `build` commands. ([#37661](https://github.com/WordPress/gutenberg/pull/37661)).
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -351,12 +351,12 @@ _Example:_
 This is how you execute the script with presented setup:
 
 -   `npm start` - starts the build for development.
--   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the code.
+-   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the files.
 -   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
--   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code.
+-   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code. _For now, it requires that WordPress has the [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed._
 -   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack--devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -22,6 +22,7 @@ const postcssPlugins = require( '@wordpress/postcss-plugins-preset' );
 const {
 	fromConfigRoot,
 	hasBabelConfig,
+	hasArgInCLI,
 	hasCssnanoConfig,
 	hasPostCSSConfig,
 	getWebpackEntryPoints,
@@ -33,6 +34,7 @@ let target = 'browserslist';
 if ( ! browserslist.findConfig( '.' ) ) {
 	target += ':' + fromConfigRoot( '.browserslistrc' );
 }
+const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 
 const cssLoaders = [
 	{
@@ -159,7 +161,7 @@ const config = {
 									),
 								],
 								plugins: [
-									! isProduction &&
+									hasReactFastRefresh &&
 										require.resolve(
 											'react-refresh/babel'
 										),
@@ -238,7 +240,7 @@ const config = {
 		// MiniCSSExtractPlugin to extract the CSS thats gets imported into JavaScript.
 		new MiniCSSExtractPlugin( { filename: '[name].css' } ),
 		// React Fast Refresh.
-		! isProduction && new ReactRefreshWebpackPlugin(),
+		hasReactFastRefresh && new ReactRefreshWebpackPlugin(),
 		// WP_NO_EXTERNALS global variable controls whether scripts' assets get
 		// generated, and the default externals set.
 		! process.env.WP_NO_EXTERNALS &&


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Reported by @vena in https://github.com/WordPress/gutenberg/pull/28273#issuecomment-1023747242:

> I've created a little test plugin project at https://github.com/vena/wps-test - it uses @wordpress/scripts 20.0.0, but all it does is enqueue an editor script that should pop alert('hello!')
> 
> first thing that happens when I run npm start (note, no --hot flag in package.json), I get a warning:
> 
> `<w> [ReactRefreshPlugin] Hot Module Replacement (HMR) is not enabled! React Refresh requires HMR to function properly.`
> 
> Activating the plugin in a fresh WP 5.9 docker container and entering the editor, the first thing I noticed was that the test plugin's enqueued script wasn't loading. For some reason WP won't load it if 'wp-react-refresh-runtime' is in the deps of the wp_enqueue_script call. 
> 
> That's weird and I don't know why it's doing that, it wasn't doing that in another plugin i'm working on that made me post my last comment... but I'm not using that dependency anyway, and I get the same error, so I leave it out of the deps array for purposes of demonstration.
> 
> Reload the post editor, and dev console reports:
> 
> ![image](https://user-images.githubusercontent.com/867733/151461211-080efe44-c44d-4e46-8639-66e7a706204c.png)
> 
> My alert never gets a chance to run.
> 

Confirmed on Slack by emeaguiar on WordPress Slack (link requires registration at https://make.wordpress.org/chat):

https://wordpress.slack.com/archives/C5UNMSU4R/p1643316217073600

> I seem to be having an issue with `@wordpress/create-block`. Running `npm start` just makes the block disappear, I need to be running npm run build to fix it, am I doing something wrong?

https://user-images.githubusercontent.com/699132/151501730-985499f0-13bd-48e4-b57f-2a38d266f6ae.mp4

The fix proposed ensures that React Fast Refresh is only wired when the `--hot` flag is passed when running `wp-scripts start --hot`. I also included a note in the documentation and changelog that React Fast Refresh requires the Gutenberg plugin installed (one of the recent versions) and WordPress needs to have `SCRIPT_DEBUG` flag set to true.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

Pick a block plugin that uses `@wordpress/scripts` from this PR.

One way to test it is to run:

```js
npx wp-create-block esnext-test --no-wp-scripts
cd esnext-test
../node_modules/.bin/wp-scripts build start
```

You need to ensure that the plugin is located in `/wp-content/plugins/` and it's activated.

Ensure that the plugin works with `SCRIPT_DEBUG` set to `false` in WordPress config.
Ensure that the plugin works with `SCRIPT_DEBUG` set to `true` in WordPress config and no Gutenberg plugin installed.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
