### PR TITLE
UnitControl: Add support for complex CSS in the UI

### DIFF
--- a/packages/components/src/box-control/all-input-control.js
+++ b/packages/components/src/box-control/all-input-control.js
@@ -24,6 +24,7 @@ export default function AllInputControl( {
 	sides,
 	selectedUnits,
 	setSelectedUnits,
+	supportsCustomCSS,
 	...props
 } ) {
 	const allValue = getAllValue( values, sides );
@@ -67,7 +68,7 @@ export default function AllInputControl( {
 
 	const handleOnChange = ( next ) => {
 		const isNumeric = ! isNaN( parseFloat( next ) );
-		const nextValue = isNumeric ? next : undefined;
+		const nextValue = isNumeric || supportsCustomCSS ? next : undefined;
 		const nextValues = applyValueToSides( values, nextValue );
 
 		onChange( nextValues );

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -27,7 +27,7 @@ import {
 	Header,
 	HeaderControlWrapper,
 } from './styles/box-control-styles';
-import { parseUnit } from '../unit-control/utils';
+import { parseUnit, supportsCustomCSS } from '../unit-control/utils';
 import {
 	DEFAULT_VALUES,
 	DEFAULT_VISUALIZER_VALUES,
@@ -129,6 +129,7 @@ export default function BoxControl( {
 		selectedUnits,
 		setSelectedUnits,
 		sides,
+		supportsCustomCSS: supportsCustomCSS( units ),
 		values: inputValues,
 	};
 

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -91,10 +91,7 @@ export function getAllValue( values = {}, availableSides = ALL_SIDES ) {
 	 * The shared value can include non-numeric values if it is custom CSS. In this
 	 * case, the value is handled specially and the unit is not appended.
 	 */
-	if (
-		allUnits.every( ( u ) => u === CUSTOM_CSS_UNIT.value ) &&
-		!! value
-	) {
+	if ( allUnits.every( ( u ) => u === CUSTOM_CSS_UNIT.value ) && !! value ) {
 		allValue = `${ value }`;
 	}
 
@@ -126,10 +123,7 @@ export function getAllUnitFallback( selectedUnits ) {
  * @return {boolean} Whether values are mixed.
  */
 export function isValuesMixed( values = {}, sides = ALL_SIDES ) {
-	const allValue = getAllValue( values, sides );
-	const isMixed = isNaN( parseFloat( allValue ) );
-
-	return isMixed;
+	return getAllValue( values, sides ) === null;
 }
 
 /**

--- a/packages/components/src/box-control/utils.js
+++ b/packages/components/src/box-control/utils.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { parseUnit } from '../unit-control/utils';
+import { parseUnit, CUSTOM_CSS_UNIT } from '../unit-control/utils';
 
 export const LABELS = {
 	all: __( 'All' ),
@@ -85,7 +85,18 @@ export function getAllValue( values = {}, availableSides = ALL_SIDES ) {
 	 * isNumber() is more specific for these cases, rather than relying on a
 	 * simple truthy check.
 	 */
-	const allValue = isNumber( value ) ? `${ value }${ unit }` : null;
+	let allValue = isNumber( value ) ? `${ value }${ unit }` : null;
+
+	/**
+	 * The shared value can include non-numeric values if it is custom CSS. In this
+	 * case, the value is handled specially and the unit is not appended.
+	 */
+	if (
+		allUnits.every( ( u ) => u === CUSTOM_CSS_UNIT.value ) &&
+		!! value
+	) {
+		allValue = `${ value }`;
+	}
 
 	return allValue;
 }

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -32,10 +32,10 @@ import UnitSelectControl from './unit-select-control';
 import {
 	CSS_UNITS,
 	CUSTOM_CSS_UNIT,
-	DEFAULT_UNIT,
 	getParsedValue,
 	getUnitsWithCurrentUnit,
 	getValidParsedUnit,
+	getValidValueWithUnit,
 } from './utils';
 import { useControlledState } from '../utils/hooks';
 import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
@@ -117,17 +117,13 @@ function UnitControl(
 				? data?.default
 				: value;
 
-		let nextUnit = next;
-		if ( isNextCustomCSS ) {
-			nextUnit = !! unit ? unit : DEFAULT_UNIT.value;
-		}
-
-		const nextValueWithUnit = !! nextValue
-			? `${ nextValue }${ nextUnit }`
-			: '';
+		const nextUnit = isNextCustomCSS ? unit : next;
+		const nextValueWithUnit = getValidValueWithUnit( nextValue, nextUnit );
 
 		onChange( nextValueWithUnit, changeProps );
-		onUnitChange( next, changeProps );
+		// The CUSTOM_CSS_UNIT is not a normal CSS unit and should never be saved
+		// into attributes.
+		onUnitChange( isNextCustomCSS ? undefined : next, changeProps );
 
 		setUnit( next );
 	};
@@ -254,7 +250,7 @@ function UnitControl(
 			{ isCustomCSS && (
 				<CustomValueInput
 					{ ...inputProps }
-					value={ String( valueProp ) }
+					value={ String( valueProp || '' ) }
 					onDrag={ noop }
 					onDragEnd={ noop }
 					onDragStart={ noop }

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -8,6 +8,7 @@ import styled from '@emotion/styled';
  */
 import { COLORS, rtl } from '../../utils';
 import NumberControl from '../../number-control';
+import InputControl from '../../input-control';
 import type { SelectSize } from '../types';
 
 // Using `selectSize` instead of `size` to avoid a type conflict with the
@@ -60,6 +61,20 @@ const arrowStyles = ( { disableUnits }: InputProps ) => {
 // https://github.com/WordPress/gutenberg/issues/18483
 
 export const ValueInput = styled( NumberControl )`
+	&&& {
+		input {
+			appearance: none;
+			-moz-appearance: textfield;
+			display: block;
+			width: 100%;
+
+			${ arrowStyles };
+			${ paddingStyles };
+		}
+	}
+`;
+
+export const CustomValueInput = styled( InputControl )`
 	&&& {
 		input {
 			appearance: none;

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -36,7 +36,7 @@ export type WPUnitControlUnit = {
 	/**
 	 * A step value used when incrementing/decrementing the value.
 	 */
-	step?: number;
+	step?: number | 'any';
 };
 
 export type WPUnitControlUnitList = Array< WPUnitControlUnit > | false;

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -395,6 +395,16 @@ export function getUnitsWithCurrentUnit(
 
 	const unitsWithCurrentUnit = [ ...units ];
 
+	// The Custom CSS unit is not supported when using legacy units. This
+	// is to prevent attempting to save string CSS values into number type
+	// value attributes.
+	const customUnit = unitsWithCurrentUnit.findIndex(
+		( unit ) => unit.value === CUSTOM_CSS_UNIT.value
+	);
+	if ( !! legacyUnit && customUnit ) {
+		unitsWithCurrentUnit.splice( customUnit );
+	}
+
 	const currentUnit = matchUnit(
 		legacyUnit ? `${ currentValue }${ legacyUnit }` : currentValue,
 		ALL_CSS_UNITS

--- a/packages/components/src/unit-control/utils.ts
+++ b/packages/components/src/unit-control/utils.ts
@@ -425,7 +425,7 @@ export function getUnitsWithCurrentUnit(
 	const customUnit = unitsWithCurrentUnit.findIndex(
 		( unit ) => unit.value === CUSTOM_CSS_UNIT.value
 	);
-	if ( !! legacyUnit && customUnit ) {
+	if ( !! legacyUnit && customUnit > -1 ) {
 		unitsWithCurrentUnit.splice( customUnit );
 	}
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

This is an alternative implementation to #38096, which explored adding an actual button to the UnitControl that would toggle open a custom CSS input (as opposed to the dropdown).

## Description
<!-- Please describe what you have changed or added -->
Adds support for a `css` "unit" to the UnitControl which can be used to add complex CSS values like `max...` or `clamp...` through the UI. Themes can configure whether or not to support the unit by its inclusion in the `spacing` settings in `theme.json`:

```
"spacing": {
			"customPadding": true,
			"units": [
				"px",
				"em",
				"rem",
				"vh",
				"vw",
				"css"
			]
		},
```

These types of values are already _technically_ supported by attributes that accept custom units (like padding, margin, and the Spacer block's height), in the sense that you can manually set those attributes (using the Code editor, for example). But since the `UnitControl` doesn't currently support these arbitrary strings, you'll see an empty input in the UI and you won't be able to edit the value through the control panel.

This can lead to strange scenarios. For example, the space beneath the header in Twenty Twenty-Two uses a spacer with height `max(1.25rem, 5vw)` as defined in the theme. If a user goes to edit that spacer, they won't see that value in the Inspector Controls (the height input appears empty). If they set their own value in the controls, they may not realize what they're overriding. It would be nice to be able to quickly see what values are set and tweak them yourself.

## Notes:
* TL;DR I disabled the custom CSS unit if the legacy unit prop is passed.
    * When `value` and `unit` are passed as separate props, for example in the Min Height control for the Cover block, it's usually because those values are stored in separate attributes. In Cover's case, `height` is an attribute with type `number`, and arbitrary custom CSS strings simply can't be stored in it. The best way I can think of handling this is by assuming all uses of the legacy unit prop cannot support custom CSS, and removing the unit even if it is otherwise supported in `theme.json`.
    

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

Video below also has changes from #38340 applied

https://user-images.githubusercontent.com/63313398/151614420-72949cfc-98e9-4e21-b3ec-12d68deb5ba6.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
