### PR TITLE
Scripts: Fallback to `src/index.js` when no valid scripts in metadata for `build` command

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Bug Fix
 
--   Fix the `build` command that does not generate assets on Windows OS [#38348](https://github.com/WordPress/gutenberg/pull/38348).
+-   Fix the `build` command that does not generate assets on Windows OS ([#38348](https://github.com/WordPress/gutenberg/pull/38348)).
+-   Adds fallback to `src/index.js` when no valid scripts discovered in metadata files when running the `build` command ([#38367](https://github.com/WordPress/gutenberg/pull/38367)).
 
 ## 20.0.1 (2022-01-28)
 

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -188,7 +188,7 @@ function getWebpackEntryPoints() {
 	} );
 
 	if ( blockMetadataFiles.length > 0 ) {
-		return blockMetadataFiles.reduce(
+		const entryPoints = blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
 				const {
 					editorScript,
@@ -227,6 +227,10 @@ function getWebpackEntryPoints() {
 			},
 			{}
 		);
+
+		if ( Object.keys( entryPoints ).length > 0 ) {
+			return entryPoints;
+		}
 	}
 
 	// 3. Checks whether a standard file name can be detected in the `src` directory,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Improves #38357.

When testing the [Superlist](https://github.com/createwithrani/superlist) plugin with two blocks from @createwithrani I figured out that we don't have proper handling when there are no scripts in the `src` subfolder discovered when scanning existing `block.json` files. This PR ensures that the `wp-scripts build` command falls back to `src/index.js` when that happens.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

You can use the [Superlist](https://github.com/createwithrani/superlist) plugin for testing however, you will need to remove the `webpack.config.js` files that override the entry points.

The steps I used:

1. Cloned Gutenberg.
2. Cloned Superlist in the Gutenberg project.
3. Run `cd superlist`.
4. Run `rm webpack.config.js`.
5. Run `../node_modules/.bin/wp-scripts build`.
6. You should see all `block.json` files copied over, but also other files built from `src/index.js`. 

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
