### PR TITLE
Update theme support docs

### DIFF
--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -133,7 +133,7 @@ Some colors change dynamically — such as "Primary" and "Secondary" color — s
 
 The colors will be shown in order on the palette, and there's no limit to how many can be specified.
 
-Themes are responsible for creating the classes that apply the colors in different contexts. Core blocks use "color", "background-color", and "border-color" contexts. So to correctly apply "strong magenta" to all contexts of core blocks a theme should implement the following classes:
+Themes are responsible for creating the classes that apply the colors in different contexts. Core blocks use "color", "background-color", and "border-color" contexts. So to correctly apply "strong magenta" to all contexts of core blocks a theme should implement the classes itself. The class name is built appending 'has-', followed by the class name _using_ kebab case and ending with the context name.
 
 ```css
 .has-strong-magenta-background-color {
@@ -149,7 +149,14 @@ Themes are responsible for creating the classes that apply the colors in differe
 }
 ```
 
-The class name is built appending 'has-', followed by the class name _using_ kebab case and ending with the context name.
+Starting in WordPress 5.9, to override color values defined by core, themes without a `theme.json` have to set their values via CSS Custom Properties instead of providing the classes. The CSS Custom Properties use the following naming `--wp--preset--color--<slug>`. See more info in [this devnote](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). For example:
+
+```css
+:root {
+	--wp--preset--color--cyan-bluish-gray: <new_value>;
+	--wp--preset--color--pale-pink: <new_value>;
+}
+```
 
 ### Block Gradient Presets
 
@@ -202,6 +209,15 @@ Themes are responsible for creating the classes that apply the gradients. So to 
 }
 ```
 
+Starting in WordPress 5.9, to override gradient values defined by core, themes without a `theme.json` have to set their values via CSS Custom Properties instead of providing the classes. The CSS Custom Properties use the following naming `--wp--preset--gradient--<slug>`. See more info in [this devnote](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). For example:
+
+```css
+:root {
+	--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple: <new_value>;
+	--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan: <new_value>;
+}
+```
+
 ### Block Font Sizes
 
 Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. The block provides a default set of font sizes, but a theme can overwrite it and provide its own:
@@ -247,6 +263,15 @@ As an example for the regular font size, a theme may provide the following class
 <div class="callout callout-info">
 <strong>Note:</strong> The slugs `default` and `custom` are reserved and cannot be used by themes.
 </div>
+
+Starting in WordPress 5.9, to override font size values defined by core, themes without a `theme.json` have to set their values via CSS Custom Properties instead of providing the classes. The CSS Custom Properties use the following naming `--wp--preset--font-size--<slug>`. See more info in [this devnote](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). For example:
+
+```css
+:root {
+	--wp--preset--font-size--small: <new_value>;
+	--wp--preset--font-size--large: <new_value>;
+}
+```
 
 ### Disabling custom font sizes
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -202,7 +202,7 @@ Themes are responsible for creating the classes that apply the gradients. So to 
 }
 ```
 
-### Block Font Sizes:
+### Block Font Sizes
 
 Blocks may allow the user to configure the font sizes they use, e.g., the paragraph block. The block provides a default set of font sizes, but a theme can overwrite it and provide its own:
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -133,15 +133,19 @@ Some colors change dynamically — such as "Primary" and "Secondary" color — s
 
 The colors will be shown in order on the palette, and there's no limit to how many can be specified.
 
-Themes are responsible for creating the classes that apply the colors in different contexts. Core blocks use "color" and "background-color" contexts. So to correctly apply "strong magenta" to all contexts of core blocks a theme should implement the following classes:
+Themes are responsible for creating the classes that apply the colors in different contexts. Core blocks use "color", "background-color", and "border-color" contexts. So to correctly apply "strong magenta" to all contexts of core blocks a theme should implement the following classes:
 
 ```css
 .has-strong-magenta-background-color {
-	background-color: #313131;
+	background-color: #a156b4;
 }
 
 .has-strong-magenta-color {
-	color: #f78da7;
+	color: #a156b4;
+}
+
+.has-strong-magenta-border-color {
+	color: #a156b4;
 }
 ```
 


### PR DESCRIPTION
This PR updates the theme support docs to clarify how to override default presets upon the changes introduced in WordPress 5.9 and described in [this devnote](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/).

We're aiming to change this behavior for a potential 5.9.1 (see [PR](https://github.com/WordPress/wordpress-develop/pull/2233)) and make it automatic for themes, so they don't have to do anything. Until that happens, we should offer clarity about what's the current mechanism.

