### PR TITLE
Site Editor: Remove extra div on post content

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -31,8 +31,9 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>
 	) : (
-		<div { ...blockProps }
-			dangerouslySetInnerHTML={{ __html: content?.rendered }}
+		<div
+			{ ...blockProps }
+			dangerouslySetInnerHTML={ { __html: content?.rendered } }
 		></div>
 	);
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { createElement } from '@wordpress/element';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -32,10 +31,9 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>
 	) : (
-		createElement( 'div', {
-			dangerouslySetInnerHTML: { __html: content?.rendered },
-			...blockProps,
-		} )
+		<div { ...blockProps }
+			dangerouslySetInnerHTML={{ __html: content?.rendered }}
+		></div>
 	);
 }
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -32,7 +32,9 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>
 	) : (
-		<RawHTML key="html" { ...blockProps }>{ content?.rendered }</RawHTML>
+		<RawHTML key="html" { ...blockProps }>
+			{ content?.rendered }
+		</RawHTML>
 	);
 }
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -32,9 +32,7 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>
 	) : (
-		<div { ...blockProps }>
-			<RawHTML key="html">{ content?.rendered }</RawHTML>
-		</div>
+		<RawHTML key="html" { ...blockProps }>{ content?.rendered }</RawHTML>
 	);
 }
 

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { RawHTML } from '@wordpress/element';
+import { createElement } from '@wordpress/element';
 import {
 	useBlockProps,
 	useInnerBlocksProps,
@@ -32,9 +32,10 @@ function ReadOnlyContent( { userCanEdit, postType, postId } ) {
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>
 	) : (
-		<RawHTML key="html" { ...blockProps }>
-			{ content?.rendered }
-		</RawHTML>
+		createElement( 'div', {
+			dangerouslySetInnerHTML: { __html: content?.rendered },
+			...blockProps,
+		} )
 	);
 }
 


### PR DESCRIPTION
## Description
The post content block outputs and additional div when being rendered in the Site Editor. This is coming from the RawHTML component. There is a comment which suggests the extra div should be removed when the block is serialized but that doesn't seem to be happening.

This additional div is causing issues with out alignment styles for themes - see https://github.com/Automattic/themes/pull/5385

## Testing Instructions
Checkout this PR: https://github.com/Automattic/themes/pull/5385
Switch to the Livro theme
Open the Site Editor
Confirm that wide and full blocks go to the edge of the editor

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
