### PR TITLE
Capture state changes scheduled between render and effect

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -153,6 +153,7 @@ export default function useSelect( mapSelect, deps ) {
 
 	let mapOutput;
 
+	let selectorRan = false;
 	if ( _mapSelect ) {
 		mapOutput = latestMapOutput.current;
 		const hasReplacedRegistry = latestRegistry.current !== registry;
@@ -168,6 +169,7 @@ export default function useSelect( mapSelect, deps ) {
 		) {
 			try {
 				mapOutput = wrapSelect( _mapSelect );
+				selectorRan = true;
 			} catch ( error ) {
 				let errorMessage = `An error occurred while running 'mapSelect': ${ error.message }`;
 
@@ -188,19 +190,15 @@ export default function useSelect( mapSelect, deps ) {
 			return;
 		}
 
+		if ( selectorRan ) {
+			latestMapOutput.current = mapOutput;
+		}
+
 		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestIsAsync.current = isAsync;
 		latestMapOutputError.current = undefined;
 	} );
-
-	useIsomorphicLayoutEffect( () => {
-		if ( ! hasMappingFunction ) {
-			return;
-		}
-
-		latestMapOutput.current = mapOutput;
-	}, [ mapOutput ] );
 
 	// React can sometimes clear the `useMemo` cache.
 	// We use the cache-stable `useMemoOne` to avoid
@@ -317,19 +315,24 @@ export function useSuspenseSelect( mapSelect, deps ) {
 	const hasReplacedMapSelect = latestMapSelect.current !== _mapSelect;
 	const hasLeftAsyncMode = latestIsAsync.current && ! isAsync;
 
+	let selectorRan = false;
 	if ( hasReplacedRegistry || hasReplacedMapSelect || hasLeftAsyncMode ) {
 		try {
 			mapOutput = wrapSelect( _mapSelect );
+			selectorRan = true;
 		} catch ( error ) {
 			mapOutputError = error;
 		}
 	}
 
 	useIsomorphicLayoutEffect( () => {
+		if ( selectorRan ) {
+			latestMapOutput.current = mapOutput;
+		}
+
 		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestIsAsync.current = isAsync;
-		latestMapOutput.current = mapOutput;
 		latestMapOutputError.current = mapOutputError;
 	} );
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -190,13 +190,12 @@ export default function useSelect( mapSelect, deps ) {
 			return;
 		}
 
-		if ( selectorRan ) {
-			latestMapOutput.current = mapOutput;
-		}
-
 		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestIsAsync.current = isAsync;
+		if ( selectorRan ) {
+			latestMapOutput.current = mapOutput;
+		}
 		latestMapOutputError.current = undefined;
 	} );
 
@@ -326,13 +325,12 @@ export function useSuspenseSelect( mapSelect, deps ) {
 	}
 
 	useIsomorphicLayoutEffect( () => {
-		if ( selectorRan ) {
-			latestMapOutput.current = mapOutput;
-		}
-
 		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestIsAsync.current = isAsync;
+		if ( selectorRan ) {
+			latestMapOutput.current = mapOutput;
+		}
 		latestMapOutputError.current = mapOutputError;
 	} );
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -191,9 +191,16 @@ export default function useSelect( mapSelect, deps ) {
 		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestIsAsync.current = isAsync;
-		latestMapOutput.current = mapOutput;
 		latestMapOutputError.current = undefined;
 	} );
+
+	useIsomorphicLayoutEffect( () => {
+		if ( ! hasMappingFunction ) {
+			return;
+		}
+
+		latestMapOutput.current = mapOutput;
+	}, [ mapOutput ] );
 
 	// React can sometimes clear the `useMemo` cache.
 	// We use the cache-stable `useMemoOne` to avoid

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -434,7 +434,7 @@ describe( 'useSelect', () => {
 			);
 		} );
 
-		it( 'captures state changes before the subscription is set', () => {
+		it( 'captures state changes scheduled between render and effect', () => {
 			registry.registerStore( 'store-1', counterStore );
 
 			class ChildComponent extends Component {

--- a/packages/editor/src/components/provider/use-block-editor-settings.native.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.native.js
@@ -16,24 +16,23 @@ function useNativeBlockEditorSettings( settings, hasTemplate ) {
 	const editorSettings = useBlockEditorSettings( settings, hasTemplate );
 
 	const supportReusableBlock = capabilities.reusableBlock === true;
-	const { reusableBlocks } = useSelect(
-		( select ) => ( {
-			reusableBlocks: supportReusableBlock
-				? select( coreStore ).getEntityRecords(
-						'postType',
-						'wp_block',
-						// Unbounded queries are not supported on native so as a workaround, we set per_page with the maximum value that native version can handle.
-						// Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
-						{ per_page: 100 }
-				  )
-				: [],
-		} ),
+	const { reusableBlocks, isTitleSelected } = useSelect(
+		( select ) => {
+			return {
+				reusableBlocks: supportReusableBlock
+					? select( coreStore ).getEntityRecords(
+							'postType',
+							'wp_block',
+							// Unbounded queries are not supported on native so as a workaround, we set per_page with the maximum value that native version can handle.
+							// Related issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2661
+							{ per_page: 100 }
+					  )
+					: [],
+				isTitleSelected: select( editorStore ).isPostTitleSelected(),
+			};
+		},
 		[ supportReusableBlock ]
 	);
-
-	const { isTitleSelected } = useSelect( ( select ) => ( {
-		isTitleSelected: select( editorStore ).isPostTitleSelected(),
-	} ) );
 
 	return useMemo(
 		() => ( {


### PR DESCRIPTION
## What?
Fixes #32154. Supersedes #32831.  Avoid stale mappings overwriting new state in specific contexts where `onStoreChange` updates the state before the effect writes the initial mapping.

## Why?
In the event that a child component dispatched an action modifying the store before the selector mapping was written, the changes in the store were lost due to `useSelect`'s `useIsomorphicLayoutEffect` referencing a stale value.

A specific example of this issue occurring is the following code where `onUnselect` is called. This call triggers an update to the store the occurs in between `useSelect`'s reading and writing the selector value, resulting in a stale `isTitleSelected` value. This resulted in the blocks inserted to the incorrect location, which is captured in https://github.com/WordPress/gutenberg/issues/32154. 

https://github.com/WordPress/gutenberg/blob/3987f612a77fd346093de1a1239aea11a6dc8e38/packages/editor/src/components/post-title/index.native.js#L36-L48

https://github.com/WordPress/gutenberg/blob/3987f612a77fd346093de1a1239aea11a6dc8e38/packages/editor/src/components/provider/use-block-editor-settings.native.js#L31

## How?
Avoid setting a reference to the selector output mapping until after the selector is run. 

## Testing Instructions
The following was manually tested: 

1. Launch the native Demo editor.
2. Focus the first block. 
3. Tap the + button to add a block.
4. **Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the selected block.
5. Focus the title for the post.
6. Tap the + button to add a block.
7. **Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the title. 
2. Focus the first block.
3. Tap the + button to add a block.
4. **Expected:** The "ADD BLOCK HERE" insertion point is displayed beneath the selected block.

## Screenshots or screencast 

<details><summary>Before</summary>

https://user-images.githubusercontent.com/438664/190246371-85c9d7bf-500a-4409-9b1b-597ac7d8eeb1.mov

</details>

<details><summary>After</summary>

https://user-images.githubusercontent.com/438664/190246407-e31b51d0-740a-4962-9d00-51882a4fb914.mov

</details>