### PR TITLE
Backport from core: Global styles duotone not rendering in post editor

### DIFF
--- a/lib/compat/wordpress-5.9/render-svg-filters.php
+++ b/lib/compat/wordpress-5.9/render-svg-filters.php
@@ -19,7 +19,7 @@ if ( ! function_exists( 'wp_global_styles_render_svg_filters' ) ) {
 	 * but it should be rendered before the filtered content
 	 * in the body to satisfy Safari's rendering quirks.
 	 */
-	function gutenberg_experimental_global_styles_render_svg_filters() {
+	function wp_global_styles_render_svg_filters() {
 		/*
 		 * When calling via the in_admin_header action, we only want to render the
 		 * SVGs on block editor pages.
@@ -39,10 +39,10 @@ if ( ! function_exists( 'wp_global_styles_render_svg_filters' ) ) {
 
 	add_action(
 		'wp_body_open',
-		'gutenberg_experimental_global_styles_render_svg_filters'
+		'wp_global_styles_render_svg_filters'
 	);
 	add_action(
 		'in_admin_header',
-		'gutenberg_experimental_global_styles_render_svg_filters'
+		'wp_global_styles_render_svg_filters'
 	);
 }

--- a/lib/compat/wordpress-5.9/render-svg-filters.php
+++ b/lib/compat/wordpress-5.9/render-svg-filters.php
@@ -5,22 +5,44 @@
  * @package gutenberg
  */
 
-/**
- * Render the SVG filters supplied by theme.json.
- *
- * Note that this doesn't render the per-block user-defined
- * filters which are handled by duotone.php, but it should
- * be rendered in the same location as those to satisfy
- * Safari's rendering quirks.
+/*
+ * If wp_global_styles_render_svg_filters is defined, it means the plugin
+ * is running on WordPress 5.9.1, so don't need to render the global styles
+ * SVG filters as it was already done by WordPress core.
  */
-function gutenberg_experimental_global_styles_render_svg_filters() {
-	$filters = wp_get_global_styles_svg_filters();
-	if ( ! empty( $filters ) ) {
-		echo $filters;
-	}
-}
+if ( ! function_exists( 'wp_global_styles_render_svg_filters' ) ) {
+	/**
+	 * Render the SVG filters supplied by theme.json.
+	 *
+	 * Note that this doesn't render the per-block user-defined
+	 * filters which are handled by wp_render_duotone_support,
+	 * but it should be rendered before the filtered content
+	 * in the body to satisfy Safari's rendering quirks.
+	 */
+	function gutenberg_experimental_global_styles_render_svg_filters() {
+		/*
+		 * When calling via the in_admin_header action, we only want to render the
+		 * SVGs on block editor pages.
+		 */
+		if (
+			is_admin() &&
+			! get_current_screen()->is_block_editor()
+		) {
+			return;
+		}
 
-add_action(
-	'wp_body_open',
-	'gutenberg_experimental_global_styles_render_svg_filters'
-);
+		$filters = wp_get_global_styles_svg_filters();
+		if ( ! empty( $filters ) ) {
+			echo $filters;
+		}
+	}
+
+	add_action(
+		'wp_body_open',
+		'gutenberg_experimental_global_styles_render_svg_filters'
+	);
+	add_action(
+		'in_admin_header',
+		'gutenberg_experimental_global_styles_render_svg_filters'
+	);
+}


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Backport the changes from [changeset/52768](https://core.trac.wordpress.org/changeset/52768). As part of the 5.9.1-RC1 release, these changes were made to core.

In addition, since core is loading the global duotone SVG filters, they can be skipped in the plugin if running with WP 5.9.1 or later.

## Testing

Using wordpress-develop 5.9.0 and 5.9.1-RC1.

Using a theme that uses global duotone styles such as Skatepark or Twenty Twenty-Two with the following added to the theme.json

```json
{
    "styles": {
        "blocks": {
            "core/image": {
                "filter": {
                    "duotone": "var(--wp--preset--duotone--primary-and-secondary)"
                }
            }
        }
    }
}
```

Check that the global duotones are applied to images in the post editor without manually adding them via the block interface. And check that there are no duplicate SVGs generated (ex. `#wp-duotone-dark-grayscale`).

## Screenshots 

<img width="1024" alt="Duotone image in the Skatepark theme post editor" src="https://user-images.githubusercontent.com/5129775/154590334-c4893771-459b-42d4-ab50-2d2c069d5d96.png">

