### PR TITLE
[RNMobile] Silence `act` warnings triggered after test finishes

### DIFF
--- a/test/native/jest.config.js
+++ b/test/native/jest.config.js
@@ -25,7 +25,12 @@ module.exports = {
 	// Automatically clear mock calls and instances between every test
 	clearMocks: true,
 	preset: 'react-native',
-	setupFiles: [ '<rootDir>/' + configPath + '/setup.js' ],
+	setupFiles: [
+		'<rootDir>/' + configPath + '/setup.js',
+		// Disable React Native Testing Library auto-cleanup to provide our own implementation.
+		// Reference: https://callstack.github.io/react-native-testing-library/docs/migration-v2#auto-cleanup
+		'<rootDir>/node_modules/@testing-library/react-native/dont-cleanup-after-each.js',
+	],
 	setupFilesAfterEnv: [ '<rootDir>/' + configPath + '/setup-after-env.js' ],
 	testMatch: [
 		'**/test/*.native.[jt]s?(x)',

--- a/test/native/setup-after-env.js
+++ b/test/native/setup-after-env.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { cleanup } from '@testing-library/react-native';
+
+/**
  * Internal dependencies
  */
 import { toBeVisible } from './matchers/to-be-visible';
@@ -7,3 +12,9 @@ import { toBeVisible } from './matchers/to-be-visible';
 expect.extend( {
 	toBeVisible,
 } );
+
+// Automatically cleanup mounted React trees after rendering components with the React
+// Native Testing Library. Although this is already done by the library, we provide our
+// own logic in order to prevent unexpected "act" warnings after the test finishes.
+// Reference: https://callstack.github.io/react-native-testing-library/docs/api#cleanup
+afterEach( cleanup );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes https://github.com/WordPress/gutenberg/issues/38332.

After investigating further following the findings posted in https://github.com/WordPress/gutenberg/pull/38052, I realized that the `act` warnings are caused by [this line](https://github.com/callstack/react-native-testing-library/blob/a010ffdbca906615279ecc3abee423525e528101/src/index.js#L13) related to the auto cleanup logic of tests. If the test finishes before any of the Redux selector resolver has finished, React state updates would happen after the test is finished and before the editor is unmounted hence, the React Native Testing library will detect them and display the `act` warnings.

As a workaround, I overrode in this PR the auto cleanup logic of the React Native Testing library and provided our own implementation, based on the examples provided by the library in relation to the [`cleanup` function](https://callstack.github.io/react-native-testing-library/docs/api#cleanup).

**UPDATE:** This approach is based on the fact that it's safe to omit the React tree updates, produced by the Redux selectors resolvers triggered during the editor initialization (i.e. the ones that produce the `act` warnings after the test finishes). This means that when initializing the editor we won't wait for those selectors to be finished.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Verify that the `act` warnings are not displayed following the reproduction instructions from https://github.com/WordPress/gutenberg/issues/38332.
2. Run `npm run native test` and observe that all tests pass.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
