### PR TITLE
Page for Posts: Display notice in template panel

### DIFF
--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -223,6 +223,16 @@ function register_site_editor_homepage_settings() {
 			'description'  => __( 'The ID of the page that should be displayed on the front page', 'gutenberg' ),
 		)
 	);
+
+	register_setting(
+		'reading',
+		'page_for_posts',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'number',
+			'description'  => __( 'The ID of the page that should display the latest posts', 'gutenberg' ),
+		)
+	);
 }
 add_action( 'init', 'register_site_editor_homepage_settings', 10 );
 

--- a/packages/edit-post/src/components/sidebar/template/actions.js
+++ b/packages/edit-post/src/components/sidebar/template/actions.js
@@ -25,7 +25,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as editPostStore } from '../../../store';
 import { createBlock, serialize } from '@wordpress/blocks';
 
-function PostTemplateActions() {
+function PostTemplateActions( { isPostsPage } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ title, setTitle ] = useState( '' );
@@ -128,12 +128,17 @@ function PostTemplateActions() {
 						{ __( 'Edit' ) }
 					</Button>
 				) }
-				<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
-					{
-						/* translators: button to create a new template */
-						_x( 'New', 'action' )
-					}
-				</Button>
+				{ ! isPostsPage && (
+					<Button
+						variant="link"
+						onClick={ () => setIsModalOpen( true ) }
+					>
+						{
+							/* translators: button to create a new template */
+							_x( 'New', 'action' )
+						}
+					</Button>
+				) }
 			</div>
 			{ isModalOpen && (
 				<Modal

--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -28,6 +28,7 @@ export function TemplatePanel() {
 	const {
 		isEnabled,
 		isOpened,
+		isPostsPage,
 		selectedTemplate,
 		availableTemplates,
 		fetchedTemplates,
@@ -44,10 +45,19 @@ export function TemplatePanel() {
 		const {
 			getEditedPostAttribute,
 			getEditorSettings,
+			getCurrentPostId,
 			getCurrentPostType,
 		} = select( editorStore );
-		const { getPostType, getEntityRecords, canUser } = select( coreStore );
+		const {
+			getPostType,
+			getEntityRecord,
+			getEntityRecords,
+			canUser,
+		} = select( coreStore );
+
+		const currentPostId = getCurrentPostId();
 		const currentPostType = getCurrentPostType();
+		const settings = getEntityRecord( 'root', 'site' );
 		const _isViewable = getPostType( currentPostType )?.viewable ?? false;
 		const _supportsTemplateMode =
 			select( editorStore ).getEditorSettings().supportsTemplateMode &&
@@ -61,6 +71,7 @@ export function TemplatePanel() {
 		return {
 			isEnabled: isEditorPanelEnabled( PANEL_NAME ),
 			isOpened: isEditorPanelOpened( PANEL_NAME ),
+			isPostsPage: currentPostId === settings?.page_for_posts,
 			selectedTemplate: getEditedPostAttribute( 'template' ),
 			availableTemplates: getEditorSettings().availableTemplates,
 			fetchedTemplates: templateRecords,
@@ -85,6 +96,10 @@ export function TemplatePanel() {
 
 	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
 	const { editPost } = useDispatch( editorStore );
+
+	if ( isPostsPage ) {
+		return null;
+	}
 
 	if (
 		! isEnabled ||

--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -129,7 +129,7 @@ export function TemplatePanel() {
 					status="warning"
 					isDismissible={ false }
 				>
-					{ __( 'The posts page template connot be changed.' ) }
+					{ __( 'The posts page template cannot be changed.' ) }
 				</Notice>
 			) : (
 				<SelectControl

--- a/packages/edit-post/src/components/sidebar/template/index.js
+++ b/packages/edit-post/src/components/sidebar/template/index.js
@@ -8,7 +8,7 @@ import { partial, isEmpty, map, fromPairs } from 'lodash';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { Notice, PanelBody, SelectControl } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -97,10 +97,6 @@ export function TemplatePanel() {
 	const { toggleEditorPanelOpened } = useDispatch( editPostStore );
 	const { editPost } = useDispatch( editorStore );
 
-	if ( isPostsPage ) {
-		return null;
-	}
-
 	if (
 		! isEnabled ||
 		! isViewable ||
@@ -127,25 +123,40 @@ export function TemplatePanel() {
 			opened={ isOpened }
 			onToggle={ onTogglePanel }
 		>
-			<SelectControl
-				hideLabelFromVision
-				label={ __( 'Template:' ) }
-				value={
-					Object.keys( templates ).includes( selectedTemplate )
-						? selectedTemplate
-						: ''
-				}
-				onChange={ ( templateSlug ) => {
-					editPost( {
-						template: templateSlug || '',
-					} );
-				} }
-				options={ map( templates, ( templateName, templateSlug ) => ( {
-					value: templateSlug,
-					label: templateName,
-				} ) ) }
-			/>
-			{ canUserCreate && <PostTemplateActions /> }
+			{ isPostsPage ? (
+				<Notice
+					className="edit-post-template__notice"
+					status="warning"
+					isDismissible={ false }
+				>
+					{ __( 'The posts page template connot be changed.' ) }
+				</Notice>
+			) : (
+				<SelectControl
+					hideLabelFromVision
+					label={ __( 'Template:' ) }
+					value={
+						Object.keys( templates ).includes( selectedTemplate )
+							? selectedTemplate
+							: ''
+					}
+					onChange={ ( templateSlug ) => {
+						editPost( {
+							template: templateSlug || '',
+						} );
+					} }
+					options={ map(
+						templates,
+						( templateName, templateSlug ) => ( {
+							value: templateSlug,
+							label: templateName,
+						} )
+					) }
+				/>
+			) }
+			{ canUserCreate && (
+				<PostTemplateActions isPostsPage={ isPostsPage } />
+			) }
 		</PanelBody>
 	);
 }

--- a/packages/edit-post/src/components/sidebar/template/style.scss
+++ b/packages/edit-post/src/components/sidebar/template/style.scss
@@ -28,6 +28,14 @@
 	}
 }
 
+.edit-post-template__notice {
+	margin: 0 0 $grid-unit-10 0;
+
+	.components-notice__content {
+		margin: 0;
+	}
+}
+
 .edit-post-template__actions {
 	button:not(:last-child) {
 		margin-right: $grid-unit-10;


### PR DESCRIPTION
## Description
PR displays notice inside the "Templates" panel when editing "Page for Posts." Changing the template for this page has no effects; ~~this also [matches logic](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-admin/includes/meta-boxes.php#L976) in Classic Editor.~~

## Testing Instructions
1. Using Settings -> Reading, set static page.
2. Set a post page.
3. Edit this page and check that the Templates panel isn't displayed.
4. Edit another page and confirm that the Templates panel is visible.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-08 at 11 19 31](https://user-images.githubusercontent.com/240569/152937327-fe54530a-8fc1-4161-8eaf-367f99489326.png)


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
