### PR TITLE
Separator block: Remove width from wide style

### DIFF
--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -3,11 +3,6 @@
 	border-bottom: 1px solid currentColor;
 	// Default, thin style, is stored in theme.scss so it can be opted out of
 
-	// Wide style
-	&.is-style-wide {
-		border-bottom-width: 1px;
-	}
-
 	// Dots style
 	&.is-style-dots {
 		// Override any background themes often set on the hr tag for this style.


### PR DESCRIPTION
## Description
This line of CSS fixes the wide style of the separator to 1px wide. In some themes we want to be able to control the width of the separator using theme.json and we'd like that change to apply to all separator blocks. The problem with this approach is that existing "wide" separator blocks may change their appearance to match the theme settings.

## Testing Instructions
- Switch to the Skatepark theme
- Add a wide separator block
- Notice that with this change the width of the block has to be controlled with custom CSS. Without that CSS the block looks like this:
<img width="794" alt="Screenshot 2022-02-08 at 17 51 08" src="https://user-images.githubusercontent.com/275961/153047472-ac7717e5-39f3-4290-8e99-6436b124d810.png">

With this PR it looks like this:
<img width="820" alt="Screenshot 2022-02-08 at 17 51 17" src="https://user-images.githubusercontent.com/275961/153047505-bf102196-1f1f-4cbb-8000-c846db9e392a.png">

Alternatively using emptytheme, add this to the theme.json file:
```
	"styles": {
		"blocks": {
			"core/separator": {
				"border": {
					"width": "0 0 30px 0"
				}
			}
		}
	}
```

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
