### PR TITLE
Refactor Nav creation hooks and associated code

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -403,7 +403,6 @@ function Navigation( {
 				classicMenuName,
 				classicMenuBlocks
 			);
-			// onSelect( navigationMenu );
 			setRef( navigationMenuPost?.id );
 		}
 		if (
@@ -416,7 +415,6 @@ function Navigation( {
 	}, [
 		classicMenuBlocks,
 		classicMenuName,
-		isResolvingClassicMenuConversion,
 		hasResolvedClassicMenuConversion,
 	] );
 
@@ -530,9 +528,13 @@ function Navigation( {
 											setRef( id );
 											onClose();
 										} }
-										onSelectClassicMenu={
-											convertClassicMenuToBlocks
-										}
+										onSelectClassicMenu={ ( menu ) => {
+											onClose();
+											convertClassicMenuToBlocks(
+												menu?.id,
+												menu?.name
+											);
+										} }
 										onCreateNew={ startWithEmptyMenu }
 										/* translators: %s: The name of a menu. */
 										actionLabel={ __( "Switch to '%s'" ) }
@@ -714,6 +716,7 @@ function Navigation( {
 						/>
 					) }
 					{ ! hasResolvedCanUserCreateNavigation ||
+						isResolvingClassicMenuConversion ||
 						( ! isEntityAvailable && ! isPlaceholderShown && (
 							<PlaceholderPreview isLoading />
 						) ) }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -236,7 +236,7 @@ function Navigation( {
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
 	const {
-		dispatch: convertClassicMenuToBlocks,
+		run: convertClassicMenuToBlocks,
 		blocks: classicMenuBlocks,
 		name: classicMenuName,
 		isResolving: isResolvingClassicMenuConversion,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -241,7 +241,7 @@ function Navigation( {
 		name: classicMenuName,
 		isResolving: isResolvingClassicMenuConversion,
 		hasResolved: hasResolvedClassicMenuConversion,
-	} = useConvertClassicMenu( () => {} );
+	} = useConvertClassicMenu();
 
 	const navRef = useRef();
 	const isDraftNavigationMenu = navigationMenu?.status === 'draft';

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -56,6 +56,8 @@ import UnsavedInnerBlocks from './unsaved-inner-blocks';
 import NavigationMenuDeleteControl from './navigation-menu-delete-control';
 import useNavigationNotice from './use-navigation-notice';
 import OverlayMenuIcon from './overlay-menu-icon';
+import useConvertClassicMenu from '../use-convert-classic-menu';
+import useCreateNavigationMenu from './use-create-navigation-menu';
 
 const EMPTY_ARRAY = [];
 
@@ -231,6 +233,16 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigation,
 	} = useNavigationMenu( ref );
 
+	const createNavigationMenu = useCreateNavigationMenu( clientId );
+
+	const {
+		dispatch: convertClassicMenuToBlocks,
+		blocks: classicMenuBlocks,
+		name: classicMenuName,
+		isResolving: isResolvingClassicMenuConversion,
+		hasResolved: hasResolvedClassicMenuConversion,
+	} = useConvertClassicMenu( () => {} );
+
 	const navRef = useRef();
 	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
@@ -385,6 +397,29 @@ function Navigation( {
 		ref,
 	] );
 
+	useEffect( () => {
+		async function handleCreateNav() {
+			const navigationMenuPost = await createNavigationMenu(
+				classicMenuName,
+				classicMenuBlocks
+			);
+			// onSelect( navigationMenu );
+			setRef( navigationMenuPost?.id );
+		}
+		if (
+			hasResolvedClassicMenuConversion &&
+			classicMenuName &&
+			classicMenuBlocks?.length
+		) {
+			handleCreateNav();
+		}
+	}, [
+		classicMenuBlocks,
+		classicMenuName,
+		isResolvingClassicMenuConversion,
+		hasResolvedClassicMenuConversion,
+	] );
+
 	const startWithEmptyMenu = useCallback( () => {
 		registry.batch( () => {
 			if ( navigationArea ) {
@@ -495,6 +530,9 @@ function Navigation( {
 											setRef( id );
 											onClose();
 										} }
+										onSelectClassicMenu={
+											convertClassicMenuToBlocks
+										}
 										onCreateNew={ startWithEmptyMenu }
 										/* translators: %s: The name of a menu. */
 										actionLabel={ __( "Switch to '%s'" ) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -5,19 +5,16 @@ import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import useNavigationMenu from '../use-navigation-menu';
 import useNavigationEntities from '../use-navigation-entities';
-import useConvertClassicMenu from '../use-convert-classic-menu';
-import useCreateNavigationMenu from './use-create-navigation-menu';
 
 export default function NavigationMenuSelector( {
-	clientId,
 	onSelect,
+	onSelectClassicMenu,
 	onCreateNew,
 	showManageActions = false,
 	actionLabel,
@@ -35,53 +32,6 @@ export default function NavigationMenuSelector( {
 		canUserUpdateNavigationEntity: canUserUpdateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
-
-	const createNavigationMenu = useCreateNavigationMenu( clientId );
-
-	// const onFinishMenuCreation = async (
-	// 	blocks,
-	// 	navigationMenuTitle = null
-	// ) => {
-	// 	if ( ! canUserCreateNavigationMenu ) {
-	// 		return;
-	// 	}
-
-	// 	const navigationMenu = await createNavigationMenu(
-	// 		navigationMenuTitle,
-	// 		blocks
-	// 	);
-	// 	onSelect( navigationMenu );
-	// };
-
-	const {
-		dispatch: convertClassicMenuToBlocks,
-		blocks: classicMenuBlocks,
-		name: classicMenuName,
-		isResolving: isResolvingClassicMenuConversion,
-		hasResolved: hasResolvedClassicMenuConversion,
-	} = useConvertClassicMenu( () => {} );
-
-	useEffect( () => {
-		async function handleCreateNav() {
-			const navigationMenu = await createNavigationMenu(
-				classicMenuName,
-				classicMenuBlocks
-			);
-			onSelect( navigationMenu );
-		}
-		if (
-			hasResolvedClassicMenuConversion &&
-			classicMenuName &&
-			classicMenuBlocks?.length
-		) {
-			handleCreateNav();
-		}
-	}, [
-		classicMenuBlocks,
-		classicMenuName,
-		isResolvingClassicMenuConversion,
-		hasResolvedClassicMenuConversion,
-	] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
@@ -124,10 +74,7 @@ export default function NavigationMenuSelector( {
 						return (
 							<MenuItem
 								onClick={ () => {
-									convertClassicMenuToBlocks(
-										menu.id,
-										menu.name
-									);
+									onSelectClassicMenu( menu.id, menu.name );
 								} }
 								key={ menu.id }
 								aria-label={ sprintf(

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -5,6 +5,7 @@ import { MenuGroup, MenuItem } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,24 +38,50 @@ export default function NavigationMenuSelector( {
 
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
-	const onFinishMenuCreation = async (
-		blocks,
-		navigationMenuTitle = null
-	) => {
-		if ( ! canUserCreateNavigationMenu ) {
-			return;
+	// const onFinishMenuCreation = async (
+	// 	blocks,
+	// 	navigationMenuTitle = null
+	// ) => {
+	// 	if ( ! canUserCreateNavigationMenu ) {
+	// 		return;
+	// 	}
+
+	// 	const navigationMenu = await createNavigationMenu(
+	// 		navigationMenuTitle,
+	// 		blocks
+	// 	);
+	// 	onSelect( navigationMenu );
+	// };
+
+	const {
+		dispatch: convertClassicMenuToBlocks,
+		blocks: classicMenuBlocks,
+		name: classicMenuName,
+		isResolving: isResolvingClassicMenuConversion,
+		hasResolved: hasResolvedClassicMenuConversion,
+	} = useConvertClassicMenu( () => {} );
+
+	useEffect( () => {
+		async function handleCreateNav() {
+			const navigationMenu = await createNavigationMenu(
+				classicMenuName,
+				classicMenuBlocks
+			);
+			onSelect( navigationMenu );
 		}
-
-		const navigationMenu = await createNavigationMenu(
-			navigationMenuTitle,
-			blocks
-		);
-		onSelect( navigationMenu );
-	};
-
-	const convertClassicMenuToBlocks = useConvertClassicMenu(
-		onFinishMenuCreation
-	);
+		if (
+			hasResolvedClassicMenuConversion &&
+			classicMenuName &&
+			classicMenuBlocks?.length
+		) {
+			handleCreateNav();
+		}
+	}, [
+		classicMenuBlocks,
+		classicMenuName,
+		isResolvingClassicMenuConversion,
+		hasResolvedClassicMenuConversion,
+	] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -74,7 +74,7 @@ export default function NavigationMenuSelector( {
 						return (
 							<MenuItem
 								onClick={ () => {
-									onSelectClassicMenu( menu.id, menu.name );
+									onSelectClassicMenu( menu );
 								} }
 								key={ menu.id }
 								aria-label={ sprintf(

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -48,7 +48,7 @@ export default function NavigationPlaceholder( {
 	} = useNavigationEntities();
 
 	const {
-		dispatch: convertClassicMenuToBlocks,
+		run: convertClassicMenuToBlocks,
 		blocks: classicMenuBlocks,
 		name: classicMenuName,
 		isResolving: isResolvingClassicMenuConversion,

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -53,7 +53,7 @@ export default function NavigationPlaceholder( {
 		name: classicMenuName,
 		isResolving: isResolvingClassicMenuConversion,
 		hasResolved: hasResolvedClassicMenuConversion,
-	} = useConvertClassicMenu( () => {} );
+	} = useConvertClassicMenu();
 
 	useEffect( () => {
 		async function handleCreateNav() {

--- a/packages/block-library/src/navigation/use-convert-classic-menu.js
+++ b/packages/block-library/src/navigation/use-convert-classic-menu.js
@@ -9,7 +9,7 @@ import { useCallback, useState, useEffect } from '@wordpress/element';
 import useNavigationEntities from './use-navigation-entities';
 import menuItemsToBlocks from './menu-items-to-blocks';
 
-export default function useConvertClassicMenu( onFinish ) {
+export default function useConvertClassicMenu() {
 	const [ selectedMenu, setSelectedMenu ] = useState();
 	const [
 		isAwaitingMenuItemResolution,
@@ -24,20 +24,16 @@ export default function useConvertClassicMenu( onFinish ) {
 		isResolvingMenus,
 	} = useNavigationEntities( selectedMenu );
 
-	const createFromMenu = useCallback(
-		( name ) => {
-			const { innerBlocks: _blocks } = menuItemsToBlocks( menuItems );
-			setBlocks( _blocks );
-			onFinish( _blocks, name );
-		},
-		[ menuItems, menuItemsToBlocks, onFinish ]
-	);
+	const createBlocksFromMenuItems = useCallback( () => {
+		const { innerBlocks: _blocks } = menuItemsToBlocks( menuItems );
+		setBlocks( _blocks );
+	}, [ menuItems, menuItemsToBlocks ] );
 
 	useEffect( () => {
 		// If the user selected a menu but we had to wait for menu items to
 		// finish resolving, then create the block once resolution finishes.
 		if ( isAwaitingMenuItemResolution && hasResolvedMenuItems ) {
-			createFromMenu( menuName );
+			createBlocksFromMenuItems();
 			setIsAwaitingMenuItemResolution( false );
 		}
 	}, [ isAwaitingMenuItemResolution, hasResolvedMenuItems, menuName ] );
@@ -48,7 +44,7 @@ export default function useConvertClassicMenu( onFinish ) {
 
 			// If we have menu items, create the block right away.
 			if ( hasResolvedMenuItems ) {
-				createFromMenu( name );
+				createBlocksFromMenuItems();
 				return;
 			}
 
@@ -57,7 +53,7 @@ export default function useConvertClassicMenu( onFinish ) {
 			// Store the name to use later.
 			setMenuName( name );
 		},
-		[ hasResolvedMenuItems, createFromMenu ]
+		[ hasResolvedMenuItems, createBlocksFromMenuItems ]
 	);
 
 	return {

--- a/packages/block-library/src/navigation/use-convert-classic-menu.js
+++ b/packages/block-library/src/navigation/use-convert-classic-menu.js
@@ -16,15 +16,19 @@ export default function useConvertClassicMenu( onFinish ) {
 		setIsAwaitingMenuItemResolution,
 	] = useState( false );
 	const [ menuName, setMenuName ] = useState( '' );
+	const [ blocks, setBlocks ] = useState( [] );
 
-	const { menuItems, hasResolvedMenuItems } = useNavigationEntities(
-		selectedMenu
-	);
+	const {
+		menuItems,
+		hasResolvedMenuItems,
+		isResolvingMenus,
+	} = useNavigationEntities( selectedMenu );
 
 	const createFromMenu = useCallback(
 		( name ) => {
-			const { innerBlocks: blocks } = menuItemsToBlocks( menuItems );
-			onFinish( blocks, name );
+			const { innerBlocks: _blocks } = menuItemsToBlocks( menuItems );
+			setBlocks( _blocks );
+			onFinish( _blocks, name );
 		},
 		[ menuItems, menuItemsToBlocks, onFinish ]
 	);
@@ -38,7 +42,7 @@ export default function useConvertClassicMenu( onFinish ) {
 		}
 	}, [ isAwaitingMenuItemResolution, hasResolvedMenuItems, menuName ] );
 
-	return useCallback(
+	const dispatch = useCallback(
 		( id, name ) => {
 			setSelectedMenu( id );
 
@@ -55,4 +59,12 @@ export default function useConvertClassicMenu( onFinish ) {
 		},
 		[ hasResolvedMenuItems, createFromMenu ]
 	);
+
+	return {
+		dispatch,
+		blocks,
+		name: menuName,
+		isResolving: isResolvingMenus,
+		hasResolved: hasResolvedMenuItems,
+	};
 }

--- a/packages/block-library/src/navigation/use-convert-classic-menu.js
+++ b/packages/block-library/src/navigation/use-convert-classic-menu.js
@@ -38,7 +38,7 @@ export default function useConvertClassicMenu() {
 		}
 	}, [ isAwaitingMenuItemResolution, hasResolvedMenuItems, menuName ] );
 
-	const dispatch = useCallback(
+	const run = useCallback(
 		( id, name ) => {
 			setSelectedMenu( id );
 
@@ -57,7 +57,7 @@ export default function useConvertClassicMenu() {
 	);
 
 	return {
-		dispatch,
+		run,
 		blocks,
 		name: menuName,
 		isResolving: isResolvingMenus,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Continues work on https://github.com/WordPress/gutenberg/issues/37190.

This PR looks to address the inconsistencies around the code paths (especially hooks) around the creation of classic menus into block based menus.

Currently many of the hooks involved are very opaque and despite being async, provide little or not information about the resolution status of the async requests involved. This causes UI issues such as that which is experienced when selecting a classic menu from the dropdown and observing how the UI appears "locked" whilst the async request resolves.

This PR takes a step towards solving these problems. Principally it exposes information about the resolution status of the `useConvertClassicMenu` hook which allows the UI to respond according. 



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
