### PR TITLE
[Inserter]: Prioritize core blocks over core block variations when they have the same rank

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -163,7 +163,9 @@ export function getItemSearchRank( item, searchTerm, config = {} ) {
 
 	// Give a better rank to "core" namespaced items.
 	if ( rank !== 0 && name.startsWith( 'core/' ) ) {
-		rank++;
+		const isCoreBlockVariation = name !== item.id;
+		// Give a bit better rank to "core" blocks over "core" block variations.
+		rank += isCoreBlockVariation ? 1 : 2;
 	}
 
 	return rank;


### PR DESCRIPTION
Based on this: https://github.com/WordPress/gutenberg/pull/38589#issuecomment-1032340092

>I often find myself typing /sp for "Spacer", and inserting "Spotify". And so I wonder if we could:
>Could we make a rule that the embed aliases are all automatically ranked lower than any other block?


This PR gives just a bit better rank to core blocks over core block variations in the Inserter search results. This affects only blocks/variations that have the **same rank** from the algorithm, so search results still remain relevant based on the searched term.

## Testing instructions
1. A test case could be to search in the inserter with `sp`.
2. Now the core block `Spacer` would show above the other core variations that have the same rank, like `Spotify`.
3. Both results were very relevant since their titles start with `sp`, but now we prioritize the `core` blocks.