### PR TITLE
Build workflow: Don't update version in readme.txt

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -124,12 +124,11 @@ jobs:
                   cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package.json) > package.json
                   cat <<< $(jq --tab --arg version "${VERSION}" '.version = $version' package-lock.json) > package-lock.json
                   sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" gutenberg.php
-                  sed -i "s/${{ steps.get_version.outputs.old_version }}/${VERSION}/g" readme.txt
 
             - name: Commit the version bump to the release branch
               id: commit_version_bump_to_release_branch
               run: |
-                  git add gutenberg.php package.json package-lock.json readme.txt
+                  git add gutenberg.php package.json package-lock.json
                   git commit -m "Bump plugin version to ${{ steps.get_version.outputs.new_version }}"
                   git push --set-upstream origin "${{ steps.get_version.outputs.release_branch }}"
                   echo "::set-output name=version_bump_commit::$(git rev-parse --verify --short HEAD)"


### PR DESCRIPTION
## Description
Follow-up to https://github.com/WordPress/gutenberg/pull/38550#issuecomment-1031816064. Per https://github.com/WordPress/gutenberg/pull/38550, the `readme.txt` no longer contains a reference to Gutenberg's current version number.

That version number was previously updated upon release by the build plugin workflow. Since that updating is now obsolete, this PR removes it.

## Testing Instructions
This can really only be tested by running the release workflow. It's possible to do that by forking the repo and trying it out there, but that's a bit of a hassle.

Since this PR only removes one line of code that updated the version via `sed`, and then added it to the git index via `git add`, we might be confident enough that removing those bits won't break anything, and just keep an eye on the workflow the next time we run it 🤞 

## Types of changes
Code quality.
