### PR TITLE
Guard against undefined entity in site editor page setter

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -208,8 +208,8 @@ export function* setPage( page ) {
 			page.context.postType || 'post',
 			page.context.postId
 		);
-
-		page.path = getPathAndQueryString( entity.link );
+		// If the entity is undefined for some reason, path will resolve to "/"
+		page.path = getPathAndQueryString( entity?.link );
 	}
 	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
 		coreStore,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
We have discovered a case where the entity can be undefined in the `setPage` action in the site editor. Unfortunately, we aren't yet sure what causes this scenario. However, since it causes a WSOD, it's worth guarding against the possibility of an undefined value in the meantime.

Thankfully, the other portions of this action do handle undefined values. For example, if `getPathAndQueryString( url )` is passed an undefined value, it will ultimately resolve to "/", which is a fair place to start.

## Testing Instructions
Unfortunately, I'm unsure how to replicate this issue in `wp-env`, but the code is simple enough I think that should be ok.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
