### PR TITLE
[WIP] Add background image support to group block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -258,7 +258,7 @@ Combine blocks into a group. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/group
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** tagName, templateLock
+-	**Attributes:** alt, backgroundType, customOverlayColor, dimRatio, focalPoint, hasParallax, id, isRepeated, overlayColor, tagName, templateLock, url
 
 ## Heading
 

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,6 +15,44 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
+		},
+		"url": {
+			"type": "string"
+		},
+		"id": {
+			"type": "number"
+		},
+		"alt": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "img",
+			"attribute": "alt",
+			"default": ""
+		},
+		"hasParallax": {
+			"type": "boolean",
+			"default": false
+		},
+		"isRepeated": {
+			"type": "boolean",
+			"default": false
+		},
+		"dimRatio": {
+			"type": "number",
+			"default": 100
+		},
+		"overlayColor": {
+			"type": "string"
+		},
+		"customOverlayColor": {
+			"type": "string"
+		},
+		"backgroundType": {
+			"type": "string",
+			"default": "image"
+		},
+		"focalPoint": {
+			"type": "object"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -27,17 +27,17 @@ import { compose } from '@wordpress/compose';
  */
 /* eslint-disable no-unused-vars */
 import {
-	ALLOWED_MEDIA_TYPES,
 	attributesFromMedia,
 	IMAGE_BACKGROUND_TYPE,
-	VIDEO_BACKGROUND_TYPE,
-	COVER_MIN_HEIGHT,
 	backgroundImageStyles,
 	dimRatioToClass,
 	isContentPositionCenter,
 	getPositionClassName,
 } from './shared';
 /* eslint-enable no-unused-vars */
+
+// For now let's keep things simple and use only images.
+const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const htmlElementMessages = {
 	header: __(

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -37,8 +37,6 @@ import {
 	IMAGE_BACKGROUND_TYPE,
 	backgroundImageStyles,
 	dimRatioToClass,
-	isContentPositionCenter,
-	getPositionClassName,
 } from './shared';
 /* eslint-enable no-unused-vars */
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -79,7 +79,10 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { tagName: TagName = 'div', templateLock, layout = {} } = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { type = 'default' } = usedLayout;
-	const layoutSupportEnabled = themeSupportsLayout || type !== 'default';
+
+	// TODO - temp disabled
+	const layoutSupportEnabled =
+		( false && themeSupportsLayout ) || type !== 'default';
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps(
@@ -148,7 +151,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 				{ showBgImage && (
 					<img
 						ref={ isDarkElement }
-						className="wp-block-cover__image-background"
+						className="wp-block-group__image-background"
 						alt={ alt }
 						src={ url }
 						style={ mediaStyle }

--- a/packages/block-library/src/group/shared.js
+++ b/packages/block-library/src/group/shared.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { getBlobTypeByURL, isBlobURL } from '@wordpress/blob';
+
+const POSITION_CLASSNAMES = {
+	'top left': 'is-position-top-left',
+	'top center': 'is-position-top-center',
+	'top right': 'is-position-top-right',
+	'center left': 'is-position-center-left',
+	'center center': 'is-position-center-center',
+	center: 'is-position-center-center',
+	'center right': 'is-position-center-right',
+	'bottom left': 'is-position-bottom-left',
+	'bottom center': 'is-position-bottom-center',
+	'bottom right': 'is-position-bottom-right',
+};
+
+export const IMAGE_BACKGROUND_TYPE = 'image';
+export const VIDEO_BACKGROUND_TYPE = 'video';
+export const COVER_MIN_HEIGHT = 50;
+export const COVER_MAX_HEIGHT = 1000;
+export const COVER_DEFAULT_HEIGHT = 300;
+export function backgroundImageStyles( url ) {
+	return url ? { backgroundImage: `url(${ url })` } : {};
+}
+export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+
+export function dimRatioToClass( ratio ) {
+	return ratio === 50 || ! ratio === undefined
+		? null
+		: 'has-background-dim-' + 10 * Math.round( ratio / 10 );
+}
+
+export function attributesFromMedia( setAttributes, dimRatio ) {
+	return ( media ) => {
+		if ( ! media || ! media.url ) {
+			setAttributes( { url: undefined, id: undefined } );
+			return;
+		}
+
+		if ( isBlobURL( media.url ) ) {
+			media.type = getBlobTypeByURL( media.url );
+		}
+
+		let mediaType;
+		// for media selections originated from a file upload.
+		if ( media.media_type ) {
+			if ( media.media_type === IMAGE_BACKGROUND_TYPE ) {
+				mediaType = IMAGE_BACKGROUND_TYPE;
+			} else {
+				// only images and videos are accepted so if the media_type is not an image we can assume it is a video.
+				// Videos contain the media type of 'file' in the object returned from the rest api.
+				mediaType = VIDEO_BACKGROUND_TYPE;
+			}
+		} else {
+			// for media selections originated from existing files in the media library.
+			if (
+				media.type !== IMAGE_BACKGROUND_TYPE &&
+				media.type !== VIDEO_BACKGROUND_TYPE
+			) {
+				return;
+			}
+			mediaType = media.type;
+		}
+
+		setAttributes( {
+			dimRatio: dimRatio === 100 ? 50 : dimRatio,
+			url: media.url,
+			id: media.id,
+			alt: media?.alt,
+			backgroundType: mediaType,
+			...( mediaType === VIDEO_BACKGROUND_TYPE
+				? { focalPoint: undefined, hasParallax: undefined }
+				: {} ),
+		} );
+	};
+}
+
+/**
+ * Checks of the contentPosition is the center (default) position.
+ *
+ * @param {string} contentPosition The current content position.
+ * @return {boolean} Whether the contentPosition is center.
+ */
+export function isContentPositionCenter( contentPosition ) {
+	return (
+		! contentPosition ||
+		contentPosition === 'center center' ||
+		contentPosition === 'center'
+	);
+}
+
+/**
+ * Retrieves the className for the current contentPosition.
+ * The default position (center) will not have a className.
+ *
+ * @param {string} contentPosition The current content position.
+ * @return {string} The className assigned to the contentPosition.
+ */
+export function getPositionClassName( contentPosition ) {
+	/*
+	 * Only render a className if the contentPosition is not center (the default).
+	 */
+	if ( isContentPositionCenter( contentPosition ) ) return '';
+
+	return POSITION_CLASSNAMES[ contentPosition ];
+}

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,64 @@
+.wp-block-group-image,
 .wp-block-group {
+	position: relative;
+	background-size: cover;
+	background-position: center center;
+
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	&.has-parallax {
+		background-attachment: fixed;
+
+		// Mobile Safari does not support fixed background attachment properly.
+		// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+		// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+		@supports (-webkit-overflow-scrolling: touch) {
+			background-attachment: scroll;
+		}
+
+		// Remove the appearance of scrolling based on OS-level animation preferences.
+		@media (prefers-reduced-motion: reduce) {
+			background-attachment: scroll;
+		}
+	}
+
+	&.is-repeated {
+		background-repeat: repeat;
+		background-size: auto;
+	}
+
+	.wp-block-group__inner-container {
+		width: 100%;
+		// z-index: z-index(".wp-block-group__inner-container");
+		z-index: 1; // TODO
+		color: $white;
+	}
+
+	&.has-custom-content-position.has-custom-content-position {
+		.wp-block-group__inner-container {
+			margin: 0;
+			width: auto;
+		}
+	}
+
+	// Extra specificity for in edit mode where other styles would override it otherwise.
+	img.wp-block-group__image-background,
+	video.wp-block-group__video-background {
+		position: absolute;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		margin: 0;
+		padding: 0;
+		width: 100%;
+		height: 100%;
+		max-width: none;
+		max-height: none;
+		object-fit: cover;
+		outline: none;
+		border: none;
+		box-shadow: none;
+	}
 }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -62,8 +62,8 @@
 		box-shadow: none;
 	}
 
-	&.has-background-color .wp-block-group__background,
-	&.has-background-color .wp-block-group__gradient-background {
+	.wp-block-group__background,
+	.wp-block-group__gradient-background {
 		position: absolute;
 		top: 0;
 		left: 0;
@@ -72,7 +72,7 @@
 		// TODO - refactor to common selector
 		z-index: z-index(".wp-block-cover.has-background-dim::before");
 		opacity: 0.5;
-		max-width: none;
+		max-width: none !important; // TODO - refactor to avoid !important
 	}
 
 	// Opacity classnames

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -61,4 +61,24 @@
 		border: none;
 		box-shadow: none;
 	}
+
+	&.has-background-color .wp-block-group__background,
+	&.has-background-color .wp-block-group__gradient-background {
+		position: absolute;
+		top: 0;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		z-index: z-index(".wp-block-cover.has-background-dim::before");
+		opacity: 0.5;
+		max-width: none;
+	}
+
+	// Opacity classnames
+	@for $i from 0 through 10 {
+		.wp-block-group__gradient-background.has-background-dim.has-background-dim-#{ $i * 10 },
+		.wp-block-group__background.has-background-dim.has-background-dim-#{ $i * 10 } {
+			opacity: $i * 0.1;
+		}
+	}
 }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -31,7 +31,7 @@
 	.wp-block-group__inner-container {
 		width: 100%;
 		// z-index: z-index(".wp-block-group__inner-container");
-		z-index: 1; // TODO
+		z-index: 1; // TODO refactor to common selector
 		color: $white;
 	}
 
@@ -69,6 +69,7 @@
 		left: 0;
 		bottom: 0;
 		right: 0;
+		// TODO - refactor to common selector
 		z-index: z-index(".wp-block-cover.has-background-dim::before");
 		opacity: 0.5;
 		max-width: none;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

As illustrated by the number of 👍 comments on https://github.com/WordPress/gutenberg/issues/14744 there is user demand for the ability to set image backgrounds on the Group block.

This has been a long-time outstanding issue and with the standardizing of Global Styles it's now one I think we can look to address. 

This PR is _currently_ a WIP which simply copy/pastes the implementation from the Cover block to gauge interest in the feature.

**Note**: currently this only works in the Editor. The block will not _yet_ output images on the front of the site.

Further work will proceed in phases:

2. Port over `save.js` implementation from `core/cover` to allow for front end to reflect changes in editor.
3. Refactor shared utils/implementation details to share between Group and Cover (possibly in a separate PR).
4. Finalise and test.

## Feedback required

I'm looking for feedback principally on whether folks still want to proceed with adding background images to the Group block. Is it necessary? What alternatives are there? What technical problems do we need to solve?

One of the main technical problems is that the Group block was adjusted (by @youknowriad) to remove the inner `<div>` element which we would probably need to restore if we proceed with this PR. Currently I've restored the `<div>` but we'll need to revisit it.


## Testing Instructions

At this stage I'm looking for feedback on feature parity with the Cover block.

* What doesn't work?
* What is missing?
* What features does Group need that Cover doesn't?
* Any quirks?

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/444434/153877221-24e65632-635e-403b-ab0d-bb722c2f4159.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
