### PR TITLE
Add site editor initial redirect error handling

### DIFF
--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -2,19 +2,11 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
-import { Warning } from '@wordpress/block-editor';
-import { useCopyToClipboard } from '@wordpress/compose';
 
-function CopyButton( { text, children } ) {
-	const ref = useCopyToClipboard( text );
-	return (
-		<Button variant="secondary" ref={ ref }>
-			{ children }
-		</Button>
-	);
-}
+/**
+ * Internal dependencies
+ */
+import ErrorBoundaryWarning from './warning';
 
 export default class ErrorBoundary extends Component {
 	constructor() {
@@ -41,24 +33,6 @@ export default class ErrorBoundary extends Component {
 			return this.props.children;
 		}
 
-		return (
-			<Warning
-				className="editor-error-boundary"
-				actions={ [
-					<Button
-						key="recovery"
-						onClick={ this.reboot }
-						variant="secondary"
-					>
-						{ __( 'Attempt Recovery' ) }
-					</Button>,
-					<CopyButton key="copy-error" text={ error.stack }>
-						{ __( 'Copy Error' ) }
-					</CopyButton>,
-				] }
-			>
-				{ __( 'The editor has encountered an unexpected error.' ) }
-			</Warning>
-		);
+		return <ErrorBoundaryWarning error={ error } reboot={ this.reboot } />;
 	}
 }

--- a/packages/edit-site/src/components/error-boundary/index.js
+++ b/packages/edit-site/src/components/error-boundary/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -33,6 +34,14 @@ export default class ErrorBoundary extends Component {
 			return this.props.children;
 		}
 
-		return <ErrorBoundaryWarning error={ error } reboot={ this.reboot } />;
+		return (
+			<ErrorBoundaryWarning
+				message={ __(
+					'The editor has encountered an unexpected error.'
+				) }
+				error={ error }
+				reboot={ this.reboot }
+			/>
+		);
 	}
 }

--- a/packages/edit-site/src/components/error-boundary/warning.js
+++ b/packages/edit-site/src/components/error-boundary/warning.js
@@ -15,7 +15,12 @@ function CopyButton( { text, children } ) {
 	);
 }
 
-export default function ErrorBoundaryWarning( { error, reboot } ) {
+export default function ErrorBoundaryWarning( {
+	message,
+	error,
+	reboot,
+	dashboardLink,
+} ) {
 	const actions = [];
 
 	if ( reboot ) {
@@ -34,9 +39,21 @@ export default function ErrorBoundaryWarning( { error, reboot } ) {
 		);
 	}
 
+	if ( dashboardLink ) {
+		actions.push(
+			<Button
+				key="back-to-dashboard"
+				variant="secondary"
+				href={ dashboardLink }
+			>
+				{ __( 'Back to dashboard' ) }
+			</Button>
+		);
+	}
+
 	return (
 		<Warning className="editor-error-boundary" actions={ actions }>
-			{ __( 'The editor has encountered an unexpected error.' ) }
+			{ message }
 		</Warning>
 	);
 }

--- a/packages/edit-site/src/components/error-boundary/warning.js
+++ b/packages/edit-site/src/components/error-boundary/warning.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { Warning } from '@wordpress/block-editor';
+import { useCopyToClipboard } from '@wordpress/compose';
+
+function CopyButton( { text, children } ) {
+	const ref = useCopyToClipboard( text );
+	return (
+		<Button variant="secondary" ref={ ref }>
+			{ children }
+		</Button>
+	);
+}
+
+export default function ErrorBoundaryWarning( { error, reboot } ) {
+	const actions = [];
+
+	if ( reboot ) {
+		actions.push(
+			<Button key="recovery" onClick={ reboot } variant="secondary">
+				{ __( 'Attempt Recovery' ) }
+			</Button>
+		);
+	}
+
+	if ( error ) {
+		actions.push(
+			<CopyButton key="copy-error" text={ error.stack }>
+				{ __( 'Copy Error' ) }
+			</CopyButton>
+		);
+	}
+
+	return (
+		<Warning className="editor-error-boundary" actions={ actions }>
+			{ __( 'The editor has encountered an unexpected error.' ) }
+		</Warning>
+	);
+}

--- a/packages/edit-site/src/components/routes/redirect-to-homepage.js
+++ b/packages/edit-site/src/components/routes/redirect-to-homepage.js
@@ -20,10 +20,17 @@ function getNeedsHomepageRedirect( params ) {
 	);
 }
 
