### PR TITLE
Template Editing Mode: Fix horizontal scrollbar

### DIFF
--- a/packages/edit-post/src/components/visual-editor/style.scss
+++ b/packages/edit-post/src/components/visual-editor/style.scss
@@ -66,6 +66,7 @@
 	width: 100%;
 	height: 100%;
 	position: relative;
+	box-sizing: border-box;
 	display: flex;
 
 	// This is necessary for older browsers due to their flex height interpretation.


### PR DESCRIPTION
## Description
PR fixes horizontal scrollbar inside template editing mode. This regression was introduced after removing blanked CSS rule for box-sizing (#37902).

Resolves #38374.

## Testing Instructions
1. Using TT2 theme.
2. Open a post or a page.
3. Click "Edit" inside the "Templates panel.
4. Confirm that there's no horizontal scrollbar.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-08 at 12 39 48](https://user-images.githubusercontent.com/240569/152949535-7ad80400-5203-4d3d-9223-d11747e354e4.png)

## Types of changes
Bugfix/Regression

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
