### PR TITLE
Edit Site: Migrate store to thunks.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16201,7 +16201,6 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
-				"@wordpress/data-controls": "file:packages/data-controls",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -36,7 +36,6 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
-		"@wordpress/data-controls": "file:../data-controls",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
-import { controls, dispatch } from '@wordpress/data';
-import { apiFetch } from '@wordpress/data-controls';
 import { addQueryArgs, getPathAndQueryString } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -19,7 +18,7 @@ import { STORE_NAME as editSiteStoreName } from './constants';
 import isTemplateRevertable from '../utils/is-template-revertable';
 
 /**
- * Returns an action object used to toggle a feature flag.
+ * Action that toggles a feature flag.
  *
  * @param {string} feature Feature name.
  *
@@ -33,7 +32,7 @@ export function toggleFeature( feature ) {
 }
 
 /**
- * Returns an action object used to toggle the width of the editing canvas.
+ * Action that changes the width of the editing canvas.
  *
  * @param {string} deviceType
  *
@@ -47,97 +46,83 @@ export function __experimentalSetPreviewDeviceType( deviceType ) {
 }
 
 /**
- * Returns an action object used to set a template.
+ * Action that sets a template, optionally fetching it from REST API.
  *
  * @param {number} templateId   The template ID.
  * @param {string} templateSlug The template slug.
  * @return {Object} Action object.
  */
-export function* setTemplate( templateId, templateSlug ) {
-	const pageContext = { templateSlug };
+export const setTemplate = ( templateId, templateSlug ) => async ( {
+	dispatch,
+	registry,
+} ) => {
 	if ( ! templateSlug ) {
-		const template = yield controls.resolveSelect(
-			coreStore,
-			'getEntityRecord',
-			'postType',
-			'wp_template',
-			templateId
-		);
-		pageContext.templateSlug = template?.slug;
+		const template = await registry
+			.resolveSelect( coreStore )
+			.getEntityRecord( 'postType', 'wp_template', templateId );
+		templateSlug = template?.slug;
 	}
-	return {
+
+	dispatch( {
 		type: 'SET_TEMPLATE',
 		templateId,
-		page: { context: pageContext },
-	};
-}
+		page: { context: { templateSlug } },
+	} );
+};
 
 /**
- * Adds a new template, and sets it as the current template.
+ * Action that adds a new template and sets it as the current template.
  *
  * @param {Object} template The template.
  *
  * @return {Object} Action object used to set the current template.
  */
-export function* addTemplate( template ) {
-	const newTemplate = yield controls.dispatch(
-		coreStore,
-		'saveEntityRecord',
-		'postType',
-		'wp_template',
-		template
-	);
+export const addTemplate = ( template ) => async ( { dispatch, registry } ) => {
+	const newTemplate = await registry
+		.dispatch( coreStore )
+		.saveEntityRecord( 'postType', 'wp_template', template );
 
 	if ( template.content ) {
-		yield controls.dispatch(
-			coreStore,
-			'editEntityRecord',
-			'postType',
-			'wp_template',
-			newTemplate.id,
-			{ blocks: parse( template.content ) },
-			{ undoIgnore: true }
-		);
+		registry
+			.dispatch( coreStore )
+			.editEntityRecord(
+				'postType',
+				'wp_template',
+				newTemplate.id,
+				{ blocks: parse( template.content ) },
+				{ undoIgnore: true }
+			);
 	}
 
-	return {
+	dispatch( {
 		type: 'SET_TEMPLATE',
 		templateId: newTemplate.id,
 		page: { context: { templateSlug: newTemplate.slug } },
-	};
-}
+	} );
+};
 
 /**
- * Removes a template.
+ * Action that removes a template.
  *
  * @param {Object} template The template object.
  */
