### PR TITLE
Site Editor: Limit template part slugs to Latin chars

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template-part.js
+++ b/packages/edit-site/src/components/add-new-template/new-template-part.js
@@ -35,11 +35,17 @@ export default function NewTemplatePart( { postType } ) {
 		}
 
 		try {
+			// Currently template parts only allow latin chars.
+			// Fallback slug will receive suffix by default.
+			const cleanSlug =
+				kebabCase( title ).replace( /[^\w-]+/g, '' ) ||
+				'wp-custom-part';
+
 			const templatePart = await saveEntityRecord(
 				'postType',
 				'wp_template_part',
 				{
-					slug: kebabCase( title ),
+					slug: cleanSlug,
 					title,
 					content: '',
 					area,

--- a/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-template-part.js
@@ -30,11 +30,16 @@ export default function ConvertToTemplatePart( { clientIds, blocks } ) {
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	const onConvert = async ( { title, area } ) => {
+		// Currently template parts only allow latin chars.
+		// Fallback slug will receive suffix by default.
+		const cleanSlug =
+			kebabCase( title ).replace( /[^\w-]+/g, '' ) || 'wp-custom-part';
+
 		const templatePart = await saveEntityRecord(
 			'postType',
 			'wp_template_part',
 			{
-				slug: kebabCase( title ),
+				slug: cleanSlug,
 				title,
 				content: serialize( blocks ),
 				area,


### PR DESCRIPTION
## Description
Resolves #38160.

Currently, templates and template parts don't allow non-Latin characters as a slug.

This PR tries to "clean" up the slug first, and if this isn't possible, use a fallback slug.

## Testing Instructions
1. Go to Site Editor -> Template Parts
2. Click the "Add New" button.
3. Try creating a Template Part using a non-Latin title - `私のテンプレートパーツのテスト` or `ქართული ნაწილი`.
4. Confirm it was successfully created and with a fallback slug.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
