### PR TITLE
canUser resolver: remove fallback for OPTIONS response headers

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, includes, get, hasIn, compact, uniq } from 'lodash';
+import { find, includes, get, compact, uniq } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -296,17 +296,7 @@ export const canUser = ( action, resource, id ) => async ( { dispatch } ) => {
 		return;
 	}
 
-	let allowHeader;
-	if ( hasIn( response, [ 'headers', 'get' ] ) ) {
-		// If the request is fetched using the fetch api, the header can be
-		// retrieved using the 'get' method.
-		allowHeader = response.headers.get( 'allow' );
-	} else {
-		// If the request was preloaded server-side and is returned by the
-		// preloading middleware, the header will be a simple property.
-		allowHeader = get( response, [ 'headers', 'Allow' ], '' );
-	}
-
+	const allowHeader = response.headers.get( 'allow' );
 	const key = compact( [ action, resource, id ] ).join( '/' );
 	const isAllowed = includes( allowHeader, method );
 	dispatch.receiveUserPermission( key, isAllowed );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -312,9 +312,7 @@ describe( 'canUser', () => {
 		} );
 
 		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				Allow: 'GET',
-			},
+			headers: new Map( [ [ 'allow', 'GET' ] ] ),
 		} ) );
 
 		await canUser( 'create', 'media' )( { dispatch } );
@@ -337,9 +335,7 @@ describe( 'canUser', () => {
 		} );
 
 		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				Allow: 'POST, GET, PUT, DELETE',
-			},
+			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
 
 		await canUser( 'create', 'media' )( { dispatch } );
@@ -362,9 +358,7 @@ describe( 'canUser', () => {
 		} );
 
 		triggerFetch.mockImplementation( () => ( {
-			headers: {
-				Allow: 'POST, GET, PUT, DELETE',
-			},
+			headers: new Map( [ [ 'allow', 'POST, GET, PUT, DELETE' ] ] ),
 		} ) );
 
 		await canUser( 'create', 'blocks', 123 )( { dispatch } );


### PR DESCRIPTION
After #38051, `apiFetch( { method: 'OPTIONS', parse: false } )`, always returns a `Response` object with a `Headers` subobject, never a plain JS object, even for preloaded responses. Therefore the `canUser` resolver can call `response.headers.get( 'allow' )` without any checks or fallback for plain objects.

I also had to update unit tests to mock responses in such a way that `headers.get` works. I used `Map` for mocking that, which is not perfect (the lookup is not case-insensitive for example), but to construct a real `Headers` object I would have to use JSDOM environment for the test.