### PR TITLE
Adding the "env" script when --wp-env or wpEnv is present.

### DIFF
--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## New Features
+-    Automatically add a `"env": "wp-env"` to scripts when the `--wp-env` is passed or when a template sets `wpEnv` to `true`.
+
 ## 2.8.0 (2022-01-27)
 
 ### New Features

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-## New Features
+### New Features
+
 -    Automatically add a `"env": "wp-env"` entry to scripts when the `--wp-env` is passed or when a template sets `wpEnv` to `true`.
 
 ## 2.8.0 (2022-01-27)

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ## New Features
--    Automatically add a `"env": "wp-env"` to scripts when the `--wp-env` is passed or when a template sets `wpEnv` to `true`.
+-    Automatically add a `"env": "wp-env"` entry to scripts when the `--wp-env` is passed or when a template sets `wpEnv` to `true`.
 
 ## 2.8.0 (2022-01-27)
 

--- a/packages/create-block/README.md
+++ b/packages/create-block/README.md
@@ -206,7 +206,7 @@ The following configurable variables are used with the template files. Template 
 -   `licenseURI` (default: `'https://www.gnu.org/licenses/gpl-2.0.html'`)
 -   `version` (default: `'0.1.0'`)
 -   `wpScripts` (default: `true`)
--   `wpEnv` (default: `false`)
+-   `wpEnv` (default: `false`) - enables integration with the `@wordpress/env` package and adds the `env` command to the package.json.
 -   `npmDependencies` (default: `[]`) – the list of remote npm packages to be installed in the project with [`npm install`](https://docs.npmjs.com/cli/v8/commands/npm-install) when `wpScripts` is enabled.
 -   `folderName` (default: `.`) – the location for the `block.json` file and other optional block files generated from block templates included in the folder set with the `blockTemplatesPath` setting.
 -   `editorScript` (default: `'file:./build/index.js'`)

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -37,15 +37,17 @@ module.exports = async ( {
 				author,
 				license,
 				main: wpScripts && 'build/index.js',
-				scripts: wpScripts && {
-					build: 'wp-scripts build',
-					format: 'wp-scripts format',
-					'lint:css': 'wp-scripts lint-style',
-					'lint:js': 'wp-scripts lint-js',
-					'packages-update': 'wp-scripts packages-update',
-					'plugin-zip': 'wp-scripts plugin-zip',
-					start: 'wp-scripts start',
-					...( wpEnv === true && { env: 'wp-env' } ),
+				scripts: {
+					...( wpScripts && {
+						build: 'wp-scripts build',
+						format: 'wp-scripts format',
+						'lint:css': 'wp-scripts lint-style',
+						'lint:js': 'wp-scripts lint-js',
+						'packages-update': 'wp-scripts packages-update',
+						'plugin-zip': 'wp-scripts plugin-zip',
+						start: 'wp-scripts start',
+					} ),
+					...( wpEnv && { env: 'wp-env' } ),
 				},
 			},
 			isEmpty

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -18,6 +18,7 @@ module.exports = async ( {
 	license,
 	slug,
 	version,
+	wpEnv,
 	wpScripts,
 	npmDependencies,
 } ) => {
@@ -43,6 +44,7 @@ module.exports = async ( {
 					'packages-update': 'wp-scripts packages-update',
 					'plugin-zip': 'wp-scripts plugin-zip',
 					start: 'wp-scripts start',
+					env: wpEnv && 'wp-env',
 				},
 			},
 			isEmpty

--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -26,6 +26,7 @@ module.exports = async ( {
 
 	info( '' );
 	info( 'Creating a "package.json" file.' );
+
 	await writePkg(
 		cwd,
 		omitBy(
@@ -44,7 +45,7 @@ module.exports = async ( {
 					'packages-update': 'wp-scripts packages-update',
 					'plugin-zip': 'wp-scripts plugin-zip',
 					start: 'wp-scripts start',
-					env: wpEnv && 'wp-env',
+					...( wpEnv === true && { env: 'wp-env' } ),
 				},
 			},
 			isEmpty

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -65,6 +65,7 @@ module.exports = async (
 		licenseURI,
 		textdomain: slug,
 		wpScripts,
+		wpEnv,
 		npmDependencies,
 		folderName,
 		editorScript,


### PR DESCRIPTION
## Description
As discussed in https://github.com/WordPress/gutenberg/issues/25188#issuecomment-1030044917, when the `--wp-env` flag is passed or the`wpEnv` is added to a template, there is no accompanying script added to the package. json.

## Testing Instructions
Test locally using: 
* `./node_modules/.bin/wp-create-block --wp-env` to test the flag
* `./node_modules/.bin/wp-create-block --template=@ryanwelcher/dynamic-block-template` to test a template using `wpEnv`
* `./node_modules/.bin/wp-create-block` to ensure that no additional scripts are added.

## Types of changes
New feature. Adds  `"env": "wp-env"` to the package.json

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
