### PR TITLE
Hide Settings button to screen readers

### DIFF
--- a/packages/edit-navigation/src/components/sidebar/index.js
+++ b/packages/edit-navigation/src/components/sidebar/index.js
@@ -84,6 +84,7 @@ export default function Sidebar( {
 			header={ <SidebarHeader sidebarName={ sidebarName } /> }
 			headerClassName="edit-navigation-sidebar__panel-tabs"
 			isPinnable
+			hideToggleToScreenReader="true"
 		>
 			{ sidebarName === SIDEBAR_MENU && (
 				<>

--- a/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
+++ b/packages/edit-post/src/components/sidebar/settings-sidebar/index.js
@@ -82,6 +82,7 @@ const SettingsSidebar = () => {
 			toggleShortcut={ keyboardShortcut }
 			icon={ cog }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
+			hideToggleToScreenReader="true"
 		>
 			{ ! isTemplateMode && sidebarName === 'edit-post/document' && (
 				<>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -66,6 +66,7 @@ export function SidebarComplementaryAreaFills() {
 				closeLabel={ __( 'Close settings sidebar' ) }
 				header={ <SettingsHeader sidebarName={ sidebarName } /> }
 				headerClassName="edit-site-sidebar__panel-tabs"
+				hideToggleToScreenReader="true"
 			>
 				{ sidebarName === SIDEBAR_TEMPLATE && (
 					<PanelBody>

--- a/packages/edit-widgets/src/components/sidebar/index.js
+++ b/packages/edit-widgets/src/components/sidebar/index.js
@@ -173,6 +173,7 @@ export default function Sidebar() {
 			identifier={ currentArea }
 			icon={ cog }
 			isActiveByDefault={ SIDEBAR_ACTIVE_BY_DEFAULT }
+			hideToggleToScreenReader="true"
 		>
 			{ currentArea === WIDGET_AREAS_IDENTIFIER && (
 				<WidgetAreas

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -37,7 +37,7 @@ function ComplementaryAreaToggle( {
 	return (
 		<ComponentToUse
 			icon={ selectedIcon && isSelected ? selectedIcon : icon }
-			aria-hidden={ hideToggleToScreenReader || undefined }
+			aria-hidden={ hideToggleToScreenReader }
 			onClick={ () => {
 				if ( isSelected ) {
 					disableComplementaryArea( scope );

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -21,6 +21,7 @@ function ComplementaryAreaToggle( {
 	identifier,
 	icon,
 	selectedIcon,
+	hideToggleToScreenReader,
 	...props
 } ) {
 	const ComponentToUse = as;
@@ -36,6 +37,7 @@ function ComplementaryAreaToggle( {
 	return (
 		<ComponentToUse
 			icon={ selectedIcon && isSelected ? selectedIcon : icon }
+			aria-hidden={ hideToggleToScreenReader || undefined }
 			onClick={ () => {
 				if ( isSelected ) {
 					disableComplementaryArea( scope );

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -151,7 +151,9 @@ function ComplementaryArea( {
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
-							hideToggleToScreenReader={ hideToggleToScreenReader }
+							hideToggleToScreenReader={
+								hideToggleToScreenReader
+							}
 						/>
 					) }
 				</PinnedItems>

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -97,6 +97,7 @@ function ComplementaryArea( {
 	toggleShortcut,
 	isActiveByDefault,
 	showIconLabels = false,
+	hideToggleToScreenReader,
 } ) {
 	const { isActive, isPinned, activeArea, isSmall, isLarge } = useSelect(
 		( select ) => {
@@ -150,6 +151,7 @@ function ComplementaryArea( {
 							icon={ showIconLabels ? check : icon }
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
+							hideToggleToScreenReader={ hideToggleToScreenReader }
 						/>
 					) }
 				</PinnedItems>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Because the Settings Sidebar opens so far away, I've hidden the Settings button to screen readers to avoid confusion. You can still access the Settings Sidebar if it is closed by selecting Open Document Settings button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open up Gutenberg.
2. Notice the Settings button at the top of the page now contains aria-hidden.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
