### PR TITLE
First Time Contributor check: update args for getByUsername

### DIFF
--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/index.js
@@ -57,9 +57,9 @@ async function firstTimeContributorAccountLink( payload, octokit ) {
 		return;
 	}
 
-	const { data: user } = await octokit.rest.users.getByUsername(
-		commit.author.username
-	);
+	const { data: user } = await octokit.rest.users.getByUsername( {
+		username: commit.author.username,
+	} );
 
 	if ( user.type === 'Bot' ) {
 		debug( 'first-time-contributor-account-link: User is a bot. Aborting' );

--- a/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
+++ b/packages/project-management-automation/lib/tasks/first-time-contributor-account-link/test/index.js
@@ -119,9 +119,9 @@ describe( 'firstTimeContributorAccountLink', () => {
 
 		await firstTimeContributorAccountLink( payload, octokit );
 
-		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith(
-			payload.commits[ 0 ].author.username
-		);
+		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith( {
+			username: payload.commits[ 0 ].author.username,
+		} );
 		expect( octokit.rest.repos.listCommits ).not.toHaveBeenCalled();
 	} );
 
@@ -155,9 +155,9 @@ describe( 'firstTimeContributorAccountLink', () => {
 
 		await firstTimeContributorAccountLink( payload, octokit );
 
-		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith(
-			payload.commits[ 0 ].author.username
-		);
+		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith( {
+			username: payload.commits[ 0 ].author.username,
+		} );
 		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
@@ -196,9 +196,9 @@ describe( 'firstTimeContributorAccountLink', () => {
 
 		await firstTimeContributorAccountLink( payload, octokit );
 
-		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith(
-			payload.commits[ 0 ].author.username
-		);
+		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith( {
+			username: payload.commits[ 0 ].author.username,
+		} );
 		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',
@@ -235,9 +235,9 @@ describe( 'firstTimeContributorAccountLink', () => {
 
 		await firstTimeContributorAccountLink( payload, octokit );
 
-		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith(
-			payload.commits[ 0 ].author.username
-		);
+		expect( octokit.rest.users.getByUsername ).toHaveBeenCalledWith( {
+			username: payload.commits[ 0 ].author.username,
+		} );
 		expect( octokit.rest.repos.listCommits ).toHaveBeenCalledWith( {
 			owner: 'WordPress',
 			repo: 'gutenberg',


### PR DESCRIPTION
## Description

Greetings!

The PR automation pipeline is reporting the following error:

```bash
main: Starting task firstTimeContributorAccountLink
Error: main: Task firstTimeContributorAccountLink failed with error: HttpError: request to https://api.github.commysweetusername/ failed, reason: getaddrinfo ENOTFOUND api.github.commysweetusername
```

Do you see the absence of a `/` in the API url `api.github.commysweetusername`? 

This PR is trying out switching `getByUsername`'s argument from a string to an object. See the relevant docs: https://octokit.github.io/rest.js/v18/

Will it work? LET THE PIPELINE DECIDE! 🏄 

Related PR:  https://github.com/WordPress/gutenberg/pull/38393

## Testing Instructions
The pull-request-automation jobs should run.


## Types of changes
Automation

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
