### PR TITLE
[RNMobile] Highlight text: Check if style attribute value is defined during filtering

### DIFF
--- a/packages/format-library/src/text-color/index.native.js
+++ b/packages/format-library/src/text-color/index.native.js
@@ -181,7 +181,7 @@ export const textColor = {
 	__unstableFilterAttributeValue( key, value ) {
 		if ( key !== 'style' ) return value;
 		// We need to remove the extra spaces within the styles on mobile
-		const newValue = value.replace( / /g, '' );
+		const newValue = value?.replace( / /g, '' );
 		// We should not add a background-color if it's already set
 		if ( newValue && newValue.includes( 'background-color' ) )
 			return newValue;

--- a/packages/format-library/src/text-color/test/__snapshots__/index.native.js.snap
+++ b/packages/format-library/src/text-color/test/__snapshots__/index.native.js.snap
@@ -17,3 +17,13 @@ exports[`Text color creates a paragraph block with the text color format 1`] = `
 <p>Hello <mark style=\\"background-color:rgba(0,0,0,0);color:#cf2e2e\\" class=\\"has-inline-color has-vivid-red-color\\">this is a test</mark></p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Text color supports old text color format using "span" tag 1`] = `
+"<!-- wp:paragraph -->
+<p>this <span class=\\"has-inline-color has-green-color\\">is</span> <span class=\\"has-inline-color has-red-color\\">test</span></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><span style=\\"color:#08a5e9\\" class=\\"has-inline-color\\">this is a test</span></p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/format-library/src/text-color/test/index.native.js
+++ b/packages/format-library/src/text-color/test/index.native.js
@@ -161,4 +161,18 @@ describe( 'Text color', () => {
 
 		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
+
+	it( 'supports old text color format using "span" tag', async () => {
+		await initializeEditor( {
+			initialHtml: `<!-- wp:paragraph -->
+			<p>this <span class="has-inline-color has-green-color">is</span> <span class="has-inline-color has-red-color">test</span></p>
+			<!-- /wp:paragraph -->
+			
+			<!-- wp:paragraph -->
+			<p><span style="color:#08a5e9" class="has-inline-color">this is a test</span></p>
+			<!-- /wp:paragraph -->`,
+		} );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
 } );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -15,6 +15,7 @@ For each user feature we should also add a importance categorization label  to i
 
 -   [*] Image block: Replacing the media for an image set as featured prompts to update the featured image [#34666]
 -   [***] Font size and line-height support for text-based blocks used in block-based themes [#38205]
+-   [*] Highlight text: Check if style attribute value is defined during filtering [#38670]
 
 ## 1.70.2
 


### PR DESCRIPTION
**Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4560.**

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Following up on the changes introduced in https://github.com/WordPress/gutenberg/pull/37915, I noticed that the value of the style attribute when it's being filtered might be `undefined` in some cases, especially when using the old text color format with `span` tag ([reference](https://github.com/WordPress/gutenberg/pull/35516#pullrequestreview-784832627)).

This case leads to a crash in the app because we try to access the value in:

https://github.com/WordPress/gutenberg/blob/93de664de54b4eb5b8eb3d45b0962dabae549445/packages/format-library/src/text-color/index.native.js#L184

This PR fixes the issue by assuring that the value is defined before using it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a post/page.
2. Switch to HTML mode.
3. Paste the following HTML code:
```
<!-- wp:paragraph -->
<p>this <span class="has-inline-color has-green-color">is</span> <span class="has-inline-color has-red-color">test</span></p>
<!-- /wp:paragraph -->
```
4. Switch to Visual mode.
5. Observe that no errors are displayed.

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
