### PR TITLE
Enhancement: Display a Button Appender when Buttons block is empty

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -4,6 +4,7 @@
 import {
 	useBlockProps,
 	useInnerBlocksProps,
+	InnerBlocks,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -30,7 +31,7 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes: { layout = {} } } ) {
+function ButtonsEdit( { attributes: { layout = {} }, clientId } ) {
 	const blockProps = useBlockProps();
 	const preferredStyle = useSelect( ( select ) => {
 		const preferredStyleVariations = select(
@@ -39,6 +40,15 @@ function ButtonsEdit( { attributes: { layout = {} } } ) {
 		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
+	const { hasChildBlocks } = useSelect(
+		( select ) => {
+			const { getBlockOrder } = select( blockEditorStore );
+			return {
+				hasChildBlocks: getBlockOrder( clientId ).length > 0,
+			};
+		},
+		[ clientId ]
+	);
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: ALLOWED_BLOCKS,
 		__experimentalDefaultBlock: DEFAULT_BLOCK,
@@ -51,8 +61,10 @@ function ButtonsEdit( { attributes: { layout = {} } } ) {
 		],
 		__experimentalLayout: layout,
 		templateInsertUpdatesSelection: true,
+		renderAppender: hasChildBlocks
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
 	} );
-
 	return (
 		<>
 			<div { ...innerBlocksProps } />

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -83,6 +83,7 @@ export default function ButtonsEdit( {
 	const { insertBlock, removeBlock, selectBlock } = useDispatch(
 		blockEditorStore
 	);
+	const hasChildBlocks = getBlockOrder( clientId ).length > 0;
 
 	useEffect( () => {
 		const { width } = sizes || {};
@@ -164,6 +165,9 @@ export default function ButtonsEdit( {
 				] }
 				renderFooterAppender={
 					shouldRenderFooterAppender && renderFooterAppender.current
+				}
+				renderAppender={
+					hasChildBlocks ? undefined : InnerBlocks.ButtonBlockAppender
 				}
 				orientation="horizontal"
 				horizontalAlignment={ justifyContent }


### PR DESCRIPTION
Based on a [Twitter conversation](https://twitter.com/aurooba/status/1487114654086139906) with @heathergray (closes #38338), it looks like the lack of a visual cue that the `Buttons` block is still in the editor, seems to cause confusion for more than one person. Although, upon refreshing the `Buttons` block auto populates with an empty `Button` block, it can be frustrating not realizing that deleting the `Button` block doesn't mean you've deleted the `Buttons` parent block.

## Description
To solve this issue, I've changed the `Buttons` block just slightly, to show the `Button Appender` when the block is empty, making it easy to see that the `Buttons` block is still in the editor, you can easily select it to delete/add/etc.

## Testing Instructions
1. Open up the Block Editor
2. Add a `Buttons` block
3. Delete all `Button` blocks
4. See the appender appear when the `Buttons` block is empty.

## Screenshots
https://user-images.githubusercontent.com/6925260/151595081-f1f14b10-523c-414c-8fac-674b1dd59a9f.mov


## Types of changes
When empty, the `Buttons` block displays the `Button Appender` to indicate its existence.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
