### PR TITLE
Increase support for `experimental-link-color` until WordPress 5.9 is the minimum version

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -308,7 +308,7 @@ To retain backward compatibility, the existing `add_theme_support` declarations 
 | `editor-color-palette`      | Provide the list of colors via `color.palette`.           |
 | `editor-font-sizes`         | Provide the list of font size via `typography.fontSizes`. |
 | `editor-gradient-presets`   | Provide the list of gradients via `color.gradients`.      |
-| `experimental-link-color`   | Set `color.link` to `true`.                               |
+| `experimental-link-color`   | Set `color.link` to `true`. `experimental-link-color` will be removed when the plugin requires WordPress 5.9 as the minimum version. |
 
 #### Presets
 

--- a/docs/how-to-guides/themes/theme-support.md
+++ b/docs/how-to-guides/themes/theme-support.md
@@ -435,7 +435,7 @@ Link support has been made stable as part of WordPress 5.8. It's `false` by defa
 }
 ```
 
-> Alternatively, with the Gutenberg plugin active, the old legacy support `add_theme_support( 'experimental-link-color' )` would also work. This fallback would be removed when the Gutenberg plugin requires WordPress 5.8 as the minimum version.
+> Alternatively, with the Gutenberg plugin active, the old legacy support `add_theme_support( 'experimental-link-color' )` would also work. This fallback would be removed when the Gutenberg plugin requires WordPress 5.9 as the minimum version.
 
 When the user sets the link color of a block, a new style will be added in the form of:
 

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -1906,6 +1906,12 @@ class WP_Theme_JSON_5_9 {
 		// This should be removed when the plugin minimum WordPress version
 		// is bumped to 5.9.
 		//
+		// Since WordPress 5.9, the CSS Custom Properties are enqueued for all themes,
+		// so we no longer need to detect theme support for this.
+		// Removing this code will have the effect of making link color
+		// not visible for classic themes that opted-in and depended on the plugin
+		// to show the UI control for link color to users.
+		//
 		// Do not port this to WordPress core.
 		if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {
 			if ( ! isset( $theme_settings['settings']['color'] ) ) {

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -1904,7 +1904,7 @@ class WP_Theme_JSON_5_9 {
 
 		// Things that didn't land in core yet, so didn't have a setting assigned.
 		// This should be removed when the plugin minimum WordPress version
-		// is bumped to 5.8.
+		// is bumped to 5.9.
 		//
 		// Do not port this to WordPress core.
 		if ( current( (array) get_theme_support( 'experimental-link-color' ) ) ) {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/38701

This PR increases the support for `experimental-link-color` in the Gutenberg plugin when it requires WordPress 5.9 as the minimum version (previously it was at WordPress 5.8).

Since WordPress 5.9.1, the CSS Custom Properties will be enqueued for all themes, including classic ones (see [trac ticket](https://core.trac.wordpress.org/ticket/54782)), so we no longer need to detect this support to enqueue the CSS Custom Properties. The side-effect of removing this support is that the UI for link color won't be visible in classic themes that had opted-in and depended on the plugin to show it.
