### PR TITLE
Fix search block html handling for label and button text

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -42,16 +42,38 @@ function render_block_core_search( $attributes ) {
 	// Border color classes need to be applied to the elements that have a border color.
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
 
+	$wp_kses_formatting_tags = array(
+		'code'   => array(),
+		'em'     => array(),
+		'img'    => array(
+			'scale' => array(),
+			'class' => array(),
+			'style' => array(),
+			'src'   => array(),
+			'alt'   => array(),
+		),
+		's'      => array(),
+		'span'   => array(
+			'style' => array(),
+		),
+		'strong' => array(),
+	);
+
+	$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses(
+		$attributes['label'],
+		$wp_kses_formatting_tags
+	);
+
 	$label_markup = sprintf(
 		'<label for="%1$s" class="wp-block-search__label screen-reader-text">%2$s</label>',
 		esc_attr( $input_id ),
-		empty( $attributes['label'] ) ? __( 'Search' ) : esc_html( $attributes['label'] )
+		$label_inner_html
 	);
 	if ( $show_label && ! empty( $attributes['label'] ) ) {
 		$label_markup = sprintf(
 			'<label for="%1$s" class="wp-block-search__label">%2$s</label>',
 			$input_id,
-			esc_html( $attributes['label'] )
+			$label_inner_html
 		);
 	}
 
@@ -76,7 +98,10 @@ function render_block_core_search( $attributes ) {
 		}
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
-				$button_internal_markup = esc_html( $attributes['buttonText'] );
+				$button_internal_markup = wp_kses(
+					$attributes['buttonText'],
+					$wp_kses_formatting_tags
+				);
 			}
 		} else {
 			$button_classes        .= ' has-icon';

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -42,27 +42,7 @@ function render_block_core_search( $attributes ) {
 	// Border color classes need to be applied to the elements that have a border color.
 	$border_color_classes = get_border_color_classes_for_block_core_search( $attributes );
 
-	$wp_kses_formatting_tags = array(
-		'code'   => array(),
-		'em'     => array(),
-		'img'    => array(
-			'scale' => array(),
-			'class' => array(),
-			'style' => array(),
-			'src'   => array(),
-			'alt'   => array(),
-		),
-		's'      => array(),
-		'span'   => array(
-			'style' => array(),
-		),
-		'strong' => array(),
-	);
-
-	$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses(
-		$attributes['label'],
-		$wp_kses_formatting_tags
-	);
+	$label_inner_html = empty( $attributes['label'] ) ? __( 'Search' ) : wp_kses_post( $attributes['label'] );
 
 	$label_markup = sprintf(
 		'<label for="%1$s" class="wp-block-search__label screen-reader-text">%2$s</label>',
@@ -98,10 +78,7 @@ function render_block_core_search( $attributes ) {
 		}
 		if ( ! $use_icon_button ) {
 			if ( ! empty( $attributes['buttonText'] ) ) {
-				$button_internal_markup = wp_kses(
-					$attributes['buttonText'],
-					$wp_kses_formatting_tags
-				);
+				$button_internal_markup = wp_kses_post( $attributes['buttonText'] );
 			}
 		} else {
 			$button_classes        .= ' has-icon';


### PR DESCRIPTION
## Description
Fixes #38644

The search block was outputting escaped html in its label and button text, when it should have been outputting the tags.

In this PR I've swapped out `esc_html` for `wp_kses`.

## Testing Instructions
1. Add a search block to a post
2. Use formatting on the label and button text (e.g. bold, italic)
3. Preview the post

Expected - the formatting should be displayed correctly

## Screenshots <!-- if applicable -->
#### Before
![Screen Shot 2022-02-09 at 10 01 05 am](https://user-images.githubusercontent.com/677833/153111491-f496388f-a965-405f-99ae-beac1edb034f.png)

#### After
![Screen Shot 2022-02-09 at 10 39 20 am](https://user-images.githubusercontent.com/677833/153111530-91e1c839-4596-4bdf-8abd-3107f141e34d.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
