### PR TITLE
Tests: Enable post type UI for templates and template parts

### DIFF
--- a/packages/e2e-tests/mu-plugins/enable-templates-ui.php
+++ b/packages/e2e-tests/mu-plugins/enable-templates-ui.php
@@ -10,10 +10,15 @@
 /**
  * Enable Templates & Template Parts post type UI during e2e testing.
  */
-add_filter( 'register_post_type_args', function( $args, $name ) {
-	if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
-		$args['show_ui'] = true;
-	}
+add_filter(
+	'register_post_type_args',
+	function( $args, $name ) {
+		if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
+			$args['show_ui'] = true;
+		}
 
-	return $args;
-}, 20, 2 );
+		return $args;
+	},
+	20,
+	2
+);

--- a/packages/e2e-tests/mu-plugins/enable-templates-ui.php
+++ b/packages/e2e-tests/mu-plugins/enable-templates-ui.php
@@ -12,9 +12,9 @@
  */
 add_filter(
 	'register_post_type_args',
-	function( $args, $name ) {
+	static function( $args, $name ) {
 		if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
-			$args['show_ui'] = true;
+			$args['show_ui'] = wp_is_block_theme();
 		}
 
 		return $args;

--- a/packages/e2e-tests/mu-plugins/enable-templates-ui.php
+++ b/packages/e2e-tests/mu-plugins/enable-templates-ui.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Plugin Name: Gutenberg Test Plugin, Enable Templates UI
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Author: Gutenberg Team
+ *
+ * @package gutenberg-test-enable-templates-ui
+ */
+
+/**
+ * Enable Templates & Template Parts post type UI during e2e testing.
+ */
+add_filter( 'register_post_type_args', function( $args, $name ) {
+	if ( in_array( $name, array( 'wp_template', 'wp_template_part' ), true ) ) {
+		$args['show_ui'] = true;
+	}
+
+	return $args;
+}, 20, 2 );


### PR DESCRIPTION
## Description
Core [fully disabled](https://github.com/WordPress/wordpress-develop/commit/14e20f72b568cfb5a85f57c77eaa538c17a5f302) UI for Templates and Template Parts post types. It caused e2e test failures since we still rely on UI to delete them.

PR adds `mu-plugin` to override post-registration arguments and enable UI for e2e tests. However, this is a short-term solution. I think we should use REST API to delete templates, similar to #33414.

## Testing Instructions
All tests should pass.

## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
