### PR TITLE
Template Parts: Limit slug to Latin chars

### DIFF
--- a/packages/block-library/src/template-part/edit/utils/hooks.js
+++ b/packages/block-library/src/template-part/edit/utils/hooks.js
@@ -102,13 +102,18 @@ export function useCreateTemplatePartFromBlocks( area, setAttributes ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 
 	return async ( blocks = [], title = __( 'Untitled Template Part' ) ) => {
+		// Currently template parts only allow latin chars.
+		// Fallback slug will receive suffix by default.
+		const cleanSlug =
+			kebabCase( title ).replace( /[^\w-]+/g, '' ) || 'wp-custom-part';
+
 		// If we have `area` set from block attributes, means an exposed
 		// block variation was inserted. So add this prop to the template
 		// part entity on creation. Afterwards remove `area` value from
 		// block attributes.
 		const record = {
 			title,
-			slug: kebabCase( title ),
+			slug: cleanSlug,
 			content: serialize( blocks ),
 			// `area` is filterable on the server and defaults to `UNCATEGORIZED`
 			// if provided value is not allowed.


### PR DESCRIPTION
## Description
Follow-up of #38695 based on this comment https://github.com/WordPress/gutenberg/issues/38160#issuecomment-1040352905

> Currently, templates and template parts don't allow non-Latin characters as a slug.
> This PR tries to "clean" up the slug first, and if this isn't possible, use a fallback slug.

## Testing Instructions
1. Go to Site Editor.
2. Add template part to the page.
3. Click "New template part".
4. Try creating a Template Part using a non-Latin title - `私のテンプレートパーツのテスト` or `ქართული ნაწილი`.
5. Confirm it was successfully created and with a fallback slug.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
