### PR TITLE
Fixed snackbar console error

### DIFF
--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -65,7 +65,10 @@ function Snackbar(
 		}
 
 		// Prevent focus loss by moving it to the list element.
-		listRef.current.focus();
+		if ( listRef && listRef.current  ) {
+			listRef.current.focus();
+		}
+		
 
 		onDismiss();
 		onRemove();

--- a/packages/components/src/snackbar/index.js
+++ b/packages/components/src/snackbar/index.js
@@ -65,10 +65,7 @@ function Snackbar(
 		}
 
 		// Prevent focus loss by moving it to the list element.
-		if ( listRef && listRef.current  ) {
-			listRef.current.focus();
-		}
-		
+		listRef?.current?.focus();
 
 		onDismiss();
 		onRemove();


### PR DESCRIPTION
## Description

Console error when click on snackbar: 
react-dom.js?ver=17.0.1:4088 Uncaught TypeError: Cannot read properties of undefined (reading 'current') at dismissMe (components.js)


## Screenshots <!-- if applicable -->
![snackbar-console-error](https://user-images.githubusercontent.com/76091228/151749031-9e2a66d8-3679-4ca6-9f22-39ede3fadede.png)


## Types of changes
check added on listRef object in dismissMe function in snackbar component
