### PR TITLE
Don't ignore legitimate files when pasting mixed content

### DIFF
--- a/packages/block-editor/src/components/rich-text/use-paste-handler.js
+++ b/packages/block-editor/src/components/rich-text/use-paste-handler.js
@@ -155,9 +155,22 @@ export function usePasteHandler( props ) {
 				return;
 			}
 
-			// Only process file if no HTML is present.
-			// Note: a pasted file may have the URL as plain text.
-			if ( files && files.length && ! html ) {
+			// Process any attached files, unless we detect Microsoft Office as
+			// the source.
+			//
+			// When content is copied from Microsoft Office, an image of the
+			// content is rendered and attached to the clipboard along with the
+			// plain-text and HTML content. This artifact is a distraction from
+			// the relevant clipboard data, so we ignore it.
+			//
+			// Props https://github.com/pubpub/pubpub/commit/2f933277a15a263a1ab4bbd36b96d3a106544aec
+			if (
+				files &&
+				files.length &&
+				! html?.includes(
+					'xmlns:o="urn:schemas-microsoft-com:office:office'
+				)
+			) {
 				const content = pasteHandler( {
 					HTML: filePasteHandler( files ),
 					mode: 'BLOCKS',


### PR DESCRIPTION
## The problem

1. Using Google Chrome, open the single view of any image in Google Photos
2. Right-click the image and select "Copy image"
3. Paste it onto a fresh block editor canvas

**Expected:** The image is automatically uploaded to the site and appears in the form of an Image block
**Observed:** An image block appears but the image remains a external resource

To make matters worse, the option to manually upload the image is absent from this new image block.

## Causes

There are two causes at play, one of which we have little control over:

* Gutenberg's paste handler is favouring the fallback HTML data in the clipboard and ignoring the actual image file. _[this we can fix]_
* This causes the new Image block to refer to an external resource, but the runtime is blocked from reading it due to the existing [CORS](https://developer.mozilla.org/en-US/docs/Glossary/CORS) policy. This is why the option to manually upload the image is disabled. _[not much we can do here]_

## On pasting

Gutenberg's paste handler generally processes any files present in the clipboard data of a paste event.

However, an exception was introduced in 2018 in #4882 to deal with the fact that paste objects from Microsoft Word and other Office software contain a rendered image of the copied content. Users expected the actual content to be pasted, not an image thereof. Thus, the workaround was to ignore any files if the clipboard also contained HTML data, favouring the latter.

This workaround is now leading to false positives. In certain platforms (e.g. Google Photos using Google Chrome), when users copy an image, the resulting clipboard includes fallback HTML data.

With the present fix, pasted files are only ignored if the concurrent HTML data matches a distinct string signature from Microsoft Office. Props https://github.com/pubpub/pubpub/commit/2f933277a15a263a1ab4bbd36b96d3a106544aec for the solution.

## Testing Instructions

1. Follow the steps at the top to test that images copied from Google Photos (using Chrome) are correctly uploaded to the media library and that the resulting Image block uses this new local image.
2. Follow the steps in #4882 to test that there is no regression when pasting from Microsoft Word.

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
