### PR TITLE
Remove site icon animation

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -17,7 +17,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { wordpress } from '@wordpress/icons';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { useReducedMotion } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -49,26 +48,15 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 		[]
 	);
 
-	const disableMotion = useReducedMotion();
-
 	if ( ! isActive || ! postType ) {
 		return null;
 	}
 
 	let buttonIcon = <Icon size="36px" icon={ wordpress } />;
 
-	const effect = {
-		expand: {
-			scale: 1.7,
-			borderRadius: 0,
-			transition: { type: 'tween', duration: '0.2' },
-		},
-	};
-
 	if ( siteIconUrl ) {
 		buttonIcon = (
-			<motion.img
-				variants={ ! disableMotion && effect }
+			<img
 				alt={ __( 'Site Icon' ) }
 				className="edit-post-fullscreen-mode-close_site-icon"
 				src={ siteIconUrl }


### PR DESCRIPTION
## Description
Removes animation for Site icon from Fullscreen mode close button.

Resolves #38575
## Testing Instructions
1. Add Site Logo block to post or page.
2. Enable `Use as site icon` from block settings.
3. Refresh the page.
4. Hovering on this icon in the top left corner shouldn't trigger animations.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-10 at 16 18 57](https://user-images.githubusercontent.com/240569/153407782-79395c31-b2a5-4035-bca4-f02c66efc762.png)

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
