### PR TITLE
Images: Try moving responsive rule to common.scss.

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -120,3 +120,13 @@ html :where(.has-border-color) {
 html :where([style*="border-width"]) {
 	border-style: solid;
 }
+
+
+/**
+ * Provide baseline responsiveness for images.
+ */
+
+html :where(img) {
+	height: auto;
+	max-width: 100%;
+}

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -125,7 +125,6 @@ html :where([style*="border-width"]) {
 /**
  * Provide baseline responsiveness for images.
  */
-
 html :where(img) {
 	height: auto;
 	max-width: 100%;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -2,8 +2,6 @@
 	margin: 0 0 1em 0;
 
 	img {
-		height: auto;
-		max-width: 100%;
 		vertical-align: bottom;
 	}
 


### PR DESCRIPTION
## Description

Fixes #38384. We have CSS in place to provide a default responsive behavior for Image blocks (`max-width: 100%; height: auto;`), but this doesn't affect images inserted in the classic block. Before:

<img width="1661" alt="before" src="https://user-images.githubusercontent.com/1204802/151946304-473dd9d3-abd5-43d0-84d8-77718f891248.png">

This PR moves that responsive baseline to the `common.scss` file so it becomes boilerplate CSS rather than CSS specifically for the Image block. After:

<img width="1197" alt="after" src="https://user-images.githubusercontent.com/1204802/151946393-f52ef9b6-73ba-46bc-9168-3e0d31de2e7c.png">

I'm unsure whether this is good practice. There's an argument to be made that the responsive behavior is a feature of the image block, and that when you're inserting a non-block image, it can be a sign that you want the freeform behavior. Also, the less boilerplate CSS, arguably, the better. 

Nevertheless this does fix the issue, even if this PR needs testing across every single element in the canvas that uses Images, if we want to land it.

## Testing Instructions

Insert test content, such as [from this comment](https://github.com/WordPress/gutenberg/issues/38384#issuecomment-1026651297), and observe as in the screenshot above that the classic image is bounded by the main column.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
