### PR TITLE
Experiment: Live Block

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -50,7 +50,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$data_attributes = sprintf(
-				'data-block="%1$s" data-attribute="%2$s" data-new-value="%3$s", data-nonce="%4$s"',
+				'data-block="%1$s" data-query-arg="%2$s" data-new-query-arg-value="%3$s", data-nonce="%4$s"',
 				'core/query',
 				esc_attr( $page_key ),
 				esc_attr( $page + 1 ),

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -49,10 +49,17 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query           = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
+			$data_attributes = sprintf(
+				'data-block="%1$s" data-attribute="%2$s" data-new-value="%3$s"',
+				'core/query',
+				esc_attr( $page_key ),
+				esc_attr( $page + 1 )
+			);
 			$content = sprintf(
-				'<a href="%1$s" %2$s>%3$s</a>',
+				'<a href="%1$s" %2$s %3$s>%4$s</a>',
 				esc_url( add_query_arg( $page_key, $page + 1 ) ),
 				$wrapper_attributes,
+				$data_attributes,
 				$label
 			);
 		}

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -50,10 +50,11 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		$custom_query_max_pages = (int) $custom_query->max_num_pages;
 		if ( $custom_query_max_pages && $custom_query_max_pages !== $page ) {
 			$data_attributes = sprintf(
-				'data-block="%1$s" data-attribute="%2$s" data-new-value="%3$s"',
+				'data-block="%1$s" data-attribute="%2$s" data-new-value="%3$s", data-nonce="%4$s"',
 				'core/query',
 				esc_attr( $page_key ),
-				esc_attr( $page + 1 )
+				esc_attr( $page + 1 ),
+				wp_create_nonce( 'wp_rest' )
 			);
 			$content = sprintf(
 				'<a href="%1$s" %2$s %3$s>%4$s</a>',

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -11,17 +11,22 @@ const load = () => {
 
 		const {
 			block: blockName,
-			attribute,
-			newValue,
+			// attribute,
+			// newValue,
 			nonce,
 		} = e.target.dataset;
 		const blockSelector = `.wp-block-${ blockName.replace( 'core/', '' ) }`; // TODO: Need a better mechanism here.
 
 		// TODO: Need to include blocks' current attributes.
 		// Fetch the HTML of the new block.
+		// const html = await fetchRenderedBlock(
+		// 	blockName,
+		// 	{ [ attribute ]: newValue },
+		// 	nonce
+		// ); // FIXME
 		const html = await fetchRenderedBlock(
-			blockName,
-			{ [ attribute ]: newValue },
+			'core/calendar',
+			{ month: '12', year: '2021' },
 			nonce
 		);
 

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -20,19 +20,11 @@ const load = () => {
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
 
-		const rawAttributes = root.attributes;
-		const attributes = {};
-		for ( let i = 0; i < rawAttributes.length; i++ ) {
-			if ( rawAttributes[ i ].name !== 'type' ) {
-				attributes[ rawAttributes[ i ].name ] =
-					rawAttributes[ i ].value;
-			}
-		}
 		// TODO: Need to include blocks' current attributes.
 		// Fetch the HTML of the new block.
 		const html = await fetchRenderedBlock(
 			blockName,
-			attributes,
+			root.dataset,
 			{ [ queryArg ]: newQueryArgValue },
 			nonce
 		);

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -18,9 +18,12 @@ const load = () => {
 		const blockSelector = `.wp-block-${ blockName.replace( 'core/', '' ) }`; // TODO: Need a better mechanism here.
 
 		// TODO: Need to include blocks' current attributes.
-		const attributes = { [ attribute ]: newValue };
 		// Fetch the HTML of the new block.
-		const html = await fetchRenderedBlock( blockName, attributes, nonce );
+		const html = await fetchRenderedBlock(
+			blockName,
+			{ [ attribute ]: newValue },
+			nonce
+		);
 
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
@@ -43,16 +46,14 @@ window.addEventListener( 'load', load );
 
 async function fetchRenderedBlock( blockName, attributes, nonce ) {
 	// TODO: Auth should be done inside of this function (or ideally not at all.)
-	let route = `wp/v2/block-renderer/${ blockName }`;
-	if ( Object.keys( attributes ).length ) {
-		const queryArgs = new URLSearchParams( attributes );
-		route += '?' + queryArgs.toString();
-	}
+	const route = `wp/v2/block-renderer/${ blockName }`;
 	const restApiBase = document.head.querySelector(
 		'link[rel="https://api.w.org/"]'
 	).href;
 	const url = new URL( restApiBase + route );
-	//url.searchParams.append( 'rest_route', route );
+	for ( const attr in attributes ) {
+		url.searchParams.append( `attributes[${ attr }]`, attributes[ attr ] );
+	}
 	url.searchParams.append( 'context', 'edit' );
 	url.searchParams.append( '_locale', 'user' );
 

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -20,7 +20,7 @@ const load = () => {
 		).href;
 		const url = new URL( restApiBase + route );
 		//url.searchParams.append( 'rest_route', route );
-		url.searchParams.append( 'context', 'view' );
+		url.searchParams.append( 'context', 'edit' );
 		url.searchParams.append( '_locale', 'user' );
 
 		const html = await loadHtml( url );

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -27,8 +27,7 @@ const load = () => {
 				attributes[ attr ] = root.dataset[ attr ];
 			}
 		}
-		//console.log( attributes );
-		// TODO: Need to include blocks' current attributes.
+
 		// Fetch the HTML of the new block.
 		const html = await fetchRenderedBlock(
 			blockName,

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -23,7 +23,7 @@ const load = () => {
 		for ( const attr in root.dataset ) {
 			try {
 				attributes[ attr ] = JSON.parse( root.dataset[ attr ] );
-			} catch ( e ) {
+			} catch ( err ) {
 				attributes[ attr ] = root.dataset[ attr ];
 			}
 		}

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -19,12 +19,20 @@ const load = () => {
 
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
-
+		const attributes = {};
+		for ( const attr in root.dataset ) {
+			try {
+				attributes[ attr ] = JSON.parse( root.dataset[ attr ] );
+			} catch ( e ) {
+				attributes[ attr ] = root.dataset[ attr ];
+			}
+		}
+		//console.log( attributes );
 		// TODO: Need to include blocks' current attributes.
 		// Fetch the HTML of the new block.
 		const html = await fetchRenderedBlock(
 			blockName,
-			root.dataset,
+			attributes,
 			{ [ queryArg ]: newQueryArgValue },
 			nonce
 		);

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -19,17 +19,12 @@ const load = () => {
 
 		// Fetch the HTML of the new block.
 		// TODO: Need to include blocks' current attributes.
-		const route = `wp/v2/block-renderer/${ blockName }?${ attribute }=${ newValue }`;
-		const restApiBase = document.head.querySelector(
-			'link[rel="https://api.w.org/"]'
-		).href;
-		const url = new URL( restApiBase + route );
-		//url.searchParams.append( 'rest_route', route );
-		url.searchParams.append( 'context', 'edit' );
-		url.searchParams.append( '_locale', 'user' );
-
-		const headers = { 'X-WP-Nonce': nonce };
-		const html = await loadHtml( url, headers );
+		const html = await fetchRenderedBlock(
+			blockName,
+			attribute,
+			newValue,
+			nonce
+		);
 
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
@@ -50,7 +45,18 @@ const load = () => {
 
 window.addEventListener( 'load', load );
 
-async function loadHtml( url, headers ) {
+async function fetchRenderedBlock( blockName, attribute, newValue, nonce ) {
+	// TODO: Auth should be done inside of this function (or ideally not at all.)
+	const route = `wp/v2/block-renderer/${ blockName }?${ attribute }=${ newValue }`;
+	const restApiBase = document.head.querySelector(
+		'link[rel="https://api.w.org/"]'
+	).href;
+	const url = new URL( restApiBase + route );
+	//url.searchParams.append( 'rest_route', route );
+	url.searchParams.append( 'context', 'edit' );
+	url.searchParams.append( '_locale', 'user' );
+
+	const headers = { 'X-WP-Nonce': nonce };
 	const data = await window.fetch( url, { headers } );
 	const { rendered } = await data.json();
 	return rendered;

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -52,6 +52,6 @@ window.addEventListener( 'load', load );
 
 async function loadHtml( url, headers ) {
 	const data = await window.fetch( url, { headers } );
-	const html = await data.text();
-	return html;
+	const { rendered } = await data.json();
+	return rendered;
 }

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -9,21 +9,30 @@ const load = () => {
 	link.addEventListener( 'click', async ( e ) => {
 		e.preventDefault();
 
-		// Fetch the HTML of the new page.
-		const url = e.target.href;
+		const { block: blockName, attribute, newValue } = e.target.dataset;
+		const blockSelector = `.wp-block-${ blockName.replace( 'core/', '' ) }`; // TODO: Need a better mechanism here.
+
+		// Fetch the HTML of the new block.
+		// TODO: Need to include blocks' current attributes.
+		const route = `wp/v2/block-renderer/${ blockName }?${ attribute }=${ newValue }`;
+		const restApiBase = document.head.querySelector(
+			'link[rel="https://api.w.org/"]'
+		).href;
+		const url = new URL( restApiBase + route );
+		//url.searchParams.append( 'rest_route', route );
+		url.searchParams.append( 'context', 'view' );
+		url.searchParams.append( '_locale', 'user' );
+
 		const html = await loadHtml( url );
 
-		// Find the root of the real DOM and the new page.
-		const root = document.querySelector( '.wp-site-blocks' );
-		const newRoot = /<div class="wp-site-blocks".*<\/div>/s.exec(
-			html
-		)[ 0 ];
+		// Find the root of the real DOM.
+		const root = e.target.closest( blockSelector );
 
 		// Replace root with the new HTML.
-		morphdom( root, newRoot );
+		morphdom( root, html );
 
 		// Change the browser URL.
-		window.history.pushState( {}, '', url );
+		window.history.pushState( {}, '', e.target.href );
 
 		// Scroll to the top to simulate page load.
 		window.scrollTo( 0, 0 );

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -9,7 +9,12 @@ const load = () => {
 	link.addEventListener( 'click', async ( e ) => {
 		e.preventDefault();
 
-		const { block: blockName, attribute, newValue } = e.target.dataset;
+		const {
+			block: blockName,
+			attribute,
+			newValue,
+			nonce,
+		} = e.target.dataset;
 		const blockSelector = `.wp-block-${ blockName.replace( 'core/', '' ) }`; // TODO: Need a better mechanism here.
 
 		// Fetch the HTML of the new block.
@@ -23,7 +28,8 @@ const load = () => {
 		url.searchParams.append( 'context', 'edit' );
 		url.searchParams.append( '_locale', 'user' );
 
-		const html = await loadHtml( url );
+		const headers = { 'X-WP-Nonce': nonce };
+		const html = await loadHtml( url, headers );
 
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
@@ -44,8 +50,8 @@ const load = () => {
 
 window.addEventListener( 'load', load );
 
-async function loadHtml( url ) {
-	const data = await window.fetch( url );
+async function loadHtml( url, headers ) {
+	const data = await window.fetch( url, { headers } );
 	const html = await data.text();
 	return html;
 }

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -17,14 +17,10 @@ const load = () => {
 		} = e.target.dataset;
 		const blockSelector = `.wp-block-${ blockName.replace( 'core/', '' ) }`; // TODO: Need a better mechanism here.
 
-		// Fetch the HTML of the new block.
 		// TODO: Need to include blocks' current attributes.
-		const html = await fetchRenderedBlock(
-			blockName,
-			attribute,
-			newValue,
-			nonce
-		);
+		const attributes = { [ attribute ]: newValue };
+		// Fetch the HTML of the new block.
+		const html = await fetchRenderedBlock( blockName, attributes, nonce );
 
 		// Find the root of the real DOM.
 		const root = e.target.closest( blockSelector );
@@ -45,9 +41,13 @@ const load = () => {
 
 window.addEventListener( 'load', load );
 
-async function fetchRenderedBlock( blockName, attribute, newValue, nonce ) {
+async function fetchRenderedBlock( blockName, attributes, nonce ) {
 	// TODO: Auth should be done inside of this function (or ideally not at all.)
-	const route = `wp/v2/block-renderer/${ blockName }?${ attribute }=${ newValue }`;
+	let route = `wp/v2/block-renderer/${ blockName }`;
+	if ( Object.keys( attributes ).length ) {
+		const queryArgs = new URLSearchParams( attributes );
+		route += '?' + queryArgs.toString();
+	}
 	const restApiBase = document.head.querySelector(
 		'link[rel="https://api.w.org/"]'
 	).href;

--- a/packages/block-library/src/query-pagination-next/view.js
+++ b/packages/block-library/src/query-pagination-next/view.js
@@ -79,7 +79,7 @@ async function fetchRenderedBlock( blockName, attributes, queryArgs, nonce ) {
 	}
 
 	for ( const arg in queryArgs ) {
-		url.searchParams.append( 'arg', queryArgs[ arg ] );
+		url.searchParams.append( arg, queryArgs[ arg ] );
 	}
 	url.searchParams.append( 'context', 'edit' );
 	url.searchParams.append( '_locale', 'user' );


### PR DESCRIPTION
## Description
WIP. Experiment, based on @michalczaplinski's #38713.

Currently using the Calendar block since I couldn't get the Query block to work with the `block-renderer` endpoint (see comments below).

The idea is to replace a block in the markup with a server-rendered block (fetched from the `block-renderer` endpoint), to avoid server-rendering an entire page and extracting the relevant markup from it.

## Testing Instructions
Use the Twenty Twenty Two theme. Make sure you have a sizable number of posts (you can use `wp post generate --count=30` to auto-generate them.)
On the frontpage, click the "Next" pagination link at the bottom, and observe the network tab. It should fetch the Calendar block and replace the Post Query block with it 😬 

## Screenshots <!-- if applicable -->

## Types of changes
Experiment/demo