### PR TITLE
Image Block: explicitly check for false from strpos()

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -20,7 +20,7 @@ function render_block_core_image( $attributes, $content ) {
 		// which now wraps Image Blocks within innerBlocks.
 		// The data-id attribute is added in a core/gallery `render_block_data` hook.
 		$data_id_attribute = 'data-id="' . esc_attr( $attributes['data-id'] ) . '"';
-		if ( ! strpos( $content, $data_id_attribute ) ) {
+		if ( false === strpos( $content, $data_id_attribute ) ) {
 			$content = str_replace( '<img', '<img ' . $data_id_attribute . ' ', $content );
 		}
 	}


### PR DESCRIPTION
## Description
Following on from the conversation in https://github.com/WordPress/gutenberg/pull/35975#pullrequestreview-872189591

This PR explicitly checks for a return value of `false` from `strpos()` just in case the check returns `0`, which would also be falsey and satisfy the if-statement's condition.

If `data-id` were at the leading position in the string though, we'd have other problems :)

Props to @mcsf for catching it.

## Testing Instructions

Insert a gallery and a single image into a post. Publish the page and head over to your site.

Make sure that the published gallery images include the `data-id` attribute on the `<img /> `tags. The single image will not have the `data-id` attribute.

## Screenshots 

<img width="1064" alt="Screen Shot 2022-02-04 at 9 40 35 am" src="https://user-images.githubusercontent.com/6458278/152442693-873c567f-6e34-4e2f-bbc1-fdea65a9a11d.png">

## Types of changes
Code qual.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
