### PR TITLE
Refactor useSelect usages to useEntityRecords

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -1,11 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import {
 	useEntityBlockEditor,
 	useEntityProp,
-	store as coreStore,
+	__experimentalUseEntityRecord as useEntityRecord,
 } from '@wordpress/core-data';
 import {
 	Placeholder,
@@ -33,27 +33,12 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	const [ hasAlreadyRendered, RecursionProvider ] = useNoRecursiveRenders(
 		ref
 	);
-	const { isMissing, hasResolved } = useSelect(
-		( select ) => {
-			const persistedBlock = select( coreStore ).getEntityRecord(
-				'postType',
-				'wp_block',
-				ref
-			);
-			const hasResolvedBlock = select(
-				coreStore
-			).hasFinishedResolution( 'getEntityRecord', [
-				'postType',
-				'wp_block',
-				ref,
-			] );
-			return {
-				hasResolved: hasResolvedBlock,
-				isMissing: hasResolvedBlock && ! persistedBlock,
-			};
-		},
-		[ ref, clientId ]
+	const { record, hasResolved } = useEntityRecord(
+		'postType',
+		'wp_block',
+		ref
 	);
+	const isMissing = hasResolved && ! record;
 
 	const {
 		__experimentalConvertBlockToStatic: convertBlockToStatic,

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -14,11 +14,10 @@ import {
 	VisuallyHidden,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -30,23 +29,14 @@ export default function CategoriesEdit( {
 	setAttributes,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
-	const { categories, isRequesting } = useSelect(
-		( select ) => {
-			const { getEntityRecords, isResolving } = select( coreStore );
-			const query = { per_page: -1, hide_empty: true, context: 'view' };
-			if ( showOnlyTopLevel ) {
-				query.parent = 0;
-			}
-			return {
-				categories: getEntityRecords( 'taxonomy', 'category', query ),
-				isRequesting: isResolving( 'getEntityRecords', [
-					'taxonomy',
-					'category',
-					query,
-				] ),
-			};
-		},
-		[ showOnlyTopLevel ]
+	const query = { per_page: -1, hide_empty: true, context: 'view' };
+	if ( showOnlyTopLevel ) {
+		query.parent = 0;
+	}
+	const { categories, isResolving } = useEntityRecords(
+		'taxonomy',
+		'category',
+		query
 	);
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
@@ -163,19 +153,19 @@ export default function CategoriesEdit( {
 					) }
 				</PanelBody>
 			</InspectorControls>
-			{ isRequesting && (
+			{ isResolving && (
 				<Placeholder icon={ pin } label={ __( 'Categories' ) }>
 					<Spinner />
 				</Placeholder>
 			) }
-			{ ! isRequesting && categories?.length === 0 && (
+			{ ! isResolving && categories?.length === 0 && (
 				<p>
 					{ __(
 						'Your site does not have any posts, so there is nothing to display here at the moment.'
 					) }
 				</p>
 			) }
-			{ ! isRequesting &&
+			{ ! isResolving &&
 				categories?.length > 0 &&
 				( displayAsDropdown
 					? renderCategoryDropdown()

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -33,7 +33,7 @@ export default function CategoriesEdit( {
 	if ( showOnlyTopLevel ) {
 		query.parent = 0;
 	}
-	const { categories, isResolving } = useEntityRecords(
+	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
 		'category',
 		query,

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -36,7 +36,8 @@ export default function CategoriesEdit( {
 	const { categories, isResolving } = useEntityRecords(
 		'taxonomy',
 		'category',
-		query
+		query,
+		[ showOnlyTopLevel ]
 	);
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -36,8 +36,7 @@ export default function CategoriesEdit( {
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
 		'category',
-		query,
-		[ showOnlyTopLevel ]
+		query
 	);
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	__experimentalUseEntityRecords as useEntityRecords,
+} from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData
@@ -34,31 +37,17 @@ export default function useNavigationEntities( menuId ) {
 }
 
 function useMenuEntities() {
-	const { menus, isResolvingMenus, hasResolvedMenus } = useSelect(
-		( select ) => {
-			const { getMenus, isResolving, hasFinishedResolution } = select(
-				coreStore
-			);
-
-			const menusParameters = [ { per_page: -1, context: 'view' } ];
-
-			return {
-				menus: getMenus( ...menusParameters ),
-				isResolvingMenus: isResolving( 'getMenus', menusParameters ),
-				hasResolvedMenus: hasFinishedResolution(
-					'getMenus',
-					menusParameters
-				),
-			};
-		},
-		[]
+	const { records, isResolving, hasResolved } = useEntityRecords(
+		'root',
+		'menu',
+		{ per_page: -1, context: 'view' }
 	);
 
 	return {
-		menus,
-		isResolvingMenus,
-		hasResolvedMenus,
-		hasMenus: !! ( hasResolvedMenus && menus?.length ),
+		menus: records,
+		isResolvingMenus: isResolving,
+		hasResolvedMenus: hasResolved,
+		hasMenus: !! ( hasResolved && records?.length ),
 	};
 }
 
@@ -100,45 +89,22 @@ function useMenuItemEntities( menuId ) {
 }
 
 function usePageEntities() {
-	const { pages, isResolvingPages, hasResolvedPages } = useSelect(
-		( select ) => {
-			const {
-				getEntityRecords,
-				isResolving,
-				hasFinishedResolution,
-			} = select( coreStore );
-
-			const pagesParameters = [
-				'postType',
-				'page',
-				{
-					parent: 0,
-					order: 'asc',
-					orderby: 'id',
-					per_page: -1,
-					context: 'view',
-				},
-			];
-
-			return {
-				pages: getEntityRecords( ...pagesParameters ) || null,
-				isResolvingPages: isResolving(
-					'getEntityRecords',
-					pagesParameters
-				),
-				hasResolvedPages: hasFinishedResolution(
-					'getEntityRecords',
-					pagesParameters
-				),
-			};
-		},
-		[]
+	const { records, isResolving, hasResolved } = useEntityRecords(
+		'postType',
+		'page',
+		{
+			parent: 0,
+			order: 'asc',
+			orderby: 'id',
+			per_page: -1,
+			context: 'view',
+		}
 	);
 
 	return {
-		pages,
-		isResolvingPages,
-		hasResolvedPages,
-		hasPages: !! ( hasResolvedPages && pages?.length ),
+		pages: records,
+		isResolvingPages: isResolving,
+		hasResolvedPages: hasResolved,
+		hasPages: !! ( hasResolved && records?.length ),
 	};
 }

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -3,8 +3,8 @@
  */
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreDataStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
@@ -74,34 +74,20 @@ export const convertSelectedBlockToNavigationLinks = ( {
 };
 
 export default function ConvertToLinksModal( { onClose, clientId } ) {
-	const { pages, pagesFinished } = useSelect(
-		( select ) => {
-			const { getEntityRecords, hasFinishedResolution } = select(
-				coreDataStore
-			);
-			const query = [
-				'postType',
-				'page',
-				{
-					per_page: MAX_PAGE_COUNT,
-					_fields: PAGE_FIELDS,
-					// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby
-					// values is resolved, update 'orderby' to [ 'menu_order', 'post_title' ] to provide a consistent
-					// sort.
-					orderby: 'menu_order',
-					order: 'asc',
-				},
-			];
-			return {
-				pages: getEntityRecords( ...query ),
-				pagesFinished: hasFinishedResolution(
-					'getEntityRecords',
-					query
-				),
-			};
-		},
-		[ clientId ]
+	const { records: pages, hasResolved: pagesFinished } = useEntityRecords(
+		'postType',
+		'page',
+		{
+			per_page: MAX_PAGE_COUNT,
+			_fields: PAGE_FIELDS,
+			// TODO: When https://core.trac.wordpress.org/ticket/39037 REST API support for multiple orderby
+			// values is resolved, update 'orderby' to [ 'menu_order', 'post_title' ] to provide a consistent
+			// sort.
+			orderby: 'menu_order',
+			order: 'asc',
+		}
 	);
+
 	const { replaceBlock } = useDispatch( blockEditorStore );
 
 	return (

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -16,7 +16,10 @@ import { ToolbarButton, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	__experimentalUseEntityRecords as useEntityRecords,
+} from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -113,28 +116,16 @@ function useFrontPageId() {
 }
 
 function usePageData() {
-	const { pages, hasResolvedPages } = useSelect( ( select ) => {
-		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
-
-		return {
-			pages: getEntityRecords( 'postType', 'page', {
-				orderby: 'menu_order',
-				order: 'asc',
-				_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
-				per_page: -1,
-			} ),
-			hasResolvedPages: hasFinishedResolution( 'getEntityRecords', [
-				'postType',
-				'page',
-				{
-					orderby: 'menu_order',
-					order: 'asc',
-					_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
-					per_page: -1,
-				},
-			] ),
-		};
-	}, [] );
+	const { records: pages, hasResolved: hasResolvedPages } = useEntityRecords(
+		'postType',
+		'page',
+		{
+			orderby: 'menu_order',
+			order: 'asc',
+			_fields: [ 'id', 'link', 'parent', 'title', 'menu_order' ],
+			per_page: -1,
+		}
+	);
 
 	return useMemo( () => {
 		// TODO: Once the REST API supports passing multiple values to

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
 import useQuerySelect from './use-query-select';
@@ -29,7 +34,6 @@ interface EntityRecordsResolution< RecordType > {
  * @param  kind      Kind of the requested entities.
  * @param  name      Name of the requested entities.
  * @param  queryArgs HTTP query for the requested entities.
- * @param  deps      Array of additional deps, see useSelect.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -64,13 +68,18 @@ interface EntityRecordsResolution< RecordType > {
 export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
-	queryArgs: unknown = {},
-	deps: unknown[] = []
+	queryArgs: unknown = {}
 ): EntityRecordsResolution< RecordType > {
+	// Serialize queryArgs to a string that can be safely used as a React dep.
+	// We can't just pass queryArgs as one of the deps, because if it is passed
+	// as an object literal, then it will be a different object on each call even
+	// if the values remain the same.
+	const queryAsString = addQueryArgs( '', queryArgs );
+
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) =>
 			query( coreStore ).getEntityRecords( kind, name, queryArgs ),
-		[ kind, name, ...deps ]
+		[ kind, name, queryAsString ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -29,7 +29,7 @@ interface EntityRecordsResolution< RecordType > {
  * @param  kind      Kind of the requested entities.
  * @param  name      Name of the requested entities.
  * @param  queryArgs HTTP query for the requested entities.
- *
+ * @param  deps      Array of additional deps, see useSelect.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -64,12 +64,13 @@ interface EntityRecordsResolution< RecordType > {
 export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
-	queryArgs: unknown = {}
+	queryArgs: unknown = {},
+	deps: unknown[] = []
 ): EntityRecordsResolution< RecordType > {
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) =>
 			query( coreStore ).getEntityRecords( kind, name, queryArgs ),
-		[ kind, name, queryArgs ]
+		[ kind, name, ...deps ]
 	);
 
 	return {

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -2,8 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	__experimentalUseEntityRecords as useEntityRecords,
+} from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -63,13 +63,13 @@ export default function useNavigationEntities( menuId ) {
 function useMenuItemEntities( menuId ) {
 	const { menuItems, hasResolvedMenuItems } = useSelect(
 		( select ) => {
-			const { getMenuItems, hasFinishedResolution } = select( coreStore );
-
 			if ( ! menuId ) {
 				return {
 					hasResolvedMenuItems: false,
 				};
 			}
+
+			const { getMenuItems, hasFinishedResolution } = select( coreStore );
 
 			const query = {
 				menus: menuId,

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -61,12 +61,10 @@ export default function useNavigationEntities( menuId ) {
 }
 
 function useMenuItemEntities( menuId ) {
-	const { menuItems, hasResolvedMenuItems } = useSelect(
+	const { menuItems, hasResolvedMenuItems = false } = useSelect(
 		( select ) => {
 			if ( ! menuId ) {
-				return {
-					hasResolvedMenuItems: false,
-				};
+				return {};
 			}
 
 			const { getMenuItems, hasFinishedResolution } = select( coreStore );

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData
@@ -34,31 +35,14 @@ export default function useNavigationEntities( menuId ) {
 }
 
 function useMenuEntities() {
-	const { menus, isResolvingMenus, hasResolvedMenus } = useSelect(
-		( select ) => {
-			const { getMenus, isResolving, hasFinishedResolution } = select(
-				coreStore
-			);
-
-			const menusParameters = [ { per_page: -1 } ];
-
-			return {
-				menus: getMenus( ...menusParameters ),
-				isResolvingMenus: isResolving( 'getMenus', menusParameters ),
-				hasResolvedMenus: hasFinishedResolution(
-					'getMenus',
-					menusParameters
-				),
-			};
-		},
-		[]
-	);
+	const response = useEntityRecords( 'root', 'menu', [ { per_page: -1 } ] );
+	const { records, isResolving, hasResolved } = response;
 
 	return {
-		menus,
-		isResolvingMenus,
-		hasResolvedMenus,
-		hasMenus: !! ( hasResolvedMenus && menus?.length ),
+		menus: records,
+		isResolvingMenus: isResolving,
+		hasResolvedMenus: hasResolved,
+		hasMenus: !! ( hasResolved && records?.length ),
 	};
 }
 

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -65,25 +65,21 @@ function useMenuItemEntities( menuId ) {
 		( select ) => {
 			const { getMenuItems, hasFinishedResolution } = select( coreStore );
 
-			const hasSelectedMenu = menuId !== undefined;
-			if ( ! hasSelectedMenu ) {
+			if ( ! menuId ) {
 				return {
 					hasResolvedMenuItems: false,
 				};
 			}
 
-			const menuItemsParameters = [
-				{
-					menus: menuId,
-					per_page: -1,
-				},
-			];
+			const query = {
+				menus: menuId,
+				per_page: -1,
+			};
 			return {
-				menuItems: getMenuItems( ...menuItemsParameters ),
-				hasResolvedMenuItems: hasFinishedResolution(
-					'getMenuItems',
-					menuItemsParameters
-				),
+				menuItems: getMenuItems( query ),
+				hasResolvedMenuItems: hasFinishedResolution( 'getMenuItems', [
+					query,
+				] ),
 			};
 		},
 		[ menuId ]

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -68,7 +68,6 @@ function useMenuItemEntities( menuId ) {
 			}
 
 			const { getMenuItems, hasFinishedResolution } = select( coreStore );
-
 			const query = {
 				menus: menuId,
 				per_page: -1,

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	__experimentalUseEntityRecords as useEntityRecords,
+} from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	VisuallyHidden,
@@ -18,26 +21,15 @@ import Actions from './actions';
 import AddedBy from './added-by';
 
 export default function Table( { templateType } ) {
-	const { templates, isLoading, postType } = useSelect(
-		( select ) => {
-			const {
-				getEntityRecords,
-				hasFinishedResolution,
-				getPostType,
-			} = select( coreStore );
-
-			return {
-				templates: getEntityRecords( 'postType', templateType, {
-					per_page: -1,
-				} ),
-				isLoading: ! hasFinishedResolution( 'getEntityRecords', [
-					'postType',
-					templateType,
-					{ per_page: -1 },
-				] ),
-				postType: getPostType( templateType ),
-			};
-		},
+	const { records: templates, isResolving: isLoading } = useEntityRecords(
+		'postType',
+		templateType,
+		{
+			per_page: -1,
+		}
+	);
+	const postType = useSelect(
+		( select ) => select( coreStore ).getPostType( templateType ),
 		[ templateType ]
 	);
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -18,7 +18,7 @@ import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { __experimentalUseEntityRecord as useEntityRecord } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -94,17 +94,14 @@ function NotEmpty( {
 } ) {
 	const [ hasPreview, setHasPreview ] = useState( null );
 
-	const { widgetType, hasResolvedWidgetType, isNavigationMode } = useSelect(
-		( select ) => {
-			const widgetTypeId = id ?? idBase;
-			return {
-				widgetType: select( coreStore ).getWidgetType( widgetTypeId ),
-				hasResolvedWidgetType: select(
-					coreStore
-				).hasFinishedResolution( 'getWidgetType', [ widgetTypeId ] ),
-				isNavigationMode: select( blockEditorStore ).isNavigationMode(),
-			};
-		},
+	const widgetTypeId = id ?? idBase;
+	const {
+		data: widgetType,
+		hasResolved: hasResolvedWidgetType,
+	} = useEntityRecord( 'root', 'widgetType', widgetTypeId );
+
+	const isNavigationMode = useSelect(
+		( select ) => select( blockEditorStore ).isNavigationMode(),
 		[ id, idBase ]
 	);
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -96,7 +96,7 @@ function NotEmpty( {
 
 	const widgetTypeId = id ?? idBase;
 	const {
-		data: widgetType,
+		record: widgetType,
 		hasResolved: hasResolvedWidgetType,
 	} = useEntityRecord( 'root', 'widgetType', widgetTypeId );
 

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -102,7 +102,7 @@ function NotEmpty( {
 
 	const isNavigationMode = useSelect(
 		( select ) => select( blockEditorStore ).isNavigationMode(),
-		[ id, idBase ]
+		[]
 	);
 
 	const setInstance = useCallback( ( nextInstance ) => {


### PR DESCRIPTION
## Description

This PR refactors the verbose usages of `getEntityRecord` and `getEntityRecords` like this:

```js
const { menus, isResolvingMenus, hasResolvedMenus } = useSelect(
	( select ) => {
		const { getMenus, isResolving, hasFinishedResolution } = select(
			coreStore
		);

		const menusParameters = [ { per_page: -1, context: 'view' } ];

		return {
			menus: getMenus( ...menusParameters ),
			isResolvingMenus: isResolving( 'getMenus', menusParameters ),
			hasResolvedMenus: hasFinishedResolution(
				'getMenus',
				menusParameters
			),
		};
	},
	[]
);
```

Into more succinct ones like this:

```js
const { records, isResolving, hasResolved } = useEntityRecords(
	'root',
	'menu',
	{ per_page: -1, context: 'view' }
);
```

Based on the new useEntityRecord and useEntityRecords hooks introduced starting at #38135

## Test plan

Confirm all the tests are green