### PR TITLE
Cover block: update deprecated gradient fixture

### DIFF
--- a/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.html
+++ b/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.html
@@ -1,10 +1,10 @@
-<!-- wp:cover {"gradient":"luminous-dusk","isDark":false} -->
-<div class="wp-block-cover">
-    <span aria-hidden="true" class="has-background-dim-100 wp-block-cover__gradient-background has-luminous-dusk-gradient-background has-background-dim has-background-gradient has-luminous-dusk-gradient-background"></span>
-	<div class="wp-block-cover__inner-container">
-		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
-		<p class="has-text-align-center has-large-font-size">Cover!</p>
-		<!-- /wp:paragraph -->
-	</div>
+<!-- wp:cover {"gradient":"electric-grass","isDark":false} -->
+<div class="wp-block-cover is-light">
+    <span aria-hidden="true" class="has-background-dim-100 wp-block-cover__gradient-background has-electric-grass-gradient-background has-background-dim has-background-gradient has-electric-grass-gradient-background"></span>
+    <div class="wp-block-cover__inner-container">
+        <!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+        <p class="has-text-align-center has-large-font-size">Cover!</p>
+        <!-- /wp:paragraph -->
+    </div>
 </div>
 <!-- /wp:cover -->

--- a/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.json
@@ -1,14 +1,14 @@
 [
 	{
 		"name": "core/cover",
-		"isValid": false,
+		"isValid": true,
 		"attributes": {
 			"alt": "",
 			"hasParallax": false,
 			"isRepeated": false,
 			"dimRatio": 100,
 			"backgroundType": "image",
-			"gradient": "luminous-dusk",
+			"gradient": "electric-grass",
 			"isDark": false
 		},
 		"innerBlocks": [

--- a/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.parsed.json
+++ b/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.parsed.json
@@ -2,7 +2,7 @@
 	{
 		"blockName": "core/cover",
 		"attrs": {
-			"gradient": "luminous-dusk",
+			"gradient": "electric-grass",
 			"isDark": false
 		},
 		"innerBlocks": [
@@ -14,17 +14,17 @@
 					"fontSize": "large"
 				},
 				"innerBlocks": [],
-				"innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\">Cover!</p>\n\t\t",
+				"innerHTML": "\n        <p class=\"has-text-align-center has-large-font-size\">Cover!</p>\n        ",
 				"innerContent": [
-					"\n\t\t<p class=\"has-text-align-center has-large-font-size\">Cover!</p>\n\t\t"
+					"\n        <p class=\"has-text-align-center has-large-font-size\">Cover!</p>\n        "
 				]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-cover\">\n    <span aria-hidden=\"true\" class=\"has-background-dim-100 wp-block-cover__gradient-background has-luminous-dusk-gradient-background has-background-dim has-background-gradient has-luminous-dusk-gradient-background\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+		"innerHTML": "\n<div class=\"wp-block-cover is-light\">\n    <span aria-hidden=\"true\" class=\"has-background-dim-100 wp-block-cover__gradient-background has-electric-grass-gradient-background has-background-dim has-background-gradient has-electric-grass-gradient-background\"></span>\n    <div class=\"wp-block-cover__inner-container\">\n        \n    </div>\n</div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-cover\">\n    <span aria-hidden=\"true\" class=\"has-background-dim-100 wp-block-cover__gradient-background has-luminous-dusk-gradient-background has-background-dim has-background-gradient has-luminous-dusk-gradient-background\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+			"\n<div class=\"wp-block-cover is-light\">\n    <span aria-hidden=\"true\" class=\"has-background-dim-100 wp-block-cover__gradient-background has-electric-grass-gradient-background has-background-dim has-background-gradient has-electric-grass-gradient-background\"></span>\n    <div class=\"wp-block-cover__inner-container\">\n        ",
 			null,
-			"\n\t</div>\n</div>\n"
+			"\n    </div>\n</div>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.serialized.html
+++ b/test/integration/fixtures/blocks/core__cover__gradient__deprecated-8.serialized.html
@@ -1,5 +1,5 @@
-<!-- wp:cover {"gradient":"luminous-dusk","isDark":false} -->
-<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-luminous-dusk-gradient-background"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<!-- wp:cover {"gradient":"electric-grass","isDark":false} -->
+<div class="wp-block-cover is-light"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim has-background-gradient has-electric-grass-gradient-background"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
 <p class="has-text-align-center has-large-font-size">Cover!</p>
 <!-- /wp:paragraph --></div></div>
 <!-- /wp:cover -->


### PR DESCRIPTION
## Description
This PR regenerates the Cover Block gradient deprecation fixture because the attribute `"isDark":false` should have had a corresponding `is-light` classname on the container.

This was a human copy 🍝 error.

I generated the new fixture by rolling back 4bfd7b3d8a9ff575ccae27ee690ccd7327811574 (pre https://github.com/WordPress/gutenberg/pull/38392) and copying the Cover Block code from the editor very carefully this time.

The only other change is the choice of preset gradient color: from `luminous-dusk` to `electric-grass`, which is way cooler. ☮️ 

See: https://github.com/WordPress/gutenberg/pull/38685#issuecomment-1035305924 and https://github.com/WordPress/gutenberg/pull/38392#discussion_r804359712

Props to @talldan for raising it

## Testing Instructions
Check that the core__cover__gradient__deprecated-8.json block validity prop `isValid` is `true`

The fixture tests (all E2Es) should pass.


## Types of changes
Fixing bad fixture HTML

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
