### PR TITLE
Hide read more link if theme provides one in excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -70,6 +70,11 @@ export default function PostExcerptEditor( {
 			</div>
 		);
 	}
+	/**
+	 * Sometimes the excerpt contains a read more link and it should be
+	 * the only time the excerpt even contains HTML.
+	 */
+	const hasReadMore = renderedExcerpt.toLowerCase().includes( '</a></p>' );
 	const readMoreLink = (
 		<RichText
 			className="wp-block-post-excerpt__more-link"
@@ -118,26 +123,28 @@ export default function PostExcerptEditor( {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Post Excerpt Settings' ) }>
-					<ToggleControl
-						label={ __( 'Show link on new line' ) }
-						checked={ showMoreOnNewLine }
-						onChange={ ( newShowMoreOnNewLine ) =>
-							setAttributes( {
-								showMoreOnNewLine: newShowMoreOnNewLine,
-							} )
-						}
-					/>
+					{ ! hasReadMore && (
+						<ToggleControl
+							label={ __( 'Show link on new line' ) }
+							checked={ showMoreOnNewLine }
+							onChange={ ( newShowMoreOnNewLine ) =>
+								setAttributes( {
+									showMoreOnNewLine: newShowMoreOnNewLine,
+								} )
+							}
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ excerptContent }
 				{ ! showMoreOnNewLine && ' ' }
-				{ showMoreOnNewLine ? (
+				{ ! hasReadMore && showMoreOnNewLine ? (
 					<p className="wp-block-post-excerpt__more-text">
 						{ readMoreLink }
 					</p>
 				) : (
-					readMoreLink
+					! hasReadMore && readMoreLink
 				) }
 			</div>
 		</>


### PR DESCRIPTION
This is a naive attempt to just not show anything if the theme comes with a link in the excerpt. 
An attempt to fix #38373. The problem is that the fix is kinda useless:

- if the theme has read more links just don't set any on the query block
- if the theme does not have more links set one in the query block
- if the theme has read more links and you also set the one in the query block then you get read more links for places where excerpt is empty.