### PR TITLE
Fix: Add bottom padding to mobile side panel's cancel button

### DIFF
--- a/packages/edit-post/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-post/src/components/secondary-sidebar/style.scss
@@ -14,6 +14,7 @@
 .edit-post-editor__inserter-panel-header {
 	padding-top: $grid-unit-10;
 	padding-right: $grid-unit-10;
+	padding-bottom: $grid-unit-10;
 	display: flex;
 	justify-content: flex-end;
 }

--- a/packages/edit-site/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-site/src/components/secondary-sidebar/style.scss
@@ -14,6 +14,7 @@
 .edit-site-editor__inserter-panel-header {
 	padding-top: $grid-unit-10;
 	padding-right: $grid-unit-10;
+	padding-bottom: $grid-unit-10;
 	display: flex;
 	justify-content: flex-end;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
Resolves #38140

Current mobile side panel's cancel button in the site editor and post editor are partially blocked by the main content. Adding bottom padding to both of these cancel buttons fixes the above issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up site/post editor in mobile view
2. Click on the + icon to toggle block inserter
3. The X icon is no longer blocked by the main content

## Screenshots <!-- if applicable -->
| **Before** | **After** |
| ----------- | ---------  |
|![Capture](https://user-images.githubusercontent.com/47470981/151693103-96af5f57-ca47-42ac-a6a7-07eee51841a9.PNG)|![Capture2](https://user-images.githubusercontent.com/47470981/151693117-33d3d435-a91d-4949-9631-cf4cac3892a8.PNG)|

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
