### PR TITLE
[Blocks] Preserve source markup in invalid blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -65,7 +65,7 @@ function Block( { children, isHtml, ...props } ) {
 }
 
 function BlockListBlock( {
-	block,
+	block: { sourceMarkup },
 	mode,
 	isLocked,
 	canRemove,
@@ -131,19 +131,19 @@ function BlockListBlock( {
 		);
 	}
 
-	let BlockComponent;
+	let block;
 
 	if ( ! isValid ) {
-		BlockComponent = (
+		block = (
 			<Block className="has-warning">
 				<BlockInvalidWarning clientId={ clientId } />
-				<RawHTML>{ safeHTML( block.sourceMarkup ) }</RawHTML>
+				<RawHTML>{ safeHTML( sourceMarkup ) }</RawHTML>
 			</Block>
 		);
 	} else if ( mode === 'html' ) {
 		// Render blockEdit so the inspector controls don't disappear.
 		// See #8969.
-		BlockComponent = (
+		block = (
 			<>
 				<div style={ { display: 'none' } }>{ blockEdit }</div>
 				<Block isHtml>
@@ -152,9 +152,9 @@ function BlockListBlock( {
 			</>
 		);
 	} else if ( blockType?.apiVersion > 1 ) {
-		BlockComponent = blockEdit;
+		block = blockEdit;
 	} else {
-		BlockComponent = <Block { ...wrapperProps }>{ blockEdit }</Block>;
+		block = <Block { ...wrapperProps }>{ blockEdit }</Block>;
 	}
 
 	const value = {
@@ -174,7 +174,7 @@ function BlockListBlock( {
 					</Block>
 				}
 			>
-				{ BlockComponent }
+				{ block }
 			</BlockCrashBoundary>
 		</BlockListBlockContext.Provider>
 	);

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -13,11 +13,7 @@ import {
 	useCallback,
 	RawHTML,
 } from '@wordpress/element';
-import {
-	getBlockType,
-	getSaveContent,
-	isUnmodifiedDefaultBlock,
-} from '@wordpress/blocks';
+import { getBlockType, isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import { withDispatch, withSelect, useDispatch } from '@wordpress/data';
 import { compose, pure, ifCondition } from '@wordpress/compose';
@@ -69,6 +65,7 @@ function Block( { children, isHtml, ...props } ) {
 }
 
 function BlockListBlock( {
+	block,
 	mode,
 	isLocked,
 	canRemove,
@@ -134,21 +131,19 @@ function BlockListBlock( {
 		);
 	}
 
-	let block;
+	let BlockComponent;
 
 	if ( ! isValid ) {
-		const saveContent = getSaveContent( blockType, attributes );
-
-		block = (
+		BlockComponent = (
 			<Block className="has-warning">
 				<BlockInvalidWarning clientId={ clientId } />
-				<RawHTML>{ safeHTML( saveContent ) }</RawHTML>
+				<RawHTML>{ safeHTML( block.sourceMarkup ) }</RawHTML>
 			</Block>
 		);
 	} else if ( mode === 'html' ) {
 		// Render blockEdit so the inspector controls don't disappear.
 		// See #8969.
-		block = (
+		BlockComponent = (
 			<>
 				<div style={ { display: 'none' } }>{ blockEdit }</div>
 				<Block isHtml>
@@ -157,9 +152,9 @@ function BlockListBlock( {
 			</>
 		);
 	} else if ( blockType?.apiVersion > 1 ) {
-		block = blockEdit;
+		BlockComponent = blockEdit;
 	} else {
-		block = <Block { ...wrapperProps }>{ blockEdit }</Block>;
+		BlockComponent = <Block { ...wrapperProps }>{ blockEdit }</Block>;
 	}
 
 	const value = {
@@ -179,7 +174,7 @@ function BlockListBlock( {
 					</Block>
 				}
 			>
-				{ block }
+				{ BlockComponent }
 			</BlockCrashBoundary>
 		</BlockListBlockContext.Provider>
 	);

--- a/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
+++ b/packages/reusable-blocks/src/store/test/__snapshots__/actions.js.snap
@@ -15,6 +15,7 @@ Array [
         "isValid": true,
         "name": "core/test-block",
         "originalContent": "",
+        "sourceMarkup": "<!-- wp:test-block {\\"name\\":\\"Oscar the Grouch\\"} /-->",
         "validationIssues": Array [],
       },
       Object {
@@ -25,12 +26,17 @@ Array [
         "isValid": true,
         "name": "core/test-block",
         "originalContent": "",
+        "sourceMarkup": "<!-- wp:test-block {\\"name\\":\\"Cookie Monster\\"} /-->",
         "validationIssues": Array [],
       },
     ],
     "isValid": true,
     "name": "core/test-block",
     "originalContent": "",
+    "sourceMarkup": "<!-- wp:test-block {\\"name\\":\\"Big Bird\\"} -->
+<!-- wp:test-block {\\"name\\":\\"Oscar the Grouch\\"} /-->
+<!-- wp:test-block {\\"name\\":\\"Cookie Monster\\"} /-->
+<!-- /wp:test-block -->",
     "validationIssues": Array [],
   },
 ]


### PR DESCRIPTION
## Status

Currently this is **ON HOLD** as I prepare a broader change that addresses the shortcomings noted in the discussion, namely the `originalContent` field and all the little places we need to compare the preserved markup with the re-generated markup, such as in the block comparer during a "Resolve" for an invalid block.

 - [x] Can we avoid updating all the test fixtures? I feel really bad about making an otherwise small PR blow up with changes that are hard to review. I considered modifying our custom snapshot testing runner to exclude the `sourceMarkup` attribute but wanted to hear thoughts first about it. I wondered if we rely on these fixtures and if they are providing much value to us. If they are, I wonder why we have a custom runner instead of using `jest`, if that's a carry-over from earlier times.
      - I've updated the test runner to ignore/remove the `sourceMarkup` property when comparing. On one hand I like this but on the other hand maybe it would be best to leave it in and update the fixtures with the 600+ lines of code that adds to this PR because it would be less surprising to come across. Any thoughts are appreciated.
 - [x] Identify places that are still inconsistent or already consistent. For example, the "Resolve" screen comparing the invalid block against its fix gets things right somehow. Other places might use `originalContent` and I'd like to audit all those places and even get rid of `originalContent` if we can.
     - [ ] [install-button](https://github.com/WordPress/gutenberg/blob/1a8971ba51d1f69b718bf2f77261184b43950217/packages/block-directory/src/plugins/get-install-missing/install-button.js#L28-L31) parses `originalContent` but should we have it parse `sourceMarkup` instead?
     - [ ] [block-compare](https://github.com/WordPress/gutenberg/blob/1a8971ba51d1f69b718bf2f77261184b43950217/packages/block-editor/src/components/block-compare/index.js) shows a diff view of the `innerHTML` between a source block and the re-generated markup. showing the difference with `sourceMarkup` would show the delimiters and also the inner blocks. inner blocks could be noisy, but also essential. showing the delimiters could be confusing.
     - [ ] [getBlockInnerHTML](https://github.com/WordPress/gutenberg/blob/1a8971ba51d1f69b718bf2f77261184b43950217/packages/blocks/src/api/serializer.js#L280) returns `innerHTML` if it fails to validate or re-generate block output. can this wipe out inner blocks?
     - [ ] ⚠️ [validateBlock](https://github.com/WordPress/gutenberg/blob/1a8971ba51d1f69b718bf2f77261184b43950217/packages/blocks/src/api/validation/index.js#L732-L736) only looks at `innerHTML` which means that if we get different `innerBlocks` we'll accept it as valid.
     - [ ] ⚠️ [isValidBlockContent](https://github.com/WordPress/gutenberg/blob/1a8971ba51d1f69b718bf2f77261184b43950217/packages/blocks/src/api/validation/index.js#L764-L776) overwrites a block's `innerBlocks` with an empty array for validation, completely ignoring them.
 - [x] Assess more concretely the inner blocks problem whereas we want to be able to edit and modify recognized inner blocks for parent blocks that are invalid. This isn't totally pertinent to this PR so I don't want to hold it up on that account, but I'd like to better understand the implications and future work before merging.
     - for the sake of this PR I don't think we have to consider this problem. we're not making it worse and we're not getting in the way of fixing it. all we'll be doing is making sure that on save an invalid block leaves the original markup.

## Description

Previously we have been re-generating a block's save content when
we fail to properly validate that block. While this can work in many
cases it breaks down quickly because of the invalidly-parsed attributes.

Consider a list block whose `<ul>` tag has been removed. The block will
fail to validate and then also fail to read the content of the list items
because the CSS selector used to source the attribute won't work. The
attribute for the list's content will be empty and `getSaveContent` will
return an empty list, this despite the fact that the contents were largely
fine in the post HTML when loaded.

In this patch we're threading a new property into the block node called
`sourceMarkup` whose purpose is to preserve the original HTML in a post
so that we can choose to preserve that on save instead of corrupting or
losing content through the HTML re-generation.

With `sourceMarkup` we get a less-processed version of the source to
relay into save which should eliminate a common point of frustration:
saving a post erases content.

## Testing Instructions


## Screenshots

### Invalid list before
![Screen Shot 2022-02-02 at 11 41 00 AM](https://user-images.githubusercontent.com/5431237/152219589-070c1614-fff2-467e-bb8b-a9641700e7bb.png)

Note that the "Resolve" dialog already showed the proper content, but in the editor it looks like an empty list.

### Invalid list after
![Screen Shot 2022-02-02 at 11 38 57 AM](https://user-images.githubusercontent.com/5431237/152219818-2fd52e67-49e2-4d08-8353-ac1de9716254.png)

The editor shows the proper list items and will preserve them on save.


## Types of changes
 - Preserving original block attributes, HTML, and inner blocks when saving an invalid block vs. attempting to re-generate that content from the attributes which parsed but failed to validate.
 - Render existing broken content as HTML in editor for invalid blocks instead of showing broken re-generated content.

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
