### PR TITLE
[Block Library]: Add transform between `Tag Cloud` and `Categories`

### DIFF
--- a/packages/block-library/src/tag-cloud/index.js
+++ b/packages/block-library/src/tag-cloud/index.js
@@ -6,6 +6,7 @@ import { tag as icon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import transforms from './transforms';
 import metadata from './block.json';
 import edit from './edit';
 
@@ -17,4 +18,5 @@ export const settings = {
 	icon,
 	example: {},
 	edit,
+	transforms,
 };

--- a/packages/block-library/src/tag-cloud/transforms.js
+++ b/packages/block-library/src/tag-cloud/transforms.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/categories' ],
+			transform: () => createBlock( 'core/tag-cloud' ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/categories' ],
+			transform: () => createBlock( 'core/categories' ),
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/30769

This PR just adds transform between `Tag Cloud` and `Categories` blocks.