### PR TITLE
Blocks: Remember raw source block for invalid blocks.

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -75,7 +75,7 @@ function Block( { children, isHtml, ...props } ) {
 }
 
 function BlockListBlock( {
-	block: { source },
+	block: { __unstableBlockSource },
 	mode,
 	isLocked,
 	canRemove,
@@ -157,8 +157,8 @@ function BlockListBlock( {
 	let block;
 
 	if ( ! isValid ) {
-		const saveContent = source
-			? serializeRawBlock( source )
+		const saveContent = __unstableBlockSource
+			? serializeRawBlock( __unstableBlockSource )
 			: getSaveContent( blockType, attributes );
 
 		block = (

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,6 +15,7 @@ import {
 } from '@wordpress/element';
 import {
 	getBlockType,
+	getSaveContent,
 	isUnmodifiedDefaultBlock,
 	serializeRawBlock,
 } from '@wordpress/blocks';
@@ -156,7 +157,9 @@ function BlockListBlock( {
 	let block;
 
 	if ( ! isValid ) {
-		const saveContent = serializeRawBlock( source );
+		const saveContent = source
+			? serializeRawBlock( source )
+			: getSaveContent( blockType, attributes );
 
 		block = (
 			<Block className="has-warning">

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -15,8 +15,8 @@ import {
 } from '@wordpress/element';
 import {
 	getBlockType,
-	getSaveContent,
 	isUnmodifiedDefaultBlock,
+	serializeRawBlock,
 } from '@wordpress/blocks';
 import { withFilters } from '@wordpress/components';
 import {
@@ -74,6 +74,7 @@ function Block( { children, isHtml, ...props } ) {
 }
 
 function BlockListBlock( {
+	block: { source },
 	mode,
 	isLocked,
 	canRemove,
@@ -155,7 +156,7 @@ function BlockListBlock( {
 	let block;
 
 	if ( ! isValid ) {
-		const saveContent = getSaveContent( blockType, attributes );
+		const saveContent = serializeRawBlock( source );
 
 		block = (
 			<Block className="has-warning">

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -735,6 +735,31 @@ _Returns_
 
 -   `string`: The post content.
 
+### serializeRawBlock
+
+Serializes a block node into the native HTML-comment-powered block format.
+CAVEAT: This function is intended for reserializing blocks as parsed by
+valid parsers and skips any validation steps. This is NOT a generic
+serialization function for in-memory blocks. For most purposes, see the
+following functions available in the `@wordpress/blocks` package:
+
+_Related_
+
+-   serializeBlock
+-   serialize For more on the format of block nodes as returned by valid parsers:
+-   `@wordpress/block-serialization-default-parser` package
+-   `@wordpress/block-serialization-spec-parser` package
+
+_Parameters_
+
+-   _rawBlock_ `import(".").WPRawBlock`: A block node as returned by a valid parser.
+-   _options_ `?Object`: Serialization options.
+-   _options.isCommentDelimited_ `?boolean`: Whether to output HTML comments around blocks.
+
+_Returns_
+
+-   `string`: An HTML string representing a block.
+
 ### setCategories
 
 Sets the block categories.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -738,7 +738,7 @@ _Returns_
 ### serializeRawBlock
 
 Serializes a block node into the native HTML-comment-powered block format.
-CAVEAT: This function is intended for reserializing blocks as parsed by
+CAVEAT: This function is intended for re-serializing blocks as parsed by
 valid parsers and skips any validation steps. This is NOT a generic
 serialization function for in-memory blocks. For most purposes, see the
 following functions available in the `@wordpress/blocks` package:
@@ -752,9 +752,8 @@ _Related_
 
 _Parameters_
 
--   _rawBlock_ `import(".").WPRawBlock`: A block node as returned by a valid parser.
--   _options_ `?Object`: Serialization options.
--   _options.isCommentDelimited_ `?boolean`: Whether to output HTML comments around blocks.
+-   _rawBlock_ `WPRawBlock`: A block node as returned by a valid parser.
+-   _options_ `[Options]`: Serialization options.
 
 _Returns_
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -34,6 +34,7 @@ export {
 // components whose mechanisms can be shielded from the `edit` implementation
 // and just passed along.
 export { default as parse } from './parser';
+export { serializeRawBlock } from './parser/serialize-raw-block';
 export {
 	getBlockAttributes,
 	parseWithAttributeSchema,

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -41,13 +41,13 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
  *
  * @typedef WPBlock
  *
- * @property {string}     name             Block name
- * @property {Object }    attributes       Block raw or comment attributes.
- * @property {WPBlock[]}  innerBlocks      Inner Blocks.
- * @property {string}     originalContent  Original content of the block before validation fixes.
- * @property {boolean}    isValid          Whether the block is valid.
- * @property {Object[]}   validationIssues Validation issues.
- * @property {WPRawBlock} [source]         Un-processed original copy of block if created through parser.
+ * @property {string}     name                    Block name
+ * @property {Object }    attributes              Block raw or comment attributes.
+ * @property {WPBlock[]}  innerBlocks             Inner Blocks.
+ * @property {string}     originalContent         Original content of the block before validation fixes.
+ * @property {boolean}    isValid                 Whether the block is valid.
+ * @property {Object[]}   validationIssues        Validation issues.
+ * @property {WPRawBlock} [__unstableBlockSource] Un-processed original copy of block if created through parser.
  */
 
 /**
@@ -247,7 +247,7 @@ export function parseRawBlock( rawBlock ) {
 		// Preserve the original unprocessed version of the block
 		// that we received so that we can preserve it in its
 		// existing state when we save.
-		updatedBlock.source = rawBlock;
+		updatedBlock.__unstableBlockSource = rawBlock;
 	}
 
 	if ( ! validatedBlock.isValid && updatedBlock.isValid ) {

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -42,7 +42,7 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
  * @typedef WPBlock
  *
  * @property {string}     name                    Block name
- * @property {Object }    attributes              Block raw or comment attributes.
+ * @property {Object}     attributes              Block raw or comment attributes.
  * @property {WPBlock[]}  innerBlocks             Inner Blocks.
  * @property {string}     originalContent         Original content of the block before validation fixes.
  * @property {boolean}    isValid                 Whether the block is valid.

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -41,12 +41,13 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
  *
  * @typedef WPBlock
  *
- * @property {string}    name             Block name
- * @property {Object }   attributes       Block raw or comment attributes.
- * @property {WPBlock[]} innerBlocks      Inner Blocks.
- * @property {string}    originalContent  Original content of the block before validation fixes.
- * @property {boolean}   isValid          Whether the block is valid.
- * @property {Object[]}  validationIssues Validation issues.
+ * @property {string}     name             Block name
+ * @property {Object }    attributes       Block raw or comment attributes.
+ * @property {WPBlock[]}  innerBlocks      Inner Blocks.
+ * @property {string}     originalContent  Original content of the block before validation fixes.
+ * @property {boolean}    isValid          Whether the block is valid.
+ * @property {Object[]}   validationIssues Validation issues.
+ * @property {WPRawBlock} [source]         Un-processed original copy of block if created through parser.
  */
 
 /**
@@ -241,6 +242,13 @@ export function parseRawBlock( rawBlock ) {
 		normalizedBlock,
 		blockType
 	);
+
+	if ( ! updatedBlock.isValid ) {
+		// Preserve the original unprocessed version of the block
+		// that we received so that we can preserve it in its
+		// existing state when we save.
+		updatedBlock.source = rawBlock;
+	}
 
 	if ( ! validatedBlock.isValid && updatedBlock.isValid ) {
 		/* eslint-disable no-console */

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -245,8 +245,11 @@ export function parseRawBlock( rawBlock ) {
 
 	if ( ! updatedBlock.isValid ) {
 		// Preserve the original unprocessed version of the block
-		// that we received so that we can preserve it in its
-		// existing state when we save.
+		// that we received (no fixes, no deprecations) so that
+		// we can save it as close to exactly the same way as
+		// we loaded it. This is important to avoid corruption
+		// and data loss caused by block implementations trying
+		// to process data that isn't fully recognized.
 		updatedBlock.__unstableBlockSource = rawBlock;
 	}
 

--- a/packages/blocks/src/api/parser/serialize-raw-block.js
+++ b/packages/blocks/src/api/parser/serialize-raw-block.js
@@ -4,8 +4,15 @@
 import { getCommentDelimitedContent } from '../serializer';
 
 /**
+ * @typedef {Object}   Options                   Serialization options.
+ * @property {boolean} [isCommentDelimited=true] Whether to output HTML comments around blocks.
+ */
+
+/** @typedef {import("./").WPRawBlock} WPRawBlock */
+
+/**
  * Serializes a block node into the native HTML-comment-powered block format.
- * CAVEAT: This function is intended for reserializing blocks as parsed by
+ * CAVEAT: This function is intended for re-serializing blocks as parsed by
  * valid parsers and skips any validation steps. This is NOT a generic
  * serialization function for in-memory blocks. For most purposes, see the
  * following functions available in the `@wordpress/blocks` package:
@@ -18,9 +25,8 @@ import { getCommentDelimitedContent } from '../serializer';
  * @see `@wordpress/block-serialization-default-parser` package
  * @see `@wordpress/block-serialization-spec-parser` package
  *
- * @param {import(".").WPRawBlock} rawBlock                   A block node as returned by a valid parser.
- * @param {?Object}                options                    Serialization options.
- * @param {?boolean}               options.isCommentDelimited Whether to output HTML comments around blocks.
+ * @param {WPRawBlock} rawBlock     A block node as returned by a valid parser.
+ * @param {Options}    [options={}] Serialization options.
  *
  * @return {string} An HTML string representing a block.
  */


### PR DESCRIPTION
# Status

While this PR looks like it introduces a property that doesn't get much
use (`source`) I'd like to go ahead and merge it in to get the most basic
fix (invalid block previews are notoriously broken) while setting the stage
for the more thorough fixes to come later.

Everything that relies on `originalContent` and most of what relies on
`innerHTML` is broken but fixing those issues is so expansive that I cannot
focus on them in one mega PR. Thankfully, because they are all separate
problems I do believe that we can fix them piecemeal and let "fixes one
thing" take priority over "fixes everything."

# Description

Part of #38922
Replaces #38922

When the editor is unable to validate a block it should preserve the
broken content in the post and show an accurate representation of that
underlying markup in the absence of being able to interact with it.

Currently when showing a preview of an invalid block in the editor we
attempt to re-generate the save output for a block given the attributes
we originally parsed. This is a flawed approach, however, because by
the nature of being invalid we know that there is a problem with those
attributes as they are.

In this patch we're introducing the `source` attribute on a block which
only exists for invalid blocks at the time of this patch. That `source`
carries the original un-processed data for a block node and can be used
to reconstruct the original markup without using garbage data and without
inadvertently changing it through the series of autofixes, deprecations,
and the like that happen during normal block loading.

The noticable change is in `block-list/block` where we will be showing
that reconstruction rather than the re-generated block content. Previously
it was the case that the preview might represent a corrupted version of the
block or show the block as if emptied of all its content. Now, however,
the preview sould accurately reflect the HTML in the source post even
when it's invalid or unrecognized according to the editor.

Further work should take advantage of the `source` property to provide
a more consistent and trusting experience for working with unrecognized
content.

## Testing Instructions

To test this you will want to compare the block preview for invalid
blocks in the editor. This change limits itself to that preview and
leaves other broken UI bits broken, to be addressed in follow-up work
for the sake of focus during review and testing.

Two primary cases to asses are when the block attributes fail to
properly parse and when there are inner blocks involved.

### Failed attribute parsing

We've removed the `<ul>` tag from the following list. The three
bullet points render fine as HTML but are hidden in the editor
because it loads an empty string for the `values` attribute, since
it was unable to find `LI` content inside a `UL` as the attribute
sourcing describes it should.

```
<!-- wp:list -->
<li>one</li><li>two</li><li>three</li>
<!-- /wp:list -->
```


| `trunk` | this branch |
|---|---|
| <img width="694" alt="Screen Shot 2022-02-18 at 4 11 58 PM" src="https://user-images.githubusercontent.com/5431237/154773218-f079ce32-3530-4bd6-98f2-895bba953dfb.png"> | <img width="679" alt="Screen Shot 2022-02-18 at 4 08 28 PM" src="https://user-images.githubusercontent.com/5431237/154773181-207b798b-b160-4954-80af-c014fbdc4d3c.png"> |

### Inner blocks on invalid block

Because inner blocks are ignored by the existing `originalContent` attribute they will disappear in the preview for invalid blocks even if they are themselves valid.

```
<!-- wp:group -->
<div class="wp-block-group"><!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:group {"layout":{"type":"flerx","allowOrientation":false}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Nested!</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns --></div>
<!-- /wp:group -->
```

| `trunk` | this branch |
|---|---|
| <img width="686" alt="Screen Shot 2022-02-18 at 4 12 01 PM" src="https://user-images.githubusercontent.com/5431237/154773320-7120ac8a-ce2e-483f-9b35-b8b4852e755e.png"> | <img width="683" alt="Screen Shot 2022-02-18 at 4 08 32 PM" src="https://user-images.githubusercontent.com/5431237/154773345-b3678f6f-a547-4c30-a385-95e6ddd55249.png"> |

## Types of changes

Introduces a new property on a loaded block which refers to the
un-processed block data when it was originally loaded and which
is used to better represent the unrecognized content in the editor.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
