### PR TITLE
Remove data-align divs for themes that support layout

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -55,6 +55,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		if ( $content_size || $wide_size ) {
 			$style  = "$selector > * {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
+			$style .= '}';
+			$style  = "$selector > :not(.alignleft):not(.alignright) {";
 			$style .= 'margin-left: auto !important;';
 			$style .= 'margin-right: auto !important;';
 			$style .= '}';
@@ -63,8 +65,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= "$selector .alignfull { max-width: none; }";
 		}
 
-		$style .= "$selector .alignleft { float: left; margin-right: 2em; }";
-		$style .= "$selector .alignright { float: right; margin-left: 2em; }";
+		$style .= "$selector .alignleft { float: left; margin-right: 2em; margin-left: 0; }";
+		$style .= "$selector .alignright { float: right; margin-left: 2em; margin-right: 0; }";
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap )';
 			$style    .= "$selector > * { margin-top: 0; margin-bottom: 0; }";

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -53,10 +53,8 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		$style = '';
 		if ( $content_size || $wide_size ) {
-			$style  = "$selector > * {";
-			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
-			$style .= '}';
 			$style  = "$selector > :not(.alignleft):not(.alignright) {";
+			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 			$style .= 'margin-left: auto !important;';
 			$style .= 'margin-right: auto !important;';
 			$style .= '}';

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -183,7 +183,7 @@ function BlockListBlock( {
 	const value = {
 		clientId,
 		className:
-			wrapperProps[ 'data-align' ] && themeSupportsLayout
+			wrapperProps?.[ 'data-align' ] && themeSupportsLayout
 				? classnames(
 						className,
 						`align${ wrapperProps[ 'data-align' ] }`

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -128,7 +128,10 @@ function BlockListBlock( {
 		);
 	}
 
-	const isAligned = wrapperProps && !! wrapperProps[ 'data-align' ];
+	const isAligned =
+		wrapperProps &&
+		!! wrapperProps[ 'data-align' ] &&
+		! themeSupportsLayout;
 
 	// For aligned blocks, provide a wrapper element so the block can be
 	// positioned relative to the block column.
@@ -138,7 +141,7 @@ function BlockListBlock( {
 	// Due to the differences between frontend and backend, we migrated
 	// to the layout feature, and we're now aligning the markup of frontend
 	// and backend.
-	if ( isAligned && ! themeSupportsLayout ) {
+	if ( isAligned ) {
 		blockEdit = (
 			<div
 				className="wp-block"
@@ -180,7 +183,7 @@ function BlockListBlock( {
 	const value = {
 		clientId,
 		className:
-			isAligned && themeSupportsLayout
+			wrapperProps[ 'data-align' ] && themeSupportsLayout
 				? classnames(
 						className,
 						`align${ wrapperProps[ 'data-align' ] }`

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -321,7 +321,9 @@
 }
 
 .wp-block[data-align="left"] > *,
-.wp-block[data-align="right"] > * {
+.wp-block[data-align="right"] > *,
+.wp-block.alignleft,
+.wp-block.alignright {
 	// Without z-index, won't be clickable as "above" adjacent content.
 	z-index: z-index("{core/image aligned left or right} .wp-block");
 }

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -121,23 +121,23 @@ export default {
 						margin-right: auto !important;
 					}
 
-					${ appendSelectors( selector, '> [data-align="wide"]' ) }  {
+					${ appendSelectors( selector, '> .alignwide' ) }  {
 						max-width: ${ wideSize ?? contentSize };
 					}
 
-					${ appendSelectors( selector, '> [data-align="full"]' ) } {
+					${ appendSelectors( selector, '> .alignfull' ) } {
 						max-width: none;
 					}
 				`
 				: '';
 
 		output += `
-			${ appendSelectors( selector, '> [data-align="left"]' ) } {
+			${ appendSelectors( selector, '> .alignleft' ) } {
 				float: left;
 				margin-right: 2em;
 			}
 
-			${ appendSelectors( selector, '> [data-align="right"]' ) } {
+			${ appendSelectors( selector, '> .alignright' ) } {
 				float: right;
 				margin-left: 2em;
 			}

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -117,6 +117,9 @@ export default {
 				? `
 					${ appendSelectors( selector, '> *' ) } {
 						max-width: ${ contentSize ?? wideSize };
+					}
+
+					${ appendSelectors( selector, '> :not(.alignleft):not(.alignright)' ) } {
 						margin-left: auto !important;
 						margin-right: auto !important;
 					}
@@ -135,11 +138,13 @@ export default {
 			${ appendSelectors( selector, '> .alignleft' ) } {
 				float: left;
 				margin-right: 2em;
+				margin-left: 0;
 			}
 
 			${ appendSelectors( selector, '> .alignright' ) } {
 				float: right;
 				margin-left: 2em;
+				margin-right: 0;
 			}
 
 		`;

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -115,11 +115,8 @@ export default {
 		let output =
 			!! contentSize || !! wideSize
 				? `
-					${ appendSelectors( selector, '> *' ) } {
-						max-width: ${ contentSize ?? wideSize };
-					}
-
 					${ appendSelectors( selector, '> :not(.alignleft):not(.alignright)' ) } {
+						max-width: ${ contentSize ?? wideSize };
 						margin-left: auto !important;
 						margin-right: auto !important;
 					}

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -70,24 +70,6 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
-*:not([data-align]) {
-	> .wp-block-image {
-		display: grid;
-		grid-template-columns: [image] minmax(0, max-content) [placeholder] auto;
-		.components-placeholder {
-			grid-column: placeholder;
-		}
-		> div:not(.components-placeholder) {
-			grid-column: image;
-		}
-		> figcaption {
-			grid-column: image;
-			display: table-caption;
-			caption-side: bottom;
-		}
-	}
-}
-
 .wp-block[data-align="left"] > .wp-block-image {
 	margin-right: 1em;
 	margin-left: 0;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -22,6 +22,9 @@
 		width: 100%;
 	}
 
+	&.alignleft,
+	&.alignright,
+	&.aligncenter,
 	.alignleft,
 	.alignright,
 	.aligncenter {

--- a/packages/e2e-tests/specs/editor/blocks/image.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/image.test.js
@@ -103,9 +103,10 @@ describe( 'Image', () => {
 			`<!-- wp:image {"id":\\d+,"sizeSlug":"full","linkDestination":"none"} -->\\s*<figure class="wp-block-image size-full"><img src="[^"]+\\/${ filename2 }\\.png" alt="" class="wp-image-\\d+"/></figure>\\s*<!-- \\/wp:image -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex3 );
-		// For some reason just clicking the block wrapper causes figcaption to get focus
-		// in puppeteer but not in live browser, so clicking on the image wrapper div here instead.
-		await page.click( '.wp-block-image > div' );
+		// Focus outside the block to avoid the image caption being selected
+		// It can happen on CI specially.
+		await page.click( '.wp-block-post-title' );
+		await page.click( '.wp-block-image img' );
 		await page.keyboard.press( 'Backspace' );
 
 		expect( await getEditedPostContent() ).toBe( '' );


### PR DESCRIPTION
alternative #38597 
closes #37811 
closes #33142

Historically, in the editor, we used to add wrapper divs with `data-align` attribute in order align things properly in the editor. This had several issues:

 - Markup is different between frontend and backend.
 - Remount blocks when switching alignments.
 - Very hard for themes to provide styles.

With the recent updates and the introduction of the `layout` feature, alignments are now styles provided by the framework and the layout feature, meaning we can remove these "data-align" divs and align the backend with the frontend markup.

This PR tries to do so for themes that support the layout feature. It has some potential of breakage so we need to test this properly across all kind of themes and blocks.

**Notes**

 - The following blocks seem to have alignment specific styles and would be good to test them properly: button, buttons, comments-pagination, cover, embed, file, image, pull quote, query-pagination, search, site logo, social links, table, video.

**Testing instructions**

 - Check the alignments for the blocks above for different kind of themes: classic themes, classic themes with theme.json, FSE themes in post editor, template mode, and site editor.

This PR is important but would take a lot of testing to check for potential regressions, I'd appreciate help here :) 

Some of the styles for the blocks targeting `data-align` things can be moved to `classic.css` maybe after this PR.