### PR TITLE
Editor store: remove a noop SETUP_EDITOR action

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1263,16 +1263,10 @@ _Parameters_
 
 ### resetPost
 
+> **Deprecated** Since WordPress 6.0.
+
 Returns an action object used in signalling that the latest version of the
 post has been received, either by initialization or save.
-
-_Parameters_
-
--   _post_ `Object`: Post object.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### savePost
 

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -37,7 +37,6 @@ import {
  * @param {Array?} template Block Template.
  */
 export function* setupEditor( post, edits, template ) {
-	yield resetPost( post );
 	yield setupEditorState( post );
 	// Apply a template for new posts only, if exists.
 	const isNewPost = post.status === 'auto-draft';
@@ -83,15 +82,15 @@ export function __experimentalTearDownEditor() {
  * Returns an action object used in signalling that the latest version of the
  * post has been received, either by initialization or save.
  *
- * @param {Object} post Post object.
- *
- * @return {Object} Action object.
+ * @deprecated Since WordPress 6.0.
  */
-export function resetPost( post ) {
-	return {
-		type: 'RESET_POST',
-		post,
-	};
+export function resetPost() {
+	deprecated( "wp.data.dispatch( 'core/editor' ).resetPost", {
+		since: '6.0',
+		version: '6.3',
+		alternative: 'Initialize the editor with the setupEditorState action',
+	} );
+	return { type: 'DO_NOTHING' };
 }
 
 /**

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -38,12 +38,6 @@ import {
  */
 export function* setupEditor( post, edits, template ) {
 	yield resetPost( post );
-	yield {
-		type: 'SETUP_EDITOR',
-		post,
-		edits,
-		template,
-	};
 	yield setupEditorState( post );
 	// Apply a template for new posts only, if exists.
 	const isNewPost = post.status === 'auto-draft';

--- a/packages/editor/src/store/reducer.js
+++ b/packages/editor/src/store/reducer.js
@@ -84,7 +84,6 @@ export function shouldOverwriteState( action, previousAction ) {
 export function postId( state = null, action ) {
 	switch ( action.type ) {
 		case 'SETUP_EDITOR_STATE':
-		case 'RESET_POST':
 			return action.post.id;
 	}
 
@@ -94,7 +93,6 @@ export function postId( state = null, action ) {
 export function postType( state = null, action ) {
 	switch ( action.type ) {
 		case 'SETUP_EDITOR_STATE':
-		case 'RESET_POST':
 			return action.post.type;
 	}
 

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -368,11 +368,6 @@ describe( 'Editor actions', () => {
 			let { value } = fulfillment.next();
 			expect( value ).toEqual( actions.resetPost( post ) );
 			value = fulfillment.next().value;
-			expect( value ).toEqual( {
-				type: 'SETUP_EDITOR',
-				post: { content: { raw: '' }, status: 'publish' },
-			} );
-			value = fulfillment.next().value;
 			expect( value ).toEqual(
 				actions.setupEditorState( {
 					content: { raw: '' },

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -365,26 +365,13 @@ describe( 'Editor actions', () => {
 		it( 'should yield the setup editor actions but not reset blocks when the template is empty', () => {
 			const post = { content: { raw: '' }, status: 'publish' };
 			const fulfillment = actions.setupEditor( post );
-			let { value } = fulfillment.next();
-			expect( value ).toEqual( actions.resetPost( post ) );
-			value = fulfillment.next().value;
+			const value = fulfillment.next().value;
 			expect( value ).toEqual(
 				actions.setupEditorState( {
 					content: { raw: '' },
 					status: 'publish',
 				} )
 			);
-		} );
-	} );
-
-	describe( 'resetPost', () => {
-		it( 'should return the RESET_POST action', () => {
-			const post = {};
-			const result = actions.resetPost( post );
-			expect( result ).toEqual( {
-				type: 'RESET_POST',
-				post,
-			} );
 		} );
 	} );
 


### PR DESCRIPTION
In the `dispatch( editorStore ).setupEditor` action, this PR removes the dispatch of the `SETUP_EDITOR` effect/action. There is no effect registered or a reducer reacting to this action type, so it's a noop. There is only a `SETUP_EDITOR_STATE` action that is active.

Stumbled upon this when working on #35929, migrating the `editor` store to thunks.