### PR TITLE
Fix: wp-scripts command does not generate assets on Windows OS

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 20.0.2 (2022-01-31)
+
+### Bug Fix
+
+-   Fix the `build` command that does not generate assets on Windows OS [#38348](https://github.com/WordPress/gutenberg/pull/38348).
+
 ## 20.0.1 (2022-01-28)
 
 ### Bug Fix

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -186,6 +186,7 @@ function getWebpackEntryPoints() {
 	const blockMetadataFiles = glob( 'src/**/block.json', {
 		absolute: true,
 	} );
+
 	if ( blockMetadataFiles.length > 0 ) {
 		return blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
@@ -202,7 +203,7 @@ function getWebpackEntryPoints() {
 						const filepath = join(
 							dirname( blockMetadataFile ),
 							value.replace( 'file:', '' )
-						);
+						).replace( /\\/g, '/' );
 
 						// Takes the path without the file extension, and relative to the `src` directory.
 						const [ , entryName ] = filepath


### PR DESCRIPTION
## Description
See: https://github.com/WordPress/gutenberg/issues/38343

This PR solves the problem that assets are not generated in the `build` directory when the `wp-scripts` command is executed in Windows OS.

I think this problem is caused by the fact that in the process of parsing the metadata in `block.json`, the entry point is not detected correctly because the `filepath` has a backslash in Windows OS.

## Testing Instructions
Check out this branch and run `create-block` in the gutenberg repository with the option to not install wp-script.

`npx @wordpress/create-block gutennpride --no-wp-scripts`

Move to the directory where it was created.

`cd gutenpride`

Run the following command using the local wp-scripts.

```
../node_modules/.bin/wp-scripts start
../node_modules/.bin/wp-scripts start --hot
../node_modules/.bin/wp-scripts start src/index.js --output-path=custom
../node_modules/.bin/wp-scripts build
```

Make sure that the assets are generated in the gutenpride/build directory.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
