### PR TITLE
Remove the div wrapper from the aligned image blocks

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -233,3 +233,36 @@ if ( function_exists( 'wp_restore_group_inner_container' ) ) {
 	remove_filter( 'render_block', 'wp_restore_group_inner_container', 10, 2 );
 }
 add_filter( 'render_block', 'gutenberg_restore_group_inner_container', 10, 2 );
+
+
+/**
+ * For themes without theme.json file, make sure
+ * to restore the outer div for the aligned image block
+ * to avoid breaking styles relying on that div.
+ *
+ * @param string $block_content Rendered block content.
+ * @param array  $block         Block object.
+ * @return string Filtered block content.
+ */
+function gutenberg_restore_image_outer_container( $block_content, $block ) {
+	$image_with_align = '/(^\s*<figure\b[^>]*)wp-block-image\s([^"]*((alignleft)|(alignright)|(aligncenter))(\s|")[^>]*>((.|\S|\s)*)<\/figure>)/U';
+
+	if (
+		'core/image' !== $block['blockName'] ||
+		WP_Theme_JSON_Resolver::theme_has_support() ||
+		0 === preg_match( $image_with_align, $block_content )
+	) {
+		return $block_content;
+	}
+
+	$updated_content = preg_replace_callback(
+		$image_with_align,
+		static function( $matches ) {
+			return '<div class="wp-block-image">' . $matches[1] . $matches[2] . '</div>';
+		},
+		$block_content
+	);
+	return $updated_content;
+}
+
+add_filter( 'render_block', 'gutenberg_restore_image_outer_container', 10, 2 );

