### PR TITLE
Gallery block: copy all attributes when transforming to Image blocks

### DIFF
--- a/packages/block-library/src/gallery/transforms.js
+++ b/packages/block-library/src/gallery/transforms.js
@@ -291,7 +291,10 @@ const transforms = {
 									url,
 									alt,
 									caption,
-									imageSizeSlug,
+									sizeSlug: imageSizeSlug,
+									linkDestination,
+									href,
+									linkTarget,
 								},
 							} ) =>
 								createBlock( 'core/image', {
@@ -301,6 +304,9 @@ const transforms = {
 									caption,
 									sizeSlug: imageSizeSlug,
 									align,
+									linkDestination,
+									href,
+									linkTarget,
 								} )
 						);
 					}


### PR DESCRIPTION
## Description
Fixes: #38544

Currently when transforming from the Gallery block to Image blocks the link destination, link target and image size settings are lost. This PR adds these missing attributes into the transform.

## Testing Instructions
Add a Gallery block with several images and set the link destination, link target, and image size on the images
Transform the Gallery block to Image blocks
Check that each Image block still has the same link destination, link target, and image size that you set

## Screenshots

Before:
![transform-before](https://user-images.githubusercontent.com/3629020/153079143-44ff6c82-fe3e-4a28-b6d7-bf57f15cfe6d.gif)

After:
![transform-after](https://user-images.githubusercontent.com/3629020/153079155-4307be6a-2d23-40d6-bd27-69a1f670e51d.gif)

