### PR TITLE
Fix unexpected dragging triggered on spinner buttons on hover in Safari.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15347,6 +15347,19 @@
 				}
 			}
 		},
+		"@use-gesture/core": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.2.6.tgz",
+			"integrity": "sha512-+GpVSEoCLv1OeZ+qgAV+tLUKit1LKgKO3PgIiEVZqNr4A/YTXzbC1unlThpfzwyj5Dx22UxHDh0UfgRrQ9Lb1w=="
+		},
+		"@use-gesture/react": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.2.6.tgz",
+			"integrity": "sha512-s/QDhKvsQVaSNq1ljRBMR2PWRkOp9BmoI+kgZR1DsHUSp5XDORtU33D5TZfJoWnD5X3E9SmePikPl66dDaEeDA==",
+			"requires": {
+				"@use-gesture/core": "10.2.6"
+			}
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -15874,6 +15887,7 @@
 				"@emotion/serialize": "^1.0.2",
 				"@emotion/styled": "^11.6.0",
 				"@emotion/utils": "1.0.0",
+				"@use-gesture/react": "^10.2.6",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/date": "file:packages/date",
@@ -15902,7 +15916,6 @@
 				"react-colorful": "^5.3.1",
 				"react-dates": "^17.1.1",
 				"react-resize-aware": "^3.1.0",
-				"react-use-gesture": "^9.0.0",
 				"reakit": "^1.3.8",
 				"uuid": "^8.3.0"
 			},
@@ -49982,11 +49995,6 @@
 				"loose-envify": "^1.4.0",
 				"prop-types": "^15.6.2"
 			}
-		},
-		"react-use-gesture": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.0.0.tgz",
-			"integrity": "sha512-inTAcmX0Y8LWr7XViim5+6XlTsJ7kCgwYRrwxSu1Vkjv+8GyClHITFkGGKYXAv5QywZ8YqiJXpzFx8RZpEVF+w=="
 		},
 		"react-with-direction": {
 			"version": "1.3.1",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix spin buttons of number inputs in Safari ([#38840](https://github.com/WordPress/gutenberg/pull/38840))
+
 ## 19.4.0 (2022-02-10)
 
 ### Bug Fix

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -36,6 +36,7 @@
 		"@emotion/serialize": "^1.0.2",
 		"@emotion/styled": "^11.6.0",
 		"@emotion/utils": "1.0.0",
+		"@use-gesture/react": "^10.2.6",
 		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/date": "file:../date",
@@ -64,7 +65,6 @@
 		"react-colorful": "^5.3.1",
 		"react-dates": "^17.1.1",
 		"react-resize-aware": "^3.1.0",
-		"react-use-gesture": "^9.0.0",
 		"reakit": "^1.3.8",
 		"uuid": "^8.3.0"
 	},

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import { useHover } from 'react-use-gesture';
+import { useHover } from '@use-gesture/react';
 
 /**
  * Internal dependencies

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -170,7 +170,7 @@ function InputField(
 			const { distance, dragging, event } = dragProps;
 			// The event is persisted to prevent errors in components using this
 			// to check if a modifier key was held while dragging.
-			event.persist();
+			event.persist?.();
 
 			if ( ! distance ) return;
 			event.stopPropagation();
@@ -196,6 +196,7 @@ function InputField(
 		{
 			threshold: dragThreshold,
 			enabled: isDragEnabled,
+			pointer: { capture: false },
 		}
 	);
 

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
-import { useDrag } from 'react-use-gesture';
+import { useDrag } from '@use-gesture/react';
 import type {
 	SyntheticEvent,
 	ChangeEvent,

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -168,9 +168,6 @@ function InputField(
 	const dragGestureProps = useDrag< PointerEvent< HTMLInputElement > >(
 		( dragProps ) => {
 			const { distance, dragging, event } = dragProps;
-			// The event is persisted to prevent errors in components using this
-			// to check if a modifier key was held while dragging.
-			event.persist?.();
 
 			if ( ! distance ) return;
 			event.stopPropagation();

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -7,7 +7,7 @@ import type {
 	ChangeEvent,
 	SyntheticEvent,
 } from 'react';
-import type { useDrag } from 'react-use-gesture';
+import type { useDrag } from '@use-gesture/react';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Upgrades react-use-gesture to the latest version (now @use-gesture/react) and uses one of its new features to avoid a Safari bug with number inputs and pointer capture.

Fix #32497 fix #37127

## Testing Instructions
1. Load the Block Editor in Safari >= 13
2. Insert a Column, Cover, Gallery or other block that has a setting that employs a NumberControl or RangeControl
3. Find the input with the spinner arrows and press them to change the value
4. Verify that hovering over the spinner arrows does nothing

## Screenshots
![fix-safari-spin-button](https://user-images.githubusercontent.com/9000376/154181550-63ec4470-1545-4cb4-9b6c-4a92debebe2e.gif)

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
