### PR TITLE
Prefer kses to blanket esc_html on label

### DIFF
--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -49,13 +49,13 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		 */
 		if ( ! $attributes['linkLabel'] ) {
 			if ( $label ) {
-				$format = '<span class="post-navigation-link__label">' . esc_html( $label ) . '</span> %link';
+				$format = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> %link';
 			}
 			$link = '%title';
 		} elseif ( isset( $attributes['linkLabel'] ) && $attributes['linkLabel'] ) {
 			// If the label link option is enabled and there is a custom label, display it before the title.
 			if ( $label ) {
-				$link = '<span class="post-navigation-link__label">' . esc_html( $label ) . '</span> <span class="post-navigation-link__title">%title</title>';
+				$link = '<span class="post-navigation-link__label">' . wp_kses_post( $label ) . '</span> <span class="post-navigation-link__title">%title</title>';
 			} else {
 				/*
 				 * If the label link option is enabled and there is no custom label,
@@ -64,7 +64,7 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 				$label = 'next' === $navigation_type ? _x( 'Next:', 'label before the title of the next post' ) : _x( 'Previous:', 'label before the title of the previous post' );
 				$link  = sprintf(
 					'<span class="post-navigation-link__label">%1$s</span> <span class="post-navigation-link__title">%2$s</span>',
-					esc_html( $label ),
+					wp_kses_post( $label ),
 					'%title'
 				);
 			}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR fixes [a bug](https://github.com/WordPress/gutenberg/issues/38560#issuecomment-1034500270) introduced when adding additional escaping to the output of blocks whereby any rich formatting or HTML would be output in it's raw form.

This PR refines the approach to use `wp_kses_post` which sanitizes input with allowed HTML elements for post content. This affords more flexibility whilst still warding off anything nefarious.

Kudos to @randhirexpresstech for catching and reporting this one.



## Testing Instructions

1. Add Query Loop. Select default layout.
2. Below the post excerpt add x2 Post Navigation Link blocks - one for "next" and the other for "previous" (they appear as "Next" and "Previous" in the block inserter.
3. In inspector controls set both blocks to `Display the title as a link` and also `Include the label as part of the link`.
4. Add as much HTML as you can to the label. Use the rich text formatting and custom HTML.
5. Publish.
6. Check front of site. No raw HTML should be displayed unless it falls outside the bounds of [what `wp_kses_post` deems acceptable for Post content](https://github.com/WordPress/wordpress-develop/blob/5b2cd500232f31432f19f99bc29fe48e6e08e886/src/wp-includes/kses.php#L882).

## Screenshots <!-- if applicable -->
<img width="628" alt="Screen Shot 2022-02-10 at 10 48 44" src="https://user-images.githubusercontent.com/444434/153391718-a34fe275-afab-405d-8fea-148dd41a83ec.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
