### PR TITLE
wp-env: document some caveats when using xdebug with VSCode

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -203,6 +203,14 @@ wp-env start
 wp-env start --xdebug=profile,trace,debug
 ```
 
+When you're running `wp-env` using `npm run`, like when working in the Gutenberg repo or when having `wp-env` as a local project dependency, don't forget to add an extra dash before the `--xdebug` command:
+
+```sh
+npm run wp-env start -- --xdebug
+```
+
+If you forget about that, the `--xdebug` parameter will be passed to NPM instead of the `wp-env start` command and it will be ignored.
+
 You can see a reference on each of the Xdebug modes and what they do in the [Xdebug documentation](https://xdebug.org/docs/all_settings#mode).
 
 _Since we are only installing Xdebug 3, Xdebug is only supported for PHP versions greater than or equal to 7.2 (the default). Xdebug won't be installed if `phpVersion` is set to a legacy version._
@@ -224,6 +232,8 @@ You should only have to translate `port` and `pathMappings` to the format used b
 	}
 }
 ```
+
+After you create a `.vscode/launch.json` file in your repository, you probably want to add it to your [global gitignore file](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files#configuring-ignored-files-for-all-repositories-on-your-computer) so that it stays private for you and is not committed to the repository.
 
 Once your IDEs Xdebug settings have been enabled, you should just have to launch the debugger, put a breakpoint on any line of PHP code, and then refresh your browser!
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -51,7 +51,7 @@ Then modify your package.json and add an extra command to npm `scripts` (https:/
 When installing `wp-env` in this way, all `wp-env` commands detailed in these docs must be prefixed with `npm run`, for example:
 
 ```sh
-# You must add another dash to pass the "update" flag to wp-env
+# You must add another double dash to pass the "update" flag to wp-env
 $ npm run wp-env start -- --update
 ```
 
@@ -203,7 +203,7 @@ wp-env start
 wp-env start --xdebug=profile,trace,debug
 ```
 
-When you're running `wp-env` using `npm run`, like when working in the Gutenberg repo or when having `wp-env` as a local project dependency, don't forget to add an extra dash before the `--xdebug` command:
+When you're running `wp-env` using `npm run`, like when working in the Gutenberg repo or when having `wp-env` as a local project dependency, don't forget to add an extra double dash before the `--xdebug` command:
 
 ```sh
 npm run wp-env start -- --xdebug


### PR DESCRIPTION
After setting up XDebug debugging in my `wp-env` container with VSCode, I have two little improvements to offer:
- add the `.vscode/launch.json` to git ignore. It's a private file that shouldn't be under version control. Only the `launch-example.json` example file is.
- add note about passing the `--xdebug` parameter to `npm run wp-env start` to the `wp-env` README. It's a mistake that cost me a lot of time 🙂 