### PR TITLE
apiFetch preloading middleware: handle urlencoded and rest_route query params 

### DIFF
--- a/packages/api-fetch/src/middlewares/test/preloading.js
+++ b/packages/api-fetch/src/middlewares/test/preloading.js
@@ -190,6 +190,60 @@ describe( 'Preloading Middleware', () => {
 		expect( value ).toEqual( body );
 	} );
 
+	it( 'should recognize an urlencoded query param', async () => {
+		const body = { foo: 'foo', bar: 'bar' };
+
+		const preloadingMiddleware = createPreloadingMiddleware( {
+			'/?_fields=foo,bar': { body },
+		} );
+
+		const response = await preloadingMiddleware(
+			{
+				method: 'GET',
+				path: '/?_fields=foo%2Cbar',
+			},
+			() => {}
+		);
+
+		expect( response ).toEqual( body );
+	} );
+
+	it( 'should recognize rest_route query param as path', async () => {
+		const body = { foo: 'foo' };
+
+		const preloadingMiddleware = createPreloadingMiddleware( {
+			'/': { body },
+		} );
+
+		const response = await preloadingMiddleware(
+			{
+				method: 'GET',
+				url: '/index.php?rest_route=%2F',
+			},
+			() => {}
+		);
+
+		expect( response ).toEqual( body );
+	} );
+
+	it( 'should recognize additional query params after rest_route', async () => {
+		const body = { foo: 'foo', bar: 'bar' };
+
+		const preloadingMiddleware = createPreloadingMiddleware( {
+			'/?_fields=foo,bar': { body },
+		} );
+
+		const response = await preloadingMiddleware(
+			{
+				method: 'GET',
+				url: '/index.php?rest_route=%2F&_fields=foo%2Cbar',
+			},
+			() => {}
+		);
+
+		expect( response ).toEqual( body );
+	} );
+
 	it( 'should remove OPTIONS type requests from the cache after the first hit', async () => {
 		const body = { content: 'example' };
 		const preloadedData = {

--- a/packages/url/src/normalize-path.js
+++ b/packages/url/src/normalize-path.js
@@ -15,20 +15,24 @@ export function normalizePath( path ) {
 		return base;
 	}
 
-	// 'b=1&c=2&a=5'
+	// 'b=1%2C2&c=2&a=5'
 	return (
 		base +
 		'?' +
 		query
-			// [ 'b=1', 'c=2', 'a=5' ]
+			// [ 'b=1%2C2', 'c=2', 'a=5' ]
 			.split( '&' )
-			// [ [ 'b, '1' ], [ 'c', '2' ], [ 'a', '5' ] ]
+			// [ [ 'b, '1%2C2' ], [ 'c', '2' ], [ 'a', '5' ] ]
 			.map( ( entry ) => entry.split( '=' ) )
-			// [ [ 'a', '5' ], [ 'b, '1' ], [ 'c', '2' ] ]
+			// [ [ 'b', '1,2' ], [ 'c', '2' ], [ 'a', '5' ] ]
+			.map( ( pair ) => pair.map( decodeURIComponent ) )
+			// [ [ 'a', '5' ], [ 'b, '1,2' ], [ 'c', '2' ] ]
 			.sort( ( a, b ) => a[ 0 ].localeCompare( b[ 0 ] ) )
-			// [ 'a=5', 'b=1', 'c=2' ]
+			// [ [ 'a', '5' ], [ 'b, '1%2C2' ], [ 'c', '2' ] ]
+			.map( ( pair ) => pair.map( encodeURIComponent ) )
+			// [ 'a=5', 'b=1%2C2', 'c=2' ]
 			.map( ( pair ) => pair.join( '=' ) )
-			// 'a=5&b=1&c=2'
+			// 'a=5&b=1%2C2&c=2'
 			.join( '&' )
 	);
 }

--- a/packages/url/src/test/index.js
+++ b/packages/url/src/test/index.js
@@ -1008,4 +1008,9 @@ describe( 'normalizePath', () => {
 		expect( acb ).toBe( cba );
 		expect( cba ).toBe( cab );
 	} );
+
+	it( 'sorts urldecoded values and returns property urlencoded query string', () => {
+		const ab = normalizePath( '/foo/bar?a%2Ca=5,5&a,b=1,1' );
+		expect( ab ).toBe( '/foo/bar?a%2Ca=5%2C5&a%2Cb=1%2C1' );
+	} );
 } );


### PR DESCRIPTION
This fixes two bugs in the preloading middleware that are triggered when the preloaded URL has query param that gets urlencoded. For example, the preloaded data can look like this:
```
{
  '/?fields=home,title': baseData
}
```
But the actual `options.path` that the `apiFetch` function is called with has the commas urlencoded:
```
/?_fields=home%2Ctitle
```
The preloading middleware doesn't match the path correctly and the preloaded data are not used. This PR fixes this by adding urldecoding and urlencoding steps to the `normalizePath` function. This also leads to the query param names to be sorted correctly: they are urldecoded before sorting.

The second bug is that when dealing with a REST path that uses the `rest_route` query param to encode the REST path:
```
/index.php?rest_route=/&_fields=home,title
```
the additional query params (`_fields` in our example) would get ignored. This PR fixes that.

I'm wondering whether adding this new behavior to `normalizePath` can't break something -- and it seems to me that it's OK. The function is used only at two places, in two preloading middlewares, and in both cases the updated behavior is desired. (what do you think @anton-vlasenko?)

**How to test:**
It's well covered by unit tests. I discovered the bugs when adding a `_fields` param to the base `/` entity query. A few other bugs will need to be solved because that starts to really work and can be shipped as a PR.