### PR TITLE
Raise z-index of content div relative to sidebars

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,7 +33,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
-	".interface-interface-skeleton__content": 20,
+	".interface-interface-skeleton__content": 91,
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter


### PR DESCRIPTION
## Description
Adjusts the pinned `z-index` of `interface-interface-skeleton__content` so that it has a value **relative to its sibling elements**:

- `interface-interface-skeleton__sidebar`
- `interface-interface-skeleton__secondary-sidebar`

which are set to `z-index: 90` at medium screens and up.

This change allows popover modals triggered in the block editor content area to appear at a higher z-axis than the sidebars,  `z-index: 91`. From a UX perspective, a modal should be easily accessible and visible given screen size constraints.

Addresses #38723 (and ~#38957~).

## History
Issue #32631 was raised due to a display quirk in iOS Safari, whereby a static `z-index` was applied to `interface-interface-skeleton__body` (the editor's "body" element) via #32732.

In that PR, the editor's "header" (`.interface-interface-skeleton__header`) had `z-index: 30`. Logically, setting the body to a lower index would stack it underneath the header, so it was assigned `z-index: 20`.

During testing, it was found that pinning the editor's body `z-index` caused the buttons at the top of `.interface-interface-skeleton__actions` to be hidden, preventing access to the **Publish** button for new posts. In response, the pin was moved lower in the DOM to the body's "content" div, `.interface-interface-skeleton__content`, updated in #32869.

The result was that the content div was now pinned, *but had sibling elements with a preexisting `z-index` of a higher value*. Since the sidebars were set to `z-index: 90`, the lower value of `20` -- originally meant for the body div -- would mean the content section would always appear "under" the sidebars. This introduced [the issue addressed in this PR](#38723).

## Testing Instructions
Apply the patch to Gutenberg and re-build the plugin. Make sure the plugin is activated.

1. On medium and up screen (tablet, laptop, desktop):
2. Create a new post.
3. Open the **List View** and/or **Settings** sidebar.
4. Enter test paragraph content into the editor.
5. Select text on the extreme left or right of the paragraph, and click the "link" option from the inline toolbar.
6. The Link popover (modal) should activate.
7. Observe that the popover appears "above" either sidebar, and is not hidden. See the before/after screenshots below for examples.

## Screenshots

#### Before Fix
![image](https://user-images.githubusercontent.com/824344/154562201-b965b837-c089-459f-9e86-fcb8ec835a3c.png)

#### After Fix
![image](https://user-images.githubusercontent.com/824344/154562274-312f1542-0fbf-4925-af88-d3f98855031d.png)

#### Regression for #32869
![image](https://user-images.githubusercontent.com/824344/154562940-7d369688-38e0-417d-8d5e-521095424c3b.png)
*Actions panel retains priority stacking context (i.e. content appears "under" panel).*

#### Regression for #32732 (tested with Browserstack real device: iPhone 11 Pro)
<img src="https://user-images.githubusercontent.com/824344/154563570-3e93fdd1-d71f-49e9-95fb-4c01e2196da5.png" width="375">

*iOS Safari header bar content remains visible (no bleed from editor content area).*

## Types of changes
Changes the default `z-index` of `.interface-interface-skeleton__content`.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
