### PR TITLE
Data: enable thunks by default and remove the experimental flag

### DIFF
--- a/docs/how-to-guides/thunks.md
+++ b/docs/how-to-guides/thunks.md
@@ -114,7 +114,6 @@ Let's see how this indirection can be removed with thunks:
 
 ```js
 const store = wp.data.createReduxStore( 'my-store', {
-    __experimentalUseThunks: true,
     actions: {
         saveTemperatureToAPI: ( temperature ) => async () => {
             const response = await window.fetch( 'https://...', {
@@ -147,7 +146,8 @@ const store = wp.data.createReduxStore( 'my-store', {
 } );
 ```
 
-Support for thunks is experimental for now. You can enable it by setting `__experimentalUseThunks: true` when registering your store.
+Support for thunks is included by default in every data store, just like the (now legacy) support for
+generators and controls.
 
 ## Thunks API
 
@@ -225,4 +225,3 @@ const thunk = () => ( { registry } ) => {
   /* ... */
 }
 ```
-

--- a/packages/block-directory/src/store/index.js
+++ b/packages/block-directory/src/store/index.js
@@ -28,7 +28,6 @@ export const storeConfig = {
 	selectors,
 	actions,
 	resolvers,
-	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/block-editor/src/store/index.js
+++ b/packages/block-editor/src/store/index.js
@@ -22,7 +22,6 @@ export const storeConfig = {
 	reducer,
 	selectors,
 	actions,
-	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -1166,7 +1166,6 @@ describe( 'actions', () => {
 				actions,
 				selectors,
 				reducer,
-				__experimentalUseThunks: true,
 			} );
 
 			registerBlockType( 'core/test-block', defaultBlockSettings );

--- a/packages/blocks/src/store/index.js
+++ b/packages/blocks/src/store/index.js
@@ -22,7 +22,6 @@ export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	selectors,
 	actions,
-	__experimentalUseThunks: true,
 } );
 
 register( store );

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -131,7 +131,6 @@ describe( 'useQuerySelect', () => {
 	it( 'returns the expected "response" details – resolvers and arguments', async () => {
 		registry.register(
 			createReduxStore( 'resolverStore', {
-				__experimentalUseThunks: true,
 				reducer: ( state = { resolvedFoo: 0 }, action ) => {
 					if ( action?.type === 'RECEIVE_FOO' ) {
 						return { ...state, resolvedFoo: action.value };

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -59,7 +59,6 @@ const storeConfig = () => ( {
 	actions: { ...actions, ...entityActions, ...createLocksActions() },
 	selectors: { ...selectors, ...entitySelectors },
 	resolvers: { ...resolvers, ...entityResolvers },
-	__experimentalUseThunks: true,
 } );
 
 /**

--- a/packages/data/CHANGELOG.md
+++ b/packages/data/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+- Enabled thunks by default for all stores and removed the `__experimentalUseThunks` flag.
+
 ## 6.2.1 (2022-02-10)
 
 ### Bug Fix

--- a/packages/data/src/redux-store/index.js
+++ b/packages/data/src/redux-store/index.js
@@ -232,11 +232,8 @@ function instantiateReduxStore( key, options, registry, thunkArgs ) {
 		createResolversCacheMiddleware( registry, key ),
 		promise,
 		createReduxRoutineMiddleware( normalizedControls ),
+		createThunkMiddleware( thunkArgs ),
 	];
-
-	if ( options.__experimentalUseThunks ) {
-		middlewares.push( createThunkMiddleware( thunkArgs ) );
-	}
 
 	const enhancers = [ applyMiddleware( ...middlewares ) ];
 	if (

--- a/packages/edit-navigation/src/store/index.js
+++ b/packages/edit-navigation/src/store/index.js
@@ -25,7 +25,6 @@ const storeConfig = {
 	resolvers,
 	actions,
 	persist: [ 'selectedMenuId' ],
-	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/edit-post/src/store/index.js
+++ b/packages/edit-post/src/store/index.js
@@ -15,7 +15,6 @@ const storeConfig = {
 	reducer,
 	actions,
 	selectors,
-	__experimentalUseThunks: true,
 	persist: [ 'preferences' ],
 };
 

--- a/packages/edit-site/src/store/index.js
+++ b/packages/edit-site/src/store/index.js
@@ -15,7 +15,6 @@ export const storeConfig = {
 	reducer,
 	actions,
 	selectors,
-	__experimentalUseThunks: true,
 	persist: [ 'preferences' ],
 };
 

--- a/packages/edit-widgets/src/store/index.js
+++ b/packages/edit-widgets/src/store/index.js
@@ -25,7 +25,6 @@ const storeConfig = {
 	selectors,
 	resolvers,
 	actions,
-	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -22,7 +22,6 @@ export const storeConfig = {
 	reducer,
 	selectors,
 	actions,
-	__experimentalUseThunks: true,
 };
 
 /**

--- a/packages/interface/src/store/index.js
+++ b/packages/interface/src/store/index.js
@@ -11,6 +11,13 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import { STORE_NAME } from './constants';
 
+const storeConfig = {
+	reducer,
+	actions,
+	selectors,
+	persist: [ 'enableItems', 'preferences' ],
+};
+
 /**
  * Store definition for the interface namespace.
  *
@@ -18,20 +25,8 @@ import { STORE_NAME } from './constants';
  *
  * @type {Object}
  */
-export const store = createReduxStore( STORE_NAME, {
-	reducer,
-	actions,
-	selectors,
-	persist: [ 'enableItems', 'preferences' ],
-	__experimentalUseThunks: true,
-} );
+export const store = createReduxStore( STORE_NAME, storeConfig );
 
 // Once we build a more generic persistence plugin that works across types of stores
 // we'd be able to replace this with a register call.
-registerStore( STORE_NAME, {
-	reducer,
-	actions,
-	selectors,
-	persist: [ 'enableItems', 'preferences' ],
-	__experimentalUseThunks: true,
-} );
+registerStore( STORE_NAME, storeConfig );

--- a/packages/reusable-blocks/src/store/index.js
+++ b/packages/reusable-blocks/src/store/index.js
@@ -23,7 +23,6 @@ export const store = createReduxStore( STORE_NAME, {
 	actions,
 	reducer,
 	selectors,
-	__experimentalUseThunks: true,
 } );
 
 register( store );


### PR DESCRIPTION
The thunks API has been around for quite a long time (one year, since #27276) and all Gutenberg stores have been migrated to it. That means that the API is battle tested and stable, and we can graduate it from the experimental status to stable. This PR does that. Removes the `__experimentalUseThunks` flag for store config and enables the thunk middleware by default for all stores.