--- a/packages/block-library/src/image/deprecated.js
+++ b/packages/block-library/src/image/deprecated.js
@@ -2,11 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 
 const blockAttributes = {
 	align: {
@@ -68,7 +69,110 @@ const blockAttributes = {
 	},
 };
 
+const blockSupports = {
+	anchor: true,
+	color: {
+		__experimentalDuotone: 'img',
+		text: false,
+		background: false,
+	},
+	__experimentalBorder: {
+		radius: true,
+		__experimentalDefaultControls: {
+			radius: true,
+		},
+	},
+};
+
 const deprecated = [
+	{
+		attributes: {
+			...blockAttributes,
+			title: {
+				type: 'string',
+				source: 'attribute',
+				selector: 'img',
+				attribute: 'title',
+			},
+			sizeSlug: {
+				type: 'string',
+			},
+		},
+		supports: blockSupports,
+		save( { attributes } ) {
+			const {
+				url,
+				alt,
+				caption,
+				align,
+				href,
+				rel,
+				linkClass,
+				width,
+				height,
+				id,
+				linkTarget,
+				sizeSlug,
+				title,
+			} = attributes;
+
+			const newRel = isEmpty( rel ) ? undefined : rel;
+
+			const classes = classnames( {
+				[ `align${ align }` ]: align,
+				[ `size-${ sizeSlug }` ]: sizeSlug,
+				'is-resized': width || height,
+			} );
+
+			const image = (
+				<img
+					src={ url }
+					alt={ alt }
+					className={ id ? `wp-image-${ id }` : null }
+					width={ width }
+					height={ height }
+					title={ title }
+				/>
+			);
+
+			const figure = (
+				<>
+					{ href ? (
+						<a
+							className={ linkClass }
+							href={ href }
+							target={ linkTarget }
+							rel={ newRel }
+						>
+							{ image }
+						</a>
+					) : (
+						image
+					) }
+					{ ! RichText.isEmpty( caption ) && (
+						<RichText.Content
+							tagName="figcaption"
+							value={ caption }
+						/>
+					) }
+				</>
+			);
+
+			if ( 'left' === align || 'right' === align || 'center' === align ) {
+				return (
+					<div { ...useBlockProps.save() }>
+						<figure className={ classes }>{ figure }</figure>
+					</div>
+				);
+			}
+
+			return (
+				<figure { ...useBlockProps.save( { className: classes } ) }>
+					{ figure }
+				</figure>
+			);
+		},
+	},
 	{
 		attributes: blockAttributes,
 		save( { attributes } ) {

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -65,14 +65,6 @@ export default function save( { attributes } ) {
 		</>
 	);
 
-	if ( 'left' === align || 'right' === align || 'center' === align ) {
-		return (
-			<div { ...useBlockProps.save() }>
-				<figure className={ classes }>{ figure }</figure>
-			</div>
-		);
-	}
-
 	return (
 		<figure { ...useBlockProps.save( { className: classes } ) }>
 			{ figure }

--- a/test/integration/fixtures/blocks/core__image__center-caption.html
+++ b/test/integration/fixtures/blocks/core__image__center-caption.html
@@ -1,3 +1,3 @@
 <!-- wp:core/image {"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>
+<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>
 <!-- /wp:core/image -->

--- a/test/integration/fixtures/blocks/core__image__center-caption.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__center-caption.parsed.json
@@ -5,9 +5,9 @@
 			"align": "center"
 		},
 		"innerBlocks": [],
-		"innerHTML": "\n<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>\n",
+		"innerHTML": "\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-image\"><figure class=\"aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure></div>\n"
+			"\n<figure class=\"wp-block-image aligncenter\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" /><figcaption>Give it a try. Press the &quot;really wide&quot; button on the image toolbar.</figcaption></figure>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__image__center-caption.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__center-caption.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"center"} -->
-<div class="wp-block-image"><figure class="aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure></div>
+<figure class="wp-block-image aligncenter"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/><figcaption>Give it a try. Press the "really wide" button on the image toolbar.</figcaption></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-1.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-1.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left"} -->
-<div class="wp-block-image"><figure class="alignleft"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></figure></div>
+<figure class="wp-block-image alignleft"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt=""/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-2.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-2.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","width":100,"height":100} -->
-<div class="wp-block-image"><figure class="alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" width="100" height="100"/></figure></div>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" width="100" height="100"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-3.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-3.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:image {"align":"left","width":100,"height":100} -->
-<div class="wp-block-image"><figure class="alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" width="100" height="100"/></figure></div>
+<figure class="wp-block-image alignleft is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" width="100" height="100"/></figure>
 <!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"align":"left","id":13,"width":358,"height":164,"sizeSlug":"large","linkDestination":"none","style":{"border":{"radius":"10px"}}} -->
+<div class="wp-block-image" style="border-radius:10px"><figure class="alignleft size-large is-resized"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" width="358" height="164"/></figure></div>
+<!-- /wp:image -->

--- a/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.json
@@ -1,0 +1,23 @@
+[
+	{
+		"name": "core/image",
+		"isValid": true,
+		"attributes": {
+			"align": "left",
+			"url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==",
+			"alt": "",
+			"caption": "",
+			"id": 13,
+			"width": 358,
+			"height": 164,
+			"linkDestination": "none",
+			"sizeSlug": "large",
+			"style": {
+				"border": {
+					"radius": "10px"
+				}
+			}
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.parsed.json
+++ b/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.parsed.json
@@ -1,0 +1,23 @@
+[
+	{
+		"blockName": "core/image",
+		"attrs": {
+			"align": "left",
+			"id": 13,
+			"width": 358,
+			"height": 164,
+			"sizeSlug": "large",
+			"linkDestination": "none",
+			"style": {
+				"border": {
+					"radius": "10px"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-image\" style=\"border-radius:10px\"><figure class=\"alignleft size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" class=\"wp-image-13\" width=\"358\" height=\"164\"/></figure></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-image\" style=\"border-radius:10px\"><figure class=\"alignleft size-large is-resized\"><img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==\" alt=\"\" class=\"wp-image-13\" width=\"358\" height=\"164\"/></figure></div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.serialized.html
+++ b/test/integration/fixtures/blocks/core__image__deprecated-align-wrapper.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:image {"align":"left","id":13,"width":358,"height":164,"sizeSlug":"large","linkDestination":"none","style":{"border":{"radius":"10px"}}} -->
+<figure class="wp-block-image alignleft size-large is-resized" style="border-radius:10px"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==" alt="" class="wp-image-13" width="358" height="164"/></figure>
+<!-- /wp:image -->

--- a/test/integration/fixtures/documents/wordpress-out.html
+++ b/test/integration/fixtures/documents/wordpress-out.html
@@ -27,7 +27,7 @@
 <!-- /wp:image -->
 
 <!-- wp:image {"align":"right","id":5114} -->
-<div class="wp-block-image"><figure class="alignright"><img src="aligned.png" alt="" class="wp-image-5114"/></figure></div>
+<figure class="wp-block-image alignright"><img src="aligned.png" alt="" class="wp-image-5114"/></figure>
 <!-- /wp:image -->
 
 <!-- wp:paragraph -->


### PR DESCRIPTION
Related #38613 

For historic reasons, the image block had a div wrapper around the block when it was left/right or center aligned (Frontend only). This has a number of issues:

 - It's inconsistent with other blocks,
 - It makes the markup of the frontend and the backend different

In this PR, I'm updating the image block to remove that extra div and make the block work like any other block. That said, and since this block has been like that for a long time, I'm dynamically restoring that div in the frontend for classic themes (themes without theme.json and layout support). The idea is that if you don't use the layout, you're providing your own alignment styles, so we should limit the impact with your theme's existing styles for backward compatibility. 

**Testing instructions**

This is a somewhat impactful change that we need to check properly:

 - We need to test that image blocks (aligned left, right or center) with the old markup are upgraded properly to the new markup without block invalidation when opening the editor.
 - We need to check that the markup in the frontend stayed exactly the same for classic themes for these blocks (avoid breakage)
 - We need to check that for FSE themes, there's no extra div in the frontend for aligned (left, right or center) blocks making the behavior consistent between the frontend and the backend.

I'd appreciate a lot of help testing this PR cause it can be impactful.