### PR TITLE
Context: Omit `as` prop in types

### DIFF
--- a/packages/components/src/ui/context/wordpress-component.ts
+++ b/packages/components/src/ui/context/wordpress-component.ts
@@ -20,7 +20,7 @@ export type WordPressComponentProps<
 		? {
 				as?: T | keyof JSX.IntrinsicElements;
 		  }
-		: { as?: never } );
+		: {} );
 
 export type WordPressComponent<
 	T extends React.ElementType,
@@ -29,7 +29,7 @@ export type WordPressComponent<
 > = {
 	< TT extends React.ElementType >(
 		props: WordPressComponentProps< O, TT, IsPolymorphic > &
-			( IsPolymorphic extends true ? { as: TT } : { as: never } )
+			( IsPolymorphic extends true ? { as: TT } : {} )
 	): JSX.Element | null;
 	(
 		props: WordPressComponentProps< O, T, IsPolymorphic >


### PR DESCRIPTION
## Description

This is an attempt to actually omit the `as` prop from `WordPressComponentProps` when polymorphism is disabled.

Given some code like this with a component flagged as non-polymorphic:

```tsx
// some-file.tsx
const InvalidDivider = () => <Divider as="a" />;
```

The current implementation still acknowledges `as` as an actual prop type, only that it has to be `undefined`. This will cause some docgens to list `as` as a member of the props. It also gives us a TS error like this:

```
Type 'string' is not assignable to type 'undefined'.
```

Whereas, if it were any other non-existent prop, it should give you an error like:

```
Type '{ as: string; }' is not assignable to type 'IntrinsicAttributes & Props & Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement>, "key" | keyof HTMLAttributes<...>> & { ...; }, "as" | ... 1 more ... | keyof Props>'.

Property 'as' does not exist on type 'IntrinsicAttributes & Props & Omit<Pick<DetailedHTMLProps<HTMLAttributes<HTMLHRElement>, HTMLHRElement>, "key" | keyof HTMLAttributes<...>> & { ...; }, "as" | ... 1 more ... | keyof Props>'.
```

I'm not 100% sure if the approach in this PR is the best way to achieve it though. Let me know if there are better ways.

## Testing Instructions

1. In some `.tsx` file, add a code snippet like `const InvalidDivider = () => <Divider as="a" />` for a non-polymorphic component. It should give you the expected TS error.
2. Similarly, try a snippet like `const ValidSpacer = () => <Spacer as="aside" />` for a polymorphic component. It should not emit TS errors.

## Types of changes

New feature

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
