### PR TITLE
Include tests-mysql port in dev:start output

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -174,12 +174,20 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 
 	const siteUrl = config.env.development.config.WP_SITEURL;
 	const e2eSiteUrl = config.env.tests.config.WP_TESTS_DOMAIN;
+
 	const { out: mySQLAddress } = await dockerCompose.port(
 		'mysql',
 		3306,
 		dockerComposeConfig
 	);
 	const mySQLPort = mySQLAddress.split( ':' ).pop();
+
+	const { out: testsMySQLAddress } = await dockerCompose.port(
+		'tests-mysql',
+		3306,
+		dockerComposeConfig
+	);
+	const testsMySQLPort = testsMySQLAddress.split( ':' ).pop();
 
 	spinner.prefixText = 'WordPress development site started'
 		.concat( siteUrl ? ` at ${ siteUrl }` : '.' )
@@ -188,6 +196,9 @@ module.exports = async function start( { spinner, debug, update, xdebug } ) {
 		.concat( e2eSiteUrl ? ` at ${ e2eSiteUrl }` : '.' )
 		.concat( '\n' )
 		.concat( `MySQL is listening on port ${ mySQLPort }` )
+		.concat(
+			`MySQL for automated testing is listening on port ${ testsMySQLPort }`
+		)
 		.concat( '\n' );
 
 	spinner.text = 'Done!';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When running `npm run wp-env start`, print the host-local port which is mapped for the `tests-mysql` container:

https://github.com/WordPress/gutenberg/blob/48da1d92f5ffc5ea3369f19498aa3dbab7aed1cc/packages/env/lib/build-docker-compose-config.js#L186-L195

This is in addition to the port for the "standard" mysql container which is printed in a similar manner immediately prior to the line in this change.

My workaround has been to run a script like this:
`docker-compose -f $(npm run --silent wp-env install-path)/docker-compose.yml port tests-mysql 3306` and inspect the port returned.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Clone this branch
* `npm i`
* `npm run wp-env start`
* Note the correct port number on the host machine which points to port `3306` on the `tests-mysql` container.

## Screenshots <!-- if applicable -->

![Screenshot from 2022-02-07 12-32-40](https://user-images.githubusercontent.com/1587282/152841930-524156c9-ddb2-4a16-a5a8-212788a68638.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
