### PR TITLE
Try: Remove iframe 100% width rule.

### DIFF
--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -95,10 +95,6 @@ body.block-editor-page {
 		max-width: 100%;
 		height: auto;
 	}
-
-	iframe {
-		width: 100%;
-	}
 }
 
 @include wordpress-admin-schemes();


### PR DESCRIPTION
## Description

Addresses #38586.

The following rule is output in the post editor canvas, but not in the site editor canvas:

```
	iframe {
		width: 100%;
	}
```

As discussed in the ticket above, it's creating an inconsistency where it appears to be contained in editor, but not on the frontend. This PR removes the rule, bringing consistency between post editor and frontend, but also post editor and site editor.

**Note:** this exact same rule was removed in the past as well, in #18240, and then added back again in #18287. Before merging this one, it's worth finding out exactly why it was added back again.

## Testing Instructions

1. Try the code example in #38586
2. Observe the editor showing the same overflowing embed (it would not overflow if the embed block was used)
3. Try the rest of the post editor with various content and verify no change compared to trunk.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
