### PR TITLE
[Documentation]: Add docs about the `patterns` field of `theme.json`

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -991,6 +991,21 @@ Currently block variations exist for "header" and "footer" values of the area te
 }
 ```
 
+### patterns
+
+<div class="callout callout-alert">
+This field is only allowed when the Gutenberg plugin is active. It will be added in WordPress 6.0 so in previous versions it will be ignored.
+</div>
+
+Within this field themes can list patterns to register from [Pattern Directory](https://wordpress.org/patterns/). The `patterns` field is an array of pattern `slugs` from the Pattern Directory. Pattern slugs can be extracted by the `url` in single pattern view at the Pattern Directory. For example in this url `https://wordpress.org/patterns/pattern/partner-logos` the slug is `partner-logos`.
+
+```json
+{
+    "version": 2,
+	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
+}
+```
+
 ## Developing with theme.json
 
 It can be difficult to remember the theme.json settings and properties while you develop, so a JSON scheme was created to help. The schema is available at https://schemas.wp.org/trunk/theme.json

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -995,7 +995,7 @@ Currently block variations exist for "header" and "footer" values of the area te
 ### patterns
 
 <div class="callout callout-alert">
-This field is only allowed when the Gutenberg plugin is active. It will be added in WordPress 6.0 so in previous versions it will be ignored.
+This field requires the Gutenberg plugin active and using the [version 2](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/) of `theme.json`.
 </div>
 
 Within this field themes can list patterns to register from [Pattern Directory](https://wordpress.org/patterns/). The `patterns` field is an array of pattern `slugs` from the Pattern Directory. Pattern slugs can be extracted by the `url` in single pattern view at the Pattern Directory. For example in this url `https://wordpress.org/patterns/pattern/partner-logos` the slug is `partner-logos`.

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -20,6 +20,7 @@ WordPress 5.8 comes with [a new mechanism](https://make.wordpress.org/core/2021/
         - Elements
     - customTemplates
     - templateParts
+    - patterns
 - FAQ
     - The naming schema of CSS Custom Properties
     - Why using -- as a separator?


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/38323

Adds documentation about the added `patterns` field in `theme.json`.