### PR TITLE
Handle resolution errors in @wordpress/data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19364,16 +19364,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"are-we-there-yet": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19364,6 +19364,16 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
+						"are-we-there-yet": {
+							"version": "2.0.0",
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+							"dev": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### New Features
 
 - Enabled thunks by default for all stores and removed the `__experimentalUseThunks` flag.
+- Store the resolution errors in store metadata and expose them using `hasResolutionFailed` the `getResolutionError` meta-selectors ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
+- Expose the resolution status (undefined, resolving, finished, error) via the `getResolutionState` meta-selector ([#38669](https://github.com/WordPress/gutenberg/pull/38669)).
 
 ## 6.2.1 (2022-02-10)
 

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -352,7 +352,7 @@ function mapResolveSelectors( selectors, store ) {
 				// trigger the selector (to trigger the resolver)
 				const result = getResult();
 				if ( hasFinished() ) {
-					finalize( result );
+					return finalize( result );
 				}
 
 				const unsubscribe = store.subscribe( () => {

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -441,12 +441,12 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 								args
 							)
 						);
-					} catch ( e ) {
+					} catch ( error ) {
 						store.dispatch(
 							metadataActions.failResolution(
 								selectorName,
 								args,
-								e
+								error
 							)
 						);
 					}

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -413,25 +413,28 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 					store.dispatch(
 						metadataActions.startResolution( selectorName, args )
 					);
-					// try {
-					await fulfillResolver(
-						store,
-						mappedResolvers,
-						selectorName,
-						...args
-					);
-					store.dispatch(
-						metadataActions.finishResolution( selectorName, args )
-					);
-					// } catch ( e ) {
-					// 	store.dispatch(
-					// 		metadataActions.failResolution(
-					// 			selectorName,
-					// 			args,
-					// 			e
-					// 		)
-					// 	);
-					// }
+					try {
+						await fulfillResolver(
+							store,
+							mappedResolvers,
+							selectorName,
+							...args
+						);
+						store.dispatch(
+							metadataActions.finishResolution(
+								selectorName,
+								args
+							)
+						);
+					} catch ( e ) {
+						store.dispatch(
+							metadataActions.failResolution(
+								selectorName,
+								args,
+								e
+							)
+						);
+					}
 				} );
 			}
 

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -334,12 +334,12 @@ function mapResolveSelectors( selectors, store ) {
 				const hasFinished = () =>
 					selectors.hasFinishedResolution( selectorName, args );
 				const finalize = ( result ) => {
-					const hasFailed = selectors.hasLastResolutionFailed(
+					const hasFailed = selectors.hasResolutionFailed(
 						selectorName,
 						args
 					);
 					if ( hasFailed ) {
-						const error = selectors.getLastResolutionFailure(
+						const error = selectors.getResolutionFailure(
 							selectorName,
 							args
 						);

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -413,15 +413,28 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 					store.dispatch(
 						metadataActions.startResolution( selectorName, args )
 					);
-					await fulfillResolver(
-						store,
-						mappedResolvers,
-						selectorName,
-						...args
-					);
-					store.dispatch(
-						metadataActions.finishResolution( selectorName, args )
-					);
+					try {
+						await fulfillResolver(
+							store,
+							mappedResolvers,
+							selectorName,
+							...args
+						);
+						store.dispatch(
+							metadataActions.finishResolution(
+								selectorName,
+								args
+							)
+						);
+					} catch ( e ) {
+						store.dispatch(
+							metadataActions.failResolution(
+								selectorName,
+								args,
+								e
+							)
+						);
+					}
 				} );
 			}
 

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -339,7 +339,7 @@ function mapResolveSelectors( selectors, store ) {
 						args
 					);
 					if ( hasFailed ) {
-						const error = selectors.getResolutionFailure(
+						const error = selectors.getResolutionError(
 							selectorName,
 							args
 						);

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -413,28 +413,25 @@ function mapResolvers( resolvers, selectors, store, resolversCache ) {
 					store.dispatch(
 						metadataActions.startResolution( selectorName, args )
 					);
-					try {
-						await fulfillResolver(
-							store,
-							mappedResolvers,
-							selectorName,
-							...args
-						);
-						store.dispatch(
-							metadataActions.finishResolution(
-								selectorName,
-								args
-							)
-						);
-					} catch ( e ) {
-						store.dispatch(
-							metadataActions.failResolution(
-								selectorName,
-								args,
-								e
-							)
-						);
-					}
+					// try {
+					await fulfillResolver(
+						store,
+						mappedResolvers,
+						selectorName,
+						...args
+					);
+					store.dispatch(
+						metadataActions.finishResolution( selectorName, args )
+					);
+					// } catch ( e ) {
+					// 	store.dispatch(
+					// 		metadataActions.failResolution(
+					// 			selectorName,
+					// 			args,
+					// 			e
+					// 		)
+					// 	);
+					// }
 				} );
 			}
 

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -55,9 +55,9 @@ export function failResolution( selectorName, args, error ) {
  * Returns an action object used in signalling that a batch of selector resolutions has
  * started.
  *
- * @param {string}    selectorName Name of selector for which resolver triggered.
+ * @param {string}      selectorName Name of selector for which resolver triggered.
  * @param {unknown[][]} args         Array of arguments to associate for uniqueness, each item
- *                                 is associated to a resolution.
+ *                                   is associated to a resolution.
  *
  * @return {{ type: 'START_RESOLUTIONS', selectorName: string, args: unknown[][] }} Action object.
  */
@@ -73,9 +73,9 @@ export function startResolutions( selectorName, args ) {
  * Returns an action object used in signalling that a batch of selector resolutions has
  * completed.
  *
- * @param {string}    selectorName Name of selector for which resolver triggered.
+ * @param {string}      selectorName Name of selector for which resolver triggered.
  * @param {unknown[][]} args         Array of arguments to associate for uniqueness, each item
- *                                 is associated to a resolution.
+ *                                   is associated to a resolution.
  *
  * @return {{ type: 'FINISH_RESOLUTIONS', selectorName: string, args: unknown[][] }} Action object.
  */

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -33,6 +33,25 @@ export function finishResolution( selectorName, args ) {
 }
 
 /**
+ * Returns an action object used in signalling that selector resolution has
+ * failed.
+ *
+ * @param {string}    selectorName Name of selector for which resolver triggered.
+ * @param {unknown[]} args         Arguments to associate for uniqueness.
+ * @param {Error}     error        The error that caused the failure
+ *
+ * @return {{ type: 'FAIL_RESOLUTION', selectorName: string, args: unknown[], error: Error }} Action object.
+ */
+export function failResolution( selectorName, args, error ) {
+	return {
+		type: 'FAIL_RESOLUTION',
+		selectorName,
+		args,
+		error,
+	};
+}
+
+/**
  * Returns an action object used in signalling that a batch of selector resolutions has
  * started.
  *
@@ -65,6 +84,26 @@ export function finishResolutions( selectorName, args ) {
 		type: 'FINISH_RESOLUTIONS',
 		selectorName,
 		args,
+	};
+}
+
+/**
+ * Returns an action object used in signalling that a batch of selector resolutions has
+ * completed and at least one of them has failed.
+ *
+ * @param {string}         selectorName Name of selector for which resolver triggered.
+ * @param {unknown[]}      args         Array of arguments to associate for uniqueness, each item
+ *                                      is associated to a resolution.
+ * @param {(Error|null)[]} errors       Array of errors to associate for uniqueness, each item
+ *                                      is associated to a resolution.
+ * @return {{ type: 'FAIL_RESOLUTIONS', selectorName: string, args: unknown[], errors: Array<Error|null> }} Action object.
+ */
+export function failResolutions( selectorName, args, errors ) {
+	return {
+		type: 'FAIL_RESOLUTIONS',
+		selectorName,
+		args,
+		errors,
 	};
 }
 

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -36,11 +36,11 @@ export function finishResolution( selectorName, args ) {
  * Returns an action object used in signalling that selector resolution has
  * failed.
  *
- * @param {string}    selectorName Name of selector for which resolver triggered.
- * @param {unknown[]} args         Arguments to associate for uniqueness.
- * @param {Error}     error        The error that caused the failure
+ * @param {string}        selectorName Name of selector for which resolver triggered.
+ * @param {unknown[]}     args         Arguments to associate for uniqueness.
+ * @param {Error|unknown} error        The error that caused the failure
  *
- * @return {{ type: 'FAIL_RESOLUTION', selectorName: string, args: unknown[], error: Error }} Action object.
+ * @return {{ type: 'FAIL_RESOLUTION', selectorName: string, args: unknown[], error: Error|unknown }} Action object.
  */
 export function failResolution( selectorName, args, error ) {
 	return {
@@ -91,12 +91,12 @@ export function finishResolutions( selectorName, args ) {
  * Returns an action object used in signalling that a batch of selector resolutions has
  * completed and at least one of them has failed.
  *
- * @param {string}         selectorName Name of selector for which resolver triggered.
- * @param {unknown[]}      args         Array of arguments to associate for uniqueness, each item
- *                                      is associated to a resolution.
- * @param {(Error|null)[]} errors       Array of errors to associate for uniqueness, each item
- *                                      is associated to a resolution.
- * @return {{ type: 'FAIL_RESOLUTIONS', selectorName: string, args: unknown[], errors: Array<Error|null> }} Action object.
+ * @param {string}            selectorName Name of selector for which resolver triggered.
+ * @param {unknown[]}         args         Array of arguments to associate for uniqueness, each item
+ *                                         is associated to a resolution.
+ * @param {(Error|unknown)[]} errors       Array of errors to associate for uniqueness, each item
+ *                                         is associated to a resolution.
+ * @return {{ type: 'FAIL_RESOLUTIONS', selectorName: string, args: unknown[], errors: Array<Error|unknown> }} Action object.
  */
 export function failResolutions( selectorName, args, errors ) {
 	return {

--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -38,7 +38,7 @@ export function finishResolution( selectorName, args ) {
  *
  * @param {string}        selectorName Name of selector for which resolver triggered.
  * @param {unknown[]}     args         Arguments to associate for uniqueness.
- * @param {Error|unknown} error        The error that caused the failure
+ * @param {Error|unknown} error        The error that caused the failure.
  *
  * @return {{ type: 'FAIL_RESOLUTION', selectorName: string, args: unknown[], error: Error|unknown }} Action object.
  */

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -24,14 +24,11 @@ type Action =
 	  >;
 
 type StateKey = unknown[] | unknown;
-export enum Status {
-	FINISHED = 'finished',
-	RESOLVING = 'resolving',
-	ERROR = 'error',
-}
 export type StateValue =
-	| { status: Status.RESOLVING | Status.FINISHED }
-	| { status: Status.ERROR; error: Error | unknown };
+	| { status: 'resolving' | 'finished' | undefined }
+	| { status: 'error'; error: Error | unknown };
+
+export type Status = StateValue[ 'status' ];
 export type State = EquivalentKeyMap< StateKey, StateValue >;
 
 /**
@@ -48,21 +45,21 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 		case 'START_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
 			nextState.set( selectorArgsToStateKey( action.args ), {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 			return nextState;
 		}
 		case 'FINISH_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
 			nextState.set( selectorArgsToStateKey( action.args ), {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 			return nextState;
 		}
 		case 'FAIL_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
 			nextState.set( selectorArgsToStateKey( action.args ), {
-				status: Status.ERROR,
+				status: 'error',
 				error: action.error,
 			} );
 			return nextState;
@@ -71,7 +68,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 			const nextState = new EquivalentKeyMap( state );
 			for ( const resolutionArgs of action.args ) {
 				nextState.set( selectorArgsToStateKey( resolutionArgs ), {
-					status: Status.RESOLVING,
+					status: 'resolving',
 				} );
 			}
 			return nextState;
@@ -80,7 +77,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 			const nextState = new EquivalentKeyMap( state );
 			for ( const resolutionArgs of action.args ) {
 				nextState.set( selectorArgsToStateKey( resolutionArgs ), {
-					status: Status.FINISHED,
+					status: 'finished',
 				} );
 			}
 			return nextState;
@@ -89,7 +86,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 			const nextState = new EquivalentKeyMap( state );
 			action.args.forEach( ( resolutionArgs, idx ) => {
 				const resolutionState: StateValue = {
-					status: Status.ERROR,
+					status: 'error',
 					error: undefined,
 				};
 

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -40,7 +40,9 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 	switch ( action.type ) {
 		case 'START_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
-			nextState.set( action.args, { isResolving: true } );
+			nextState.set( selectorArgsToStateKey( action.args ), {
+				isResolving: true,
+			} );
 			return nextState;
 		}
 		case 'FINISH_RESOLUTION': {
@@ -61,7 +63,9 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 		case 'START_RESOLUTIONS': {
 			const nextState = new EquivalentKeyMap( state );
 			for ( const resolutionArgs of action.args ) {
-				nextState.set( resolutionArgs, { isResolving: true } );
+				nextState.set( selectorArgsToStateKey( resolutionArgs ), {
+					isResolving: true,
+				} );
 			}
 			return nextState;
 		}

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -25,7 +25,7 @@ type Action =
 
 type StateKey = unknown[] | unknown;
 export type StateValue =
-	| { status: 'resolving' | 'finished' | undefined }
+	| { status: 'resolving' | 'finished' }
 	| { status: 'error'; error: Error | unknown };
 
 export type Status = StateValue[ 'status' ];

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -24,7 +24,7 @@ type Action =
 	  >;
 
 type StateKey = unknown[] | unknown;
-export type StateValue = { isResolving: boolean; error?: Error };
+export type StateValue = { isResolving: boolean; error?: Error | unknown };
 export type State = EquivalentKeyMap< StateKey, StateValue >;
 
 /**

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -54,6 +54,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 				isResolving: false,
 				error: action.error,
 			} );
+
 			return nextState;
 		}
 		case 'START_RESOLUTIONS':

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -13,15 +13,19 @@ import { selectorArgsToStateKey, onSubKey } from './utils';
 type Action =
 	| ReturnType< typeof import('./actions').startResolution >
 	| ReturnType< typeof import('./actions').finishResolution >
+	| ReturnType< typeof import('./actions').failResolution >
 	| ReturnType< typeof import('./actions').startResolutions >
 	| ReturnType< typeof import('./actions').finishResolutions >
+	| ReturnType< typeof import('./actions').failResolutions >
 	| ReturnType< typeof import('./actions').invalidateResolution >
 	| ReturnType< typeof import('./actions').invalidateResolutionForStore >
 	| ReturnType<
 			typeof import('./actions').invalidateResolutionForStoreSelector
 	  >;
 
-export type State = EquivalentKeyMap< unknown[] | unknown, boolean >;
+type StateKey = unknown[] | unknown;
+export type StateValue = { isResolving: boolean; error?: Error };
+export type State = EquivalentKeyMap< StateKey, StateValue >;
 
 /**
  * Reducer function returning next state for selector resolution of
@@ -36,19 +40,47 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 	switch ( action.type ) {
 		case 'START_RESOLUTION':
 		case 'FINISH_RESOLUTION': {
-			const isStarting = action.type === 'START_RESOLUTION';
+			const isResolving = action.type === 'START_RESOLUTION';
 			const nextState = new EquivalentKeyMap( state );
-			nextState.set( selectorArgsToStateKey( action.args ), isStarting );
+
+			nextState.set( selectorArgsToStateKey( action.args ), {
+				isResolving,
+			} );
+			return nextState;
+		}
+		case 'FAIL_RESOLUTION': {
+			const nextState = new EquivalentKeyMap( state );
+			nextState.set( selectorArgsToStateKey( action.args ), {
+				isResolving: false,
+				error: action.error,
+			} );
 			return nextState;
 		}
 		case 'START_RESOLUTIONS':
 		case 'FINISH_RESOLUTIONS': {
-			const isStarting = action.type === 'START_RESOLUTIONS';
+			const isResolving = action.type === 'START_RESOLUTIONS';
 			const nextState = new EquivalentKeyMap( state );
-			for ( const resolutionArgs of action.args ) {
+			for ( const resolutionArgs of selectorArgsToStateKey(
+				action.args
+			) ) {
+				nextState.set( resolutionArgs, { isResolving } );
+			}
+			return nextState;
+		}
+		case 'FAIL_RESOLUTIONS': {
+			const nextState = new EquivalentKeyMap( state );
+			for ( const idx in action.args ) {
+				const resolutionArgs = action.args[ idx ] as unknown[];
+				const resolutionState: StateValue = { isResolving: false };
+
+				const error = action.errors[ idx ];
+				if ( error ) {
+					resolutionState.error = error;
+				}
+
 				nextState.set(
 					selectorArgsToStateKey( resolutionArgs ),
-					isStarting
+					resolutionState
 				);
 			}
 			return nextState;
@@ -82,8 +114,10 @@ const isResolved = ( state: Record< string, State > = {}, action: Action ) => {
 				: state;
 		case 'START_RESOLUTION':
 		case 'FINISH_RESOLUTION':
+		case 'FAIL_RESOLUTION':
 		case 'START_RESOLUTIONS':
 		case 'FINISH_RESOLUTIONS':
+		case 'FAIL_RESOLUTIONS':
 		case 'INVALIDATE_RESOLUTION':
 			return subKeysIsResolved( state, action );
 	}

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -101,7 +101,7 @@ export function hasResolutionFailed( state, selectorName, args ) {
  * @param {string}     selectorName Selector name.
  * @param {unknown[]?} args         Arguments passed to selector.
  *
- * @return {Error|undefined} Last resolution error
+ * @return {Error|unknown} Last resolution error
  */
 export function getResolutionError( state, selectorName, args ) {
 	return getResolutionState( state, selectorName, args )?.error;

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -86,7 +86,7 @@ export function hasFinishedResolution( state, selectorName, args ) {
  *
  * @return {boolean} Has resolution failed
  */
-export function hasLastResolutionFailed( state, selectorName, args ) {
+export function hasResolutionFailed( state, selectorName, args ) {
 	const resolutionState = getResolutionState( state, selectorName, args );
 	const hasFailed = resolutionState && 'error' in resolutionState;
 	return !! hasFailed;
@@ -102,7 +102,7 @@ export function hasLastResolutionFailed( state, selectorName, args ) {
  *
  * @return {Error|undefined} Last resolution error
  */
-export function getLastResolutionFailure( state, selectorName, args ) {
+export function getResolutionFailure( state, selectorName, args ) {
 	return getResolutionState( state, selectorName, args )?.error;
 }
 

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import { Status } from './reducer';
 
 /**
  * Internal dependencies
@@ -45,7 +49,11 @@ export function getResolutionState( state, selectorName, args ) {
  * @return {boolean | undefined} isResolving value.
  */
 export function getIsResolving( state, selectorName, args ) {
-	return getResolutionState( state, selectorName, args )?.isResolving;
+	const resolutionState = getResolutionState( state, selectorName, args );
+
+	return resolutionState
+		? resolutionState.status === Status.RESOLVING
+		: undefined;
 }
 
 /**
@@ -59,7 +67,9 @@ export function getIsResolving( state, selectorName, args ) {
  * @return {boolean} Whether resolution has been triggered.
  */
 export function hasStartedResolution( state, selectorName, args ) {
-	return getIsResolving( state, selectorName, args ) !== undefined;
+	return (
+		getResolutionState( state, selectorName, args )?.status !== undefined
+	);
 }
 
 /**
@@ -73,7 +83,8 @@ export function hasStartedResolution( state, selectorName, args ) {
  * @return {boolean} Whether resolution has completed.
  */
 export function hasFinishedResolution( state, selectorName, args ) {
-	return getIsResolving( state, selectorName, args ) === false;
+	const status = getResolutionState( state, selectorName, args )?.status;
+	return status === Status.FINISHED || status === Status.ERROR;
 }
 
 /**
@@ -87,9 +98,9 @@ export function hasFinishedResolution( state, selectorName, args ) {
  * @return {boolean} Has resolution failed
  */
 export function hasResolutionFailed( state, selectorName, args ) {
-	const resolutionState = getResolutionState( state, selectorName, args );
-	const hasFailed = resolutionState && 'error' in resolutionState;
-	return !! hasFailed;
+	return (
+		getResolutionState( state, selectorName, args )?.status === Status.ERROR
+	);
 }
 
 /**
@@ -104,7 +115,10 @@ export function hasResolutionFailed( state, selectorName, args ) {
  * @return {Error|unknown} Last resolution error
  */
 export function getResolutionError( state, selectorName, args ) {
-	return getResolutionState( state, selectorName, args )?.error;
+	const resolutionState = getResolutionState( state, selectorName, args );
+	return resolutionState?.status === Status.ERROR
+		? resolutionState?.error
+		: null;
 }
 
 /**

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -102,7 +102,7 @@ export function hasResolutionFailed( state, selectorName, args ) {
  *
  * @return {Error|undefined} Last resolution error
  */
-export function getResolutionFailure( state, selectorName, args ) {
+export function getResolutionError( state, selectorName, args ) {
 	return getResolutionState( state, selectorName, args )?.error;
 }
 

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -59,7 +59,7 @@ export function getIsResolving( state, selectorName, args ) {
  * @return {boolean} Whether resolution has been triggered.
  */
 export function hasStartedResolution( state, selectorName, args ) {
-	return getResolutionState( state, selectorName, args ) !== undefined;
+	return getIsResolving( state, selectorName, args ) !== undefined;
 }
 
 /**

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -93,8 +93,9 @@ export function hasResolutionFailed( state, selectorName, args ) {
 }
 
 /**
- * Returns the resolution error for a given selector
- * name, and arguments set.
+ * Returns the resolution error for a given selector name, and arguments set.
+ * Note it may be of an Error type, but may also be null, undefined, or anything else
+ * that can be `throw`-n.
  *
  * @param {State}      state        Data state.
  * @param {string}     selectorName Selector name.

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -62,9 +62,7 @@ export function getIsResolving( state, selectorName, args ) {
  * @return {boolean} Whether resolution has been triggered.
  */
 export function hasStartedResolution( state, selectorName, args ) {
-	return (
-		getResolutionState( state, selectorName, args )?.status !== undefined
-	);
+	return getResolutionState( state, selectorName, args ) !== undefined;
 }
 
 /**

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -22,19 +22,15 @@ import { selectorArgsToStateKey } from './utils';
  * @param {string}     selectorName Selector name.
  * @param {unknown[]?} args         Arguments passed to selector.
  *
- * @return {StateValue} isResolving value.
+ * @return {StateValue|undefined} isResolving value.
  */
 export function getResolutionState( state, selectorName, args ) {
 	const map = get( state, [ selectorName ] );
 	if ( ! map ) {
-		return { status: undefined };
+		return;
 	}
 
-	const resolutionState = map.get( selectorArgsToStateKey( args ) );
-	if ( ! resolutionState ) {
-		return { status: undefined };
-	}
-	return resolutionState;
+	return map.get( selectorArgsToStateKey( args ) );
 }
 
 /**
@@ -52,9 +48,7 @@ export function getResolutionState( state, selectorName, args ) {
 export function getIsResolving( state, selectorName, args ) {
 	const resolutionState = getResolutionState( state, selectorName, args );
 
-	return resolutionState.status === undefined
-		? undefined
-		: resolutionState.status === 'resolving';
+	return resolutionState && resolutionState.status === 'resolving';
 }
 
 /**
@@ -68,7 +62,9 @@ export function getIsResolving( state, selectorName, args ) {
  * @return {boolean} Whether resolution has been triggered.
  */
 export function hasStartedResolution( state, selectorName, args ) {
-	return getResolutionState( state, selectorName, args ).status !== undefined;
+	return (
+		getResolutionState( state, selectorName, args )?.status !== undefined
+	);
 }
 
 /**
@@ -82,7 +78,7 @@ export function hasStartedResolution( state, selectorName, args ) {
  * @return {boolean} Whether resolution has completed.
  */
 export function hasFinishedResolution( state, selectorName, args ) {
-	const { status } = getResolutionState( state, selectorName, args );
+	const status = getResolutionState( state, selectorName, args )?.status;
 	return status === 'finished' || status === 'error';
 }
 
@@ -97,7 +93,7 @@ export function hasFinishedResolution( state, selectorName, args ) {
  * @return {boolean} Has resolution failed
  */
 export function hasResolutionFailed( state, selectorName, args ) {
-	return getResolutionState( state, selectorName, args ).status === 'error';
+	return getResolutionState( state, selectorName, args )?.status === 'error';
 }
 
 /**
@@ -113,7 +109,7 @@ export function hasResolutionFailed( state, selectorName, args ) {
  */
 export function getResolutionError( state, selectorName, args ) {
 	const resolutionState = getResolutionState( state, selectorName, args );
-	return resolutionState.status === 'error' ? resolutionState.error : null;
+	return resolutionState?.status === 'error' ? resolutionState.error : null;
 }
 
 /**
@@ -128,7 +124,7 @@ export function getResolutionError( state, selectorName, args ) {
  */
 export function isResolving( state, selectorName, args ) {
 	return (
-		getResolutionState( state, selectorName, args ).status === 'resolving'
+		getResolutionState( state, selectorName, args )?.status === 'resolving'
 	);
 }
 

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -9,6 +9,28 @@ import { get } from 'lodash';
 import { selectorArgsToStateKey } from './utils';
 
 /** @typedef {Record<string, import('./reducer').State>} State */
+/** @typedef {import('./reducer').StateValue} StateValue */
+
+/**
+ * Returns the raw resolution state value for a given selector name,
+ * and arguments set. May be undefined if the selector has never been resolved
+ * or not resolved for the given set of arguments, otherwise true or false for
+ * resolution started and completed respectively.
+ *
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
+ *
+ * @return {StateValue | undefined} isResolving value.
+ */
+export function getResolutionState( state, selectorName, args ) {
+	const map = get( state, [ selectorName ] );
+	if ( ! map ) {
+		return undefined;
+	}
+
+	return map.get( selectorArgsToStateKey( args ) );
+}
 
 /**
  * Returns the raw `isResolving` value for a given selector name,
@@ -23,12 +45,7 @@ import { selectorArgsToStateKey } from './utils';
  * @return {boolean | undefined} isResolving value.
  */
 export function getIsResolving( state, selectorName, args ) {
-	const map = get( state, [ selectorName ] );
-	if ( ! map ) {
-		return undefined;
-	}
-
-	return map.get( selectorArgsToStateKey( args ) );
+	return getResolutionState( state, selectorName, args )?.isResolving;
 }
 
 /**
@@ -42,7 +59,7 @@ export function getIsResolving( state, selectorName, args ) {
  * @return {boolean} Whether resolution has been triggered.
  */
 export function hasStartedResolution( state, selectorName, args ) {
-	return getIsResolving( state, selectorName, args ) !== undefined;
+	return getResolutionState( state, selectorName, args ) !== undefined;
 }
 
 /**
@@ -57,6 +74,36 @@ export function hasStartedResolution( state, selectorName, args ) {
  */
 export function hasFinishedResolution( state, selectorName, args ) {
 	return getIsResolving( state, selectorName, args ) === false;
+}
+
+/**
+ * Returns true if resolution has failed for a given selector
+ * name, and arguments set.
+ *
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
+ *
+ * @return {boolean} Has resolution failed
+ */
+export function hasLastResolutionFailed( state, selectorName, args ) {
+	const resolutionState = getResolutionState( state, selectorName, args );
+	const hasFailed = resolutionState && 'error' in resolutionState;
+	return !! hasFailed;
+}
+
+/**
+ * Returns the resolution error for a given selector
+ * name, and arguments set.
+ *
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
+ *
+ * @return {Error|undefined} Last resolution error
+ */
+export function getLastResolutionFailure( state, selectorName, args ) {
+	return getResolutionState( state, selectorName, args )?.error;
 }
 
 /**

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer from '../reducer';
+import reducer, { Status } from '../reducer';
 
 describe( 'reducer', () => {
 	it( 'should default to an empty object', () => {
@@ -23,8 +23,10 @@ describe( 'reducer', () => {
 				args: [],
 			} );
 
-			// { test: { getFoo: EquivalentKeyMap( [] =>  isResolving: true } ) } }
-			expect( state.getFoo.get( [] ) ).toEqual( { isResolving: true } );
+			// { test: { getFoo: EquivalentKeyMap( [] =>  status: 'resolving } ) } }
+			expect( state.getFoo.get( [] ) ).toEqual( {
+				status: Status.RESOLVING,
+			} );
 		} );
 
 		it( 'should return with finished resolution', () => {
@@ -39,8 +41,10 @@ describe( 'reducer', () => {
 				args: [],
 			} );
 
-			// { test: { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) } }
-			expect( state.getFoo.get( [] ) ).toEqual( { isResolving: false } );
+			// { test: { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) } }
+			expect( state.getFoo.get( [] ) ).toEqual( {
+				status: Status.FINISHED,
+			} );
 		} );
 
 		it( 'should remove invalidations', () => {
@@ -81,12 +85,12 @@ describe( 'reducer', () => {
 				args: [ 'block' ],
 			} );
 
-			// { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) }
+			// { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) }
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 		} );
 
@@ -127,9 +131,9 @@ describe( 'reducer', () => {
 				} );
 
 				expect( state.getBar ).toBeUndefined();
-				// { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) }
+				// { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) }
 				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-					isResolving: false,
+					status: Status.FINISHED,
 				} );
 			}
 		);
@@ -141,7 +145,7 @@ describe( 'reducer', () => {
 				args: [ 1, undefined ],
 			} );
 			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 
 			const finished = reducer( started, {
@@ -150,7 +154,7 @@ describe( 'reducer', () => {
 				args: [ 1, undefined, undefined ],
 			} );
 			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 		} );
 	} );
@@ -164,10 +168,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 		} );
 
@@ -184,10 +188,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 		} );
 
@@ -210,7 +214,7 @@ describe( 'reducer', () => {
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toBe( undefined );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 		} );
 
@@ -232,10 +236,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 		} );
 
@@ -277,10 +281,10 @@ describe( 'reducer', () => {
 
 				expect( state.getBar ).toBeUndefined();
 				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-					isResolving: false,
+					status: Status.FINISHED,
 				} );
 				expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-					isResolving: false,
+					status: Status.FINISHED,
 				} );
 			}
 		);
@@ -295,10 +299,10 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 			expect( started.getFoo.get( [ 2 ] ) ).toEqual( {
-				isResolving: true,
+				status: Status.RESOLVING,
 			} );
 
 			const finished = reducer( started, {
@@ -310,10 +314,10 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 			expect( finished.getFoo.get( [ 2 ] ) ).toEqual( {
-				isResolving: false,
+				status: Status.FINISHED,
 			} );
 		} );
 	} );

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -140,14 +140,18 @@ describe( 'reducer', () => {
 				selectorName: 'getFoo',
 				args: [ 1, undefined ],
 			} );
-			expect( started.getFoo.get( [ 1 ] ) ).toBe( true );
+			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
+				isResolving: true,
+			} );
 
 			const finished = reducer( started, {
 				type: 'FINISH_RESOLUTION',
 				selectorName: 'getFoo',
 				args: [ 1, undefined, undefined ],
 			} );
-			expect( finished.getFoo.get( [ 1 ] ) ).toBe( false );
+			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
+				isResolving: false,
+			} );
 		} );
 	} );
 
@@ -290,8 +294,12 @@ describe( 'reducer', () => {
 					[ 2, undefined, undefined ],
 				],
 			} );
-			expect( started.getFoo.get( [ 1 ] ) ).toBe( true );
-			expect( started.getFoo.get( [ 2 ] ) ).toBe( true );
+			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
+				isResolving: true,
+			} );
+			expect( started.getFoo.get( [ 2 ] ) ).toEqual( {
+				isResolving: true,
+			} );
 
 			const finished = reducer( started, {
 				type: 'FINISH_RESOLUTIONS',
@@ -301,8 +309,12 @@ describe( 'reducer', () => {
 					[ 2, undefined ],
 				],
 			} );
-			expect( finished.getFoo.get( [ 1 ] ) ).toBe( false );
-			expect( finished.getFoo.get( [ 2 ] ) ).toBe( false );
+			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
+				isResolving: false,
+			} );
+			expect( finished.getFoo.get( [ 2 ] ) ).toEqual( {
+				isResolving: false,
+			} );
 		} );
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -23,8 +23,8 @@ describe( 'reducer', () => {
 				args: [],
 			} );
 
-			// { test: { getFoo: EquivalentKeyMap( [] => true ) } }
-			expect( state.getFoo.get( [] ) ).toBe( true );
+			// { test: { getFoo: EquivalentKeyMap( [] =>  isResolving: true } ) } }
+			expect( state.getFoo.get( [] ) ).toEqual( { isResolving: true } );
 		} );
 
 		it( 'should return with finished resolution', () => {
@@ -39,8 +39,8 @@ describe( 'reducer', () => {
 				args: [],
 			} );
 
-			// { test: { getFoo: EquivalentKeyMap( [] => false ) } }
-			expect( state.getFoo.get( [] ) ).toBe( false );
+			// { test: { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) } }
+			expect( state.getFoo.get( [] ) ).toEqual( { isResolving: false } );
 		} );
 
 		it( 'should remove invalidations', () => {
@@ -81,9 +81,13 @@ describe( 'reducer', () => {
 				args: [ 'block' ],
 			} );
 
-			// { getFoo: EquivalentKeyMap( [] => false ) }
-			expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
-			expect( state.getFoo.get( [ 'block' ] ) ).toBe( true );
+			// { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) }
+			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+				isResolving: false,
+			} );
+			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+				isResolving: true,
+			} );
 		} );
 
 		it(
@@ -123,8 +127,10 @@ describe( 'reducer', () => {
 				} );
 
 				expect( state.getBar ).toBeUndefined();
-				// { getFoo: EquivalentKeyMap( [] => false ) }
-				expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
+				// { getFoo: EquivalentKeyMap( [] => { isResolving: false } ) }
+				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+					isResolving: false,
+				} );
 			}
 		);
 
@@ -153,8 +159,12 @@ describe( 'reducer', () => {
 				args: [ [ 'post' ], [ 'block' ] ],
 			} );
 
-			expect( state.getFoo.get( [ 'post' ] ) ).toBe( true );
-			expect( state.getFoo.get( [ 'block' ] ) ).toBe( true );
+			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+				isResolving: true,
+			} );
+			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+				isResolving: true,
+			} );
 		} );
 
 		it( 'should return with finished resolutions', () => {
@@ -169,8 +179,12 @@ describe( 'reducer', () => {
 				args: [ [ 'post' ], [ 'block' ] ],
 			} );
 
-			expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
-			expect( state.getFoo.get( [ 'block' ] ) ).toBe( false );
+			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+				isResolving: false,
+			} );
+			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+				isResolving: false,
+			} );
 		} );
 
 		it( 'should remove invalidations', () => {
@@ -191,7 +205,9 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toBe( undefined );
-			expect( state.getFoo.get( [ 'block' ] ) ).toBe( false );
+			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+				isResolving: false,
+			} );
 		} );
 
 		it( 'different arguments should not conflict', () => {
@@ -211,8 +227,12 @@ describe( 'reducer', () => {
 				args: [ [ 'block' ] ],
 			} );
 
-			expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
-			expect( state.getFoo.get( [ 'block' ] ) ).toBe( true );
+			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+				isResolving: false,
+			} );
+			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+				isResolving: true,
+			} );
 		} );
 
 		it(
@@ -252,8 +272,12 @@ describe( 'reducer', () => {
 				} );
 
 				expect( state.getBar ).toBeUndefined();
-				expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
-				expect( state.getFoo.get( [ 'block' ] ) ).toBe( false );
+				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
+					isResolving: false,
+				} );
+				expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
+					isResolving: false,
+				} );
 			}
 		);
 

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -6,7 +6,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { Status } from '../reducer';
+import reducer from '../reducer';
 
 describe( 'reducer', () => {
 	it( 'should default to an empty object', () => {
@@ -25,7 +25,7 @@ describe( 'reducer', () => {
 
 			// { test: { getFoo: EquivalentKeyMap( [] =>  status: 'resolving } ) } }
 			expect( state.getFoo.get( [] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 		} );
 
@@ -41,9 +41,9 @@ describe( 'reducer', () => {
 				args: [],
 			} );
 
-			// { test: { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) } }
+			// { test: { getFoo: EquivalentKeyMap( [] => { status: 'finished' } ) } }
 			expect( state.getFoo.get( [] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 		} );
 
@@ -85,12 +85,12 @@ describe( 'reducer', () => {
 				args: [ 'block' ],
 			} );
 
-			// { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) }
+			// { getFoo: EquivalentKeyMap( [] => { status: 'finished' } ) }
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 		} );
 
@@ -131,9 +131,9 @@ describe( 'reducer', () => {
 				} );
 
 				expect( state.getBar ).toBeUndefined();
-				// { getFoo: EquivalentKeyMap( [] => { status: Status.FINISHED } ) }
+				// { getFoo: EquivalentKeyMap( [] => { status: 'finished' } ) }
 				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-					status: Status.FINISHED,
+					status: 'finished',
 				} );
 			}
 		);
@@ -145,7 +145,7 @@ describe( 'reducer', () => {
 				args: [ 1, undefined ],
 			} );
 			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 
 			const finished = reducer( started, {
@@ -154,7 +154,7 @@ describe( 'reducer', () => {
 				args: [ 1, undefined, undefined ],
 			} );
 			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 		} );
 	} );
@@ -168,10 +168,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 		} );
 
@@ -188,10 +188,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 		} );
 
@@ -214,7 +214,7 @@ describe( 'reducer', () => {
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toBe( undefined );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 		} );
 
@@ -236,10 +236,10 @@ describe( 'reducer', () => {
 			} );
 
 			expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 			expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 		} );
 
@@ -281,10 +281,10 @@ describe( 'reducer', () => {
 
 				expect( state.getBar ).toBeUndefined();
 				expect( state.getFoo.get( [ 'post' ] ) ).toEqual( {
-					status: Status.FINISHED,
+					status: 'finished',
 				} );
 				expect( state.getFoo.get( [ 'block' ] ) ).toEqual( {
-					status: Status.FINISHED,
+					status: 'finished',
 				} );
 			}
 		);
@@ -299,10 +299,10 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( started.getFoo.get( [ 1 ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 			expect( started.getFoo.get( [ 2 ] ) ).toEqual( {
-				status: Status.RESOLVING,
+				status: 'resolving',
 			} );
 
 			const finished = reducer( started, {
@@ -314,10 +314,10 @@ describe( 'reducer', () => {
 				],
 			} );
 			expect( finished.getFoo.get( [ 1 ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 			expect( finished.getFoo.get( [ 2 ] ) ).toEqual( {
-				status: Status.FINISHED,
+				status: 'finished',
 			} );
 		} );
 	} );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -4,7 +4,6 @@
 import { createRegistry } from '@wordpress/data';
 
 jest.useRealTimers();
-jest.setTimeout( 1000000 );
 const testStore = {
 	reducer: ( state = null, action ) => {
 		if ( action.type === 'RECEIVE' ) {

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -17,11 +17,10 @@ import {
  */
 import { createRegistry } from '@wordpress/data';
 
-jest.useFakeTimers();
+jest.useRealTimers();
 
 async function resolve( registry, selector ) {
 	const resolution = registry.resolveSelect( 'store' )[ selector ]();
-	jest.advanceTimersByTime( 100 );
 	try {
 		await resolution;
 	} catch ( e ) {}
@@ -159,7 +158,6 @@ describe( 'hasResolutionFailed', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
@@ -232,7 +230,6 @@ describe( 'getResolutionError', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getResolutionError( 'getItems' )
@@ -269,7 +266,6 @@ describe( 'getResolutionError', () => {
 		).toBeTruthy();
 
 		registry.dispatch( 'store' ).invalidateResolution( 'getItems', [] );
-		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getResolutionError( 'getItems' )
@@ -277,7 +273,6 @@ describe( 'getResolutionError', () => {
 
 		shouldFail = false;
 		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getResolutionError( 'getItems' )

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -12,6 +12,12 @@ import {
 	hasFinishedResolution,
 	isResolving,
 } from '../selectors';
+/**
+ * WordPress dependencies
+ */
+import { createRegistry } from '@wordpress/data';
+
+jest.useFakeTimers();
 
 describe( 'getIsResolving', () => {
 	it( 'should return undefined if no state by reducerKey, selectorName', () => {
@@ -113,5 +119,175 @@ describe( 'isResolving', () => {
 		const result = isResolving( state, 'getFoo', [] );
 
 		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'hasLastResolutionFailed', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+	} );
+
+	it( 'returns false if the resolution has succeeded', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => {},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeFalsy();
+
+		registry.select( 'store' ).getItems();
+		await jest.advanceTimersByTime( 1 );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeFalsy();
+	} );
+
+	it( 'returns true if the resolution has failed', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => {
+					throw new Error( 'cannot fetch items' );
+				},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeFalsy();
+
+		registry.select( 'store' ).getItems();
+		await jest.advanceTimersByTime( 1 );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeTruthy();
+	} );
+
+	it( 'returns true if the resolution has failed (thunks)', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => async () => {
+					throw new Error( 'cannot fetch items' );
+				},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeFalsy();
+
+		registry.select( 'store' ).getItems();
+		await jest.advanceTimersByTime( 1 );
+
+		expect(
+			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+		).toBeTruthy();
+	} );
+} );
+
+describe( 'getLastResolutionFailure', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+	} );
+
+	it( 'returns undefined if the resolution has succeeded', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => {},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+		).toBeFalsy();
+
+		registry.select( 'store' ).getItems();
+		await jest.advanceTimersByTime( 1 );
+
+		expect(
+			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+		).toBeFalsy();
+	} );
+
+	it( 'returns error if the resolution has failed', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => {
+					throw new Error( 'cannot fetch items' );
+				},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+		).toBeFalsy();
+
+		registry.select( 'store' ).getItems();
+		await jest.advanceTimersByTime( 1 );
+
+		expect(
+			registry
+				.select( 'store' )
+				.getLastResolutionFailure( 'getItems' )
+				.toString()
+		).toBe( 'Error: cannot fetch items' );
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -18,9 +18,8 @@ const testStore = {
 };
 
 async function resolve( registry, selector ) {
-	const resolution = registry.resolveSelect( 'store' )[ selector ]();
 	try {
-		await resolution;
+		await registry.resolveSelect( 'store' )[ selector ]();
 	} catch ( e ) {}
 }
 

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -1,23 +1,22 @@
 /**
- * External dependencies
- */
-import EquivalentKeyMap from 'equivalent-key-map';
-
-/**
- * Internal dependencies
- */
-import {
-	getIsResolving,
-	hasStartedResolution,
-	hasFinishedResolution,
-	isResolving,
-} from '../selectors';
-/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
 
 jest.useRealTimers();
+
+const testStore = {
+	reducer: ( state = null, action ) => {
+		if ( action.type === 'RECEIVE' ) {
+			return action.items;
+		}
+
+		return state;
+	},
+	selectors: {
+		getFoo: ( state ) => state,
+	},
+};
 
 async function resolve( registry, selector ) {
 	const resolution = registry.resolveSelect( 'store' )[ selector ]();
@@ -27,103 +26,125 @@ async function resolve( registry, selector ) {
 }
 
 describe( 'getIsResolving', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'testStore', testStore );
+	} );
+
 	it( 'should return undefined if no state by reducerKey, selectorName', () => {
-		const state = {};
-		const result = getIsResolving( state, 'getFoo', [] );
+		const result = registry
+			.select( 'testStore' )
+			.getIsResolving( 'getFoo', [] );
 
 		expect( result ).toBe( undefined );
 	} );
 
 	it( 'should return undefined if state by reducerKey, selectorName, but not args', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
-		};
-		const result = getIsResolving( state, 'getFoo', [ 'bar' ] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const result = registry
+			.select( 'testStore' )
+			.getIsResolving( 'getFoo', [ 'bar' ] );
 
 		expect( result ).toBe( undefined );
 	} );
 
 	it( 'should return value by reducerKey, selectorName', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
-		};
-		const result = getIsResolving( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const result = registry
+			.select( 'testStore' )
+			.getIsResolving( 'getFoo', [] );
 
 		expect( result ).toBe( true );
 	} );
 
 	it( 'should normalize args ard return the right value', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
-		};
-		expect( getIsResolving( state, 'getFoo' ) ).toBe( true );
-		expect( getIsResolving( state, 'getFoo', [ undefined ] ) ).toBe( true );
-		expect(
-			getIsResolving( state, 'getFoo', [ undefined, undefined ] )
-		).toBe( true );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const { getIsResolving } = registry.select( 'testStore' );
+
+		expect( getIsResolving( 'getFoo' ) ).toBe( true );
+		expect( getIsResolving( 'getFoo', [ undefined ] ) ).toBe( true );
+		expect( getIsResolving( 'getFoo', [ undefined, undefined ] ) ).toBe(
+			true
+		);
 	} );
 } );
 
 describe( 'hasStartedResolution', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'testStore', testStore );
+	} );
+
 	it( 'returns false if not has started', () => {
-		const state = {};
-		const result = hasStartedResolution( state, 'getFoo', [] );
+		const result = registry
+			.select( 'testStore' )
+			.hasStartedResolution( 'getFoo', [] );
 
 		expect( result ).toBe( false );
 	} );
 
 	it( 'returns true if has started', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
-		};
-		const result = hasStartedResolution( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const { hasStartedResolution } = registry.select( 'testStore' );
+		const result = hasStartedResolution( 'getFoo', [] );
 
 		expect( result ).toBe( true );
 	} );
 } );
 
 describe( 'hasFinishedResolution', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'testStore', testStore );
+	} );
+
 	it( 'returns false if not has finished', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
-		};
-		const result = hasFinishedResolution( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const { hasFinishedResolution } = registry.select( 'testStore' );
+		const result = hasFinishedResolution( 'getFoo', [] );
 
 		expect( result ).toBe( false );
 	} );
 
 	it( 'returns true if has finished', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: false } ] ] ),
-		};
-		const result = hasFinishedResolution( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).finishResolution( 'getFoo', [] );
+		const { hasFinishedResolution } = registry.select( 'testStore' );
+		const result = hasFinishedResolution( 'getFoo', [] );
 
 		expect( result ).toBe( true );
 	} );
 } );
 
 describe( 'isResolving', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'testStore', testStore );
