### PR TITLE
Try/add consolidate styles to editor store

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -137,7 +137,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				'__experimentalStyles'                   => array(
 					'description' => __( 'Styles consolidated from core, theme, and user origins.', 'gutenberg' ),
 					'type'        => 'object',
-					'context'     => array( 'mobile' ),
+					'context'     => array( 'mobile', 'post-editor' ),
 				),
 
 				'alignWide'                              => array(

--- a/packages/block-editor/src/components/use-consolidated-styles/index.js
+++ b/packages/block-editor/src/components/use-consolidated-styles/index.js
@@ -9,18 +9,51 @@ import { useSelect } from '@wordpress/data';
 import { useBlockEditContext } from '../block-edit';
 import { store as blockEditorStore } from '../../store';
 
-export default function useConsolidatedStyles() {
+/**
+ * // TODO This is an example targeted at specific style properties. We could consolidate at the highest level, e.g., return a merged styles object for all in packages/block-editor/src/hooks/style.js
+ * Hook that retrieves consolidated styles from the block editor store,
+ * and merges them with incoming user styles for a particular property.
+ *
+ * @param  {Object} userStyles    User-selected styles from the editor.
+ * @param  {string} styleProperty Targets a specific property. If not passed then we return the entire merged object.
+ *
+ * @return {Object}               The merged user styles, or original user styles if no consolidated styles.
+ *
+ * @example
+ * ```js
+ * const consolidatedStyles = useConsolidatedStyles( props.attributes?.style, 'border' );
+ * ```
+ */
+export default function useConsolidatedStyles( userStyles, styleProperty ) {
 	const { name: blockName } = useBlockEditContext();
-	const consolidatedStyles = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const consolidatedBlockStyles =
-			getSettings().__experimentalStyles?.blocks || {};
 
+	const consolidatedStyles = useSelect(
+		( select ) => {
+			const { getSettings } = select( blockEditorStore );
+			const consolidatedBlockStyles =
+				getSettings().__experimentalStyles?.blocks || {};
 
-		return consolidatedBlockStyles && consolidatedBlockStyles[ blockName ]
-			? consolidatedBlockStyles[ blockName ]
-			: null;
-	}, [] );
+			return consolidatedBlockStyles &&
+				consolidatedBlockStyles[ blockName ]
+				? consolidatedBlockStyles[ blockName ]
+				: undefined;
+		},
+		[ blockName, styleProperty ]
+	);
 
-	return consolidatedStyles;
+	if ( ! userStyles || ! styleProperty ) {
+		return userStyles;
+	}
+
+	if ( consolidatedStyles ) {
+		return {
+			...userStyles,
+			[ styleProperty ]: {
+				...consolidatedStyles[ styleProperty ],
+				...userStyles[ styleProperty ],
+			},
+		};
+	}
+
+	return userStyles;
 }

--- a/packages/block-editor/src/components/use-consolidated-styles/index.js
+++ b/packages/block-editor/src/components/use-consolidated-styles/index.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockEditContext } from '../block-edit';
+import { store as blockEditorStore } from '../../store';
+
+export default function useConsolidatedStyles() {
+	const { name: blockName } = useBlockEditContext();
+	const consolidatedStyles = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const consolidatedBlockStyles =
+			getSettings().__experimentalStyles?.blocks || {};
+
+
+		return consolidatedBlockStyles && consolidatedBlockStyles[ blockName ]
+			? consolidatedBlockStyles[ blockName ]
+			: null;
+	}, [] );
+
+	return consolidatedStyles;
+}

--- a/packages/style-engine/src/store/actions.ts
+++ b/packages/style-engine/src/store/actions.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+
+
+export const CREATE_STYLE = 'CREATE_STYLE';
+export const DELETE_STYLE = 'DELETE_STYLE';
+export const UPDATE_STYLE = 'UPDATE_STYLE';
+
+export type Action< Type > = {
+	type: Type;
+	selector: string;
+	value: {
+		rule: string;
+	};
+};
+
+export type CreateStyle = Action< typeof CREATE_STYLE >;
+export type UpdateStyle = Action< typeof UPDATE_STYLE >;
+export type DeleteStyle = Omit< Action< typeof DELETE_STYLE >, 'value' >;
+
+export type StyleAction = CreateStyle | UpdateStyle | DeleteStyle;

--- a/packages/style-engine/src/store/index.ts
+++ b/packages/style-engine/src/store/index.ts
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { createReduxStore, register } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import reducer from './reducer';
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+const STORE_NAME = 'core/style-engine';
+
+/**
+ * Store definition for the style-engine namespace.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
+ *
+ * @type {Object}
+ */
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
+
+register( store );

