### PR TITLE
Fix undefined window in Resizable-box tooltip

### DIFF
--- a/packages/components/src/resizable-box/resize-tooltip/utils.ts
+++ b/packages/components/src/resizable-box/resize-tooltip/utils.ts
@@ -9,7 +9,8 @@ import useResizeAware from 'react-resize-aware';
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
 
-const { clearTimeout, setTimeout } = window;
+const { clearTimeout = () => undefined, setTimeout = () => undefined } =
+	typeof window !== 'undefined' ? window : {};
 
 export type Axis = 'x' | 'y';
 


### PR DESCRIPTION
## Description
Following the refactor and transformation of the resisable-box to typescript (PR https://github.com/WordPress/gutenberg/pull/35062) the window object were not anymore tested to be `undefined`. ([exactly here](https://github.com/WordPress/gutenberg/pull/35062/files#diff-9353883674b04acc7c8c2d3e236a418dbcf0f3f39e783e82083c94a649393c81L12-R12))

This PR revert this single line of code to verify wether `window` is `undefined` and sets default to `clearTimeout` and
`setTimeout` to avoid any crash of the app using **@wordpress/components** packages

We use **@wordpress/components** in the frontend of our app built in nextjs. Therefore when building the app or generating a static version on the server, the window object is not accessible. Hence the bug encountered when updating the package to its latest version which removed the `undefined` test of the window object.


## Types of changes
- Bug fix 

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- ~[ ] My code follows the accessibility standards.~ not relevant as no changes made on displayed component
- ~[ ] I've tested my changes with keyboard and screen readers.~ not relevant
- ~[ ] My code has proper inline documentation.~ not relevant
- ~[ ] I've included developer documentation if appropriate.~ not relevant
- ~[ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal).~ not relevant
- ~[ ] I've updated related schemas if appropriate.~ not relevant
