### PR TITLE
Storybook: Move experimental components to correct section

### DIFF
--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -1,5 +1,9 @@
 # AlignmentMatrixControl
 
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+
 AlignmentMatrixControl components enable adjustments to horizontal and vertical alignments for UI.
 
 ## Usage

--- a/packages/components/src/alignment-matrix-control/stories/index.js
+++ b/packages/components/src/alignment-matrix-control/stories/index.js
@@ -17,7 +17,7 @@ const alignmentOptions = ALIGNMENTS.reduce( ( options, item ) => {
 }, {} );
 
 export default {
-	title: 'Components/AlignmentMatrixControl',
+	title: 'Components (Experimental)/AlignmentMatrixControl',
 	component: AlignmentMatrixControl,
 	parameters: {
 		knobs: { disable: false },

--- a/packages/components/src/box-control/stories/index.js
+++ b/packages/components/src/box-control/stories/index.js
@@ -14,7 +14,10 @@ import BoxControl from '../';
 import BoxControlVisualizer from '../visualizer';
 import { Flex, FlexBlock } from '../../flex';
 
-export default { title: 'Components/BoxControl', component: BoxControl };
+export default {
+	title: 'Components (Experimental)/BoxControl',
+	component: BoxControl,
+};
 
 export const _default = () => {
 	return <BoxControl />;

--- a/packages/components/src/input-control/stories/index.js
+++ b/packages/components/src/input-control/stories/index.js
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
 import InputControl from '../';
 
 export default {
-	title: 'Components/InputControl',
+	title: 'Components (Experimental)/InputControl',
 	component: InputControl,
 	parameters: {
 		knobs: { disable: false },

--- a/packages/components/src/navigation/stories/index.js
+++ b/packages/components/src/navigation/stories/index.js
@@ -15,7 +15,7 @@ import { HideIfEmptyStory } from './hide-if-empty';
 import './style.css';
 
 export default {
-	title: 'Components/Navigation',
+	title: 'Components (Experimental)/Navigation',
 	component: Navigation,
 	subcomponents: {
 		NavigationBackButton,

--- a/packages/components/src/number-control/stories/index.js
+++ b/packages/components/src/number-control/stories/index.js
@@ -14,7 +14,7 @@ import { useState } from '@wordpress/element';
 import NumberControl from '../';
 
 export default {
-	title: 'Components/NumberControl',
+	title: 'Components (Experimental)/NumberControl',
 	component: NumberControl,
 	parameters: {
 		knobs: { disable: false },

--- a/packages/components/src/radio-group/stories/index.js
+++ b/packages/components/src/radio-group/stories/index.js
@@ -9,7 +9,10 @@ import { useState } from '@wordpress/element';
 import Radio from '../../radio';
 import RadioGroup from '../';
 
-export default { title: 'Components/RadioGroup', component: RadioGroup };
+export default {
+	title: 'Components (Experimental)/RadioGroup',
+	component: RadioGroup,
+};
 
 export const _default = () => {
 	/* eslint-disable no-restricted-syntax */

--- a/packages/components/src/radio/stories/index.js
+++ b/packages/components/src/radio/stories/index.js
@@ -4,7 +4,7 @@
 import RadioGroup from '../../radio-group';
 import Radio from '../';
 
-export default { title: 'Components/Radio', component: Radio };
+export default { title: 'Components (Experimental)/Radio', component: Radio };
 
 export const _default = () => {
 	// Radio components must be a descendent of a RadioGroup component.

--- a/packages/components/src/toggle-group-control/stories/index.js
+++ b/packages/components/src/toggle-group-control/stories/index.js
@@ -17,7 +17,7 @@ import Button from '../../button';
 
 export default {
 	component: ToggleGroupControl,
-	title: 'Components/ToggleGroupControl',
+	title: 'Components (Experimental)/ToggleGroupControl',
 	parameters: {
 		knobs: { disable: false },
 	},

--- a/packages/components/src/tree-grid/stories/index.js
+++ b/packages/components/src/tree-grid/stories/index.js
@@ -9,7 +9,10 @@ import { Fragment } from '@wordpress/element';
 import TreeGrid, { TreeGridRow, TreeGridCell } from '../';
 import { Button } from '../../';
 
-export default { title: 'Components/TreeGrid', component: TreeGrid };
+export default {
+	title: 'Components (Experimental)/TreeGrid',
+	component: TreeGrid,
+};
 
 const groceries = [
 	{

--- a/packages/components/src/unit-control/stories/index.js
+++ b/packages/components/src/unit-control/stories/index.js
@@ -16,7 +16,7 @@ import UnitControl from '../';
 import { CSS_UNITS } from '../utils';
 
 export default {
-	title: 'Components/UnitControl',
+	title: 'Components (Experimental)/UnitControl',
 	component: UnitControl,
 	parameters: {
 		knobs: { disable: false },

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -27,4 +27,16 @@ export const parameters = {
 		// Will be enabled on a per-story basis until migration is complete.
 		disable: true,
 	},
+	options: {
+		storySort: {
+			order: [
+				'Docs',
+				'Playground',
+				'BlockEditor',
+				'Components',
+				'Components (Experimental)',
+				'Icons',
+			],
+		},
+	},
 };


### PR DESCRIPTION
Closes #36129 

## Description

There were some experimental components that were not listed under the correct heading, "Components (Experimental)". I did a sweep of all the existing stories and moved the ones that were out of place.

## Testing Instructions

1. `npm run storybook:dev`
2. Experimental components are in the correct section, and the "Components" section comes before the "Components (Experimental)" section.

## Types of changes

Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
