### PR TITLE
Fix: npm script error on Windows (api-docs:ref)

### DIFF
--- a/bin/api-docs/update-api-docs.js
+++ b/bin/api-docs/update-api-docs.js
@@ -24,21 +24,24 @@ const { readFile } = require( 'fs' ).promises;
  *
  * @type {string}
  */
-const ROOT_DIR = resolve( __dirname, '../..' );
+const ROOT_DIR = resolve( __dirname, '../..' ).replace( /\\/g, '/' );
 
 /**
  * Path to packages directory.
  *
  * @type {string}
  */
-const PACKAGES_DIR = resolve( ROOT_DIR, 'packages' );
+const PACKAGES_DIR = resolve( ROOT_DIR, 'packages' ).replace( /\\/g, '/' );
 
 /**
  * Path to data documentation directory.
  *
  * @type {string}
  */
-const DATA_DOCS_DIR = resolve( ROOT_DIR, 'docs/reference-guides/data' );
+const DATA_DOCS_DIR = resolve( ROOT_DIR, 'docs/reference-guides/data' ).replace(
+	/\\/g,
+	'/'
+);
 
 /**
  * Pattern matching start token of a README file.


### PR DESCRIPTION
## Description

Related issue: https://github.com/WordPress/gutenberg/issues/37123

When I run the npm run `api-docs:ref` script on Windows OS, the pattern string in `glob.stream` is a mixture of forward slashes and backslashes.

Like this:

```javascript
console.log( `${ PACKAGES_DIR }/${ getPackagePattern( files ) }/README.md` );

→ D:\path\to\gutenberg\packages/*/README.md
```

The cause is that backslashes (Windows separator) are no longer converted to forward slashes in glob expressions from fast-glob v3.0.0.

In this PR, I added a process to replace backslashes with forward slashes in the generation of various paths.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
