### PR TITLE
Block Quick Inserter: Prioritize showing patterns instead of blocks.

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -64,10 +64,10 @@ export default function QuickInserter( {
 			return {
 				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
 				prioritizePatterns:
-					settings.__experimentalPrioritizePatternsOnQuickInserterRoot &&
+					settings.__experimentalPreferPatternsOnRoot &&
 					! rootClientId &&
 					index > 0 &&
-					index < blockCount,
+					( index < blockCount || blockCount === 0 ),
 				insertionIndex: index === -1 ? blockCount : index,
 			};
 		},
@@ -128,7 +128,7 @@ export default function QuickInserter( {
 					maxBlockPatterns={ maxBlockPatterns }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
-					__experimentalPrioritizePatterns={ prioritizePatterns }
+					prioritizePatterns={ prioritizePatterns }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -23,6 +23,7 @@ import { store as blockEditorStore } from '../../store';
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
 const SHOWN_BLOCK_PATTERNS = 2;
+const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
 
 export default function QuickInserter( {
 	onSelect,
@@ -46,25 +47,38 @@ export default function QuickInserter( {
 		onInsertBlocks,
 		destinationRootClientId
 	);
-	const showPatterns = patterns.length && !! filterValue;
-	const showSearch =
-		( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
-		blockTypes.length > SEARCH_THRESHOLD;
 
-	const { setInserterIsOpened, insertionIndex } = useSelect(
+	const {
+		setInserterIsOpened,
+		insertionIndex,
+		prioritizePatterns,
+	} = useSelect(
 		( select ) => {
 			const { getSettings, getBlockIndex, getBlockCount } = select(
 				blockEditorStore
 			);
+			const settings = getSettings();
 			const index = getBlockIndex( clientId );
+			const blockCount = getBlockCount();
+
 			return {
-				setInserterIsOpened: getSettings()
-					.__experimentalSetIsInserterOpened,
-				insertionIndex: index === -1 ? getBlockCount() : index,
+				setInserterIsOpened: settings.__experimentalSetIsInserterOpened,
+				prioritizePatterns:
+					settings.__experimentalPrioritizePatternsOnQuickInserterRoot &&
+					! rootClientId &&
+					index > 0 &&
+					index < blockCount,
+				insertionIndex: index === -1 ? blockCount : index,
 			};
 		},
 		[ clientId, rootClientId ]
 	);
+
+	const showPatterns =
+		patterns.length && ( !! filterValue || prioritizePatterns );
+	const showSearch =
+		( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
+		blockTypes.length > SEARCH_THRESHOLD;
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {
@@ -77,6 +91,13 @@ export default function QuickInserter( {
 	const onBrowseAll = () => {
 		setInserterIsOpened( { rootClientId, insertionIndex, filterValue } );
 	};
+
+	let maxBlockPatterns = 0;
+	if ( showPatterns ) {
+		maxBlockPatterns = prioritizePatterns
+			? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
+			: SHOWN_BLOCK_PATTERNS;
+	}
 
 	return (
 		<div
@@ -104,9 +125,10 @@ export default function QuickInserter( {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					maxBlockPatterns={ showPatterns ? SHOWN_BLOCK_PATTERNS : 0 }
+					maxBlockPatterns={ maxBlockPatterns }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
+					__experimentalPrioritizePatterns={ prioritizePatterns }
 				/>
 			</div>
 

--- a/packages/block-editor/src/components/inserter/search-results.js
+++ b/packages/block-editor/src/components/inserter/search-results.js
@@ -48,7 +48,7 @@ function InserterSearchResults( {
 	showBlockDirectory = false,
 	isDraggable = true,
 	shouldFocusBlock = true,
-	__experimentalPrioritizePatterns,
+	prioritizePatterns,
 } ) {
 	const debouncedSpeak = useDebounce( speak, 500 );
 
@@ -72,6 +72,9 @@ function InserterSearchResults( {
 	);
 
 	const filteredBlockPatterns = useMemo( () => {
+		if ( maxBlockPatterns === 0 ) {
+			return [];
+		}
 		const results = searchItems( patterns, filterValue );
 		return maxBlockPatterns !== undefined
 			? results.slice( 0, maxBlockPatterns )
@@ -79,14 +82,14 @@ function InserterSearchResults( {
 	}, [ filterValue, patterns, maxBlockPatterns ] );
 
 	let maxBlockTypesToShow = maxBlockTypes;
-	if (
-		__experimentalPrioritizePatterns &&
-		filteredBlockPatterns.length > 2
-	) {
+	if ( prioritizePatterns && filteredBlockPatterns.length > 2 ) {
 		maxBlockTypesToShow = 0;
 	}
 
 	const filteredBlockTypes = useMemo( () => {
+		if ( maxBlockTypesToShow === 0 ) {
+			return [];
+		}
 		const results = searchBlockItems(
 			orderBy( blockTypes, [ 'frecency' ], [ 'desc' ] ),
 			blockTypeCategories,
@@ -166,14 +169,14 @@ function InserterSearchResults( {
 		<InserterListbox>
 			{ ! showBlockDirectory && ! hasItems && <InserterNoResults /> }
 
-			{ __experimentalPrioritizePatterns ? patternsUI : blocksUI }
+			{ prioritizePatterns ? patternsUI : blocksUI }
 
 			{ !! filteredBlockTypes.length &&
 				!! filteredBlockPatterns.length && (
 					<div className="block-editor-inserter__quick-inserter-separator" />
 				) }
 
-			{ __experimentalPrioritizePatterns ? blocksUI : patternsUI }
+			{ prioritizePatterns ? blocksUI : patternsUI }
 
 			{ showBlockDirectory && (
 				<__unstableInserterMenuExtension.Slot

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -98,7 +98,7 @@ export const getSettings = createSelector(
 			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
 			__experimentalSetIsInserterOpened: setIsInserterOpen,
 			__experimentalReusableBlocks: getReusableBlocks( state ),
-			__experimentalPrioritizePatternsOnQuickInserterRoot:
+			__experimentalPreferPatternsOnRoot:
 				'wp_template' === getEditedPostType( state ),
 		};
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -98,6 +98,8 @@ export const getSettings = createSelector(
 			hasFixedToolbar: isFeatureActive( state, 'fixedToolbar' ),
 			__experimentalSetIsInserterOpened: setIsInserterOpen,
 			__experimentalReusableBlocks: getReusableBlocks( state ),
+			__experimentalPrioritizePatternsOnQuickInserterRoot:
+				'wp_template' === getEditedPostType( state ),
 		};
 
 		const canUserCreateMedia = getCanUserCreateMedia( state );
@@ -120,6 +122,7 @@ export const getSettings = createSelector(
 		isFeatureActive( state, 'focusMode' ),
 		isFeatureActive( state, 'fixedToolbar' ),
 		getReusableBlocks( state ),
+		getEditedPostType( state ),
 	]
 );
 

--- a/packages/edit-site/src/store/test/selectors.js
+++ b/packages/edit-site/src/store/test/selectors.js
@@ -106,7 +106,11 @@ describe( 'selectors', () => {
 		it( "returns the settings when the user can't create media", () => {
 			canUser.mockReturnValueOnce( false );
 			canUser.mockReturnValueOnce( false );
-			const state = { settings: {}, preferences: {} };
+			const state = {
+				settings: {},
+				preferences: {},
+				editedPost: { type: 'wp_template' },
+			};
 			const setInserterOpened = () => {};
 			expect( getSettings( state, setInserterOpened ) ).toEqual( {
 				outlineMode: true,
@@ -114,6 +118,7 @@ describe( 'selectors', () => {
 				hasFixedToolbar: false,
 				__experimentalSetIsInserterOpened: setInserterOpened,
 				__experimentalReusableBlocks: [],
+				__experimentalPreferPatternsOnRoot: true,
 			} );
 		} );
 
@@ -126,6 +131,7 @@ describe( 'selectors', () => {
 						fixedToolbar: true,
 					},
 				},
+				editedPost: { type: 'wp_template_part' },
 			};
 			const setInserterOpened = () => {};
 
@@ -137,6 +143,7 @@ describe( 'selectors', () => {
 				__experimentalSetIsInserterOpened: setInserterOpened,
 				__experimentalReusableBlocks: [],
 				mediaUpload: expect.any( Function ),
+				__experimentalPreferPatternsOnRoot: false,
 			} );
 		} );
 	} );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -148,6 +148,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
 			pageOnFront,
+			__experimentalPrioritizePatternsOnQuickInserterRoot: hasTemplate,
 		} ),
 		[
 			settings,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -148,7 +148,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
 			pageOnFront,
-			__experimentalPrioritizePatternsOnQuickInserterRoot: hasTemplate,
+			__experimentalPreferPatternsOnRoot: hasTemplate,
 		} ),
 		[
 			settings,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/36697


This PR follows the design proposed in https://github.com/WordPress/gutenberg/issues/36697:
![image](https://user-images.githubusercontent.com/11271197/153437413-f94003a6-2098-4c7d-807d-55fb43da5f03.png)

And prioritizes patterns on the quick inserter when all the following conditions match:
- We are editing a template either on site editor or post editor.
- The inserter is at the root.
- The content being inserted is between some block (not as first block nor as last).

By default we have four patterns following the order the server provided them. We don't have any sorting mechanism like last used time, heuristics of the place of insertion, etc, the type of template, etc. As a follow-up, we need to have a mechanism for sorting patterns so what we show is more relevant.

We allow searching for patterns or blocks if we have 3 or more patterns to show we show only patterns if we have 2 or less patterns we show patterns and blocks (patterns being at the top). This allows the user to search for a paragraph block and insert it using the quick inserter if the user wants two (provided there are no 3 or more patterns containing "paragraph" in the name).

![image](https://user-images.githubusercontent.com/11271197/153439576-061589b4-99cd-442e-9151-01084e2b052b.png)

![image](https://user-images.githubusercontent.com/11271197/153440510-f3794151-a5c3-41e0-a0c9-4b60708e6909.png)


## Testing 
I verified the patterns are prioritized on the inserter on post editor and site editor when the condition are met.


 
