### PR TITLE
[Block Library]: Remove unnecessary usages of `RawHTML`

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -7,7 +7,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RawHTML } from '@wordpress/element';
 import {
 	BaseControl,
 	PanelBody,
@@ -491,13 +490,13 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 									) }
 								</div>
 							) }
-							<a href={ post.link } rel="noreferrer noopener">
-								{ titleTrimmed ? (
-									<RawHTML>{ titleTrimmed }</RawHTML>
-								) : (
-									__( '(no title)' )
-								) }
-							</a>
+							<a
+								href={ post.link }
+								rel="noreferrer noopener"
+								dangerouslySetInnerHTML={ {
+									__html: titleTrimmed || __( '(no title)' ),
+								} }
+							/>
 							{ displayAuthor && currentAuthor && (
 								<div className="wp-block-latest-posts__post-author">
 									{ sprintf(
@@ -523,11 +522,12 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								) }
 							{ displayPostContent &&
 								displayPostContentRadio === 'full_post' && (
-									<div className="wp-block-latest-posts__post-full-content">
-										<RawHTML key="html">
-											{ post.content.raw.trim() }
-										</RawHTML>
-									</div>
+									<div
+										className="wp-block-latest-posts__post-full-content"
+										dangerouslySetInnerHTML={ {
+											__html: post.content.raw.trim(),
+										} }
+									/>
 								) }
 						</li>
 					);

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -493,10 +493,16 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 							<a
 								href={ post.link }
 								rel="noreferrer noopener"
-								dangerouslySetInnerHTML={ {
-									__html: titleTrimmed || __( '(no title)' ),
-								} }
-							/>
+								dangerouslySetInnerHTML={
+									!! titleTrimmed
+										? {
+												__html: titleTrimmed,
+										  }
+										: undefined
+								}
+							>
+								{ ! titleTrimmed ? __( '(no title)' ) : null }
+							</a>
 							{ displayAuthor && currentAuthor && (
 								<div className="wp-block-latest-posts__post-author">
 									{ sprintf(

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -13,7 +13,6 @@ import {
 	useBlockProps,
 	PlainText,
 } from '@wordpress/block-editor';
-import { RawHTML } from '@wordpress/element';
 import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
@@ -61,9 +60,10 @@ export default function PostTitleEdit( {
 					{ ...blockProps }
 				/>
 			) : (
-				<TagName { ...blockProps }>
-					<RawHTML key="html">{ fullTitle?.rendered }</RawHTML>
-				</TagName>
+				<TagName
+					{ ...blockProps }
+					dangerouslySetInnerHTML={ { __html: fullTitle?.rendered } }
+				/>
 			);
 	}
 
@@ -91,9 +91,10 @@ export default function PostTitleEdit( {
 						target={ linkTarget }
 						rel={ rel }
 						onClick={ ( event ) => event.preventDefault() }
-					>
-						<RawHTML key="html">{ fullTitle?.rendered }</RawHTML>
-					</a>
+						dangerouslySetInnerHTML={ {
+							__html: fullTitle?.rendered,
+						} }
+					/>
 				</TagName>
 			);
 	}


### PR DESCRIPTION
Related: https://github.com/WordPress/gutenberg/pull/38451

It seems in some cases we don't need to use `RawHTML` component as it creates an extra `div`. This PR just does that and uses `dangerouslySetInnerHTML` directly - which is what `RawHTML` uses anyway.

## Testing instructions
1. Everything works as before
2. In a `Query Loop` block add the `Post Title` block (this PR affects only the readonly view) and observe in the dev tool the html markup that an extra `div` is not rendered.
3. Add `Latest Posts` block and observe the same as above in dev tools for the post title and `full` content(have to enable it through inspector controls).

This PR doesn't change anything in the front end.