### PR TITLE
[Block Library - Site Tagline]: Disable line breaks

### DIFF
--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -15,8 +15,13 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
-export default function SiteTaglineEdit( { attributes, setAttributes } ) {
+export default function SiteTaglineEdit( {
+	attributes,
+	setAttributes,
+	insertBlocksAfter,
+} ) {
 	const { textAlign } = attributes;
 	const [ siteTagline, setSiteTagline ] = useEntityProp(
 		'root',
@@ -46,6 +51,10 @@ export default function SiteTaglineEdit( { attributes, setAttributes } ) {
 			placeholder={ __( 'Write site tagline…' ) }
 			tagName="p"
 			value={ siteTagline }
+			disableLineBreaks
+			__unstableOnSplitAtEnd={ () =>
+				insertBlocksAfter( createBlock( getDefaultBlockName() ) )
+			}
 			{ ...blockProps }
 		/>
 	) : (


### PR DESCRIPTION

<!-- Please describe what you have changed or added -->
This PR disables line breaks inside `Site Tagline` block and if you press `Enter` at the end of the tagline will create the default block(usually paragraph).

## Testing instructions
1. Add a `Site Tagline` block
2. Focus on tagline's text at the end and press enter - observe new default block is created
3. Focus on tagline's text anywhere **but** the end and press enter - observe nothing is happening.