### PR TITLE
Add: End to end tests for style variations.

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,7 +6,8 @@
 		"tests": {
 			"mappings": {
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
-				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins"
+				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
+				"wp-content/themes/gutenberg-test-themes": "./packages/e2e-tests/themes"
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
@@ -81,7 +81,8 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Global_Styles_Cont
 		$base_directory = get_stylesheet_directory() . '/styles';
 		if ( is_dir( $base_directory ) ) {
 			$nested_files      = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $base_directory ) );
-			$nested_html_files = new RegexIterator( $nested_files, '/^.+\.json$/i', RecursiveRegexIterator::GET_MATCH );
+			$nested_html_files = iterator_to_array( new RegexIterator( $nested_files, '/^.+\.json$/i', RecursiveRegexIterator::GET_MATCH ) );
+			ksort( $nested_html_files );
 			foreach ( $nested_html_files as $path => $file ) {
 				$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
 				if ( is_array( $decoded_file ) ) {

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -589,6 +589,14 @@ Clicks on the button in the header which opens Document Settings sidebar when it
 
 Opens the global block inserter.
 
+### openGlobalStylesPanel
+
+Opens a global styles panel.
+
+_Parameters_
+
+-   _panelName_ `string`: Name of the panel that is going to be opened.
+
 ### openListView
 
 Opens list view
@@ -604,6 +612,10 @@ _Parameters_
 _Returns_
 
 -   `Page`: preview page.
+
+### openPreviousGlobalStylesPanel
+
+Opens the previous global styles panel.
 
 ### openPublishPanel
 
@@ -800,6 +812,10 @@ running the tests as (if we're not already that user).
 ### toggleGlobalBlockInserter
 
 Toggles the global inserter.
+
+### toggleGlobalStyles
+
+Toggles the global styles sidebar (opens it if closed and closes it if open).
 
 ### toggleMoreMenu
 

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -110,6 +110,9 @@ export {
 	openSiteEditorNavigationPanel,
 	siteEditorNavigateSequence,
 	visitSiteEditor,
+	toggleGlobalStyles,
+	openGlobalStylesPanel,
+	openPreviousGlobalStylesPanel,
 } from './site-editor';
 
 export * from './mocks';

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -219,3 +219,31 @@ export async function visitSiteEditor( query, skipWelcomeGuide = true ) {
 		await disableSiteEditorWelcomeGuide();
 	}
 }
+
+/**
+ * Toggles the global styles sidebar (opens it if closed and closes it if open).
+ */
+export async function toggleGlobalStyles() {
+	await page.click(
+		'.edit-site-header__actions button[aria-label="Styles"]'
+	);
+}
+
+/**
+ * Opens a global styles panel.
+ *
+ * @param {string} panelName Name of the panel that is going to be opened.
+ */
+export async function openGlobalStylesPanel( panelName ) {
+	const selector = `//div[@aria-label="Settings"]//button[.//*[text()="${ panelName }"]]`;
+	await ( await page.waitForXPath( selector ) ).click();
+}
+
+/**
+ * Opens the previous global styles panel.
+ */
+export async function openPreviousGlobalStylesPanel() {
+	await page.click(
+		'div[aria-label="Settings"] button[aria-label="Navigate to the previous view"]'
+	);
+}

--- a/packages/e2e-tests/specs/site-editor/style-variations.test.js
+++ b/packages/e2e-tests/specs/site-editor/style-variations.test.js
@@ -1,0 +1,211 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	trashAllPosts,
+	activateTheme,
+	visitSiteEditor,
+	toggleGlobalStyles,
+	openGlobalStylesPanel,
+	openPreviousGlobalStylesPanel,
+} from '@wordpress/e2e-test-utils';
+
+async function openOtherStyles() {
+	const OTHER_STYLES_SELECTOR = '//div[contains(text(),"Other styles")]';
+	await ( await page.waitForXPath( OTHER_STYLES_SELECTOR ) ).click();
+}
+
+async function getAvailableStyleVariations() {
+	const VARIATION_ITEMS_STYLES_SELECTOR =
+		'.edit-site-global-styles-variations_item';
+	await page.waitForSelector( VARIATION_ITEMS_STYLES_SELECTOR );
+	return page.$$( VARIATION_ITEMS_STYLES_SELECTOR );
+}
+
+async function applyVariation( number ) {
+	await toggleGlobalStyles();
+	await openOtherStyles();
+	const variations = await getAvailableStyleVariations();
+	await variations[ number ].click();
+}
+
+async function applyPinkVariation() {
+	await applyVariation( 1 );
+}
+
+async function applyYellowVariation() {
+	await applyVariation( 2 );
+}
+
+async function openColorsPanel() {
+	await openGlobalStylesPanel( 'Colors' );
+}
+
+async function openTypographyPanel() {
+	await openGlobalStylesPanel( 'Typography' );
+}
+
+async function openTextPanel() {
+	await openGlobalStylesPanel( 'Text' );
+}
+
+async function openPalettePanel() {
+	const selector = `//div[./h2[text()="Palette"]]//button`;
+	await ( await page.waitForXPath( selector ) ).click();
+}
+
+async function getFontSizeHint() {
+	const element = await page.$(
+		'.components-font-size-picker__header__hint'
+	);
+	return element.evaluate( ( el ) => el.textContent );
+}
+
+async function getCustomFontSizeValue() {
+	const element = await page.$(
+		'.components-font-size-picker input[aria-label="Custom"]'
+	);
+	return element.evaluate( ( el ) => el.value );
+}
+
+async function getColorValue( colorType ) {
+	return page.evaluate( ( _colorType ) => {
+		return document.evaluate(
+			`substring-before(substring-after(//div[@aria-label="Settings"]//button[.//*[text()="${ _colorType }"]]//*[contains(@class,"component-color-indicator")]/@style, "background: "), ";")`,
+			document,
+			null,
+			XPathResult.ANY_TYPE,
+			null
+		).stringValue;
+	}, colorType );
+}
+
+async function getBackgroundColorValue() {
+	return getColorValue( 'Background' );
+}
+
+async function getTextColorValue() {
+	return getColorValue( 'Text' );
+}
+
+async function getColorPalette( paletteSource ) {
+	const paletteOptions = await page.$x(
+		`//div[./*/h2[text()="${ paletteSource }"]]//button[contains(@class,"components-circular-option-picker__option")]`
+	);
+	return Promise.all(
+		paletteOptions.map( ( element ) => {
+			return element.evaluate( ( el ) => {
+				const color = el.style.backgroundColor;
+				const name = el
+					.getAttribute( 'aria-label' )
+					.substring( 'Color: '.length );
+				return { color, name };
+			} );
+		} )
+	);
+}
+
+async function getThemePalette() {
+	return getColorPalette( 'Theme' );
+}
+
+describe( 'Global styles variations', () => {
+	beforeAll( async () => {
+		await activateTheme( 'gutenberg-test-themes/style-variations' );
+		await trashAllPosts( 'wp_template' );
+		await trashAllPosts( 'wp_template_part' );
+	} );
+	afterAll( async () => {
+		await activateTheme( 'twentytwentyone' );
+	} );
+	beforeEach( async () => {
+		await visitSiteEditor();
+	} );
+
+	it( 'Should have three variations available with the first one being active', async () => {
+		await toggleGlobalStyles();
+		await openOtherStyles();
+		const variations = await getAvailableStyleVariations();
+		expect( variations ).toHaveLength( 3 );
+		expect(
+			await (
+				await variations[ 0 ].getProperty( 'className' )
+			 ).jsonValue()
+		).toContain( 'is-active' );
+		expect(
+			await (
+				await variations[ 1 ].getProperty( 'className' )
+			 ).jsonValue()
+		).not.toContain( 'is-active' );
+		expect(
+			await (
+				await variations[ 2 ].getProperty( 'className' )
+			 ).jsonValue()
+		).not.toContain( 'is-active' );
+	} );
+
+	it( 'Should apply preset colors and font sizes in a variation', async () => {
+		await applyPinkVariation();
+		await openPreviousGlobalStylesPanel();
+		await openColorsPanel();
+		expect( await getBackgroundColorValue() ).toBe( 'rgb(202, 105, 211)' );
+		expect( await getTextColorValue() ).toBe( 'rgb(74, 7, 74)' );
+		await openPreviousGlobalStylesPanel();
+		await openTypographyPanel();
+		await openTextPanel();
+		expect( await getFontSizeHint() ).toBe( 'Medium(px)' );
+	} );
+
+	it( 'Should apply custom colors and font sizes in a variation', async () => {
+		await applyYellowVariation();
+		await openPreviousGlobalStylesPanel();
+		await openColorsPanel();
+		expect( await getBackgroundColorValue() ).toBe( 'rgb(255, 239, 11)' );
+		expect( await getTextColorValue() ).toBe( 'rgb(25, 25, 17)' );
+		await openPreviousGlobalStylesPanel();
+		await openTypographyPanel();
+		await openTextPanel();
+		expect( await getFontSizeHint() ).toBe( '(Custom)' );
+		expect( await getCustomFontSizeValue() ).toBe( '15' );
+	} );
+
+	it( 'Should apply a color palette in a variation', async () => {
+		await applyPinkVariation();
+		await openPreviousGlobalStylesPanel();
+		await openColorsPanel();
+		await openPalettePanel();
+		expect( await getThemePalette() ).toMatchObject( [
+			{
+				color: 'rgb(74, 7, 74)',
+				name: 'Foreground',
+			},
+			{
+				color: 'rgb(202, 105, 211)',
+				name: 'Background',
+			},
+			{
+				color: 'rgba(204, 0, 255, 0.77)',
+				name: 'Awesome pink',
+			},
+		] );
+	} );
+
+	it( 'Should reflect style variations in the styles applied to the editor', async () => {
+		await applyYellowVariation();
+		const frame = await (
+			await page.waitForSelector( '.edit-site-visual-editor iframe' )
+		 ).contentFrame();
+		const paragraph = await frame.waitForXPath(
+			`//p[text()="My awesome paragraph"]`
+		);
+		const paragraphColor = await paragraph.evaluate( ( el ) => {
+			return window.getComputedStyle( el ).color;
+		} );
+		expect( paragraphColor ).toBe( 'rgb(25, 25, 17)' );
+		const body = await frame.$( 'body' );
+		const backgroundColor = await body.evaluate( ( el ) => {
+			return window.getComputedStyle( el ).backgroundColor;
+		} );
+		expect( backgroundColor ).toBe( 'rgb(255, 239, 11)' );
+	} );
+} );

--- a/packages/e2e-tests/themes/style-variations/block-templates/index.html
+++ b/packages/e2e-tests/themes/style-variations/block-templates/index.html
@@ -1,0 +1,11 @@
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:post-title {"isLink":true} /-->
+	<!-- wp:post-excerpt /-->
+	<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->
+<!-- wp:paragraph -->
+<p>My awesome paragraph</p>
+<!-- /wp:paragraph -->

--- a/packages/e2e-tests/themes/style-variations/style.css
+++ b/packages/e2e-tests/themes/style-variations/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Style variations
+Theme URI: https://github.com/wordpress/theme-experiments/
+Author: the WordPress team
+Description: Style variations test theme.
+Requires at least: 5.3
+Tested up to: 5.5
+Requires PHP: 5.6
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: style-variations
+Style variations WordPress Theme, (C) 2021 WordPress.org
+Style variations is distributed under the terms of the GNU GPL.
+*/

--- a/packages/e2e-tests/themes/style-variations/styles/pink.json
+++ b/packages/e2e-tests/themes/style-variations/styles/pink.json
@@ -1,0 +1,33 @@
+{
+	"version": 2,
+	"settings": {
+		"color": {
+			"palette": [
+				{
+					"slug": "foreground",
+					"color": "#4a074a",
+					"name": "Foreground"
+				},
+				{
+					"slug": "background",
+					"color": "#ca69d3",
+					"name": "Background"
+				},
+				{
+					"slug": "awesome-pink",
+					"color": "#cc00ffc4",
+					"name": "Awesome pink"
+				}
+			]
+		}
+	},
+	"styles": {
+		"color": {
+			"background": "var(--wp--preset--color--background)",
+			"text": "var(--wp--preset--color--foreground)"
+		},
+		"typography": {
+			"fontSize": "var(--wp--preset--font-size--medium)"
+		}
+	}
+}

--- a/packages/e2e-tests/themes/style-variations/styles/yellow.json
+++ b/packages/e2e-tests/themes/style-variations/styles/yellow.json
@@ -1,0 +1,12 @@
+{
+	"version": 2,
+	"styles": {
+		"color": {
+			"background": "#ffef0b",
+			"text": "#191911"
+		},
+		"typography": {
+			"fontSize": "15px"
+		}
+	}
+}

--- a/packages/e2e-tests/themes/style-variations/theme.json
+++ b/packages/e2e-tests/themes/style-variations/theme.json
@@ -1,0 +1,8 @@
+{
+	"version": 2,
+	"styles": {
+		"color": {
+			"background": "red"
+		}
+	}
+}


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/35619. 
Adds end-to-end tests for the style variations.

Adds a test theme with some style variations so end to end tests can use it.