### PR TITLE
Block Manager: Announce search results

### DIFF
--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -53,7 +53,7 @@ function BlockManager( {
 			count
 		);
 		debouncedSpeak( resultsFoundMessage );
-	}, [ search, debouncedSpeak ] );
+	}, [ blockTypes, search, debouncedSpeak ] );
 
 	return (
 		<div className="edit-post-block-manager__content">

--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -10,7 +10,9 @@ import { store as blocksStore } from '@wordpress/blocks';
 import { withSelect } from '@wordpress/data';
 import { SearchControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Internal dependencies
@@ -25,6 +27,7 @@ function BlockManager( {
 	isMatchingSearchTerm,
 	numberOfHiddenBlocks,
 } ) {
+	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ search, setSearch ] = useState( '' );
 
 	// Filtering occurs here (as opposed to `withSelect`) to avoid
@@ -37,6 +40,20 @@ function BlockManager( {
 			( ! blockType.parent ||
 				includes( blockType.parent, 'core/post-content' ) )
 	);
+
+	// Announce search results on change
+	useEffect( () => {
+		if ( ! search ) {
+			return;
+		}
+		const count = blockTypes.length;
+		const resultsFoundMessage = sprintf(
+			/* translators: %d: number of results. */
+			_n( '%d result found.', '%d results found.', count ),
+			count
+		);
+		debouncedSpeak( resultsFoundMessage );
+	}, [ search, debouncedSpeak ] );
 
 	return (
 		<div className="edit-post-block-manager__content">

--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -53,7 +53,7 @@ function BlockManager( {
 			count
 		);
 		debouncedSpeak( resultsFoundMessage );
-	}, [ blockTypes, search, debouncedSpeak ] );
+	}, [ blockTypes.length, search, debouncedSpeak ] );
 
 	return (
 		<div className="edit-post-block-manager__content">


### PR DESCRIPTION
## Description
Resolves #15498.

Announce search results in Block Manager. This matches behavior of Inserter and Patterns search fields.

## Testing Instructions
1. Open Preferences modal and navigate to Block Manager.
2. Enable VoiceOver.
3. Confirm that search results are announced.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-09 at 11 28 45](https://user-images.githubusercontent.com/240569/153142755-4840fb0f-cb06-45ce-b46c-ebb448e14ad6.png)

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
