### PR TITLE
Scripts: Improve the handling for build entry points

### DIFF
--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-const { basename, dirname, join } = require( 'path' );
+const chalk = require( 'chalk' );
+const { basename, dirname, extname, join, sep } = require( 'path' );
 const { sync: glob } = require( 'fast-glob' );
 
 /**
@@ -15,6 +16,8 @@ const {
 } = require( './cli' );
 const { fromConfigRoot, fromProjectRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
+const { exit } = require( './process' );
+const { log } = console;
 
 // See https://babeljs.io/docs/en/config-files#configuration-file-types.
 const hasBabelConfig = () =>
@@ -188,6 +191,7 @@ function getWebpackEntryPoints() {
 	} );
 
 	if ( blockMetadataFiles.length > 0 ) {
+		const srcDirectory = fromProjectRoot( 'src' + sep );
 		const entryPoints = blockMetadataFiles.reduce(
 			( accumulator, blockMetadataFile ) => {
 				const {
@@ -203,15 +207,26 @@ function getWebpackEntryPoints() {
 						const filepath = join(
 							dirname( blockMetadataFile ),
 							value.replace( 'file:', '' )
-						).replace( /\\/g, '/' );
+						);
 
 						// Takes the path without the file extension, and relative to the `src` directory.
-						const [ , entryName ] = filepath
-							.split( '.' )[ 0 ]
-							.split( 'src/' );
-						if ( ! entryName ) {
+						if ( ! filepath.startsWith( srcDirectory ) ) {
+							log(
+								chalk.yellow(
+									`Skipping "${ value.replace(
+										'file:',
+										''
+									) }" listed in "${ blockMetadataFile.replace(
+										fromProjectRoot( sep ),
+										''
+									) }". File is located outside of the "src" directory.`
+								)
+							);
 							return;
 						}
+						const entryName = filepath
+							.replace( extname( filepath ), '' )
+							.replace( srcDirectory, '' );
 
 						// Detects the proper file extension used in the `src` directory.
 						const [ entryFilepath ] = glob(
@@ -221,6 +236,20 @@ function getWebpackEntryPoints() {
 							}
 						);
 
+						if ( ! entryFilepath ) {
+							log(
+								chalk.yellow(
+									`Skipping "${ value.replace(
+										'file:',
+										''
+									) }" listed in "${ blockMetadataFile.replace(
+										fromProjectRoot( sep ),
+										''
+									) }". File does not exist in the "src" directory.`
+								)
+							);
+							return;
+						}
 						accumulator[ entryName ] = entryFilepath;
 					} );
 				return accumulator;
@@ -239,7 +268,10 @@ function getWebpackEntryPoints() {
 		absolute: true,
 	} );
 	if ( ! entryFile ) {
-		return {};
+		log(
+			chalk.bold.red( 'No entry files discovered in the "src" folder.' )
+		);
+		exit( 1 );
 	}
 
 	return {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #38526.

As reported by @markcummins:

> The path that my WordPress directory is '/home/mark/Development/www/WordPress/src/wp-content/plugins/demo/src/index.js'.
> 
> The Webpack file tries to extract the filename by splitting the path between src and .js, but because my WordPress install is located in a folder called src, that function returns an array instead of a string.
> 
> So the soultion for me is to rename the 'src' directory that my WordPress install is located in.
> 
> The function is in config.js [here](https://github.com/WordPress/gutenberg/blob/b563cea0bb081f9506d88753f7dfaf070aa186b1/packages/scripts/utils/config.js) in case you think it needs to be addressed, but it might be an edge case.
> 
> // Takes the path without the file extension, and relative to the src directory. const [, entryName] = filepath .split('.')[0] .split('src/'); if (!entryName) { return; }

I resolved the issue by removing the path to the `src` directory in the project instead of splitting the path by the location of `src/`. 

In addition to that, I added warnings and errors with detailed description what can be improved in the configuration. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run:
```
npx wp-create-block my-block --no-wp-scripts
cd my-block
../node_modules/.bin/wp-scripts build
```

Try removing a script referenced in the `block.json` and run the build again:
```
../node_modules/.bin/wp-scripts build
```

You should see an error message.

Try adding in `block.json` a path to a script that is outside of `src` folder and watch for warning when running the build again.


## Screenshots <!-- if applicable -->

<img width="1461" alt="Screenshot 2022-02-07 at 15 32 56" src="https://user-images.githubusercontent.com/699132/152808759-101c95ce-ec32-4516-a419-40592bbd06e6.png">
<img width="1467" alt="Screenshot 2022-02-07 at 15 33 07" src="https://user-images.githubusercontent.com/699132/152808773-fad71b0f-2747-4732-97a8-e60c6c582ef4.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
