### PR TITLE
Navigation: Fix issue where block collapses to zero height when empty.

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -317,6 +317,17 @@ $color-control-label-height: 20px;
 	}
 }
 
+// Selected "Start empty" state.
+// In this state, the block is entirely empty and will collapse to zero height unless there's
+// content inside. The below rule lets the placeholder staty in an invisible state to avoid
+// collapse and layout shift.
+// @todo: This fix could be augmented with showing the generic appender when there are no
+// innerblocks, a la how the Row block does it.
+.wp-block-navigation.is-selected .wp-block-navigation__container .wp-block-navigation-placeholder__preview:first-of-type {
+	visibility: hidden;
+	display: flex;
+}
+
 // Selected state.
 .wp-block-navigation-placeholder__preview,
 .wp-block-navigation-placeholder__controls {

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -321,8 +321,9 @@ $color-control-label-height: 20px;
 // In this state, the block is entirely empty and will collapse to zero height unless there's
 // content inside. The below rule lets the placeholder stay in an invisible state to avoid
 // collapsing and shifting the layout.
-// @todo: This fix could be augmented with showing the generic appender when there are no
-// innerblocks, a la how the Row block does it.
+// @todo: Other container blocks show a white/bordered add block button when empty.
+// If we implement the same for Navigation, that button would also prevent the collapse
+// so this fix could be removed.
 .wp-block-navigation.is-selected .wp-block-navigation__container .wp-block-navigation-placeholder__preview:first-of-type {
 	visibility: hidden;
 	display: flex;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -319,8 +319,8 @@ $color-control-label-height: 20px;
 
 // Selected "Start empty" state.
 // In this state, the block is entirely empty and will collapse to zero height unless there's
-// content inside. The below rule lets the placeholder staty in an invisible state to avoid
-// collapse and layout shift.
+// content inside. The below rule lets the placeholder stay in an invisible state to avoid
+// collapsing and shifting the layout.
 // @todo: This fix could be augmented with showing the generic appender when there are no
 // innerblocks, a la how the Row block does it.
 .wp-block-navigation.is-selected .wp-block-navigation__container .wp-block-navigation-placeholder__preview:first-of-type {


### PR DESCRIPTION
## Description

Followup to #37099. When a navigation block is entirely empty, i.e. you click "Start empty", you can land in this collapsed state:

<img width="774" alt="before" src="https://user-images.githubusercontent.com/1204802/152118166-de38d3b6-6036-43e3-ae38-d5e926a11153.png">

It's technically accurate in terms of the block literally being empty, but it's not a great user experience. We should look at doing what the Row block is doing, and show the generic in-canvas appender (black plus in a bordered white box) when there are no innerblocks. In the mean time, this PR provides a guardrail so it doesn't collapse or shift between selected and empty state:

![after](https://user-images.githubusercontent.com/1204802/152118302-0ac476ee-3874-42b6-9bf3-3cbbd1c91c23.gif)


## Testing Instructions

- Insert a navigation block, deselect it, select it again, note no layout shifts.
- Select that same navigation block, click "Start empty", then deselect it, select it again, and note no layout shifts.
- Try menus with navigation items as well, and they should work as they do already.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
