### PR TITLE
Fix for late static binding in the resolver

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -101,12 +101,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array Returns the modified $theme_json_structure.
 	 */
 	protected static function translate( $theme_json, $domain = 'default' ) {
-		if ( null === self::$i18n_schema ) {
+		if ( null === static::$i18n_schema ) {
 			$i18n_schema       = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
-			self::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
+			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
-		return wp_translate_settings_using_i18n_schema( self::$i18n_schema, $theme_json, $domain );
+		return wp_translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );
 	}
 
 	/**
@@ -115,15 +115,15 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds core data.
 	 */
 	public static function get_core_data() {
-		if ( null !== self::$core ) {
-			return self::$core;
+		if ( null !== static::$core ) {
+			return static::$core;
 		}
 
-		$config     = self::read_json_file( __DIR__ . '/theme.json' );
-		$config     = self::translate( $config );
-		self::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
+		$config     = static::read_json_file( __DIR__ . '/theme.json' );
+		$config     = static::translate( $config );
+		static::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
 
-		return self::$core;
+		return static::$core;
 	}
 
 	/**
@@ -141,21 +141,21 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
-		if ( null === self::$theme ) {
-			$theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'theme.json' ) );
-			$theme_json_data = self::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			self::$theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+		if ( null === static::$theme ) {
+			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+			static::$theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
 			if ( wp_get_theme()->parent() ) {
 				// Get parent theme.json.
-				$parent_theme_json_data = self::read_json_file( self::get_file_path_from_theme( 'theme.json', true ) );
-				$parent_theme_json_data = self::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
 				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 
 				// Merge the child theme.json into the parent theme.json.
 				// The child theme takes precedence over the parent.
-				$parent_theme->merge( self::$theme );
-				self::$theme = $parent_theme;
+				$parent_theme->merge( static::$theme );
+				static::$theme = $parent_theme;
 			}
 		}
 
@@ -163,10 +163,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		* We want the presets and settings declared in theme.json
 		* to override the ones declared via theme supports.
 		* So we take theme supports, transform it to theme.json shape
-		* and merge the self::$theme upon that.
+		* and merge the static::$theme upon that.
 		*/
 		$theme_support_data = WP_Theme_JSON_Gutenberg::get_from_editor_settings( get_default_block_editor_settings() );
-		if ( ! self::theme_has_support() ) {
+		if ( ! static::theme_has_support() ) {
 			if ( ! isset( $theme_support_data['settings']['color'] ) ) {
 				$theme_support_data['settings']['color'] = array();
 			}
@@ -192,7 +192,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			$theme_support_data['settings']['color']['defaultGradients'] = $default_gradients;
 		}
 		$with_theme_supports = new WP_Theme_JSON_Gutenberg( $theme_support_data );
-		$with_theme_supports->merge( self::$theme );
+		$with_theme_supports->merge( static::$theme );
 
 		return $with_theme_supports;
 	}
@@ -277,12 +277,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds styles for user data.
 	 */
 	public static function get_user_data() {
-		if ( null !== self::$user ) {
-			return self::$user;
+		if ( null !== static::$user ) {
+			return static::$user;
 		}
 
 		$config   = array();
-		$user_cpt = self::get_user_data_from_wp_global_styles( wp_get_theme() );
+		$user_cpt = static::get_user_data_from_wp_global_styles( wp_get_theme() );
 
 		if ( array_key_exists( 'post_content', $user_cpt ) ) {
 			$decoded_data = json_decode( $user_cpt['post_content'], true );
@@ -304,9 +304,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				$config = $decoded_data;
 			}
 		}
-		self::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
+		static::$user = new WP_Theme_JSON_Gutenberg( $config, 'custom' );
 
-		return self::$user;
+		return static::$user;
 	}
 
 	/**
@@ -336,11 +336,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		}
 
 		$result = new WP_Theme_JSON_Gutenberg();
-		$result->merge( self::get_core_data() );
-		$result->merge( self::get_theme_data() );
+		$result->merge( static::get_core_data() );
+		$result->merge( static::get_theme_data() );
 
 		if ( 'custom' === $origin ) {
-			$result->merge( self::get_user_data() );
+			$result->merge( static::get_user_data() );
 		}
 
 		return $result;
@@ -353,17 +353,17 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return integer|null
 	 */
 	public static function get_user_global_styles_post_id() {
-		if ( null !== self::$user_custom_post_type_id ) {
-			return self::$user_custom_post_type_id;
+		if ( null !== static::$user_custom_post_type_id ) {
+			return static::$user_custom_post_type_id;
 		}
 
-		$user_cpt = self::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$user_cpt = static::get_user_data_from_wp_global_styles( wp_get_theme(), true );
 
 		if ( array_key_exists( 'ID', $user_cpt ) ) {
-			self::$user_custom_post_type_id = $user_cpt['ID'];
+			static::$user_custom_post_type_id = $user_cpt['ID'];
 		}
 
-		return self::$user_custom_post_type_id;
+		return static::$user_custom_post_type_id;
 	}
 
 	/**
@@ -372,14 +372,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return bool
 	 */
 	public static function theme_has_support() {
-		if ( ! isset( self::$theme_has_support ) ) {
-			self::$theme_has_support = (
-				is_readable( self::get_file_path_from_theme( 'theme.json' ) ) ||
-				is_readable( self::get_file_path_from_theme( 'theme.json', true ) )
+		if ( ! isset( static::$theme_has_support ) ) {
+			static::$theme_has_support = (
+				is_readable( static::get_file_path_from_theme( 'theme.json' ) ) ||
+				is_readable( static::get_file_path_from_theme( 'theme.json', true ) )
 			);
 		}
 
-		return self::$theme_has_support;
+		return static::$theme_has_support;
 	}
 
 	/**
@@ -402,12 +402,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * Cleans the cached data so it can be recalculated.
 	 */
 	public static function clean_cached_data() {
-		self::$core                     = null;
-		self::$theme                    = null;
-		self::$user                     = null;
-		self::$user_custom_post_type_id = null;
-		self::$theme_has_support        = null;
-		self::$i18n_schema              = null;
+		static::$core                     = null;
+		static::$theme                    = null;
+		static::$user                     = null;
+		static::$user_custom_post_type_id = null;
+		static::$theme_has_support        = null;
+		static::$i18n_schema              = null;
 	}
 
 }

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php
@@ -102,7 +102,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 */
 	protected static function translate( $theme_json, $domain = 'default' ) {
 		if ( null === static::$i18n_schema ) {
-			$i18n_schema       = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
+			$i18n_schema         = wp_json_file_decode( __DIR__ . '/theme-i18n.json' );
 			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
@@ -119,8 +119,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return static::$core;
 		}
 
-		$config     = static::read_json_file( __DIR__ . '/theme.json' );
-		$config     = static::translate( $config );
+		$config       = static::read_json_file( __DIR__ . '/theme.json' );
+		$config       = static::translate( $config );
 		static::$core = new WP_Theme_JSON_Gutenberg( $config, 'default' );
 
 		return static::$core;
@@ -144,7 +144,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			static::$theme     = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
 			if ( wp_get_theme()->parent() ) {
 				// Get parent theme.json.


### PR DESCRIPTION
A follow-up to https://github.com/WordPress/gutenberg/pull/38625 and https://github.com/WordPress/gutenberg/pull/38671

This makes sure that late static binding work properly, letting child classes to override the protected methods and they'll be called instead of the parent's.

Props to @Mamaduka for bringing this up as something missing while doing the backport at https://github.com/WordPress/wordpress-develop/pull/2322