### PR TITLE
Style engine: refine `Box` type

### DIFF
--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -3,12 +3,12 @@
  */
 import type { CSSProperties } from 'react';
 
-type BoxVariants = 'margin' | 'padding';
-export type Box< T extends BoxVariants = 'margin' > = {
-	top?: CSSProperties[ `${ T }Top` ];
-	right?: CSSProperties[ `${ T }Right` ];
-	bottom?: CSSProperties[ `${ T }Bottom` ];
-	left?: CSSProperties[ `${ T }Left` ];
+type BoxVariants = 'margin' | 'padding' | undefined;
+export type Box< T extends BoxVariants = undefined > = {
+	top?: CSSProperties[ T extends undefined ? 'top' : `${ T }Top` ];
+	right?: CSSProperties[ T extends undefined ? 'right' : `${ T }Right` ];
+	bottom?: CSSProperties[ T extends undefined ? 'bottom' : `${ T }Bottom` ];
+	left?: CSSProperties[ T extends undefined ? 'left' : `${ T }Left` ];
 };
 
 export interface Style {

--- a/packages/style-engine/src/types.ts
+++ b/packages/style-engine/src/types.ts
@@ -3,17 +3,18 @@
  */
 import type { CSSProperties } from 'react';
 
-export type Box = {
-	top?: CSSProperties[ 'top' ];
-	right?: CSSProperties[ 'right' ];
-	bottom?: CSSProperties[ 'bottom' ];
-	left?: CSSProperties[ 'left' ];
+type BoxVariants = 'margin' | 'padding';
+export type Box< T extends BoxVariants = 'margin' > = {
+	top?: CSSProperties[ `${ T }Top` ];
+	right?: CSSProperties[ `${ T }Right` ];
+	bottom?: CSSProperties[ `${ T }Bottom` ];
+	left?: CSSProperties[ `${ T }Left` ];
 };
 
 export interface Style {
 	spacing?: {
-		margin?: CSSProperties[ 'margin' ] | Box;
-		padding?: CSSProperties[ 'padding' ] | Box;
+		margin?: CSSProperties[ 'margin' ] | Box< 'margin' >;
+		padding?: CSSProperties[ 'padding' ] | Box< 'padding' >;
 	};
 	typography?: {
 		fontSize?: CSSProperties[ 'fontSize' ];


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Follow-up to [this conversation](https://github.com/WordPress/gutenberg/pull/37978#discussion_r803713414), this PR proposes a more advanced type for `Box` which is closer to the actual values that `Box` is going to assume.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
