### PR TITLE
admin-manifest: Fix url query param issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15624,7 +15624,8 @@
 		"@wordpress/admin-manifest": {
 			"version": "file:packages/admin-manifest",
 			"requires": {
-				"@babel/runtime": "^7.16.0"
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/url": "file:packages/url"
 			}
 		},
 		"@wordpress/annotations": {

--- a/packages/admin-manifest/package.json
+++ b/packages/admin-manifest/package.json
@@ -26,7 +26,8 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"dependencies": {
-		"@babel/runtime": "^7.16.0"
+		"@babel/runtime": "^7.16.0",
+		"@wordpress/url": "file:../url"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/admin-manifest/src/index.js
+++ b/packages/admin-manifest/src/index.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
 function addManifest( manifest ) {
 	const link = document.createElement( 'link' );
 	link.rel = 'manifest';
@@ -164,6 +169,8 @@ window.addEventListener( 'load', () => {
 		),
 	] ).then( () => {
 		addManifest( manifest );
-		window.navigator.serviceWorker.register( adminUrl + '?service-worker' );
+		window.navigator.serviceWorker.register(
+			addQueryArgs( adminUrl, { 'service-worker': true } )
+		);
 	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
It is possible for the `adminUrl` to already have a query parameter, in which case the URL can be set to something like `example.com/wp-admin/?something=true?service-worker`. If that happens, the service worker fails to register, as the URL doesn't return the expected JSON. The fix is to add the query param in the "canonical" way, with the URL package.

## Testing Instructions
I am unsure how to test the admin manifest package, but I don't expect this to change anything in most cases.

You could test visiting these URLs to verify that the fix would work. (These URLs operate the same way before and after the PR. We're just changing the code to load the second URL instead of the first.)
- `localhost:8888/wp-admin?foo=true?service-worker`. This will _not_ return JSON.
- `localhost:8888/wp-admin?foo=true&service-worker=true`. This _will_ return JSON.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
