### PR TITLE
[Code Quality - Cover]: Remove unnecessary `temporaryMinHeight`

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -309,6 +309,7 @@ function CoverEdit( {
 	overlayColor,
 	setAttributes,
 	setOverlayColor,
+	toggleSelection,
 } ) {
 	const {
 		contentPosition,
@@ -327,10 +328,9 @@ function CoverEdit( {
 		allowedBlocks,
 		templateLock,
 	} = attributes;
-	const {
-		toggleSelection,
-		__unstableMarkNextChangeAsNotPersistent,
-	} = useDispatch( blockEditorStore );
+	const { __unstableMarkNextChangeAsNotPersistent } = useDispatch(
+		blockEditorStore
+	);
 	const {
 		gradientClass,
 		gradientValue,

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -27,7 +27,7 @@ import {
 	__experimentalBoxControl as BoxControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
-import { compose, withInstanceId, useInstanceId } from '@wordpress/compose';
+import { compose, useInstanceId } from '@wordpress/compose';
 import {
 	BlockControls,
 	BlockIcon,
@@ -47,7 +47,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { withDispatch, useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { cover as icon } from '@wordpress/icons';
 import { isBlobURL } from '@wordpress/blob';
 
@@ -309,8 +309,6 @@ function CoverEdit( {
 	overlayColor,
 	setAttributes,
 	setOverlayColor,
-	toggleSelection,
-	markNextChangeAsNotPersistent,
 } ) {
 	const {
 		contentPosition,
@@ -329,6 +327,10 @@ function CoverEdit( {
 		allowedBlocks,
 		templateLock,
 	} = attributes;
+	const {
+		toggleSelection,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 	const {
 		gradientClass,
 		gradientValue,
@@ -393,14 +395,12 @@ function CoverEdit( {
 
 	useEffect( () => {
 		// This side-effect should not create an undo level.
-		markNextChangeAsNotPersistent();
+		__unstableMarkNextChangeAsNotPersistent();
 		setAttributes( { isDark: isCoverDark } );
 	}, [ isCoverDark ] );
 
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
-
-	const [ temporaryMinHeight, setTemporaryMinHeight ] = useState( null );
 
 	const minHeightWithUnit = minHeightUnit
 		? `${ minHeight }${ minHeightUnit }`
@@ -412,7 +412,7 @@ function CoverEdit( {
 		...( isImageBackground && ! isImgElement
 			? backgroundImageStyles( url )
 			: undefined ),
-		minHeight: temporaryMinHeight || minHeightWithUnit || undefined,
+		minHeight: minHeightWithUnit || undefined,
 	};
 
 	const bgStyle = { backgroundColor: overlayColor.color };
@@ -593,7 +593,7 @@ function CoverEdit( {
 					panelId={ clientId }
 				>
 					<CoverHeightInput
-						value={ temporaryMinHeight || minHeight }
+						value={ minHeight }
 						unit={ minHeightUnit }
 						onChange={ ( newMinHeight ) =>
 							setAttributes( { minHeight: newMinHeight } )
@@ -646,10 +646,7 @@ function CoverEdit( {
 						onSelectMedia={ onSelectMedia }
 						noticeOperations={ noticeOperations }
 						style={ {
-							minHeight:
-								temporaryMinHeight ||
-								minHeightWithUnit ||
-								undefined,
+							minHeight: minHeightWithUnit || undefined,
 						} }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
@@ -667,11 +664,12 @@ function CoverEdit( {
 							setAttributes( { minHeightUnit: 'px' } );
 							toggleSelection( false );
 						} }
-						onResize={ setTemporaryMinHeight }
+						onResize={ ( value ) => {
+							setAttributes( { minHeight: value } );
+						} }
 						onResizeStop={ ( newMinHeight ) => {
 							toggleSelection( true );
 							setAttributes( { minHeight: newMinHeight } );
-							setTemporaryMinHeight( null );
 						} }
 						showHandle={ isSelected }
 					/>
@@ -714,11 +712,12 @@ function CoverEdit( {
 						setAttributes( { minHeightUnit: 'px' } );
 						toggleSelection( false );
 					} }
-					onResize={ setTemporaryMinHeight }
+					onResize={ ( value ) => {
+						setAttributes( { minHeight: value } );
+					} }
 					onResizeStop={ ( newMinHeight ) => {
 						toggleSelection( true );
 						setAttributes( { minHeight: newMinHeight } );
-						setTemporaryMinHeight( null );
 					} }
 					showHandle={ isSelected }
 				/>
@@ -777,18 +776,6 @@ function CoverEdit( {
 }
 
 export default compose( [
-	withDispatch( ( dispatch ) => {
-		const {
-			toggleSelection,
-			__unstableMarkNextChangeAsNotPersistent,
-		} = dispatch( blockEditorStore );
-
-		return {
-			toggleSelection,
-			markNextChangeAsNotPersistent: __unstableMarkNextChangeAsNotPersistent,
-		};
-	} ),
 	withColors( { overlayColor: 'background-color' } ),
 	withNotices,
-	withInstanceId,
 ] )( CoverEdit );


### PR DESCRIPTION
While investigating a bug in `Cover` block I saw that besides the 800 lines of the `edit` function that makes it really hard to follow the logic, there are also some weird(to me at least) things that make it even harder.

I think this block needs a bit cleanup and I'm starting with this PR which is intentionally small, to be better tested for regressions.

In this PR I'm removing the usage of `withDispatch` and the unused `withInstanceId`, but most importantly I'm removing an extra variable used for minHeight in various places (`temporaryMinHeight`). I'm guessing this was for not updating the main attribute on resize, in order to not create `undo` levels in history, but that's not the case here, since we don't mark consecutive quick changes of the same block attribute for history in the core data store.

## Testing instructions
Everything in Cover block should work exactly as before for either existing or new Cover blocks.