### PR TITLE
Allow child classes to use the private methods and constants

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
@@ -21,7 +21,7 @@ class WP_Theme_JSON_Gutenberg {
 	 *
 	 * @var array
 	 */
-	private $theme_json = null;
+	protected $theme_json = null;
 
 	/**
 	 * Holds block metadata extracted from block.json
@@ -426,7 +426,7 @@ class WP_Theme_JSON_Gutenberg {
 			return $output;
 		}
 
-		$output = array_intersect_key( $input, array_flip( self::VALID_TOP_LEVEL_KEYS ) );
+		$output = array_intersect_key( $input, array_flip( static::VALID_TOP_LEVEL_KEYS ) );
 
 		// Some styles are only meant to be available at the top-level (e.g.: blockGap),
 		// hence, the schema for blocks & elements should not have them.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -22,28 +22,28 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @var WP_Theme_JSON_Gutenberg
 	 */
-	private static $core = null;
+	protected static $core = null;
 
 	/**
 	 * Container for data coming from the theme.
 	 *
 	 * @var WP_Theme_JSON_Gutenberg
 	 */
-	private static $theme = null;
+	protected static $theme = null;
 
 	/**
 	 * Whether or not the theme supports theme.json.
 	 *
 	 * @var bool
 	 */
-	private static $theme_has_support = null;
+	protected static $theme_has_support = null;
 
 	/**
 	 * Container for data coming from the user.
 	 *
 	 * @var WP_Theme_JSON_Gutenberg
 	 */
-	private static $user = null;
+	protected static $user = null;
 
 	/**
 	 * Stores the ID of the custom post type
@@ -51,14 +51,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @var integer
 	 */
-	private static $user_custom_post_type_id = null;
+	protected static $user_custom_post_type_id = null;
 
 	/**
 	 * Container to keep loaded i18n schema for `theme.json`.
 	 *
 	 * @var array
 	 */
-	private static $i18n_schema = null;
+	protected static $i18n_schema = null;
 
 	/**
 	 * Processes a file that adheres to the theme.json
@@ -68,7 +68,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @param string $file_path Path to file. Empty if no file.
 	 * @return array Contents that adhere to the theme.json schema.
 	 */
-	private static function read_json_file( $file_path ) {
+	protected static function read_json_file( $file_path ) {
 		$config = array();
 		if ( $file_path ) {
 			$decoded_file = wp_json_file_decode( $file_path, array( 'associative' => true ) );
@@ -100,7 +100,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *                           Default 'default'.
 	 * @return array Returns the modified $theme_json_structure.
 	 */
-	private static function translate( $theme_json, $domain = 'default' ) {
+	protected static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === self::$i18n_schema ) {
 			$i18n_schema       = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
 			self::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
@@ -391,7 +391,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @param bool   $template  Optional. Use template theme directory. Default false.
 	 * @return string The whole file path or empty if the file doesn't exist.
 	 */
-	private static function get_file_path_from_theme( $file_name, $template = false ) {
+	protected static function get_file_path_from_theme( $file_name, $template = false ) {
 		$path      = $template ? get_template_directory() : get_stylesheet_directory();
 		$candidate = $path . '/' . $file_name;
 


### PR DESCRIPTION
This PR allows https://github.com/WordPress/gutenberg/pull/37140 to override the `WP_Theme_JSON_Resolver_Gutenberg` class and the `VALID_TOP_LEVEL_SETTINGS` for this https://github.com/WordPress/gutenberg/pull/38323

