### PR TITLE
Duotone: Allow users to specify custom filters

### DIFF
--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * API to interact with global settings & styles.
+ *
+ * @package gutenberg
+ */
+
+ if ( ! function_exists( 'wp_get_global_styles_svg_filters' ) ) {
+	/**
+	 * Returns a string containing the SVGs to be referenced as filters (duotone).
+	 *
+	 * @return string
+	 */
+	function wp_get_global_styles_svg_filters() {
+		// Return cached value if it can be used and exists.
+		// It's cached by theme to make sure that theme switching clears the cache.
+		$transient_name = 'gutenberg_global_styles_svg_filters_' . get_stylesheet();
+		$can_use_cached = (
+			( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
+			( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
+			( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
+			! is_admin()
+		);
+		if ( $can_use_cached ) {
+			$cached = get_transient( $transient_name );
+			if ( $cached ) {
+				return $cached;
+			}
+		}
+
+		$supports_theme_json = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+
+		$origins = array( 'default', 'theme', 'user' );
+		if ( ! $supports_theme_json ) {
+			$origins = array( 'default' );
+		}
+
+		$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+		$svgs = $tree->get_svg_filters( $origins );
+
+		if ( $can_use_cached ) {
+			// Cache for a minute, same as gutenberg_get_global_stylesheet.
+			set_transient( $transient_name, $svgs, MINUTE_IN_SECONDS );
+		}
+
+		return $svgs;
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -63,6 +63,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 }
 
 require __DIR__ . '/compat.php';
+require __DIR__ . '/compat/wordpress-6.0/get-global-styles-and-settings.php';
 require __DIR__ . '/compat/wordpress-5.9/widget-render-api-endpoint/index.php';
 require __DIR__ . '/compat/wordpress-5.9/blocks.php';
 require __DIR__ . '/compat/wordpress-5.9/block-patterns.php';

--- a/packages/block-library/src/tag-cloud/block.json
+++ b/packages/block-library/src/tag-cloud/block.json
@@ -22,6 +22,10 @@
 			"default": false
 		}
 	},
+	"styles": [
+		{ "name": "default", "label": "Default", "isDefault": true },
+		{ "name": "outline", "label": "Outline" }
+	],
 	"supports": {
 		"html": false,
 		"align": true

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -57,7 +57,6 @@ function register_block_core_tag_cloud() {
 		array(
 			'name'         => 'outline',
 			'label'        => __( 'Outline', 'gutenberg' ),
-			'style_handle' => 'outline',
 		)
 	);
 }

--- a/packages/block-library/src/tag-cloud/index.php
+++ b/packages/block-library/src/tag-cloud/index.php
@@ -51,13 +51,5 @@ function register_block_core_tag_cloud() {
 			'render_callback' => 'render_block_core_tag_cloud',
 		)
 	);
-
-	register_block_style(
-		'core/tag-cloud',
-		array(
-			'name'         => 'outline',
-			'label'        => __( 'Outline', 'gutenberg' ),
-		)
-	);
 }
 add_action( 'init', 'register_block_core_tag_cloud' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
In order to allow themes to specify their own custom duotone filters, we need to allow SVG to be output for filters defined in the custom key of the Global Styles json object.

This is an alternative to https://github.com/WordPress/gutenberg/pull/38055. I'm not sure if this approach is right.

## How has this been tested?
Use the Skatepark theme
Open the customizer and select a custom color
Check that images have duotone applied with the new colors

## Screenshots
<img width="1439" alt="Screenshot 2022-01-18 at 16 30 00" src="https://user-images.githubusercontent.com/275961/149978031-532454c3-e7e2-4fce-8362-353aa7b7c17b.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
