### PR TITLE
Blocks: Deprecate `isValidBlockContent`

### DIFF
--- a/docs/contributors/code/deprecations.md
+++ b/docs/contributors/code/deprecations.md
@@ -2,6 +2,10 @@
 
 For features included in the Gutenberg plugin, the deprecation policy is intended to support backward compatibility for two minor plugin releases, when possible. Features and code included in a stable release of WordPress are not included in this deprecation timeline, and are instead subject to the [versioning policies of the WordPress project](https://make.wordpress.org/core/handbook/about/release-cycle/version-numbering/). The current deprecations are listed below and are grouped by _the version at which they will be removed completely_. If your plugin depends on these behaviors, you must update to the recommended alternative before the noted version.
 
+## Unreleased
+
+-   `wp.blocks.isValidBlockContent` has been removed. Please use `wp.blocks.validateBlock` instead.
+
 ## 11.0.0
 
 -   `wp.blocks.registerBlockTypeFromMetadata` method has been removed. Use `wp.blocks.registerBlockType` method instead.

--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -12,8 +12,8 @@ import {
 	getBlockAttributes,
 	getBlockContent,
 	getBlockType,
-	isValidBlockContent,
 	getSaveContent,
+	validateBlock,
 } from '@wordpress/blocks';
 
 /**
@@ -43,9 +43,13 @@ function BlockHTML( { clientId } ) {
 
 		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
 		const content = html ? html : getSaveContent( blockType, attributes );
-		const isValid = html
-			? isValidBlockContent( blockType, attributes, content )
-			: true;
+		const [ isValid ] = html
+			? validateBlock( {
+					...block,
+					attributes,
+					originalContent: content,
+			  } )
+			: [ true ];
 
 		updateBlock( clientId, {
 			attributes,

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -566,6 +566,8 @@ _Returns_
 
 ### isValidBlockContent
 
+> **Deprecated** Use validateBlock instead to avoid data loss.
+
 Returns true if the parsed block is valid given the input content. A block
 is considered valid if, when serialized with assumed attributes, the content
 matches the original value.
@@ -880,6 +882,22 @@ _Parameters_
 
 -   _slug_ `string`: Block category slug.
 -   _category_ `WPBlockCategory`: Object containing the category properties that should be updated.
+
+### validateBlock
+
+Returns an object with `isValid` property set to `true` if the parsed block
+is valid given the input content. A block is considered valid if, when serialized
+with assumed attributes, the content matches the original value. If block is
+invalid, this function returns all validations issues as well.
+
+_Parameters_
+
+-   _block_ `import('../parser').WPBlock`: block object.
+-   _blockTypeOrName_ `[import('../registration').WPBlockType]`: Block type or name, inferred from block if not given.
+
+_Returns_
+
+-   `[boolean,Object]`: validation results.
 
 ### withBlockContentContext
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -892,12 +892,12 @@ invalid, this function returns all validations issues as well.
 
 _Parameters_
 
--   _block_ `import('../parser').WPBlock`: block object.
--   _blockTypeOrName_ `[import('../registration').WPBlockType]`: Block type or name, inferred from block if not given.
+-   _block_ `WPBlock`: block object.
+-   _blockTypeOrName_ `[WPBlockType|string]`: Block type or name, inferred from block if not given.
 
 _Returns_
 
--   `[boolean,Object]`: validation results.
+-   `[boolean,Array<LoggerItem>]`: validation results.
 
 ### withBlockContentContext
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -89,7 +89,7 @@ export {
 // they will be run for all valid and invalid blocks alike. However, once a
 // block is detected as invalid -- failing the three first steps -- it is
 // adequate to spend more time determining validity before throwing a conflict.
-export { isValidBlockContent } from './validation';
+export { isValidBlockContent, validateBlock } from './validation';
 export { getCategories, setCategories, updateCategory } from './categories';
 
 // Blocks are inherently indifferent about where the data they operate with ends

--- a/packages/blocks/src/api/test/validation.js
+++ b/packages/blocks/src/api/test/validation.js
@@ -16,7 +16,7 @@ import {
 	isEqualTokensOfType,
 	getNextNonWhitespaceToken,
 	isEquivalentHTML,
-	isValidBlockContent,
+	validateBlock,
 	isClosedByToken,
 } from '../validation';
 import { createLogger } from '../validation/logger';
@@ -24,7 +24,6 @@ import {
 	registerBlockType,
 	unregisterBlockType,
 	getBlockTypes,
-	getBlockType,
 } from '../registration';
 
 describe( 'validation', () => {
@@ -717,15 +716,17 @@ describe( 'validation', () => {
 		} );
 	} );
 
-	describe( 'isValidBlockContent()', () => {
+	describe( 'validateBlock()', () => {
 		it( 'returns false if block is not valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isValidBlockContent(
-				'core/test-block',
-				{ fruit: 'Bananas' },
-				'Apples'
-			);
+			const [ isValid ] = validateBlock( {
+				name: 'core/test-block',
+				attrs: {
+					fruit: 'Bananas',
+				},
+				originalContent: 'Apples',
+			} );
 
 			expect( isValid ).toBe( false );
 		} );
@@ -738,11 +739,13 @@ describe( 'validation', () => {
 				},
 			} );
 
-			const isValid = isValidBlockContent(
-				'core/test-block',
-				{ fruit: 'Bananas' },
-				'Bananas'
-			);
+			const [ isValid ] = validateBlock( {
+				name: 'core/test-block',
+				attrs: {
+					fruit: 'Bananas',
+				},
+				originalContent: 'Bananas',
+			} );
 
 			expect( isValid ).toBe( false );
 		} );
@@ -750,23 +753,11 @@ describe( 'validation', () => {
 		it( 'returns true is block is valid', () => {
 			registerBlockType( 'core/test-block', defaultBlockSettings );
 
-			const isValid = isValidBlockContent(
-				'core/test-block',
-				{ fruit: 'Bananas' },
-				'Bananas'
-			);
-
-			expect( isValid ).toBe( true );
-		} );
-
-		it( 'works also when block type object is passed as object', () => {
-			registerBlockType( 'core/test-block', defaultBlockSettings );
-
-			const isValid = isValidBlockContent(
-				getBlockType( 'core/test-block' ),
-				{ fruit: 'Bananas' },
-				'Bananas'
-			);
+			const [ isValid ] = validateBlock( {
+				name: 'core/test-block',
+				attributes: { fruit: 'Bananas' },
+				originalContent: 'Bananas',
+			} );
 
 			expect( isValid ).toBe( true );
 		} );

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -21,6 +21,10 @@ import {
 } from '../registration';
 import { normalizeBlockType } from '../utils';
 
+/** @typedef {import('../parser').WPBlock} WPBlock */
+/** @typedef {import('../registration').WPBlockType} WPBlockType */
+/** @typedef {import('./logger').LoggerItem} LoggerItem */
+
 /**
  * Globally matches any consecutive whitespace
  *
@@ -701,10 +705,10 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  * with assumed attributes, the content matches the original value. If block is
  * invalid, this function returns all validations issues as well.
  *
- * @param {import('../parser').WPBlock}           block             block object.
- * @param {import('../registration').WPBlockType} [blockTypeOrName] Block type or name, inferred from block if not given.
+ * @param {WPBlock}            block                          block object.
+ * @param {WPBlockType|string} [blockTypeOrName = block.name] Block type or name, inferred from block if not given.
  *
- * @return {[boolean,Object]} validation results.
+ * @return {[boolean,Array<LoggerItem>]} validation results.
  */
 export function validateBlock( block, blockTypeOrName = block.name ) {
 	const isFallbackBlock =
@@ -713,7 +717,7 @@ export function validateBlock( block, blockTypeOrName = block.name ) {
 
 	// Shortcut to avoid costly validation.
 	if ( isFallbackBlock ) {
-		return [ true ];
+		return [ true, [] ];
 	}
 
 	const logger = createQueuedLogger();

--- a/packages/blocks/src/api/validation/index.js
+++ b/packages/blocks/src/api/validation/index.js
@@ -7,6 +7,7 @@ import { identity, xor, fromPairs, isEqual, includes, stubTrue } from 'lodash';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -700,12 +701,12 @@ export function isEquivalentHTML( actual, expected, logger = createLogger() ) {
  * with assumed attributes, the content matches the original value. If block is
  * invalid, this function returns all validations issues as well.
  *
- * @param {import('../parser').WPBlock}           block           block object.
- * @param {import('../registration').WPBlockType} blockTypeOrName Block type or name.
+ * @param {import('../parser').WPBlock}           block             block object.
+ * @param {import('../registration').WPBlockType} [blockTypeOrName] Block type or name, inferred from block if not given.
  *
  * @return {[boolean,Object]} validation results.
  */
-export function validateBlock( block, blockTypeOrName ) {
+export function validateBlock( block, blockTypeOrName = block.name ) {
 	const isFallbackBlock =
 		block.name === getFreeformContentHandlerName() ||
 		block.name === getUnregisteredTypeHandlerName();
@@ -755,6 +756,8 @@ export function validateBlock( block, blockTypeOrName ) {
  *
  * Logs to console in development environments when invalid.
  *
+ * @deprecated Use validateBlock instead to avoid data loss.
+ *
  * @param {string|Object} blockTypeOrName      Block type.
  * @param {Object}        attributes           Parsed block attributes.
  * @param {string}        originalBlockContent Original block content.
@@ -766,6 +769,12 @@ export function isValidBlockContent(
 	attributes,
 	originalBlockContent
 ) {
+	deprecated( 'isValidBlockContent introduces opportunity for data loss', {
+		since: '12.6',
+		plugin: 'Gutenberg',
+		alternative: 'validateBlock',
+	} );
+
 	const blockType = normalizeBlockType( blockTypeOrName );
 	const block = {
 		name: blockType.name,

--- a/packages/blocks/src/api/validation/logger.js
+++ b/packages/blocks/src/api/validation/logger.js
@@ -1,3 +1,9 @@
+/**
+ * @typedef LoggerItem
+ * @property {Function}   log  Which logger recorded the message
+ * @property {Array<any>} args White arguments were supplied to the logger
+ */
+
 export function createLogger() {
 	/**
 	 * Creates a log handler with block validation prefix.
@@ -36,7 +42,7 @@ export function createQueuedLogger() {
 	/**
 	 * The list of enqueued log actions to print.
 	 *
-	 * @type {Array}
+	 * @type {Array<LoggerItem>}
 	 */
 	const queue = [];
 


### PR DESCRIPTION
## Description

The `isValidBlockContent` function attempts to validate a block by
re-generating its output but does so by ignoring any `innerBlocks`
that might exist. Since blocks can change their output based on the
presence or content of its inner blocks this will lead to incorrect
results from the validator.

`validateBlock` also makes this mistake however it is fixable since
it requires passing in the block itself (fixable in another patch
once there are no longer two interfaces for what appears to be the
same purpose). `isValidBlockContent` doesn't pass in the block and
so is fundamentally limited in being able to validate properly.
This limitation also means that we can't rely on `isValidBlockContent`
once we start threading source information into blocks; that is, as
we improve our ability to catch and fix or preserve issues with the
block markup, this function provides no way forward to incorporate
those updates.

After scouring through the commit logs I was unable to find a clear
purpose for this second validation method and in Core it only seems
to be used as a convenience function for tests. We're deprecating it
in this patch because it's an exposed public interface and it's not
clear if anyone relies on it.

## Testing Instructions

There are two testable changes in this PR:
 - Are you aware of external code relying on `isValidBlockContent`?
   What do we think about the deprecation? Should we schedule removal?
   Should we outright remove it instead?
 - By rewriting the internal tests to use `validateBlock` we have
   removed the tests and constraints on `isValidBlockContent`. We could
   preserve them but I want to avoid as much confusion as possible and
   suggest people only use `validateBlock`.

The only affected code in Core should be the tests, so if they pass
then there's nothing more to test.

## Types of changes

As part of ongoing work to preserve existing unrecognized content (via invalid or missing blocks) this patch is deprecating an interface for block validation that overlooks inner blocks and parse failures. Because of this and because of the broader issue the editor has a tendency to corrupt or lose content on save, even for unrelated changes.

This change works to make it easier to account for inner blocks on validation as well as better preservation of those unrecognized bits.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
