### PR TITLE
Replace no-shadow eslint rule with @typescript-eslint/no-shadow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,8 +67,6 @@ module.exports = {
 		'@wordpress/data-no-store-string-literals': 'error',
 		'import/default': 'error',
 		'import/named': 'error',
-		'no-shadow': 'off',
-		'@typescript-eslint/no-shadow': 'error',
 		'no-restricted-imports': [
 			'error',
 			{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -67,6 +67,8 @@ module.exports = {
 		'@wordpress/data-no-store-string-literals': 'error',
 		'import/default': 'error',
 		'import/named': 'error',
+		'no-shadow': 'off',
+		'@typescript-eslint/no-shadow': 'error',
 		'no-restricted-imports': [
 			'error',
 			{

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+–   Replaced no-shadow eslint rule with @typescript-eslint/no-shadow ([#38665](https://github.com/WordPress/gutenberg/pull/38665)).
+
 ## 10.0.0 (2022-01-27)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -50,6 +50,9 @@ if ( isPackageInstalled( 'typescript' ) ) {
 				'jsdoc/require-returns-type': 'off',
 				// handled by TS itself
 				'no-unused-vars': 'off',
+				// no-shadow doesn't work correctly in TS, so let's use a TS-dedicated version instead.
+				'no-shadow': 'off',
+				'@typescript-eslint/no-shadow': 'error',
 			},
 		},
 	];


### PR DESCRIPTION
## Description
At the moment, declaring any typescript enum triggers the following eslint error:

```
ESLint: 'Status' is already declared in the upper scope on line 1 column 13.(no-shadow)
```

You can confirm that by creating a `status.ts` file somewhere in the repo and pasting the following contents:

```ts
export enum Status {
	Idle = 'IDLE',
	Resolving = 'RESOLVING',
	Error = 'ERROR',
	Success = 'SUCCESS',
}
```

[The StackOverflow discussion](https://stackoverflow.com/questions/63961803/eslint-says-all-enums-in-typescript-app-are-already-declared-in-the-upper-scope
) reveals there is a dedicated `no-shadow` rule for typescript code called `@typescript-eslint/no-shadow`:

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-shadow.md#how-to-use

And so I propose we use that rule instead.

## Testing Instructions
1. Confirm all the checks are green
2. Confirm that `@typescript-eslint/no-shadow` covers the same cases as `no-shadow`

cc @gziolo @kevin940726 @youknowriad @jsnajdr