### PR TITLE
[Try/unify user avatar] / Fix duotone in editor

### DIFF
--- a/packages/block-library/src/avatar/block.json
+++ b/packages/block-library/src/avatar/block.json
@@ -35,6 +35,7 @@
 			"padding": true
 		},
 		"__experimentalBorder": {
+			"__experimentalSkipSerialization": true,
 			"radius": true,
 			"width": true,
 			"color": true,

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -10,6 +10,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	__experimentalGetSpacingClassesAndStyles as useSpacingProps,
+	__experimentalUseBorderProps as useBorderProps,
 } from '@wordpress/block-editor';
 import {
 	PanelBody,
@@ -70,8 +71,9 @@ const ResizableAvatar = ( {
 	isSelected,
 } ) => {
 	const spacingProps = useSpacingProps( attributes );
+	const borderProps = useBorderProps( attributes );
 	return (
-		<div { ...spacingProps }>
+		<div { ...spacingProps } { ...blockProps }>
 			<ResizableBox
 				size={ {
 					width: attributes.width,
@@ -97,7 +99,7 @@ const ResizableAvatar = ( {
 				minWidth={ avatar.minSize }
 				maxWidth={ avatar.maxSize }
 			>
-				<img src={ avatar.src } alt={ avatar.alt } { ...blockProps } />
+				<img src={ avatar.src } alt={ avatar.alt } { ...borderProps } />
 			</ResizableBox>
 		</div>
 	);


### PR DESCRIPTION
With this Pull Request, we fixed Duotone styling in the editor and the alignment in the frontend. 
Both, the border and duotone in the front end will still don't work, until a future update.