### PR TITLE
Template List: Decode entities in record titles

### DIFF
--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -8,6 +8,7 @@ import {
 	VisuallyHidden,
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -98,8 +99,10 @@ export default function Table( { templateType } ) {
 										postType: template.type,
 									} }
 								>
-									{ template.title?.rendered ||
-										template.slug }
+									{ decodeEntities(
+										template.title?.rendered ||
+											template.slug
+									) }
 								</Link>
 							</Heading>
 							{ template.description }


### PR DESCRIPTION
## Description
It looks like I missed the spot in #38805. This should fix the entity decoding issue for the Template and Template Parts list view.

## Testing Instructions
1. Go to Site Editor.
2. Navigate to Template Parts lists.
3. Create a new template part that contains an apostrophe in the name - `George's Footer`.
4. Check the Template Parts list view, the label is correctly decoded.

## Screenshots <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-02-16 at 21 22 55](https://user-images.githubusercontent.com/240569/154322270-e10934ba-1311-4bc3-8a56-b55a9ff89474.png)|![CleanShot 2022-02-16 at 21 22 33](https://user-images.githubusercontent.com/240569/154322258-d09337cd-d171-4516-ab4d-29c554156539.png)|


## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
