### PR TITLE
Scripts: Fix Entry points are not detected in Windows OS

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fix
 
 -   Return a default entry object in the `build` command when no entry files discovered in the project ([#38737](https://github.com/WordPress/gutenberg/pull/38737)).
+-   Entry points are not detected in Windows OS ([#38781](https://github.com/WordPress/gutenberg/pull/38781)).
 
 ## 21.0.0 (2022-02-10)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,12 +6,15 @@
 
 -   Automatically copy PHP files located in the `src` folder and its subfolders to the output directory (`build` by default) ([#38715](https://github.com/WordPress/gutenberg/pull/38715)).
 
+## 21.0.2 (2022-02-15)
+
+-   Entry points are not detected in Windows OS ([#38781](https://github.com/WordPress/gutenberg/pull/38781)).
+
 ## 21.0.1 (2022-02-11)
 
 ### Bug Fix
 
 -   Return a default entry object in the `build` command when no entry files discovered in the project ([#38737](https://github.com/WordPress/gutenberg/pull/38737)).
--   Entry points are not detected in Windows OS ([#38781](https://github.com/WordPress/gutenberg/pull/38781)).
 
 ## 21.0.0 (2022-02-10)
 

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -230,14 +230,12 @@ function getWebpackEntryPoints() {
 						}
 						const entryName = filepath
 							.replace( extname( filepath ), '' )
-							.replace( srcDirectory, '' );
+							.replace( srcDirectory, '' )
+							.replace( /\\/g, '/' );
 
 						// Detects the proper file extension used in the `src` directory.
 						const [ entryFilepath ] = glob(
-							`src/${ entryName }.[jt]s?(x)`.replace(
-								/\\/g,
-								'/'
-							),
+							`src/${ entryName }.[jt]s?(x)`,
 							{
 								absolute: true,
 							}

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -234,7 +234,10 @@ function getWebpackEntryPoints() {
 
 						// Detects the proper file extension used in the `src` directory.
 						const [ entryFilepath ] = glob(
-							`src/${ entryName }.[jt]s?(x)`,
+							`src/${ entryName }.[jt]s?(x)`.replace(
+								/\\/g,
+								'/'
+							),
 							{
 								absolute: true,
 							}


### PR DESCRIPTION
See: #38343, #38348

## Description

The entry point is not detected and the build file is not generated on Windows OS when placing the JavaScript file that will be the entry point in a subfolder.

I fixed that problem in this PR.

It would be great if you could test it on Windows OS and Mac OS, if you like.

## Testing Instructions
- Check out this branch.

- Run create-block without installing wp-scirpts.

```
npx @wordpress/create-block gutenpride --no-wp-scripts
cd gutenpride
```

- Create the following configuration using the generated files.
  (I added some PHP files to to test the copy of the PHP files as well)

```
gutenberg/gutenpride
└─ src
    ├─ block-a
    |   ├─ block-a.php
    |   ├─ block.json
    |   ├─ edit.js
    |   ├─ editor.scss
    |   ├─ index.js
    |   ├─ save.js
    |   └─ style.scss
    ├─ block-b
    |   ├─ block-b.php
    |   ├─ block.json
    |   ├─ edit.js
    |   ├─ editor.scss
    |   ├─ index.js
    |   ├─ save.js
    |   └─ style.scss 
    └─ index.php    
```

- Run `start` or `build` command to generate assets.

```
../node_modules/.bin/wp-scripts start
../node_modules/.bin/wp-scripts build
```

### Build result before fix

The `block.json` and PHP files will be copied, but the JavaScript will not be built.
Also `index.assets.php` was not generated.

```
gutenberg/gutenpride
└─ build
    ├─ block-a
    |   ├─ block-a.php
    |   └─ block.json
    ├─ block-b
    |   ├─ block-b.php
    |   └─ block.json
    └─ index.php 
```

You will also see the following message, indicating that the entry point was not detected.

```
Skipping "./index.js" listed in "path/to/gutenberg/gutenpride/src/block-a/block.json". File does not exist in the "src" directory.
Skipping "./index.js" listed in "path/to/gutenberg/gutenpride/src/block-b/block.json". File does not exist in the "src" directory.
No entry file discovered in the "src" directory.
```

https://user-images.githubusercontent.com/54422211/153869012-b5b8432c-93d7-40b6-a9b3-1226ad5a8174.mp4

### Build result after fix

All assets should be generated correctly as shown below with this fix.

```
gutenberg/gutenpride
└─ build
    ├─ block-a
    |   ├─ block-a.php
    |   ├─ block.json
    |   ├─ index.asset.php
    |   ├─ index.css
    |   ├─ index.js
    |   └─ style-index.css
    ├─ block-b
    |   ├─ block-b.php
    |   ├─ block.json
    |   ├─ index.asset.php
    |   ├─ index.css
    |   ├─ index.js
    |   └─ style-index.css
    └─ index.php 
```

## Types of changes
https://github.com/WordPress/gutenberg/blob/c034da18f3b53ac741bedb0258dd95e050502f86/packages/scripts/utils/config.js#L231-L241

At this point, the path separator for `entryName` will be a backslash.

Therefore, the regular expression string in the `glob` for detecting `entryFilePath` will be replaced by a string with different delimiters mixed in, as follows

```
src/${ entryName }.[jt]s?(x)
↓
src/block-a\index.[jt]s?(x)
src/block-b\index.[jt]s?(x)
```

As described in the [v3.0.0 release notes](https://github.com/mrmlnc/fast-glob/releases?page=2), I think the reason is that only forward slashes are allowed in regular expressions in globs, and slash replacement is no longer processed.

I was a little confused about how to write it, I simply added a process to replace the regular expression string with a forward slash to minimize the scope of the impact.)

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->