### PR TITLE
Ensure placeholder description is read by VoiceOver

### DIFF
--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -73,12 +73,16 @@ function Placeholder( {
 				<Icon icon={ icon } />
 				{ label }
 			</div>
-			{ !! instructions && (
-				<div className="components-placeholder__instructions">
-					{ instructions }
-				</div>
-			) }
-			<div className={ fieldsetClasses }>{ children }</div>
+			<fieldset className={ fieldsetClasses }>
+				<legend>
+					{ !! instructions && (
+						<div className="components-placeholder__instructions">
+							{ instructions }
+						</div>
+					) }
+				</legend>
+				{ children }
+			</fieldset>
 		</div>
 	);
 }

--- a/packages/components/src/placeholder/index.js
+++ b/packages/components/src/placeholder/index.js
@@ -74,13 +74,11 @@ function Placeholder( {
 				{ label }
 			</div>
 			<fieldset className={ fieldsetClasses }>
-				<legend>
-					{ !! instructions && (
-						<div className="components-placeholder__instructions">
-							{ instructions }
-						</div>
-					) }
-				</legend>
+				{ !! instructions && (
+					<legend className="components-placeholder__instructions">
+						{ instructions }
+					</legend>
+				) }
 				{ children }
 			</fieldset>
 		</div>

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -77,6 +77,18 @@
 	}
 }
 
+// Overrides for browser and editor fieldset styles.
+.components-placeholder__fieldset.components-placeholder__fieldset {
+	border: none;
+	padding: 0;
+
+	.components-placeholder__instructions {
+		padding: 0;
+		font-weight: normal;
+		font-size: 1em;
+	}
+}
+
 .components-placeholder__fieldset.is-column-layout,
 .components-placeholder__fieldset.is-column-layout form {
 	flex-direction: column;

--- a/packages/components/src/placeholder/test/index.js
+++ b/packages/components/src/placeholder/test/index.js
@@ -88,12 +88,29 @@ describe( 'Placeholder', () => {
 			const element = <div>Fieldset</div>;
 			const placeholder = shallow( <Placeholder children={ element } /> );
 			const placeholderFieldset = placeholder.find(
-				'.components-placeholder__fieldset'
+				'fieldset.components-placeholder__fieldset'
 			);
 			const child = placeholderFieldset.childAt( 0 );
 
 			expect( placeholderFieldset.exists() ).toBe( true );
 			expect( child.matchesElement( element ) ).toBe( true );
+		} );
+
+		it( 'should display a legend if instructions are passed', () => {
+			const element = <div>Fieldset</div>;
+			const instructions = 'Choose an option.';
+			const placeholder = shallow(
+				<Placeholder
+					children={ element }
+					instructions={ instructions }
+				/>
+			);
+			const placeholderLegend = placeholder.find(
+				'legend.components-placeholder__instructions'
+			);
+
+			expect( placeholderLegend.exists() ).toBe( true );
+			expect( placeholderLegend.text() ).toEqual( instructions );
 		} );
 
 		it( 'should add an additional className to the top container', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When inserting or selecting a block with a placeholder, VoiceOver doesn't read out the description, so there's often not enough context to know what the controls are supposed to do.

This PR changes the placeholder markup slightly to wrap the contents in a fieldset, and the description in a legend. This causes the description to be read by VoiceOver when the first control is focused.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Columns or Table block to a post.
2. Move focus into the block placeholder by pressing Arrow Down (this won't work if "Contain text cursor inside block" is enabled, see #37934)
3. Verify that VoiceOver reads the placeholder description.

I haven't checked with any Windows screen readers, but previous testing shows this isn't an issue on NVDA, so it would be good to double-check this doesn't make the experience worse for Windows users.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
