### PR TITLE
Fix UI broken due to error when deleting first item in canvas.

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -146,11 +146,13 @@ function ListViewBlock( {
 	} );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const settingsAriaLabel = sprintf(
-		// translators: %s: The title of the block.
-		__( 'Options for %s block' ),
-		blockInformation.title
-	);
+	const settingsAriaLabel = blockInformation
+		? sprintf(
+				// translators: %s: The title of the block.
+				__( 'Options for %s block' ),
+				blockInformation.title
+		  )
+		: __( 'Options' );
 
 	return (
 		<ListViewLeaf

--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -6,6 +6,7 @@ import {
 	insertBlock,
 	getEditedPostContent,
 	pressKeyWithModifier,
+	pressKeyTimes,
 } from '@wordpress/e2e-test-utils';
 
 async function dragAndDrop( draggableElement, targetElement, offsetY ) {
@@ -53,5 +54,47 @@ describe( 'List view', () => {
 		await dragAndDrop( paragraphBlock, headingBlock, -5 );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	// Check for regressions of https://github.com/WordPress/gutenberg/issues/38763.
+	it( 'shows the correct amount of blocks after a block is removed in the canvas', async () => {
+		// Insert some blocks of different types.
+		await insertBlock( 'Image' );
+		await insertBlock( 'Heading' );
+		await insertBlock( 'Paragraph' );
+
+		// Open list view.
+		await pressKeyWithModifier( 'access', 'o' );
+
+		// The last inserted paragraph block should be selected in List View.
+		await page.waitForXPath(
+			'//a[contains(., "Paragraph(selected block)")]'
+		);
+
+		// Go to the image block in list view.
+		await pressKeyTimes( 'ArrowUp', 2 );
+		const listViewImageBlock = await page.waitForXPath(
+			'//a[contains(., "Image")]'
+		);
+		expect( listViewImageBlock ).toHaveFocus();
+
+		// Select the image block in the canvas.
+		await page.keyboard.press( 'Enter' );
+
+		const canvasImageBlock = await page.waitForSelector(
+			'figure[aria-label="Block: Image"]'
+		);
+		expect( canvasImageBlock ).toHaveFocus();
+
+		// Delete the image block in the canvas.
+		await page.keyboard.press( 'Backspace' );
+
+		// List view should have two rows.
+		const listViewRows = await page.$$( 'tr.block-editor-list-view-leaf' );
+		expect( listViewRows ).toHaveLength( 2 );
+
+		// The console didn't throw an error as reported in
+		// https://github.com/WordPress/gutenberg/issues/38763.
+		expect( console ).not.toHaveErrored();
 	} );
 } );


### PR DESCRIPTION
## Description
Fixes #38763

I'm unsure of the root cause of this bug, but it's likely to be some kind of synchronization issue with `useSelect` - there have been other instances of this kind of bug. See https://github.com/WordPress/gutenberg/pull/32088 and the related issue https://github.com/WordPress/gutenberg/issues/29498 for more info.

I think the problem is that the fix in https://github.com/WordPress/gutenberg/pull/32088 wouldn't extend to `useBlockDisplayInformation`—it avoids throwing an error by instead returning `null`. `ListView` doesn't handle that `null` value, which it should. I imagine TypeScript wouldn't have caught this bug.

## Testing Instructions
I found this one difficult to reproduce consistently. I had most luck reproducing with a fairly complex navigation block as the first block, and then doing the following:
1. Open List View
2. Select the navigation block via list view
3. Press the backspace key

I've added some end to end test coverage, but because of the inconsistent nature of the bug, it's hard to say how successful this test will be.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
