### PR TITLE
Fix error triggering after duplicating a block making it unselectable.

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -103,11 +103,8 @@ function ListViewBlock( {
 	}, [ clientId, setIsHovered, highlightBlock ] );
 
 	const selectEditorBlock = useCallback(
-		( event ) => {
-			event.stopPropagation();
-			selectBlock( clientId );
-		},
-		[ clientId, selectBlock ]
+		( _clientId ) => selectBlock( _clientId ),
+		[ selectBlock ]
 	);
 
 	const toggleExpanded = useCallback(
@@ -176,7 +173,10 @@ function ListViewBlock( {
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
 							block={ block }
-							onClick={ selectEditorBlock }
+							onClick={ ( event ) => {
+								event.stopPropagation();
+								selectEditorBlock( clientId );
+							} }
 							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							position={ position }

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -103,8 +103,11 @@ function ListViewBlock( {
 	}, [ clientId, setIsHovered, highlightBlock ] );
 
 	const selectEditorBlock = useCallback(
-		( _clientId ) => selectBlock( _clientId ),
-		[ selectBlock ]
+		( event ) => {
+			event.stopPropagation();
+			selectBlock( clientId );
+		},
+		[ clientId, selectBlock ]
 	);
 
 	const toggleExpanded = useCallback(
@@ -173,10 +176,7 @@ function ListViewBlock( {
 					<div className="block-editor-list-view-block__contents-container">
 						<ListViewBlockContents
 							block={ block }
-							onClick={ ( event ) => {
-								event.stopPropagation();
-								selectEditorBlock( clientId );
-							} }
+							onClick={ selectEditorBlock }
 							onToggleExpanded={ toggleExpanded }
 							isSelected={ isSelected }
 							position={ position }
@@ -236,7 +236,7 @@ function ListViewBlock( {
 								onFocus,
 							} }
 							disableOpenOnArrowDown
-							__experimentalSelectBlock={ selectEditorBlock }
+							__experimentalSelectBlock={ selectBlock }
 						/>
 					) }
 				</TreeGridCell>


### PR DESCRIPTION
Fixes: #38759

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

After duplicating a block from List View, it doesn't select that block and throws an error.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
