### PR TITLE
Update version required before gutenberg_safe_style_attrs filter can be removed

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -175,7 +175,7 @@ add_filter( 'post_type_labels_wp_block', 'gutenberg_override_reusable_block_post
 /**
  * Update allowed inline style attributes list.
  *
- * Note: This should be removed when the minimum required WP version is >= 5.8.
+ * Note: This should be removed when the minimum required WP version is >= 5.9.
  *
  * @param string[] $attrs Array of allowed CSS attributes.
  * @return string[] CSS attributes.


### PR DESCRIPTION
## Description

Changes made to the `gutenberg_safe_style_attrs` filter in https://github.com/WordPress/gutenberg/pull/31641 and https://github.com/WordPress/gutenberg/pull/36280 changed the minimum version requirement before the filter could be removed to be 5.9. This PR just updates the comment to reflect this requirement.

## Testing Instructions

Double-check the WP version that contains the changes from https://github.com/WordPress/gutenberg/pull/31641 and https://github.com/WordPress/gutenberg/pull/36280.

## Types of changes

Typo fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
