### PR TITLE
PostTrash: call trashPost action with no arguments, rewrite to hooks

### DIFF
--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -3,47 +3,35 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
 
-function PostTrash( { isNew, postId, postType, ...props } ) {
+export default function PostTrash() {
+	const { isNew, postId } = useSelect( ( select ) => {
+		const store = select( editorStore );
+		return {
+			isNew: store.isEditedPostNew(),
+			postId: store.getCurrentPostId(),
+		};
+	} );
+	const { trashPost } = useDispatch( editorStore );
+
 	if ( isNew || ! postId ) {
 		return null;
 	}
-
-	const onClick = () => props.trashPost( postId, postType );
 
 	return (
 		<Button
 			className="editor-post-trash"
 			isDestructive
 			variant="secondary"
-			onClick={ onClick }
+			onClick={ () => trashPost() }
 		>
 			{ __( 'Move to trash' ) }
 		</Button>
 	);
 }
-
-export default compose( [
-	withSelect( ( select ) => {
-		const {
-			isEditedPostNew,
-			getCurrentPostId,
-			getCurrentPostType,
-		} = select( editorStore );
-		return {
-			isNew: isEditedPostNew(),
-			postId: getCurrentPostId(),
-			postType: getCurrentPostType(),
-		};
-	} ),
-	withDispatch( ( dispatch ) => ( {
-		trashPost: dispatch( editorStore ).trashPost,
-	} ) ),
-] )( PostTrash );

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -17,7 +17,7 @@ export default function PostTrash() {
 			isNew: store.isEditedPostNew(),
 			postId: store.getCurrentPostId(),
 		};
-	} );
+	}, [] );
 	const { trashPost } = useDispatch( editorStore );
 
 	if ( isNew || ! postId ) {


### PR DESCRIPTION
Updates the `PostTrash` component to call the `trashPost` action with no arguments instead of `( postId, postType )`. The action (in the `editor` data store) doesn't take any arguments, but reads the post ID and type from the store itself (`getCurrentPostId` etc).

I'm also rewriting the component to hooks (`useSelect`/`useDispatch`) which makes the code much shorter.