### PR TITLE
Search Block: Fix border radius reset

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -392,7 +392,8 @@ export default function SearchEdit( {
 			borderWidth: isButtonPositionInside ? borderWidth : undefined,
 		};
 
-		const isNonZeroBorderRadius = parseInt( borderRadius, 10 ) !== 0;
+		const isNonZeroBorderRadius =
+			borderRadius !== undefined && parseInt( borderRadius, 10 ) !== 0;
 
 		if ( isButtonPositionInside && isNonZeroBorderRadius ) {
 			// We have button inside wrapper and a border radius value to apply.


### PR DESCRIPTION
## Description

When the search block positions its button "inside" the border radius values are applied to the wrapper (`ResizableBox`). With this setup, when you reset the radius via the border panel's radius menu item or "Reset all" option, the value is correctly cleared however there is a `parseInt` check in the application of styles on the wrapper. This PR fixes that so it will handle an `undefined` value.

## Testing Instructions
1. Create a post, add a search block, position the button inside and set a border radius value
2. Reset the border radius via the border panel menu and confirm the wrapper keeps the old style
3. Save the post and checkout this PR branch
4. Reload the post and attempt to reset the border radius again. This time the wrapper's styles should be correct.

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![SearchBorderRadiusBug](https://user-images.githubusercontent.com/60436221/152311109-87cd46ca-5256-4aae-b7a5-f2e7499b9019.gif) | ![SearchBorderRadiusFix](https://user-images.githubusercontent.com/60436221/152311141-cdaef40b-3ca3-4ec0-951d-2b04b115f42a.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
