### PR TITLE
FontSizePicker: Refactor stories to use Controls

### DIFF
--- a/packages/components/src/font-size-picker/README.md
+++ b/packages/components/src/font-size-picker/README.md
@@ -100,8 +100,7 @@ If `true`, the UI will contain a slider, instead of a numeric text input field. 
 
 ### withReset
 
-If `true`, a reset button will be displayed alongside the predefined and custom
-font size fields.
+If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` or `withSlider` is `true`.
 
 -   Type: `Boolean`
 -   Required: no

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -14,6 +14,10 @@ export default {
 	argTypes: {
 		initialValue: { table: { disable: true } }, // hide prop because it's not actually part of FontSizePicker
 	},
+	parameters: {
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
+	},
 };
 
 const FontSizePickerWithState = ( { initialValue, ...props } ) => {

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -100,7 +100,7 @@ WithCustomSizesDisabled.parameters = {
 	docs: {
 		description: {
 			story:
-				'When disabled, the user will only be able to pick one of the predefined sizes passed in `fontSizes`.',
+				'With custom font sizes disabled via the `disableCustomFontSizes` prop, the user will only be able to pick one of the predefined sizes passed in `fontSizes`.',
 		},
 	},
 };

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -13,6 +13,13 @@ export default {
 	component: FontSizePicker,
 	argTypes: {
 		initialValue: { table: { disable: true } }, // hide prop because it's not actually part of FontSizePicker
+		withReset: {
+			control: { type: 'boolean' },
+			table: {
+				type: 'boolean',
+				defaultValue: { summary: true },
+			},
+		},
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -68,7 +75,6 @@ Default.args = {
 	],
 	initialValue: 16,
 	withSlider: false,
-	withReset: true,
 };
 
 export const WithSlider = FontSizePickerWithState.bind( {} );

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -91,10 +91,18 @@ WithSlider.args = {
 	withSlider: true,
 };
 
-export const WithoutCustomSizes = FontSizePickerWithState.bind( {} );
-WithoutCustomSizes.args = {
+export const WithCustomSizesDisabled = FontSizePickerWithState.bind( {} );
+WithCustomSizesDisabled.args = {
 	...Default.args,
 	disableCustomFontSizes: true,
+};
+WithCustomSizesDisabled.parameters = {
+	docs: {
+		description: {
+			story:
+				'When disabled, the user will only be able to pick one of the predefined sizes passed in `fontSizes`.',
+		},
+	},
 };
 
 export const WithMoreFontSizes = FontSizePickerWithState.bind( {} );
@@ -134,6 +142,14 @@ WithMoreFontSizes.args = {
 	],
 	initialValue: 8,
 };
+WithMoreFontSizes.parameters = {
+	docs: {
+		description: {
+			story:
+				'When there are more than 5 font size options, the UI is no longer a toggle group.',
+		},
+	},
+};
 
 export const WithUnits = TwoFontSizePickersWithState.bind( {} );
 WithUnits.args = {
@@ -143,6 +159,14 @@ WithUnits.args = {
 		size: `${ option.size }px`,
 	} ) ),
 	initialValue: '8px',
+};
+WithUnits.parameters = {
+	docs: {
+		description: {
+			story:
+				'When units like `px` are specified explicitly, it will be shown as a label hint.',
+		},
+	},
 };
 
 export const WithComplexCSSValues = TwoFontSizePickersWithState.bind( {} );
@@ -182,4 +206,12 @@ WithComplexCSSValues.args = {
 		},
 	],
 	initialValue: '1.125rem',
+};
+WithComplexCSSValues.parameters = {
+	docs: {
+		description: {
+			story:
+				'The label hint will not be shown if it is a complex CSS value. Some examples of complex CSS values in this context are CSS functions like `calc()`, `clamp()`, and `var()`.',
+		},
+	},
 };

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { number, object, boolean } from '@storybook/addon-knobs';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -16,14 +11,13 @@ import FontSizePicker from '../';
 export default {
 	title: 'Components/FontSizePicker',
 	component: FontSizePicker,
-	parameters: {
-		knobs: { disable: false },
+	argTypes: {
+		initialValue: { table: { disable: true } }, // hide prop because it's not actually part of FontSizePicker
 	},
 };
 
 const FontSizePickerWithState = ( { initialValue, ...props } ) => {
-	const [ fontSize, setFontSize ] = useState( initialValue || 16 );
-
+	const [ fontSize, setFontSize ] = useState( initialValue );
 	return (
 		<FontSizePicker
 			{ ...props }
@@ -33,57 +27,25 @@ const FontSizePickerWithState = ( { initialValue, ...props } ) => {
 	);
 };
 
-export const _default = () => {
-	const fontSizes = object( 'Font Sizes', [
-		{
-			name: 'Small',
-			slug: 'small',
-			size: 12,
-		},
-		{
-			name: 'Normal',
-			slug: 'normal',
-			size: 16,
-		},
-		{
-			name: 'Big',
-			slug: 'big',
-			size: 26,
-		},
-	] );
-	return <FontSizePickerWithState fontSizes={ fontSizes } />;
-};
-
-export const withSlider = () => {
-	const fontSizes = object( 'Font Sizes', [
-		{
-			name: 'Small',
-			slug: 'small',
-			size: 12,
-		},
-		{
-			name: 'Normal',
-			slug: 'normal',
-			size: 16,
-		},
-		{
-			name: 'Big',
-			slug: 'big',
-			size: 26,
-		},
-	] );
-	const fallbackFontSize = number( 'Fallback Font Size - Slider Only', 16 );
+const TwoFontSizePickersWithState = ( { fontSizes, ...props } ) => {
 	return (
-		<FontSizePickerWithState
-			fontSizes={ fontSizes }
-			fallbackFontSize={ fallbackFontSize }
-			withSlider
-		/>
+		<>
+			<h2>Fewer font sizes</h2>
+			<FontSizePickerWithState
+				{ ...props }
+				fontSizes={ fontSizes.slice( 0, 4 ) }
+			/>
+
+			<h2>More font sizes</h2>
+			<FontSizePickerWithState { ...props } fontSizes={ fontSizes } />
+		</>
 	);
 };
 
-export const withoutCustomSizes = () => {
-	const fontSizes = object( 'Font Sizes', [
+export const Default = FontSizePickerWithState.bind( {} );
+Default.args = {
+	disableCustomFontSizes: false,
+	fontSizes: [
 		{
 			name: 'Small',
 			slug: 'small',
@@ -99,17 +61,30 @@ export const withoutCustomSizes = () => {
 			slug: 'big',
 			size: 26,
 		},
-	] );
-	return (
-		<FontSizePickerWithState
-			fontSizes={ fontSizes }
-			disableCustomFontSizes
-		/>
-	);
+	],
+	initialValue: 16,
+	withSlider: false,
+	withReset: true,
 };
 
-export const differentControlBySize = () => {
-	const options = [
+export const WithSlider = FontSizePickerWithState.bind( {} );
+WithSlider.args = {
+	...Default.args,
+	fallbackFontSize: 16,
+	initialValue: undefined,
+	withSlider: true,
+};
+
+export const WithoutCustomSizes = FontSizePickerWithState.bind( {} );
+WithoutCustomSizes.args = {
+	...Default.args,
+	disableCustomFontSizes: true,
+};
+
+export const WithMoreFontSizes = FontSizePickerWithState.bind( {} );
+WithMoreFontSizes.args = {
+	...Default.args,
+	fontSizes: [
 		{
 			name: 'Tiny',
 			slug: 'tiny',
@@ -140,29 +115,29 @@ export const differentControlBySize = () => {
 			slug: 'huge',
 			size: 36,
 		},
-	];
-	const optionsWithUnits = options.map( ( option ) => ( {
-		...option,
-		size: `${ option.size }px`,
-	} ) );
-	const showMoreFontSizes = boolean( 'Add more font sizes', false );
-	const addUnitsToSizes = boolean( 'Add units to font sizes', false );
-	const _options = addUnitsToSizes ? optionsWithUnits : options;
-	const fontSizes = _options.slice(
-		0,
-		showMoreFontSizes ? _options.length : 4
-	);
-	return (
-		<FontSizePickerWithState fontSizes={ fontSizes } initialValue={ 8 } />
-	);
+	],
+	initialValue: 8,
 };
 
-export const withComplexCSSValues = () => {
-	const options = [
+export const WithUnits = TwoFontSizePickersWithState.bind( {} );
+WithUnits.args = {
+	...WithMoreFontSizes.args,
+	fontSizes: WithMoreFontSizes.args.fontSizes.map( ( option ) => ( {
+		...option,
+		size: `${ option.size }px`,
+	} ) ),
+	initialValue: '8px',
+};
+
+export const WithComplexCSSValues = TwoFontSizePickersWithState.bind( {} );
+WithComplexCSSValues.args = {
+	...Default.args,
+	fontSizes: [
 		{
 			name: 'Small',
 			slug: 'small',
-			size: '0.65rem',
+			// Adding just one complex css value is enough
+			size: 'clamp(1.75rem, 3vw, 2.25rem)',
 		},
 		{
 			name: 'Medium',
@@ -189,32 +164,6 @@ export const withComplexCSSValues = () => {
 			slug: 'huge',
 			size: '2.8rem',
 		},
-	];
-	const showMoreFontSizes = boolean( 'Add more font sizes', false );
-	const addComplexCssValues = boolean(
-		'Add some complex css values(calc, var, etc..)',
-		true
-	);
-
-	const _options = options.map( ( option, index ) => {
-		const _option = { ...option };
-		// Adding just one complex css value is enough (first element);
-		if ( addComplexCssValues && ! index ) {
-			_option.size = 'clamp(1.75rem, 3vw, 2.25rem)';
-		}
-		return _option;
-	} );
-
-	const fontSizes = _options.slice(
-		0,
-		showMoreFontSizes ? _options.length : 5
-	);
-	return (
-		<div style={ { maxWidth: '248px' } }>
-			<FontSizePickerWithState
-				fontSizes={ fontSizes }
-				initialValue={ '1.125rem' }
-			/>
-		</div>
-	);
+	],
+	initialValue: '1.125rem',
 };

--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -13,7 +13,13 @@ export default {
 	component: FontSizePicker,
 	argTypes: {
 		initialValue: { table: { disable: true } }, // hide prop because it's not actually part of FontSizePicker
+		fallbackFontSize: {
+			description:
+				'If no value exists, this prop defines the starting position for the font size picker slider. Only relevant if `withSlider` is `true`.',
+		},
 		withReset: {
+			description:
+				'If `true`, a reset button will be displayed alongside the input field when a custom font size is active. Has no effect when `disableCustomFontSizes` or `withSlider` is `true`.',
 			control: { type: 'boolean' },
 			table: {
 				type: 'boolean',


### PR DESCRIPTION
Part of #35665
In preparation for #38720 

## Description

Refactors the `FontSizePicker` stories to use Controls instead of Knobs, and reworks some of the stories for clarity and correctness.

### Reworked stories

- "With Slider"
  - [Bug fix] The `fallbackFontSize` prop only kicks in when `initialValue` is `0` or `undefined`, but this was not set correctly so it wasn't showcasing the fallback behavior.
- "Different Control By Size"
  - This was split into two stories ("With More Font Sizes" and "With Units") for clarity.
  - [Bug fix] The "With Units" case was setting an `initialValue` of `8` instead of `8px`, thus showcasing a custom value by default.
- "With Complex CSS Values"
  - Simplified so it doesn't require Storybook-only toggles.

I tried not to drop any of the intent captured in the original stories — let me know if I missed something.

## Testing Instructions

1. `npm run storybook:dev` and see the stories for `FontSizePicker`.
2. Compare with the ones on https://wordpress.github.io/gutenberg/?path=/story/components-fontsizepicker--default

Pro tip: Knobs can be kind of buggy when you click through multiple stories. Click the "Reset" button in the bottom right corner if they get stuck.

## Types of changes

Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
