### PR TITLE
Provide proper path to image in the handbook

### DIFF
--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -153,7 +153,7 @@ This mechanism was [introduced in WordPress 5.8](https://make.wordpress.org/core
 
 This is the general data flow:
 
-![global-styles-input-output](./assets/global-styles-input-output.png)
+![Data flow of Global Styles](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/explanations/architecture/assets/global-styles-input-output.png)
 
 The process of generating the stylesheet has, in essence, three steps:
 


### PR DESCRIPTION
This fixes the path to an image in the block editor handbook, in the [styles](https://developer.wordpress.org/block-editor/explanations/architecture/styles/) page. The image path needs to point to an existing URL and can't be a relative path to the handbook.