### PR TITLE
Widget Group: Make `save()` markup the same as `render_callback` markup

### DIFF
--- a/packages/widgets/src/blocks/widget-group/deprecated.js
+++ b/packages/widgets/src/blocks/widget-group/deprecated.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, RichText } from '@wordpress/block-editor';
+
+const v1 = {
+	attributes: {
+		title: {
+			type: 'string',
+		},
+	},
+	supports: {
+		html: false,
+		inserter: true,
+		customClassName: true,
+		reusable: false,
+	},
+	save( { attributes } ) {
+		return (
+			<>
+				<RichText.Content
+					tagName="h2"
+					className="widget-title"
+					value={ attributes.title }
+				/>
+				<InnerBlocks.Content />
+			</>
+		);
+	},
+};
+
+export default [ v1 ];

--- a/packages/widgets/src/blocks/widget-group/index.js
+++ b/packages/widgets/src/blocks/widget-group/index.js
@@ -11,6 +11,8 @@ import { group as icon } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import deprecated from './deprecated';
+
 const { name } = metadata;
 export { metadata, name };
 
@@ -73,4 +75,5 @@ export const settings = {
 			},
 		],
 	},
+	deprecated,
 };

--- a/packages/widgets/src/blocks/widget-group/save.js
+++ b/packages/widgets/src/blocks/widget-group/save.js
@@ -11,7 +11,9 @@ export default function save( { attributes } ) {
 				className="widget-title"
 				value={ attributes.title }
 			/>
-			<InnerBlocks.Content />
+			<div className="wp-widget-group__inner-blocks">
+				<InnerBlocks.Content />
+			</div>
 		</>
 	);
 }


### PR DESCRIPTION
## Description

I noticed during testing that the Widget Group block's `save()` function doesn't return the same markup as what's returned in the block's `render_callback`. The `save()` function is missing the `<div class="wp-widget-group__inner-blocks">`.

I don't think this actually causes any problems, but thought I'd fix that up while I had it open.

`save()`:

https://github.com/WordPress/gutenberg/blob/037c82baf4f8e0d4901759efed5a32f9ccd66cb6/packages/widgets/src/blocks/widget-group/save.js#L9-L14

`render_callback`:

https://github.com/WordPress/gutenberg/blob/037c82baf4f8e0d4901759efed5a32f9ccd66cb6/packages/widgets/src/blocks/widget-group/index.php#L30-L38

## Testing Instructions

I tested that the deprecation works by:

1. Check out `trunk`.
2. Activate a classic theme.
3. Go to Appearance → Widgets and insert a Widget Group.
4. Save.
5. Check out this PR.
6. Refresh the page.
7. There should not be an invalid block error.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->