### PR TITLE
Editor store: remove createUndoLevel and refreshPost actions

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1043,7 +1043,7 @@ _Related_
 
 ### createUndoLevel
 
-> **Deprecated** Since Gutenberg 13.0.0
+> **Deprecated** Since WordPress 6.0
 
 Action that creates an undo history record.
 
@@ -1218,7 +1218,7 @@ restore last popped state.
 
 ### refreshPost
 
-> **Deprecated** Since Gutenberg 13.0.0.
+> **Deprecated** Since WordPress 6.0.
 
 Action for refreshing the current post.
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1043,12 +1043,9 @@ _Related_
 
 ### createUndoLevel
 
-Returns an action object used in signalling that undo history record should
-be created.
+> **Deprecated** Since Gutenberg 13.0.0
 
-_Returns_
-
--   `Object`: Action object.
+Action that creates an undo history record.
 
 ### disablePublishSidebar
 
@@ -1221,7 +1218,9 @@ restore last popped state.
 
 ### refreshPost
 
-Action generator for handling refreshing the current post.
+> **Deprecated** Since Gutenberg 13.0.0.
+
+Action for refreshing the current post.
 
 ### removeBlock
 

--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   Removed unused `@wordpress/autop`, `@wordpress/blob` and `@wordpress/is-shallow-equal` dependencies ([#38388](https://github.com/WordPress/gutenberg/pull/38388)).
 
+### Deprecations
+
+- the `createUndoLevel` and `refreshPost` actions were marked as deprecated. They were already defunct and acting as noops.
+
 ## 12.1.0 (2022-01-27)
 
 ## 12.0.0 (2021-10-12)

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -280,27 +280,16 @@ export function* savePost( options = {} ) {
 }
 
 /**
- * Action generator for handling refreshing the current post.
+ * Action for refreshing the current post.
+ *
+ * @deprecated Since Gutenberg 13.0.0.
  */
-export function* refreshPost() {
-	const post = yield controls.select( STORE_NAME, 'getCurrentPost' );
-	const postTypeSlug = yield controls.select(
-		STORE_NAME,
-		'getCurrentPostType'
-	);
-	const postType = yield controls.resolveSelect(
-		coreStore,
-		'getPostType',
-		postTypeSlug
-	);
-	const newPost = yield apiFetch( {
-		// Timestamp arg allows caller to bypass browser caching, which is
-		// expected for this specific function.
-		path:
-			`/wp/v2/${ postType.rest_base }/${ post.id }` +
-			`?context=edit&_timestamp=${ Date.now() }`,
+export function refreshPost() {
+	deprecated( "wp.data.dispatch( 'core/editor' ).refreshPost", {
+		since: '5.9',
+		alternative: 'Use the core entities store instead',
 	} );
-	yield controls.dispatch( STORE_NAME, 'resetPost', newPost );
+	return { type: 'DO_NOTHING' };
 }
 
 /**
@@ -404,13 +393,16 @@ export function* undo() {
 }
 
 /**
- * Returns an action object used in signalling that undo history record should
- * be created.
+ * Action that creates an undo history record.
  *
- * @return {Object} Action object.
+ * @deprecated Since Gutenberg 13.0.0
  */
 export function createUndoLevel() {
-	return { type: 'CREATE_UNDO_LEVEL' };
+	deprecated( "wp.data.dispatch( 'core/editor' ).createUndoLevel", {
+		since: '5.9',
+		alternative: 'Use the core entities store instead',
+	} );
+	return { type: 'DO_NOTHING' };
 }
 
 /**

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -282,11 +282,12 @@ export function* savePost( options = {} ) {
 /**
  * Action for refreshing the current post.
  *
- * @deprecated Since Gutenberg 13.0.0.
+ * @deprecated Since WordPress 6.0.
  */
 export function refreshPost() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).refreshPost", {
-		since: '5.9',
+		since: '6.0',
+		version: '6.3',
 		alternative: 'Use the core entities store instead',
 	} );
 	return { type: 'DO_NOTHING' };
@@ -395,11 +396,12 @@ export function* undo() {
 /**
  * Action that creates an undo history record.
  *
- * @deprecated Since Gutenberg 13.0.0
+ * @deprecated Since WordPress 6.0
  */
 export function createUndoLevel() {
 	deprecated( "wp.data.dispatch( 'core/editor' ).createUndoLevel", {
-		since: '5.9',
+		since: '6.0',
+		version: '6.3',
 		alternative: 'Use the core entities store instead',
 	} );
 	return { type: 'DO_NOTHING' };

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -358,46 +358,6 @@ describe( 'Post generator actions', () => {
 			} );
 		} );
 	} );
-	describe( 'refreshPost()', () => {
-		let fulfillment;
-		const currentPost = { id: 10, content: 'foo' };
-		const reset = () => ( fulfillment = actions.refreshPost() );
-		it( 'yields expected action for selecting the currentPost', () => {
-			reset();
-			const { value } = fulfillment.next();
-			expect( value ).toEqual(
-				controls.select( STORE_NAME, 'getCurrentPost' )
-			);
-		} );
-		it( 'yields expected action for selecting the current post type', () => {
-			const { value } = fulfillment.next( currentPost );
-			expect( value ).toEqual(
-				controls.select( STORE_NAME, 'getCurrentPostType' )
-			);
-		} );
-		it( 'yields expected action for selecting the post type object', () => {
-			const { value } = fulfillment.next( postTypeSlug );
-			expect( value ).toEqual(
-				controls.resolveSelect( 'core', 'getPostType', postTypeSlug )
-			);
-		} );
-		it( 'yields expected action for the api fetch call', () => {
-			const { value } = fulfillment.next( postType );
-			// since the timestamp is a computed value we can't do a direct comparison.
-			// so we'll just see if the path has most of the value.
-			expect( value.request.path ).toEqual(
-				expect.stringContaining(
-					`/wp/v2/${ postType.rest_base }/${ currentPost.id }?context=edit&_timestamp=`
-				)
-			);
-		} );
-		it( 'yields expected action for dispatching the reset of the post', () => {
-			const { value } = fulfillment.next( currentPost );
-			expect( value ).toEqual(
-				controls.dispatch( STORE_NAME, 'resetPost', currentPost )
-			);
-		} );
-	} );
 } );
 
 describe( 'Editor actions', () => {


### PR DESCRIPTION
This PR removes two `editor` store actions that are unused. Even if someone tried to use them, they would discover they don't do anything useful at all.

`createUndoLevel` was gradually moved to the `core` store (especially in #13088), and today the `editor` reducer doesn't react to the `CREATE_UNDO_LEVEL` action at all.

`refreshPost` used to be used in the `PostPermalink` component, but that one was removed in #21099. The action used to fetch the latest version of the post from REST API, and store it in state with `resetPost`. But today the `resetPost` action resets just the `id` and `type` fields, which are kind of guaranteed to never change.

In short, gradual and mechanical refactorings removed all meaning from these two actions. Regarding backward compatibility, can we safely remove them? Given that the Gutenberg codebase doesn't use them, and anyone else doesn't have any reason to call them?

Discovered this when refreshing #35929, my PR to migrate the `editor` store to thunks.