### PR TITLE
Heading: Omit anchor when transforming to paragraph

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -84,11 +84,8 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
-				attributes.map( ( { content, anchor } ) =>
-					createBlock( 'core/paragraph', {
-						content,
-						anchor,
-					} )
+				attributes.map( ( { content } ) =>
+					createBlock( 'core/paragraph', { content } )
 				),
 		},
 	],

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/keep-styles-on-block-transforms.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Keep styles on block transforms Should keep colors during a transform 1`] = `
 "<!-- wp:paragraph {\\"textColor\\":\\"luminous-vivid-orange\\"} -->
-<p class=\\"has-luminous-vivid-orange-color has-text-color\\" id=\\"heading\\">Heading</p>
+<p class=\\"has-luminous-vivid-orange-color has-text-color\\">Heading</p>
 <!-- /wp:paragraph -->"
 `;
 


### PR DESCRIPTION
## Description
PR removes anchor when transforming Heading to a Paragraph. Headings have their anchor auto-generated, so users might have to clean them up manually after transformation.

Resolves #38572

## Testing Instructions
1. Add a heading to a post.
2. Transform to paragraph.
3. Check that it doesn't have an anchor.

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
