### PR TITLE
Experiment: "Live block" using the latest-comments block

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -73,6 +73,7 @@ function gutenberg_reregister_core_block_types() {
 				'image.php'                        => 'core/image',
 				'gallery.php'                      => 'core/gallery',
 				'latest-comments.php'              => 'core/latest-comments',
+				'latest-comments-filter.php'       => 'core/latest-comments-filter',
 				'latest-posts.php'                 => 'core/latest-posts',
 				'loginout.php'                     => 'core/loginout',
 				'navigation.php'                   => 'core/navigation',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15802,7 +15802,8 @@
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
 				"micromodal": "^0.4.10",
-				"moment": "^2.22.1"
+				"moment": "^2.22.1",
+				"morphdom": "^2.6.1"
 			},
 			"dependencies": {
 				"colord": {
@@ -19240,16 +19241,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"are-we-there-yet": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
@@ -44601,6 +44592,11 @@
 			"resolved": "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz",
 			"integrity": "sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==",
 			"dev": true
+		},
+		"morphdom": {
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.6.1.tgz",
+			"integrity": "sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA=="
 		},
 		"mousetrap": {
 			"version": "1.6.5",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -65,7 +65,8 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0",
 		"micromodal": "^0.4.10",
-		"moment": "^2.22.1"
+		"moment": "^2.22.1",
+		"morphdom": "^2.6.1"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -44,6 +44,7 @@ import * as homeLink from './home-link';
 import * as html from './html';
 import * as image from './image';
 import * as latestComments from './latest-comments';
+import * as latestCommentsFilter from './latest-comments-filter';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
 import * as logInOut from './loginout';
@@ -155,6 +156,7 @@ export const __experimentalGetCoreBlocks = () => [
 	group,
 	html,
 	latestComments,
+	latestCommentsFilter,
 	latestPosts,
 	mediaText,
 	missing,

--- a/packages/block-library/src/latest-comments-filter/block.json
+++ b/packages/block-library/src/latest-comments-filter/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/latest-comments-filter",
+	"title": "Latest Comments Filter",
+	"keywords": [ "comments filter" ],
+	"category": "widgets",
+	"description": "Allows the user to select the number comments that it shows",
+	"textdomain": "default",
+	"style": "wp-block-latest-comments-filter",
+	"viewScript": "file:./view.min.js",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false
+	}
+}

--- a/packages/block-library/src/latest-comments-filter/block.json
+++ b/packages/block-library/src/latest-comments-filter/block.json
@@ -9,8 +9,10 @@
 	"textdomain": "default",
 	"style": "wp-block-latest-comments-filter",
 	"viewScript": "file:./view.min.js",
-	"supports": {
-		"align": [ "wide", "full" ],
-		"html": false
+	"attributes": {
+		"numComments": {
+			"type": "number",
+			"default": 4
+		}
 	}
 }

--- a/packages/block-library/src/latest-comments-filter/edit.js
+++ b/packages/block-library/src/latest-comments-filter/edit.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+function Edit( { setAttributes, attributes } ) {
+	const blockProps = useBlockProps();
+
+	const { numComments } = attributes;
+
+	return (
+		<>
+			<div { ...blockProps }>
+				<div>
+					<input
+						type="range"
+						min="1"
+						max="5"
+						value={ numComments }
+						className="slider"
+						onChange={ ( e ) =>
+							setAttributes( { numComments: e.target.value } )
+						}
+					/>
+				</div>
+			</div>
+		</>
+	);
+}
+
+export default Edit;

--- a/packages/block-library/src/latest-comments-filter/index.js
+++ b/packages/block-library/src/latest-comments-filter/index.js
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import { comment as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	example: {},
+	edit,
+	save,
+};

--- a/packages/block-library/src/latest-comments-filter/index.php
+++ b/packages/block-library/src/latest-comments-filter/index.php
@@ -1,0 +1,20 @@
+<?php
+
+function render_block_core_latest_comments_filter( $attributes, $content, $block ) {
+  wp_enqueue_script( 'wp-block-latest-comments-filter-view' );  
+  return $content;
+}
+
+/**
+ * Registers the `core/latest-comments` block.
+ */
+function register_block_core_latest_comments_filter() {
+	register_block_type_from_metadata(
+		__DIR__ . '/latest-comments-filter',
+		array(
+			'render_callback' => 'render_block_core_latest_comments_filter',
+		)
+	);
+}
+
+add_action( 'init', 'register_block_core_latest_comments_filter' );

--- a/packages/block-library/src/latest-comments-filter/save.js
+++ b/packages/block-library/src/latest-comments-filter/save.js
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+function Edit( { attributes } ) {
+	const { numComments } = attributes;
+
+	return (
+		<>
+			<div { ...useBlockProps.save() }>
+				<div>
+					<input
+						type="range"
+						min="1"
+						max="5"
+						value={ numComments }
+						className="slider"
+					/>
+				</div>
+			</div>
+		</>
+	);
+}
+
+export default Edit;

--- a/packages/block-library/src/latest-comments-filter/view.js
+++ b/packages/block-library/src/latest-comments-filter/view.js
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import morphdom from 'morphdom';
+
+const load = () => {
+	const link = document.querySelector(
+		'.wp-block-latest-comments-filter .slider'
+	);
+
+	link.addEventListener( 'change', async ( e ) => {
+		const newBlock = await loadBlock(
+			window.location.origin +
+				`/wp-json/wp/v2/block-renderer/core/latest-comments?context=edit&attributes[commentsToShow]=${ e.target.value }&post_id=1`
+		);
+
+		// Find the root of the block.
+		const root = document.querySelector( '.wp-block-latest-comments' );
+
+		// Replace root with the new HTML.
+		morphdom( root, newBlock );
+	} );
+};
+
+window.addEventListener( 'load', load );
+
+async function loadBlock( url ) {
+	const data = await window.fetch( url );
+	const json = await data.json();
+	return json.rendered;
+}


### PR DESCRIPTION
This is an experiment in "server components" pattern. It's related to the #38713 as this PR is using the same pattern of data loading + `morphdom`.

Here, I have created a new block called `latest-comments-filter` which dynamically loads the HTML for the `latest-comments` block from the props passed to the `block-renderer` endpoint. It then uses `morphdom` to update the `latest-comments` block's DOM with new HTML.

Some video demos (there is some vague speculation at the end of the first video, sorry for that 😅)

https://user-images.githubusercontent.com/5417266/154175151-faad5f26-189d-4568-90e8-a6beeae65c78.mp4

I've forgotten to mention some additional stuff so short part 2:

https://user-images.githubusercontent.com/5417266/154175267-6ea0f3af-2053-4fa3-945a-e51f43fca501.mp4


