### PR TITLE
Post Template: add no results message on frontend

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -37,7 +37,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {
-		return __( 'No results found.' );
+		return '<p>' . __( 'No results found.' ) . '</p>';
 	}
 
 	$classnames = '';

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -37,7 +37,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {
-		return '';
+		return __( 'No results found.' );
 	}
 
 	$classnames = '';


### PR DESCRIPTION
## Description

Adds a `"__( 'No results found.' )` string to the post template frontend where no posts are returned from the query.

❗ This is a PR in waiting: that is, it's in a holding pattern until we come up with a plan to make the "no results" view configurable. It might be a good idea to add content here, it probably isn't. 

🤔 Having a piece of text that isn't editable show up might not be in the spirit of the block editor, and it might be best to wait until we deliver an editable solution.

## Testing Instructions

Empty your site of all posts and pull up an archive page, or any query-based post using the Post Template Block.

Or search for http://localhost:4759/?s=where+is+my+coffee%3F

<img width="1047" alt="Screen Shot 2022-02-02 at 7 12 22 pm" src="https://user-images.githubusercontent.com/6458278/152117367-4b72dd73-89a5-4d14-b040-d4b646befa6e.png">




## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
