### PR TITLE
Add __experimentalUseResourcePermissions

### DIFF
--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -89,10 +89,11 @@ describe( 'useNavigationMenus', () => {
 	it( 'Should return no information when no data is resolved', () => {
 		expect( useNavigationMenu() ).toEqual( {
 			navigationMenus: null,
+			navigationMenu: undefined,
 			canSwitchNavigationMenu: false,
 			canUserCreateNavigationMenu: false,
-			canUserDeleteNavigationMenu: false,
-			canUserUpdateNavigationMenu: false,
+			canUserDeleteNavigationMenu: undefined,
+			canUserUpdateNavigationMenu: undefined,
 			hasResolvedCanUserCreateNavigationMenu: false,
 			hasResolvedCanUserDeleteNavigationMenu: false,
 			hasResolvedCanUserUpdateNavigationMenu: false,
@@ -109,13 +110,14 @@ describe( 'useNavigationMenus', () => {
 		resolveCreatePermission( registry, true );
 		expect( useNavigationMenu() ).toEqual( {
 			navigationMenus,
+			navigationMenu: undefined,
 			canSwitchNavigationMenu: true,
 			canUserCreateNavigationMenu: true,
-			canUserDeleteNavigationMenu: false,
-			canUserUpdateNavigationMenu: false,
+			canUserDeleteNavigationMenu: undefined,
+			canUserUpdateNavigationMenu: undefined,
 			hasResolvedCanUserCreateNavigationMenu: true,
-			hasResolvedCanUserDeleteNavigationMenu: false,
-			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: true,
+			hasResolvedCanUserUpdateNavigationMenu: true,
 			hasResolvedNavigationMenus: true,
 			isNavigationMenuMissing: true,
 			isNavigationMenuResolved: false,
@@ -170,6 +172,7 @@ describe( 'useNavigationMenus', () => {
 		resolveRecords( registry, navigationMenus );
 		resolveCreatePermission( registry, true );
 		resolveUpdatePermission( registry, 1, true );
+		resolveDeletePermission( registry, 1, false );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,
 			navigationMenus,
@@ -178,7 +181,7 @@ describe( 'useNavigationMenus', () => {
 			canUserDeleteNavigationMenu: false,
 			canUserUpdateNavigationMenu: true,
 			hasResolvedCanUserCreateNavigationMenu: true,
-			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: true,
 			hasResolvedCanUserUpdateNavigationMenu: true,
 			hasResolvedNavigationMenus: true,
 			isNavigationMenuMissing: false,
@@ -190,6 +193,8 @@ describe( 'useNavigationMenus', () => {
 
 	it( 'Should return correct permissions (delete only)', () => {
 		resolveRecords( registry, navigationMenus );
+		resolveCreatePermission( registry, false );
+		resolveUpdatePermission( registry, 1, false );
 		resolveDeletePermission( registry, 1, true );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,
@@ -198,9 +203,9 @@ describe( 'useNavigationMenus', () => {
 			canUserCreateNavigationMenu: false,
 			canUserDeleteNavigationMenu: true,
 			canUserUpdateNavigationMenu: false,
-			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: true,
 			hasResolvedCanUserDeleteNavigationMenu: true,
-			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: true,
 			hasResolvedNavigationMenus: true,
 			isNavigationMenuMissing: false,
 			isNavigationMenuResolved: false,

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -1,12 +1,22 @@
 /**
  * WordPress dependencies
  */
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	__experimentalUseResourcePermissions as useResourcePermissions,
+} from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
 export default function useNavigationMenu( ref ) {
+	const permissions = useResourcePermissions( 'navigation', ref );
+
 	return useSelect(
 		( select ) => {
+			const [
+				hasResolvedPermissions,
+				{ canCreate, canUpdate, canDelete, isResolving },
+			] = permissions;
+
 			const {
 				navigationMenus,
 				isResolvingNavigationMenus,
@@ -19,22 +29,6 @@ export default function useNavigationMenu( ref ) {
 				isNavigationMenuMissing,
 			} = selectExistingMenu( select, ref );
 
-			const {
-				canUserCreateNavigationMenu,
-				isResolvingCanUserCreateNavigationMenu,
-				hasResolvedCanUserCreateNavigationMenu,
-			} = selectMenuCreatePermissions( select );
-
-			const {
-				canUserUpdateNavigationMenu,
-				hasResolvedCanUserUpdateNavigationMenu,
-			} = selectMenuUpdatePermissions( select, ref );
-
-			const {
-				canUserDeleteNavigationMenu,
-				hasResolvedCanUserDeleteNavigationMenu,
-			} = selectMenuDeletePermissions( select, ref );
-
 			return {
 				navigationMenus,
 				isResolvingNavigationMenus,
@@ -44,22 +38,22 @@ export default function useNavigationMenu( ref ) {
 				isNavigationMenuResolved,
 				isNavigationMenuMissing,
 
-				canUserCreateNavigationMenu,
-				isResolvingCanUserCreateNavigationMenu,
-				hasResolvedCanUserCreateNavigationMenu,
-
-				canUserUpdateNavigationMenu,
-				hasResolvedCanUserUpdateNavigationMenu,
-
-				canUserDeleteNavigationMenu,
-				hasResolvedCanUserDeleteNavigationMenu,
-
 				canSwitchNavigationMenu: ref
 					? navigationMenus?.length > 1
 					: navigationMenus?.length > 0,
+
+				canUserCreateNavigationMenu: canCreate,
+				isResolvingCanUserCreateNavigationMenu: isResolving,
+				hasResolvedCanUserCreateNavigationMenu: hasResolvedPermissions,
+
+				canUserUpdateNavigationMenu: canUpdate,
+				hasResolvedCanUserUpdateNavigationMenu: hasResolvedPermissions,
+
+				canUserDeleteNavigationMenu: canDelete,
+				hasResolvedCanUserDeleteNavigationMenu: hasResolvedPermissions,
 			};
 		},
-		[ ref ]
+		[ ref, permissions ]
 	);
 }
 
@@ -111,60 +105,5 @@ function selectExistingMenu( select, ref ) {
 			editedNavigationMenu.status === 'publish'
 				? editedNavigationMenu
 				: null,
-	};
-}
-
-function selectMenuCreatePermissions( select ) {
-	const { hasFinishedResolution, isResolving, canUser } = select( coreStore );
-
-	const args = [ 'create', 'navigation' ];
-	return {
-		canUserCreateNavigationMenu: !! canUser( ...args ),
-		isResolvingCanUserCreateNavigationMenu: !! isResolving(
-			'canUser',
-			args
-		),
-		hasResolvedCanUserCreateNavigationMenu: !! hasFinishedResolution(
-			'canUser',
-			args
-		),
-	};
-}
-
-function selectMenuUpdatePermissions( select, ref ) {
-	if ( ! ref ) {
-		return {
-			canUserUpdateNavigationMenu: false,
-			hasResolvedCanUserUpdateNavigationMenu: false,
-		};
-	}
-
-	const { hasFinishedResolution, canUser } = select( coreStore );
-	const args = [ 'update', 'navigation', ref ];
-	return {
-		canUserUpdateNavigationMenu: !! canUser( ...args ),
-		hasResolvedCanUserUpdateNavigationMenu: !! hasFinishedResolution(
-			'canUser',
-			args
-		),
-	};
-}
-
-function selectMenuDeletePermissions( select, ref ) {
-	if ( ! ref ) {
-		return {
-			canUserDeleteNavigationMenu: false,
-			hasResolvedCanUserDeleteNavigationMenu: false,
-		};
-	}
-
-	const { hasFinishedResolution, canUser } = select( coreStore );
-	const args = [ 'delete', 'navigation', ref ];
-	return {
-		canUserDeleteNavigationMenu: !! canUser( ...args ),
-		hasResolvedCanUserDeleteNavigationMenu: !! hasFinishedResolution(
-			'canUser',
-			args
-		),
 	};
 }

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import triggerFetch from '@wordpress/api-fetch';
+import { createRegistry, RegistryProvider } from '@wordpress/data';
+
+jest.mock( '@wordpress/api-fetch' );
+
+/**
+ * External dependencies
+ */
+import { act, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreDataStore } from '../../index';
+import useResourcePermissions from '../use-resource-permissions';
+
+describe( 'useResourcePermissions', () => {
+	let registry;
+	beforeEach( () => {
+		jest.useFakeTimers();
+
+		registry = createRegistry();
+		registry.register( coreDataStore );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	it( 'retrieves the relevant permissions for a key-less resource', async () => {
+		triggerFetch.mockImplementation( () => ( {
+			headers: {
+				Allow: 'POST',
+			},
+		} ) );
+		let data;
+		const TestComponent = () => {
+			data = useResourcePermissions( 'widgets' );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+		expect( data ).toEqual( [
+			false,
+			{
+				status: 'IDLE',
+				isResolving: false,
+				canCreate: false,
+			},
+		] );
+
+		// Required to make sure no updates happen outside of act()
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		expect( data ).toEqual( [
+			true,
+			{
+				status: 'SUCCESS',
+				isResolving: false,
+				canCreate: true,
+			},
+		] );
+	} );
+
+	it( 'retrieves the relevant permissions for a resource with a key', async () => {
+		triggerFetch.mockImplementation( () => ( {
+			headers: {
+				Allow: 'POST',
+			},
+		} ) );
+		let data;
+		const TestComponent = () => {
+			data = useResourcePermissions( 'widgets', 1 );
+			return <div />;
+		};
+		render(
+			<RegistryProvider value={ registry }>
+				<TestComponent />
+			</RegistryProvider>
+		);
+		expect( data ).toEqual( [
+			false,
+			{
+				status: 'IDLE',
+				isResolving: false,
+				canCreate: false,
+				canUpdate: false,
+				canDelete: false,
+			},
+		] );
+
+		// Required to make sure no updates happen outside of act()
+		await act( async () => {
+			jest.advanceTimersByTime( 1 );
+		} );
+
+		expect( data ).toEqual( [
+			true,
+			{
+				status: 'SUCCESS',
+				isResolving: false,
+				canCreate: true,
+				canUpdate: false,
+				canDelete: false,
+			},
+		] );
+	} );
+} );

--- a/packages/core-data/src/hooks/test/use-resource-permissions.js
+++ b/packages/core-data/src/hooks/test/use-resource-permissions.js
@@ -24,6 +24,14 @@ describe( 'useResourcePermissions', () => {
 
 		registry = createRegistry();
 		registry.register( coreDataStore );
+
+		triggerFetch.mockImplementation( () => ( {
+			headers: {
+				get: () => ( {
+					allow: 'POST',
+				} ),
+			},
+		} ) );
 	} );
 
 	afterEach( () => {
@@ -32,11 +40,6 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'retrieves the relevant permissions for a key-less resource', async () => {
-		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				Allow: 'POST',
-			},
-		} ) );
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( 'widgets' );
@@ -72,11 +75,6 @@ describe( 'useResourcePermissions', () => {
 	} );
 
 	it( 'retrieves the relevant permissions for a resource with a key', async () => {
-		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				Allow: 'POST',
-			},
-		} ) );
 		let data;
 		const TestComponent = () => {
 			data = useResourcePermissions( 'widgets', 1 );

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -1,0 +1,120 @@
+/**
+ * Internal dependencies
+ */
+import { store as coreStore } from '../';
+import { Status } from './constants';
+import useQuerySelect from './use-query-select';
+
+interface GlobalResourcePermissionsResolution {
+	/** Can the current user create new resources of this type? */
+	canCreate: boolean;
+}
+interface SpecificResourcePermissionsResolution {
+	/** Can the current user update resources of this type? */
+	canUpdate: boolean;
+	/** Can the current user delete resources of this type? */
+	canDelete: boolean;
+}
+interface ResolutionDetails {
+	/** Resolution status */
+	status: Status;
+	/**
+	 * Is the data still being resolved?
+	 */
+	isResolving: boolean;
+}
+
+/**
+ * Is the data resolved by now?
+ */
+type HasResolved = boolean;
+
+type ResourcePermissionsResolution< IdType > = [
+	HasResolved,
+	ResolutionDetails &
+		GlobalResourcePermissionsResolution &
+		( IdType extends void ? SpecificResourcePermissionsResolution : {} )
+];
+
+/**
+ * Resolves resource permissions.
+ *
+ * @param  resource The resource in question, e.g. media.
+ * @param  id       ID of a specific resource entry, if needed, e.g. 10.
+ *
+ * @example
+ * ```js
+ * import { useResourcePermissions } from '@wordpress/core-data';
+ *
+ * function PagesList() {
+ *   const { canCreate, isResolving } = useResourcePermissions( 'pages' );
+ *
+ *   if ( isResolving ) {
+ *     return 'Loading ...';
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       {canCreate ? (<button>+ Create a new page</button>) : false}
+ *       // ...
+ *     </div>
+ *   );
+ * }
+ *
+ * // Rendered in the application:
+ * // <PagesList />
+ * ```
+ *
+ * In the above example, when `PagesList` is rendered into an
+ * application, the appropriate permissions and the resolution details will be retrieved from
+ * the store state using `canUser()`, or resolved if missing.
+ *
+ * @return Entity records data.
+ * @template IdType
+ */
+export default function __experimentalUseResourcePermissions< IdType = void >(
+	resource: string,
+	id: IdType
+): ResourcePermissionsResolution< IdType > {
+	return useQuerySelect(
+		( resolve ) => {
+			const { canUser } = resolve( coreStore );
+			const create = canUser( 'create', resource );
+			if ( ! id ) {
+				return [
+					create.hasResolved,
+					{
+						status: create.status,
+						isResolving: create.isResolving,
+						canCreate: create.hasResolved && create.data,
+					},
+				];
+			}
+
+			const update = canUser( 'update', resource, id );
+			const _delete = canUser( 'delete', resource, id );
+			const isResolving =
+				create.isResolving || update.isResolving || _delete.isResolving;
+			const hasResolved =
+				create.hasResolved && update.hasResolved && _delete.hasResolved;
+
+			let status = Status.Idle;
+			if ( isResolving ) {
+				status = Status.Resolving;
+			} else if ( hasResolved ) {
+				status = Status.Success;
+			}
+			return [
+				hasResolved,
+				{
+					status,
+					isResolving,
+					canCreate: hasResolved && create.data,
+					canUpdate: hasResolved && update.data,
+					canDelete: hasResolved && _delete.data,
+				},
+			];
+		},
+		[ resource, id ]
+	);
+}

--- a/packages/core-data/src/hooks/use-resource-permissions.ts
+++ b/packages/core-data/src/hooks/use-resource-permissions.ts
@@ -74,7 +74,7 @@ type ResourcePermissionsResolution< IdType > = [
  */
 export default function __experimentalUseResourcePermissions< IdType = void >(
 	resource: string,
-	id: IdType
+	id?: IdType
 ): ResourcePermissionsResolution< IdType > {
 	return useQuerySelect(
 		( resolve ) => {

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -68,6 +68,9 @@ export const store = createReduxStore( STORE_NAME, storeConfig() );
 register( store );
 
 export { default as EntityProvider } from './entity-provider';
+export { default as useEntityRecord } from './hooks/use-entity-record';
+export { default as useEntityRecords } from './hooks/use-entity-records';
+export { default as useResourcePermissions } from './hooks/use-resource-permissions';
 export * from './entity-provider';
 export * from './entity-types';
 export * from './fetch';

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -70,7 +70,7 @@ register( store );
 export { default as EntityProvider } from './entity-provider';
 export { default as useEntityRecord } from './hooks/use-entity-record';
 export { default as useEntityRecords } from './hooks/use-entity-records';
-export { default as useResourcePermissions } from './hooks/use-resource-permissions';
+export { default as __experimentalUseResourcePermissions } from './hooks/use-resource-permissions';
 export * from './entity-provider';
 export * from './entity-types';
 export * from './fetch';

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -401,7 +401,7 @@ describe( 'Navigation', () => {
 				{
 					match: ( request ) => {
 						return decodeURIComponent( request.url() ).includes(
-							`navigation/${ testNavId }`
+							`navigation/`
 						);
 					},
 					onRequestMatch: ( request ) => {

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -400,11 +400,8 @@ describe( 'Navigation', () => {
 			await setUpResponseMocking( [
 				{
 					match: ( request ) => {
-						return (
-							[ 'GET', 'OPTIONS' ].includes( request.method() ) &&
-							decodeURIComponent( request.url() ).includes(
-								`navigation/${ testNavId }`
-							)
+						return decodeURIComponent( request.url() ).includes(
+							`navigation/${ testNavId }`
 						);
 					},
 					onRequestMatch: ( request ) => {


### PR DESCRIPTION
## Description
This PR is a minimal subset of https://github.com/WordPress/gutenberg/pull/38135 focused solely on the `useResourcePermissions` hook.

The goal of these new APIs is to lower the barrier of entry for new contributors and make the life of existing contributors easier.

### Example usage:
**Before**
```js
useSelect(
  ( select ) => {
	  return {
		canUserUpdateNavigationEntity: ref
			? canUser( 'update', 'navigation', ref )
			: undefined,
		hasResolvedCanUserUpdateNavigationEntity: hasFinishedResolution(
			'canUser',
			[ 'update', 'navigation', ref ]
		),
		canUserDeleteNavigationEntity: ref
			? canUser( 'delete', 'navigation', ref )
			: undefined,
		hasResolvedCanUserDeleteNavigationEntity: hasFinishedResolution(
			'canUser',
			[ 'delete', 'navigation', ref ]
		),
		canUserCreateNavigation: canUser( 'create', 'navigation' ),
		hasResolvedCanUserCreateNavigation: hasFinishedResolution(
			'canUser',
			[ 'create', 'navigation' ]
		),
	  };
  },
  [ ref ]
);
```

**After:**
```js
const [ hasResolved, { canCreate, canUpdate, canDelete } ] = __experimentalUseResourcePermissions( 'navigation', ref );
```

It returns a tuple and with `hasResolved` the first item so that it's intentionally too hard to overlook. Thank you @kevin940726 for this suggestion!

See also [how the combination of all proposed hooks makes the navigation block ~200 lines leaner](https://github.com/WordPress/gutenberg/pull/38289).

### Test plan

1. Confirm if the tests are green
2. Confirm if the code makes sense

### Other considerations

@gziolo [said](https://github.com/WordPress/gutenberg/pull/38135/files#r794378548):
> Nit: for consistency, it might use a more explicit name like useEntityRecordPermissions since it works only for a single record.

API resources are separate from entity records, we refer to them using a different set of identifiers.

> What's the story for multiple records?

You can either pass an id to this hook and get a create/update/delete permissions, or skip an id and get only the create permissions. Both are useful, e.g. in the Gutenberg codebase we sometimes do `canUser( 'update', 'settings' );` and other times we do `canUser( 'delete', resource, postId )`.

cc @kevin940726 @talldan @gziolo @draganescu @ellatrix @noisysocks @jsnajdr @getdave @Mamaduka @spencerfinnell