### PR TITLE
Full Site Editing: Improve compat with 3rd party Customizer links

### DIFF
--- a/lib/compat/wordpress-5.9/admin-menu.php
+++ b/lib/compat/wordpress-5.9/admin-menu.php
@@ -22,8 +22,11 @@ function gutenberg_remove_legacy_pages() {
 	$customize_menu    = null;
 	foreach ( $submenu['themes.php'] as $index => $menu_item ) {
 		if ( false !== strpos( $menu_item[2], 'customize.php' ) ) {
-			$indexes_to_remove[] = $index;
-			$customize_menu      = $menu_item;
+			// Assume the first entry is the Customizer proper, if customize.php is linked > once.
+			if ( is_null( $customize_menu ) ) {
+				$indexes_to_remove[] = $index;
+				$customize_menu      = $menu_item;
+			}
 		}
 
 		if ( false !== strpos( $menu_item[2], 'site-editor.php' ) ) {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Only try to move and/or remove Core's Customizer link when a block theme is active.

Note that this is a real-world issue on WordPress.com, where the [AMP plugin](https://wordpress.org/plugins/amp/) uses the Customizer to autofocus an AMP section in the Customizer. You will not see the bug on a standard install as our load order is a bit different so the AMP callback to `admin_menu` calls prior to `gutenberg_remove_legacy_pages`, despite both being on the default `10` priority. Any plugin that leverages the Customizer will see its link restored rather than the Customizer itself. 

## Testing Instructions
Add a customizer-based appearance menu at an early priority. Eg:
```php
add_action( 'customize_register', '__return_false' );
add_action( 'admin_menu', function() {
	add_theme_page(
		'Third Party',
		'Third Party',
		'edit_theme_options',
		'customize.php?autofocus'
	);
}, 9 );
```
Without this patch, you should see that the Third Party item is restored rather than the Core Customizer link. With this patch, both are maintained, but the Customizer is demoted according to the intent the original code by @Mamaduka in #37175

## Screenshots <!-- if applicable -->
Before:
<img width="158" alt="Screen Shot 2022-02-07 at 15 23 08" src="https://user-images.githubusercontent.com/195089/152874191-2e35c7c3-87fe-4bd6-8132-e82264caa6de.png">

After:
<img width="160" alt="Screen Shot 2022-02-07 at 15 23 45" src="https://user-images.githubusercontent.com/195089/152874323-f7de51bf-0c97-4128-a8d3-b7f2b01a2b74.png">

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
