### PR TITLE
Editor: Adds additional check to guard against incompete presets.

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -1030,7 +1030,7 @@ class WP_Theme_JSON_5_9 {
 				$slug = _wp_to_kebab_case( $preset['slug'] );
 
 				$value = '';
-				if ( isset( $preset_metadata['value_key'] ) ) {
+				if ( isset( $preset_metadata['value_key'], $preset[ $preset_metadata['value_key'] ] ) ) {
 					$value_key = $preset_metadata['value_key'];
 					$value     = $preset[ $value_key ];
 				} elseif (
@@ -1745,7 +1745,7 @@ class WP_Theme_JSON_5_9 {
 						sanitize_html_class( $preset['slug'] ) === $preset['slug']
 					) {
 						$value = null;
-						if ( isset( $preset_metadata['value_key'] ) ) {
+						if ( isset( $preset_metadata['value_key'], $preset[ $preset_metadata['value_key'] ] ) ) {
 							$value = $preset[ $preset_metadata['value_key'] ];
 						} elseif (
 							isset( $preset_metadata['value_func'] ) &&


### PR DESCRIPTION
## Description
﻿
* Related Core ticket: https://core.trac.wordpress.org/ticket/55161
* Related Core commit for 5.9.1: https://core.trac.wordpress.org/changeset/52764

In some scenarios, especially on sites that started experimenting with Full Site Editing with the Gutenberg plugin when the feature was still under development, and then switched to WordPress 5.9, one may run into the following warning on the frontend, when using a block-based theme:

```
Warning: Undefined array key "fontFamily" in /wp-includes/class-wp-theme-json.php on line 1093
```

I believe the attached patch should get rid of the warning.

For reference, the warning was the following when using the Gutenberg plugin:

```
Warning: Undefined array key "fontFamily" in /wp-content/plugins/gutenberg/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php
```

## Testing Instructions

To test this, you would need to start from a site running WordPress 5.8.x with an old version of Gutenberg and an older block theme, and then update to a more recent version of Gutenberg.

## Types of changes

* Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
