### PR TITLE
Fix global styles loading logic

### DIFF
--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-/*
+/**
  * This code lives in script-loader.php
  * where we just load styles using wp_get_global_stylesheet.
  */

--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -9,37 +9,40 @@
  * This code lives in script-loader.php
  * where we just load styles using wp_get_global_stylesheet.
  */
-if ( ! function_exists( 'wp_get_global_styles' ) ) {
-	// Running on WordPress 5.8.
-	function gutenberg_enqueue_global_styles_assets() {
-		$separate_assets = wp_should_load_separate_core_block_assets();
-		$stylesheet      = wp_get_global_stylesheet();
-		if ( empty( $stylesheet ) ) {
-			return;
-		}
+function gutenberg_enqueue_global_styles_assets() {
+	$separate_assets  = wp_should_load_separate_core_block_assets();
+	$is_block_theme   = wp_is_block_theme();
+	$is_classic_theme = ! $is_block_theme;
 
-		if (
-			( doing_action( 'wp_footer' ) && ! $separate_assets ) ||
-			( doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
-		) {
-			// Block themes are not supported in WordPress 5.8.
-			// Classic themes load the GS stylesheet in the head by default,
-			// and load in body if they opted-in into loading separate assets.
-			return;
-		}
-
-		if ( isset( wp_styles()->registered['global-styles'] ) ) {
-			// There's a GS stylesheet (theme has theme.json),
-			// so we overwrite it.
-			wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
-		} else {
-			// There's no GS stylesheet (theme has no theme.json),
-			// so we enqueue a new one.
-			wp_register_style( 'global-styles', false, array(), true, true );
-			wp_add_inline_style( 'global-styles', $stylesheet );
-			wp_enqueue_style( 'global-styles' );
-		}
+	/*
+	 * Global styles should be printed in the head when loading all styles combined.
+	 * The footer should only be used to print global styles for classic themes with separate core assets enabled.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/53494.
+	 */
+	if (
+		( $is_block_theme && doing_action( 'wp_footer' ) ) ||
+		( $is_classic_theme && doing_action( 'wp_footer' ) && ! $separate_assets ) ||
+		( $is_classic_theme && doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
+	) {
+		return;
 	}
-	add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
-	add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
+
+	$stylesheet = wp_get_global_stylesheet();
+
+	if ( empty( $stylesheet ) ) {
+		return;
+	}
+
+	if ( isset( wp_styles()->registered['global-styles'] ) ) {
+		// There's a GS stylesheet (theme has theme.json), so we overwrite it.
+		wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
+	} else {
+		// No GS stylesheet (theme has no theme.json), so we enqueue a new one.
+		wp_register_style( 'global-styles', false, array(), true, true );
+		wp_add_inline_style( 'global-styles', $stylesheet );
+		wp_enqueue_style( 'global-styles' );
+	}
 }
+add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
+add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );

--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -10,25 +10,36 @@
  * where we just load styles using wp_get_global_stylesheet.
  */
 if ( ! function_exists( 'wp_get_global_styles' ) ) {
-	/**
-	 * Fetches the preferences for each origin (core, theme, user)
-	 * and enqueues the resulting stylesheet.
-	 */
+	// Running on WordPress 5.8.
 	function gutenberg_enqueue_global_styles_assets() {
-		$stylesheet = wp_get_global_stylesheet();
+		$separate_assets = wp_should_load_separate_core_block_assets();
+		$stylesheet      = wp_get_global_stylesheet();
 		if ( empty( $stylesheet ) ) {
 			return;
 		}
 
+		if (
+			( doing_action( 'wp_footer' ) && ! $separate_assets ) ||
+			( doing_action( 'wp_enqueue_scripts' ) && $separate_assets )
+		) {
+			// Block themes are not supported in WordPress 5.8.
+			// Classic themes load the GS stylesheet in the head by default,
+			// and load in body if they opted-in into loading separate assets.
+			return;
+		}
+
 		if ( isset( wp_styles()->registered['global-styles'] ) ) {
-			// We're in WordPress 5.8, so we overwrite the existing.
+			// There's a GS stylesheet (theme has theme.json),
+			// so we overwrite it.
 			wp_styles()->registered['global-styles']->extra['after'][0] = $stylesheet;
 		} else {
-			// WordPress 5.7 or lower.
+			// There's no GS stylesheet (theme has no theme.json),
+			// so we enqueue a new one.
 			wp_register_style( 'global-styles', false, array(), true, true );
 			wp_add_inline_style( 'global-styles', $stylesheet );
 			wp_enqueue_style( 'global-styles' );
 		}
 	}
 	add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
+	add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/38434

The global styles stylesheet should be loaded using this logic, no matter the WordPress version:

1. Block theme. Always load in the `<head>`.
2. Classic theme that hasn't opted into loading core assets separately. Load in the `<head>`.
3. Classic theme that has opted into loading core assets separately. Load in the `<body>`.

In `trunk` it's not working as expected and shows differences between WordPress 5.8 and WordPress 5.9.

## Backport

The parts of this that need backporting to core are in this PR already https://github.com/WordPress/wordpress-develop/pull/2303

## How to test

Use TwentyTwenty, unmodified. Test both in WordPress 5.8 and WordPress 5.9.

- Load the front end.
- Verify the `global-styles-inline-css` embedded stylesheet is loaded in the head.

Use TwentyTwenty after opting into loading separate assets. Test both in WordPress 5.8 and WordPress 5.9.

- Paste `add_filter( 'should_load_separate_core_block_assets', '__return_true' );` in TwentyTwenty's `functions.php`.
- Load the front end.
- Verify the `global-styles-inline-css` embedded stylesheet is loaded in the body.

Use EmptyTheme. Test both in WordPress 5.8 and WordPress 5.9.

- Load the front end.
- Verify the `global-styles-inline-css` embedded stylesheet is loaded in the head.
