### PR TITLE
Plugins: Add error boundary

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api/error-boundary.js
+++ b/packages/e2e-tests/plugins/plugins-api/error-boundary.js
@@ -1,0 +1,12 @@
+( function () {
+	const registerPlugin = wp.plugins.registerPlugin;
+
+	function MyErrorPlugin() {
+		// throw new Error('Whoops!')
+		throw new TypeError('Hello', "someFile.js", 10)
+	}
+
+	registerPlugin( 'my-error-plugin', {
+		render: MyErrorPlugin,
+	} );
+} )();

--- a/packages/e2e-tests/plugins/plugins-api/error-boundary.js
+++ b/packages/e2e-tests/plugins/plugins-api/error-boundary.js
@@ -2,8 +2,7 @@
 	const registerPlugin = wp.plugins.registerPlugin;
 
 	function MyErrorPlugin() {
-		// throw new Error('Whoops!')
-		throw new TypeError('Hello', "someFile.js", 10)
+		throw new Error('Whoops!');
 	}
 
 	registerPlugin( 'my-error-plugin', {

--- a/packages/e2e-tests/plugins/plugins-error-boundary.php
+++ b/packages/e2e-tests/plugins/plugins-error-boundary.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Plugins Error Boundary
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-plugin-plugins-error-boundary
+ */
+
+/**
+ * Registers custom scripts for the plugin error boundary.
+ */
+function enqueue_plugins_error_boundary_plugin_scripts() {
+	wp_enqueue_script(
+		'gutenberg-test-plugin-plugins-error-boundary',
+		plugins_url( 'plugins-api/error-boundary.js', __FILE__ ),
+		array(
+			'wp-edit-post',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/error-boundary.js' ),
+		true
+	);
+}
+add_action( 'init', 'enqueue_plugins_error_boundary_plugin_scripts' );

--- a/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js
@@ -156,4 +156,34 @@ describe( 'Using Plugins API', () => {
 			expect( pluginDocumentSettingsText ).toMatchSnapshot();
 		} );
 	} );
+
+	describe( 'Error Boundary', () => {
+		beforeAll( async () => {
+			await activatePlugin(
+				'gutenberg-test-plugin-plugins-error-boundary'
+			);
+		} );
+
+		afterAll( async () => {
+			await deactivatePlugin(
+				'gutenberg-test-plugin-plugins-error-boundary'
+			);
+		} );
+
+		it( 'Should create notice using plugin error boundary callback', async () => {
+			const noticeContent = await page.waitForSelector(
+				'.is-error .components-notice__content'
+			);
+			expect(
+				await page.evaluate(
+					( _noticeContent ) => _noticeContent.firstChild.nodeValue,
+					noticeContent
+				)
+			).toEqual(
+				'The "my-error-plugin" plugin has encountered an error and cannot be rendered.'
+			);
+
+			expect( console ).toHaveErrored();
+		} );
+	} );
 } );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -20,7 +20,7 @@ import { BlockBreadcrumb, BlockStyles } from '@wordpress/block-editor';
 import { Button, ScrollLock, Popover } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { PluginArea } from '@wordpress/plugins';
