### PR TITLE
Fixes block highlight after block move

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -70,6 +70,7 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const nodeRef = useRef();
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
 		{
+			clientId: blockClientId,
 			ref: nodeRef,
 			onChange( isFocused ) {
 				if ( isFocused && hasReducedUI ) {

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -70,7 +70,6 @@ export default function BlockToolbar( { hideDragHandle } ) {
 	const nodeRef = useRef();
 	const { showMovers, gestures: showMoversGestures } = useShowMoversGestures(
 		{
-			clientId: blockClientId,
 			ref: nodeRef,
 			onChange( isFocused ) {
 				if ( isFocused && hasReducedUI ) {

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -7,12 +7,6 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useState, useRef, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { store as blockEditorStore } from '../../store';
 
 const { clearTimeout, setTimeout } = window;
 
@@ -105,15 +99,12 @@ export function useDebouncedShowMovers( {
  * @param {Object}   props.ref                   Element reference.
  * @param {number}   [props.debounceTimeout=250] Debounce timeout in milliseconds.
  * @param {Function} [props.onChange=noop]       Callback function.
- * @param {string}   props.clientId              Block Client Id
  */
 export function useShowMoversGestures( {
-	clientId,
 	ref,
 	debounceTimeout = DEBOUNCE_TIMEOUT,
 	onChange = noop,
 } ) {
-	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 	const [ isFocused, setIsFocused ] = useState( false );
 	const {
 		showMovers,
@@ -136,7 +127,7 @@ export function useShowMoversGestures( {
 		const handleOnFocus = () => {
 			if ( isFocusedWithin() ) {
 				setIsFocused( true );
-				toggleBlockHighlight( clientId, true );
+				onChange( true );
 				debouncedShowMovers();
 			}
 		};
@@ -144,7 +135,7 @@ export function useShowMoversGestures( {
 		const handleOnBlur = () => {
 			if ( ! isFocusedWithin() ) {
 				setIsFocused( false );
-				toggleBlockHighlight( clientId, false );
+				onChange( false );
 				debouncedHideMovers();
 			}
 		};

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -44,7 +44,6 @@ export function useDebouncedShowMovers( {
 
 	const shouldHideMovers = () => {
 		const isHovered = getIsHovered();
-
 		return ! isFocused && ! isHovered;
 	};
 
@@ -82,7 +81,13 @@ export function useDebouncedShowMovers( {
 		}, debounceTimeout );
 	};
 
-	useEffect( () => () => clearTimeoutRef(), [] );
+	useEffect(
+		() => () => {
+			handleOnChange( false );
+			clearTimeoutRef();
+		},
+		[]
+	);
 
 	return {
 		showMovers,
@@ -127,16 +132,12 @@ export function useShowMoversGestures( {
 		const handleOnFocus = () => {
 			if ( isFocusedWithin() ) {
 				setIsFocused( true );
-				onChange( true );
-				debouncedShowMovers();
 			}
 		};
 
 		const handleOnBlur = () => {
 			if ( ! isFocusedWithin() ) {
 				setIsFocused( false );
-				onChange( false );
-				debouncedHideMovers();
 			}
 		};
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -83,6 +83,11 @@ export function useDebouncedShowMovers( {
 
 	useEffect(
 		() => () => {
+			/**
+			 * We need to call the change handler with `isFocused`
+			 * set to false on unmount because we also clear the
+			 * timeout that would handle that.
+			 */
 			handleOnChange( false );
 			clearTimeoutRef();
 		},
@@ -132,12 +137,14 @@ export function useShowMoversGestures( {
 		const handleOnFocus = () => {
 			if ( isFocusedWithin() ) {
 				setIsFocused( true );
+				debouncedShowMovers();
 			}
 		};
 
 		const handleOnBlur = () => {
 			if ( ! isFocusedWithin() ) {
 				setIsFocused( false );
+				debouncedHideMovers();
 			}
 		};
 

--- a/packages/block-editor/src/components/block-toolbar/utils.js
+++ b/packages/block-editor/src/components/block-toolbar/utils.js
@@ -7,6 +7,12 @@ import { noop } from 'lodash';
  * WordPress dependencies
  */
 import { useState, useRef, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
 
 const { clearTimeout, setTimeout } = window;
 
@@ -99,12 +105,15 @@ export function useDebouncedShowMovers( {
  * @param {Object}   props.ref                   Element reference.
  * @param {number}   [props.debounceTimeout=250] Debounce timeout in milliseconds.
  * @param {Function} [props.onChange=noop]       Callback function.
+ * @param {string}   props.clientId              Block Client Id
  */
 export function useShowMoversGestures( {
+	clientId,
 	ref,
 	debounceTimeout = DEBOUNCE_TIMEOUT,
 	onChange = noop,
 } ) {
+	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 	const [ isFocused, setIsFocused ] = useState( false );
 	const {
 		showMovers,
@@ -127,6 +136,7 @@ export function useShowMoversGestures( {
 		const handleOnFocus = () => {
 			if ( isFocusedWithin() ) {
 				setIsFocused( true );
+				toggleBlockHighlight( clientId, true );
 				debouncedShowMovers();
 			}
 		};
@@ -134,6 +144,7 @@ export function useShowMoversGestures( {
 		const handleOnBlur = () => {
 			if ( ! isFocusedWithin() ) {
 				setIsFocused( false );
+				toggleBlockHighlight( clientId, false );
 				debouncedHideMovers();
 			}
 		};


### PR DESCRIPTION
Closes #28742

Seems the bug was simply a missed call to a `toggleBlockHighlight`, otherwise a quick fix. I hope I am not missing something, but manual testing shows the bug gone:

https://user-images.githubusercontent.com/107534/154722958-2f9aa57d-bb69-440f-90c3-27c8fe4c662a.mp4


