### PR TITLE
Hide current menu from dropdown list in Nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -35,7 +35,6 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToolbarGroup,
-	ToolbarDropdownMenu,
 	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -483,26 +482,17 @@ function Navigation( {
 				<BlockControls>
 					{ ! isDraftNavigationMenu && isEntityAvailable && (
 						<ToolbarGroup>
-							<ToolbarDropdownMenu
-								label={ __( 'Select Menu' ) }
-								text={ __( 'Select Menu' ) }
-								icon={ null }
-							>
-								{ ( { onClose } ) => (
-									<NavigationMenuSelector
-										currentMenuId={ ref }
-										clientId={ clientId }
-										onSelect={ ( { id } ) => {
-											setRef( id );
-											onClose();
-										} }
-										onCreateNew={ startWithEmptyMenu }
-										/* translators: %s: The name of a menu. */
-										actionLabel={ __( "Switch to '%s'" ) }
-										showManageActions
-									/>
-								) }
-							</ToolbarDropdownMenu>
+							<NavigationMenuSelector
+								currentMenuId={ ref }
+								clientId={ clientId }
+								onSelect={ ( { id } ) => {
+									setRef( id );
+								} }
+								onCreateNew={ startWithEmptyMenu }
+								/* translators: %s: The name of a menu. */
+								actionLabel={ __( "Switch to '%s'" ) }
+								showManageActions
+							/>
 						</ToolbarGroup>
 					) }
 					<ToolbarGroup>{ listViewToolbarButton }</ToolbarGroup>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -490,6 +490,7 @@ function Navigation( {
 							>
 								{ ( { onClose } ) => (
 									<NavigationMenuSelector
+										currentMenuId={ ref }
 										clientId={ clientId }
 										onSelect={ ( { id } ) => {
 											setRef( id );
@@ -660,6 +661,7 @@ function Navigation( {
 				<nav { ...blockProps }>
 					{ isPlaceholderShown && (
 						<PlaceholderComponent
+							currentMenuId={ ref }
 							onFinish={ ( post ) => {
 								setIsPlaceholderShown( false );
 								if ( post ) {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -481,7 +481,7 @@ function Navigation( {
 			<RecursionProvider>
 				<BlockControls>
 					{ ! isDraftNavigationMenu && isEntityAvailable && (
-						<ToolbarGroup>
+						<ToolbarGroup className="wp-block-navigation__toolbar-menu-selector">
 							<NavigationMenuSelector
 								currentMenuId={ ref }
 								clientId={ clientId }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { MenuGroup, MenuItem } from '@wordpress/components';
+import {
+	MenuGroup,
+	MenuItem,
+	ToolbarDropdownMenu,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
@@ -21,6 +25,7 @@ export default function NavigationMenuSelector( {
 	onCreateNew,
 	showManageActions = false,
 	actionLabel,
+	toggleProps = {},
 } ) {
 	/* translators: %s: The name of a menu. */
 	const createActionLabel = __( "Create from '%s'" );
@@ -78,66 +83,82 @@ export default function NavigationMenuSelector( {
 	}
 
 	return (
-		<>
-			{ showNavigationMenus && hasNavigationMenus && (
-				<MenuGroup label={ __( 'Menus' ) }>
-					{ navigationMenusOmitCurrent.map( ( menu ) => {
-						const label = decodeEntities( menu.title.rendered );
-						return (
-							<MenuItem
-								onClick={ () => {
-									onSelect( menu );
-								} }
-								key={ menu.id }
-								aria-label={ sprintf( actionLabel, label ) }
-							>
-								{ label }
-							</MenuItem>
-						);
-					} ) }
-				</MenuGroup>
-			) }
-			{ showClassicMenus && hasClassicMenus && (
-				<MenuGroup label={ __( 'Classic Menus' ) }>
-					{ classicMenus.map( ( menu ) => {
-						const label = decodeEntities( menu.name );
-						return (
-							<MenuItem
-								onClick={ () => {
-									convertClassicMenuToBlocks(
-										menu.id,
-										menu.name
-									);
-								} }
-								key={ menu.id }
-								aria-label={ sprintf(
-									createActionLabel,
-									label
-								) }
-							>
-								{ label }
-							</MenuItem>
-						);
-					} ) }
-				</MenuGroup>
-			) }
-
-			{ showManageActions && hasManagePermissions && (
-				<MenuGroup label={ __( 'Tools' ) }>
-					{ canUserCreateNavigationMenu && (
-						<MenuItem onClick={ onCreateNew }>
-							{ __( 'Create new menu' ) }
-						</MenuItem>
+		<ToolbarDropdownMenu
+			label={ __( 'Select Menu' ) }
+			text={ __( 'Select Menu' ) }
+			icon={ null }
+			toggleProps={ toggleProps }
+		>
+			{ ( { onClose } ) => (
+				<>
+					{ showNavigationMenus && hasNavigationMenus && (
+						<MenuGroup label={ __( 'Menus' ) }>
+							{ navigationMenusOmitCurrent.map( ( menu ) => {
+								const label = decodeEntities(
+									menu.title.rendered
+								);
+								return (
+									<MenuItem
+										onClick={ () => {
+											onClose();
+											onSelect( menu );
+										} }
+										key={ menu.id }
+										aria-label={ sprintf(
+											actionLabel,
+											label
+										) }
+									>
+										{ label }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
 					) }
-					<MenuItem
-						href={ addQueryArgs( 'edit.php', {
-							post_type: 'wp_navigation',
-						} ) }
-					>
-						{ __( 'Manage menus' ) }
-					</MenuItem>
-				</MenuGroup>
+					{ showClassicMenus && hasClassicMenus && (
+						<MenuGroup label={ __( 'Classic Menus' ) }>
+							{ classicMenus.map( ( menu ) => {
+								const label = decodeEntities( menu.name );
+								return (
+									<MenuItem
+										onClick={ () => {
+											onClose();
+											convertClassicMenuToBlocks(
+												menu.id,
+												menu.name
+											);
+										} }
+										key={ menu.id }
+										aria-label={ sprintf(
+											createActionLabel,
+											label
+										) }
+									>
+										{ label }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					) }
+
+					{ showManageActions && hasManagePermissions && (
+						<MenuGroup label={ __( 'Tools' ) }>
+							{ canUserCreateNavigationMenu && (
+								<MenuItem onClick={ onCreateNew }>
+									{ __( 'Create new menu' ) }
+								</MenuItem>
+							) }
+							<MenuItem
+								href={ addQueryArgs( 'edit.php', {
+									post_type: 'wp_navigation',
+								} ) }
+							>
+								{ __( 'Manage menus' ) }
+							</MenuItem>
+						</MenuGroup>
+					) }
+				</>
 			) }
-		</>
+		</ToolbarDropdownMenu>
 	);
 }

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -15,6 +15,7 @@ import useConvertClassicMenu from '../use-convert-classic-menu';
 import useCreateNavigationMenu from './use-create-navigation-menu';
 
 export default function NavigationMenuSelector( {
+	currentMenuId,
 	clientId,
 	onSelect,
 	onCreateNew,
@@ -34,6 +35,12 @@ export default function NavigationMenuSelector( {
 		canUserUpdateNavigationMenu,
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
+
+	// Avoid showing any currently active menu in the list of
+	// menus that can be selected.
+	const navigationMenusOmitCurrent = navigationMenus.filter(
+		( menu ) => ! currentMenuId || menu.id !== currentMenuId
+	);
 
 	const createNavigationMenu = useCreateNavigationMenu( clientId );
 
@@ -56,7 +63,7 @@ export default function NavigationMenuSelector( {
 		onFinishMenuCreation
 	);
 
-	const hasNavigationMenus = !! navigationMenus?.length;
+	const hasNavigationMenus = !! navigationMenusOmitCurrent?.length;
 	const hasClassicMenus = !! classicMenus?.length;
 	const showNavigationMenus = !! canSwitchNavigationMenu;
 	const showClassicMenus = !! canUserCreateNavigationMenu;
@@ -74,7 +81,7 @@ export default function NavigationMenuSelector( {
 		<>
 			{ showNavigationMenus && hasNavigationMenus && (
 				<MenuGroup label={ __( 'Menus' ) }>
-					{ navigationMenus.map( ( menu ) => {
+					{ navigationMenusOmitCurrent.map( ( menu ) => {
 						const label = decodeEntities( menu.title.rendered );
 						return (
 							<MenuItem

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -74,9 +74,14 @@ export default function NavigationMenuSelector( {
 	const showClassicMenus = !! canUserCreateNavigationMenu;
 	const hasManagePermissions =
 		canUserCreateNavigationMenu || canUserUpdateNavigationMenu;
+
+	// Show the selector if:
+	// - has switch or create permissions and there are block or classic menus.
+	// - user has create or update permisisons and component should show the menu actions.
 	const showSelectMenus =
-		( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
-		( hasNavigationMenus || hasClassicMenus );
+		( ( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
+			( hasNavigationMenus || hasClassicMenus ) ) ||
+		( hasManagePermissions && showManageActions );
 
 	if ( ! showSelectMenus ) {
 		return null;

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -16,6 +16,7 @@ import useCreateNavigationMenu from '../use-create-navigation-menu';
 import NavigationMenuSelector from '../navigation-menu-selector';
 
 export default function NavigationPlaceholder( {
+	currentMenuId,
 	clientId,
 	onFinish,
 	canSwitchNavigationMenu,
@@ -91,6 +92,7 @@ export default function NavigationPlaceholder( {
 									>
 										{ () => (
 											<NavigationMenuSelector
+												currentMenuId={ currentMenuId }
 												clientId={ clientId }
 												onSelect={ onFinish }
 											/>

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Placeholder, Button, DropdownMenu } from '@wordpress/components';
+import { Placeholder, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { navigation, Icon } from '@wordpress/icons';
 
@@ -11,7 +11,6 @@ import { navigation, Icon } from '@wordpress/icons';
 
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
-import useNavigationMenu from '../../use-navigation-menu';
 import useCreateNavigationMenu from '../use-create-navigation-menu';
 import NavigationMenuSelector from '../navigation-menu-selector';
 
@@ -19,7 +18,6 @@ export default function NavigationPlaceholder( {
 	currentMenuId,
 	clientId,
 	onFinish,
-	canSwitchNavigationMenu,
 	hasResolvedNavigationMenus,
 	canUserCreateNavigationMenu = false,
 } ) {
@@ -40,25 +38,13 @@ export default function NavigationPlaceholder( {
 		onFinish( navigationMenu, blocks );
 	};
 
-	const {
-		isResolvingPages,
-		isResolvingMenus,
-		hasMenus,
-	} = useNavigationEntities();
+	const { isResolvingPages, isResolvingMenus } = useNavigationEntities();
 
 	const isStillLoading = isResolvingPages || isResolvingMenus;
 
 	const onCreateEmptyMenu = () => {
 		onFinishMenuCreation( [] );
 	};
-
-	const { navigationMenus } = useNavigationMenu();
-
-	const hasNavigationMenus = !! navigationMenus?.length;
-
-	const showSelectMenus =
-		( canSwitchNavigationMenu || canUserCreateNavigationMenu ) &&
-		( hasNavigationMenus || hasMenus );
 
 	return (
 		<>
@@ -77,30 +63,19 @@ export default function NavigationPlaceholder( {
 
 							<hr />
 
-							{ showSelectMenus ? (
-								<>
-									<DropdownMenu
-										text={ __( 'Select menu' ) }
-										icon={ null }
-										toggleProps={ {
-											variant: 'tertiary',
-											iconPosition: 'right',
-											className:
-												'wp-block-navigation-placeholder__actions__dropdown',
-										} }
-										popoverProps={ { isAlternate: true } }
-									>
-										{ () => (
-											<NavigationMenuSelector
-												currentMenuId={ currentMenuId }
-												clientId={ clientId }
-												onSelect={ onFinish }
-											/>
-										) }
-									</DropdownMenu>
-									<hr />
-								</>
-							) : undefined }
+							<NavigationMenuSelector
+								currentMenuId={ currentMenuId }
+								clientId={ clientId }
+								onSelect={ onFinish }
+								toggleProps={ {
+									variant: 'tertiary',
+									iconPosition: 'right',
+									className:
+										'wp-block-navigation-placeholder__actions__dropdown',
+								} }
+							/>
+
+							<hr />
 
 							{ canUserCreateNavigationMenu && (
 								<Button

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -613,3 +613,10 @@ body.editor-styles-wrapper
 .wp-block-navigation__toolbar-menu-selector.components-toolbar-group:empty {
 	display: none;
 }
+
+// Temp - hide adjacent <hr>s when Nav Menu Selector is empty.
+// TODO - extract state to common hook or parent component to avoid render of <hr>.
+.wp-block-navigation-placeholder__actions hr + hr {
+	display: none;
+}
+

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -119,7 +119,6 @@
 	display: none;
 }
 
-
 /**
  * Colors Selector component
  */
@@ -607,4 +606,10 @@ body.editor-styles-wrapper
 		outline: 1px solid transparent; // Box shadow is removed in high contrast mode, a transparent outline is made opaque.
 		background-color: $white;
 	}
+}
+
+// Temp - hide toolbar component when Nav Menu Selector is empty.
+// TODO - extract state to common hook or parent component to avoid render.
+.wp-block-navigation__toolbar-menu-selector.components-toolbar-group:empty {
+	display: none;
 }

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -584,14 +584,17 @@ describe( 'Navigation', () => {
 		const markup =
 			'<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->';
 		await page.keyboard.type( markup );
+
 		await clickButton( 'Exit code editor' );
-		const navBlock = await page.waitForSelector(
-			'nav[aria-label="Block: Navigation"]'
-		);
-		// Select the block to convert to a wp_navigation and publish.
-		// The select menu button shows up when saving is complete.
+
+		const navBlock = await waitForBlock( 'Navigation' );
+
+		// Select the block to convert to a wp_navigation
 		await navBlock.click();
-		await page.waitForSelector( 'button[aria-label="Select Menu"]' );
+
+		// The Page List block is rendered within Navigation InnerBlocks when saving is complete.
+		await waitForBlock( 'Page List' );
+
 		await publishPost();
 
 		// Check that the wp_navigation post has the page list block.

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -144,7 +144,7 @@ async function populateNavWithOneItem() {
 const PLACEHOLDER_ACTIONS_CLASS = 'wp-block-navigation-placeholder__actions';
 const PLACEHOLDER_ACTIONS_XPATH = `//*[contains(@class, '${ PLACEHOLDER_ACTIONS_CLASS }')]`;
 const START_EMPTY_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Start empty']`;
-const SELECT_MENU_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Select menu']`;
+const SELECT_MENU_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Select Menu']`;
 
 /**
  * Delete all items for the given REST resources using the REST API.
@@ -883,9 +883,10 @@ describe( 'Navigation', () => {
 
 			await insertBlock( 'Navigation' );
 
-			// Select the Navigation post created by the Admin early
+			// Select the Navigation post created by the Admin earlier
 			// in the test.
 			const navigationPostCreatedByAdminName = 'Navigation';
+
 			const dropdown = await page.waitForXPath( SELECT_MENU_XPATH );
 			await dropdown.click();
 			const theOption = await page.waitForXPath(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -627,17 +627,18 @@ describe( 'Navigation', () => {
 				'<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->';
 			await page.keyboard.type( markup );
 			await clickButton( 'Exit code editor' );
-			const navBlock = await page.waitForSelector(
-				'nav[aria-label="Block: Navigation"]'
-			);
 
-			// Select the block to convert to a wp_navigation and publish.
-			// The select menu button shows up when saving is complete.
+			const navBlock = await waitForBlock( 'Navigation' );
+
+			// Select the block to convert to a wp_navigation
 			await navBlock.click();
-			await page.waitForSelector( 'button[aria-label="Select Menu"]' );
+
+			// The Page List block is rendered within Navigation InnerBlocks when saving is complete.
+			await waitForBlock( 'Page List' );
 
 			// Reset the nav block to create a new entity.
 			await resetNavBlockToInitialState();
+
 			const startEmptyButton = await page.waitForXPath(
 				START_EMPTY_XPATH
 			);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

The Nav block has a `Select menu` dropdown which allows you to select/switch your menu to once that was previous created.

Annoyingly however, if you have a menu already selected and applied to the block that menu will still show up in the dropdown list of menus you can switch to. This can lead to you creating multiple copies of the same Navigation simply by selecting the menu you already have active 🤦‍♂️ .

This PR fixes that by **filtering the list** to omit the current menu item if it is set. If it is not set then all menus are shown.

## Testing Instructions

Firstly clear out all your Navigation Menus and **empty the trash**!

1. New Post -> create a single Navigation menu via the block and save it.
2. Reload the page.
3. Click the `Select menu` dropdown. You should not see the current menu in the list. In fact the list should be empty as you have no other menus.
4. Add a new Nav block and click `Select menu`. You should see the single menu you created in the list.
5. Create a few more menus.
6. Check that each time you select one it is omitted from the list.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/444434/154727641-1c1d5240-aa3a-4ab1-9941-8d90c3a36076.mov


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
