### PR TITLE
Load unminified JS when SCRIPT_DEBUG is true.

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -261,6 +261,13 @@ function gutenberg_register_packages_scripts( $scripts ) {
 				break;
 		}
 
+		// Load unminified JS in SCRIPT_DEBUG mode.
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			// We can't replace the glob call above with index.js because the PHP
+			// asset file is associated with the .min file. (index.min.asset.php).
+			$path = str_replace( '.min.js', '.js', $path );
+		}
+
 		// Get the path from Gutenberg directory as expected by `gutenberg_url`.
 		$gutenberg_path = substr( $path, strlen( gutenberg_dir_path() ) );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves #23960. (Though, I wonder if this will not be possible because of #32621.)

When `SCRIPT_DEBUG` is true, load `index.js` build files instead of `index.min.js` build files.

## Testing Instructions
Locally, in `wp-env`, `SCRIPT_DEBUG` is true by default. If you have no other overrides, you should see non-minified files in the debug devtools tab when loading the editor.

Then, add this to `.wp-env.json` or `.wp-env.override.json`:

```json
	"config": {
		"SCRIPT_DEBUG": false
	}
```

Then, when loading the editor, you'll see minified files in the debug devtools tab:


## Screenshots <!-- if applicable -->

### Minified files:
<img width="851" alt="Screen Shot 2022-02-11 at 1 53 58 PM" src="https://user-images.githubusercontent.com/6265975/153676269-9ccb8d3d-04f0-4095-a4e2-85fb7153e896.png">

### Unminified files:
<img width="851" alt="Screen Shot 2022-02-11 at 1 54 36 PM" src="https://user-images.githubusercontent.com/6265975/153676298-23ace621-5d4c-4513-b915-c800622f08d4.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
