### PR TITLE
Improve Nav block loading and placeholder states

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -231,8 +231,23 @@ function Navigation( {
 		clientId
 	);
 
+	// The standard HTML5 tag for the block wrapper.
+	const TagName = 'nav';
+
+	// "placeholder" shown if:
+	// - we don't have a ref attribute pointing to a Navigation Post.
+	// - we don't have uncontrolled blocks.
+	// - (legacy) we have a Navigation Area without a ref attribute pointing to a Navigation Post.
+	const isPlaceholder =
+		! ref && ( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
+
 	const isEntityAvailable =
 		! isNavigationMenuMissing && isNavigationMenuResolved;
+
+	// "loading" state:
+	// - there is a ref attribute pointing to a Navigation Post
+	// - the Navigation Post isn't available (hasn't resolved) yet.
+	const isLoading = !! ( ref && ! isEntityAvailable );
 
 	const blockProps = useBlockProps( {
 		ref: navRef,
@@ -294,20 +309,6 @@ function Navigation( {
 		setDetectedOverlayBackgroundColor,
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
-
-	const TagName = 'nav';
-
-	// "placeholder" shown if:
-	// - we don't have a ref attribute pointing to a Navigation Post.
-	// - we don't have uncontrolled blocks.
-	// - (legacy) we have a Navigation Area without a ref attribute pointing to a Navigation Post.
-	const isPlaceholderShown =
-		! ref && ( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
-
-	// "loading" state:
-	// - there is a ref attribute pointing to a Navigation Post
-	// - the Navigation Post hasn't resolved yet.
-	const isLoading = !! ( ref && ! isEntityAvailable );
 
 	// Spacer block needs orientation from context. This is a patch until
 	// https://github.com/WordPress/gutenberg/issues/36197 is addressed.
@@ -478,7 +479,7 @@ function Navigation( {
 		{ open: overlayMenuPreview }
 	);
 
-	if ( isPlaceholderShown ) {
+	if ( isPlaceholder ) {
 		return (
 			<TagName { ...blockProps }>
 				<PlaceholderComponent
@@ -679,9 +680,9 @@ function Navigation( {
 					</TagName>
 				) }
 
-				{ ! isLoading && ! isPlaceholderShown && (
+				{ ! isLoading && ! isPlaceholder && (
 					<TagName { ...blockProps }>
-						{ ! isPlaceholderShown && (
+						{ ! isPlaceholder && (
 							<ResponsiveWrapper
 								id={ clientId }
 								onToggle={ setResponsiveMenuVisibility }

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -680,31 +680,29 @@ function Navigation( {
 					</TagName>
 				) }
 
-				{ ! isLoading && ! isPlaceholder && (
+				{ ! isLoading && (
 					<TagName { ...blockProps }>
-						{ ! isPlaceholder && (
-							<ResponsiveWrapper
-								id={ clientId }
-								onToggle={ setResponsiveMenuVisibility }
-								label={ __( 'Menu' ) }
-								hasIcon={ hasIcon }
-								isOpen={ isResponsiveMenuOpen }
-								isResponsive={ isResponsive }
-								isHiddenByDefault={ 'always' === overlayMenu }
-								classNames={ overlayClassnames }
-								styles={ overlayStyles }
-							>
-								{ isEntityAvailable && (
-									<NavigationInnerBlocks
-										clientId={ clientId }
-										hasCustomPlaceholder={
-											!! CustomPlaceholder
-										}
-										orientation={ orientation }
-									/>
-								) }
-							</ResponsiveWrapper>
-						) }
+						<ResponsiveWrapper
+							id={ clientId }
+							onToggle={ setResponsiveMenuVisibility }
+							label={ __( 'Menu' ) }
+							hasIcon={ hasIcon }
+							isOpen={ isResponsiveMenuOpen }
+							isResponsive={ isResponsive }
+							isHiddenByDefault={ 'always' === overlayMenu }
+							classNames={ overlayClassnames }
+							styles={ overlayStyles }
+						>
+							{ isEntityAvailable && (
+								<NavigationInnerBlocks
+									clientId={ clientId }
+									hasCustomPlaceholder={
+										!! CustomPlaceholder
+									}
+									orientation={ orientation }
+								/>
+							) }
+						</ResponsiveWrapper>
 					</TagName>
 				) }
 			</RecursionProvider>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -296,11 +296,11 @@ function Navigation( {
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
 	// "placeholder" shown if:
+	// - we don't have a ref attribute pointing to a Navigation Post.
 	// - we don't have uncontrolled blocks.
 	// - (legacy) we have a Navigation Area without a ref attribute pointing to a Navigation Post.
-	// - we don't have a ref attribute pointing to a Navigation Post.
 	const isPlaceholderShown =
-		!! ( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea ) && ! ref;
+		! ref && ( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
 
 	// "loading" state:
 	// - there is a ref attribute pointing to a Navigation Post

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -295,6 +295,8 @@ function Navigation( {
 	] = useState();
 	const [ detectedOverlayColor, setDetectedOverlayColor ] = useState();
 
+	const TagName = 'nav';
+
 	// "placeholder" shown if:
 	// - we don't have a ref attribute pointing to a Navigation Post.
 	// - we don't have uncontrolled blocks.
@@ -407,7 +409,7 @@ function Navigation( {
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 	if ( hasUnsavedBlocks ) {
 		return (
-			<nav { ...blockProps }>
+			<TagName { ...blockProps }>
 				<ResponsiveWrapper
 					id={ clientId }
 					onToggle={ setResponsiveMenuVisibility }
@@ -434,7 +436,7 @@ function Navigation( {
 						} }
 					/>
 				</ResponsiveWrapper>
-			</nav>
+			</TagName>
 		);
 	}
 
@@ -476,17 +478,9 @@ function Navigation( {
 		{ open: overlayMenuPreview }
 	);
 
-	if ( isLoading ) {
-		return (
-			<nav { ...blockProps }>
-				<Spinner className="wp-block-navigation__loading-indicator" />
-			</nav>
-		);
-	}
-
 	if ( isPlaceholderShown ) {
 		return (
-			<nav { ...blockProps }>
+			<TagName { ...blockProps }>
 				<PlaceholderComponent
 					isSelected={ isSelected }
 					currentMenuId={ ref }
@@ -502,7 +496,7 @@ function Navigation( {
 						selectBlock( clientId );
 					} }
 				/>
-			</nav>
+			</TagName>
 		);
 	}
 
@@ -678,31 +672,40 @@ function Navigation( {
 							) }
 					</InspectorControls>
 				) }
-				<nav { ...blockProps }>
-					{ ! isPlaceholderShown && (
-						<ResponsiveWrapper
-							id={ clientId }
-							onToggle={ setResponsiveMenuVisibility }
-							label={ __( 'Menu' ) }
-							hasIcon={ hasIcon }
-							isOpen={ isResponsiveMenuOpen }
-							isResponsive={ isResponsive }
-							isHiddenByDefault={ 'always' === overlayMenu }
-							classNames={ overlayClassnames }
-							styles={ overlayStyles }
-						>
-							{ isEntityAvailable && (
-								<NavigationInnerBlocks
-									clientId={ clientId }
-									hasCustomPlaceholder={
-										!! CustomPlaceholder
-									}
-									orientation={ orientation }
-								/>
-							) }
-						</ResponsiveWrapper>
-					) }
-				</nav>
+
+				{ isLoading && (
+					<TagName { ...blockProps }>
+						<Spinner className="wp-block-navigation__loading-indicator" />
+					</TagName>
+				) }
+
+				{ ! isLoading && ! isPlaceholderShown && (
+					<TagName { ...blockProps }>
+						{ ! isPlaceholderShown && (
+							<ResponsiveWrapper
+								id={ clientId }
+								onToggle={ setResponsiveMenuVisibility }
+								label={ __( 'Menu' ) }
+								hasIcon={ hasIcon }
+								isOpen={ isResponsiveMenuOpen }
+								isResponsive={ isResponsive }
+								isHiddenByDefault={ 'always' === overlayMenu }
+								classNames={ overlayClassnames }
+								styles={ overlayStyles }
+							>
+								{ isEntityAvailable && (
+									<NavigationInnerBlocks
+										clientId={ clientId }
+										hasCustomPlaceholder={
+											!! CustomPlaceholder
+										}
+										orientation={ orientation }
+									/>
+								) }
+							</ResponsiveWrapper>
+						) }
+					</TagName>
+				) }
 			</RecursionProvider>
 		</EntityProvider>
 	);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -214,8 +214,6 @@ function Navigation( {
 	const {
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
-		canSwitchNavigationMenu,
-		hasResolvedNavigationMenus,
 		navigationMenus,
 		navigationMenu,
 		canUserUpdateNavigationMenu,
@@ -492,19 +490,18 @@ function Navigation( {
 			<nav { ...blockProps }>
 				<PlaceholderComponent
 					isSelected={ isSelected }
+					currentMenuId={ ref }
+					clientId={ clientId }
+					canUserCreateNavigationMenu={ canUserCreateNavigationMenu }
+					isResolvingCanUserCreateNavigationMenu={
+						isResolvingCanUserCreateNavigationMenu
+					}
 					onFinish={ ( post ) => {
 						if ( post ) {
 							setRef( post.id );
 						}
 						selectBlock( clientId );
 					} }
-					canSwitchNavigationMenu={ canSwitchNavigationMenu }
-					hasResolvedNavigationMenus={ hasResolvedNavigationMenus }
-					clientId={ clientId }
-					canUserCreateNavigationMenu={ canUserCreateNavigationMenu }
-					isResolvingCanUserCreateNavigationMenu={
-						isResolvingCanUserCreateNavigationMenu
-					}
 				/>
 			</nav>
 		);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -172,8 +172,7 @@ function Navigation( {
 			// introduce a selector like `getUncontrolledInnerBlocks`, just in
 			// case `getBlock` is fixed.
 			const _uncontrolledInnerBlocks = getBlock( clientId ).innerBlocks;
-			const _hasUncontrolledInnerBlocks =
-				_uncontrolledInnerBlocks?.length;
+			const _hasUncontrolledInnerBlocks = !! _uncontrolledInnerBlocks?.length;
 			const _controlledInnerBlocks = _hasUncontrolledInnerBlocks
 				? EMPTY_ARRAY
 				: getBlocks( clientId );
@@ -185,7 +184,7 @@ function Navigation( {
 				hasSubmenus: !! innerBlocks.find(
 					( block ) => block.name === 'core/navigation-submenu'
 				),
-				hasUncontrolledInnerBlocks: !! _hasUncontrolledInnerBlocks,
+				hasUncontrolledInnerBlocks: _hasUncontrolledInnerBlocks,
 				uncontrolledInnerBlocks: _uncontrolledInnerBlocks,
 				isInnerBlockSelected: hasSelectedInnerBlock( clientId, true ),
 			};

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -38,7 +38,6 @@ const LAYOUT = {
 };
 
 export default function NavigationInnerBlocks( {
-	isVisible,
 	clientId,
 	hasCustomPlaceholder,
 	orientation,
@@ -98,6 +97,15 @@ export default function NavigationInnerBlocks( {
 
 	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
+	const hasMenuItems = !! blocks?.length;
+
+	// If here is a `ref` attribute pointing to a `wp_navigation` but
+	// that menu has no **items** (i.e. empty) then show a placeholder.
+	// The block must also be selected else the placeholder will display
+	// alongside the appender.
+	const showPlaceholder =
+		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -130,8 +138,7 @@ export default function NavigationInnerBlocks( {
 			// inherit templateLock={ 'all' }.
 			templateLock: false,
 			__experimentalLayout: LAYOUT,
-			placeholder:
-				! isVisible || hasCustomPlaceholder ? undefined : placeholder,
+			placeholder: showPlaceholder ? placeholder : undefined,
 		}
 	);
 

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -95,7 +95,10 @@ export default function NavigationInnerBlocks( {
 		isSelected ||
 		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants );
 
-	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
+	const placeholder = useMemo(
+		() => <PlaceholderPreview isVisible={ true } />,
+		[]
+	);
 
 	const hasMenuItems = !! blocks?.length;
 

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -99,7 +99,7 @@ export default function NavigationInnerBlocks( {
 
 	const hasMenuItems = !! blocks?.length;
 
-	// If here is a `ref` attribute pointing to a `wp_navigation` but
+	// If there is a `ref` attribute pointing to a `wp_navigation` but
 	// that menu has no **items** (i.e. empty) then show a placeholder.
 	// The block must also be selected else the placeholder will display
 	// alongside the appender.

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -95,10 +95,7 @@ export default function NavigationInnerBlocks( {
 		isSelected ||
 		( isImmediateParentOfSelectedBlock && ! selectedBlockHasDescendants );
 
-	const placeholder = useMemo(
-		() => <PlaceholderPreview isVisible={ true } />,
-		[]
-	);
+	const placeholder = useMemo( () => <PlaceholderPreview />, [] );
 
 	const hasMenuItems = !! blocks?.length;
 

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -4,6 +4,7 @@
 import {
 	MenuGroup,
 	MenuItem,
+	MenuItemsChoice,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -41,13 +42,6 @@ export default function NavigationMenuSelector( {
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
-	// Avoid showing any currently active menu in the list of
-	// menus that can be selected.
-	const navigationMenusOmitCurrent =
-		navigationMenus?.filter(
-			( menu ) => ! currentMenuId || menu.id !== currentMenuId
-		) || [];
-
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
 	const onFinishMenuCreation = async (
@@ -69,7 +63,7 @@ export default function NavigationMenuSelector( {
 		onFinishMenuCreation
 	);
 
-	const hasNavigationMenus = !! navigationMenusOmitCurrent?.length;
+	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
 	const showNavigationMenus = !! canSwitchNavigationMenu;
 	const showClassicMenus = !! canUserCreateNavigationMenu;
@@ -99,26 +93,32 @@ export default function NavigationMenuSelector( {
 				<>
 					{ showNavigationMenus && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
-							{ navigationMenusOmitCurrent?.map( ( menu ) => {
-								const label = decodeEntities(
-									menu.title.rendered
-								);
-								return (
-									<MenuItem
-										onClick={ () => {
-											onClose();
-											onSelect( menu );
-										} }
-										key={ menu.id }
-										aria-label={ sprintf(
-											actionLabel,
-											label
-										) }
-									>
-										{ label }
-									</MenuItem>
-								);
-							} ) }
+							<MenuItemsChoice
+								value={ currentMenuId }
+								onSelect={ ( selectedId ) => {
+									onClose();
+									onSelect(
+										navigationMenus.find(
+											( post ) => post.id === selectedId
+										)
+									);
+								} }
+								choices={ navigationMenus.map(
+									( { id, title } ) => {
+										const label = decodeEntities(
+											title.rendered
+										);
+										return {
+											value: id,
+											label,
+											ariaLabel: sprintf(
+												actionLabel,
+												label
+											),
+										};
+									}
+								) }
+							/>
 						</MenuGroup>
 					) }
 					{ showClassicMenus && hasClassicMenus && (

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -43,9 +43,10 @@ export default function NavigationMenuSelector( {
 
 	// Avoid showing any currently active menu in the list of
 	// menus that can be selected.
-	const navigationMenusOmitCurrent = navigationMenus?.filter(
-		( menu ) => ! currentMenuId || menu.id !== currentMenuId
-	);
+	const navigationMenusOmitCurrent =
+		navigationMenus?.filter(
+			( menu ) => ! currentMenuId || menu.id !== currentMenuId
+		) || [];
 
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
@@ -98,7 +99,7 @@ export default function NavigationMenuSelector( {
 				<>
 					{ showNavigationMenus && hasNavigationMenus && (
 						<MenuGroup label={ __( 'Menus' ) }>
-							{ navigationMenusOmitCurrent.map( ( menu ) => {
+							{ navigationMenusOmitCurrent?.map( ( menu ) => {
 								const label = decodeEntities(
 									menu.title.rendered
 								);

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -68,21 +68,23 @@ export default function NavigationMenuSelector( {
 		( _onClose ) => ( selectedId ) => {
 			_onClose();
 			onSelect(
-				navigationMenus.find( ( post ) => post.id === selectedId )
+				navigationMenus?.find( ( post ) => post.id === selectedId )
 			);
 		},
 		[ navigationMenus ]
 	);
 
 	const menuChoices = useMemo( () => {
-		return navigationMenus.map( ( { id, title } ) => {
-			const label = decodeEntities( title.rendered );
-			return {
-				value: id,
-				label,
-				ariaLabel: sprintf( actionLabel, label ),
-			};
-		} );
+		return (
+			navigationMenus?.map( ( { id, title } ) => {
+				const label = decodeEntities( title.rendered );
+				return {
+					value: id,
+					label,
+					ariaLabel: sprintf( actionLabel, label ),
+				};
+			} ) || []
+		);
 	}, [ navigationMenus ] );
 
 	const hasNavigationMenus = !! navigationMenus?.length;
@@ -124,7 +126,7 @@ export default function NavigationMenuSelector( {
 					) }
 					{ showClassicMenus && hasClassicMenus && (
 						<MenuGroup label={ __( 'Classic Menus' ) }>
-							{ classicMenus.map( ( menu ) => {
+							{ classicMenus?.map( ( menu ) => {
 								const label = decodeEntities( menu.name );
 								return (
 									<MenuItem

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -10,6 +10,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
+import { useCallback, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -63,6 +64,27 @@ export default function NavigationMenuSelector( {
 		onFinishMenuCreation
 	);
 
+	const handleSelect = useCallback(
+		( _onClose ) => ( selectedId ) => {
+			_onClose();
+			onSelect(
+				navigationMenus.find( ( post ) => post.id === selectedId )
+			);
+		},
+		[ navigationMenus ]
+	);
+
+	const menuChoices = useMemo( () => {
+		return navigationMenus.map( ( { id, title } ) => {
+			const label = decodeEntities( title.rendered );
+			return {
+				value: id,
+				label,
+				ariaLabel: sprintf( actionLabel, label ),
+			};
+		} );
+	}, [ navigationMenus ] );
+
 	const hasNavigationMenus = !! navigationMenus?.length;
 	const hasClassicMenus = !! classicMenus?.length;
 	const showNavigationMenus = !! canSwitchNavigationMenu;
@@ -95,29 +117,8 @@ export default function NavigationMenuSelector( {
 						<MenuGroup label={ __( 'Menus' ) }>
 							<MenuItemsChoice
 								value={ currentMenuId }
-								onSelect={ ( selectedId ) => {
-									onClose();
-									onSelect(
-										navigationMenus.find(
-											( post ) => post.id === selectedId
-										)
-									);
-								} }
-								choices={ navigationMenus.map(
-									( { id, title } ) => {
-										const label = decodeEntities(
-											title.rendered
-										);
-										return {
-											value: id,
-											label,
-											ariaLabel: sprintf(
-												actionLabel,
-												label
-											),
-										};
-									}
-								) }
+								onSelect={ handleSelect( onClose ) }
+								choices={ menuChoices }
 							/>
 						</MenuGroup>
 					) }

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -48,11 +48,11 @@ export default function NavigationPlaceholder( {
 		}
 
 		if ( isResolvingMenus ) {
-			speak( __( 'Loading Navigation block setup options.' ), 'polite' );
+			speak( __( 'Loading Navigation block setup options.' ) );
 		}
 
 		if ( hasResolvedMenus ) {
-			speak( __( 'Navigation block setup options ready.' ), 'polite' );
+			speak( __( 'Navigation block setup options ready.' ) );
 		}
 	}, [ isResolvingMenus, isSelected ] );
 

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -16,12 +16,12 @@ import useCreateNavigationMenu from '../use-create-navigation-menu';
 import NavigationMenuSelector from '../navigation-menu-selector';
 
 export default function NavigationPlaceholder( {
-	currentMenuId,
 	isSelected,
+	currentMenuId,
 	clientId,
-	onFinish,
 	canUserCreateNavigationMenu = false,
 	isResolvingCanUserCreateNavigationMenu,
+	onFinish,
 } ) {
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
@@ -36,11 +36,7 @@ export default function NavigationPlaceholder( {
 		onFinish( navigationMenu, blocks );
 	};
 
-	const {
-		hasMenus,
-		isResolvingMenus,
-		hasResolvedMenus,
-	} = useNavigationEntities();
+	const { isResolvingMenus, hasResolvedMenus } = useNavigationEntities();
 
 	const onCreateEmptyMenu = () => {
 		onFinishMenuCreation( [] );

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -48,17 +48,11 @@ export default function NavigationPlaceholder( {
 		}
 
 		if ( isResolvingMenus ) {
-			speak(
-				__( 'Loading Navigation block setup placeholder options.' ),
-				'polite'
-			);
+			speak( __( 'Loading Navigation block setup options.' ), 'polite' );
 		}
 
 		if ( hasResolvedMenus ) {
-			speak(
-				__( 'Navigation block setup placeholder options ready.' ),
-				'polite'
-			);
+			speak( __( 'Navigation block setup options ready.' ), 'polite' );
 		}
 	}, [ isResolvingMenus, isSelected ] );
 

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -75,7 +75,7 @@ export default function NavigationPlaceholder( {
 				 }
 				<PlaceholderPreview isVisible={ ! isSelected } />
 				<div
-					aria-hidden={ ! isSelected }
+					aria-hidden={ ! isSelected ? true : undefined }
 					className="wp-block-navigation-placeholder__controls"
 				>
 					<div className="wp-block-navigation-placeholder__actions">

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -1,14 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { Placeholder, Button } from '@wordpress/components';
+import { Placeholder, Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { navigation, Icon } from '@wordpress/icons';
+import { speak } from '@wordpress/a11y';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
 import useCreateNavigationMenu from '../use-create-navigation-menu';
@@ -16,10 +17,11 @@ import NavigationMenuSelector from '../navigation-menu-selector';
 
 export default function NavigationPlaceholder( {
 	currentMenuId,
+	isSelected,
 	clientId,
 	onFinish,
-	hasResolvedNavigationMenus,
 	canUserCreateNavigationMenu = false,
+	isResolvingCanUserCreateNavigationMenu,
 } ) {
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
@@ -27,10 +29,6 @@ export default function NavigationPlaceholder( {
 		blocks,
 		navigationMenuTitle = null
 	) => {
-		if ( ! canUserCreateNavigationMenu ) {
-			return;
-		}
-
 		const navigationMenu = await createNavigationMenu(
 			navigationMenuTitle,
 			blocks
@@ -38,57 +36,86 @@ export default function NavigationPlaceholder( {
 		onFinish( navigationMenu, blocks );
 	};
 
-	const { isResolvingPages, isResolvingMenus } = useNavigationEntities();
-
-	const isStillLoading = isResolvingPages || isResolvingMenus;
+	const {
+		hasMenus,
+		isResolvingMenus,
+		hasResolvedMenus,
+	} = useNavigationEntities();
 
 	const onCreateEmptyMenu = () => {
 		onFinishMenuCreation( [] );
 	};
 
+	useEffect( () => {
+		if ( ! isSelected ) {
+			return;
+		}
+
+		if ( isResolvingMenus ) {
+			speak(
+				'Loading Navigation block setup placeholder options.',
+				'polite'
+			);
+		}
+
+		if ( hasResolvedMenus ) {
+			speak(
+				'Navigation block setup placeholder options ready.',
+				'polite'
+			);
+		}
+	}, [ isResolvingMenus, isSelected ] );
+
+	const isResolvingActions =
+		isResolvingMenus && isResolvingCanUserCreateNavigationMenu;
+
 	return (
 		<>
-			{ ( ! hasResolvedNavigationMenus || isStillLoading ) && (
-				<PlaceholderPreview isLoading />
-			) }
-			{ hasResolvedNavigationMenus && ! isStillLoading && (
-				<Placeholder className="wp-block-navigation-placeholder">
-					<PlaceholderPreview />
-					<div className="wp-block-navigation-placeholder__controls">
-						<div className="wp-block-navigation-placeholder__actions">
-							<div className="wp-block-navigation-placeholder__actions__indicator">
-								<Icon icon={ navigation } />{ ' ' }
-								{ __( 'Navigation' ) }
-							</div>
-
-							<hr />
-
-							<NavigationMenuSelector
-								currentMenuId={ currentMenuId }
-								clientId={ clientId }
-								onSelect={ onFinish }
-								toggleProps={ {
-									variant: 'tertiary',
-									iconPosition: 'right',
-									className:
-										'wp-block-navigation-placeholder__actions__dropdown',
-								} }
-							/>
-
-							<hr />
-
-							{ canUserCreateNavigationMenu && (
-								<Button
-									variant="tertiary"
-									onClick={ onCreateEmptyMenu }
-								>
-									{ __( 'Start empty' ) }
-								</Button>
-							) }
+			<Placeholder className="wp-block-navigation-placeholder">
+				{
+					// The <PlaceholderPreview> component is displayed conditionally via CSS depending on
+					// whether the block is selected or not. This is achieved via CSS to avoid
+					// component re-renders
+				 }
+				<PlaceholderPreview isVisible={ ! isSelected } />
+				<div
+					aria-hidden={ ! isSelected }
+					className="wp-block-navigation-placeholder__controls"
+				>
+					<div className="wp-block-navigation-placeholder__actions">
+						<div className="wp-block-navigation-placeholder__actions__indicator">
+							<Icon icon={ navigation } /> { __( 'Navigation' ) }
 						</div>
+
+						<hr />
+
+						{ isResolvingActions && <Spinner /> }
+
+						<NavigationMenuSelector
+							currentMenuId={ currentMenuId }
+							clientId={ clientId }
+							onSelect={ onFinish }
+							toggleProps={ {
+								variant: 'tertiary',
+								iconPosition: 'right',
+								className:
+									'wp-block-navigation-placeholder__actions__dropdown',
+							} }
+						/>
+
+						<hr />
+
+						{ canUserCreateNavigationMenu && (
+							<Button
+								variant="tertiary"
+								onClick={ onCreateEmptyMenu }
+							>
+								{ __( 'Start empty' ) }
+							</Button>
+						) }
 					</div>
-				</Placeholder>
-			) }
+				</div>
+			</Placeholder>
 		</>
 	);
 }

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -49,14 +49,14 @@ export default function NavigationPlaceholder( {
 
 		if ( isResolvingMenus ) {
 			speak(
-				'Loading Navigation block setup placeholder options.',
+				__( 'Loading Navigation block setup placeholder options.' ),
 				'polite'
 			);
 		}
 
 		if ( hasResolvedMenus ) {
 			speak(
-				'Navigation block setup placeholder options ready.',
+				__( 'Navigation block setup placeholder options ready.' ),
 				'polite'
 			);
 		}

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Icon, navigation } from '@wordpress/icons';
@@ -13,9 +8,7 @@ const PlaceholderPreview = ( { isVisible } ) => {
 	return (
 		<div
 			aria-hidden={ ! isVisible }
-			className={ classnames(
-				'wp-block-navigation-placeholder__preview'
-			) }
+			className="wp-block-navigation-placeholder__preview"
 		>
 			<div className="wp-block-navigation-placeholder__actions__indicator">
 				<Icon icon={ navigation } />

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -9,12 +9,12 @@ import classnames from 'classnames';
 import { Icon, navigation } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-const PlaceholderPreview = ( { isLoading } ) => {
+const PlaceholderPreview = ( { isVisible } ) => {
 	return (
 		<div
+			aria-hidden={ ! isVisible }
 			className={ classnames(
-				'wp-block-navigation-placeholder__preview',
-				{ 'is-loading': isLoading }
+				'wp-block-navigation-placeholder__preview'
 			) }
 		>
 			<div className="wp-block-navigation-placeholder__actions__indicator">

--- a/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
+++ b/packages/block-library/src/navigation/edit/placeholder/placeholder-preview.js
@@ -4,10 +4,10 @@
 import { Icon, navigation } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
-const PlaceholderPreview = ( { isVisible } ) => {
+const PlaceholderPreview = ( { isVisible = true } ) => {
 	return (
 		<div
-			aria-hidden={ ! isVisible }
+			aria-hidden={ ! isVisible ? true : undefined }
 			className="wp-block-navigation-placeholder__preview"
 		>
 			<div className="wp-block-navigation-placeholder__actions__indicator">

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -261,6 +261,10 @@ $color-control-label-height: 20px;
 	}
 }
 
+.wp-block-navigation-placeholder .components-spinner {
+	margin-top: 0;
+}
+
 // Unselected state.
 .wp-block-navigation-placeholder__preview {
 	display: flex;

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -561,6 +561,12 @@ body.editor-styles-wrapper
 	}
 }
 
+// Space spinner to give it breathing
+// room when block is selected and has focus outline.
+.wp-block-navigation .components-spinner {
+	padding: $grid-unit-10 $grid-unit-15;
+}
+
 .wp-block-navigation__unsaved-changes {
 	position: relative;
 

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -12,6 +12,7 @@ export default function useNavigationMenu( ref ) {
 				getEditedEntityRecord,
 				getEntityRecords,
 				hasFinishedResolution,
+				isResolving,
 				canUser,
 			} = select( coreStore );
 
@@ -80,6 +81,10 @@ export default function useNavigationMenu( ref ) {
 					[ 'delete', 'navigation', ref ]
 				),
 				canUserCreateNavigationMenu: canUser( 'create', 'navigation' ),
+				isResolvingCanUserCreateNavigationMenu: isResolving(
+					'canUser',
+					[ 'create', 'navigation' ]
+				),
 				hasResolvedCanUserCreateNavigationMenu: hasFinishedResolution(
 					'canUser',
 					[ 'create', 'navigation' ]

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -1,20 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
-"<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
-`;
-
-exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"`;
-
-exports[`Navigation encodes URL when create block if needed 1`] = `
-"<!-- wp:navigation-link {\\"label\\":\\"wordpress.org/шеллы\\",\\"url\\":\\"https://wordpress.org/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
-
-<!-- wp:navigation-link {\\"label\\":\\"お問い合わせ\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
-`;
-
-exports[`Navigation placeholder actions allows a navigation block to be created from existing menus 1`] = `
+exports[`Navigation Placeholder placeholder actions allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\"} /-->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} -->
@@ -42,6 +28,20 @@ exports[`Navigation placeholder actions allows a navigation block to be created 
 <!-- /wp:navigation-submenu -->"
 `;
 
-exports[`Navigation placeholder actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
+exports[`Navigation Placeholder placeholder actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
+
+exports[`Navigation allows an empty navigation block to be created and manually populated using a mixture of internal and external links 1`] = `
+"<!-- wp:navigation-link {\\"label\\":\\"WP\\",\\"url\\":\\"https://wordpress.org\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"Contact\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/get-in-touch\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
+`;
+
+exports[`Navigation allows pages to be created from the navigation block and their links added to menu 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A really long page name that will not exist\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"`;
+
+exports[`Navigation encodes URL when create block if needed 1`] = `
+"<!-- wp:navigation-link {\\"label\\":\\"wordpress.org/шеллы\\",\\"url\\":\\"https://wordpress.org/%D1%88%D0%B5%D0%BB%D0%BB%D1%8B\\",\\"kind\\":\\"custom\\",\\"isTopLevelLink\\":true} /-->
+
+<!-- wp:navigation-link {\\"label\\":\\"お問い合わせ\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
+`;
 
 exports[`Navigation supports navigation blocks that have inner blocks within their markup and converts them to wp_navigation posts 1`] = `"<!-- wp:page-list /-->"`;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -14,7 +14,7 @@ exports[`Navigation encodes URL when create block if needed 1`] = `
 <!-- wp:navigation-link {\\"label\\":\\"お問い合わせ\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
 `;
 
-exports[`Navigation placeholder allows a navigation block to be created from existing menus 1`] = `
+exports[`Navigation placeholder actions allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\"} /-->
 
 <!-- wp:navigation-submenu {\\"label\\":\\"About\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} -->
@@ -42,6 +42,6 @@ exports[`Navigation placeholder allows a navigation block to be created from exi
 <!-- /wp:navigation-submenu -->"
 `;
 
-exports[`Navigation placeholder creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
+exports[`Navigation placeholder actions creates an empty navigation block when the selected existing menu is also empty 1`] = `""`;
 
 exports[`Navigation supports navigation blocks that have inner blocks within their markup and converts them to wp_navigation posts 1`] = `"<!-- wp:page-list /-->"`;

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -271,11 +271,14 @@ describe( 'Navigation', () => {
 			const codeEditorInput = await page.waitForSelector(
 				'.editor-post-text-editor'
 			);
+
+			// Simulate block behaviour when loading a page containing an unconfigured Nav block.
 			await codeEditorInput.click();
 			const markup = '<!-- wp:navigation /-->';
 			await page.keyboard.type( markup );
 			await clickButton( 'Exit code editor' );
 
+			// Wait for block to render...
 			const navBlock = await waitForBlock( 'Navigation' );
 
 			// Test specifically for the primary loading indicator because a spinner also exists
@@ -284,6 +287,7 @@ describe( 'Navigation', () => {
 				'.wp-block-navigation__loading-indicator.components-spinner'
 			);
 
+			// We should not see the loading state if the block has not been configured and is empty.
 			expect( loadingSpinner ).toBeNull();
 		} );
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -272,7 +272,8 @@ describe( 'Navigation', () => {
 				'.editor-post-text-editor'
 			);
 
-			// Simulate block behaviour when loading a page containing an unconfigured Nav block.
+			// Simulate block behaviour when loading a page containing an unconfigured Nav block
+			// that is not selected.
 			await codeEditorInput.click();
 			const markup = '<!-- wp:navigation /-->';
 			await page.keyboard.type( markup );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -292,10 +292,14 @@ describe( 'Navigation', () => {
 		} );
 
 		it( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
-			let resolveNavigationRequest;
-
 			const testNavId = 1;
 
+			let resolveNavigationRequest;
+
+			// Mock the request for the single Navigation post in order to fully
+			// control the resolution of the request. This will enable the ability
+			// to assert on how the UI responds during the API resolution without
+			// relying on variable factors such as network conditions.
 			await setUpResponseMocking( [
 				{
 					match: ( request ) =>
@@ -303,7 +307,11 @@ describe( 'Navigation', () => {
 						request.url().includes( `navigation` ) &&
 						request.url().includes( testNavId ),
 					onRequestMatch: () => {
+						// The Promise simulates a REST API request whose resolultion
+						// the test has full control over.
 						return new Promise( ( resolve ) => {
+							// Assign the resolution function to the var in the
+							// upper scope to afford control over resolution.
 							resolveNavigationRequest = resolve;
 						} );
 					},
@@ -316,6 +324,9 @@ describe( 'Navigation', () => {
 				'.editor-post-text-editor'
 			);
 			await codeEditorInput.click();
+
+			// The ID used in this `ref` is that which we mock in the request
+			// above to ensure we can control the resolution of the Navigation post.
 			const markup = `<!-- wp:navigation {"ref":${ testNavId }} /-->`;
 			await page.keyboard.type( markup );
 			await clickButton( 'Exit code editor' );
@@ -325,7 +336,7 @@ describe( 'Navigation', () => {
 			// Check for the spinner to be present whilst loading.
 			await navBlock.waitForSelector( '.components-spinner' );
 
-			// Resolve the mocked API request.
+			// Resolve the controlled mocked API request.
 			resolveNavigationRequest();
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Currently the loading and placeholder states for the Nav block are quite difficult to reason about. 

- There's a lot of component nesting and states within states. An example is the `PlacholderPreview` which is rendered at both the root block level _and_ within the `PlaceholderComponent` itself. 
- The logic determining when the placeholder is shown requires setting state when this can simply be derived from existing state.
- The loading states are too complex and obscured.
- The loading state visuals are difficult to distinguish.
- Little or no non-visual communication of loading progress.

This PR seeks to solve the above issues by:

- deriving the placeholder visibility from existing state rather than requiring `setState()`s.
- add a clear "loading" spinner to the loading state as discussed with @jasmussen.
- consolidate all loading state logic into the block _root_ - leaving only "locally relevant" loading logic (i.e. resolution status of which optoins are available within the placeholder actions) within the Placeholder component.
- avoid potential for overlapping rendering by returning distinct components early for both placeholder and loading states
- adds `aria-live` announcement of block loading progress.
- avoid rendering both placeholder preview and block appender when the selected menu is empty

🙏 **Please note**:  this PR does not attempt to fix the "freezing" of the UI that occurs when you create a new Menu or select an existing one. That issue is addressed in https://github.com/WordPress/gutenberg/pull/38858. The aim of this PR is simply to iterate towards an improved loading state for the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I recommend testing the scenario on `trunk` first to get a sense of just how suboptimal the current loading experience is.

Now on this PR's branch:

1. Create new Post.
2. Set Devtools to `Slow 3G` and add a Nav block.
3. Notice the loading spinner.
4. Choose an existing Menu with items.
5. Save and reload page.
6. See loading spinner whilst items are being resolved.
7. Add a new Nav block and choose create _empty_.
8. Save and reload page.
9. See loading state whilst items are resolved and then see the placeholder (this shows because there are no items in the menu/block).

## Screenshots <!-- if applicable -->

#### Before

No clear loading state for initial setup or subsequent loading of existing blocks:

https://user-images.githubusercontent.com/444434/154667604-529a9879-2394-42b1-a949-faa8361f6adf.mov


#### After

Clear loading state for initial setup _and_ subsequent loading of existing blocks:


https://user-images.githubusercontent.com/444434/155123560-cd7a43b4-e1f2-4d2f-893e-f8ff31d1ae41.mov


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