-import { __, _x } from '@wordpress/i18n';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import {
 	ComplementaryArea,
 	FullscreenMode,
@@ -29,6 +29,7 @@ import {
 } from '@wordpress/interface';
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -70,6 +71,7 @@ function Layout( { styles } ) {
 		closeGeneralSidebar,
 		setIsInserterOpened,
 	} = useDispatch( editPostStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 	const {
 		mode,
 		isFullscreenActive,
@@ -178,6 +180,18 @@ function Layout( { styles } ) {
 		return null;
 	};
 
+	function handlePluginErrors( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
+
 	return (
 		<>
 			<FullscreenMode isActive={ isFullscreenActive } />
@@ -273,7 +287,7 @@ function Layout( { styles } ) {
 			<KeyboardShortcutHelpModal />
 			<WelcomeGuide />
 			<Popover.Slot />
-			<PluginArea />
+			<PluginArea onError={ handlePluginErrors } />
 		</>
 	);
 }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -180,7 +180,7 @@ function Layout( { styles } ) {
 		return null;
 	};
 
-	function handlePluginErrors( name ) {
+	function onPluginAreaError( name ) {
 		createErrorNotice(
 			sprintf(
 				/* translators: %s: plugin name */
@@ -287,7 +287,7 @@ function Layout( { styles } ) {
 			<KeyboardShortcutHelpModal />
 			<WelcomeGuide />
 			<Popover.Slot />
-			<PluginArea onError={ handlePluginErrors } />
+			<PluginArea onError={ onPluginAreaError } />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -16,12 +16,13 @@ import {
 	EditorSnackbars,
 	EntitiesSavedStates,
 } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { PluginArea } from '@wordpress/plugins';
 import {
 	ShortcutProvider,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -110,6 +111,7 @@ function Editor( { onError } ) {
 	}, [] );
 	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const [
 		isEntitiesSavedStatesOpen,
@@ -180,6 +182,18 @@ function Editor( { onError } ) {
 		}
 		return null;
 	};
+
+	function onPluginAreaError( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
@@ -294,7 +308,9 @@ function Editor( { onError } ) {
 										/>
 										<WelcomeGuide />
 										<Popover.Slot />
-										<PluginArea />
+										<PluginArea
+											onError={ onPluginAreaError }
+										/>
 									</ErrorBoundary>
 								</BlockContextProvider>
 							</GlobalStylesProvider>

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,8 +1,11 @@
 /**
  * WordPress dependencies
  */
+import { __, sprintf } from '@wordpress/i18n';
 import { Popover } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { PluginArea } from '@wordpress/plugins';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -15,6 +18,20 @@ import UnsavedChangesWarning from './unsaved-changes-warning';
 import WelcomeGuide from '../welcome-guide';
 
 function Layout( { blockEditorSettings, onError } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	function onPluginAreaError( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
+
 	return (
 		<ErrorBoundary onError={ onError }>
 			<WidgetAreasBlockEditorProvider
@@ -23,7 +40,7 @@ function Layout( { blockEditorSettings, onError } ) {
 				<Interface blockEditorSettings={ blockEditorSettings } />
 				<Sidebar />
 				<Popover.Slot />
-				<PluginArea />
+				<PluginArea onError={ onPluginAreaError } />
 				<UnsavedChangesWarning />
 				<WelcomeGuide />
 			</WidgetAreasBlockEditorProvider>

--- a/packages/plugins/src/components/plugin-area/index.js
+++ b/packages/plugins/src/components/plugin-area/index.js
@@ -14,6 +14,7 @@ import { addAction, removeAction } from '@wordpress/hooks';
  * Internal dependencies
  */
 import { PluginContextProvider } from '../plugin-context';
+import { PluginErrorBoundary } from '../plugin-error-boundary';
 import { getPlugins } from '../../api';
 
 /**
@@ -114,7 +115,12 @@ class PluginArea extends Component {
 						key={ context.name }
 						value={ context }
 					>
-						<Plugin />
+						<PluginErrorBoundary
+							name={ context.name }
+							onError={ this.props.onError }
+						>
+							<Plugin />
+						</PluginErrorBoundary>
 					</PluginContextProvider>
 				) ) }
 			</div>

--- a/packages/plugins/src/components/plugin-error-boundary/index.js
+++ b/packages/plugins/src/components/plugin-error-boundary/index.js
@@ -4,8 +4,8 @@
 import { Component } from '@wordpress/element';
 
 export class PluginErrorBoundary extends Component {
-	constructor() {
-		super( ...arguments );
+	constructor( props ) {
+		super( props );
 		this.state = {
 			hasError: false,
 		};

--- a/packages/plugins/src/components/plugin-error-boundary/index.js
+++ b/packages/plugins/src/components/plugin-error-boundary/index.js
@@ -23,8 +23,7 @@ export class PluginErrorBoundary extends Component {
 	}
 
 	render() {
-		const { hasError } = this.state;
-		if ( ! hasError ) {
+		if ( ! this.state.hasError ) {
 			return this.props.children;
 		}
 

--- a/packages/plugins/src/components/plugin-error-boundary/index.js
+++ b/packages/plugins/src/components/plugin-error-boundary/index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+export class PluginErrorBoundary extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			hasError: false,
+		};
+	}
+
+	static getDerivedStateFromError() {
+		return { hasError: true };
+	}
+
+	componentDidCatch( error ) {
+		const { name, onError } = this.props;
+		if ( onError ) {
+			onError( name, error );
+		}
+	}
+
+	render() {
+		const { hasError } = this.state;
+		if ( ! hasError ) {
+			return this.props.children;
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Description
PR adds an error boundary around the plugin renderer component.

The editors can handle displaying error messages using the new `onError` prop of `PluginArea`. It's a callback that will receive the plugin's name and an error.

Resolves #9630.

## Todos
- [x] Add error handlers to other editors.
- [x] Decide if we want to include the "Copy error" action in the notice.
- [ ] Add documentation for `onError` prop.

## Testing Instructions
1. Open a post editor.
2. Paste the snippet in the DevTools console.
3. Check that the new error notice is displayed.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-01 at 12 32 46](https://user-images.githubusercontent.com/240569/151936963-105cb047-1b41-466e-8f25-61d299f53b85.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
