### PR TITLE
Most Used Terms: Update show terms condition

### DIFF
--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -15,9 +15,9 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { unescapeTerms } from '../../utils/terms';
 
-const MAX_MOST_USED_TERMS = 10;
+const MIN_MOST_USED_TERMS = 3;
 const DEFAULT_QUERY = {
-	per_page: MAX_MOST_USED_TERMS,
+	per_page: 10,
 	orderby: 'count',
 	order: 'desc',
 	hide_empty: true,
@@ -34,7 +34,7 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 		);
 		return {
 			_terms: mostUsedTerms,
-			showTerms: mostUsedTerms?.length === MAX_MOST_USED_TERMS,
+			showTerms: mostUsedTerms?.length > MIN_MOST_USED_TERMS,
 		};
 	}, [] );
 

--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -34,7 +34,7 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 		);
 		return {
 			_terms: mostUsedTerms,
-			showTerms: mostUsedTerms?.length > MIN_MOST_USED_TERMS,
+			showTerms: mostUsedTerms?.length >= MIN_MOST_USED_TERMS,
 		};
 	}, [] );
 


### PR DESCRIPTION
## Description
PR updates threshold number for minimum terms to display. The component is displayed when a site has three or more "most used terms."

Resolves #38394.

## Testing Instructions
1. Assing at least three tags to published posts.
2. Edit posts.
3. Check that the "Most Used" component is displayed in the "Tags" panel.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-04 at 11 02 28](https://user-images.githubusercontent.com/240569/152486197-9d3bc57b-ed74-4f00-86a3-df3e3183d02b.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
