### PR TITLE
Gallery: register gallery in block_names dynamic block array

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -23,7 +23,6 @@ function gutenberg_reregister_core_block_types() {
 				'columns',
 				'comments-query-loop',
 				'cover',
-				'gallery',
 				'group',
 				'heading',
 				'html',

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -34,17 +34,10 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
 
 /**
  * Registers the `core/gallery` block on server.
- * This render callback needs to be here
- * so that the gallery styles are loaded in block-based themes.
  */
 function register_block_core_gallery() {
 	register_block_type_from_metadata(
 		__DIR__ . '/gallery',
-		array(
-			'render_callback' => function ( $attributes, $content ) {
-				return $content;
-			},
-		)
 	);
 }
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -37,7 +37,7 @@ add_filter( 'render_block_data', 'block_core_gallery_data_id_backcompatibility' 
  */
 function register_block_core_gallery() {
 	register_block_type_from_metadata(
-		__DIR__ . '/gallery',
+		__DIR__ . '/gallery'
 	);
 }
 


### PR DESCRIPTION
## Description
Hi! We're already registering the Gallery block in `gallery/index.php`, so it doesn't need to be in both `block_folders` and `block_names` array. 

It should be in the `block_names` array however, since it's server-side rendered, and also so we can register the core assets.

We also don't need the empty render function in block.php.


## Testing Instructions
1. Create a new gallery
2. Check that it looks as it should on the frontend
3. Repeat using both block ,such as TwentyTwentyTwo, and non-block themes, TwentyTwentyOne for example.

## Screenshots <!-- if applicable -->


<img width="986" alt="Screen Shot 2022-02-10 at 11 51 45 am" src="https://user-images.githubusercontent.com/6458278/153315826-d5d10cf2-75ab-41ae-906c-9a34b2508d3c.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
