### PR TITLE
Site Editor: Add template check to 'setPage' action.

### DIFF
--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -211,11 +211,17 @@ export function* setPage( page ) {
 		// If the entity is undefined for some reason, path will resolve to "/"
 		page.path = getPathAndQueryString( entity?.link );
 	}
-	const { id: templateId, slug: templateSlug } = yield controls.resolveSelect(
+	const template = yield controls.resolveSelect(
 		coreStore,
 		'__experimentalGetTemplateForLink',
 		page.path
 	);
+
+	if ( ! template ) {
+		return;
+	}
+
+	const { id: templateId, slug: templateSlug } = template;
 	yield {
 		type: 'SET_PAGE',
 		page: ! templateSlug


### PR DESCRIPTION
## Description
The `__experimentalGetTemplateForLink` selector can return `null` when there's no template. PR adds check to avoid errors during destructuring.

https://github.com/WordPress/gutenberg/blob/fe8707ba2e3ce1cae44ed1d556115d5e785ca897/packages/core-data/src/selectors.js#L880-L895

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