+	} );
+
 	it( 'returns false if not has started', () => {
-		const state = {};
-		const result = isResolving( state, 'getFoo', [] );
+		const { isResolving } = registry.select( 'testStore' );
+		const result = isResolving( 'getFoo', [] );
 
 		expect( result ).toBe( false );
 	} );
 
 	it( 'returns false if has finished', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: false } ] ] ),
-		};
-		const result = isResolving( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		registry.dispatch( 'testStore' ).finishResolution( 'getFoo', [] );
+		const { isResolving } = registry.select( 'testStore' );
+		const result = isResolving( 'getFoo', [] );
 
 		expect( result ).toBe( false );
 	} );
 
 	it( 'returns true if has started but not finished', () => {
-		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
-		};
-		const result = isResolving( state, 'getFoo', [] );
+		registry.dispatch( 'testStore' ).startResolution( 'getFoo', [] );
+		const { isResolving } = registry.select( 'testStore' );
+		const result = isResolving( 'getFoo', [] );
 
 		expect( result ).toBe( true );
 	} );
@@ -146,21 +167,21 @@ describe( 'hasResolutionFailed', () => {
 				return state;
 			},
 			selectors: {
-				getItems: ( state ) => state,
+				getFoo: ( state ) => state,
 			},
 			resolvers: {
-				getItems: () => {},
+				getFoo: () => {},
 			},
 		} );
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeFalsy();
 
