### PR TITLE
Avoid duplicate labels for "Save Draft" and "Save as pending" buttons

### DIFF
--- a/packages/editor/src/components/post-saved-state/index.js
+++ b/packages/editor/src/components/post-saved-state/index.js
@@ -154,7 +154,7 @@ export default function PostSavedState( {
 			shortcut={ displayShortcut.primary( 's' ) }
 			variant={ isLargeViewport ? 'tertiary' : undefined }
 			icon={ isLargeViewport ? undefined : cloudUpload }
-			label={ label }
+			label={ showIconLabels ? undefined : label }
 			aria-disabled={ isDisabled }
 		>
 			{ isSavedState && <Icon icon={ isSaved ? check : cloud } /> }


### PR DESCRIPTION
## Description
PR fixes the issue when duplicated labels are displayed for the `PostSavedState` button.

Resolves #38773.

## Testing Instructions
1. Open a Post or Page.
2. Enable "Display button labels" from Preferences.
3. Confirm that duplicated labels aren't displayed for the "Save Draft" or "Save as pending" buttons.

## Screenshots <!-- if applicable -->
![CleanShot 2022-02-14 at 14 11 59](https://user-images.githubusercontent.com/240569/153844310-e9d71de8-6a19-41e6-be9b-fc286d65367c.png)

## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
