### PR TITLE
E2E: Fix flakey gallery and template e2e specs

### DIFF
--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -70,12 +70,14 @@ export const Gallery = ( props ) => {
 		>
 			{ children }
 
-			<View
-				className="blocks-gallery-media-placeholder-wrapper"
-				onClick={ removeCaptionFocus }
-			>
-				{ mediaPlaceholder }
-			</View>
+			{ isSelected && ! children && (
+				<View
+					className="blocks-gallery-media-placeholder-wrapper"
+					onClick={ removeCaptionFocus }
+				>
+					{ mediaPlaceholder }
+				</View>
+			) }
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -70,14 +70,12 @@ export const Gallery = ( props ) => {
 		>
 			{ children }
 
-			{ isSelected && ! children && (
-				<View
-					className="blocks-gallery-media-placeholder-wrapper"
-					onClick={ removeCaptionFocus }
-				>
-					{ mediaPlaceholder }
-				</View>
-			) }
+			<View
+				className="blocks-gallery-media-placeholder-wrapper"
+				onClick={ removeCaptionFocus }
+			>
+				{ mediaPlaceholder }
+			</View>
 			<RichTextVisibilityHelper
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
 				captionFocused={ captionFocused }

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -57,8 +57,13 @@ describe( 'Gallery', () => {
 
 		await insertBlock( 'Gallery' );
 		await upload( '.wp-block-gallery input[type="file"]' );
+		await page.waitForSelector( '.wp-block-gallery .wp-block-image' );
 
-		await page.click( '.wp-block-gallery>.blocks-gallery-caption' );
+		// The newly added image gets the focus, so refocus parent Gallery
+		// block before trying to edit caption.
+		await clickButton( 'Gallery' );
+
+		await page.click( '.wp-block-gallery .blocks-gallery-caption' );
 		await page.keyboard.type( galleryCaption );
 
 		expect( await getEditedPostContent() ).toMatch(

--- a/packages/e2e-tests/specs/editor/plugins/templates.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/templates.test.js
@@ -3,7 +3,6 @@
  */
 import {
 	activatePlugin,
-	clickBlockAppender,
 	createNewPost,
 	deactivatePlugin,
 	getEditedPostContent,
@@ -100,12 +99,7 @@ describe( 'templates', () => {
 			// Remove the default block template to verify that it's not
 			// re-added after saving and reloading the editor.
 			await page.type( '.editor-post-title__input', 'My Image Format' );
-			await clickBlockAppender();
-			await page.keyboard.press( 'Backspace' );
-			// Wait for the selection to update.
-			await page.evaluate(
-				() => new Promise( window.requestAnimationFrame )
-			);
+			await page.click( '.wp-block-image' );
 			await page.keyboard.press( 'Backspace' );
 			await saveDraft();
 			await page.reload();


### PR DESCRIPTION
## Description
The test for gallery caption sometimes fails due to timing differences with the newly uploaded file getting the focus before the caption is edited. This PR makes sure the Gallery block is selected before trying to edit the caption

## Testing Instructions

- Make sure ` PUPPETEER_HEADLESS="false" npm run test-e2e specs/editor/blocks/gallery.test.js ` passes locally and that the e2e tests pass in CI