-		registry.select( 'store' ).getItems();
+		registry.select( 'store' ).getFoo();
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeFalsy();
 	} );
 
@@ -174,23 +195,23 @@ describe( 'hasResolutionFailed', () => {
 				return state;
 			},
 			selectors: {
-				getItems: ( state ) => state,
+				getFoo: ( state ) => state,
 			},
 			resolvers: {
-				getItems: () => {
+				getFoo: () => {
 					throw new Error( 'cannot fetch items' );
 				},
 			},
 		} );
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeFalsy();
 
-		await resolve( registry, 'getItems' );
+		await resolve( registry, 'getFoo' );
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeTruthy();
 	} );
 
@@ -204,23 +225,23 @@ describe( 'hasResolutionFailed', () => {
 				return state;
 			},
 			selectors: {
-				getItems: ( state ) => state,
+				getFoo: ( state ) => state,
 			},
 			resolvers: {
-				getItems: () => {
+				getFoo: () => {
 					throw null;
 				},
 			},
 		} );
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeFalsy();
 
-		await resolve( registry, 'getItems' );
+		await resolve( registry, 'getFoo' );
 
 		expect(
-			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getFoo' )
 		).toBeTruthy();
 	} );
 } );
@@ -242,10 +263,10 @@ describe( 'getResolutionError', () => {
 				return state;
 			},
 			selectors: {
-				getItems: ( state ) => state,
+				getFoo: ( state ) => state,
 			},
 			resolvers: {
-				getItems: () => {
+				getFoo: () => {
 					if ( shouldFail ) {
 						throw new Error( 'cannot fetch items' );
 					}
@@ -256,13 +277,13 @@ describe( 'getResolutionError', () => {
 
 	it( 'returns undefined if the resolution has succeeded', async () => {
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 
-		registry.select( 'store' ).getItems();
+		registry.select( 'store' ).getFoo();
 
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 	} );
 
@@ -270,42 +291,39 @@ describe( 'getResolutionError', () => {
 		shouldFail = true;
 
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 
-		await resolve( registry, 'getItems' );
+		await resolve( registry, 'getFoo' );
 
 		expect(
-			registry
-				.select( 'store' )
-				.getResolutionError( 'getItems' )
-				.toString()
+			registry.select( 'store' ).getResolutionError( 'getFoo' ).toString()
 		).toBe( 'Error: cannot fetch items' );
 	} );
 
 	it( 'returns undefined if the failed resolution succeeded after retry', async () => {
 		shouldFail = true;
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 
-		await resolve( registry, 'getItems' );
+		await resolve( registry, 'getFoo' );
 
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeTruthy();
 
-		registry.dispatch( 'store' ).invalidateResolution( 'getItems', [] );
+		registry.dispatch( 'store' ).invalidateResolution( 'getFoo', [] );
 
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 
 		shouldFail = false;
-		registry.select( 'store' ).getItems();
+		registry.select( 'store' ).getFoo();
 
 		expect(
-			registry.select( 'store' ).getResolutionError( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getFoo' )
 		).toBeFalsy();
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -4,7 +4,7 @@
 import { createRegistry } from '@wordpress/data';
 
 jest.useRealTimers();
-
+jest.setTimeout( 1000000 );
 const testStore = {
 	reducer: ( state = null, action ) => {
 		if ( action.type === 'RECEIVE' ) {

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -197,7 +197,7 @@ describe( 'hasResolutionFailed', () => {
 	} );
 } );
 
-describe( 'getResolutionFailure', () => {
+describe( 'getResolutionError', () => {
 	let registry;
 	let shouldFail;
 
@@ -228,14 +228,14 @@ describe( 'getResolutionFailure', () => {
 
 	it( 'returns undefined if the resolution has succeeded', async () => {
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 	} );
 
@@ -243,7 +243,7 @@ describe( 'getResolutionFailure', () => {
 		shouldFail = true;
 
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 
 		await resolve( registry, 'getItems' );
@@ -251,7 +251,7 @@ describe( 'getResolutionFailure', () => {
 		expect(
 			registry
 				.select( 'store' )
-				.getResolutionFailure( 'getItems' )
+				.getResolutionError( 'getItems' )
 				.toString()
 		).toBe( 'Error: cannot fetch items' );
 	} );
@@ -259,20 +259,20 @@ describe( 'getResolutionFailure', () => {
 	it( 'returns undefined if the failed resolution succeeded after retry', async () => {
 		shouldFail = true;
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 
 		await resolve( registry, 'getItems' );
 
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeTruthy();
 
 		registry.dispatch( 'store' ).invalidateResolution( 'getItems', [] );
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 
 		shouldFail = false;
@@ -280,7 +280,7 @@ describe( 'getResolutionFailure', () => {
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionError( 'getItems' )
 		).toBeFalsy();
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -151,7 +151,7 @@ describe( 'hasLastResolutionFailed', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
@@ -182,38 +182,7 @@ describe( 'hasLastResolutionFailed', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
-
-		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
-		).toBeTruthy();
-	} );
-
-	it( 'returns true if the resolution has failed (thunks)', async () => {
-		registry.registerStore( 'store', {
-			reducer: ( state = null, action ) => {
-				if ( action.type === 'RECEIVE' ) {
-					return action.items;
-				}
-
-				return state;
-			},
-			selectors: {
-				getItems: ( state ) => state,
-			},
-			resolvers: {
-				getItems: () => async () => {
-					throw new Error( 'cannot fetch items' );
-				},
-			},
-		} );
-
-		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
-		).toBeFalsy();
-
-		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
@@ -256,7 +225,7 @@ describe( 'getLastResolutionFailure', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
@@ -271,7 +240,7 @@ describe( 'getLastResolutionFailure', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry
@@ -288,14 +257,14 @@ describe( 'getLastResolutionFailure', () => {
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
 		).toBeTruthy();
 
 		registry.dispatch( 'store' ).invalidateResolution( 'getItems', [] );
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
@@ -303,7 +272,7 @@ describe( 'getLastResolutionFailure', () => {
 
 		shouldFail = false;
 		registry.select( 'store' ).getItems();
-		await jest.advanceTimersByTime( 1 );
+		jest.advanceTimersByTime( 1 );
 
 		expect(
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -130,7 +130,7 @@ describe( 'isResolving', () => {
 	} );
 } );
 
-describe( 'hasLastResolutionFailed', () => {
+describe( 'hasResolutionFailed', () => {
 	let registry;
 
 	beforeEach( () => {
@@ -155,14 +155,14 @@ describe( 'hasLastResolutionFailed', () => {
 		} );
 
 		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
 		).toBeFalsy();
 	} );
 
@@ -186,18 +186,18 @@ describe( 'hasLastResolutionFailed', () => {
 		} );
 
 		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
 		).toBeFalsy();
 
 		await resolve( registry, 'getItems' );
 
 		expect(
-			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
 		).toBeTruthy();
 	} );
 } );
 
-describe( 'getLastResolutionFailure', () => {
+describe( 'getResolutionFailure', () => {
 	let registry;
 	let shouldFail;
 
@@ -228,14 +228,14 @@ describe( 'getLastResolutionFailure', () => {
 
 	it( 'returns undefined if the resolution has succeeded', async () => {
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
 		registry.select( 'store' ).getItems();
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 	} );
 
@@ -243,7 +243,7 @@ describe( 'getLastResolutionFailure', () => {
 		shouldFail = true;
 
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
 		await resolve( registry, 'getItems' );
@@ -251,7 +251,7 @@ describe( 'getLastResolutionFailure', () => {
 		expect(
 			registry
 				.select( 'store' )
-				.getLastResolutionFailure( 'getItems' )
+				.getResolutionFailure( 'getItems' )
 				.toString()
 		).toBe( 'Error: cannot fetch items' );
 	} );
@@ -259,20 +259,20 @@ describe( 'getLastResolutionFailure', () => {
 	it( 'returns undefined if the failed resolution succeeded after retry', async () => {
 		shouldFail = true;
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
 		await resolve( registry, 'getItems' );
 
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeTruthy();
 
 		registry.dispatch( 'store' ).invalidateResolution( 'getItems', [] );
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
 		shouldFail = false;
@@ -280,7 +280,7 @@ describe( 'getLastResolutionFailure', () => {
 		jest.advanceTimersByTime( 1 );
 
 		expect(
-			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
+			registry.select( 'store' ).getResolutionFailure( 'getItems' )
 		).toBeFalsy();
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -23,7 +23,7 @@ describe( 'getIsResolving', () => {
 
 	it( 'should return undefined if state by reducerKey, selectorName, but not args', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
 		};
 		const result = getIsResolving( state, 'getFoo', [ 'bar' ] );
 
@@ -32,7 +32,7 @@ describe( 'getIsResolving', () => {
 
 	it( 'should return value by reducerKey, selectorName', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
 		};
 		const result = getIsResolving( state, 'getFoo', [] );
 
@@ -61,7 +61,7 @@ describe( 'hasStartedResolution', () => {
 
 	it( 'returns true if has started', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
 		};
 		const result = hasStartedResolution( state, 'getFoo', [] );
 
@@ -72,7 +72,7 @@ describe( 'hasStartedResolution', () => {
 describe( 'hasFinishedResolution', () => {
 	it( 'returns false if not has finished', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
 		};
 		const result = hasFinishedResolution( state, 'getFoo', [] );
 
@@ -81,7 +81,7 @@ describe( 'hasFinishedResolution', () => {
 
 	it( 'returns true if has finished', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], false ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: false } ] ] ),
 		};
 		const result = hasFinishedResolution( state, 'getFoo', [] );
 
@@ -99,7 +99,7 @@ describe( 'isResolving', () => {
 
 	it( 'returns false if has finished', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], false ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: false } ] ] ),
 		};
 		const result = isResolving( state, 'getFoo', [] );
 
@@ -108,7 +108,7 @@ describe( 'isResolving', () => {
 
 	it( 'returns true if has started but not finished', () => {
 		const state = {
-			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+			getFoo: new EquivalentKeyMap( [ [ [], { isResolving: true } ] ] ),
 		};
 		const result = isResolving( state, 'getFoo', [] );
 

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -19,6 +19,14 @@ import { createRegistry } from '@wordpress/data';
 
 jest.useFakeTimers();
 
+async function resolve( registry, selector ) {
+	const resolution = registry.resolveSelect( 'store' )[ selector ]();
+	jest.advanceTimersByTime( 100 );
+	try {
+		await resolution;
+	} catch ( e ) {}
+}
+
 describe( 'getIsResolving', () => {
 	it( 'should return undefined if no state by reducerKey, selectorName', () => {
 		const state = {};
@@ -181,8 +189,7 @@ describe( 'hasLastResolutionFailed', () => {
 			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
 		).toBeFalsy();
 
-		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
+		await resolve( registry, 'getItems' );
 
 		expect(
 			registry.select( 'store' ).hasLastResolutionFailed( 'getItems' )
@@ -239,8 +246,7 @@ describe( 'getLastResolutionFailure', () => {
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
-		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
+		await resolve( registry, 'getItems' );
 
 		expect(
 			registry
@@ -256,8 +262,7 @@ describe( 'getLastResolutionFailure', () => {
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )
 		).toBeFalsy();
 
-		registry.select( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
+		await resolve( registry, 'getItems' );
 
 		expect(
 			registry.select( 'store' ).getLastResolutionFailure( 'getItems' )

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -193,6 +193,36 @@ describe( 'hasResolutionFailed', () => {
 			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
 		).toBeTruthy();
 	} );
+
+	it( 'returns true if the resolution has failed even if the error is falsy', async () => {
+		registry.registerStore( 'store', {
+			reducer: ( state = null, action ) => {
+				if ( action.type === 'RECEIVE' ) {
+					return action.items;
+				}
+
+				return state;
+			},
+			selectors: {
+				getItems: ( state ) => state,
+			},
+			resolvers: {
+				getItems: () => {
+					throw null;
+				},
+			},
+		} );
+
+		expect(
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+		).toBeFalsy();
+
+		await resolve( registry, 'getItems' );
+
+		expect(
+			registry.select( 'store' ).hasResolutionFailed( 'getItems' )
+		).toBeTruthy();
+	} );
 } );
 
 describe( 'getResolutionError', () => {

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -264,14 +264,14 @@ describe( 'resolveSelect', () => {
 	it( 'resolves when the resolution succeeded', async () => {
 		shouldFail = false;
 		const promise = registry.resolveSelect( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
+		jest.runAllTimers();
 		await expect( promise ).resolves.toEqual( 'items' );
 	} );
 
 	it( 'rejects when the resolution failed', async () => {
 		shouldFail = true;
 		const promise = registry.resolveSelect( 'store' ).getItems();
-		jest.advanceTimersByTime( 1 );
+		jest.runAllTimers();
 		await expect( promise ).rejects.toEqual(
 			new Error( 'cannot fetch items' )
 		);

--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -235,3 +235,45 @@ describe( 'controls', () => {
 		} );
 	} );
 } );
+
+describe( 'resolveSelect', () => {
+	let registry;
+	let shouldFail;
+
+	beforeEach( () => {
+		shouldFail = false;
+		registry = createRegistry();
+
+		registry.registerStore( 'store', {
+			reducer: ( state = null ) => {
+				return state;
+			},
+			selectors: {
+				getItems: () => 'items',
+			},
+			resolvers: {
+				getItems: () => {
+					if ( shouldFail ) {
+						throw new Error( 'cannot fetch items' );
+					}
+				},
+			},
+		} );
+	} );
+
+	it( 'resolves when the resolution succeeded', async () => {
+		shouldFail = false;
+		const promise = registry.resolveSelect( 'store' ).getItems();
+		jest.advanceTimersByTime( 1 );
+		await expect( promise ).resolves.toEqual( 'items' );
+	} );
+
+	it( 'rejects when the resolution failed', async () => {
+		shouldFail = true;
+		const promise = registry.resolveSelect( 'store' ).getItems();
+		jest.advanceTimersByTime( 1 );
+		await expect( promise ).rejects.toEqual(
+			new Error( 'cannot fetch items' )
+		);
+	} );
+} );

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -38,11 +38,11 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 			}
 			resolversByArgs.forEach( ( value, args ) => {
 				// resolversByArgs is the map Map([ args ] => boolean) storing the cache resolution status for a given selector.
-				// If the value is false it means this resolver has finished its resolution which means we need to invalidate it,
-				// if it's true it means it's inflight and the invalidation is not necessary.
+				// If the value is "finished" or "error" it means this resolver has finished its resolution which means we need
+				// to invalidate it, if it's true it means it's inflight and the invalidation is not necessary.
 				if (
-					value?.status === 'resolving' ||
-					! value?.status ||
+					( value?.status !== 'finished' &&
+						value?.status !== 'error' ) ||
 					! resolver.shouldInvalidate( action, ...args )
 				) {
 					return;

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -7,7 +7,6 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import coreDataStore from './store';
-import { Status } from './redux-store/metadata/reducer';
 
 /** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
 
@@ -42,7 +41,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 				// If the value is false it means this resolver has finished its resolution which means we need to invalidate it,
 				// if it's true it means it's inflight and the invalidation is not necessary.
 				if (
-					value?.status === Status.RESOLVING ||
+					value?.status === 'resolving' ||
 					! value?.status ||
 					! resolver.shouldInvalidate( action, ...args )
 				) {

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -41,7 +41,7 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 				// If the value is false it means this resolver has finished its resolution which means we need to invalidate it,
 				// if it's true it means it's inflight and the invalidation is not necessary.
 				if (
-					value !== false ||
+					value?.isResolving !== false ||
 					! resolver.shouldInvalidate( action, ...args )
 				) {
 					return;

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -7,6 +7,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import coreDataStore from './store';
+import { Status } from './redux-store/metadata/reducer';
 
 /** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
 
@@ -41,7 +42,8 @@ const createResolversCacheMiddleware = ( registry, reducerKey ) => () => (
 				// If the value is false it means this resolver has finished its resolution which means we need to invalidate it,
 				// if it's true it means it's inflight and the invalidation is not necessary.
 				if (
-					value?.isResolving !== false ||
+					value?.status === Status.RESOLVING ||
+					! value?.status ||
 					! resolver.shouldInvalidate( action, ...args )
 				) {
 					return;


### PR DESCRIPTION
## Description

`@wodrpress/data` exposes a resolvers API, but ignores any errors thrown during the resolution:

https://github.com/WordPress/gutenberg/blob/70730e61ba3148ebfa2be125d17c8138ab16392c/packages/core-data/src/resolvers.js#L107-L111

This PR proposes an error handling mechanism that works roughly as follows:

* Any thrown exception is stored using the new `failResolution` action which also finalizes the resolution
* The error details may be fetched using the `hasLastResolutionFailed` and `getLastResolutionFailure` selectors
* A promise returned by the `resolveSelect` will now be rejected in case of resolution error. Previously it just hanged forever.

To that last point, we may need to wrap any `resolveSelect` in try/catch to make sure redux actions don't start unexpectedly throwing exceptions.

## Test plan

It is a new feature, so testing is mostly about confirming the CI checks, reading the code, and discussing.

cc @youknowriad @jsnajdr @mcsf @gziolo @ellatrix @draganescu @noisysocks @jsnajdr @Mamaduka @jorgefilipecosta @talldan @getdave @kevin940726 @anton-vlasenko