### PR TITLE
Rehabilitate drag gesture in `LineHeightControl`

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -93,6 +93,7 @@ export default function LineHeightControl( {
 				__unstableInputWidth={ __unstableInputWidth }
 				__unstableStateReducer={ stateReducer }
 				onChange={ onChange }
+				isDragEnabled={ false }
 				label={ __( 'Line height' ) }
 				placeholder={ BASE_DEFAULT_VALUE }
 				step={ STEP }

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -61,7 +61,7 @@ export default function LineHeightControl( {
 		// For example, Firefox emits an input event with inputType="insertReplacementText"
 		// on spin button clicks, while other browsers do not even emit an input event.
 		const wasTypedOrPasted = [ 'insertText', 'insertFromPaste' ].includes(
-			action.payload.event.nativeEvent.inputType
+			action.payload.event.nativeEvent?.inputType
 		);
 		state.value = adjustNextValue( state.value, wasTypedOrPasted );
 		return state;
@@ -93,7 +93,6 @@ export default function LineHeightControl( {
 				__unstableInputWidth={ __unstableInputWidth }
 				__unstableStateReducer={ stateReducer }
 				onChange={ onChange }
-				isDragEnabled={ false }
 				label={ __( 'Line height' ) }
 				placeholder={ BASE_DEFAULT_VALUE }
 				step={ STEP }


### PR DESCRIPTION
With #37164 `LineHeightControl` became based on `NumberControl` and inherited the latter’s ability to adjust its value via drag gestures. After the library upgrade in #38840, the drag gesture will error and this PR fixes it.

## Before, block crash when attempting to select line height value

https://user-images.githubusercontent.com/9000376/154820569-0139c2ee-0ef2-4d7c-832b-8e312c3ae20a.mp4

<details>
<summary>Error details</summary>

The error:
`[Error] TypeError: undefined is not an object (evaluating 'action.payload.event.nativeEvent.inputType')`
Stemming from this statement:
https://github.com/WordPress/gutenberg/blob/1d7fa7a995e24b9fca60186a6be8f51cdbef9ffb/packages/block-editor/src/components/line-height-control/index.js#L63-L65
</details>

## Testing Instructions
1. Select a Paragraph block in the Block Editor
2. Click and drag inside the Line height input
3. Verify expected operation without error

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
