### PR TITLE
Experiment: Client-side navigation with pagination block and query loop.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15798,17 +15798,82 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.3.1",
 				"colord": "^2.7.0",
+				"css-select": "^4.2.1",
 				"fast-average-color": "4.3.0",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.10",
-				"moment": "^2.22.1"
+				"moment": "^2.22.1",
+				"morphdom": "2.6.1"
 			},
 			"dependencies": {
 				"colord": {
 					"version": "2.8.0",
 					"resolved": "https://registry.npmjs.org/colord/-/colord-2.8.0.tgz",
 					"integrity": "sha512-kNkVV4KFta3TYQv0bzs4xNwLaeag261pxgzGQSh4cQ1rEhYjcTJfFRP0SDlbhLONg0eSoLzrDd79PosjbltufA=="
+				},
+				"css-select": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
+					"integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+					"requires": {
+						"boolbase": "^1.0.0",
+						"css-what": "^5.1.0",
+						"domhandler": "^4.3.0",
+						"domutils": "^2.8.0",
+						"nth-check": "^2.0.1"
+					}
+				},
+				"css-what": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
+					"integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw=="
+				},
+				"dom-serializer": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+					"integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+					"requires": {
+						"domelementtype": "^2.0.1",
+						"domhandler": "^4.2.0",
+						"entities": "^2.0.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
+					"integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
+				},
+				"domhandler": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.0.tgz",
+					"integrity": "sha512-fC0aXNQXqKSFTr2wDNZDhsEYjCiYsDWl3D01kwt25hm1YIPyDGHvvi3rw+PLqHAl/m71MaiF7d5zvBr0p5UB2g==",
+					"requires": {
+						"domelementtype": "^2.2.0"
+					}
+				},
+				"domutils": {
+					"version": "2.8.0",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+					"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+					"requires": {
+						"dom-serializer": "^1.0.1",
+						"domelementtype": "^2.2.0",
+						"domhandler": "^4.2.0"
+					}
+				},
+				"entities": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+					"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+				},
+				"nth-check": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
+					"integrity": "sha512-it1vE95zF6dTT9lBsYbxvqh0Soy4SPowchj0UBGj/V6cTPnXXtQOPUbhZ6CmGzAD/rW22LQK6E96pcdJXk4A4w==",
+					"requires": {
+						"boolbase": "^1.0.0"
+					}
 				}
 			}
 		},
@@ -19240,16 +19305,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"are-we-there-yet": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
@@ -44601,6 +44656,11 @@
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
 			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
 			"dev": true
+		},
+		"morphdom": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.6.1.tgz",
+			"integrity": "sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA=="
 		},
 		"mousetrap": {
 			"version": "1.6.5",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -65,7 +65,8 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",
-		"moment": "^2.22.1"
+		"moment": "^2.22.1",
+		"morphdom": "2.6.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -12,6 +12,7 @@
 			"type": "string"
 		}
 	},
+	"viewScript": "file:./view.min.js",
 	"usesContext": [ "queryId", "query", "paginationArrow" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -19,6 +19,8 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$max_page = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 
+	wp_enqueue_script( 'wp-block-query-pagination-next-view' );
+
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$default_label      = __( 'Next Page' );
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import morphdom from 'morphdom';
+
+const load = () => {
+	const link = document.querySelector( '.wp-block-query-pagination-next' );
+
+	link.addEventListener( 'click', async ( e ) => {
+		e.preventDefault();
+
+		// Fetch the HTML of the new page.
+		const url = e.target.href;
+		const html = await loadHtml( url );
+
+		// Find the root of the real DOM and the new page.
+		const root = document.querySelector( '.wp-site-blocks' );
+		const newRoot = /<div class="wp-site-blocks".*<\/div>/s.exec(
+			html
+		)[ 0 ];
+
+		// Replace root with the new HTML.
+		morphdom( root, newRoot );
+
+		// Change the browser URL.
+		window.history.pushState( {}, '', url );
+
+		// Scroll to the top to simulate page load.
+		window.scrollTo( 0, 0 );
+
+		// Rehydrate
+		load();
+	} );
+};
+
+window.addEventListener( 'load', load );
+
+async function loadHtml( url ) {
+	const data = await window.fetch( url );
+	const html = await data.text();
+	return html;
+}


### PR DESCRIPTION
This is an experiment with the Pagination and Query Loop blocks.

Modified the `Pagination Next` block to load the new HTML from the server [Turbolinks](https://github.com/hotwired/turbo)-style and merge the new HTML into the current page without a full page reload.

You can check the code, it's barely 30 lines but the steps are roughly:

1. Load a frontend script in `view.js` file of the `Pagination Next` block
2. Override the default click handler of the pagination block's anchor
3. Load the HTML for the new page with Fetch instead
4. Use [morphdom](https://github.com/patrick-steele-idem/morphdom) library to merge new HTML into the current page
5. We've overriden the browser's default behaviour so now we have to update the browser history with `history.pushState()`
6. Rehydrate the page. Since we've loaded new HTML we have to re-run the script that overrides the default click handler of the anchor again... yada yada yada 😄 


Still a bit buggy, but you get the idea:

https://user-images.githubusercontent.com/5417266/153475757-80779351-4e6f-4565-aa72-7c6a3635f52c.mov


