### PR TITLE
[Inserter]: Fix focus loss after closing patterns explorer from modal

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab.js
@@ -144,23 +144,19 @@ function BlockPatternsTabs( {
 
 	return (
 		<>
+			<PatternInserterPanel
+				selectedCategory={ patternCategory }
+				patternCategories={ populatedCategories }
+				onClickCategory={ onClickCategory }
+				openPatternExplorer={ () => setShowPatternsExplorer( true ) }
+			/>
 			{ ! showPatternsExplorer && (
-				<>
-					<PatternInserterPanel
-						selectedCategory={ patternCategory }
-						patternCategories={ populatedCategories }
-						onClickCategory={ onClickCategory }
-						openPatternExplorer={ () =>
-							setShowPatternsExplorer( true )
-						}
-					/>
-					<BlockPatternsCategory
-						rootClientId={ rootClientId }
-						onInsert={ onInsert }
-						selectedCategory={ patternCategory }
-						populatedCategories={ populatedCategories }
-					/>
-				</>
+				<BlockPatternsCategory
+					rootClientId={ rootClientId }
+					onInsert={ onInsert }
+					selectedCategory={ patternCategory }
+					populatedCategories={ populatedCategories }
+				/>
 			) }
 			{ showPatternsExplorer && (
 				<PatternsExplorerModal


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/38877

As @talldan explains the issue was:
>You can see that when the explore modal is open, the sidebar in the background has no contents (if your browser window is wide enough), so this is no doubt why focus isn't transferred back—there's no element to return focus to.

### Testing instructions

1. Open the main inserter
1. Open the patterns explorer in `patterns` tab (`explore` button)
1. Close the explorer modal from the `close` (x) button
2. Close the main inserter with the `x` button
3. Observe that now it closes as there is no focus loss

https://user-images.githubusercontent.com/16275880/154482406-74442584-341c-46ac-ab7a-b0b43a35a78d.mov