--- a/packages/style-engine/src/store/reducer.ts
+++ b/packages/style-engine/src/store/reducer.ts
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import type { CSSRuleState } from './types';
+import * as actions from './actions';
+
+/**
+ * Reducer returning the style engine state.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+
+function reducer( state: CSSRuleState = {}, action: actions.StyleAction ) {
+	switch ( action.type ) {
+		case actions.CREATE_STYLE:
+			if ( !! state[ action.selector ] ) {
+				return {
+					...state,
+					[ action.selector ]: {
+						...state[ action.selector ],
+						...action.value,
+					},
+				};
+			}
+			return {
+				...state,
+				[ action.selector ]: {
+					...action.value,
+				},
+			};
+		case actions.UPDATE_STYLE:
+			return {
+				...state,
+				[ action.selector ]: {
+					...state[ action.selector ],
+					...action.value,
+				},
+			};
+		case actions.DELETE_STYLE:
+			const { [ action.selector ]: value, ...newState } = state;
+			return newState;
+	}
+
+	return state;
+}
+
+export default reducer;

--- a/packages/style-engine/src/store/selectors.ts
+++ b/packages/style-engine/src/store/selectors.ts
@@ -1,0 +1,46 @@
+/**
+ * Internal dependencies
+ */
+import type { CSSRuleState, CSSRule } from './types';
+
+/**
+ * Returns a style definition by selector
+ *
+ * @param {CSSRuleState} state    Global application state.
+ * @param {string}       selector
+ * @return {CSSRule} Object with error notices.
+ */
+export function getStyleBySelector(
+	state: CSSRuleState,
+	selector: string
+): CSSRule {
+	return state[ selector ];
+}
+
+function snakeCase( rule: string ): string {
+	return rule.replace( /[A-Z]/g, ( match ) => `-${ match.toLowerCase() }` );
+}
+
+function getCssDefinitions( definitions: CSSRule ): string {
+	const cssDefinitions: string[] = [];
+	for ( const [ key, value ] of Object.entries( definitions ) ) {
+		cssDefinitions.push( `${ snakeCase( key ) }: ${ value }` );
+	}
+	return cssDefinitions.join( '; ' );
+}
+
+
+/**
+ * Returns concatenated CSS from the CSSRuleState.
+ *
+ * @param {CSSRuleState} state Global application state.
+ * @return {string} Concatenated CSS
+ */
+
+export function getConcatenatedCSSFromStyles( state: CSSRuleState ): string {
+	const cssRules: string[] = [];
+	for ( const [ key, value ] of Object.entries( state ) ) {
+		cssRules.push( `${ key } { ${ getCssDefinitions( value ) } }` );
+	}
+	return cssRules.join( ' ' );
+}

--- a/packages/style-engine/src/store/test/selectors.js
+++ b/packages/style-engine/src/store/test/selectors.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getStyleBySelector,
+	getCssDefinitions,
+	getConcatenatedCSSFromStyles,
+} from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getConcatenatedCSSFromStyles', () => {
+		it( 'should return a concatenated CSS string', () => {
+			const state = {
+				'div > p strong.is-stormy': {
+					fontWeight: 'bold',
+					color: 'pink',
+				},
+			};
+			expect( getConcatenatedCSSFromStyles( state ) ).toEqual(
+				'div > p strong.is-stormy { font-weight: bold; color: pink }'
+			);
+		} );
+	} );
+} );

--- a/packages/style-engine/src/store/types.ts
+++ b/packages/style-engine/src/store/types.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import type { Reducer } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { StyleAction } from './actions';
+
+export type CSSRule = {
+	value: string;
+};
+
+export type CSSRuleState = {
+	[ selector: string ]: CSSRule;
+};
+
+export type StateReducer = Reducer< CSSRuleState, StyleAction >;


### PR DESCRIPTION
## Description

#### Why do this?

Housing all our styles in a central store will allow us to fetch, concatenate, (maybe) deduplicate all block CSS, but most important of all, publish all block styles in a single `<style />` element or stylesheet rather than in multiple style sheets.

#### What are the obstacles?

How would we use this to publish styles on the frontend? 

Where would the styles be stored so as to be accessible on the frontend?

What's the point of a central, clientside store if it won't represent all the different styles across various posts when editing? Or should this approach be only for editing, that is, to avoid the multiple style elements we have now. Is there any user benefit?

#### Do we need to do this?

Not really. I'm just  rubber duck thinking 🦆 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
