### PR TITLE
[Block Library - Query Loop]: Display nothing if we want only sticky posts but no stickies exist

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -37,7 +37,15 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 		if ( isset( $block->context['query']['sticky'] ) && ! empty( $block->context['query']['sticky'] ) ) {
 			$sticky = get_option( 'sticky_posts' );
 			if ( 'only' === $block->context['query']['sticky'] ) {
-				$query['post__in'] = $sticky;
+				/**
+				 * Passing an empty array to post__in will return have_posts() as true (and all posts will be returned).
+				 * Logic should be used before hand to determine if WP_Query should be used in the event that the array
+				 * being passed to post__in is empty.
+				 *
+				 * @see https://core.trac.wordpress.org/ticket/28099
+				 */
+				$query['post__in']            = ! empty( $sticky ) ? $sticky : array( 0 );
+				$query['ignore_sticky_posts'] = 1;
 			} else {
 				$query['post__not_in'] = array_merge( $query['post__not_in'], $sticky );
 			}


### PR DESCRIPTION

Fixes: https://github.com/WordPress/gutenberg/issues/35322

From the issue:
>If a WordPress install has no sticky posts, standard posts are displayed on the front when the query loop setting "Sticky posts" is set to "only".
This leads to an unexpected result if the theme developer has chosen one design for sticky posts, and another for standard posts. If the page has two queries, one for sticky only, and one without sticky, the posts are duplicated.

>It works correctly in the editor.

## Testing instructions
1. Trash or remove sticky from any sticky posts on your WordPress installation
2. Add a query loop in the block editor and make sure that you have the `inherit` option to `false`(that is the default).
3. Set the Sticky post setting to "only"
4. Confirm that no posts are displaying in the editor. The message "No results found." is shown.
5. Save and view the front. Confirm that non sticky posts are **not** showing on the front.

I had tried something [different in the past](https://github.com/WordPress/gutenberg/pull/35329) that caused a regression, so make sure that the [below issue](https://github.com/WordPress/gutenberg/issues/35398) doesn't occur:
> you can not see any posts on the front on index and archive templates if the Query loop setting "Inherit query from template" is enabled.

This PR solves another bug as well where when we had set `sticky` to `only` it would still display the other sticky posts in the `query` because it was missing the `ignore_sticky_posts` proper setting.

## Testing instructions 2 (for the second bug)
1. Insert a Query Loop blocks as above
2. Set `items per page` `1` (for easier testing)
3. Have more than one `sticky` posts
4. Observe that not the other sticky posts are appended in the results.