### PR TITLE
Tag Cloud: Add the style to the block.json file

### DIFF
--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -22,6 +22,10 @@
 			"default": false
 		}
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "outline", "label": "Outline" }
+	],
 	"supports": {
 		"html": false,
 		"align": true

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -57,7 +57,6 @@ function register_block_core_tag_cloud() {
 		array(
 			'name'         => 'outline',
 			'label'        => __( 'Outline', 'gutenberg' ),
-			'style_handle' => 'outline',
 		)
 	);
 }

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -51,13 +51,5 @@ function register_block_core_tag_cloud() {
 			'render_callback' => 'render_block_core_tag_cloud',
 		)
 	);
-
-	register_block_style(
-		'core/tag-cloud',
-		array(
-			'name'         => 'outline',
-			'label'        => __( 'Outline', 'gutenberg' ),
-		)
-	);
 }
 add_action( 'init', 'register_block_core_tag_cloud' );


### PR DESCRIPTION
## Description
This addresses the feedback in https://github.com/WordPress/gutenberg/pull/37092 and adds the new block style to the block.json file

## Testing Instructions
Add a tag cloud block and confirm that you can still see the styles:

## Screenshots <!-- if applicable -->
<img width="303" alt="Screenshot 2022-02-01 at 11 03 00" src="https://user-images.githubusercontent.com/275961/151957163-ba174458-039a-4175-aebb-f799de52d8f5.png">


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
