### PR TITLE
Block Editor: `insertDefaultBlock` should not trigger an error if the default block is not registered

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1208,11 +1208,7 @@ _Parameters_
 
 -   _attributes_ `?Object`: Optional attributes of the block to assign.
 -   _rootClientId_ `?string`: Optional root client ID of block list on which to append.
--   _index_ `?number`: Optional index where to insert the default block
-
-_Returns_
-
--   `Object`: Action object
+-   _index_ `?number`: Optional index where to insert the default block.
 
 ### mergeBlocks
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -996,11 +996,11 @@ export function selectionChange(
  * @param {?Object} attributes   Optional attributes of the block to assign.
  * @param {?string} rootClientId Optional root client ID of block list on which
  *                               to append.
- * @param {?number} index        Optional index where to insert the default block
- *
- * @return {Object} Action object
+ * @param {?number} index        Optional index where to insert the default block.
  */
-export function insertDefaultBlock( attributes, rootClientId, index ) {
+export const insertDefaultBlock = ( attributes, rootClientId, index ) => ( {
+	dispatch,
+} ) => {
 	// Abort if there is no default block type (if it has been unregistered).
 	const defaultBlockName = getDefaultBlockName();
 	if ( ! defaultBlockName ) {
@@ -1009,8 +1009,8 @@ export function insertDefaultBlock( attributes, rootClientId, index ) {
 
 	const block = createBlock( defaultBlockName, attributes );
 
-	return insertBlock( block, index, rootClientId );
-}
+	return dispatch.insertBlock( block, index, rootClientId );
+};
 
 /**
  * Action that changes the nested settings of a given block.


### PR DESCRIPTION
## Description
When the default block isn't registered the `insertDefaultBlock` triggers the following Redux error:

```
Error: Actions must be plain objects. Instead, the actual type was: 'undefined'.
```

## Testing Instructions
Running this e2e test shouldn't print the error above - `npm run test-e2e -- packages/e2e-tests/specs/editor/various/block-deletion.test.js`

1. Create a post.
2. De-register the default block by running this snippet in console: `wp.data.dispatch('core/blocks').removeBlockTypes('core/paragraph');`
3. In post title field press Enter.
4. This shouldn't trigger an error.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
