### PR TITLE
Restructure code bock styling

### DIFF
--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -15,7 +15,6 @@
 	},
 	"supports": {
 		"anchor": true,
-		"__experimentalSelector": ".wp-block-code > code",
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -1,6 +1,8 @@
-// Provide a minimum of overflow handling.
+// Provide a minimum of overflow handling and ensure the code markup inherits
+// the font-family set on pre.
 .wp-block-code code {
 	display: block;
-	white-space: pre-wrap;
+	font-family: inherit;
 	overflow-wrap: break-word;
+	white-space: pre-wrap;
 }

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -4,8 +4,3 @@
 	font-family: Menlo, Consolas, monaco, monospace;
 	padding: 0.8em 1em;
 }
-
-/* Ensures code markup inherits the font-family set on pre. */
-.wp-block-code > code {
-	font-family: inherit;
-}

--- a/packages/block-library/src/code/theme.scss
+++ b/packages/block-library/src/code/theme.scss
@@ -1,9 +1,11 @@
 .wp-block-code {
 	border: 1px solid #ccc;
 	border-radius: 4px;
-}
-
-.wp-block-code > code {
 	font-family: Menlo, Consolas, monaco, monospace;
 	padding: 0.8em 1em;
+}
+
+/* Ensures code markup inherits the font-family set on pre. */
+.wp-block-code > code {
+	font-family: inherit;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
The styling for the Code block has gone through many iterations. In the last PR https://github.com/WordPress/gutenberg/pull/37818, the border styling was moved to the `pre` element. While this was an improvement, any Code block styles specified in theme.json were actually mapped to the `code` element. So if a user added border styling in theme.json, they would end up with a double border, one on `pre` set by WordPress theme.css and one set by the user. 

In exploring solutions, the best appears to be removing the `"__experimentalSelector": ".wp-block-code > code"` line in block.json. Then any user styles in theme.json get applied to the `pre` element and override any theme.css styles as expected. 

The one downside of this approach is that browsers commonly set `font-family` on `code` elements. As mentioned by @jasmussen in #37818, an easy solution to this is to simply set `font-family: inherit` on the `code` element, which will inherit any custom font styling applied to the `pre` element. This approach was implemented in this PR. 

## Testing Instructions

So now everything works as expected, but there is a strange issue that I am hoping someone might be able to help with. I was under the impression that Gutenberg block styles replace any set by WordPress core. However, in testing this PR, I noticed some "orphan" styling that is getting applied, which is coming from WordPress, not Gutenberg. 

![image](https://user-images.githubusercontent.com/4832319/153467291-0140e651-3a42-4c88-863e-736ff94ec5c0.png)

This is likely a separate issue, but be aware when testing this PR. You will want to unset these styles as indicated below. They only appear on the frontend.

![image](https://user-images.githubusercontent.com/4832319/153467692-82441465-f21b-4cde-ab30-11b521b5a404.png)

**Testing Steps**

1. Use Twenty Twenty-Two
2. On a new page add a Code block and add some code to the block.
3. View the block on the frontend, unset the styles indicated above, and confirm the block looks the same as in the Editor
4. Open the theme.json file for the theme and add the following to the styles area

```
"core/code": {
    "border": {
	"color": "red",
        "radius": "4px"
	"style": "solid",
	"width": "1px"
    }
}
```

5. Navigate back to the page with the code in the Editor and confirm the border is now red. 
6. View the block on the frontend, unset the styles indicated above, and confirm the block looks the same as in the Editor
7. Got back to the Editor and manually change the border styling in the block sidebar UI. 
8. View the block on the frontend, unset the styles indicated above, and confirm the block looks the same as in the Editor

## Types of changes
Bug Fix / Enhancement

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
