### PR TITLE
Remove data-controls mock from Image block RN tests

### DIFF
--- a/packages/block-library/src/image/test/edit.native.js
+++ b/packages/block-library/src/image/test/edit.native.js
@@ -15,7 +15,6 @@ import Clipboard from '@react-native-clipboard/clipboard';
  * WordPress dependencies
  */
 import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
-import { apiFetch } from '@wordpress/data-controls';
 import {
 	setFeaturedImage,
 	sendMediaUpload,
@@ -40,14 +39,6 @@ sendMediaUpload.mockImplementation( ( payload ) => {
 	uploadCallBack( payload );
 } );
 
-jest.mock( '@wordpress/data-controls', () => {
-	const dataControls = jest.requireActual( '@wordpress/data-controls' );
-	return {
-		...dataControls,
-		apiFetch: jest.fn(),
-	};
-} );
-
 /**
  * Immediately invoke delayed functions. A better alternative would be using
  * fake timers and test the delay itself. However, fake timers does not work
@@ -59,7 +50,6 @@ jest.mock( 'lodash', () => {
 } );
 
 const apiFetchPromise = Promise.resolve( {} );
-apiFetch.mockImplementation( () => apiFetchPromise );
 
 const clipboardPromise = Promise.resolve( '' );
 Clipboard.getString.mockImplementation( () => clipboardPromise );


### PR DESCRIPTION
There's one forgotten use of the `data-controls` package in the React Native unit test for the Image block. As the `data-controls` package is no longer used by any Gutenberg code, the mock is redundant and can be fully removed.
