### PR TITLE
Avoid first time contributor workflows for bots

### DIFF
--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -57,6 +57,13 @@ async function firstTimeContributorAccountLink( payload, octokit ) {
 		return;
 	}
 
+	const userType = commit.author.type;
+
+	if ( userType === 'Bot' ) {
+		debug( 'first-time-contributor-account-link: User is a bot. Aborting' );
+		return;
+	}
+
 	const repo = payload.repository.name;
 	const owner = payload.repository.owner.login;
 	const author = commit.author.username;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -57,9 +57,11 @@ async function firstTimeContributorAccountLink( payload, octokit ) {
 		return;
 	}
 
-	const userType = commit.author.type;
+	const { data: user } = await octokit.rest.users.getByUsername(
+		commit.author.username
+	);
 
-	if ( userType === 'Bot' ) {
+	if ( user.type === 'Bot' ) {
 		debug( 'first-time-contributor-account-link: User is a bot. Aborting' );
 		return;
 	}

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
@@ -32,6 +32,36 @@ describe( 'firstTimeContributorAccountLink', () => {
 		},
 	};
 
+	it( 'does nothing for commits by bots', async () => {
+		const payloadForBot = {
+			...payload,
+			commits: [
+				{
+					id: '4c535288a6a2b75ff23ee96c75f7d9877e919241',
+					message: 'Add a feature from pull request (#123)',
+					author: {
+						name: 'Ghost',
+						email: 'ghost@example.invalid',
+						username: 'ghost',
+						type: 'Bot',
+					},
+				},
+			],
+		};
+
+		const octokit = {
+			rest: {
+				repos: {
+					listCommits: jest.fn(),
+				},
+			},
+		};
+
+		await firstTimeContributorAccountLink( payloadForBot, octokit );
+
+		expect( octokit.rest.repos.listCommits ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does nothing if not a commit to trunk', async () => {
 		const payloadForBranchPush = {
 			...payload,

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/index.js
@@ -13,6 +13,13 @@ const debug = require( '../../debug' );
  * @param {GitHub}                    octokit Initialized Octokit REST client.
  */
 async function firstTimeContributorLabel( payload, octokit ) {
+	const userType = payload.pull_request.user.type;
+
+	if ( userType === 'Bot' ) {
+		debug( 'first-time-contributor: User is a bot. Aborting' );
+		return;
+	}
+
 	const repo = payload.repository.name;
 	const owner = payload.repository.owner.login;
 	const author = payload.pull_request.user.login;

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-label/test/index.js
@@ -19,6 +19,31 @@ describe( 'firstTimeContributorLabel', () => {
 		},
 	};
 
+	it( 'does nothing for PRs by bots', async () => {
+		const payloadForBot = {
+			...payload,
+			pull_request: {
+				user: {
+					login: 'ghost',
+					type: 'Bot',
+				},
+				number: 123,
+			},
+		};
+
+		const octokit = {
+			rest: {
+				repos: {
+					listCommits: jest.fn(),
+				},
+			},
+		};
+
+		await firstTimeContributorLabel( payloadForBot, octokit );
+
+		expect( octokit.rest.repos.listCommits ).not.toHaveBeenCalled();
+	} );
+
 	it( 'does nothing if the user has at least one commit', async () => {
 		const octokit = {
 			rest: {


### PR DESCRIPTION
## Description
I've noticed some bot PRs coming in recently, and they each get the First time contributor label and welcome message.

While it's kind of sweet for a robot to welcome another robot, it'd be nice to keep the labelling in particular just to humans for anyone who is making a point of reviewing first time contributor PRs.

Looking at the github API's response (https://api.github.com/users/welcome[bot]), we can skip the workflows for bots by checking if the `type` field is set to `'Bot'`.

## Types of changes
Project automation fix
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
