### PR TITLE
Adds filters for all welcome modals

### DIFF
--- a/packages/customize-widgets/src/components/welcome-guide/index.js
+++ b/packages/customize-widgets/src/components/welcome-guide/index.js
@@ -2,11 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Button, ExternalLink } from '@wordpress/components';
+import { withFilters, Button, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 
-export default function WelcomeGuide( { sidebar } ) {
+function WelcomeGuide( { sidebar } ) {
 	const { toggleFeature } = useDispatch( interfaceStore );
 
 	const isEntirelyBlockWidgets = sidebar
@@ -79,3 +79,5 @@ export default function WelcomeGuide( { sidebar } ) {
 		</div>
 	);
 }
+
+export default withFilters( 'customizeWidgets.WelcomeGuide' )( WelcomeGuide );

--- a/packages/edit-post/src/components/welcome-guide/index.js
+++ b/packages/edit-post/src/components/welcome-guide/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { withFilters } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,7 +11,7 @@ import WelcomeGuideDefault from './default';
 import WelcomeGuideTemplate from './template';
 import { store as editPostStore } from '../../store';
 
-export default function WelcomeGuide() {
+function WelcomeGuide() {
 	const { isActive, isTemplateMode } = useSelect( ( select ) => {
 		const { isFeatureActive, isEditingTemplate } = select( editPostStore );
 		const _isTemplateMode = isEditingTemplate();
@@ -30,3 +31,5 @@ export default function WelcomeGuide() {
 
 	return isTemplateMode ? <WelcomeGuideTemplate /> : <WelcomeGuideDefault />;
 }
+
+export default withFilters( 'editPost.WelcomeGuide' )( WelcomeGuide );

--- a/packages/edit-site/src/components/welcome-guide/index.js
+++ b/packages/edit-site/src/components/welcome-guide/index.js
@@ -1,10 +1,15 @@
 /**
+ * WordPress dependencies
+ */
+import { withFilters } from '@wordpress/components';
+
+/**
  * Internal dependencies
  */
 import WelcomeGuideEditor from './editor';
 import WelcomeGuideStyles from './styles';
 
-export default function WelcomeGuide() {
+function WelcomeGuide() {
 	return (
 		<>
 			<WelcomeGuideEditor />
@@ -12,3 +17,5 @@ export default function WelcomeGuide() {
 		</>
 	);
 }
+
+export default withFilters( 'editSite.WelcomeGuide' )( WelcomeGuide );

--- a/packages/edit-widgets/src/components/welcome-guide/index.js
+++ b/packages/edit-widgets/src/components/welcome-guide/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { ExternalLink, Guide } from '@wordpress/components';
+import { withFilters, ExternalLink, Guide } from '@wordpress/components';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -12,7 +12,7 @@ import { store as interfaceStore } from '@wordpress/interface';
  */
 import { store as editWidgetsStore } from '../../store';
 
-export default function WelcomeGuide() {
+function WelcomeGuide() {
 	const isActive = useSelect(
 		( select ) =>
 			select( interfaceStore ).isFeatureActive(
@@ -192,6 +192,8 @@ export default function WelcomeGuide() {
 		/>
 	);
 }
+
+export default withFilters( 'editWidgets.WelcomeGuide' )( WelcomeGuide );
 
 function WelcomeGuideImage( { nonAnimatedSrc, animatedSrc } ) {
 	return (


### PR DESCRIPTION
Closes #33194 by adding filters for the welcome modal components in all the editors (post, site, widgets and customize-widgets).

To test this PR:

- switch to this branch
- go to appearance > widgets
- if the welcome modal appears, close it
- open your browser's developer tools
- in the console paste this:
```JS
const withoutWelcome = wp.compose.createHigherOrderComponent( ( WelcomeGuide ) => {
    return ( props ) => {
        return null;
    };
}, 'withoutWelcome' );

wp.hooks.addFilter(
    'editWidgets.WelcomeGuide',
    'testing/withoutWelcome',
    withoutWelcome
);
```
- open to the more (vertically dotted line icon) menu on the top right corner click
- click on Welcome Guide
- it should not appear