### PR TITLE
UnitControl: Preserve value when switching units

### DIFF
--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -43,10 +43,13 @@ export function NumberControl(
 	const baseStep = isStepAny ? 1 : parseFloat( step );
 	const baseValue = roundClamp( 0, min, max, baseStep );
 	const constrainValue = ( value, stepOverride ) => {
+		let val = parseFloat( value );
+		val = isNaN( val ) ? 0 : val;
+
 		// When step is "any" clamp the value, otherwise round and clamp it
 		return isStepAny
-			? Math.min( max, Math.max( min, value ) )
-			: roundClamp( value, min, max, stepOverride ?? baseStep );
+			? Math.min( max, Math.max( min, val ) )
+			: roundClamp( val, min, max, stepOverride ?? baseStep );
 	};
 
 	const autoComplete = typeProp === 'number' ? 'off' : null;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
When `isPressEnterToChange` is enabled on the `UnitControl` component, the input allows text and permits you to switch units by typing a value+unit in and pressing Enter. The unit correctly updates, but the value was always being cleared to `0`. You can see this with the `Padding` control in the Cover block for example:


https://user-images.githubusercontent.com/63313398/151611823-f6ed4174-29ad-4023-ae2d-3d31cd3b27f3.mov

This is because the `NumberInput` includes logic to constrain the value of its input to the given min/max/step values, which assumes the input value is numeric and does not handle values like `10em`. This PR just adds a `parseFloat`.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
You need to test with a UnitControl that has `isPressEnterToChange`. I used the padding controls for the Cover block.

1. Select `10px` for padding.
2. Type a value+unit into the control and hit Enter (eg `10em`).
3. Verify that the unit updates in the dropdown, and the value is preserved.
4. Try typing a new value+unit and blurring the control.
5. Verify unit updates, value is preserved.
6. Type nonsense into the input (something that cannot be parsed as a number, eg "asdf") and hit Enter.
7. Verify that the value is reset to 0 and the unit does not change.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/63313398/151612374-7816d25f-e352-439c-b4a3-c36f669ee3df.mov




## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
