### PR TITLE
Use a fixed link to the latest release in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 12.5.3, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/tag/v12.5.3">release page</a>.
+To read the changelog for Gutenberg 12.5.3, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/latest">release page</a>.

--- a/readme.txt
+++ b/readme.txt
@@ -56,4 +56,4 @@ The four phases of the project are Editing, Customization, Collaboration, and Mu
 
 == Changelog ==
 
-To read the changelog for Gutenberg 12.5.3, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/latest">release page</a>.
+To read the changelog for the latest Gutenberg release, please navigate to the <a href="https://github.com/WordPress/gutenberg/releases/latest">release page</a>.


### PR DESCRIPTION
## Description
In `readme.txt`, there is a link to the changelog for the latest release:

`To read the changelog for Gutenberg 12.5.3, please navigate to the [release page](https://github.com/WordPress/gutenberg/releases/tag/v12.5.3).`

Instead of changing the link for each release, we can just link to https://github.com/WordPress/gutenberg/releases/latest here, which automatically redirects to the latest release:

`To read the changelog for the latest Gutenberg release, please navigate to the [release page](https://github.com/WordPress/gutenberg/releases/latest).`

This would save translators some work, as they will no longer have to translate the same string over and over again. Currently, with each new release, this string is marked as "fuzzy" and requires a manual approval again, even though nothing has really changed except for the version number.

Fixes #38155.