### PR TITLE
Block API: Add `supports` object to block attributes to configure copy support

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -36,7 +36,7 @@ function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard(
 		() =>
 			serialize( blocks, {
-				__experimentalExcludeNonCopyableAttributes: true,
+				__experimentalSupports: { copy: false },
 			} ),
 		onCopy
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -36,7 +36,7 @@ function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard(
 		() =>
 			serialize( blocks, {
-				__experimentalSupports: { copy: false },
+				__experimentalExcludeAttributes: { copy: false },
 			} ),
 		onCopy
 	);

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -34,7 +34,10 @@ const POPOVER_PROPS = {
 
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard(
-		() => serialize( blocks, { retainCopyAttributes: false } ),
+		() =>
+			serialize( blocks, {
+				__experimentalExcludeNonCopyableAttributes: true,
+			} ),
 		onCopy
 	);
 	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -13,7 +13,7 @@ import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement, useCallback } from '@wordpress/element';
 import {
 	serialize,
-	__experimentalRemoveAttributesByRole,
+	__experimentalCloneSanitizedBlock,
 } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
@@ -38,7 +38,7 @@ const POPOVER_PROPS = {
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => {
 		blocks = blocks.map( ( block ) =>
-			__experimentalRemoveAttributesByRole( block, 'internal' )
+			__experimentalCloneSanitizedBlock( block )
 		);
 		return serialize( blocks );
 	}, onCopy );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -11,7 +11,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
+import { cloneBlock, serialize } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -33,13 +33,14 @@ const POPOVER_PROPS = {
 };
 
 function CopyMenuItem( { blocks, onCopy } ) {
-	const ref = useCopyToClipboard(
-		() =>
-			serialize( blocks, {
+	const ref = useCopyToClipboard( () => {
+		blocks = blocks.map( ( block ) =>
+			cloneBlock( block, {}, null, {
 				__experimentalExcludeAttributes: { copy: false },
-			} ),
-		onCopy
-	);
+			} )
+		);
+		return serialize( blocks );
+	}, onCopy );
 	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -11,10 +11,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import {
-	serialize,
-	__experimentalCloneSanitizedBlock,
-} from '@wordpress/blocks';
+import { serialize, cloneBlock } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -38,7 +35,7 @@ const POPOVER_PROPS = {
 function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => {
 		blocks = blocks.map( ( block ) =>
-			__experimentalCloneSanitizedBlock( block )
+			cloneBlock( block, {}, null, { retainInternalAttributes: false } )
 		);
 		return serialize( blocks );
 	}, onCopy );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -11,7 +11,10 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
+import {
+	serialize,
+	__experimentalRemoveAttributesByRole,
+} from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -33,7 +36,12 @@ const POPOVER_PROPS = {
 };
 
 function CopyMenuItem( { blocks, onCopy } ) {
-	const ref = useCopyToClipboard( () => serialize( blocks ), onCopy );
+	const ref = useCopyToClipboard( () => {
+		blocks = blocks.map( ( block ) =>
+			__experimentalRemoveAttributesByRole( block, 'internal' )
+		);
+		return serialize( blocks );
+	}, onCopy );
 	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -11,7 +11,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize, cloneBlock } from '@wordpress/blocks';
+import { serialize } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -33,12 +33,10 @@ const POPOVER_PROPS = {
 };
 
 function CopyMenuItem( { blocks, onCopy } ) {
-	const ref = useCopyToClipboard( () => {
-		blocks = blocks.map( ( block ) =>
-			cloneBlock( block, {}, null, { retainInternalAttributes: false } )
-		);
-		return serialize( blocks );
-	}, onCopy );
+	const ref = useCopyToClipboard(
+		() => serialize( blocks, { retainCopyAttributes: false } ),
+		onCopy
+	);
 	return <MenuItem ref={ ref }>{ __( 'Copy' ) }</MenuItem>;
 }
 

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -36,7 +36,9 @@ function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => {
 		blocks = blocks.map( ( block ) =>
 			cloneBlock( block, {}, null, {
-				__experimentalExcludeAttributes: { copy: false },
+				__experimentalExcludeAttributes: {
+					__experimentalSupports: { copy: false },
+				},
 			} )
 		);
 		return serialize( blocks );

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -36,9 +36,7 @@ function CopyMenuItem( { blocks, onCopy } ) {
 	const ref = useCopyToClipboard( () => {
 		blocks = blocks.map( ( block ) =>
 			cloneBlock( block, {}, null, {
-				__experimentalExcludeAttributes: {
-					__experimentalSupports: { copy: false },
-				},
+				__experimentalRequiredAttributeSupports: [ 'copy' ],
 			} )
 		);
 		return serialize( blocks );

--- a/packages/block-editor/src/components/block-switcher/utils.js
+++ b/packages/block-editor/src/components/block-switcher/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalGetBlockAttributesNamesByRole as getBlockAttributesNamesByRole } from '@wordpress/blocks';
+import { __experimentalFilterBlockAttributes as filterBlockAttributes } from '@wordpress/blocks';
 
 /**
  * Try to find a matching block by a block's name in a provided
@@ -46,7 +46,9 @@ export const getMatchingBlockByName = (
  * @return {Object} The block's attributes to retain.
  */
 export const getRetainedBlockAttributes = ( name, attributes ) => {
-	const contentAttributes = getBlockAttributesNamesByRole( name, 'content' );
+	const contentAttributes = filterBlockAttributes( name, {
+		__experimentalRole: 'content',
+	} );
 	if ( ! contentAttributes?.length ) return attributes;
 
 	return contentAttributes.reduce( ( _accumulator, attribute ) => {

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,7 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
-	__experimentalRemoveAttributesByRole,
+	__experimentalCloneSanitizedBlock,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -125,10 +125,7 @@ export function useClipboardHandler() {
 				let blocks = getBlocksByClientId( selectedBlockClientIds );
 				if ( event.type === 'copy' ) {
 					blocks = blocks.map( ( block ) =>
-						__experimentalRemoveAttributesByRole(
-							block,
-							'internal'
-						)
+						__experimentalCloneSanitizedBlock( block )
 					);
 				}
 				const serialized = serialize( blocks );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,6 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
+	__experimentalRemoveAttributesByRole,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -121,7 +122,15 @@ export function useClipboardHandler() {
 					flashBlock( selectedBlockClientIds[ 0 ] );
 				}
 				notifyCopy( event.type, selectedBlockClientIds );
-				const blocks = getBlocksByClientId( selectedBlockClientIds );
+				let blocks = getBlocksByClientId( selectedBlockClientIds );
+				if ( event.type === 'copy' ) {
+					blocks = blocks.map( ( block ) =>
+						__experimentalRemoveAttributesByRole(
+							block,
+							'internal'
+						)
+					);
+				}
 				const serialized = serialize( blocks );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,7 +5,6 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
-	cloneBlock,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -122,15 +121,10 @@ export function useClipboardHandler() {
 					flashBlock( selectedBlockClientIds[ 0 ] );
 				}
 				notifyCopy( event.type, selectedBlockClientIds );
-				let blocks = getBlocksByClientId( selectedBlockClientIds );
-				if ( event.type === 'copy' ) {
-					blocks = blocks.map( ( block ) =>
-						cloneBlock( block, {}, null, {
-							retainInternalAttributes: false,
-						} )
-					);
-				}
-				const serialized = serialize( blocks );
+				const blocks = getBlocksByClientId( selectedBlockClientIds );
+				const serialized = serialize( blocks, {
+					retainCopyAttributes: false,
+				} );
 
 				event.clipboardData.setData( 'text/plain', serialized );
 				event.clipboardData.setData( 'text/html', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -123,7 +123,8 @@ export function useClipboardHandler() {
 				notifyCopy( event.type, selectedBlockClientIds );
 				const blocks = getBlocksByClientId( selectedBlockClientIds );
 				const serialized = serialize( blocks, {
-					retainCopyAttributes: event.type !== 'copy',
+					__experimentalExcludeNonCopyableAttributes:
+						event.type === 'copy',
 				} );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -123,7 +123,7 @@ export function useClipboardHandler() {
 				notifyCopy( event.type, selectedBlockClientIds );
 				const blocks = getBlocksByClientId( selectedBlockClientIds );
 				const serialized = serialize( blocks, {
-					retainCopyAttributes: false,
+					retainCopyAttributes: event.type !== 'copy',
 				} );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -5,7 +5,7 @@ import { useCallback } from '@wordpress/element';
 import {
 	serialize,
 	pasteHandler,
-	__experimentalCloneSanitizedBlock,
+	cloneBlock,
 	store as blocksStore,
 } from '@wordpress/blocks';
 import {
@@ -125,7 +125,9 @@ export function useClipboardHandler() {
 				let blocks = getBlocksByClientId( selectedBlockClientIds );
 				if ( event.type === 'copy' ) {
 					blocks = blocks.map( ( block ) =>
-						__experimentalCloneSanitizedBlock( block )
+						cloneBlock( block, {}, null, {
+							retainInternalAttributes: false,
+						} )
 					);
 				}
 				const serialized = serialize( blocks );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -3,6 +3,7 @@
  */
 import { useCallback } from '@wordpress/element';
 import {
+	cloneBlock,
 	serialize,
 	pasteHandler,
 	store as blocksStore,
@@ -121,10 +122,15 @@ export function useClipboardHandler() {
 					flashBlock( selectedBlockClientIds[ 0 ] );
 				}
 				notifyCopy( event.type, selectedBlockClientIds );
-				const blocks = getBlocksByClientId( selectedBlockClientIds );
-				const serialized = serialize( blocks, {
-					__experimentalExcludeAttributes: { copy: event.type !== 'copy' },
-				} );
+				let blocks = getBlocksByClientId( selectedBlockClientIds );
+				if ( event.type === 'copy' ) {
+					blocks = blocks.map( ( block ) =>
+						cloneBlock( block, {}, null, {
+							__experimentalExcludeAttributes: { copy: false },
+						} )
+					);
+				}
+				const serialized = serialize( blocks );
 
 				event.clipboardData.setData( 'text/plain', serialized );
 				event.clipboardData.setData( 'text/html', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -123,8 +123,7 @@ export function useClipboardHandler() {
 				notifyCopy( event.type, selectedBlockClientIds );
 				const blocks = getBlocksByClientId( selectedBlockClientIds );
 				const serialized = serialize( blocks, {
-					__experimentalExcludeNonCopyableAttributes:
-						event.type === 'copy',
+					__experimentalSupports: { copy: event.type !== 'copy' },
 				} );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -123,7 +123,7 @@ export function useClipboardHandler() {
 				notifyCopy( event.type, selectedBlockClientIds );
 				const blocks = getBlocksByClientId( selectedBlockClientIds );
 				const serialized = serialize( blocks, {
-					__experimentalSupports: { copy: event.type !== 'copy' },
+					__experimentalExcludeAttributes: { copy: event.type !== 'copy' },
 				} );
 
 				event.clipboardData.setData( 'text/plain', serialized );

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -126,7 +126,9 @@ export function useClipboardHandler() {
 				if ( event.type === 'copy' ) {
 					blocks = blocks.map( ( block ) =>
 						cloneBlock( block, {}, null, {
-							__experimentalExcludeAttributes: { copy: false },
+							__experimentalExcludeAttributes: {
+								__experimentalSupports: { copy: false },
+							},
 						} )
 					);
 				}

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -126,9 +126,7 @@ export function useClipboardHandler() {
 				if ( event.type === 'copy' ) {
 					blocks = blocks.map( ( block ) =>
 						cloneBlock( block, {}, null, {
-							__experimentalExcludeAttributes: {
-								__experimentalSupports: { copy: false },
-							},
+							__experimentalRequiredAttributeSupports: [ 'copy' ],
 						} )
 					);
 				}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1181,7 +1181,7 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 		last( castArray( clientIds ) )
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
-		cloneBlock( block, {}, null, { retainInternalAttributes: false } )
+		cloneBlock( block, {}, null, { retainCopyAttributes: false } )
 	);
 	dispatch.insertBlocks(
 		clonedBlocks,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1181,7 +1181,9 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 		last( castArray( clientIds ) )
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
-		cloneBlock( block, {}, null, { retainCopyAttributes: false } )
+		cloneBlock( block, {}, null, {
+			__experimentalExcludeNonCopyableAttributes: true,
+		} )
 	);
 	dispatch.insertBlocks(
 		clonedBlocks,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -8,7 +8,6 @@ import { castArray, findKey, first, isObject, last, some } from 'lodash';
  */
 import {
 	cloneBlock,
-	__experimentalCloneSanitizedBlock,
 	createBlock,
 	doBlocksMatchTemplate,
 	getBlockType,
@@ -1182,7 +1181,7 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 		last( castArray( clientIds ) )
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
-		__experimentalCloneSanitizedBlock( block )
+		cloneBlock( block, {}, null, { retainInternalAttributes: false } )
 	);
 	dispatch.insertBlocks(
 		clonedBlocks,

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1182,7 +1182,7 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
 		cloneBlock( block, {}, null, {
-			__experimentalExcludeNonCopyableAttributes: true,
+			__experimentalExcludeAttributes: { copy: false },
 		} )
 	);
 	dispatch.insertBlocks(

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1182,7 +1182,9 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
 		cloneBlock( block, {}, null, {
-			__experimentalExcludeAttributes: { copy: false },
+			__experimentalExcludeAttributes: {
+				__experimentalSupports: { copy: false },
+			},
 		} )
 	);
 	dispatch.insertBlocks(

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1182,9 +1182,7 @@ export const duplicateBlocks = ( clientIds, updateSelection = true ) => ( {
 	);
 	const clonedBlocks = blocks.map( ( block ) =>
 		cloneBlock( block, {}, null, {
-			__experimentalExcludeAttributes: {
-				__experimentalSupports: { copy: false },
-			},
+			__experimentalRequiredAttributeSupports: [ 'copy' ],
 		} )
 	);
 	dispatch.insertBlocks(

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -195,7 +195,7 @@ _Parameters_
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
 -   _\_\_experimentalOptions_ `?Object`: Cloning options.
--   _**experimentalOptions.**experimentalExcludeNonCopyableAttributes_ `?boolean`: Whether to exclude attributes that do not have copy support in the cloned block.
+-   _**experimentalOptions.**experimentalExcludeAttributes_ `?Object`: Attributes with these supports will be excluded from the cloned block.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -194,8 +194,8 @@ _Parameters_
 -   _block_ `Object`: Block instance.
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
--   _options_ `?Object`: Cloning options.
--   _options.retainCopyAttributes_ `?boolean`: Whether to retain attributes that do not have copy support in the cloned block.
+-   _\_\_experimentalOptions_ `?Object`: Cloning options.
+-   _**experimentalOptions.**experimentalExcludeNonCopyableAttributes_ `?boolean`: Whether to exclude attributes that do not have copy support in the cloned block.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -186,13 +186,16 @@ In the random image block above, we've given the `alt` attribute of the image a 
 ### cloneBlock
 
 Given a block object, returns a copy of the block object,
-optionally merging new attributes and/or replacing its inner blocks.
+optionally merging new attributes, replacing its inner blocks, and/or
+filtering out attributes with the 'internal' role.
 
 _Parameters_
 
 -   _block_ `Object`: Block instance.
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
+-   _options_ `?Object`: Cloning options.
+-   _options.retainInternalAttributes_ `?boolean`: Whether to retain internal attributes in the cloned block.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -195,7 +195,7 @@ _Parameters_
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
 -   _options_ `?Object`: Cloning options.
--   _options.retainInternalAttributes_ `?boolean`: Whether to retain internal attributes in the cloned block.
+-   _options.retainCopyAttributes_ `?boolean`: Whether to retain attributes that do not have copy support in the cloned block.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -187,7 +187,7 @@ In the random image block above, we've given the `alt` attribute of the image a 
 
 Given a block object, returns a copy of the block object,
 optionally merging new attributes, replacing its inner blocks, and/or
-filtering out attributes with the 'internal' role.
+filtering out attributes which do not have copy support.
 
 _Parameters_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -195,7 +195,7 @@ _Parameters_
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
 -   _\_\_experimentalOptions_ `?Object`: Cloning options.
--   _**experimentalOptions.**experimentalExcludeAttributes_ `?Object`: Attributes with these supports will be excluded from the cloned block.
+-   _**experimentalOptions.**experimentalExcludeAttributes_ `?Object`: Attributes matching this filter will be excluded from the cloned block.
 
 _Returns_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -194,8 +194,7 @@ _Parameters_
 -   _block_ `Object`: Block instance.
 -   _mergeAttributes_ `Object`: Block attributes.
 -   _newInnerBlocks_ `?Array`: Nested blocks.
--   _\_\_experimentalOptions_ `?Object`: Cloning options.
--   _**experimentalOptions.**experimentalExcludeAttributes_ `?Object`: Attributes matching this filter will be excluded from the cloned block.
+-   _\_\_experimentalOptions_ `?WPBlockCloneOptions`: Cloning options.
 
 _Returns_
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -32,8 +32,8 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
-	__experimentalStripInternalBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
+	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 /**
@@ -111,21 +111,21 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Merge in new attributes and strip out attributes with the `internal` role,
-	// which should not be copied during block duplication.
-	const retainedAttributes = __experimentalStripInternalBlockAttributes(
-		block.name,
-		{
-			...block.attributes,
-			...mergeAttributes,
-		}
-	);
+	// Merge in new attributes
+	block.attributes = {
+		...block.attributes,
+		...mergeAttributes,
+	};
+
+	// Strip out attributes with the `internal` role, which should not be copied during
+	// block duplication.
+	block = __experimentalRemoveAttributesByRole( block, 'internal' );
 
 	// Remove any attributes not defined in the block type, and fill in default values for
 	// misisng attributes.
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		block.name,
-		retainedAttributes
+		block.attributes
 	);
 
 	return {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -32,6 +32,7 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
+	__experimentalStripInternalBlockAttributes,
 	__experimentalSanitizeBlockAttributes,
 } from './utils';
 
@@ -110,12 +111,21 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+	// Merge in new attributes and strip out attributes with the `internal` role,
+	// which should not be copied during block duplication.
+	const retainedAttributes = __experimentalStripInternalBlockAttributes(
 		block.name,
 		{
 			...block.attributes,
 			...mergeAttributes,
 		}
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		block.name,
+		retainedAttributes
 	);
 
 	return {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -95,8 +95,9 @@ export function createBlocksFromInnerBlocksTemplate(
 }
 
 /**
- * Given a block object, returns a copy of the block object while sanitizing its attributes,
+ * Given a block object, returns a copy of the block object,
  * optionally merging new attributes and/or replacing its inner blocks.
+ * Attributes with the `internal` role are not copied into the new object.
  *
  * @param {Object} block           Block instance.
  * @param {Object} mergeAttributes Block attributes.
@@ -122,17 +123,10 @@ export function __experimentalCloneSanitizedBlock(
 		'internal'
 	);
 
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		block.name,
-		retainedAttributes
-	);
-
 	return {
 		...block,
 		clientId,
-		attributes: sanitizedAttributes,
+		attributes: retainedAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -111,36 +111,34 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Clone the block and merge in new attributes.
-	let clonedBlock = {
-		...block,
-		clientId,
-		attributes: {
+	// Merge in new attributes and strip out attributes with the `internal` role,
+	// which should not be copied during block duplication.
+	const retainedAttributes = __experimentalRemoveAttributesByRole(
+		block.name,
+		{
 			...block.attributes,
 			...mergeAttributes,
 		},
+		'internal'
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+		block.name,
+		retainedAttributes
+	);
+
+	return {
+		...block,
+		clientId,
+		attributes: sanitizedAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>
 				__experimentalCloneSanitizedBlock( innerBlock )
 			),
 	};
-
-	// Strip out attributes with the `internal` role, which should not be copied during
-	// block duplication.
-	clonedBlock = __experimentalRemoveAttributesByRole(
-		clonedBlock,
-		'internal'
-	);
-
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	clonedBlock.attributes = __experimentalSanitizeBlockAttributes(
-		clonedBlock.name,
-		clonedBlock.attributes
-	);
-
-	return clonedBlock;
 }
 
 /**

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -16,6 +16,7 @@ import {
 	isEmpty,
 	map,
 	reduce,
+	omit,
 } from 'lodash';
 
 /**
@@ -33,7 +34,7 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
-	__experimentalRemoveAttributesByRole,
+	__experimentalGetBlockAttributesNamesByRole,
 } from './utils';
 
 /**
@@ -142,19 +143,18 @@ export function __experimentalCloneSanitizedBlock(
 
 	// Merge in new attributes and strip out attributes with the `internal` role,
 	// which should not be copied during block duplication.
-	const retainedAttributes = __experimentalRemoveAttributesByRole(
-		block.name,
+	const filteredAttributes = omit(
 		{
 			...block.attributes,
 			...mergeAttributes,
 		},
-		'internal'
+		__experimentalGetBlockAttributesNamesByRole( block.name, 'internal' )
 	);
 
 	return {
 		...block,
 		clientId,
-		attributes: retainedAttributes,
+		attributes: filteredAttributes,
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -111,33 +111,36 @@ export function __experimentalCloneSanitizedBlock(
 ) {
 	const clientId = uuid();
 
-	// Merge in new attributes
-	block.attributes = {
-		...block.attributes,
-		...mergeAttributes,
-	};
-
-	// Strip out attributes with the `internal` role, which should not be copied during
-	// block duplication.
-	block = __experimentalRemoveAttributesByRole( block, 'internal' );
-
-	// Remove any attributes not defined in the block type, and fill in default values for
-	// misisng attributes.
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		block.name,
-		block.attributes
-	);
-
-	return {
+	// Clone the block and merge in new attributes.
+	let clonedBlock = {
 		...block,
 		clientId,
-		attributes: sanitizedAttributes,
+		attributes: {
+			...block.attributes,
+			...mergeAttributes,
+		},
 		innerBlocks:
 			newInnerBlocks ||
 			block.innerBlocks.map( ( innerBlock ) =>
 				__experimentalCloneSanitizedBlock( innerBlock )
 			),
 	};
+
+	// Strip out attributes with the `internal` role, which should not be copied during
+	// block duplication.
+	clonedBlock = __experimentalRemoveAttributesByRole(
+		clonedBlock,
+		'internal'
+	);
+
+	// Remove any attributes not defined in the block type, and fill in default values for
+	// misisng attributes.
+	clonedBlock.attributes = __experimentalSanitizeBlockAttributes(
+		clonedBlock.name,
+		clonedBlock.attributes
+	);
+
+	return clonedBlock;
 }
 
 /**

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -131,8 +131,8 @@ export function createBlocksFromInnerBlocksTemplate(
  * @param {Object}   block                        Block instance.
  * @param {Object}   mergeAttributes              Block attributes.
  * @param {?Array}   newInnerBlocks               Nested blocks.
- * @param {?Object}  options                      Cloning options.
- * @param {?boolean} options.retainCopyAttributes Whether to retain attributes that do not have copy support in the cloned block.
+ * @param {?Object}  __experimentalOptions                      Cloning options.
+ * @param {?boolean} __experimentalOptions.__experimentalExcludeNonCopyableAttributes Whether to exclude attributes that do not have copy support in the cloned block.
  *
  * @return {Object} A cloned block.
  */
@@ -140,9 +140,11 @@ export function cloneBlock(
 	block,
 	mergeAttributes = {},
 	newInnerBlocks,
-	options = {}
+	__experimentalOptions = {}
 ) {
-	const { retainCopyAttributes = true } = options;
+	const {
+		__experimentalExcludeNonCopyableAttributes = false,
+	} = __experimentalOptions;
 	const clientId = uuid();
 
 	let attributes = {
@@ -150,7 +152,7 @@ export function cloneBlock(
 		...mergeAttributes,
 	};
 
-	if ( ! retainCopyAttributes ) {
+	if ( __experimentalExcludeNonCopyableAttributes ) {
 		attributes = omit(
 			attributes,
 			__experimentalFilterBlockAttributes( block.name, {

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -34,7 +34,7 @@ import {
 } from './registration';
 import {
 	normalizeBlockType,
-	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalFilterBlockAttributes,
 } from './utils';
 
 /**
@@ -128,11 +128,11 @@ export function createBlocksFromInnerBlocksTemplate(
  * optionally merging new attributes, replacing its inner blocks, and/or
  * filtering out attributes with the 'internal' role.
  *
- * @param {Object}   block                            Block instance.
- * @param {Object}   mergeAttributes                  Block attributes.
- * @param {?Array}   newInnerBlocks                   Nested blocks.
- * @param {?Object}  options                          Cloning options.
- * @param {?boolean} options.retainInternalAttributes Whether to retain internal attributes in the cloned block.
+ * @param {Object}   block                        Block instance.
+ * @param {Object}   mergeAttributes              Block attributes.
+ * @param {?Array}   newInnerBlocks               Nested blocks.
+ * @param {?Object}  options                      Cloning options.
+ * @param {?boolean} options.retainCopyAttributes Whether to retain attributes that do not have copy support in the cloned block.
  *
  * @return {Object} A cloned block.
  */
@@ -142,7 +142,7 @@ export function cloneBlock(
 	newInnerBlocks,
 	options = {}
 ) {
-	const { retainInternalAttributes = true } = options;
+	const { retainCopyAttributes = true } = options;
 	const clientId = uuid();
 
 	let attributes = {
@@ -150,13 +150,12 @@ export function cloneBlock(
 		...mergeAttributes,
 	};
 
-	if ( ! retainInternalAttributes ) {
+	if ( ! retainCopyAttributes ) {
 		attributes = omit(
 			attributes,
-			__experimentalGetBlockAttributesNamesByRole(
-				block.name,
-				'internal'
-			)
+			__experimentalFilterBlockAttributes( block.name, {
+				supports: { copy: false },
+			} )
 		);
 	}
 

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -126,7 +126,7 @@ export function createBlocksFromInnerBlocksTemplate(
 /**
  * Given a block object, returns a copy of the block object,
  * optionally merging new attributes, replacing its inner blocks, and/or
- * filtering out attributes with the 'internal' role.
+ * filtering out attributes which do not have copy support.
  *
  * @param {Object}   block                        Block instance.
  * @param {Object}   mergeAttributes              Block attributes.

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -132,7 +132,7 @@ export function createBlocksFromInnerBlocksTemplate(
  * @param {Object}   mergeAttributes              Block attributes.
  * @param {?Array}   newInnerBlocks               Nested blocks.
  * @param {?Object}  __experimentalOptions                      Cloning options.
- * @param {?boolean} __experimentalOptions.__experimentalExcludeNonCopyableAttributes Whether to exclude attributes that do not have copy support in the cloned block.
+ * @param {?Object} __experimentalOptions.__experimentalExcludeAttributes Attributes with these supports will be excluded from the cloned block.
  *
  * @return {Object} A cloned block.
  */
@@ -142,9 +142,7 @@ export function cloneBlock(
 	newInnerBlocks,
 	__experimentalOptions = {}
 ) {
-	const {
-		__experimentalExcludeNonCopyableAttributes = false,
-	} = __experimentalOptions;
+	const { __experimentalExcludeAttributes } = __experimentalOptions;
 	const clientId = uuid();
 
 	let attributes = {
@@ -152,11 +150,11 @@ export function cloneBlock(
 		...mergeAttributes,
 	};
 
-	if ( __experimentalExcludeNonCopyableAttributes ) {
+	if ( __experimentalExcludeAttributes ) {
 		attributes = omit(
 			attributes,
 			__experimentalFilterBlockAttributes( block.name, {
-				__experimentalSupports: { copy: false },
+				__experimentalSupports: __experimentalExcludeAttributes,
 			} )
 		);
 	}

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -154,7 +154,7 @@ export function cloneBlock(
 		attributes = omit(
 			attributes,
 			__experimentalFilterBlockAttributes( block.name, {
-				supports: { copy: false },
+				__experimentalSupports: { copy: false },
 			} )
 		);
 	}

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -132,7 +132,7 @@ export function createBlocksFromInnerBlocksTemplate(
  * @param {Object}   mergeAttributes              Block attributes.
  * @param {?Array}   newInnerBlocks               Nested blocks.
  * @param {?Object}  __experimentalOptions                      Cloning options.
- * @param {?Object} __experimentalOptions.__experimentalExcludeAttributes Attributes with these supports will be excluded from the cloned block.
+ * @param {?Object} __experimentalOptions.__experimentalExcludeAttributes Attributes matching this filter will be excluded from the cloned block.
  *
  * @return {Object} A cloned block.
  */
@@ -153,9 +153,10 @@ export function cloneBlock(
 	if ( __experimentalExcludeAttributes ) {
 		attributes = omit(
 			attributes,
-			__experimentalFilterBlockAttributes( block.name, {
-				__experimentalSupports: __experimentalExcludeAttributes,
-			} )
+			__experimentalFilterBlockAttributes(
+				block.name,
+				__experimentalExcludeAttributes
+			)
 		);
 	}
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -8,7 +8,6 @@ export {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
-	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	getBlockTransforms,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -142,7 +142,6 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
-	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
 	__experimentalRemoveAttributesByRole,
 } from './utils';

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -144,6 +144,7 @@ export {
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -143,7 +143,6 @@ export {
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalRemoveAttributesByRole,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -141,7 +141,7 @@ export {
 	isValidIcon,
 	getBlockLabel as __experimentalGetBlockLabel,
 	getAccessibleBlockLabel as __experimentalGetAccessibleBlockLabel,
-	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalFilterBlockAttributes,
 } from './utils';
 
 // Templates are, in a general sense, a basic collection of block nodes with any

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, isObject, castArray, startsWith, omit } from 'lodash';
+import { isEmpty, reduce, isObject, castArray, startsWith } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,17 +24,12 @@ import {
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
 } from './registration';
-import {
-	isUnmodifiedDefaultBlock,
-	normalizeBlockType,
-	__experimentalFilterBlockAttributes,
-} from './utils';
+import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
 
 /**
  * @typedef {Object} WPBlockSerializationOptions Serialization Options.
  *
  * @property {boolean} isInnerBlocks Whether we are serializing inner blocks.
- * @property {Object} __experimentalExcludeAttributes Attributes matching these filters will be excluded from the serialized block.
  */
 
 /**
@@ -347,10 +342,7 @@ export function getCommentDelimitedContent(
  *
  * @return {string} Serialized block.
  */
-export function serializeBlock(
-	block,
-	{ isInnerBlocks = false, __experimentalExcludeAttributes } = {}
-) {
+export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
 	const blockName = block.name;
 	const saveContent = getBlockInnerHTML( block );
 
@@ -362,16 +354,7 @@ export function serializeBlock(
 	}
 
 	const blockType = getBlockType( blockName );
-	let saveAttributes = getCommentAttributes( blockType, block.attributes );
-
-	if ( __experimentalExcludeAttributes ) {
-		saveAttributes = omit(
-			saveAttributes,
-			__experimentalFilterBlockAttributes( blockName, {
-				__experimentalSupports: __experimentalExcludeAttributes,
-			} )
-		);
-	}
+	const saveAttributes = getCommentAttributes( blockType, block.attributes );
 
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -27,7 +27,7 @@ import {
 import {
 	isUnmodifiedDefaultBlock,
 	normalizeBlockType,
-	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalFilterBlockAttributes,
 } from './utils';
 
 /**
@@ -367,7 +367,9 @@ export function serializeBlock(
 	if ( ! retainCopyAttributes ) {
 		saveAttributes = omit(
 			saveAttributes,
-			__experimentalGetBlockAttributesNamesByRole( blockName, 'internal' )
+			__experimentalFilterBlockAttributes( blockName, {
+				supports: { copy: false },
+			} )
 		);
 	}
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -34,7 +34,7 @@ import {
  * @typedef {Object} WPBlockSerializationOptions Serialization Options.
  *
  * @property {boolean} isInnerBlocks Whether we are serializing inner blocks.
- * @property {boolean} __experimentalExcludeNonCopyableAttributes Whether to exclude attributes that do not have copy support in the serialized block.
+ * @property {Object} __experimentalExcludeAttributes Attributes matching these filters will be excluded from the serialized block.
  */
 
 /**
@@ -349,10 +349,7 @@ export function getCommentDelimitedContent(
  */
 export function serializeBlock(
 	block,
-	{
-		isInnerBlocks = false,
-		__experimentalExcludeNonCopyableAttributes = false,
-	} = {}
+	{ isInnerBlocks = false, __experimentalExcludeAttributes } = {}
 ) {
 	const blockName = block.name;
 	const saveContent = getBlockInnerHTML( block );
@@ -367,14 +364,15 @@ export function serializeBlock(
 	const blockType = getBlockType( blockName );
 	let saveAttributes = getCommentAttributes( blockType, block.attributes );
 
-	if ( __experimentalExcludeNonCopyableAttributes ) {
+	if ( __experimentalExcludeAttributes ) {
 		saveAttributes = omit(
 			saveAttributes,
 			__experimentalFilterBlockAttributes( blockName, {
-				__experimentalSupports: { copy: false },
+				__experimentalSupports: __experimentalExcludeAttributes,
 			} )
 		);
 	}
+
 	return getCommentDelimitedContent( blockName, saveAttributes, saveContent );
 }
 

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -34,7 +34,7 @@ import {
  * @typedef {Object} WPBlockSerializationOptions Serialization Options.
  *
  * @property {boolean} isInnerBlocks Whether we are serializing inner blocks.
- * @property {boolean} retainCopyAttributes Whether to retain attributes that do not have copy support in the serialized block.
+ * @property {boolean} __experimentalExcludeNonCopyableAttributes Whether to exclude attributes that do not have copy support in the serialized block.
  */
 
 /**
@@ -349,7 +349,10 @@ export function getCommentDelimitedContent(
  */
 export function serializeBlock(
 	block,
-	{ isInnerBlocks = false, retainCopyAttributes = true } = {}
+	{
+		isInnerBlocks = false,
+		__experimentalExcludeNonCopyableAttributes = false,
+	} = {}
 ) {
 	const blockName = block.name;
 	const saveContent = getBlockInnerHTML( block );
@@ -364,7 +367,7 @@ export function serializeBlock(
 	const blockType = getBlockType( blockName );
 	let saveAttributes = getCommentAttributes( blockType, block.attributes );
 
-	if ( ! retainCopyAttributes ) {
+	if ( __experimentalExcludeNonCopyableAttributes ) {
 		saveAttributes = omit(
 			saveAttributes,
 			__experimentalFilterBlockAttributes( blockName, {

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -368,7 +368,7 @@ export function serializeBlock(
 		saveAttributes = omit(
 			saveAttributes,
 			__experimentalFilterBlockAttributes( blockName, {
-				supports: { copy: false },
+				__experimentalSupports: { copy: false },
 			} )
 		);
 	}

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -448,6 +448,33 @@ describe( 'block factory', () => {
 
 			expect( clonedBlock.attributes ).toEqual( {} );
 		} );
+		it( 'should not duplicate internal attributes, but fallback to available defaults', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					internalAttribute: {
+						type: 'string',
+						__experimentalRole: 'internal',
+					},
+					internalAttributeWithDefault: {
+						type: 'string',
+						__experimentalRole: 'internal',
+						default: 'default-value',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				internalAttribute: 'unique-value',
+				internalAttributeWithDefault: 'unique-non-default-value',
+			} );
+
+			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
+
+			expect( clonedBlock.attributes ).toEqual( {
+				internalAttributeWithDefault: 'default-value',
+			} );
+		} );
 	} );
 
 	describe( 'getPossibleBlockTransformations()', () => {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -90,9 +90,12 @@ describe( 'block factory', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
-					content: {
+					childrenContent: {
 						type: 'array',
 						source: 'children',
+					},
+					nodeContent: {
+						source: 'node',
 					},
 				},
 			} );
@@ -100,7 +103,8 @@ describe( 'block factory', () => {
 			const block = createBlock( 'core/test-block' );
 
 			expect( block.attributes ).toEqual( {
-				content: [],
+				childrenContent: [],
+				nodeContent: [],
 			} );
 		} );
 
@@ -176,6 +180,14 @@ describe( 'block factory', () => {
 			} );
 
 			expect( block.attributes ).toEqual( {} );
+		} );
+
+		it( 'throws error if the block is not registered', () => {
+			expect( () => {
+				createBlock( 'core/not-registered-test-block', {} );
+			} ).toThrowErrorMatchingInlineSnapshot(
+				`"Block type 'core/not-registered-test-block' is not registered."`
+			);
 		} );
 	} );
 

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -360,13 +360,15 @@ describe( 'block factory', () => {
 			expect( clonedBlock.clientId ).not.toBe( block.clientId );
 		} );
 
-		it( 'should retain internal attributes by default', () => {
+		it( 'should retain all attributes by default', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
 					internalAttribute: {
 						type: 'string',
-						__experimentalRole: 'internal',
+						supports: {
+							copy: false,
+						},
 					},
 					contentAttribute: {
 						type: 'string',
@@ -387,13 +389,21 @@ describe( 'block factory', () => {
 			} );
 		} );
 
-		it( 'should not duplicate internal attributes when retainInternalAttributes is false', () => {
+		it( 'should not duplicate attributes that do not support copy operation when retainCopyAttributes is false', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
 					internalAttribute: {
 						type: 'string',
-						__experimentalRole: 'internal',
+						supports: {
+							copy: false,
+						},
+					},
+					attributeWithExplicitCopySupport: {
+						type: 'string',
+						supports: {
+							copy: true,
+						},
 					},
 					contentAttribute: {
 						type: 'string',
@@ -405,15 +415,16 @@ describe( 'block factory', () => {
 			const block = createBlock( 'core/test-block', {
 				internalAttribute: 'this-should-not-be-copied',
 				contentAttribute: 'some content',
-				attributeWithNoRole: 'another attribute',
+				attributeWithExplicitCopySupport: 'another attribute',
 			} );
 
 			const clonedBlock = cloneBlock( block, {}, null, {
-				retainInternalAttributes: false,
+				retainCopyAttributes: false,
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {
 				contentAttribute: 'some content',
+				attributeWithExplicitCopySupport: 'another attribute',
 			} );
 		} );
 

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -389,7 +389,7 @@ describe( 'block factory', () => {
 			} );
 		} );
 
-		it( 'should not duplicate attributes that do not support copy operation when retainCopyAttributes is false', () => {
+		it( 'should not duplicate attributes that do not support copy operation when __experimentalExcludeNonCopyableAttributes is true', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
@@ -419,7 +419,7 @@ describe( 'block factory', () => {
 			} );
 
 			const clonedBlock = cloneBlock( block, {}, null, {
-				retainCopyAttributes: false,
+				__experimentalExcludeNonCopyableAttributes: true,
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -389,7 +389,7 @@ describe( 'block factory', () => {
 			} );
 		} );
 
-		it( 'should not duplicate attributes that do not support copy operation when __experimentalExcludeNonCopyableAttributes is true', () => {
+		it( 'should not duplicate attributes that do not support copy operation when configured with __experimentalExcludeAttributes', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
@@ -419,7 +419,7 @@ describe( 'block factory', () => {
 			} );
 
 			const clonedBlock = cloneBlock( block, {}, null, {
-				__experimentalExcludeNonCopyableAttributes: true,
+				__experimentalExcludeAttributes: { copy: false },
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -11,7 +11,6 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	cloneBlock,
-	__experimentalCloneSanitizedBlock,
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	getBlockTransforms,
@@ -361,6 +360,63 @@ describe( 'block factory', () => {
 			expect( clonedBlock.clientId ).not.toBe( block.clientId );
 		} );
 
+		it( 'should retain internal attributes by default', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					internalAttribute: {
+						type: 'string',
+						__experimentalRole: 'internal',
+					},
+					contentAttribute: {
+						type: 'string',
+						__experimentalRole: 'content',
+					},
+				},
+			} );
+			const block = createBlock( 'core/test-block', {
+				internalAttribute: 'this-should-be-copied',
+				contentAttribute: 'some content',
+			} );
+
+			const clonedBlock = cloneBlock( block, {} );
+
+			expect( clonedBlock.attributes ).toEqual( {
+				internalAttribute: 'this-should-be-copied',
+				contentAttribute: 'some content',
+			} );
+		} );
+
+		it( 'should not duplicate internal attributes when retainInternalAttributes is false', () => {
+			registerBlockType( 'core/test-block', {
+				...defaultBlockSettings,
+				attributes: {
+					internalAttribute: {
+						type: 'string',
+						__experimentalRole: 'internal',
+					},
+					contentAttribute: {
+						type: 'string',
+						__experimentalRole: 'content',
+					},
+				},
+			} );
+
+			const block = createBlock( 'core/test-block', {
+				internalAttribute: 'this-should-not-be-copied',
+				contentAttribute: 'some content',
+				attributeWithNoRole: 'another attribute',
+			} );
+
+			const clonedBlock = cloneBlock( block, {}, null, {
+				retainInternalAttributes: false,
+			} );
+
+			expect( clonedBlock.attributes ).toEqual( {
+				contentAttribute: 'some content',
+			} );
+		} );
+
 		it( 'should replace inner blocks of the existing block', () => {
 			registerBlockType( 'core/test-block', {
 				attributes: {
@@ -416,186 +472,6 @@ describe( 'block factory', () => {
 			);
 
 			const clonedBlock = cloneBlock( block );
-
-			expect( clonedBlock.innerBlocks ).toHaveLength( 2 );
-			expect( clonedBlock.innerBlocks[ 0 ].clientId ).not.toBe(
-				block.innerBlocks[ 0 ].clientId
-			);
-			expect( clonedBlock.innerBlocks[ 0 ].attributes ).not.toBe(
-				block.innerBlocks[ 0 ].attributes
-			);
-			expect( clonedBlock.innerBlocks[ 0 ].attributes ).toEqual(
-				block.innerBlocks[ 0 ].attributes
-			);
-			expect( clonedBlock.innerBlocks[ 1 ].clientId ).not.toBe(
-				block.innerBlocks[ 1 ].clientId
-			);
-			expect( clonedBlock.innerBlocks[ 1 ].attributes ).not.toBe(
-				block.innerBlocks[ 1 ].attributes
-			);
-			expect( clonedBlock.innerBlocks[ 1 ].attributes ).toEqual(
-				block.innerBlocks[ 1 ].attributes
-			);
-		} );
-	} );
-
-	describe( '__experimentalCloneSanitizedBlock', () => {
-		it( 'should not duplicate internal attributes', () => {
-			registerBlockType( 'core/test-block', {
-				...defaultBlockSettings,
-				attributes: {
-					internalAttribute: {
-						type: 'string',
-						__experimentalRole: 'internal',
-					},
-					contentAttribute: {
-						type: 'string',
-						__experimentalRole: 'content',
-					},
-					attributeWithNoRole: {
-						type: 'string',
-					},
-				},
-			} );
-
-			const block = createBlock( 'core/test-block', {
-				internalAttribute: 'this-should-not-be-copied',
-				contentAttribute: 'some content',
-				attributeWithNoRole: 'another attribute',
-			} );
-
-			const clonedBlock = __experimentalCloneSanitizedBlock( block, {} );
-
-			expect( clonedBlock.attributes ).toEqual( {
-				contentAttribute: 'some content',
-				attributeWithNoRole: 'another attribute',
-			} );
-		} );
-
-		it( 'should merge attributes into the existing block', () => {
-			registerBlockType( 'core/test-block', {
-				attributes: {
-					align: {
-						type: 'string',
-					},
-					isDifferent: {
-						type: 'boolean',
-						default: false,
-					},
-					includesDefault: {
-						type: 'boolean',
-						default: true,
-					},
-					includesFalseyDefault: {
-						type: 'number',
-						default: 0,
-					},
-					content: {
-						type: 'array',
-						source: 'children',
-					},
-					defaultContent: {
-						type: 'array',
-						source: 'children',
-						default: 'test',
-					},
-					unknownDefaultContent: {
-						type: 'array',
-						source: 'children',
-						default: 1,
-					},
-					htmlContent: {
-						source: 'html',
-					},
-				},
-				save: noop,
-				category: 'text',
-				title: 'test block',
-			} );
-			const block = deepFreeze(
-				createBlock( 'core/test-block', { align: 'left' }, [
-					createBlock( 'core/test-block' ),
-				] )
-			);
-
-			const clonedBlock = __experimentalCloneSanitizedBlock( block, {
-				isDifferent: true,
-				htmlContent: 'test',
-			} );
-
-			expect( clonedBlock.name ).toEqual( block.name );
-			expect( clonedBlock.attributes ).toEqual( {
-				includesDefault: true,
-				includesFalseyDefault: 0,
-				align: 'left',
-				isDifferent: true,
-				content: [],
-				defaultContent: [ 'test' ],
-				unknownDefaultContent: [],
-				htmlContent: 'test',
-			} );
-			expect( clonedBlock.innerBlocks ).toHaveLength( 1 );
-			expect( typeof clonedBlock.clientId ).toBe( 'string' );
-			expect( clonedBlock.clientId ).not.toBe( block.clientId );
-		} );
-
-		it( 'should replace inner blocks of the existing block', () => {
-			registerBlockType( 'core/test-block', {
-				attributes: {
-					align: {
-						type: 'string',
-					},
-					isDifferent: {
-						type: 'boolean',
-						default: false,
-					},
-				},
-				save: noop,
-				category: 'text',
-				title: 'test block',
-			} );
-			const block = deepFreeze(
-				createBlock( 'core/test-block', { align: 'left' }, [
-					createBlock( 'core/test-block', { align: 'right' } ),
-					createBlock( 'core/test-block', { align: 'left' } ),
-				] )
-			);
-
-			const clonedBlock = __experimentalCloneSanitizedBlock(
-				block,
-				undefined,
-				[ createBlock( 'core/test-block' ) ]
-			);
-
-			expect( clonedBlock.innerBlocks ).toHaveLength( 1 );
-			expect(
-				clonedBlock.innerBlocks[ 0 ].attributes
-			).not.toHaveProperty( 'align' );
-		} );
-
-		it( 'should clone innerBlocks if innerBlocks are not passed', () => {
-			registerBlockType( 'core/test-block', {
-				attributes: {
-					align: {
-						type: 'string',
-					},
-					isDifferent: {
-						type: 'boolean',
-						default: false,
-					},
-				},
-				save: noop,
-				category: 'text',
-				title: 'test block',
-			} );
-			const block = deepFreeze(
-				createBlock( 'core/test-block', { align: 'left' }, [
-					createBlock( 'core/test-block', { align: 'right' } ),
-					createBlock( 'core/test-block', { align: 'left' } ),
-				] )
-			);
-
-			const clonedBlock = __experimentalCloneSanitizedBlock( block );
 
 			expect( clonedBlock.innerBlocks ).toHaveLength( 2 );
 			expect( clonedBlock.innerBlocks[ 0 ].clientId ).not.toBe(

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -366,7 +366,7 @@ describe( 'block factory', () => {
 				attributes: {
 					internalAttribute: {
 						type: 'string',
-						supports: {
+						__experimentalSupports: {
 							copy: false,
 						},
 					},
@@ -395,13 +395,13 @@ describe( 'block factory', () => {
 				attributes: {
 					internalAttribute: {
 						type: 'string',
-						supports: {
+						__experimentalSupports: {
 							copy: false,
 						},
 					},
 					attributeWithExplicitCopySupport: {
 						type: 'string',
-						supports: {
+						__experimentalSupports: {
 							copy: true,
 						},
 					},

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -419,9 +419,7 @@ describe( 'block factory', () => {
 			} );
 
 			const clonedBlock = cloneBlock( block, {}, null, {
-				__experimentalExcludeAttributes: {
-					__experimentalSupports: { copy: false },
-				},
+				__experimentalRequiredAttributeSupports: [ 'copy' ],
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -389,7 +389,7 @@ describe( 'block factory', () => {
 			} );
 		} );
 
-		it( 'should not duplicate attributes that do not support copy operation when configured with __experimentalExcludeAttributes', () => {
+		it( 'should not duplicate attributes that do not support copy operation when configured with __experimentalSupports', () => {
 			registerBlockType( 'core/test-block', {
 				...defaultBlockSettings,
 				attributes: {
@@ -419,7 +419,9 @@ describe( 'block factory', () => {
 			} );
 
 			const clonedBlock = cloneBlock( block, {}, null, {
-				__experimentalExcludeAttributes: { copy: false },
+				__experimentalExcludeAttributes: {
+					__experimentalSupports: { copy: false },
+				},
 			} );
 
 			expect( clonedBlock.attributes ).toEqual( {

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -329,7 +329,9 @@ describe( 'block serializer', () => {
 					},
 					internal: {
 						type: 'string',
-						__experimentalRole: 'internal',
+						supports: {
+							copy: false
+						},
 					},
 				},
 				save( { attributes } ) {
@@ -394,7 +396,7 @@ describe( 'block serializer', () => {
 			);
 		} );
 
-		it( 'should omit internal attributes when retainCopyAttributes is fasle', () => {
+		it( 'should omit internal attributes when retainCopyAttributes is false', () => {
 			const block = createBlock( 'core/test-block', {
 				content: 'content',
 				internal: 'copy me',

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -329,7 +329,7 @@ describe( 'block serializer', () => {
 					},
 					internal: {
 						type: 'string',
-						supports: {
+						__experimentalSupports: {
 							copy: false,
 						},
 					},

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -396,14 +396,16 @@ describe( 'block serializer', () => {
 			);
 		} );
 
-		it( 'should omit attributes without copy support when retainCopyAttributes is false', () => {
+		it( 'should omit attributes without copy support when __experimentalExcludeNonCopyableAttributes is true', () => {
 			const block = createBlock( 'core/test-block', {
 				content: 'content',
 				internal: 'copy me',
 			} );
 
 			expect(
-				serialize( block, { retainCopyAttributes: false } )
+				serialize( block, {
+					__experimentalExcludeNonCopyableAttributes: true,
+				} )
 			).toEqual(
 				'<!-- wp:test-block -->\n<p>content</p>\n<!-- /wp:test-block -->'
 			);

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -327,6 +327,10 @@ describe( 'block serializer', () => {
 					stuff: {
 						type: 'string',
 					},
+					internal: {
+						type: 'string',
+						__experimentalRole: 'internal',
+					},
 				},
 				save( { attributes } ) {
 					if ( attributes.throw ) {
@@ -376,6 +380,30 @@ describe( 'block serializer', () => {
 
 			expect( serialize( block ) ).toEqual(
 				'<!-- wp:test-block {"throw":true} -->\nCorrect\n<!-- /wp:test-block -->'
+			);
+		} );
+
+		it( 'should serialize internal attributes by default', () => {
+			const block = createBlock( 'core/test-block', {
+				content: 'content',
+				internal: 'copy me',
+			} );
+
+			expect( serialize( block ) ).toEqual(
+				'<!-- wp:test-block {"internal":"copy me"} -->\n<p>content</p>\n<!-- /wp:test-block -->'
+			);
+		} );
+
+		it( 'should omit internal attributes when retainCopyAttributes is fasle', () => {
+			const block = createBlock( 'core/test-block', {
+				content: 'content',
+				internal: 'copy me',
+			} );
+
+			expect(
+				serialize( block, { retainCopyAttributes: false } )
+			).toEqual(
+				'<!-- wp:test-block -->\n<p>content</p>\n<!-- /wp:test-block -->'
 			);
 		} );
 	} );

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -327,12 +327,6 @@ describe( 'block serializer', () => {
 					stuff: {
 						type: 'string',
 					},
-					internal: {
-						type: 'string',
-						__experimentalSupports: {
-							copy: false,
-						},
-					},
 				},
 				save( { attributes } ) {
 					if ( attributes.throw ) {
@@ -382,32 +376,6 @@ describe( 'block serializer', () => {
 
 			expect( serialize( block ) ).toEqual(
 				'<!-- wp:test-block {"throw":true} -->\nCorrect\n<!-- /wp:test-block -->'
-			);
-		} );
-
-		it( 'should serialize all attributes by default', () => {
-			const block = createBlock( 'core/test-block', {
-				content: 'content',
-				internal: 'copy me',
-			} );
-
-			expect( serialize( block ) ).toEqual(
-				'<!-- wp:test-block {"internal":"copy me"} -->\n<p>content</p>\n<!-- /wp:test-block -->'
-			);
-		} );
-
-		it( 'should omit attributes without copy support when configured with __experimentalExcludeAttributes', () => {
-			const block = createBlock( 'core/test-block', {
-				content: 'content',
-				internal: 'copy me',
-			} );
-
-			expect(
-				serialize( block, {
-					__experimentalExcludeAttributes: { copy: false },
-				} )
-			).toEqual(
-				'<!-- wp:test-block -->\n<p>content</p>\n<!-- /wp:test-block -->'
 			);
 		} );
 	} );

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -330,7 +330,7 @@ describe( 'block serializer', () => {
 					internal: {
 						type: 'string',
 						supports: {
-							copy: false
+							copy: false,
 						},
 					},
 				},
@@ -385,7 +385,7 @@ describe( 'block serializer', () => {
 			);
 		} );
 
-		it( 'should serialize internal attributes by default', () => {
+		it( 'should serialize all attributes by default', () => {
 			const block = createBlock( 'core/test-block', {
 				content: 'content',
 				internal: 'copy me',
@@ -396,7 +396,7 @@ describe( 'block serializer', () => {
 			);
 		} );
 
-		it( 'should omit internal attributes when retainCopyAttributes is false', () => {
+		it( 'should omit attributes without copy support when retainCopyAttributes is false', () => {
 			const block = createBlock( 'core/test-block', {
 				content: 'content',
 				internal: 'copy me',

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -396,7 +396,7 @@ describe( 'block serializer', () => {
 			);
 		} );
 
-		it( 'should omit attributes without copy support when __experimentalExcludeNonCopyableAttributes is true', () => {
+		it( 'should omit attributes without copy support when configured with __experimentalExcludeAttributes', () => {
 			const block = createBlock( 'core/test-block', {
 				content: 'content',
 				internal: 'copy me',
@@ -404,7 +404,7 @@ describe( 'block serializer', () => {
 
 			expect(
 				serialize( block, {
-					__experimentalExcludeNonCopyableAttributes: true,
+					__experimentalExcludeAttributes: { copy: false },
 				} )
 			).toEqual(
 				'<!-- wp:test-block -->\n<p>content</p>\n<!-- /wp:test-block -->'

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -18,7 +18,6 @@ import {
 	getAccessibleBlockLabel,
 	getBlockLabel,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalRemoveAttributesByRole,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -300,86 +299,5 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 				'content'
 			)
 		).toEqual( [] );
-	} );
-} );
-
-describe( '__experimentalRemoveAttributesByRole', () => {
-	beforeAll( () => {
-		registerBlockType( 'core/test-block-with-internal-attrs', {
-			attributes: {
-				align: {
-					type: 'string',
-				},
-				internalData: {
-					type: 'boolean',
-					__experimentalRole: 'internal',
-				},
-				productId: {
-					type: 'number',
-					__experimentalRole: 'internal',
-				},
-				color: {
-					type: 'string',
-					__experimentalRole: 'other',
-				},
-			},
-			save: noop,
-			category: 'text',
-			title: 'test block with internal attrs',
-		} );
-		registerBlockType( 'core/test-block-with-no-internal-attrs', {
-			attributes: {
-				align: { type: 'string' },
-				color: { type: 'string' },
-			},
-			save: noop,
-			category: 'text',
-			title: 'test block with no internal attrs',
-		} );
-		registerBlockType( 'core/test-block-with-no-attrs', {
-			save: noop,
-			category: 'text',
-			title: 'test block with no attrs',
-		} );
-	} );
-	afterAll( () => {
-		[
-			'core/test-block-with-internal-attrs',
-			'core/test-block-with-no-internal-attrs',
-			'core/test-block-with-no-attrs',
-		].forEach( unregisterBlockType );
-	} );
-
-	it( 'should return empty object if no attributes are passed', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-internal-attrs',
-				{},
-				'internal'
-			)
-		).toEqual( {} );
-	} );
-	it( 'should return all attributes when block has no attributes with given role', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-no-internal-attrs',
-				{ align: 'left', color: 'blue' },
-				'internal'
-			)
-		).toEqual( { align: 'left', color: 'blue' } );
-	} );
-	it( 'should remove attributes with given role and return all others', () => {
-		expect(
-			__experimentalRemoveAttributesByRole(
-				'core/test-block-with-internal-attrs',
-				{
-					align: 'left',
-					internalData: true,
-					productId: 12345,
-					color: 'blue',
-				},
-				'internal'
-			)
-		).toEqual( { align: 'left', color: 'blue' } );
 	} );
 } );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -19,6 +19,7 @@ import {
 	getBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalStripInternalBlockAttributes,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -397,5 +398,83 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 				'content'
 			)
 		).toEqual( [] );
+	} );
+} );
+
+describe( '__experimentalStripInternalBlockAttributes', () => {
+	beforeAll( () => {
+		registerBlockType( 'core/test-block-with-internal-attrs', {
+			attributes: {
+				align: {
+					type: 'string',
+				},
+				internalData: {
+					type: 'boolean',
+					__experimentalRole: 'internal',
+				},
+				productId: {
+					type: 'number',
+					__experimentalRole: 'internal',
+				},
+				color: {
+					type: 'string',
+					__experimentalRole: 'other',
+				},
+			},
+			save: noop,
+			category: 'text',
+			title: 'test block with internal attrs',
+		} );
+		registerBlockType( 'core/test-block-with-no-internal-attrs', {
+			attributes: {
+				align: { type: 'string' },
+				color: { type: 'string' },
+			},
+			save: noop,
+			category: 'text',
+			title: 'test block with no internal attrs',
+		} );
+		registerBlockType( 'core/test-block-with-no-attrs', {
+			save: noop,
+			category: 'text',
+			title: 'test block with no attrs',
+		} );
+	} );
+	afterAll( () => {
+		[
+			'core/test-block-with-internal-attrs',
+			'core/test-block-with-no-internal-attrs',
+			'core/test-block-with-no-attrs',
+		].forEach( unregisterBlockType );
+	} );
+
+	it( 'should return empty object if no attributes are passed', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-internal-attrs',
+				{}
+			)
+		).toEqual( {} );
+	} );
+	it( 'should return all attributes when block has no attributes with internal role', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-no-internal-attrs',
+				{ align: 'left', color: 'blue' }
+			)
+		).toEqual( { align: 'left', color: 'blue' } );
+	} );
+	it( 'should remove attributes with internal role and return all others', () => {
+		expect(
+			__experimentalStripInternalBlockAttributes(
+				'core/test-block-with-internal-attrs',
+				{
+					align: 'left',
+					internalData: true,
+					productId: 12345,
+					color: 'blue',
+				}
+			)
+		).toEqual( { align: 'left', color: 'blue' } );
 	} );
 } );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,7 +17,6 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
-	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
 	__experimentalRemoveAttributesByRole,
 } from '../utils';
@@ -213,103 +212,6 @@ describe( 'getAccessibleBlockLabel', () => {
 		expect( getAccessibleBlockLabel( blockType, attributes, 3 ) ).toBe(
 			'Recipe Block. Row 3'
 		);
-	} );
-} );
-
-describe( 'sanitizeBlockAttributes', () => {
-	afterEach( () => {
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
-	} );
-
-	it( 'sanitize block attributes not defined in the block type', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				defined: {
-					type: 'string',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				defined: 'defined-attribute',
-				notDefined: 'not-defined-attribute',
-			}
-		);
-
-		expect( attributes ).toEqual( {
-			defined: 'defined-attribute',
-		} );
-	} );
-
-	it( 'throws error if the block is not registered', () => {
-		expect( () => {
-			__experimentalSanitizeBlockAttributes(
-				'core/not-registered-test-block',
-				{}
-			);
-		} ).toThrowErrorMatchingInlineSnapshot(
-			`"Block type 'core/not-registered-test-block' is not registered."`
-		);
-	} );
-
-	it( 'handles undefined values and default values', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				hasDefaultValue: {
-					type: 'string',
-					default: 'default-value',
-				},
-				noDefaultValue: {
-					type: 'string',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{}
-		);
-
-		expect( attributes ).toEqual( {
-			hasDefaultValue: 'default-value',
-		} );
-	} );
-
-	it( 'handles node and children sources as arrays', () => {
-		registerBlockType( 'core/test-block', {
-			attributes: {
-				nodeContent: {
-					source: 'node',
-				},
-				childrenContent: {
-					source: 'children',
-				},
-				withDefault: {
-					source: 'children',
-					default: 'test',
-				},
-			},
-			title: 'Test block',
-		} );
-
-		const attributes = __experimentalSanitizeBlockAttributes(
-			'core/test-block',
-			{
-				nodeContent: [ 'test-1', 'test-2' ],
-			}
-		);
-
-		expect( attributes ).toEqual( {
-			nodeContent: [ 'test-1', 'test-2' ],
-			childrenContent: [],
-			withDefault: [ 'test' ],
-		} );
 	} );
 } );
 

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -19,7 +19,7 @@ import {
 	getBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	__experimentalGetBlockAttributesNamesByRole,
-	__experimentalStripInternalBlockAttributes,
+	__experimentalRemoveAttributesByRole,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -401,7 +401,7 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 	} );
 } );
 
-describe( '__experimentalStripInternalBlockAttributes', () => {
+describe( '__experimentalRemoveAttributesByRole', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block-with-internal-attrs', {
 			attributes: {
@@ -450,30 +450,33 @@ describe( '__experimentalStripInternalBlockAttributes', () => {
 
 	it( 'should return empty object if no attributes are passed', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-internal-attrs',
-				{}
+				{},
+				'internal'
 			)
 		).toEqual( {} );
 	} );
-	it( 'should return all attributes when block has no attributes with internal role', () => {
+	it( 'should return all attributes when block has no attributes with given role', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-no-internal-attrs',
-				{ align: 'left', color: 'blue' }
+				{ align: 'left', color: 'blue' },
+				'internal'
 			)
 		).toEqual( { align: 'left', color: 'blue' } );
 	} );
-	it( 'should remove attributes with internal role and return all others', () => {
+	it( 'should remove attributes with given role and return all others', () => {
 		expect(
-			__experimentalStripInternalBlockAttributes(
+			__experimentalRemoveAttributesByRole(
 				'core/test-block-with-internal-attrs',
 				{
 					align: 'left',
 					internalData: true,
 					productId: 12345,
 					color: 'blue',
-				}
+				},
+				'internal'
 			)
 		).toEqual( { align: 'left', color: 'blue' } );
 	} );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -232,7 +232,7 @@ describe( '__experimentalFilterBlockAttributes', () => {
 				color: {
 					type: 'string',
 					__experimentalRole: 'other',
-					supports: {
+					__experimentalSupports: {
 						copy: false,
 					},
 				},
@@ -285,7 +285,7 @@ describe( '__experimentalFilterBlockAttributes', () => {
 		expect(
 			__experimentalFilterBlockAttributes( 'core/test-block-1', {
 				__experimentalRole: 'other',
-				supports: { copy: false },
+				__experimentalSupports: { copy: false },
 			} )
 		).toEqual( [ 'color' ] );
 		expect(

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -17,7 +17,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
-	__experimentalGetBlockAttributesNamesByRole,
+	__experimentalFilterBlockAttributes,
 } from '../utils';
 
 describe( 'block helpers', () => {
@@ -214,7 +214,7 @@ describe( 'getAccessibleBlockLabel', () => {
 	} );
 } );
 
-describe( '__experimentalGetBlockAttributesNamesByRole', () => {
+describe( '__experimentalFilterBlockAttributes', () => {
 	beforeAll( () => {
 		registerBlockType( 'core/test-block-1', {
 			attributes: {
@@ -232,6 +232,9 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 				color: {
 					type: 'string',
 					__experimentalRole: 'other',
+					supports: {
+						copy: false,
+					},
 				},
 			},
 			save: noop,
@@ -263,41 +266,45 @@ describe( '__experimentalGetBlockAttributesNamesByRole', () => {
 	} );
 	it( 'should return empty array if block has no attributes', () => {
 		expect(
-			__experimentalGetBlockAttributesNamesByRole( 'core/test-block-3' )
+			__experimentalFilterBlockAttributes( 'core/test-block-3' )
 		).toEqual( [] );
 	} );
-	it( 'should return all attribute names if no role is provided', () => {
+	it( 'should return all attribute names if no options are provided', () => {
 		expect(
-			__experimentalGetBlockAttributesNamesByRole( 'core/test-block-1' )
+			__experimentalFilterBlockAttributes( 'core/test-block-1' )
 		).toEqual(
 			expect.arrayContaining( [ 'align', 'content', 'level', 'color' ] )
 		);
 	} );
-	it( 'should return proper results with existing attributes and provided role', () => {
+	it( 'should return proper results with existing attributes and provided options', () => {
 		expect(
-			__experimentalGetBlockAttributesNamesByRole(
-				'core/test-block-1',
-				'content'
-			)
+			__experimentalFilterBlockAttributes( 'core/test-block-1', {
+				__experimentalRole: 'content',
+			} )
 		).toEqual( expect.arrayContaining( [ 'content', 'level' ] ) );
 		expect(
-			__experimentalGetBlockAttributesNamesByRole(
-				'core/test-block-1',
-				'other'
-			)
+			__experimentalFilterBlockAttributes( 'core/test-block-1', {
+				__experimentalRole: 'other',
+				supports: { copy: false },
+			} )
 		).toEqual( [ 'color' ] );
 		expect(
-			__experimentalGetBlockAttributesNamesByRole(
-				'core/test-block-1',
-				'not-exists'
-			)
+			__experimentalFilterBlockAttributes( 'core/test-block-1', {
+				__experimentalRole: 'not-exists',
+			} )
+		).toEqual( [] );
+		// There are no attributes that match all the conditions.
+		expect(
+			__experimentalFilterBlockAttributes( 'core/test-block-1', {
+				__experimentalRole: 'content',
+				type: 'string',
+			} )
 		).toEqual( [] );
 		// A block with no `role` in any attributes.
 		expect(
-			__experimentalGetBlockAttributesNamesByRole(
-				'core/test-block-2',
-				'content'
-			)
+			__experimentalFilterBlockAttributes( 'core/test-block-2', {
+				__experimentalRole: 'content',
+			} )
 		).toEqual( [] );
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, reduce, maxBy } from 'lodash';
+import { every, has, isFunction, isString, maxBy } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -236,49 +236,6 @@ export function getAccessibleBlockLabel(
 		/* translators: accessibility text. %s: The block title. */
 		__( '%s Block' ),
 		title
-	);
-}
-
-/**
- * Ensure attributes contains only values defined by block type, and merge
- * default values for missing attributes.
- *
- * @param {string} name       The block's name.
- * @param {Object} attributes The block's attributes.
- * @return {Object} The sanitized attributes.
- */
-export function __experimentalSanitizeBlockAttributes( name, attributes ) {
-	// Get the type definition associated with a registered block.
-	const blockType = getBlockType( name );
-
-	if ( undefined === blockType ) {
-		throw new Error( `Block type '${ name }' is not registered.` );
-	}
-
-	return reduce(
-		blockType.attributes,
-		( accumulator, schema, key ) => {
-			const value = attributes[ key ];
-
-			if ( undefined !== value ) {
-				accumulator[ key ] = value;
-			} else if ( schema.hasOwnProperty( 'default' ) ) {
-				accumulator[ key ] = schema.default;
-			}
-
-			if ( [ 'node', 'children' ].indexOf( schema.source ) !== -1 ) {
-				// Ensure value passed is always an array, which we're expecting in
-				// the RichText component to handle the deprecated value.
-				if ( typeof accumulator[ key ] === 'string' ) {
-					accumulator[ key ] = [ accumulator[ key ] ];
-				} else if ( ! Array.isArray( accumulator[ key ] ) ) {
-					accumulator[ key ] = [];
-				}
-			}
-
-			return accumulator;
-		},
-		{}
 	);
 }
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -302,31 +302,27 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 }
 
 /**
- * Given a block, remove any attributes with the given `role`.
+ * Given attributes, remove any attributes with the given `role`.
  *
- * @param {Object} block           Block instance.
- * @param {string} role            The role of a block attribute.
+ * @param {string} name       The block's name.
+ * @param {Object} attributes The block's attributes.
+ * @param {string} role       The role of a block attribute.
  *
- * @return {Object} The block, with attributes matching the `role` removed.
+ * @return {Object} The attributes, with those matching the `role` removed.
  */
-export function __experimentalRemoveAttributesByRole( block, role ) {
+export function __experimentalRemoveAttributesByRole( name, attributes, role ) {
 	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
-		block.name,
+		name,
 		role
 	);
 	if ( ! attributesByRole?.length ) {
-		return block;
+		return attributes;
 	}
 
-	block.attributes = Object.keys( block.attributes ).reduce(
-		( _accumulator, attribute ) => {
-			if ( ! attributesByRole.includes( attribute ) ) {
-				_accumulator[ attribute ] = block.attributes[ attribute ];
-			}
-			return _accumulator;
-		},
-		{}
-	);
-
-	return block;
+	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
+		if ( ! attributesByRole.includes( attribute ) ) {
+			_accumulator[ attribute ] = attributes[ attribute ];
+		}
+		return _accumulator;
+	}, {} );
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -302,25 +302,31 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 }
 
 /**
- * Given block attributes, return only those which do not have the `internal`
- * role.
+ * Given a block, remove any attributes with the given `role`.
  *
- * @param {string} name       The block's name
- * @param {Object} attributes The block's attributes
- * @return {Object} The attributes, stripped of any internal attributes.
+ * @param {Object} block           Block instance.
+ * @param {string} role            The role of a block attribute.
+ *
+ * @return {Object} The block, with attributes matching the `role` removed.
  */
-export function __experimentalStripInternalBlockAttributes( name, attributes ) {
-	const internalAttributes = __experimentalGetBlockAttributesNamesByRole(
-		name,
-		'internal'
+export function __experimentalRemoveAttributesByRole( block, role ) {
+	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
+		block.name,
+		role
+	);
+	if ( ! attributesByRole?.length ) {
+		return block;
+	}
+
+	block.attributes = Object.keys( block.attributes ).reduce(
+		( _accumulator, attribute ) => {
+			if ( ! attributesByRole.includes( attribute ) ) {
+				_accumulator[ attribute ] = block.attributes[ attribute ];
+			}
+			return _accumulator;
+		},
+		{}
 	);
 
-	if ( ! internalAttributes?.length ) return attributes;
-
-	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
-		if ( ! internalAttributes.includes( attribute ) ) {
-			_accumulator[ attribute ] = attributes[ attribute ];
-		}
-		return _accumulator;
-	}, {} );
+	return block;
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -257,29 +257,3 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 			attributes[ attributeName ]?.__experimentalRole === role
 	);
 }
-
-/**
- * Given attributes, remove any attributes with the given `role`.
- *
- * @param {string} name       The block's name.
- * @param {Object} attributes The block's attributes.
- * @param {string} role       The role of a block attribute.
- *
- * @return {Object} The attributes, with those matching the `role` removed.
- */
-export function __experimentalRemoveAttributesByRole( name, attributes, role ) {
-	const attributesByRole = __experimentalGetBlockAttributesNamesByRole(
-		name,
-		role
-	);
-	if ( ! attributesByRole?.length ) {
-		return attributes;
-	}
-
-	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
-		if ( ! attributesByRole.includes( attribute ) ) {
-			_accumulator[ attribute ] = attributes[ attribute ];
-		}
-		return _accumulator;
-	}, {} );
-}

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -300,3 +300,27 @@ export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
 			attributes[ attributeName ]?.__experimentalRole === role
 	);
 }
+
+/**
+ * Given block attributes, return only those which do not have the `internal`
+ * role.
+ *
+ * @param {string} name       The block's name
+ * @param {Object} attributes The block's attributes
+ * @return {Object} The attributes, stripped of any internal attributes.
+ */
+export function __experimentalStripInternalBlockAttributes( name, attributes ) {
+	const internalAttributes = __experimentalGetBlockAttributesNamesByRole(
+		name,
+		'internal'
+	);
+
+	if ( ! internalAttributes?.length ) return attributes;
+
+	return Object.keys( attributes ).reduce( ( _accumulator, attribute ) => {
+		if ( ! internalAttributes.includes( attribute ) ) {
+			_accumulator[ attribute ] = attributes[ attribute ];
+		}
+		return _accumulator;
+	}, {} );
+}

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { every, has, isFunction, isString, maxBy } from 'lodash';
+import { every, has, isFunction, isMatch, isString, maxBy } from 'lodash';
 import { colord, extend } from 'colord';
 import namesPlugin from 'colord/plugins/names';
 import a11yPlugin from 'colord/plugins/a11y';
@@ -240,20 +240,19 @@ export function getAccessibleBlockLabel(
 }
 
 /**
- * Filter block attributes by `role` and return their names.
+ * Filter block attributes by given options and return their names.
  *
- * @param {string} name Block attribute's name.
- * @param {string} role The role of a block attribute.
+ * @param {string} name    Block attribute's name.
+ * @param {Object} options Attribute properties to filter by.
  *
- * @return {string[]} The attribute names that have the provided role.
+ * @return {string[]} The attribute names that have the provided options.
  */
-export function __experimentalGetBlockAttributesNamesByRole( name, role ) {
+export function __experimentalFilterBlockAttributes( name, options ) {
 	const attributes = getBlockType( name )?.attributes;
 	if ( ! attributes ) return [];
+
 	const attributesNames = Object.keys( attributes );
-	if ( ! role ) return attributesNames;
-	return attributesNames.filter(
-		( attributeName ) =>
-			attributes[ attributeName ]?.__experimentalRole === role
+	return attributesNames.filter( ( attributeName ) =>
+		isMatch( attributes[ attributeName ], options )
 	);
 }

--- a/packages/customize-widgets/src/filters/move-to-sidebar.js
+++ b/packages/customize-widgets/src/filters/move-to-sidebar.js
@@ -55,10 +55,10 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 			const newSidebarControl = sidebarControls.find(
 				( sidebarControl ) => sidebarControl.id === sidebarControlId
 			);
-
-			if ( widgetId ) {
+			const activeSidebarAdapter = activeSidebarControl.sidebarAdapter;
+			if ( widgetId && activeSidebarAdapter.getWidget( widgetId ) ) {
 				/**
-				 * If there's a widgetId, move it to the other sidebar.
+				 * If there's an existing widget, move it to the other sidebar.
 				 */
 				const oldSetting = activeSidebarControl.setting;
 				const newSetting = newSidebarControl.setting;
@@ -67,15 +67,15 @@ const withMoveToSidebarToolbarItem = createHigherOrderComponent(
 				newSetting( [ ...newSetting(), widgetId ] );
 			} else {
 				/**
-				 * If there isn't a widgetId, it's most likely a inner block.
-				 * First, remove the block in the original sidebar,
+				 * If there isn't an existing widget with this id, it's most likely an
+				 * inner block. First, remove the block in the original sidebar,
 				 * then, create a new widget in the new sidebar and get back its widgetId.
 				 */
-				const sidebarAdapter = newSidebarControl.sidebarAdapter;
+				const newSidebarAdapter = newSidebarControl.sidebarAdapter;
 
 				removeBlock( clientId );
-				const addedWidgetIds = sidebarAdapter.setWidgets( [
-					...sidebarAdapter.getWidgets(),
+				const addedWidgetIds = newSidebarAdapter.setWidgets( [
+					...newSidebarAdapter.getWidgets(),
 					blockToWidget( block ),
 				] );
 				// The last non-null id is the added widget's id.

--- a/packages/customize-widgets/src/index.js
+++ b/packages/customize-widgets/src/index.js
@@ -8,6 +8,7 @@ import {
 	__experimentalRegisterExperimentalCoreBlocks,
 } from '@wordpress/block-library';
 import {
+	registerInternalWidgetIds,
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
 	registerWidgetGroupBlock,
@@ -59,6 +60,8 @@ export function initialize( editorName, blockEditorSettings ) {
 			block.name.startsWith( 'core/navigation' )
 		);
 	} );
+
+	registerInternalWidgetIds();
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {

--- a/packages/edit-widgets/src/index.js
+++ b/packages/edit-widgets/src/index.js
@@ -16,6 +16,7 @@ import {
 } from '@wordpress/block-library';
 import { __experimentalFetchLinkSuggestions as fetchLinkSuggestions } from '@wordpress/core-data';
 import {
+	registerInternalWidgetIds,
 	registerLegacyWidgetBlock,
 	registerLegacyWidgetVariations,
 	registerWidgetGroupBlock,
@@ -85,7 +86,10 @@ export function initialize( id, settings ) {
 		themeStyles: true,
 	} );
 
+	registerInternalWidgetIds();
+
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
+
 	registerCoreBlocks( coreBlocks );
 	registerLegacyWidgetBlock();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -28,7 +28,6 @@
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/api-fetch": "file:../api-fetch",
-		"@wordpress/blocks": "file:../blocks",
 		"@wordpress/components": "file:../components",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/data": "file:../data",

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -12,7 +12,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Placeholder, Spinner } from '@wordpress/components';
-import { __experimentalSanitizeBlockAttributes } from '@wordpress/blocks';
 
 export function rendererPath( block, attributes = null, urlQueryArgs = {} ) {
 	return addQueryArgs( `/wp/v2/block-renderer/${ block }`, {
@@ -88,20 +87,12 @@ export default function ServerSideRender( props ) {
 
 		setIsLoading( true );
 
-		const sanitizedAttributes =
-			attributes &&
-			__experimentalSanitizeBlockAttributes( block, attributes );
-
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.
 		// This allows sending a larger attributes object than in a GET request, where the attributes are in the URL.
 		const isPostRequest = 'POST' === httpMethod;
-		const urlAttributes = isPostRequest
-			? null
-			: sanitizedAttributes ?? null;
+		const urlAttributes = isPostRequest ? null : attributes ?? null;
 		const path = rendererPath( block, urlAttributes, urlQueryArgs );
-		const data = isPostRequest
-			? { attributes: sanitizedAttributes ?? null }
-			: null;
+		const data = isPostRequest ? { attributes: attributes ?? null } : null;
 
 		// Store the latest fetch request so that when we process it, we can
 		// check if it is the current request, to avoid race conditions on slow networks.

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -89,6 +89,7 @@ export default function ServerSideRender( props ) {
 
 		// The __internalWidgetId is only defined on the client-side and must be removed before making the
 		// request.
+		// TODO: Remove when the API is updated to allow additional properties: https://github.com/WordPress/gutenberg/issues/38754.
 		const retainedAttributes = omit( attributes, [ '__internalWidgetId' ] );
 
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.

--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
+import { isEqual, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -87,12 +87,18 @@ export default function ServerSideRender( props ) {
 
 		setIsLoading( true );
 
+		// The __internalWidgetId is only defined on the client-side and must be removed before making the
+		// request.
+		const retainedAttributes = omit( attributes, [ '__internalWidgetId' ] );
+
 		// If httpMethod is 'POST', send the attributes in the request body instead of the URL.
 		// This allows sending a larger attributes object than in a GET request, where the attributes are in the URL.
 		const isPostRequest = 'POST' === httpMethod;
-		const urlAttributes = isPostRequest ? null : attributes ?? null;
+		const urlAttributes = isPostRequest ? null : retainedAttributes ?? null;
 		const path = rendererPath( block, urlAttributes, urlQueryArgs );
-		const data = isPostRequest ? { attributes: attributes ?? null } : null;
+		const data = isPostRequest
+			? { attributes: retainedAttributes ?? null }
+			: null;
 
 		// Store the latest fetch request so that when we process it, we can
 		// check if it is the current request, to avoid race conditions on slow networks.

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -29,6 +29,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
+		"@wordpress/hooks": "file:.../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -29,7 +29,7 @@
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
 		"@wordpress/element": "file:../element",
-		"@wordpress/hooks": "file:.../hooks",
+		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -38,7 +38,7 @@ export function addWidgetIdToBlock( block, widgetId ) {
 
 /**
  * Filters registered block settings, extending attributes to include
- * `borderColor` if needed.
+ * `__internalWidgetId` if needed.
  *
  * @param {Object} settings Original block settings.
  *

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Get the internal widget id from block.
@@ -23,11 +27,33 @@ export function getWidgetIdFromBlock( block ) {
  * @return {Block} The updated block.
  */
 export function addWidgetIdToBlock( block, widgetId ) {
+	block.attributes.__internalWidgetId = widgetId;
+	return block;
+}
+
+/**
+ * Filters registered block settings, extending attributes to include
+ * `borderColor` if needed.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Updated block settings.
+ */
+function addAttributes( settings ) {
 	return {
-		...block,
+		...settings,
 		attributes: {
-			...( block.attributes || {} ),
-			__internalWidgetId: widgetId,
+			...settings.attributes,
+			__internalWidgetId: {
+				type: 'string',
+				__experimentalRole: 'internal',
+			},
 		},
 	};
 }
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/widget/addAttributes',
+	addAttributes
+);

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -27,8 +27,13 @@ export function getWidgetIdFromBlock( block ) {
  * @return {Block} The updated block.
  */
 export function addWidgetIdToBlock( block, widgetId ) {
-	block.attributes.__internalWidgetId = widgetId;
-	return block;
+	return {
+		...block,
+		attributes: {
+			...( block.attributes || {} ),
+			__internalWidgetId: widgetId,
+		},
+	};
 }
 
 /**
@@ -39,7 +44,7 @@ export function addWidgetIdToBlock( block, widgetId ) {
  *
  * @return {Object} Updated block settings.
  */
-function addAttributes( settings ) {
+function addInternalWidgetIdAttribute( settings ) {
 	return {
 		...settings,
 		attributes: {
@@ -52,8 +57,10 @@ function addAttributes( settings ) {
 	};
 }
 
-addFilter(
-	'blocks.registerBlockType',
-	'core/widget/addAttributes',
-	addAttributes
-);
+export function registerInternalWidgetIds() {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/widget/addAttributes',
+		addInternalWidgetIdAttribute
+	);
+}

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -51,7 +51,9 @@ function addInternalWidgetIdAttribute( settings ) {
 			...settings.attributes,
 			__internalWidgetId: {
 				type: 'string',
-				__experimentalRole: 'internal',
+				supports: {
+					copy: false,
+				},
 			},
 		},
 	};

--- a/packages/widgets/src/utils.js
+++ b/packages/widgets/src/utils.js
@@ -51,7 +51,7 @@ function addInternalWidgetIdAttribute( settings ) {
 			...settings.attributes,
 			__internalWidgetId: {
 				type: 'string',
-				supports: {
+				__experimentalSupports: {
 					copy: false,
 				},
 			},


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
Closes #29693
Alternative to #32604, #34750

## Description
<!-- Please describe what you have changed or added -->

This PR:
* Adds handling for a new `supports` object property to block attributes. It includes the `copy` support, used to indicate whether the attribute should be copied on block duplication. It is true by default.

Example fragment of block.json:

```
            "attributes": {
		"myAttributeThatShouldNotBeCopied": {
			"type": "string",
			"default": "my-default-value",
			"__experimentalSupports": {
				"copy": false,
			}
		}
	},
```
Copy support is true by default, meaning it is true if the `supports.copy` is not configured, and if the `supports` property is missing altogether.
* Refactors `__internalWidgetID` to use this new property/
 

For just one example of how this might be used: the Jetpack `Pay with Paypal` block uses a `productId` attribute to identify the actual product record referenced by the block. This data is meant to be internal to the block and should not be exposed to the user. When the user duplicates the block, we want to copy the other attributes used to store price info and other details, but create a brand new product record/productId.


## Notes

* In other regards, an attribute configured this way acts like a normal attribute
    * ~~It respects any configured default values~~ Default values are not filled in on block duplication either; support for this could be easily added if a viable use case becomes apparent, though
    * It can be managed as normal via `setAttributes`
    * It can apply to any type of attribute (ie it is not necessarily an id field)
* While you can give this role to an attribute with a "source"/"selector" configuration, it is not meaningful to do so. For example, adding it to the `content` attribute of the [Code block](https://github.com/WordPress/gutenberg/blob/a84c037a0e62a344005054102544c34d7b970a6b/packages/block-library/src/code/block.json#L9) would not make sense, because although the attribute would not be copied on duplication, it will populate with the same value from the html.
* Because this is experimental and also relies on experimental features, I have not added documentation; happy to do so if that is appropriate!
* A note about Reusable blocks:
Attributes without copy support are not removed when you convert a block into a Reusable block. I don’t know a ton about Reusable blocks, so calling this out so that someone more familiar can correct me; my understanding is that multiple instances of a Reusable block are not independent of each other (ie editing one copy affects them all), so even 'internal' attributes should also be shared.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
* Play around with adding `supports: { copy: false }` to any block attribute. 
* Insert the block into a new post, change its attributes, and duplicate it
* Verify that the un-copyable attributes were not copied, but all other attributes were
* ~~Test with attributes that have a `default` value and ensure that the default is respected in the duplicated block~~
* Test Copy+Paste using both the `Copy` menu item, and by keyboard commands
* Test duplicating a block in the widget editor
* Test adding and editing widgets in both the Widget editor and the Customizer
  * Test moving widgets between widget areas/side panels
  * Test a server-side rendered block in the widget editor and make sure the preview is displayed correctly (Basically verify that #29197 is still fixed with the new implementation)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
