### PR TITLE
Theme.json `styles` check: port changes from core to Gutenberg

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-5.9/class-wp-rest-global-styles-controller.php
@@ -564,8 +564,10 @@ if ( ! class_exists( 'WP_REST_Global_Styles_Controller' ) ) {
 			}
 
 			if ( rest_is_field_included( 'styles', $fields ) ) {
-				$raw_data       = $theme->get_raw_data();
-				$data['styles'] = isset( $raw_data['styles'] ) ? $raw_data['styles'] : array();
+				$raw_data = $theme->get_raw_data();
+				if ( isset( $raw_data['styles'] ) ) {
+					$data['styles'] = $raw_data['styles'];
+				}
 			}
 
 			$context = ! empty( $request['context'] ) ? $request['context'] : 'view';


### PR DESCRIPTION
There was a minor change in how we check the existence of `styles` in theme.json in `core` here:https://github.com/WordPress/wordpress-develop/commit/d2b385b7b82c092d564cae6d07e1e456c014e558.

This PR ports the change from core to GB.