### PR TITLE
Site Editor: Fix alignment styles

### DIFF
--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -121,23 +121,27 @@ export default {
 						margin-right: auto !important;
 					}
 
-					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
+					${ appendSelectors( selector, '> [data-align="wide"]' ) },
+					${ appendSelectors( selector, '> .alignwide' ) } {
 						max-width: ${ wideSize ?? contentSize };
 					}
 
-					${ appendSelectors( selector, '> [data-align="full"]' ) } {
+					${ appendSelectors( selector, '> [data-align="full"]' ) },
+					${ appendSelectors( selector, '> .alignfull' ) } {
 						max-width: none;
 					}
 				`
 				: '';
 
 		output += `
-			${ appendSelectors( selector, '> [data-align="left"]' ) } {
+			${ appendSelectors( selector, '> [data-align="left"]' ) },
+			${ appendSelectors( selector, '> .alignleft' ) } {
 				float: left;
 				margin-right: 2em;
 			}
 
-			${ appendSelectors( selector, '> [data-align="right"]' ) } {
+			${ appendSelectors( selector, '> [data-align="right"]' ) },
+			${ appendSelectors( selector, '> .alignright' ) } {
 				float: right;
 				margin-left: 2em;
 			}


### PR DESCRIPTION
## Description
When alignment styles are output in the Site Editor, they use classes (alignwide, alignfull, alignleft, alignright), not data attributes ("data-align"="wide", "data-align"="full", "data-align"="left", "data-align"="right"). This PR sets those classes in the JS alignment styles so that the alignment styles in the Site Editor work for post content.

## Testing Instructions
Using the Livro theme, add this content to a post:

```
<!-- wp:group {"backgroundColor":"primary"} -->
<div class="wp-block-group has-primary-background-color has-background"><!-- wp:paragraph {"textColor":"background"} -->
<p class="has-background-color has-text-color">Group block (no alignment)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"wide","backgroundColor":"primary"} -->
<div class="wp-block-group alignwide has-primary-background-color has-background"><!-- wp:paragraph {"textColor":"background"} -->
<p class="has-background-color has-text-color">Group block (wide alignment)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"full","backgroundColor":"primary"} -->
<div class="wp-block-group alignfull has-primary-background-color has-background"><!-- wp:paragraph {"textColor":"background"} -->
<p class="has-background-color has-text-color">Group block (full alignment)</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Open the home template in the Site Editor and check that the alignment styles are working as in the screenshot.

## Screenshots <!-- if applicable -->
<img width="1161" alt="Screenshot 2022-02-07 at 20 57 47" src="https://user-images.githubusercontent.com/275961/152870715-de1917ad-82ff-4400-b621-add4a3e384df.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