-export function* removeTemplate( template ) {
+export const removeTemplate = ( template ) => async ( { registry } ) => {
 	try {
-		yield controls.dispatch(
-			coreStore,
-			'deleteEntityRecord',
-			'postType',
-			template.type,
-			template.id,
-			{ force: true }
-		);
+		await registry
+			.dispatch( coreStore )
+			.deleteEntityRecord( 'postType', template.type, template.id, {
+				force: true,
+			} );
 
-		const lastError = yield controls.select(
-			coreStore,
-			'getLastEntityDeleteError',
-			'postType',
-			template.type,
-			template.id
-		);
+		const lastError = registry
+			.select( coreStore )
+			.getLastEntityDeleteError( 'postType', template.type, template.id );
 
 		if ( lastError ) {
 			throw lastError;
 		}
 
-		yield controls.dispatch(
-			noticesStore,
-			'createSuccessNotice',
+		registry.dispatch( noticesStore ).createSuccessNotice(
 			sprintf(
 				/* translators: The template/part's name. */
 				__( '"%s" deleted.' ),
@@ -151,17 +136,14 @@ export function* removeTemplate( template ) {
 				? error.message
 				: __( 'An error occurred while deleting the template.' );
 
-		yield controls.dispatch(
-			noticesStore,
-			'createErrorNotice',
-			errorMessage,
-			{ type: 'snackbar' }
-		);
+		registry
+			.dispatch( noticesStore )
+			.createErrorNotice( errorMessage, { type: 'snackbar' } );
 	}
-}
+};
 
 /**
- * Returns an action object used to set a template part.
+ * Action that sets a template part.
  *
  * @param {string} templatePartId The template part ID.
  *
@@ -175,8 +157,8 @@ export function setTemplatePart( templatePartId ) {
 }
 
 /**
- * Updates the homeTemplateId state with the templateId of the page resolved
- * from the given path.
+ * Action that sets the home template ID to the template ID of the page resolved
+ * from a given path.
  *
  * @param {number} homeTemplateId The template ID for the homepage.
  */
@@ -199,47 +181,46 @@ export function setHomeTemplateId( homeTemplateId ) {
  *
  * @return {number} The resolved template ID for the page route.
  */
-export function* setPage( page ) {
+export const setPage = ( page ) => async ( { dispatch, registry } ) => {
 	if ( ! page.path && page.context?.postId ) {
-		const entity = yield controls.resolveSelect(
-			coreStore,
-			'getEntityRecord',
-			'postType',
-			page.context.postType || 'post',
-			page.context.postId
-		);
+		const entity = await registry
+			.resolveSelect( coreStore )
+			.getEntityRecord(
+				'postType',
+				page.context.postType || 'post',
+				page.context.postId
+			);
 		// If the entity is undefined for some reason, path will resolve to "/"
 		page.path = getPathAndQueryString( entity?.link );
 	}
-	const template = yield controls.resolveSelect(
-		coreStore,
-		'__experimentalGetTemplateForLink',
-		page.path
-	);
+
+	const template = await registry
+		.resolveSelect( coreStore )
+		.__experimentalGetTemplateForLink( page.path );
 
 	if ( ! template ) {
 		return;
 	}
 
-	const { id: templateId, slug: templateSlug } = template;
-	yield {
+	dispatch( {
 		type: 'SET_PAGE',
-		page: ! templateSlug
-			? page
-			: {
+		page: template.slug
+			? {
 					...page,
 					context: {
 						...page.context,
-						templateSlug,
+						templateSlug: template.slug,
 					},
-			  },
-		templateId,
-	};
-	return templateId;
-}
+			  }
+			: page,
+		templateId: template.id,
+	} );
+
+	return template.id;
+};
 
 /**
- * Returns an action object used to set the active navigation panel menu.
+ * Action that sets the active navigation panel menu.
  *
  * @param {string} menu Menu prop of active menu.
  *
@@ -278,7 +259,7 @@ export function setIsNavigationPanelOpened( isOpen ) {
 }
 
 /**
- * Returns an action object used to open/close the inserter.
+ * Opens or closes the inserter.
  *
  * @param {boolean|Object} value                Whether the inserter should be
  *                                              opened (true) or closed (false).
@@ -331,33 +312,33 @@ export function setIsListViewOpened( isOpen ) {
  * @param {boolean} [options.allowUndo] Whether to allow the user to undo
  *                                      reverting the template. Default true.
  */
-export function* revertTemplate( template, { allowUndo = true } = {} ) {
+export const revertTemplate = (
+	template,
+	{ allowUndo = true } = {}
+) => async ( { registry } ) => {
 	if ( ! isTemplateRevertable( template ) ) {
-		yield controls.dispatch(
-			noticesStore,
-			'createErrorNotice',
-			__( 'This template is not revertable.' ),
-			{ type: 'snackbar' }
-		);
+		registry
+			.dispatch( noticesStore )
+			.createErrorNotice( __( 'This template is not revertable.' ), {
+				type: 'snackbar',
+			} );
 		return;
 	}
 
 	try {
-		const templateEntity = yield controls.select(
-			coreStore,
-			'getEntity',
-			'postType',
-			template.type
-		);
+		const templateEntity = await registry
+			.resolveSelect( coreStore )
+			.getEntity( 'postType', template.type );
+
 		if ( ! templateEntity ) {
-			yield controls.dispatch(
-				noticesStore,
-				'createErrorNotice',
-				__(
-					'The editor has encountered an unexpected error. Please reload.'
-				),
-				{ type: 'snackbar' }
-			);
+			registry
+				.dispatch( noticesStore )
+				.createErrorNotice(
+					__(
+						'The editor has encountered an unexpected error. Please reload.'
+					),
+					{ type: 'snackbar' }
+				);
 			return;
 		}
 
@@ -365,33 +346,30 @@ export function* revertTemplate( template, { allowUndo = true } = {} ) {
 			`${ templateEntity.baseURL }/${ template.id }`,
 			{ context: 'edit', source: 'theme' }
 		);
-		const fileTemplate = yield apiFetch( { path: fileTemplatePath } );
+
+		const fileTemplate = await apiFetch( { path: fileTemplatePath } );
 		if ( ! fileTemplate ) {
-			yield controls.dispatch(
-				noticesStore,
-				'createErrorNotice',
-				__(
-					'The editor has encountered an unexpected error. Please reload.'
-				),
-				{ type: 'snackbar' }
-			);
+			registry
+				.dispatch( noticesStore )
+				.createErrorNotice(
+					__(
+						'The editor has encountered an unexpected error. Please reload.'
+					),
+					{ type: 'snackbar' }
+				);
 			return;
 		}
 
 		const serializeBlocks = ( { blocks: blocksForSerialization = [] } ) =>
 			__unstableSerializeAndClean( blocksForSerialization );
-		const edited = yield controls.select(
-			coreStore,
-			'getEditedEntityRecord',
-			'postType',
-			template.type,
-			template.id
-		);
+
+		const edited = registry
+			.select( coreStore )
+			.getEditedEntityRecord( 'postType', template.type, template.id );
+
 		// We are fixing up the undo level here to make sure we can undo
 		// the revert in the header toolbar correctly.
-		yield controls.dispatch(
-			coreStore,
-			'editEntityRecord',
+		registry.dispatch( coreStore ).editEntityRecord(
 			'postType',
 			template.type,
 			template.id,
@@ -406,37 +384,28 @@ export function* revertTemplate( template, { allowUndo = true } = {} ) {
 		);
 
 		const blocks = parse( fileTemplate?.content?.raw );
-		yield controls.dispatch(
-			coreStore,
-			'editEntityRecord',
-			'postType',
-			template.type,
-			fileTemplate.id,
-			{
+		registry
+			.dispatch( coreStore )
+			.editEntityRecord( 'postType', template.type, fileTemplate.id, {
 				content: serializeBlocks,
 				blocks,
 				source: 'theme',
-			}
-		);
+			} );
 
 		if ( allowUndo ) {
-			const undoRevert = async () => {
-				await dispatch( coreStore ).editEntityRecord(
-					'postType',
-					template.type,
-					edited.id,
-					{
+			const undoRevert = () => {
+				registry
+					.dispatch( coreStore )
+					.editEntityRecord( 'postType', template.type, edited.id, {
 						content: serializeBlocks,
 						blocks: edited.blocks,
 						source: 'custom',
-					}
-				);
+					} );
 			};
-			yield controls.dispatch(
-				noticesStore,
-				'createSuccessNotice',
-				__( 'Template reverted.' ),
-				{
+
+			registry
+				.dispatch( noticesStore )
+				.createSuccessNotice( __( 'Template reverted.' ), {
 					type: 'snackbar',
 					actions: [
 						{
@@ -444,72 +413,53 @@ export function* revertTemplate( template, { allowUndo = true } = {} ) {
 							onClick: undoRevert,
 						},
 					],
-				}
-			);
+				} );
 		} else {
-			yield controls.dispatch(
-				noticesStore,
-				'createSuccessNotice',
-				__( 'Template reverted.' )
-			);
+			registry
+				.dispatch( noticesStore )
+				.createSuccessNotice( __( 'Template reverted.' ) );
 		}
 	} catch ( error ) {
 		const errorMessage =
 			error.message && error.code !== 'unknown_error'
 				? error.message
 				: __( 'Template revert failed. Please reload.' );
-		yield controls.dispatch(
-			noticesStore,
-			'createErrorNotice',
-			errorMessage,
-			{ type: 'snackbar' }
-		);
+		registry
+			.dispatch( noticesStore )
+			.createErrorNotice( errorMessage, { type: 'snackbar' } );
 	}
-}
+};
 /**
- * Returns an action object used in signalling that the user opened an editor sidebar.
+ * Action that opens an editor sidebar.
  *
  * @param {?string} name Sidebar name to be opened.
- *
- * @yield {Object} Action object.
  */
-export function* openGeneralSidebar( name ) {
-	yield controls.dispatch(
-		interfaceStore,
-		'enableComplementaryArea',
-		editSiteStoreName,
-		name
-	);
-}
+export const openGeneralSidebar = ( name ) => ( { registry } ) => {
+	registry
+		.dispatch( interfaceStore )
+		.enableComplementaryArea( editSiteStoreName, name );
+};
 
 /**
- * Returns an action object signalling that the user closed the sidebar.
- *
- * @yield {Object} Action object.
+ * Action that closes the sidebar.
  */
-export function* closeGeneralSidebar() {
-	yield controls.dispatch(
-		interfaceStore,
-		'disableComplementaryArea',
-		editSiteStoreName
-	);
-}
+export const closeGeneralSidebar = () => ( { registry } ) => {
+	registry
+		.dispatch( interfaceStore )
+		.disableComplementaryArea( editSiteStoreName );
+};
 
-export function* switchEditorMode( mode ) {
-	yield {
-		type: 'SWITCH_MODE',
-		mode,
-	};
+export const switchEditorMode = ( mode ) => ( { dispatch, registry } ) => {
+	dispatch( { type: 'SWITCH_MODE', mode } );
 
 	// Unselect blocks when we switch to a non visual mode.
 	if ( mode !== 'visual' ) {
-		yield controls.dispatch( blockEditorStore.name, 'clearSelectedBlock' );
+		registry.dispatch( blockEditorStore ).clearSelectedBlock();
 	}
-	const messages = {
-		visual: __( 'Visual editor selected' ),
-		mosaic: __( 'Mosaic view selected' ),
-	};
-	if ( messages[ mode ] ) {
-		speak( messages[ mode ], 'assertive' );
+
+	if ( mode === 'visual' ) {
+		speak( __( 'Visual editor selected' ), 'assertive' );
+	} else if ( mode === 'mosaic' ) {
+		speak( __( 'Mosaic view selected' ), 'assertive' );
 	}
-}
+};

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -326,8 +326,8 @@ export const revertTemplate = (
 	}
 
 	try {
-		const templateEntity = await registry
-			.resolveSelect( coreStore )
+		const templateEntity = registry
+			.select( coreStore )
 			.getEntity( 'postType', template.type );
 
 		if ( ! templateEntity ) {

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { createReduxStore, registerStore } from '@wordpress/data';
-import { controls } from '@wordpress/data-controls';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ export const storeConfig = {
 	reducer,
 	actions,
 	selectors,
-	controls,
+	__experimentalUseThunks: true,
 	persist: [ 'preferences' ],
 };
 

--- a/packages/edit-site/src/store/test/actions.js
+++ b/packages/edit-site/src/store/test/actions.js
@@ -1,129 +1,223 @@
 /**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { createRegistry } from '@wordpress/data';
+import { store as interfaceStore } from '@wordpress/interface';
+import { store as noticesStore } from '@wordpress/notices';
+
+/**
  * Internal dependencies
  */
-import {
-	toggleFeature,
-	setTemplate,
-	addTemplate,
-	setTemplatePart,
-	setPage,
-	setHomeTemplateId,
-	setIsListViewOpened,
-} from '../actions';
+import { store as editSiteStore } from '..';
+
+jest.useRealTimers();
+
+const ENTITY_TYPES = {
+	wp_template: {
+		description: 'Templates to include in your theme.',
+		hierarchical: false,
+		name: 'Templates',
+		rest_base: 'templates',
+		rest_namespace: 'wp/v2',
+		slug: 'wp_template',
+		taxonomies: [],
+	},
+};
+
+function createRegistryWithStores() {
+	// create a registry
+	const registry = createRegistry();
+
+	// register stores
+	registry.register( blockEditorStore );
+	registry.register( coreStore );
+	registry.register( editSiteStore );
+	registry.register( interfaceStore );
+	registry.register( noticesStore );
+
+	return registry;
+}
 
 describe( 'actions', () => {
 	describe( 'toggleFeature', () => {
-		it( 'should return TOGGLE_FEATURE action', () => {
-			const feature = 'name';
-			expect( toggleFeature( feature ) ).toEqual( {
-				type: 'TOGGLE_FEATURE',
-				feature,
-			} );
+		it( 'should toggle a feature flag', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editSiteStore ).toggleFeature( 'name' );
+			expect(
+				registry.select( editSiteStore ).isFeatureActive( 'name' )
+			).toBe( true );
 		} );
 	} );
 
 	describe( 'setTemplate', () => {
-		it( 'should return the SET_TEMPLATE action when slug is provided', () => {
-			const templateId = 1;
-			const templateSlug = 'archive';
-			const it = setTemplate( templateId, templateSlug );
-			expect( it.next().value ).toEqual( {
-				type: 'SET_TEMPLATE',
-				templateId,
-				page: { context: { templateSlug } },
-			} );
+		const ID = 1;
+		const SLUG = 'archive';
+
+		it( 'should set the template when slug is provided', async () => {
+			const registry = createRegistryWithStores();
+
+			await registry.dispatch( editSiteStore ).setTemplate( ID, SLUG );
+
+			const select = registry.select( editSiteStore );
+			expect( select.getEditedPostId() ).toBe( ID );
+			expect( select.getPage().context.templateSlug ).toBe( SLUG );
 		} );
-		it( 'should return the SET_TEMPLATE by getting the template slug', () => {
-			const templateId = 1;
-			const template = { slug: 'index' };
-			const it = setTemplate( templateId );
-			expect( it.next().value ).toEqual( {
-				type: '@@data/RESOLVE_SELECT',
-				storeKey: 'core',
-				selectorName: 'getEntityRecord',
-				args: [ 'postType', 'wp_template', templateId ],
+
+		it( 'should set the template by fetching the template slug', async () => {
+			const registry = createRegistryWithStores();
+
+			apiFetch.setFetchHandler( async ( options ) => {
+				const { method = 'GET', path } = options;
+				if ( method === 'GET' ) {
+					if ( path.startsWith( '/wp/v2/types' ) ) {
+						return ENTITY_TYPES;
+					}
+
+					if ( path.startsWith( `/wp/v2/templates/${ ID }` ) ) {
+						return { id: ID, slug: SLUG };
+					}
+				}
+
+				throw {
+					code: 'unknown_path',
+					message: `Unknown path: ${ method } ${ path }`,
+				};
 			} );
-			expect( it.next( template ).value ).toEqual( {
-				type: 'SET_TEMPLATE',
-				templateId,
-				page: { context: { templateSlug: template.slug } },
-			} );
+
+			await registry.dispatch( editSiteStore ).setTemplate( ID );
+
+			const select = registry.select( editSiteStore );
+			expect( select.getEditedPostId() ).toBe( ID );
+			expect( select.getPage().context.templateSlug ).toBe( SLUG );
 		} );
 	} );
 
 	describe( 'addTemplate', () => {
-		it( 'should yield the DISPATCH control to create the template and return the SET_TEMPLATE action', () => {
-			const template = { slug: 'index' };
-			const newTemplate = { id: 1, slug: 'index' };
+		it( 'should issue a REST request to create the template and then set it', async () => {
+			const registry = createRegistryWithStores();
 
-			const it = addTemplate( template );
-			expect( it.next().value ).toEqual( {
-				type: '@@data/DISPATCH',
-				storeKey: 'core',
-				actionName: 'saveEntityRecord',
-				args: [ 'postType', 'wp_template', template ],
+			const ID = 1;
+			const SLUG = 'index';
+
+			apiFetch.setFetchHandler( async ( options ) => {
+				const { method = 'GET', path, data } = options;
+
+				if ( method === 'GET' && path.startsWith( '/wp/v2/types' ) ) {
+					return ENTITY_TYPES;
+				}
+
+				if (
+					method === 'POST' &&
+					path.startsWith( '/wp/v2/templates' )
+				) {
+					return { id: ID, slug: data.slug };
+				}
+
+				throw {
+					code: 'unknown_path',
+					message: `Unknown path: ${ method } ${ path }`,
+				};
 			} );
-			expect( it.next( newTemplate ) ).toEqual( {
-				value: {
-					type: 'SET_TEMPLATE',
-					templateId: newTemplate.id,
-					page: { context: { templateSlug: newTemplate.slug } },
-				},
-				done: true,
-			} );
+
+			await registry
+				.dispatch( editSiteStore )
+				.addTemplate( { slug: SLUG } );
+
+			const select = registry.select( editSiteStore );
+			expect( select.getEditedPostId() ).toBe( ID );
+			expect( select.getPage().context.templateSlug ).toBe( SLUG );
 		} );
 	} );
 
 	describe( 'setTemplatePart', () => {
-		it( 'should return the SET_TEMPLATE_PART action', () => {
-			const templatePartId = 1;
-			expect( setTemplatePart( templatePartId ) ).toEqual( {
-				type: 'SET_TEMPLATE_PART',
-				templatePartId,
-			} );
+		it( 'should set template part', () => {
+			const registry = createRegistryWithStores();
+
+			const ID = 1;
+			registry.dispatch( editSiteStore ).setTemplatePart( ID );
+
+			const select = registry.select( editSiteStore );
+			expect( select.getEditedPostId() ).toBe( ID );
+			expect( select.getEditedPostType() ).toBe( 'wp_template_part' );
 		} );
 	} );
 
 	describe( 'setPage', () => {
-		it( 'should yield the FIND_TEMPLATE control and return the SET_PAGE action', () => {
-			const page = { path: '/' };
+		it( 'should find the template and then set the page', async () => {
+			const registry = createRegistryWithStores();
 
-			const it = setPage( page );
-			expect( it.next().value ).toEqual( {
-				type: '@@data/RESOLVE_SELECT',
-				storeKey: 'core',
-				selectorName: '__experimentalGetTemplateForLink',
-				args: [ page.path ],
+			const ID = 'emptytheme//single';
+			const SLUG = 'single';
+
+			window.fetch = async ( path ) => {
+				if ( path === '/?_wp-find-template=true' ) {
+					return {
+						json: async () => ( { data: { id: ID, slug: SLUG } } ),
+					};
+				}
+
+				throw {
+					code: 'unknown_path',
+					message: `Unknown path: ${ path }`,
+				};
+			};
+
+			apiFetch.setFetchHandler( async ( options ) => {
+				const { method = 'GET', path } = options;
+
+				if ( method === 'GET' ) {
+					if ( path.startsWith( '/wp/v2/types' ) ) {
+						return ENTITY_TYPES;
+					}
+
+					if ( path.startsWith( `/wp/v2/templates/${ ID }` ) ) {
+						return { id: ID, slug: SLUG };
+					}
+				}
+
+				throw {
+					code: 'unknown_path',
+					message: `Unknown path: ${ method } ${ path }`,
+				};
 			} );
-			expect( it.next( { id: 'emptytheme//single' } ).value ).toEqual( {
-				type: 'SET_PAGE',
-				page,
-				templateId: 'emptytheme//single',
-			} );
-			expect( it.next().done ).toBe( true );
+
+			await registry.dispatch( editSiteStore ).setPage( { path: '/' } );
+
+			const select = registry.select( editSiteStore );
+			expect( select.getEditedPostId() ).toBe( 'emptytheme//single' );
+			expect( select.getEditedPostType() ).toBe( 'wp_template' );
+			expect( select.getPage().path ).toBe( '/' );
 		} );
 	} );
 
 	describe( 'setHomeTemplateId', () => {
-		it( 'should return the SET_HOME_TEMPLATE action', () => {
-			const homeTemplateId = 90;
-			expect( setHomeTemplateId( homeTemplateId ) ).toEqual( {
-				type: 'SET_HOME_TEMPLATE',
-				homeTemplateId,
-			} );
+		it( 'should set the home template ID', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editSiteStore ).setHomeTemplateId( 90 );
+			expect( registry.select( editSiteStore ).getHomeTemplateId() ).toBe(
+				90
+			);
 		} );
 	} );
 
 	describe( 'setIsListViewOpened', () => {
-		it( 'should return the SET_IS_LIST_VIEW_OPENED action', () => {
-			expect( setIsListViewOpened( true ) ).toEqual( {
-				type: 'SET_IS_LIST_VIEW_OPENED',
-				isOpen: true,
-			} );
-			expect( setIsListViewOpened( false ) ).toEqual( {
-				type: 'SET_IS_LIST_VIEW_OPENED',
-				isOpen: false,
-			} );
+		it( 'should set the list view opened state', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editSiteStore ).setIsListViewOpened( true );
+			expect( registry.select( editSiteStore ).isListViewOpened() ).toBe(
+				true
+			);
+
+			registry.dispatch( editSiteStore ).setIsListViewOpened( false );
+			expect( registry.select( editSiteStore ).isListViewOpened() ).toBe(
+				false
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
Migrates the `edit-site` store to thunks. Unit tests for actions are completely rewritten to use a mock registry.