### PR TITLE
Fix Block Editor Iframe component to render in standards mode

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -174,11 +174,23 @@ function Iframe(
 	const setRef = useRefEffect( ( node ) => {
 		function setDocumentIfReady() {
 			const { contentDocument, ownerDocument } = node;
-			const { readyState, documentElement } = contentDocument;
+			const { readyState } = contentDocument;
 
 			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
 				return false;
 			}
+
+			// Iframe document doctype is not set by default and not having doctype
+			// will cause browser to render iframe contents in quirks mode. Appending
+			// doctype to existing document won't change iframe's rendering mode.
+			// Document.write will overwrite the document with a new one containing
+			// a correct doctype and will correctly render in stadards mode.
+			contentDocument.write(
+				'<!DOCTYPE html>' + contentDocument.documentElement.outerHTML
+			);
+			contentDocument.close();
+
+			const { documentElement } = contentDocument;
 
 			bubbleEvents( contentDocument );
 			setIframeDocument( contentDocument );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -272,7 +272,7 @@ function Iframe(
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }
 				// Correct doctype is required to enable rendering in standards mode
-				srcDoc="<!doctype html><html><head>yyy</head><body>xxx</body></html>"
+				srcDoc="<!doctype html>"
 				title={ __( 'Editor canvas' ) }
 			>
 				{ iframeDocument &&

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -174,16 +174,9 @@ function Iframe(
 	const setRef = useRefEffect( ( node ) => {
 		function setDocumentIfReady() {
 			const { contentDocument, ownerDocument } = node;
-			const { readyState, documentElement, compatMode } = contentDocument;
+			const { readyState, documentElement } = contentDocument;
 
-			// As srcDoc loads contents asynchronously this will cause the iframe to
-			// load documents twice. We need to hook react to the correct contentDocument
-			// so we need to skip the initial document and wait for the srcDoc with
-			// correct compatMode to load.
-			if (
-				compatMode !== 'CSS1Compat' ||
-				( readyState !== 'complete' && readyState !== 'interactive' )
-			) {
+			if ( readyState !== 'complete' && readyState !== 'interactive' ) {
 				return false;
 			}
 
@@ -210,11 +203,7 @@ function Iframe(
 			return true;
 		}
 
-		if ( setDocumentIfReady() ) {
-			return;
-		}
-
-		// Document is not immediately loaded in Firefox.
+		// Document set with srcDoc is not immediately ready.
 		node.addEventListener( 'load', () => {
 			setDocumentIfReady();
 		} );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -176,7 +176,7 @@ function Iframe(
 			const { contentDocument, ownerDocument } = node;
 			const { readyState, documentElement } = contentDocument;
 
-			if ( readyState !== 'complete' && readyState !== 'interactive' ) {
+			if ( readyState !== 'interactive' && readyState !== 'complete' ) {
 				return false;
 			}
 
@@ -204,9 +204,9 @@ function Iframe(
 		}
 
 		// Document set with srcDoc is not immediately ready.
-		node.addEventListener( 'load', () => {
-			setDocumentIfReady();
-		} );
+		node.addEventListener( 'load', setDocumentIfReady );
+
+		return () => node.removeEventListener( 'load', setDocumentIfReady );
 	}, [] );
 	const headRef = useRefEffect( ( element ) => {
 		scripts

--- a/packages/e2e-tests/specs/site-editor/iframe-rendering-mode.test.js
+++ b/packages/e2e-tests/specs/site-editor/iframe-rendering-mode.test.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, visitSiteEditor } from '@wordpress/e2e-test-utils';
+
+describe( 'Site editor iframe rendering mode', () => {
+	beforeAll( async () => {
+		await activateTheme( 'emptytheme' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwentyone' );
+	} );
+
+	it( 'Should render editor in standards mode.', async () => {
+		await visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+		} );
+
+		const compatMode = await page.evaluate(
+			() =>
+				document.querySelector( `iframe[name='editor-canvas']` )
+					.contentDocument.compatMode
+		);
+
+		// CSS1Compat = expected standards mode.
+		// BackCompat = quirks mode.
+		expect( compatMode ).toBe( 'CSS1Compat' );
+	} );
+} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This fixes an issue where iframe component used by Block Editor would 
render its contents differently to how they were rendered on the front-end.

Iframe document doctype is not set by default if it is not provided via iframe 
`src` or `srcDoc` and not having doctype will cause browser to render iframe 
contents in quirks mode. Appending doctype to existing document won't change 
iframe's rendering mode. `Document.write` will overwrite the document with 
a new one containing a correct doctype and will correctly render in stadards mode.

I've reviewed other areas of Gutenberg and it seems this is the only place
affected. All other places are correctly setting `<!DOCTYPE html>`.

More details provided in the related issue.

Fixes #38854

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Go to Template or Template Part editor.
2. Add block or edit template part containing quirks mode affected CSS/HTML. (Ie. [Mini Cart](https://github.com/woocommerce/woocommerce-gutenberg-products-block))
3. Confirm that contents render the same in the editor and in the front-end

## Screenshots <!-- if applicable -->




#### Example error:
|css|preview|
|-|-|
| ![table-quirks-mode](https://user-images.githubusercontent.com/112270/154259940-c4c903c2-01e2-4ad2-b53e-318c804234c8.jpg) | ![quirks-mode](https://user-images.githubusercontent.com/112270/154255814-141ee688-30f6-410e-86df-b194852fe184.jpg) |

#### Example valid after applying fix:
|css|preview|
|-|-|
| ![table-standards-mode](https://user-images.githubusercontent.com/112270/154259961-292eb10d-8018-4b12-ab92-3e91f44cd8e9.jpg) | ![standard-mode](https://user-images.githubusercontent.com/112270/154255829-9a14d840-13e7-4464-b53c-c8d6a9670504.jpg) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
