### PR TITLE
Cover block :Add back missing styles 

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -70,6 +70,10 @@
 		opacity: 0.5;
 	}
 
+	// The following styles are needed to support legacy blocks added prior to the update
+	// that moved opacity to a nested span.
+	// https://github.com/WordPress/gutenberg/pull/35065
+	// https://github.com/WordPress/gutenberg/pull/38362
 	@for $i from 1 through 10 {
 		&.has-background-dim.has-background-dim-#{ $i * 10 } {
 			&:not(.has-background-gradient)::before,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -70,6 +70,15 @@
 		opacity: 0.5;
 	}
 
+	@for $i from 1 through 10 {
+		&.has-background-dim.has-background-dim-#{ $i * 10 } {
+			&:not(.has-background-gradient)::before,
+			.wp-block-cover__gradient-background {
+				opacity: $i * 0.1;
+			}
+		}
+	}
+
 	@for $i from 0 through 10 {
 		.wp-block-cover__gradient-background.has-background-dim.has-background-dim-#{ $i * 10 } {
 			opacity: $i * 0.1;


### PR DESCRIPTION
## Description
Since a change to how Cover block handles background opacity, old block content has been defaulting to 0.5 opacity, instead of using the dimRatio that is set in the block (reported here https://core.trac.wordpress.org/ticket/55000).

## Testing Instructions
Install Classic editor on a site so you can paste the following into a post without it being migrated:
```
<!-- wp:cover {"url":"https://i.imgur.com/dXpzTYj.jpeg","dimRatio":20,"customGradient":"linear-gradient(135deg,rgb(6,229,6) 0%,rgb(109,3,14) 88%,rgb(155,81,224) 100%)"} -->
<div class="wp-block-cover has-background-dim-20 has-background-dim has-background-gradient"><span aria-hidden="true" class="wp-block-cover__gradient-background" style="background:linear-gradient(135deg,rgb(6,229,6) 0%,rgb(109,3,14) 88%,rgb(155,81,224) 100%)"></span><img class="wp-block-cover__image-background" alt="" src="https://i.imgur.com/dXpzTYj.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Lovely Gradient</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://i.imgur.com/dXpzTYj.jpeg","dimRatio":20} -->
<div class="wp-block-cover has-background-dim-20 has-background-dim"><img class="wp-block-cover__image-background" alt="" src="https://i.imgur.com/dXpzTYj.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Background Custom Opacity</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:cover {"url":"https://i.imgur.com/dXpzTYj.jpeg","dimRatio":20,"customOverlayColor":"#0babef"} -->
<div class="wp-block-cover has-background-dim-20 has-background-dim" style="background-color:#0babef"><img class="wp-block-cover__image-background" alt="" src="https://i.imgur.com/dXpzTYj.jpeg" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Custom BG Colour</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
```
View the post in the frontend and make sure black overlay over image is set to 0.2 and not 0.5 for gradient, default background and custom background colour.

## Screenshots

Before:
<img width="880" alt="Screen Shot 2022-01-31 at 3 10 27 PM" src="https://user-images.githubusercontent.com/3629020/151730475-6ea7bcdb-276f-4052-8a94-a05d8e25eefd.png">

After:
<img width="882" alt="Screen Shot 2022-01-31 at 3 12 20 PM" src="https://user-images.githubusercontent.com/3629020/151730507-0a95c17d-bf89-48f4-96bc-7e5489ed0547.png">