+/**
+ * Returns the postType and postId of the default homepage.
+ *
+ * @param {string} siteUrl The URL of the site.
+ * @return {Object} An object containing the postType and postId properties
+ *                  or `undefined` if a homepage could not be found.
+ */
 async function getHomepageParams( siteUrl ) {
 	const siteSettings = await apiFetch( { path: '/wp/v2/settings' } );
 	if ( ! siteSettings ) {
-		return;
+		throw new Error( '`getHomepageParams`: unable to load site settings.' );
 	}
 
 	const {
@@ -48,7 +55,7 @@ async function getHomepageParams( siteUrl ) {
 		.then( ( { data } ) => data );
 
 	if ( ! template?.id ) {
-		return;
+		throw new Error( '`getHomepageParams`: unable to find home template.' );
 	}
 
 	return {

--- a/packages/edit-site/src/components/routes/redirect-to-homepage.js
+++ b/packages/edit-site/src/components/routes/redirect-to-homepage.js
@@ -57,9 +57,18 @@ async function getHomepageParams( siteUrl ) {
 					`\`getHomepageParams\`: HTTP status error, ${ response.status } ${ response.statusText }`
 				);
 			}
+
 			return response.json();
 		} )
-		.then( ( { data } ) => data );
+		.then( ( { data } ) => {
+			if ( data.message ) {
+				throw new Error(
+					`\`getHomepageParams\`: REST API error, ${ data.message }`
+				);
+			}
+
+			return data;
+		} );
 
 	if ( ! template?.id ) {
 		throw new Error( '`getHomepageParams`: unable to find home template.' );

--- a/packages/edit-site/src/components/routes/redirect-to-homepage.js
+++ b/packages/edit-site/src/components/routes/redirect-to-homepage.js
@@ -51,7 +51,14 @@ async function getHomepageParams( siteUrl ) {
 	// (packages/core-data/src/resolvers.js)
 	const template = await window
 		.fetch( addQueryArgs( siteUrl, { '_wp-find-template': true } ) )
-		.then( ( res ) => res.json() )
+		.then( ( response ) => {
+			if ( ! response.ok ) {
+				throw new Error(
+					`\`getHomepageParams\`: HTTP status error, ${ response.status } ${ response.statusText }`
+				);
+			}
+			return response.json();
+		} )
 		.then( ( { data } ) => data );
 
 	if ( ! template?.id ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -49,6 +49,7 @@ export async function reinitializeEditor( target, settings ) {
 			/>,
 			target
 		);
+		return;
 	}
 
 	// This will be a no-op if the target doesn't have any React nodes.

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -13,6 +13,7 @@ import {
 	__experimentalFetchUrlData as fetchUrlData,
 } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
 import { store as viewportStore } from '@wordpress/viewport';
 import { getQueryArgs } from '@wordpress/url';
 
@@ -44,8 +45,12 @@ export async function reinitializeEditor( target, settings ) {
 	} catch ( error ) {
 		render(
 			<ErrorBoundaryWarning
+				message={ __(
+					'The editor is unable to find a block template for the homepage.'
+				) }
 				error={ error }
 				reboot={ () => reinitializeEditor( target, settings ) }
+				dashboardLink="index.php"
 			/>,
 			target
 		);

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -24,6 +24,7 @@ import { store as editSiteStore } from './store';
 import EditSiteApp from './components/app';
 import getIsListPage from './utils/get-is-list-page';
 import redirectToHomepage from './components/routes/redirect-to-homepage';
+import ErrorBoundaryWarning from './components/error-boundary/warning';
 
 /**
  * Reinitializes the editor after the user chooses to reboot the editor after
@@ -38,7 +39,17 @@ export async function reinitializeEditor( target, settings ) {
 	// define what's being edited. When visiting via the dashboard link, these
 	// won't be present. Do a client side redirect to the 'homepage' if that's
 	// the case.
-	await redirectToHomepage( settings.siteUrl );
+	try {
+		await redirectToHomepage( settings.siteUrl );
+	} catch ( error ) {
+		render(
+			<ErrorBoundaryWarning
+				error={ error }
+				reboot={ () => reinitializeEditor( target, settings ) }
+			/>,
+			target
+		);
+	}
 
 	// This will be a no-op if the target doesn't have any React nodes.
 	unmountComponentAtNode( target );

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -49,7 +49,6 @@ export async function reinitializeEditor( target, settings ) {
 					'The editor is unable to find a block template for the homepage.'
 				) }
 				error={ error }
-				reboot={ () => reinitializeEditor( target, settings ) }
 				dashboardLink="index.php"
 			/>,
 			target


### PR DESCRIPTION
## Description
Partly addresses #37236.

Adds some error handling to the site editors loading process. If an error happens when trying to fetch the home template, the editor will now show the usual error boundary warning

The caveat here is that the code in `trunk` is different to that in `wp/5.9`. The loading process was refactored in https://github.com/WordPress/gutenberg/pull/37248.

If this improvement needs to land in 5.9.x the options are:
a) backport both #37248 and this 
b) develop a separate fix for the code on `wp/5.9`.

## Testing Instructions
This is tricky to test. As suggested by @Mamaduka I modified the API response - https://github.com/WordPress/gutenberg/issues/37236#issuecomment-990934247.

But I had to use a development environment for both wordpress-develop and gutenberg and comment out the corresponding line in wordpress-develop.

1. Comment out this line - https://github.com/WordPress/wordpress-develop/blob/f745cc551bb0a54d7df72ec97d23e3359c56048d/src/wp-includes/block-template.php#L88
2. Load the site editor

Expected - an error should be shown

## Screenshots <!-- if applicable -->
![Screen Shot 2022-02-10 at 4 25 16 pm](https://user-images.githubusercontent.com/677833/153367131-7031bf0a-f126-4d45-a464-ed9d794482be.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
