### PR TITLE
Refresh `object-keys` version in package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45734,9 +45734,9 @@
 			}
 		},
 		"object-keys": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
 		"object-visit": {
 			"version": "1.0.1",


### PR DESCRIPTION
Fixes #13902

## Description

Bumps the `object-keys` version which was stuck on an old version in package-lock.

### Background

Deprecation warnings were emitted by one of our dependencies, the `object-keys` package (1.0.12). The [upstream issue was fixed](https://github.com/ljharb/object-keys/commit/4272beb18125b5d8be15b67a428f68f98ba28225) a few years ago in 1.1.1. Despite `npm ls` not revealing any hard dependencies on 1.0.12, our node modules were still resolving to 1.0.12. I think this is a case where our package-lock was simply stuck on an old version. Regenerating the package-lock from scratch does in fact make `object-keys` resolve to 1.1.1.

## Testing Instructions

1. `npm install`
2. In Firefox, go to wp-admin and edit a page.
3. These warnings should not be logged:

    ```
    onmozfullscreenchange is deprecated.
    onmozfullscreenerror is deprecated.
    ```

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
