### PR TITLE
Testing: Test Create Block with more OS and Node versions

### DIFF
--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -15,12 +15,16 @@ concurrency:
 jobs:
     checks:
         name: Checks
-        runs-on: ubuntu-latest
+        runs-on: ${{ matrix.os }}
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             fail-fast: false
             matrix:
-                node: ['12', '14']
+                node: [14]
+                os: [macos-latest, ubuntu-latest, windows-latest]
+                include:
+                    - node: 12
+                      os: ubuntu-latest
 
         steps:
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -36,6 +36,7 @@ jobs:
                   cache: npm
 
             - name: npm install, build, format and lint
+              shell: bash
               run: |
                   npm ci
                   npm run test:create-block

--- a/.github/workflows/create-block.yml
+++ b/.github/workflows/create-block.yml
@@ -39,4 +39,4 @@ jobs:
               shell: bash
               run: |
                   npm ci
-                  npm run test:create-block
+                  sh ./bin/test-create-block.sh

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -37,7 +37,7 @@ status "Building block..."
 
 status "Verifying build..."
 expected=5
-actual=$( ls build | wc -l | xargs )
+actual=$( ls build | wc -l | awk '{$1=$1};1' )
 if [ "$expected" != "$actual" ]; then
 	error "Expected $expected files in the build folder, but found $actual."
     exit 1

--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -15,6 +15,10 @@ status () {
 	echo -e "\n\033[1;34m$1\033[0m\n"
 }
 
+error () {
+	echo -e "\n\033[1;31m$1\033[0m\n"
+}
+
 cleanup() {
 	rm -rf "$DIRECTORY/esnext-test"
 }
@@ -30,6 +34,14 @@ status "Formatting files..."
 
 status "Building block..."
 ../node_modules/.bin/wp-scripts build
+
+status "Verifying build..."
+expected=5
+actual=$( ls build | wc -l | xargs )
+if [ "$expected" != "$actual" ]; then
+	error "Expected $expected files in the build folder, but found $actual."
+    exit 1
+fi
 
 status "Lintig CSS files..."
 ../node_modules/.bin/wp-scripts lint-style

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
 		"publish:patch": "lerna publish --dist-tag patch",
 		"publish:latest": "lerna publish",
 		"test": "npm run lint && npm run test-unit",
-		"test:create-block": "./bin/test-create-block.sh",
+		"test:create-block": "sh ./bin/test-create-block.sh",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",

--- a/package.json
+++ b/package.json
@@ -268,7 +268,7 @@
 		"publish:patch": "lerna publish --dist-tag patch",
 		"publish:latest": "lerna publish",
 		"test": "npm run lint && npm run test-unit",
-		"test:create-block": "sh ./bin/test-create-block.sh",
+		"test:create-block": "./bin/test-create-block.sh",
 		"test-e2e": "wp-scripts test-e2e --config packages/e2e-tests/jest.config.js",
 		"test-e2e:debug": "wp-scripts --inspect-brk test-e2e --config packages/e2e-tests/jest.config.js --puppeteer-devtools",
 		"test-e2e:watch": "npm run test-e2e -- --watch",


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

We had a regression in https://github.com/WordPress/gutenberg/pull/38348 for Windows OS when using `@wordpress/scripts`. That could be caught early in the process with GitHub Actions if we were testing more operating systems. This PR tries to include Windows and macOS when testing Create Block.

~It also adds Node 16 to the mix.~ _(Node 16 doesn't work with the current lock file because it uses npm 8)_

