### PR TITLE
Declare package visibility to query URL handler apps

### DIFF
--- a/packages/react-native-bridge/CHANGELOG.md
+++ b/packages/react-native-bridge/CHANGELOG.md
@@ -2,5 +2,13 @@
 
 ## Unreleased
 
+- [***] Fix launching video preview on Android 11+ [#38377]
+
+
+## 1.70.0
+
 - [**] Fix Android handling of Hebrew and Indonesian translations [#37565]
+
+## 1.70.1
+
 - [***] Bump minimum deployment target to iOS 13.0 [#27577]

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/AndroidManifest.xml
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/AndroidManifest.xml
@@ -2,6 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.wordpress.mobile.ReactNativeGutenbergBridge">
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="http"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https"/>
+        </intent>
+    </queries>
+
     <application>
         <activity
             android:name=".GutenbergWebViewActivity"


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Fix launching the video preview from the video block on Android 11+.

## Testing Instructions
1. Run the native mobile demo app on Android
2. Scroll down to find the video block in the demo content
3. Tap on the video block and then tap on the "Play" button to launch the video preview
4. Notice that the preview opens in a browser (perhaps asking you to download the video file actually)

## Types of changes
* Declare that we'll be querying packages for handlers of the `android.intent.action.VIEW` intent on `http` and `https` schemes.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
