### PR TITLE
Propose useEntityRecords (experimental)

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -33,34 +33,7 @@ describe( 'useEntityRecord', () => {
 
 	const TEST_RECORD = { id: 1, hello: 'world' };
 
-	it( 'retrieves the relevant entity record', async () => {
-		let data;
-		await registry
-			.dispatch( coreDataStore )
-			.receiveEntityRecords( 'root', 'widget', [ TEST_RECORD ] );
-		const TestComponent = () => {
-			data = useEntityRecord( 'root', 'widget', 1 );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
-		);
-		expect( data ).toEqual( {
-			record: TEST_RECORD,
-			hasResolved: false,
-			isResolving: false,
-			status: 'IDLE',
-		} );
-
-		// Required to make sure no updates happen outside of act()
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-	} );
-
-	it( 'resolves the entity if missing from state', async () => {
+	it( 'resolves the entity record when missing from the state', async () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORD );
 
@@ -74,6 +47,13 @@ describe( 'useEntityRecord', () => {
 				<TestComponent />
 			</RegistryProvider>
 		);
+
+		expect( data ).toEqual( {
+			records: undefined,
+			hasResolved: false,
+			isResolving: false,
+			status: 'IDLE',
+		} );
 
 		await act( async () => {
 			jest.advanceTimersByTime( 1 );

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+jest.mock( '@wordpress/api-fetch' );
+
+/**
+ * External dependencies
+ */
+import { act, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreDataStore } from '../../index';
+import useEntityRecords from '../use-entity-records';
+
+describe( 'useEntityRecords', () => {
+	let registry;
+	beforeEach( () => {
+		jest.useFakeTimers();
+
+		registry = createRegistry();
+		registry.register( coreDataStore );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	const TEST_RECORDS = [
+		{ id: 1, hello: 'world1' },
+		{ id: 2, hello: 'world2' },
+		{ id: 3, hello: 'world3' },
+	];
+
+	it( 'retrieves the relevant entity record', async () => {
+		let data;
+		await registry
+			.dispatch( coreDataStore )
+			.receiveEntityRecords( 'root', 'widget', TEST_RECORDS, {} );
+		const TestComponent = () => {
+			data = useEntityRecords( 'root', 'widget' );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+		expect( data ).toEqual( {
+			records: TEST_RECORDS,
+			hasResolved: false,
+			isResolving: false,
+			status: 'IDLE',
+		} );
+
+		// Required to make sure no updates happen outside of act()
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		expect( data ).toEqual( {
+			records: TEST_RECORDS,
+			hasResolved: true,
+			isResolving: false,
+			status: 'SUCCESS',
+		} );
+	} );
+
+	it( 'resolves the entity if missing from state', async () => {
+		// Provide response
+		triggerFetch.mockImplementation( () => TEST_RECORDS );
+
+		let data;
+		const TestComponent = () => {
+			data = useEntityRecords( 'root', 'widget', { status: 'draft' } );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		// Fetch request should have been issued
+		expect( triggerFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/widgets?context=edit&status=draft',
+		} );
+
+		expect( data ).toEqual( {
+			records: TEST_RECORDS,
+			hasResolved: true,
+			isResolving: false,
+			status: 'SUCCESS',
+		} );
+	} );
+} );

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -37,41 +37,7 @@ describe( 'useEntityRecords', () => {
 		{ id: 3, hello: 'world3' },
 	];
 
-	it( 'retrieves the relevant entity record', async () => {
-		let data;
-		await registry
-			.dispatch( coreDataStore )
-			.receiveEntityRecords( 'root', 'widget', TEST_RECORDS, {} );
-		const TestComponent = () => {
-			data = useEntityRecords( 'root', 'widget' );
-			return <div />;
-		};
-		render(
-			<RegistryProvider value={ registry }>
-				<TestComponent />
-			</RegistryProvider>
-		);
-		expect( data ).toEqual( {
-			records: TEST_RECORDS,
-			hasResolved: false,
-			isResolving: false,
-			status: 'IDLE',
-		} );
-
-		// Required to make sure no updates happen outside of act()
-		await act( async () => {
-			jest.advanceTimersByTime( 1 );
-		} );
-
-		expect( data ).toEqual( {
-			records: TEST_RECORDS,
-			hasResolved: true,
-			isResolving: false,
-			status: 'SUCCESS',
-		} );
-	} );
-
-	it( 'resolves the entity if missing from state', async () => {
+	it( 'resolves the entity records when missing from the state', async () => {
 		// Provide response
 		triggerFetch.mockImplementation( () => TEST_RECORDS );
 
@@ -85,6 +51,13 @@ describe( 'useEntityRecords', () => {
 				<TestComponent />
 			</RegistryProvider>
 		);
+
+		expect( data ).toEqual( {
+			records: null,
+			hasResolved: false,
+			isResolving: false,
+			status: 'IDLE',
+		} );
 
 		await act( async () => {
 			jest.advanceTimersByTime( 1 );

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -123,8 +123,8 @@ describe( 'useQuerySelect', () => {
 		expect( querySelectData ).toEqual( {
 			data: 'bar',
 			isResolving: false,
-			hasStarted: false,
 			hasResolved: false,
+			status: 'IDLE',
 		} );
 	} );
 
@@ -171,8 +171,8 @@ describe( 'useQuerySelect', () => {
 		expect( querySelectData ).toEqual( {
 			data: 10,
 			isResolving: false,
-			hasStarted: false,
 			hasResolved: false,
+			status: 'IDLE',
 		} );
 
 		await act( async () => {
@@ -188,8 +188,8 @@ describe( 'useQuerySelect', () => {
 		expect( querySelectData ).toEqual( {
 			data: 15,
 			isResolving: false,
-			hasStarted: true,
 			hasResolved: true,
+			status: 'SUCCESS',
 		} );
 	} );
 } );

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -49,7 +49,7 @@ interface EntityRecordResolution< RecordType > {
  * ```
  *
  * In the above example, when `PageTitleDisplay` is rendered into an
- * application, the price and the resolution details will be retrieved from
+ * application, the page and the resolution details will be retrieved from
  * the store state using `getEntityRecord()`, or resolved if missing.
  *
  * @return {EntityRecordResolution<RecordType>} Entity record data.
@@ -60,28 +60,13 @@ export default function __experimentalUseEntityRecord< RecordType >(
 	name: string,
 	recordId: string | number
 ): EntityRecordResolution< RecordType > {
-	const { data, isResolving, hasResolved } = useQuerySelect(
+	const { data: record, ...rest } = useQuerySelect(
 		( query ) => query( coreStore ).getEntityRecord( kind, name, recordId ),
 		[ kind, name, recordId ]
 	);
 
-	let status;
-	if ( isResolving ) {
-		status = Status.Resolving;
-	} else if ( hasResolved ) {
-		if ( data ) {
-			status = Status.Success;
-		} else {
-			status = Status.Error;
-		}
-	} else {
-		status = Status.Idle;
-	}
-
 	return {
-		status,
-		record: data,
-		isResolving,
-		hasResolved,
+		record,
+		...rest,
 	};
 }

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -24,10 +24,10 @@ interface EntityRecordsResolution< RecordType > {
 }
 
 /**
- * Resolves the specified entity record.
+ * Resolves the specified entity records.
  *
- * @param  kind      Kind of the requested entity.
- * @param  name      Name of the requested  entity.
+ * @param  kind      Kind of the requested entities.
+ * @param  name      Name of the requested entities.
  * @param  httpQuery HTTP query for the requested entities.
  *
  * @example
@@ -58,7 +58,7 @@ interface EntityRecordsResolution< RecordType > {
  * application, the list of records and the resolution details will be retrieved from
  * the store state using `getEntityRecords()`, or resolved if missing.
  *
- * @return {EntityRecordsResolution<RecordType>} Entity record data.
+ * @return {EntityRecordsResolution<RecordType>} Entity records data.
  * @template RecordType
  */
 export default function __experimentalUseEntityRecords< RecordType >(

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -67,7 +67,8 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	httpQuery: unknown = {}
 ): EntityRecordsResolution< RecordType > {
 	const { data: records, ...rest } = useQuerySelect(
-		( query ) => query( coreStore ).getEntityRecords( kind, name, httpQuery ),
+		( query ) =>
+			query( coreStore ).getEntityRecords( kind, name, httpQuery ),
 		[ kind, name, httpQuery ]
 	);
 

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -1,0 +1,78 @@
+/**
+ * Internal dependencies
+ */
+import useQuerySelect from './use-query-select';
+import { store as coreStore } from '../';
+import { Status } from './constants';
+
+interface EntityRecordsResolution< RecordType > {
+	/** The requested entity record */
+	records: RecordType[] | null;
+
+	/**
+	 * Is the record still being resolved?
+	 */
+	isResolving: boolean;
+
+	/**
+	 * Is the record resolved by now?
+	 */
+	hasResolved: boolean;
+
+	/** Resolution status */
+	status: Status;
+}
+
+/**
+ * Resolves the specified entity record.
+ *
+ * @param  kind      Kind of the requested entity.
+ * @param  name      Name of the requested  entity.
+ * @param  httpQuery HTTP query for the requested entities.
+ *
+ * @example
+ * ```js
+ * import { useEntityRecord } from '@wordpress/core-data';
+ *
+ * function PageTitlesList() {
+ *   const { records, isResolving } = useEntityRecords( 'postType', 'page' );
+ *
+ *   if ( isResolving ) {
+ *     return 'Loading...';
+ *   }
+ *
+ *   return (
+ *     <ul>
+ *       {records.map(( page ) => (
+ *         <li>{ page.title }</li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ *
+ * // Rendered in the application:
+ * // <PageTitlesList />
+ * ```
+ *
+ * In the above example, when `PageTitlesList` is rendered into an
+ * application, the list of records and the resolution details will be retrieved from
+ * the store state using `getEntityRecords()`, or resolved if missing.
+ *
+ * @return {EntityRecordsResolution<RecordType>} Entity record data.
+ * @template RecordType
+ */
+export default function __experimentalUseEntityRecords< RecordType >(
+	kind: string,
+	name: string,
+	httpQuery: unknown = {}
+): EntityRecordsResolution< RecordType > {
+	const { data: records, ...rest } = useQuerySelect(
+		( query ) => query( coreStore ).getEntityRecords( kind, name, httpQuery ),
+		[ kind, name, httpQuery ]
+	);
+
+	return {
+		records,
+		...rest,
+	};
+}

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -28,7 +28,7 @@ interface EntityRecordsResolution< RecordType > {
  *
  * @param  kind      Kind of the requested entities.
  * @param  name      Name of the requested entities.
- * @param  httpQuery HTTP query for the requested entities.
+ * @param  queryArgs HTTP query for the requested entities.
  *
  * @example
  * ```js
@@ -64,12 +64,12 @@ interface EntityRecordsResolution< RecordType > {
 export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
-	httpQuery: unknown = {}
+	queryArgs: unknown = {}
 ): EntityRecordsResolution< RecordType > {
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) =>
-			query( coreStore ).getEntityRecords( kind, name, httpQuery ),
-		[ kind, name, httpQuery ]
+			query( coreStore ).getEntityRecords( kind, name, queryArgs ),
+		[ kind, name, queryArgs ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-query-select.ts
+++ b/packages/core-data/src/hooks/use-query-select.ts
@@ -72,28 +72,10 @@ interface QuerySelectResponse {
  * @return {QuerySelectResponse} Queried data.
  */
 export default function __experimentalUseQuerySelect( mapQuerySelect, deps ) {
-	const { data, isResolving, hasResolved, ...rest } = useSelect(
-		( select, registry ) => {
-			const resolve = ( store ) => enrichSelectors( select( store ) );
-			return mapQuerySelect( resolve, registry );
-		},
-		deps
-	);
-
-	let status;
-	if ( isResolving ) {
-		status = Status.Resolving;
-	} else if ( hasResolved ) {
-		if ( data ) {
-			status = Status.Success;
-		} else {
-			status = Status.Error;
-		}
-	} else {
-		status = Status.Idle;
-	}
-
-	return { data, isResolving, hasResolved, status, ...rest };
+	return useSelect( ( select, registry ) => {
+		const resolve = ( store ) => enrichSelectors( select( store ) );
+		return mapQuerySelect( resolve, registry );
+	}, deps );
 }
 
 type QuerySelector = ( ...args ) => QuerySelectResponse;
@@ -118,12 +100,29 @@ const enrichSelectors = memoize( ( selectors ) => {
 			get: () => ( ...args ) => {
 				const { getIsResolving, hasFinishedResolution } = selectors;
 				const isResolving = !! getIsResolving( selectorName, args );
+				const hasResolved =
+					! isResolving &&
+					hasFinishedResolution( selectorName, args );
+				const data = selectors[ selectorName ]( ...args );
+
+				let status;
+				if ( isResolving ) {
+					status = Status.Resolving;
+				} else if ( hasResolved ) {
+					if ( data ) {
+						status = Status.Success;
+					} else {
+						status = Status.Error;
+					}
+				} else {
+					status = Status.Idle;
+				}
+
 				return {
-					data: selectors[ selectorName ]( ...args ),
+					data,
+					status,
 					isResolving,
-					hasResolved:
-						! isResolving &&
-						hasFinishedResolution( selectorName, args ),
+					hasResolved,
 				};
 			},
 		} );

--- a/packages/core-data/src/hooks/use-query-select.ts
+++ b/packages/core-data/src/hooks/use-query-select.ts
@@ -116,10 +116,7 @@ const enrichSelectors = memoize( ( selectors ) => {
 		}
 		Object.defineProperty( resolvers, selectorName, {
 			get: () => ( ...args ) => {
-				const {
-					getIsResolving,
-					hasFinishedResolution,
-				} = selectors;
+				const { getIsResolving, hasFinishedResolution } = selectors;
 				const isResolving = !! getIsResolving( selectorName, args );
 				return {
 					data: selectors[ selectorName ]( ...args ),

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -75,5 +75,6 @@ register( store );
 
 export { default as EntityProvider } from './entity-provider';
 export { default as __experimentalUseEntityRecord } from './hooks/use-entity-record';
+export { default as __experimentalUseEntityRecords } from './hooks/use-entity-records';
 export * from './entity-provider';
 export * from './fetch';


### PR DESCRIPTION
## Description
This PR is a minimal subset of https://github.com/WordPress/gutenberg/pull/38135 focused solely on the `useEntityRecords` hook. It directly follows up on the singular [useEntityRecord](https://github.com/WordPress/gutenberg/pull/38522):

The goal of these new APIs is to lower the barrier of entry for new contributors and make the life of existing contributors easier.

### Example usage:
**Before**
```js
const { pages, hasResolved } = useSelect(
  ( select ) => {
	  const selectorArgs = [ 'postType', 'page', httpQuery ];
	  return {
		  pages: select( coreDataStore ).getEntityRecords(
			  ...selectorArgs
		  ),
		  hasResolved: select( coreDataStore ).hasFinishedResolution(
			  'getEntityRecords',
			  selectorArgs
		  ),
	  };
  },
  [ httpQuery ]
);
```

**After:**
```js
const { records, hasResolved } = __experimentalUseEntityRecords( 'postType', 'page', httpQuery );
```

See also [how the combination of all proposed hooks makes the navigation block ~200 lines leaner](https://github.com/WordPress/gutenberg/pull/38289).

### Test plan

1. Confirm if the tests are green
2. Confirm if the code makes sense

### Other considerations

`useQuerySelect` is used as an internal API for both `useEntityRecord` and `useEntityRecords` hooks. It might be useful in the potential `usePermissions()` and `useEntityMutation()` hooks (to be proposed). There is a separate discussion about making it a public API on `@wordpress/data` going on in https://github.com/WordPress/gutenberg/pull/38134

cc @kevin940726 @talldan @gziolo @draganescu @ellatrix @noisysocks @jsnajdr @getdave @Mamaduka @spencerfinnell