### PR TITLE
UnitControl: Add __unstableInputWidth to prop types

### DIFF
--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { SyntheticEvent } from 'react';
+import type { CSSProperties, SyntheticEvent } from 'react';
 
 /**
  * Internal dependencies
@@ -79,6 +79,7 @@ export type UnitSelectControlProps = {
 
 export type UnitControlProps = UnitSelectControlProps & {
 	__unstableStateReducer?: StateReducer;
+	__unstableInputWidth?: CSSProperties[ 'width' ];
 	/**
 	 * If `true`, the unit `<select>` is hidden.
 	 *


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/37769

## Description

The `UnitControl` passes through props to an underlying `InputControl` component. The `InputControl` accepts an `__unstabledInputWidth` prop while the `UnitControl` types omit this. 

This PR adds `__unstableInputWidth` to the `UnitControlProps` type.

## Testing Instructions

1. Confirm the `__unstableInputWidth` prop's type for the `UnitControl` matches the [`InputControl`'s](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/input-control/types.ts#L28).
2. Check there are no errors when running `npm run build:package-types`
3. Test that the `UnitControl` continues to function in the Storybook: `npm run storybook:dev`

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
