### PR TITLE
Add load listener to live preview component

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Disabled } from '@wordpress/components';
@@ -51,9 +56,13 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 		return styles;
 	}, [ styles ] );
 
+	const handleInnerContentLoaded = debounce( ( iFrame ) => {
+		iFrame.dispatchEvent( new Event( 'resize' ) );
+	}, 100 );
+
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
-
+	// console.log( 'ok' );
 	const scale = containerWidth / viewportWidth;
 
 	return (
@@ -73,6 +82,9 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 				<Iframe
 					head={ <EditorStyles styles={ editorStyles } /> }
 					assets={ assets }
+					onLoad={ ( event ) =>
+						handleInnerContentLoaded( event.currentTarget )
+					}
 					contentRef={ useRefEffect( ( bodyElement ) => {
 						const {
 							ownerDocument: { documentElement },

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -57,7 +57,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 	}, [ styles ] );
 
 	const handleInnerContentLoaded = debounce( ( iFrame ) => {
-		iFrame.dispatchEvent( new Event( 'resize' ) );
+		iFrame?.dispatchEvent( new Event( 'resize' ) );
 	}, 100 );
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.

--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -62,7 +62,7 @@ function AutoBlockPreview( { viewportWidth, __experimentalPadding } ) {
 
 	// Initialize on render instead of module top level, to avoid circular dependency issues.
 	MemoizedBlockList = MemoizedBlockList || pure( BlockList );
-	// console.log( 'ok' );
+
 	const scale = containerWidth / viewportWidth;
 
 	return (

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Fix spin buttons of number inputs in Safari ([#38840](https://github.com/WordPress/gutenberg/pull/38840))
 
+### Enhancements
+
+- Trigger re-render on `AutoHeightBlockPreview` component when items within its iFrame load (by listening for load events)
+
 ## 19.4.0 (2022-02-10)
 
 ### Bug Fix

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Enhancements
 
-- Trigger re-render on `AutoHeightBlockPreview` component when items within its iFrame load (by listening for load events)
+- Trigger re-render on `AutoHeightBlockPreview` component when items within its iFrame load (by listening for load events) ([#38925](https://github.com/WordPress/gutenberg/pull/38925))
 
 ## 19.4.0 (2022-02-10)
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
This PR attempts to solve height issues that appear within live preview pattern components. It adds an event listener to the nested iFrame that will listen for `load` events that bubble up, and fire a `resize` event to trigger a re-render (if the height/width have changed). There is also a 100ms `debounce` wrapper.

I couldn't find a comprehensive list of what fires the load event, but images are probably the main concern here. I know stylesheets (`link` tags) and other items also fire the event. 

## Testing Instructions
I'm not confident in how to reproduce this as it seems to only happen to me on occasion. It happens enough though that I do have screenshots and video of it though. It's also happening to others on our team as well, so I suspect its common.

(**maybe others can chime in if they've experienced this as well**)

## Screenshots <!-- if applicable -->

Example of it being cut off:

![screen_shot_2022-02-16_at_6 49 19_pm](https://user-images.githubusercontent.com/1478421/154785326-a3911437-5c77-4476-8791-0c4c07f1257a.png)

Component renders that occur before this PR + load events logged (`onLoad={console.log}`):

![load events firing after render](https://user-images.githubusercontent.com/1478421/154785366-5f5028c6-bec5-457f-a6dd-d28abed22cd9.png)

This PR, showing the additional render after incoming load events

![Screen Shot 2022-02-18 at 9 55 14 PM](https://user-images.githubusercontent.com/1478421/154785388-87b9204e-c270-4c55-9e30-cd6720a871b2.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
