### PR TITLE
Block Directory: Fix the block activation when metadata registered on server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15715,6 +15715,7 @@
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/notices": "file:packages/notices",
 				"@wordpress/plugins": "file:packages/plugins",
+				"@wordpress/url": "file:packages/url",
 				"lodash": "^4.17.21"
 			}
 		},

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -43,6 +43,7 @@
 		"@wordpress/icons": "file:../icons",
 		"@wordpress/notices": "file:../notices",
 		"@wordpress/plugins": "file:../plugins",
+		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.21"
 	},
 	"publishConfig": {

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -85,33 +85,40 @@ export const installBlockType = ( block ) => async ( {
 			links: { ...block.links, ...links },
 		} );
 
-		// Ensures that the block metadata registered on the server is propagated to the editor.
-		const blockMetadata = await apiFetch( {
+		// Ensures that the block metadata is propagated to the editor when registered on the server.
+		await apiFetch( {
 			path: `/wp/v2/block-types/${ name }`,
-		} );
-		unstable__bootstrapServerSideBlockDefinitions( {
-			[ name ]: [
-				'api_version',
-				'title',
-				'category',
-				'parent',
-				'icon',
-				'description',
-				'keywords',
-				'attributes',
-				'provides_context',
-				'uses_context',
-				'supports',
-				'styles',
-				'example',
-				'variations',
-			].reduce( ( accumulator, key ) => {
-				if ( key in blockMetadata ) {
-					accumulator[ key ] = blockMetadata[ key ];
+		} )
+			// Ignore when the block is not registered on the server.
+			.catch( () => {} )
+			.then( ( response ) => {
+				if ( ! response ) {
+					return;
 				}
-				return accumulator;
-			}, {} ),
-		} );
+				unstable__bootstrapServerSideBlockDefinitions( {
+					[ name ]: [
+						'api_version',
+						'title',
+						'category',
+						'parent',
+						'icon',
+						'description',
+						'keywords',
+						'attributes',
+						'provides_context',
+						'uses_context',
+						'supports',
+						'styles',
+						'example',
+						'variations',
+					].reduce( ( accumulator, key ) => {
+						if ( key in response ) {
+							accumulator[ key ] = response[ key ];
+						}
+						return accumulator;
+					}, {} ),
+				} );
+			} );
 
 		await loadAssets();
 		const registeredBlocks = registry.select( blocksStore ).getBlockTypes();

--- a/packages/block-directory/src/store/actions.js
+++ b/packages/block-directory/src/store/actions.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { pick } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -8,6 +13,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { store as noticesStore } from '@wordpress/notices';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -86,8 +92,26 @@ export const installBlockType = ( block ) => async ( {
 		} );
 
 		// Ensures that the block metadata is propagated to the editor when registered on the server.
+		const metadataFields = [
+			'api_version',
+			'title',
+			'category',
+			'parent',
+			'icon',
+			'description',
+			'keywords',
+			'attributes',
+			'provides_context',
+			'uses_context',
+			'supports',
+			'styles',
+			'example',
+			'variations',
+		];
 		await apiFetch( {
-			path: `/wp/v2/block-types/${ name }`,
+			path: addQueryArgs( `/wp/v2/block-types/${ name }`, {
+				_fields: metadataFields,
+			} ),
 		} )
 			// Ignore when the block is not registered on the server.
 			.catch( () => {} )
@@ -96,27 +120,7 @@ export const installBlockType = ( block ) => async ( {
 					return;
 				}
 				unstable__bootstrapServerSideBlockDefinitions( {
-					[ name ]: [
-						'api_version',
-						'title',
-						'category',
-						'parent',
-						'icon',
-						'description',
-						'keywords',
-						'attributes',
-						'provides_context',
-						'uses_context',
-						'supports',
-						'styles',
-						'example',
-						'variations',
-					].reduce( ( accumulator, key ) => {
-						if ( key in response ) {
-							accumulator[ key ] = response[ key ];
-						}
-						return accumulator;
-					}, {} ),
+					[ name ]: pick( response, metadataFields ),
 				} );
 			} );
 

--- a/packages/block-directory/src/store/test/actions.js
+++ b/packages/block-directory/src/store/test/actions.js
@@ -75,6 +75,12 @@ describe( 'actions', () => {
 		},
 	};
 
+	const blockTypePath = '/wp/v2/block-types/block/block';
+	const blockTypeResponse = {
+		name: 'block/block',
+		title: 'Test Block',
+	};
+
 	describe( 'installBlockType', () => {
 		it( 'should install a block successfully', async () => {
 			const registry = createRegistryWithStores();
@@ -84,6 +90,8 @@ describe( 'actions', () => {
 				switch ( path ) {
 					case 'wp/v2/plugins':
 						return pluginResponse;
+					case blockTypePath:
+						return blockTypeResponse;
 					default:
 						throw new Error( `unexpected API endpoint: ${ path }` );
 				}
@@ -121,14 +129,14 @@ describe( 'actions', () => {
 			const registry = createRegistryWithStores();
 
 			// mock the api-fetch and load-assets modules
-			apiFetch.mockImplementation( async ( p ) => {
-				const { url } = p;
-				switch ( url ) {
-					case pluginEndpoint:
-						return pluginResponse;
-					default:
-						throw new Error( `unexpected API endpoint: ${ url }` );
+			apiFetch.mockImplementation( async ( { path, url } ) => {
+				if ( path === blockTypePath ) {
+					return blockTypeResponse;
 				}
+				if ( url === pluginEndpoint ) {
+					return pluginResponse;
+				}
+				throw new Error( `unexpected API endpoint: ${ url }` );
 			} );
 
 			loadAssets.mockImplementation( loadAssetsMock( registry ) );

--- a/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/block-directory-add.test.js
@@ -10,10 +10,19 @@ import {
 	createJSONResponse,
 } from '@wordpress/e2e-test-utils';
 
+const BLOCK1_NAME = 'block-directory-test-block/main-block';
+
 // Urls to mock
 const SEARCH_URLS = [
 	'/wp/v2/block-directory/search',
 	`rest_route=${ encodeURIComponent( '/wp/v2/block-directory/search' ) }`,
+];
+
+const BLOCK_TYPE_URLS = [
+	`/wp/v2/block-types/${ BLOCK1_NAME }`,
+	`rest_route=${ encodeURIComponent(
+		`/wp/v2/block-types/${ BLOCK1_NAME }`
+	) }`,
 ];
 
 const INSTALL_URLS = [
@@ -23,7 +32,7 @@ const INSTALL_URLS = [
 
 // Example Blocks
 const MOCK_BLOCK1 = {
-	name: 'block-directory-test-block/main-block',
+	name: BLOCK1_NAME,
 	title: 'Block Directory Test Block',
 	description: 'This plugin is useful for the block.',
 	id: 'block-directory-test-block',
@@ -108,6 +117,11 @@ const MOCK_BLOCKS_RESPONSES = [
 			matchUrl( request.url(), SEARCH_URLS ) &&
 			request.method() === 'GET',
 		onRequestMatch: createJSONResponse( [ MOCK_BLOCK1, MOCK_BLOCK2 ] ),
+	},
+	{
+		// Mock response for block type
+		match: ( request ) => matchUrl( request.url(), BLOCK_TYPE_URLS ),
+		onRequestMatch: createJSONResponse( {} ),
 	},
 	{
 		// Mock response for install


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #38245.

> ### Step-by-step reproduction instructions
> 
> 1. Toggle bock inserter.
> 2. Enter the appropriate text in the search box.
> 3. Activate some of the blocks that were extracted in the block directory.
> 4. You should get a similar error if `registerBlockType` does not have a title property.
> 
> ### Screenshots, screen recording, code snippet
> 
> ![issue](https://user-images.githubusercontent.com/54422211/151194436-6601c5a8-7f95-484e-afc8-7fd3fefde64c.png)

The action that installs the block from Block Directory triggers an additional REST API call to get the corresponding metadata for the newly installed plugin on the server. 



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Step-by-step reproduction instructions

1. Toggle bock inserter.
2. Enter the appropriate text (example: “list”) in the search box.
3. Activate some of the blocks that exist in the block directory, example: Super List.
4. You should see the block inserter correctly into the editor.

## Screenshots <!-- if applicable -->

<img width="1899" alt="Screenshot 2022-02-10 at 11 39 49" src="https://user-images.githubusercontent.com/699132/153394631-d1150c9a-9053-4188-a23c-c3ec92605544.png">


https://user-images.githubusercontent.com/699132/153394689-79438243-db30-4b8d-a244-545b04f3b531.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
