### PR TITLE
Simplify site icon animation on hover.

### DIFF
--- a/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -59,9 +60,8 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 
 	const effect = {
 		expand: {
-			scale: 1.7,
-			borderRadius: 0,
-			transition: { type: 'tween', duration: '0.2' },
+			scale: 1.25,
+			transition: { type: 'tween', duration: '0.3' },
 		},
 	};
 
@@ -85,10 +85,15 @@ function FullscreenModeClose( { showTooltip, icon, href } ) {
 		buttonIcon = <Icon size="36px" icon={ icon } />;
 	}
 
+	const classes = classnames( {
+		'edit-post-fullscreen-mode-close': true,
+		'has-icon': siteIconUrl,
+	} );
+
 	return (
 		<motion.div whileHover="expand">
 			<Button
-				className="edit-post-fullscreen-mode-close has-icon"
+				className={ classes }
 				href={
 					href ??
 					addQueryArgs( 'edit.php', {

--- a/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
+++ b/packages/edit-post/src/components/header/fullscreen-mode-close/style.scss
@@ -1,7 +1,7 @@
 // Developer notes: these rules are duplicated for the site editor.
 // They need to be updated in both places.
 
-.edit-post-fullscreen-mode-close.has-icon {
+.edit-post-fullscreen-mode-close.components-button {
 	// Do not show the toolbar icon on small screens,
 	// when Fullscreen Mode is not an option in the "More" menu.
 	display: none;
@@ -44,6 +44,10 @@
 		// Hover color.
 		&:hover::before {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+		}
+
+		&.has-icon:hover::before {
+			box-shadow: none;
 		}
 
 		// Lightened spot color focus.

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -58,9 +63,8 @@ function NavigationToggle( { icon } ) {
 
 	const effect = {
 		expand: {
-			scale: 1.7,
-			borderRadius: 0,
-			transition: { type: 'tween', duration: '0.2' },
+			scale: 1.25,
+			transition: { type: 'tween', duration: '0.3' },
 		},
 	};
 
@@ -79,6 +83,11 @@ function NavigationToggle( { icon } ) {
 		buttonIcon = <Icon size="36px" icon={ icon } />;
 	}
 
+	const classes = classnames( {
+		'edit-site-navigation-toggle__button': true,
+		'has-icon': siteIconUrl,
+	} );
+
 	return (
 		<motion.div
 			className={
@@ -88,7 +97,7 @@ function NavigationToggle( { icon } ) {
 			whileHover="expand"
 		>
 			<Button
-				className="edit-site-navigation-toggle__button has-icon"
+				className={ classes }
 				label={ __( 'Toggle navigation' ) }
 				ref={ navigationToggleRef }
 				// isPressed will add unwanted styles.

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-toggle/style.scss
@@ -12,7 +12,7 @@
 	width: $header-height;
 }
 
-.edit-site-navigation-toggle__button {
+.edit-site-navigation-toggle__button.components-button {
 	align-items: center;
 	background: $gray-900;
 	border-radius: 0;
@@ -21,42 +21,43 @@
 	width: $header-height;
 	z-index: 1;
 	margin-bottom: - $border-width;
+	min-width: $header-height;
 
-	&.has-icon {
-		min-width: $header-height;
+	&:hover,
+	&:active {
+		color: $white;
+	}
 
-		&:hover,
-		&:active {
-			color: $white;
-		}
+	&:focus {
+		box-shadow: none;
+	}
 
-		&:focus {
-			box-shadow: none;
-		}
+	&::before {
+		transition: box-shadow 0.1s ease;
+		@include reduce-motion("transition");
+		content: "";
+		display: block;
+		position: absolute;
+		top: 9px;
+		right: 9px;
+		bottom: 9px;
+		left: 9px;
+		border-radius: $radius-block-ui + $border-width + $border-width;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
+	}
 
-		&::before {
-			transition: box-shadow 0.1s ease;
-			@include reduce-motion("transition");
-			content: "";
-			display: block;
-			position: absolute;
-			top: 9px;
-			right: 9px;
-			bottom: 9px;
-			left: 9px;
-			border-radius: $radius-block-ui + $border-width + $border-width;
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-900;
-		}
+	// Hover color.
+	&:hover::before {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
+	}
 
-		// Hover color.
-		&:hover::before {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $gray-700;
-		}
+	&.has-icon:hover::before {
+		box-shadow: none;
+	}
 
-		// Lightened spot color focus.
-		&:focus::before {
-			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-		}
+	// Lightened spot color focus.
+	&:focus::before {
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) rgba($white, 0.1), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 	}
 
 	.edit-site-navigation-toggle__site-icon {


### PR DESCRIPTION
## Description

Fixes #38575. Alternative to #38702. 

This PR smooths out the animation that is added to the site icon when present. The animation helps signify the importance of the element:

![after](https://user-images.githubusercontent.com/1204802/153873897-126d0e17-c11f-4889-827f-92ba527a9d90.gif)

When no icon is applied, the existing hover style remains:

![no icon](https://user-images.githubusercontent.com/1204802/153874012-ef0dafc5-de7d-4358-8918-19f2ba6b2f8b.gif)

When you toggle "reduce motion" in your browser or operating system, no animation is shown.

## Testing Instructions

Add a site icon if you have none already. For example insert the site logo block, add and publish and image, then reload the page. Hover the top left button.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
