### PR TITLE
ColorIndicator: Add ts-nocheck to color indicator

### DIFF
--- a/packages/components/src/color-indicator/index.js
+++ b/packages/components/src/color-indicator/index.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/37769

## Description

This PR adds a `// @ts-nocheck` to the color indicator component so it can be used in new typed components such as those under development for border controls without needing to type the `ColorIndicator` as well.

## Testing Instructions
1. Confirm there are no typos in the code change
2. Confirm color indicator in Storybook if you're ultra-thorough 🙂 

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
