### PR TITLE
Post Expert: Fix missing class in post excerpt.

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -86,23 +86,22 @@ export default function PostExcerptEditor( {
 	const excerptClassName = classnames( 'wp-block-post-excerpt__excerpt', {
 		'is-inline': ! showMoreOnNewLine,
 	} );
-	const excerptValue =
-		rawExcerpt ||
-		strippedRenderedExcerpt ||
-		( isSelected ? '' : __( 'No post excerpt found' ) );
 	const excerptContent = isEditable ? (
 		<RichText
 			className={ excerptClassName }
 			aria-label={ __( 'Post excerpt text' ) }
-			value={ excerptValue }
+			value={
+				rawExcerpt ||
+				strippedRenderedExcerpt ||
+				( isSelected ? '' : __( 'No post excerpt found' ) )
+			}
 			onChange={ setExcerpt }
 			tagName="p"
 		/>
 	) : (
-		<p
-			className={ excerptClassName }
-			dangerouslySetInnerHTML={ { __html: excerptValue } }
-		/>
+		<p className={ excerptClassName }>
+			{ strippedRenderedExcerpt || __( 'No post excerpt found' ) }
+		</p>
 	);
 	return (
 		<>

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -16,7 +16,7 @@ import {
 	Warning,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { PanelBody, ToggleControl, Disabled } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -83,25 +83,26 @@ export default function PostExcerptEditor( {
 			withoutInteractiveFormatting={ true }
 		/>
 	);
-	let excerptContent = (
+	const excerptClassName = classnames( 'wp-block-post-excerpt__excerpt', {
+		'is-inline': ! showMoreOnNewLine,
+	} );
+	const excerptValue =
+		rawExcerpt ||
+		strippedRenderedExcerpt ||
+		( isSelected ? '' : __( 'No post excerpt found' ) );
+	const excerptContent = isEditable ? (
 		<RichText
-			className={ classnames( 'wp-block-post-excerpt__excerpt', {
-				'is-inline': ! showMoreOnNewLine,
-			} ) }
+			className={ excerptClassName }
 			aria-label={ __( 'Post excerpt text' ) }
-			value={
-				rawExcerpt ||
-				strippedRenderedExcerpt ||
-				( isSelected ? '' : __( 'No post excerpt found' ) )
-			}
+			value={ excerptValue }
 			onChange={ setExcerpt }
 			tagName="p"
 		/>
-	);
-	excerptContent = isEditable ? (
-		excerptContent
 	) : (
-		<Disabled>{ excerptContent }</Disabled>
+		<p
+			className={ excerptClassName }
+			dangerouslySetInnerHTML={ { __html: excerptValue } }
+		/>
 	);
 	return (
 		<>

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useEntityProp } from '@wordpress/core-data';
-import { useMemo, RawHTML } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import {
 	AlignmentToolbar,
 	BlockControls,
@@ -83,12 +83,11 @@ export default function PostExcerptEditor( {
 			withoutInteractiveFormatting={ true }
 		/>
 	);
-	const excerptContent = isEditable ? (
+	let excerptContent = (
 		<RichText
-			className={
-				! showMoreOnNewLine &&
-				'wp-block-post-excerpt__excerpt is-inline'
-			}
+			className={ classnames( 'wp-block-post-excerpt__excerpt', {
+				'is-inline': ! showMoreOnNewLine,
+			} ) }
 			aria-label={ __( 'Post excerpt text' ) }
 			value={
 				rawExcerpt ||
@@ -98,13 +97,11 @@ export default function PostExcerptEditor( {
 			onChange={ setExcerpt }
 			tagName="p"
 		/>
+	);
+	excerptContent = isEditable ? (
+		excerptContent
 	) : (
-		( renderedExcerpt && (
-			<Disabled>
-				<RawHTML key="html">{ renderedExcerpt }</RawHTML>
-			</Disabled>
-		) ) ||
-		__( 'No post excerpt found' )
+		<Disabled>{ excerptContent }</Disabled>
 	);
 	return (
 		<>


### PR DESCRIPTION
## Description
This PR fixes a few class related issues with the Post Excerpt block. Currently the class `wp-block-post-excerpt__excerpt` is added to the `<p>` element on the frontend. Unfortunately, it is not consistently added in the Editor. This PR fixes that. Without this fix, it is challenging for theme developers to accurately target the post excerpt with custom CSS.

Additionally, when the excerpt **is** editable, the class `wp-block-post-excerpt__excerpt` was only being added if the "read more" link was set to in-line. This was a bug and has also been fixed.

In order to fix the class issues, the Editor markup had to be altered. Previously, when an excerpt was not editable, the excerpt was rendered inside of a RawHTML component. That RawHTML component was also placed inside of a Disabled component. I believe this is unnecessary. Instead, when the excerpt is not editable, we now just wrap the RichText component in the Disabled component. This effectively disables excerpt editing while preserving the correct markup and eliminating the need for the RawHTML component. 

## Testing Instructions
1. Use the Twenty Twenty-Two theme.
2. On a new page, add a Query Loop block. In Twenty Twenty-Two the default option includes the Post Excerpt block. 
3. Inspect the Post Excerpt block in the browser and confirm the class `wp-block-post-excerpt__excerpt` is applied. 
4. Enable the "Show link on new line" option and confirm that the class is still applied. 
5. Finally confirm the class is applied on the frontend. 

## Types of changes
Bug fix

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
