### PR TITLE
Global Styles: Fix display of color palettes for border panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/border-panel.js
+++ b/packages/edit-site/src/components/global-styles/border-panel.js
@@ -12,13 +12,17 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { getSupportedGlobalStylesPanels, useSetting, useStyle } from './hooks';
+import {
+	getSupportedGlobalStylesPanels,
+	useColorsPerOrigin,
+	useSetting,
+	useStyle,
+} from './hooks';
 
 const MIN_BORDER_WIDTH = 0;
 
@@ -63,52 +67,6 @@ function useHasBorderWidthControl( name ) {
 		useSetting( 'border.width', name )[ 0 ] &&
 		supports.includes( 'borderWidth' )
 	);
-}
-
-function useMultiOriginColors( name ) {
-	const [ customColors ] = useSetting( 'color.palette.custom', name );
-	const [ themeColors ] = useSetting( 'color.palette.theme', name );
-	const [ defaultColors ] = useSetting( 'color.palette.default', name );
-	const [ defaultPaletteEnabled ] = useSetting(
-		'color.defaultPalette',
-		name
-	);
-
-	return useMemo( () => {
-		const result = [];
-
-		if ( themeColors && themeColors.length ) {
-			result.push( {
-				name: _x(
-					'Theme',
-					'Indicates this palette comes from the theme.'
-				),
-				colors: themeColors,
-			} );
-		}
-
-		if ( defaultPaletteEnabled && defaultColors && defaultColors.length ) {
-			result.push( {
-				name: _x(
-					'Default',
-					'Indicates this palette comes from WordPress.'
-				),
-				colors: defaultColors,
-			} );
-		}
-
-		if ( customColors && customColors.length ) {
-			result.push( {
-				name: _x(
-					'Custom',
-					'Indicates this palette comes from the theme.'
-				),
-				colors: customColors,
-			} );
-		}
-
-		return result;
-	}, [ customColors, defaultColors, defaultPaletteEnabled, themeColors ] );
 }
 
 export default function BorderPanel( { name } ) {
@@ -162,7 +120,7 @@ export default function BorderPanel( { name } ) {
 	const borderColorSettings = [
 		{
 			label: __( 'Color' ),
-			colors: useMultiOriginColors(),
+			colors: useColorsPerOrigin( name ),
 			colorValue: borderColor,
 			onColorChange: handleOnChangeWithStyle( setBorderColor ),
 			clearable: false,


### PR DESCRIPTION
## Description

The Global Styles border panel appears to only display the last source color palette. This PR updates the Global Styles border panel to display multi-origin color palettes as well as use the same dropdown style as the block editor for border color.

## Testing Instructions

1. Prior to checking out this PR add a custom color to your palette via Global Styles in the Site Editor
2. Within the Site Editor's Global Styles sidebar, navigate to Blocks > Group > Layout
3. Notice that only your custom colors are displayed for the border color control
4. Checkout this PR and reload the Site Editor, renavigating back to the same panel
5. You should now see the newer color dropdown style of control for the border color
6. Clicking on that will open a popover that should now display multi-origin color palettes

## Screenshots <!-- if applicable -->

| Before | After |
|---|---|
| ![GlobalStylesBorderColorBefore](https://user-images.githubusercontent.com/60436221/153988790-09728f83-dfbe-4f82-a96c-bd2ac9be49cc.gif) | ![GlobalStylesBorderColorAfter](https://user-images.githubusercontent.com/60436221/153988800-6ccce9fb-8c13-49ba-9730-2d7078d0e709.gif) |

## Types of changes
Bug fix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
