### PR TITLE
Add `cx` as a dependency of `useMemo` across `@wordpress/components` package

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   Fixed typing errors for `ColorPicker` ([#38430](https://github.com/WordPress/gutenberg/pull/38430)).
 -   Updated destructuring of `Dropdown` props to be TypeScript friendly ([#38431](https://github.com/WordPress/gutenberg/pull/38431)).
 -   Added `ts-nocheck` to `ColorIndicator` so it can be used in typed components ([#38433](https://github.com/WordPress/gutenberg/pull/38433)).
+-   Added `cx` as a dependency of `useMemo` across the whole package, in order to recalculate the classnames correctly when a component is rendered across more than one `StyleProvider` ([#38541](https://github.com/WordPress/gutenberg/pull/38541)).
 
 ### Enhancements
 

--- a/packages/components/src/base-field/hook.js
+++ b/packages/components/src/base-field/hook.js
@@ -50,7 +50,7 @@ export function useBaseField( props ) {
 				isInline && styles.inline,
 				className
 			),
-		[ className, controlGroupStyles, hasError, isInline, isSubtle ]
+		[ className, controlGroupStyles, cx, hasError, isInline, isSubtle ]
 	);
 
 	return {

--- a/packages/components/src/card/card-body/hook.js
+++ b/packages/components/src/card/card-body/hook.js
@@ -35,7 +35,7 @@ export function useCardBody( props ) {
 				'components-card__body',
 				className
 			),
-		[ className, isShady, size ]
+		[ className, cx, isShady, size ]
 	);
 
 	return {

--- a/packages/components/src/card/card-divider/hook.js
+++ b/packages/components/src/card/card-divider/hook.js
@@ -30,7 +30,7 @@ export function useCardDivider( props ) {
 				'components-card__divider',
 				className
 			),
-		[ className ]
+		[ className, cx ]
 	);
 
 	return {

--- a/packages/components/src/card/card-footer/hook.js
+++ b/packages/components/src/card/card-footer/hook.js
@@ -38,7 +38,7 @@ export function useCardFooter( props ) {
 				'components-card__footer',
 				className
 			),
-		[ className, isBorderless, isShady, size ]
+		[ className, cx, isBorderless, isShady, size ]
 	);
 
 	return {

--- a/packages/components/src/card/card-header/hook.js
+++ b/packages/components/src/card/card-header/hook.js
@@ -37,7 +37,7 @@ export function useCardHeader( props ) {
 				'components-card__header',
 				className
 			),
-		[ className, isBorderless, isShady, size ]
+		[ className, cx, isBorderless, isShady, size ]
 	);
 
 	return {

--- a/packages/components/src/card/card-media/hook.js
+++ b/packages/components/src/card/card-media/hook.js
@@ -27,7 +27,7 @@ export function useCardMedia( props ) {
 				'components-card__media',
 				className
 			),
-		[ className ]
+		[ className, cx ]
 	);
 
 	return {

--- a/packages/components/src/card/card/component.js
+++ b/packages/components/src/card/card/component.js
@@ -38,7 +38,7 @@ function Card( props, forwardedRef ) {
 
 	const elevationClassName = useMemo(
 		() => cx( css( { borderRadius: elevationBorderRadius } ) ),
-		[ elevationBorderRadius ]
+		[ cx, elevationBorderRadius ]
 	);
 
 	const contextProviderValue = useMemo( () => {

--- a/packages/components/src/card/card/hook.js
+++ b/packages/components/src/card/card/hook.js
@@ -61,7 +61,7 @@ export function useCard( props ) {
 			isRounded && styles.rounded,
 			className
 		);
-	}, [ className, isBorderless, isRounded ] );
+	}, [ className, cx, isBorderless, isRounded ] );
 
 	const surfaceProps = useSurface( { ...otherProps, className: classes } );
 

--- a/packages/components/src/elevation/hook.js
+++ b/packages/components/src/elevation/hook.js
@@ -112,6 +112,7 @@ export function useElevation( props ) {
 		active,
 		borderRadius,
 		className,
+		cx,
 		focus,
 		hover,
 		isInteractive,

--- a/packages/components/src/flex/flex/hook.js
+++ b/packages/components/src/flex/flex/hook.js
@@ -126,6 +126,7 @@ export function useFlex( props ) {
 	}, [
 		align,
 		className,
+		cx,
 		direction,
 		expanded,
 		gap,

--- a/packages/components/src/grid/hook.js
+++ b/packages/components/src/grid/hook.js
@@ -71,6 +71,7 @@ export default function useGrid( props ) {
 		alignment,
 		className,
 		columnGap,
+		cx,
 		gap,
 		gridTemplateColumns,
 		gridTemplateRows,

--- a/packages/components/src/item-group/item/hook.ts
+++ b/packages/components/src/item-group/item/hook.ts
@@ -48,7 +48,7 @@ export function useItem( props: WordPressComponentProps< ItemProps, 'div' > ) {
 				spacedAround && styles.spacedAround,
 				className
 			),
-		[ as, className, size, spacedAround ]
+		[ as, className, cx, size, spacedAround ]
 	);
 
 	const wrapperClassName = cx( styles.itemWrapper );

--- a/packages/components/src/item-group/stories/index.js
+++ b/packages/components/src/item-group/stories/index.js
@@ -145,7 +145,7 @@ const ItemWithChevron = ( {
 
 	const itemClassName = useMemo(
 		() => cx( ! alwaysVisible && appearingChevron, className ),
-		[ alwaysVisible, className ]
+		[ alwaysVisible, className, cx ]
 	);
 
 	const chevronIconClassName = useMemo(
@@ -155,7 +155,7 @@ const ItemWithChevron = ( {
 				fill: currentColor;
 				transform: ${ isRtlLayout ? 'scaleX( -100% )' : 'none' };
 			` ),
-		[ isRtlLayout ]
+		[ cx, isRtlLayout ]
 	);
 
 	return (

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -96,7 +96,7 @@ function NavigatorProvider(
 	const classes = useMemo(
 		// Prevents horizontal overflow while animating screen transitions
 		() => cx( css( { overflowX: 'hidden' } ), className ),
-		[ className ]
+		[ className, cx ]
 	);
 
 	return (

--- a/packages/components/src/navigator/navigator-screen/component.tsx
+++ b/packages/components/src/navigator/navigator-screen/component.tsx
@@ -61,7 +61,7 @@ function NavigatorScreen( props: Props, forwardedRef: Ref< any > ) {
 				} ),
 				className
 			),
-		[ className ]
+		[ className, cx ]
 	);
 
 	// This flag is used to only apply the focus on mount when the actual path changes.

--- a/packages/components/src/scrollable/hook.js
+++ b/packages/components/src/scrollable/hook.js
@@ -36,7 +36,7 @@ export function useScrollable( props ) {
 				scrollDirection === 'auto' && styles.scrollAuto,
 				className
 			),
-		[ className, scrollDirection, smoothScroll ]
+		[ className, cx, scrollDirection, smoothScroll ]
 	);
 
 	return { ...otherProps, className: classes };

--- a/packages/components/src/surface/hook.js
+++ b/packages/components/src/surface/hook.js
@@ -54,6 +54,7 @@ export function useSurface( props ) {
 		borderRight,
 		borderTop,
 		className,
+		cx,
 		variant,
 	] );
 

--- a/packages/components/src/text/hook.js
+++ b/packages/components/src/text/hook.js
@@ -126,6 +126,7 @@ export default function useText( props ) {
 		align,
 		className,
 		color,
+		cx,
 		display,
 		isBlock,
 		isCaption,

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -81,7 +81,7 @@ function ToggleGroupControl(
 				'medium',
 				className
 			),
-		[ className, isBlock ]
+		[ className, cx, isBlock ]
 	);
 	return (
 		<BaseControl help={ help }>

--- a/packages/components/src/tools-panel/tools-panel-header/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-header/hook.ts
@@ -23,15 +23,15 @@ export function useToolsPanelHeader(
 	const cx = useCx();
 	const classes = useMemo( () => {
 		return cx( styles.ToolsPanelHeader, className );
-	}, [ className ] );
+	}, [ className, cx ] );
 
 	const dropdownMenuClassName = useMemo( () => {
 		return cx( styles.DropdownMenu );
-	}, [] );
+	}, [ cx ] );
 
 	const headingClassName = useMemo( () => {
 		return cx( styles.ToolsPanelHeading );
-	}, [] );
+	}, [ cx ] );
 
 	const {
 		menuItems,

--- a/packages/components/src/tools-panel/tools-panel-item/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel-item/hook.ts
@@ -148,6 +148,7 @@ export function useToolsPanelItem(
 		isShown,
 		shouldRenderPlaceholder,
 		className,
+		cx,
 		firstDisplayedItem,
 		lastDisplayedItem,
 		__experimentalFirstVisibleItemClass,

--- a/packages/components/src/tools-panel/tools-panel/hook.ts
+++ b/packages/components/src/tools-panel/tools-panel/hook.ts
@@ -196,6 +196,7 @@ export function useToolsPanel(
 	}, [
 		areAllOptionalControlsHidden,
 		className,
+		cx,
 		hasInnerWrapper,
 		menuItems,
 	] );

--- a/packages/components/src/truncate/hook.js
+++ b/packages/components/src/truncate/hook.js
@@ -59,7 +59,7 @@ export default function useTruncate( props ) {
 			shouldTruncate && !! numberOfLines && sx.numberOfLines,
 			className
 		);
-	}, [ className, numberOfLines, shouldTruncate ] );
+	}, [ className, cx, numberOfLines, shouldTruncate ] );
 
 	return { ...otherProps, className: classes, children: truncatedContent };
 }

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -7,6 +7,7 @@ import { css } from '@emotion/react';
  * WordPress dependencies
  */
 import { __unstableIframe as Iframe } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -25,6 +26,20 @@ export default {
 const Example = ( { args, children } ) => {
 	const cx = useCx();
 	const classes = cx( ...args );
+	return <span className={ classes }>{ children }</span>;
+};
+
+const ExampleWithUseMemoWrong = ( { args, children } ) => {
+	const cx = useCx();
+	// Wrong: using 'useMemo' without adding 'cx' to the dependency list.
+	const classes = useMemo( () => cx( ...args ), [ ...args ] );
+	return <span className={ classes }>{ children }</span>;
+};
+
+const ExampleWithUseMemoRight = ( { args, children } ) => {
+	const cx = useCx();
+	// Right: using 'useMemo' with 'cx' listed as a dependency.
+	const classes = useMemo( () => cx( ...args ), [ ...args, cx ] );
 	return <span className={ classes }>{ children }</span>;
 };
 
@@ -90,6 +105,32 @@ export const _slotFillSimple = () => {
 			</Iframe>
 			<Slot bubblesVirtually name="test-slot" />
 		</SlotFillProvider>
+	);
+};
+
+export const _useMemoBadPractices = () => {
+	const redText = css`
+		color: red;
+	`;
+	const blueText = css`
+		color: blue;
+	`;
+	const greenText = css`
+		color: green;
+	`;
+
+	return (
+		<>
+			<ExampleWithUseMemoRight args={ [ blueText ] }>
+				This text should be blue
+			</ExampleWithUseMemoRight>
+			<Iframe>
+				<Example args={ [ redText ] }>This text should be red</Example>
+				<ExampleWithUseMemoWrong args={ [ greenText ] }>
+					This text should be green but it&apos;s not!
+				</ExampleWithUseMemoWrong>
+			</Iframe>
+		</>
 	);
 };
 

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -23,24 +23,29 @@ export default {
 	title: 'Components (Experimental)/useCx',
 };
 
-const Example = ( { args, children } ) => {
+const Example = ( { serializedStyles, children } ) => {
 	const cx = useCx();
-	const classes = cx( ...args );
+	const classes = cx( serializedStyles );
 	return <span className={ classes }>{ children }</span>;
 };
 
-const ExampleWithUseMemoWrong = ( { args, children } ) => {
+const ExampleWithUseMemoWrong = ( { serializedStyles, children } ) => {
 	const cx = useCx();
 	// Wrong: using 'useMemo' without adding 'cx' to the dependency list.
 	// eslint-disable-next-line react-hooks/exhaustive-deps
-	const classes = useMemo( () => cx( ...args ), [ ...args ] );
+	const classes = useMemo( () => cx( serializedStyles ), [
+		serializedStyles,
+	] );
 	return <span className={ classes }>{ children }</span>;
 };
 
-const ExampleWithUseMemoRight = ( { args, children } ) => {
+const ExampleWithUseMemoRight = ( { serializedStyles, children } ) => {
 	const cx = useCx();
 	// Right: using 'useMemo' with 'cx' listed as a dependency.
-	const classes = useMemo( () => cx( ...args ), [ ...args, cx ] );
+	const classes = useMemo( () => cx( serializedStyles ), [
+		cx,
+		serializedStyles,
+	] );
 	return <span className={ classes }>{ children }</span>;
 };
 
@@ -62,17 +67,17 @@ export const _slotFill = () => {
 			<StyleProvider document={ document }>
 				<Iframe>
 					<Iframe>
-						<Example args={ [ redText ] }>
+						<Example serializedStyles={ redText }>
 							This text is inside an iframe and should be red
 						</Example>
 						<Fill name="test-slot">
-							<Example args={ [ blueText ] }>
+							<Example serializedStyles={ blueText }>
 								This text is also inside the iframe, but is
 								relocated by a slot/fill and should be blue
 							</Example>
 						</Fill>
 						<Fill name="outside-frame">
-							<Example args={ [ greenText ] }>
+							<Example serializedStyles={ greenText }>
 								This text is also inside the iframe, but is
 								relocated by a slot/fill and should be green
 							</Example>
@@ -99,7 +104,7 @@ export const _slotFillSimple = () => {
 		<SlotFillProvider>
 			<Iframe>
 				<Fill name="test-slot">
-					<Example args={ [ redText ] }>
+					<Example serializedStyles={ redText }>
 						This text should be red
 					</Example>
 				</Fill>
@@ -119,13 +124,17 @@ export const _useMemoBadPractices = () => {
 
 	return (
 		<>
-			<Example args={ [ redText ] }>This text should be red</Example>
-			<ExampleWithUseMemoRight args={ [ blueText ] }>
+			<Example serializedStyles={ redText }>
+				This text should be red
+			</Example>
+			<ExampleWithUseMemoRight serializedStyles={ blueText }>
 				This text should be blue
 			</ExampleWithUseMemoRight>
 			<Iframe>
-				<Example args={ [ redText ] }>This text should be red</Example>
-				<ExampleWithUseMemoWrong args={ [ blueText ] }>
+				<Example serializedStyles={ redText }>
+					This text should be red
+				</Example>
+				<ExampleWithUseMemoWrong serializedStyles={ blueText }>
 					This text should be blue but it&apos;s not!
 				</ExampleWithUseMemoWrong>
 			</Iframe>
@@ -139,7 +148,7 @@ export const _default = () => {
 	`;
 	return (
 		<Iframe>
-			<Example args={ [ redText ] }>
+			<Example serializedStyles={ redText }>
 				This text is inside an iframe and is red!
 			</Example>
 		</Iframe>

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -32,6 +32,7 @@ const Example = ( { args, children } ) => {
 const ExampleWithUseMemoWrong = ( { args, children } ) => {
 	const cx = useCx();
 	// Wrong: using 'useMemo' without adding 'cx' to the dependency list.
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const classes = useMemo( () => cx( ...args ), [ ...args ] );
 	return <span className={ classes }>{ children }</span>;
 };

--- a/packages/components/src/utils/hooks/stories/use-cx.js
+++ b/packages/components/src/utils/hooks/stories/use-cx.js
@@ -115,19 +115,17 @@ export const _useMemoBadPractices = () => {
 	const blueText = css`
 		color: blue;
 	`;
-	const greenText = css`
-		color: green;
-	`;
 
 	return (
 		<>
+			<Example args={ [ redText ] }>This text should be red</Example>
 			<ExampleWithUseMemoRight args={ [ blueText ] }>
 				This text should be blue
 			</ExampleWithUseMemoRight>
 			<Iframe>
 				<Example args={ [ redText ] }>This text should be red</Example>
-				<ExampleWithUseMemoWrong args={ [ greenText ] }>
-					This text should be green but it&apos;s not!
+				<ExampleWithUseMemoWrong args={ [ blueText ] }>
+					This text should be blue but it&apos;s not!
 				</ExampleWithUseMemoWrong>
 			</Iframe>
 		</>


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

### Explanation of the issue

While investigating the issue flagged in https://github.com/WordPress/gutenberg/pull/35619#discussion_r783270274 in #38447 , @sarayourfriend and I managed to reproduce the issue in a Storybook example:

- a component using Emotion is being rendered both inside and outside of an `iframe`, but styles are apparently only applied correctly to the outside element
- that component would use the `useCx` hook to compute the classname, and would have that computation wrapped inside React's  `useMemo` hook. But the `cx` function would not be part of the `useMemo` dependencies

The combination of the 2 points above causes the component's classnames to be computed only once for the component outside of the `iframe`. The component inside the `iframe` gets the same classnames (because of the memoization), but those classnames can't be found inside the `iframe` (since the styles are added to the `iframe` via a different `StyleProvider`).

**Long story short:** when rendered inside the `iframe`, the component's `cx` function updates to reference the correct Emotion cache, but the component doesn't get the correct classnames because, when the `cx` function updates, the memoized classnames remains the same.

### What's included in the PR:

This PR, therefore:

- Updates all usages of `cx` and `useMemo` in the `@wordpress/components` package, **adding `cx` to the list of dependencies**
- Adds a **Storybook example** showcasing this anti-pattern

### What should we do next

As also discussed with @sarayourfriend , we should assess if the usage of `useMemo` when computing Emotion's classnames is actually necessary to optimise the rendering performance of components.

We also wondered why `eslint` didn't flag the missing `cx` dependency — it looks like we're not enforcing [the `exhaustive-deps` rule](https://reactjs.org/docs/hooks-rules.html#eslint-plugin), I wonder what's the reason for it? (cc @gziolo )

Finally, in case we have good reasons not to enforce the `exhaustive-deps` rule, and if we decided to keep memoizing Emotion classname's computation, we could consider adding our own `eslint` rule aimed specifically at making sure that `cx` is always added as a dependency of `useMemo`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Inspect the "Use Memo Bad Practices" Storybook example:
  - check that the text in the IFrame that should be blue, is not blue
  - check that, by adding `cx` to the list of dependencies of `useMemo` in the `ExampleWithUseMemoWrong` component, the color's becomes blue
- Make sure that `cx` has been added as a dependency of `useMemo` in all of the instances where the 2 are used together in the `@wordpress/components` package

## Screenshots <!-- if applicable -->

![Screenshot 2022-02-04 at 23 04 41](https://user-images.githubusercontent.com/1083581/152609452-12f71318-5635-4f52-bcf7-69613c2d8c3c.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- N/A I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- N/A I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
