### PR TITLE
Reduce the margin of the block toolbar.

### DIFF
--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,7 +1,7 @@
 .customize-widgets-header {
 	@include break-medium() {
 		// Make space for the floating toolbar.
-		margin-bottom: $grid-unit-60 + $default-block-margin;
+		margin-bottom: $grid-unit-10 + $default-block-margin;
 	}
 
 	&.is-fixed-toolbar-active {

--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -1,7 +1,7 @@
 .customize-widgets-header {
 	@include break-medium() {
 		// Make space for the floating toolbar.
-		margin-bottom: $grid-unit-10 + $default-block-margin;
+		margin-bottom: $grid-unit-20 + $default-block-margin;
 	}
 
 	&.is-fixed-toolbar-active {

--- a/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
+++ b/packages/e2e-tests/specs/widgets/customizing-widgets.test.js
@@ -880,6 +880,10 @@ async function addBlock( blockName ) {
 		}
 	} );
 
+	// Click something so that the block toolbar, which sometimes obscures
+	// buttons in the inserter, goes away.
+	await searchBox.click();
+
 	await searchBox.type( blockName );
 
 	// TODO - remove this timeout when the test plugin for disabling CSS


### PR DESCRIPTION
Reduced the margin of the block toolbar
Fixes #38391

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Reduced the spacing above the toolbar, now it sits evenly.

## Testing Instructions
1. Activate a classic theme.
2. Go to Appearance → Customize → Widgets.
3. Select the first block.
4. Check if the spacing on the top is reduced.

## Screenshots <!-- if applicable -->
![](https://i.imgur.com/AyNgMJQ.png)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
