### PR TITLE
Scripts: Do not exit `build` when no entry found in `src` directory

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,12 +6,19 @@
 
 -   Automatically copy PHP files located in the `src` folder and its subfolders to the output directory (`build` by default) ([#38715](https://github.com/WordPress/gutenberg/pull/38715)).
 
+### Bug Fix
+
+-   Return a default entry object in the `build` command when no entry files discovered in the project ([#38737](https://github.com/WordPress/gutenberg/pull/38737)).
 
 ## 21.0.0 (2022-02-10)
 
 ### Breaking Changes
 
 -   The bundled `puppeteer-core` dependency has been updated from requiring `^11.0.0` to requiring `^13.2.0` ([#37078](https://github.com/WordPress/gutenberg/pull/37078)).
+
+### Bug Fix
+
+-   Fix the handling for entry points when running `build` command ([#38584](https://github.com/WordPress/gutenberg/pull/38584)).
 
 ## 20.0.2 (2022-01-31)
 

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -183,6 +183,7 @@ function getWebpackEntryPoints() {
 		return JSON.parse( process.env.WP_ENTRY );
 	}
 
+	// Continue only if the `src` directory exists.
 	if ( ! hasProjectFile( 'src' ) ) {
 		return {};
 	}
@@ -271,7 +272,7 @@ function getWebpackEntryPoints() {
 		absolute: true,
 	} );
 	if ( ! entryFile ) {
-		log( chalk.yellow( 'No entry file discovered in the "src" folder.' ) );
+		log( chalk.yellow( 'No entry file discovered in the "src" directory.' ) );
 		return {};
 	}
 

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -16,7 +16,6 @@ const {
 } = require( './cli' );
 const { fromConfigRoot, fromProjectRoot, hasProjectFile } = require( './file' );
 const { hasPackageProp } = require( './package' );
-const { exit } = require( './process' );
 const { log } = console;
 
 // See https://babeljs.io/docs/en/config-files#configuration-file-types.
@@ -184,6 +183,10 @@ function getWebpackEntryPoints() {
 		return JSON.parse( process.env.WP_ENTRY );
 	}
 
+	if ( ! hasProjectFile( 'src' ) ) {
+		return {};
+	}
+
 	// 2. Checks whether any block metadata files can be detected in the `src` directory.
 	//    It scans all discovered files looking for JavaScript assets and converts them to entry points.
 	const blockMetadataFiles = glob( 'src/**/block.json', {
@@ -268,10 +271,8 @@ function getWebpackEntryPoints() {
 		absolute: true,
 	} );
 	if ( ! entryFile ) {
-		log(
-			chalk.bold.red( 'No entry files discovered in the "src" folder.' )
-		);
-		exit( 1 );
+		log( chalk.yellow( 'No entry file discovered in the "src" folder.' ) );
+		return {};
 	}
 
 	return {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #38739.

Addressed the issue raised by @loxK in https://github.com/WordPress/gutenberg/pull/38584#issuecomment-1035967353.

> This prevents passing custom entry point in our workflow. Exemple:
> 
> ```javascript
> import config from "../../config.js"
> 
> /** Gulp and utils **/
> import gulp from 'gulp'
> 
> const {src, dest} = gulp
> 
> import named from 'vinyl-named'
> 
> /** Webpack **/
> import webpack from 'webpack-stream'
> import webpackConfig from "@wordpress/scripts/config/webpack.config.js"
> webpackConfig.entry = null
> 
> /**
>  * Scripts
>  */
> export const process_js = () => src( config.paths.scripts_sources.src )
>         .pipe( named() )
>         .pipe( webpack( webpackConfig ) )
>         .pipe( dest( config.paths.scripts_sources.dst ) )
> 
> ```
> 
> Returns the error:
> ```
> No entry files discovered in the "src" folder.
> ```
> 
> Please revert:
> 
> ```javascript
> if ( ! entryFile ) {
> 	log(
> 		chalk.bold.red( 'No entry files discovered in the "src" folder.' )
> 	);
> 	exit( 1 );
> }
> 	
> ```
> 
> to
> 
> ```javascript
> if ( ! entryFile ) {
> 	return {};
> }
> ```

I followed the recommendation and added an early return when there is no `src` directory. In case when the `src` directory exists then the script still shows the warning but it returns the defaul value for `entry` which is `{}`.

I also included a missed CHANGELOG entry for #38584.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run:
```
npx wp-create-block my-block --no-wp-scripts
cd my-block
../node_modules/.bin/wp-scripts build
```

Try removing a script file referenced in the `block.json` and run the build again:
```
../node_modules/.bin/wp-scripts build
```

You should see a warning and the build should run but it will only copy a `block.json` file:

<img width="1480" alt="Screenshot 2022-02-11 at 11 35 16" src="https://user-images.githubusercontent.com/699132/153576877-b7495925-d31c-4f9f-8253-6f8c187bcab4.png">

If you rename the `src` directory then the build should still run but will finish without any files processed:

<img width="971" alt="Screenshot 2022-02-11 at 11 36 09" src="https://user-images.githubusercontent.com/699132/153577037-8a5611b1-d358-4b8b-8bdf-d3f75f3ac6c1.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue).
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
