### PR TITLE
Fix filtering of content when rendering read more block

### DIFF
--- a/packages/block-library/src/read-more/index.php
+++ b/packages/block-library/src/read-more/index.php
@@ -21,7 +21,7 @@ function render_block_core_read_more( $attributes, $content, $block ) {
 	$post_ID            = $block->context['postId'];
 	$justify_class_name = empty( $attributes['justifyContent'] ) ? '' : "is-justified-{$attributes['justifyContent']}";
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $justify_class_name ) );
-	$more_text          = ! empty( $attributes['content'] ) ? $attributes['content'] : __( 'Read more' );
+	$more_text          = ! empty( $attributes['content'] ) ? wp_kses_post( $attributes['content'] ) : __( 'Read more' );
 	return sprintf(
 		'<a %1s href="%2s" target="%3s">%4s</a>',
 		$wrapper_attributes,


### PR DESCRIPTION
## Description
The Read More block is a new unreleased block. It has a content attribute that's user supplied and can contain html.

When rendering this, it should be filtered for unwanted html. This PR implements that.

## Testing Instructions
1. Add a read more block to a post
2. Enter some text for the Read More links label
3. Apply formatting to the Read More (e.g. bold, italic)
4. Preview the post

Expected: formatting should be preserved.

## Screenshots <!-- if applicable -->
![Screen Shot 2022-02-09 at 12 03 11 pm](https://user-images.githubusercontent.com/677833/153119684-eda6ef6c-a212-4f20-bbb9-6fcb11d57212.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
