### PR TITLE
Update `Imgur` title to prioritize `Image` block when searching with `img`

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -182,7 +182,7 @@ const variations = [
 	},
 	{
 		name: 'imgur',
-		title: 'Imgur',
+		title: 'Embed Imgur',
 		icon: embedPhotoIcon,
 		description: __( 'Embed Imgur content.' ),
 		patterns: [ /^https?:\/\/(.+\.)?imgur\.com\/.+/i ],


### PR DESCRIPTION
Resolves: https://github.com/WordPress/gutenberg/issues/37532

In the inserter results we use a generic algorithm for `ranking` them [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/inserter/search-items.js#L142) and IMO this works well. It prioritizes the results based on the searched term and if we would sort them alphabetically, the results would be less relevant.

There is a very specific request about searching for `img`, which is a really common term for `images` where the `Imgur` embed variation is shown first instead of the `Image` block.  The above case happens because the `img` is part of the block variation's title(`imgur`) and I can't think of any adjustment that could be generic and work well in all scenarios.

So we could probably handle this on it's own. A specific approach for this is this PR, where I change the title of `imgur` variation to `embed imgur`.

### Testing instructions
1. Open any inserter and search for `img`
2. `Image` block should be shown on top of the results.

