### PR TITLE
Silence editor initialization act warnings triggered by asynchronous resolvers during unmount

### DIFF
--- a/packages/block-library/src/block/test/edit.native.js
+++ b/packages/block-library/src/block/test/edit.native.js
@@ -74,7 +74,11 @@ describe( 'Reusable block', () => {
 			return Promise.resolve( response );
 		} );
 
-		const { getByA11yLabel, getByTestId, getByText } = initializeEditor( {
+		const {
+			getByA11yLabel,
+			getByTestId,
+			getByText,
+		} = await initializeEditor( {
 			initialHtml: '',
 			capabilities: { reusableBlock: true },
 		} );
@@ -123,7 +127,7 @@ describe( 'Reusable block', () => {
 		const id = 3;
 		const initialHtml = `<!-- wp:block {"ref":${ id }} /-->`;
 
-		const { getByA11yLabel } = initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml,
 		} );
 
@@ -158,7 +162,7 @@ describe( 'Reusable block', () => {
 			return Promise.resolve( response );
 		} );
 
-		const { getByA11yLabel } = initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml,
 		} );
 

--- a/packages/block-library/src/buttons/test/edit.native.js
+++ b/packages/block-library/src/buttons/test/edit.native.js
@@ -35,7 +35,7 @@ describe( 'Buttons block', () => {
 			<div class="wp-block-button"><a class="wp-block-button__link" style="border-radius:5px" >Hello</a></div>
 			<!-- /wp:button --></div>
 			<!-- /wp:buttons -->`;
-			const { getByA11yLabel } = initializeEditor( {
+			const { getByA11yLabel } = await initializeEditor( {
 				initialHtml,
 			} );
 
@@ -90,7 +90,7 @@ describe( 'Buttons block', () => {
 				const initialHtml = `<!-- wp:buttons -->
 				<div class="wp-block-buttons"><!-- wp:button /--></div>
 				<!-- /wp:buttons -->`;
-				const { getByA11yLabel, getByText } = initializeEditor( {
+				const { getByA11yLabel, getByText } = await initializeEditor( {
 					initialHtml,
 				} );
 

--- a/packages/block-library/src/cover/test/edit.native.js
+++ b/packages/block-library/src/cover/test/edit.native.js
@@ -295,7 +295,7 @@ describe( 'when an image is attached', () => {
 
 describe( 'color settings', () => {
 	it( 'sets a color for the overlay background when the placeholder is visible', async () => {
-		const { getByTestId, getByA11yLabel } = initializeEditor( {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
@@ -350,7 +350,7 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'sets a gradient overlay background when a solid background was already selected', async () => {
-		const { getByTestId, getByA11yLabel } = initializeEditor( {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
 			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
 		} );
 
@@ -407,7 +407,7 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'toggles between solid colors and gradients', async () => {
-		const { getByTestId, getByA11yLabel } = initializeEditor( {
+		const { getByTestId, getByA11yLabel } = await initializeEditor( {
 			initialHtml: COVER_BLOCK_PLACEHOLDER_HTML,
 		} );
 
@@ -493,7 +493,11 @@ describe( 'color settings', () => {
 	} );
 
 	it( 'clears the selected overlay color and mantains the inner blocks', async () => {
-		const { getByTestId, getByA11yLabel, getByText } = initializeEditor( {
+		const {
+			getByTestId,
+			getByA11yLabel,
+			getByText,
+		} = await initializeEditor( {
 			initialHtml: COVER_BLOCK_SOLID_COLOR_HTML,
 		} );
 

--- a/packages/block-library/src/embed/test/index.native.js
+++ b/packages/block-library/src/embed/test/index.native.js
@@ -142,7 +142,7 @@ const mockEmbedResponses = ( mockedResponses ) => {
 };
 
 const insertEmbedBlock = async ( blockTitle = 'Embed' ) => {
-	const editor = initializeEditor( {
+	const editor = await initializeEditor( {
 		initialHtml: '',
 	} );
 	const { getByA11yLabel, getByText } = editor;
@@ -162,7 +162,7 @@ const insertEmbedBlock = async ( blockTitle = 'Embed' ) => {
 };
 
 const initializeWithEmbedBlock = async ( initialHtml, selectBlock = true ) => {
-	const editor = initializeEditor( { initialHtml } );
+	const editor = await initializeEditor( { initialHtml } );
 	const { getByA11yLabel } = editor;
 
 	const block = await waitFor( () =>
@@ -871,7 +871,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByTestId,
 				getByText,
-			} = initializeEditor( {
+			} = await initializeEditor( {
 				initialHtml: EMPTY_PARAGRAPH_HTML,
 			} );
 
@@ -914,7 +914,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByTestId,
 				getByText,
-			} = initializeEditor( {
+			} = await initializeEditor( {
 				initialHtml: EMPTY_PARAGRAPH_HTML,
 			} );
 
@@ -959,7 +959,7 @@ describe( 'Embed block', () => {
 				getByPlaceholderText,
 				getByA11yLabel,
 				getByText,
-			} = initializeEditor( { initialHtml: EMPTY_PARAGRAPH_HTML } );
+			} = await initializeEditor( { initialHtml: EMPTY_PARAGRAPH_HTML } );
 
 			const paragraphText = getByPlaceholderText( 'Start writing…' );
 			fireEvent( paragraphText, 'focus' );
@@ -1001,7 +1001,7 @@ describe( 'Embed block', () => {
 					getByPlaceholderText,
 					getByA11yLabel,
 					getByText,
-				} = initializeEditor( {
+				} = await initializeEditor( {
 					initialHtml: EMPTY_PARAGRAPH_HTML,
 				} );
 

--- a/packages/block-library/src/gallery/test/index.native.js
+++ b/packages/block-library/src/gallery/test/index.native.js
@@ -34,7 +34,7 @@ const GALLERY_WITH_ONE_IMAGE = `<!-- wp:gallery {"linkTo":"none"} -->
 <!-- /wp:gallery -->`;
 
 const addGalleryBlock = async () => {
-	const screen = initializeEditor();
+	const screen = await initializeEditor();
 	const { getByA11yLabel, getByTestId, getByText } = screen;
 
 	fireEvent.press( getByA11yLabel( 'Add block' ) );
@@ -67,7 +67,7 @@ describe( 'Gallery block', () => {
 	} );
 
 	it( 'selects a gallery item', async () => {
-		const { getByA11yLabel } = initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml: GALLERY_WITH_ONE_IMAGE,
 		} );
 
@@ -96,7 +96,7 @@ describe( 'Gallery block', () => {
 	} );
 
 	it( 'shows appender button when gallery has images', async () => {
-		const { getByA11yLabel, getByText } = initializeEditor( {
+		const { getByA11yLabel, getByText } = await initializeEditor( {
 			initialHtml: GALLERY_WITH_ONE_IMAGE,
 		} );
 

--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -67,7 +67,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -93,7 +93,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -119,7 +119,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -152,7 +152,7 @@ describe( 'Image Block', () => {
 			<img src="https://cldup.com/cXyG__fTLN.jpg" alt="" class="wp-image-1"/>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -192,7 +192,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -216,7 +216,7 @@ describe( 'Image Block', () => {
 			</a>
 		<figcaption>Mountain</figcaption></figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 
@@ -247,7 +247,7 @@ describe( 'Image Block', () => {
 			<figcaption>Mountain</figcaption>
 		</figure>
 		<!-- /wp:image -->`;
-		const screen = initializeEditor( { initialHtml } );
+		const screen = await initializeEditor( { initialHtml } );
 		// We must await the image fetch via `getMedia`
 		await act( () => apiFetchPromise );
 

--- a/packages/block-library/src/missing/test/edit-integration.native.js
+++ b/packages/block-library/src/missing/test/edit-integration.native.js
@@ -40,7 +40,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 			 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 			 <!-- /wp:table -->`;
-		const { getByA11yLabel } = initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml,
 		} );
 
@@ -59,7 +59,7 @@ describe( 'Unsupported block', () => {
 		const initialHtml = `<!-- wp:table -->
 		 <figure class="wp-block-table"><table><tbody><tr><td>1</td><td>2</td></tr><tr><td>3</td><td>4</td></tr></tbody></table></figure>
 		 <!-- /wp:table -->`;
-		const { getByA11yLabel, getByText } = initializeEditor( {
+		const { getByA11yLabel, getByText } = await initializeEditor( {
 			initialHtml,
 		} );
 

--- a/packages/components/src/mobile/link-settings/test/edit.native.js
+++ b/packages/components/src/mobile/link-settings/test/edit.native.js
@@ -72,7 +72,7 @@ describe.each( [
 	it( 'should display the LINK SETTINGS with an EMPTY LINK TO field.', async () => {
 		// Arrange
 		const url = 'https://tonytahmouchtest.files.wordpress.com';
-		const subject = initializeEditor( { initialHtml } );
+		const subject = await initializeEditor( { initialHtml } );
 		Clipboard.getString.mockReturnValue( url );
 
 		// Act
@@ -109,7 +109,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'tonytahmouchtest.files.wordpress.com';
-				const subject = initializeEditor( { initialHtml } );
+				const subject = await initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -162,7 +162,7 @@ describe.each( [
 			it( 'should display the LINK PICKER with NO FROM CLIPBOARD CELL.', async () => {
 				// Arrange
 				const url = 'https://tonytahmouchtest.files.wordpress.com';
-				const subject = initializeEditor( { initialHtml } );
+				const subject = await initializeEditor( { initialHtml } );
 				Clipboard.getString.mockReturnValue( url );
 
 				// Act
@@ -241,7 +241,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = initializeEditor( { initialHtml } );
+					const subject = await initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act
@@ -308,7 +308,7 @@ describe.each( [
 				async () => {
 					// Arrange
 					const url = 'https://tonytahmouchtest.files.wordpress.com';
-					const subject = initializeEditor( { initialHtml } );
+					const subject = await initializeEditor( { initialHtml } );
 					Clipboard.getString.mockReturnValue( url );
 
 					// Act

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -32,7 +32,7 @@ afterAll( () => {
 
 describe( 'Text color', () => {
 	it( 'shows the text color formatting button in the toolbar', async () => {
-		const { getByA11yLabel } = initializeEditor();
+		const { getByA11yLabel } = await initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -59,7 +59,7 @@ describe( 'Text color', () => {
 			getByA11yLabel,
 			getByTestId,
 			getByA11yHint,
-		} = initializeEditor();
+		} = await initializeEditor();
 
 		// Wait for the editor placeholder
 		const paragraphPlaceholder = await waitFor( () =>
@@ -101,7 +101,7 @@ describe( 'Text color', () => {
 			getByTestId,
 			getByPlaceholderText,
 			getByA11yHint,
-		} = initializeEditor();
+		} = await initializeEditor();
 		const text = 'Hello this is a test';
 
 		// Wait for the editor placeholder
@@ -149,7 +149,7 @@ describe( 'Text color', () => {
 	} );
 
 	it( 'creates a paragraph block with the text color format', async () => {
-		const { getByA11yLabel } = initializeEditor( {
+		const { getByA11yLabel } = await initializeEditor( {
 			initialHtml: TEXT_WITH_COLOR,
 		} );
 

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -181,12 +181,15 @@ describe( 'Register Gutenberg', () => {
 		expect( hookCallOrder ).toBeGreaterThan( onRenderEditorCallOrder );
 	} );
 
-	it( 'initializes the editor', () => {
+	it( 'initializes the editor', async () => {
 		// Unmock setup module to render the actual editor component.
 		jest.unmock( '../setup' );
 
 		const EditorComponent = getEditorComponent();
-		const screen = initializeEditor( {}, { component: EditorComponent } );
+		const screen = await initializeEditor(
+			{},
+			{ component: EditorComponent }
+		);
 		const blockList = screen.getByTestId( 'block-list-wrapper' );
 
 		expect( blockList ).toBeVisible();

--- a/packages/rich-text/src/test/index.native.js
+++ b/packages/rich-text/src/test/index.native.js
@@ -225,13 +225,13 @@ describe( '<RichText/>', () => {
 			expect( screen.toJSON() ).toMatchSnapshot();
 		} );
 
-		it( 'renders component with style and font size', () => {
+		it( 'renders component with style and font size', async () => {
 			// Arrange
 			const initialHtml = `<!-- wp:paragraph {"style":{"color":{"text":"#fcb900"},"typography":{"fontSize":35.56}}} -->
 					<p class="has-text-color" style="color:#fcb900;font-size:35.56px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed imperdiet ut nibh vitae ornare. Sed auctor nec augue at blandit.</p>
 					<!-- /wp:paragraph -->`;
 			// Act
-			initializeEditor( { initialHtml } );
+			await initializeEditor( { initialHtml } );
 			// Assert
 			expect( getEditorHtml() ).toMatchSnapshot();
 		} );


### PR DESCRIPTION
## Description
Fixes #38332. Relates to https://github.com/WordPress/gutenberg/pull/38336. 

During editor initialization,[ asynchronous store resolvers](https://github.com/WordPress/gutenberg/blob/57da3c91a166d917a2a9de98177be9c3dfe07ee5/packages/editor/src/components/provider/index.native.js#L370) leverage `apiFetch` to fetch data from the REST API. The resolvers also [rely upon `setTimeout`](https://github.com/WordPress/gutenberg/blob/e1978ea1bb20e99be9f64a189ac5f898a7cee594/packages/data/src/redux-store/index.js#L414-L428) to run at the end of the current JavaScript block execution. In order to prevent `act` warnings triggered by updates to the React tree, we manually tick fake timers and flush micro tasks before proceeding. 

My theory as to why the specific test case in #38332 exposed further `act` warnings is because it is a simplified test case that has no asynchronous logic of its own, aside from editor initialization. This is different than most of our existing tests. Our existing tests await the resolution of their own asynchronous logic, which allowed an opportunity for the editor initialization asynchronous logic to resolve undetected. 

https://github.com/WordPress/gutenberg/blob/74722f69be32bad1b55177312d1865bf5589b7fb/packages/editor/src/components/provider/index.js#L91

The `act` warning appears to originate from the above line, which triggers during unmount. Components are unmounted after each test, which would explain why the `act` warning is triggered. Flushing of micro tasks is somewhat of a "sledgehammer" to address the `act` warnings, rather than a targeted awaiting of a specific fetch request. However, it has been difficult to identify the request to await and the request resolution appears to have no meaningful impact on the subject of our tests using `initializeEditor`, which do not focus on testing editor dismount. 

## Testing Instructions
1. Verify that the `act` warnings are not displayed following the reproduction instructions from https://github.com/WordPress/gutenberg/issues/38332.
2. Run `npm run native test` and observe that all tests pass.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
