### PR TITLE
Scripts: Copy PHP files from `src` into `build`

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### New Feature
+
+-   Automatically copy PHP files located in the `src` folder and its subfolders to the output directory (`build` by default) ([#38715](https://github.com/WordPress/gutenberg/pull/38715)).
+
+
 ## 21.0.0 (2022-02-10)
 
 ### Breaking Changes

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -232,6 +232,11 @@ const config = {
 					context: 'src',
 					noErrorOnMissing: true,
 				},
+				{
+					from: '**/**.php',
+					context: 'src',
+					noErrorOnMissing: true,
+				},
 			],
 		} ),
 		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents


### PR DESCRIPTION
## Description
When building dynamic blocks, there are many cases where splitting out the markup into an external PHP file is very helpful. The current build process copies the block.json file into the `build` directory but any `.php` files are not. This PR adds them to the copying process. 

## Testing Instructions
I created a block using `npx @wordpress/create-block@ my-first-dynamic-block --template=@ryanwelcher/dynamic-block-template` ( this contains an template.php file in the src directory )
Then ran `node {FULLPATH}/gutenberg/packages/scripts/bin/wp-scripts.js -- build`

## Screenshots <!-- if applicable -->

## Types of changes
Adds any .PHP files inside of `src` to it's corresponding location in `build`

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
