### PR TITLE
Navigation Sidebar: experiment with a persistent vertical display

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -51,7 +51,6 @@ function Editor( { onError } ) {
 	const {
 		isInserterOpen,
 		isListViewOpen,
-		sidebarIsOpened,
 		settings,
 		entityId,
 		templateType,
@@ -205,13 +204,11 @@ function Editor( { onError } ) {
 										<InterfaceSkeleton
 											labels={ interfaceLabels }
 											secondarySidebar={ secondarySidebar() }
-											sidebar={
-												sidebarIsOpened && (
-													<ComplementaryArea.Slot scope="core/edit-site" />
-												)
-											}
 											drawer={
-												<NavigationSidebar.Slot />
+												<>
+													<NavigationSidebar.Slot />
+													<ComplementaryArea.Slot scope="core/edit-site" />
+												</>
 											}
 											header={
 												<Header

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -8,7 +8,6 @@ import {
 	__experimentalPreviewOptions as PreviewOptions,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
 import { listView, plus } from '@wordpress/icons';
 import { Button, ToolbarItem } from '@wordpress/components';
@@ -177,7 +176,6 @@ export default function Header( {
 						openEntitiesSavedStates={ openEntitiesSavedStates }
 						isEntitiesSavedStatesOpen={ isEntitiesSavedStatesOpen }
 					/>
-					<PinnedItems.Slot scope="core/edit-site" />
 					<MoreMenu />
 				</div>
 			</div>

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -10,7 +10,6 @@ $header-toolbar-min-width: 335px;
 	justify-content: space-between;
 
 	body.is-fullscreen-mode & {
-		padding-left: 60px;
 		transition: padding-left 20ms linear;
 		transition-delay: 80ms;
 		@include reduce-motion("transition");
@@ -65,10 +64,10 @@ body.is-navigation-sidebar-open {
 .edit-site-header__toolbar {
 	display: flex;
 	align-items: center;
-	padding-left: $grid-unit-10;
+	padding-left: $grid-unit-20;
 
 	@include break-small() {
-		padding-left: $grid-unit-30;
+		padding-left: $grid-unit-20;
 	}
 
 	@include break-wide() {

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/style.scss
@@ -39,7 +39,7 @@
 
 .edit-site-navigation-panel__site-title-container {
 	height: $header-height;
-	padding-left: $header-height;
+	padding-left: $grid-unit-30;
 	margin: 0 $grid-unit-20 0 $grid-unit-10;
 	display: flex;
 	align-items: center;

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -9,7 +9,7 @@ import {
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { wordpress } from '@wordpress/icons';
+import { sidebar, navigation, styles, wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
 
@@ -98,6 +98,9 @@ function NavigationToggle( { icon } ) {
 			>
 				{ buttonIcon }
 			</Button>
+			<Button icon={ navigation } iconSize={ 24 }></Button>
+			<Button icon={ sidebar } iconSize={ 24 }></Button>
+			<Button icon={ styles } iconSize={ 24 }></Button>
 		</motion.div>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -9,9 +9,10 @@ import {
 	__unstableMotion as motion,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { sidebar, navigation, styles, wordpress } from '@wordpress/icons';
+import { navigation, wordpress } from '@wordpress/icons';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useReducedMotion } from '@wordpress/compose';
+import { PinnedItems } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -98,9 +99,8 @@ function NavigationToggle( { icon } ) {
 			>
 				{ buttonIcon }
 			</Button>
-			<Button icon={ navigation } iconSize={ 24 }></Button>
-			<Button icon={ sidebar } iconSize={ 24 }></Button>
-			<Button icon={ styles } iconSize={ 24 }></Button>
+			<Button icon={ navigation } iconSize={ 24 } />
+			<PinnedItems.Slot scope="core/edit-site" />
 		</motion.div>
 	);
 }

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -6,17 +6,20 @@
 	background: $gray-900;
 	border-radius: 0;
 	display: flex;
-	position: absolute;
 	z-index: z-index(".edit-site-navigation-toggle");
 	height: $header-height;
 	width: $header-height;
+	flex-direction: column;
+
+	button {
+		color: $white;
+	}
 }
 
 .edit-site-navigation-toggle__button {
 	align-items: center;
 	background: $gray-900;
 	border-radius: 0;
-	color: $white;
 	height: $header-height + $border-width;
 	width: $header-height;
 	z-index: 1;
@@ -32,30 +35,6 @@
 
 		&:focus {
 			box-shadow: none;
-		}
-
-		&::before {
-			transition: box-shadow 0.1s ease;
-			@include reduce-motion("transition");
-			content: "";
-			display: block;
-			position: absolute;
-			top: 9px;
-			right: 9px;
-			bottom: 9px;
-			left: 9px;
-			border-radius: $radius-block-ui + $border-width + $border-width;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
-		}
-
-		// Hover color.
-		&:hover::before {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
-		}
-
-		// Lightened spot color focus.
-		&:focus::before {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
 

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -47,3 +47,7 @@
 		margin-top: -($border-width);
 	}
 }
+
+.edit-site-navigation-toggle .interface-pinned-items {
+	flex-direction: column-reverse;
+}

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -178,3 +178,8 @@ html.interface-interface-skeleton__html-container {
 		bottom: 0;
 	}
 }
+
+.interface-interface-skeleton__drawer {
+	background: $gray-900;
+	display: flex;
+}


### PR DESCRIPTION
Not ready to be reviewed. This is a quick spike to help inform direction on https://github.com/WordPress/gutenberg/issues/36667

https://user-images.githubusercontent.com/1270189/152258260-4ba57306-838f-4482-9573-b684fa0607c1.mp4

Some early thoughts:
- What should we see when we click on the site icon/W logo?
- Based on current structure, showing the persistent vertical strip is easier than adding horizontal buttons. The second is still possible, but likely requires tweaking the interface skeleton a bit. The W logo is currently absolutely positioned, and other elements have hardcoded padding offsets.
- Scope here is kind of big, but adding things piecemeal might not make sense (a pr for styles, another for nav, etc), We might need a larger diff, or a feature flag here.

Next Up:
- Prototype showing nav in W menu. (If there's more than one menu, let's show a dropdown selection).
- Try moving styles sidebar to the W nav. Ideally we should be able to reuse the ComplementaryArea system.
- Move templates to flat list?
