### PR TITLE
Use the theme.json classes defined by the plugin in the REST controller

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-wp-rest-global-styles-controller.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'WP_REST_Global_Styles_Controller' ) ) {
 					$config['settings'] = $existing_config['settings'];
 				}
 				$config['isGlobalStylesUserThemeJSON'] = true;
-				$config['version']                     = WP_Theme_JSON::LATEST_SCHEMA;
+				$config['version']                     = WP_Theme_JSON_Gutenberg::LATEST_SCHEMA;
 				$changes->post_content                 = wp_json_encode( $config );
 			}
 
@@ -307,7 +307,7 @@ if ( ! class_exists( 'WP_REST_Global_Styles_Controller' ) ) {
 			$is_global_styles_user_theme_json = isset( $raw_config['isGlobalStylesUserThemeJSON'] ) && true === $raw_config['isGlobalStylesUserThemeJSON'];
 			$config                           = array();
 			if ( $is_global_styles_user_theme_json ) {
-				$config = ( new WP_Theme_JSON( $raw_config, 'custom' ) )->get_raw_data();
+				$config = ( new WP_Theme_JSON_Gutenberg( $raw_config, 'custom' ) )->get_raw_data();
 			}
 
 			// Base fields for every post.
@@ -555,7 +555,7 @@ if ( ! class_exists( 'WP_REST_Global_Styles_Controller' ) ) {
 				);
 			}
 
-			$theme  = WP_Theme_JSON_Resolver::get_merged_data( 'theme' );
+			$theme  = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data( 'theme' );
 			$data   = array();
 			$fields = $this->get_fields_for_response( $request );
 


### PR DESCRIPTION
This PR updates the REST controller to use the classes defined by the plugin instead of using the ones defined by WordPress.

The plugin supports WordPress 5.8 and WordPress 5.9. Both versions have the theme.json classes but use different implementations. Using the classes defined by WordPress is problematic because the endpoint defined by the plugin will behave differently depending on the WordPress version, so we should use the ones defined by the plugin.

Some examples of things that are different that could affect this endpoint: the `LATEST_SCHEMA` changes from 1 to 2, the constructor does more things in 5.9 (such as checking whether we should remove theme colors that are already defined by core or opt-in into a few defaults), the resolver looks up for child themes in 5.9.
