### PR TITLE
Render SVG props that have dashes correctly

### DIFF
--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -282,12 +282,12 @@ function getNormalAttributeValue( attribute, value ) {
 	return value;
 }
 /**
- * This is a list of all SVG attributes that have dashes.
+ * This is a map of all SVG attributes that have dashes. Map(lower case prop => dashed lower case attribute).
  * We need this to render e.g strokeWidth as stroke-width.
  *
  * List from: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute.
  */
-const SVG_ATTRIBUTE_LIST = new Set( [
+const SVG_ATTRIBUTE_WITH_DASHES_LIST = [
 	'accentHeight',
 	'alignmentBaseline',
 	'arabicForm',
@@ -361,7 +361,110 @@ const SVG_ATTRIBUTE_LIST = new Set( [
 	'writingMode',
 	'xmlnsXlink',
 	'xHeight',
-] );
+].reduce( ( map, attribute ) => {
+	// The keys are lower-cased for more robust lookup.
+	map[ attribute.toLowerCase() ] = attribute;
+	return map;
+}, {} );
+
+/**
+ * This is a map of all case-sensitive SVG attributes. Map(lowercase key => proper case attribute).
+ * The keys are lower-cased for more robust lookup.
+ * Note that this list only contains attributes that contain at least one capital letter.
+ * Lowercase attributes don't need mapping, since we lowercase all attributes by default.
+ */
+const CASE_SENSITIVE_SVG_ATTRIBUTES = [
+	'allowReorder',
+	'attributeName',
+	'attributeType',
+	'autoReverse',
+	'baseFrequency',
+	'baseProfile',
+	'calcMode',
+	'clipPathUnits',
+	'contentScriptType',
+	'contentStyleType',
+	'diffuseConstant',
+	'edgeMode',
+	'externalResourcesRequired',
+	'filterRes',
+	'filterUnits',
+	'glyphRef',
+	'gradientTransform',
+	'gradientUnits',
+	'kernelMatrix',
+	'kernelUnitLength',
+	'keyPoints',
+	'keySplines',
+	'keyTimes',
+	'lengthAdjust',
+	'limitingConeAngle',
+	'markerHeight',
+	'markerUnits',
+	'markerWidth',
+	'maskContentUnits',
+	'maskUnits',
+	'numOctaves',
+	'pathLength',
+	'patternContentUnits',
+	'patternTransform',
+	'patternUnits',
+	'pointsAtX',
+	'pointsAtY',
+	'pointsAtZ',
+	'preserveAlpha',
+	'preserveAspectRatio',
+	'primitiveUnits',
+	'refX',
+	'refY',
+	'repeatCount',
+	'repeatDur',
+	'requiredExtensions',
+	'requiredFeatures',
+	'specularConstant',
+	'specularExponent',
+	'spreadMethod',
+	'startOffset',
+	'stdDeviation',
+	'stitchTiles',
+	'suppressContentEditableWarning',
+	'suppressHydrationWarning',
+	'surfaceScale',
+	'systemLanguage',
+	'tableValues',
+	'targetX',
+	'targetY',
+	'textLength',
+	'viewBox',
+	'viewTarget',
+	'xChannelSelector',
+	'yChannelSelector',
+].reduce( ( map, attribute ) => {
+	// The keys are lower-cased for more robust lookup.
+	map[ attribute.toLowerCase() ] = attribute;
+	return map;
+}, {} );
+
+/**
+ * This is a map of all SVG attributes that have colons.
+ * Keys are lower-cased and stripped of their colons for more robust lookup.
+ */
+const SVG_ATTRIBUTES_WITH_COLONS = [
+	'xlink:actuate',
+	'xlink:arcrole',
+	'xlink:href',
+	'xlink:role',
+	'xlink:show',
+	'xlink:title',
+	'xlink:type',
+	'xml:base',
+	'xml:lang',
+	'xml:space',
+	'xmlns:xlink',
+].reduce( ( map, attribute ) => {
+	map[ attribute.replace( ':', '' ).toLowerCase() ] = attribute;
+	return map;
+}, {} );
 
 /**
  * Returns the normal form of the element's attribute name for HTML.
@@ -370,7 +473,6 @@ const SVG_ATTRIBUTE_LIST = new Set( [
  *
  * @return {string} Normalized attribute name.
  */
-
 function getNormalAttributeName( attribute ) {
 	switch ( attribute ) {
 		case 'htmlFor':
@@ -379,10 +481,19 @@ function getNormalAttributeName( attribute ) {
 		case 'className':
 			return 'class';
 	}
-	if ( SVG_ATTRIBUTE_LIST.has( attribute ) ) {
-		return kebabCase( attribute );
+	const attributeLowerCase = attribute.toLowerCase();
+
+	if ( CASE_SENSITIVE_SVG_ATTRIBUTES[ attributeLowerCase ] ) {
+		return CASE_SENSITIVE_SVG_ATTRIBUTES[ attributeLowerCase ];
+	} else if ( SVG_ATTRIBUTE_WITH_DASHES_LIST[ attributeLowerCase ] ) {
+		return kebabCase(
+			SVG_ATTRIBUTE_WITH_DASHES_LIST[ attributeLowerCase ]
+		);
+	} else if ( SVG_ATTRIBUTES_WITH_COLONS[ attributeLowerCase ] ) {
+		return SVG_ATTRIBUTES_WITH_COLONS[ attributeLowerCase ];
 	}
-	return attribute.toLowerCase();
+
+	return attributeLowerCase;
 }
 
 /**

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -326,7 +326,7 @@ const SVG_ATTRIBUTE_LIST = new Set( [
 	'overlinePosition',
 	'overlineThickness',
 	'paintOrder',
-	'panose-1',
+	'panose1',
 	'pointerEvents',
 	'renderingIntent',
 	'shapeRendering',

--- a/packages/element/src/serialize.js
+++ b/packages/element/src/serialize.js
@@ -281,6 +281,87 @@ function getNormalAttributeValue( attribute, value ) {
 
 	return value;
 }
+/**
+ * This is a list of all SVG attributes that have dashes.
+ * We need this to render e.g strokeWidth as stroke-width.
+ *
+ * List from: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute.
+ */
+const SVG_ATTRIBUTE_LIST = new Set( [
+	'accentHeight',
+	'alignmentBaseline',
+	'arabicForm',
+	'baselineShift',
+	'capHeight',
+	'clipPath',
+	'clipRule',
+	'colorInterpolation',
+	'colorInterpolationFilters',
+	'colorProfile',
+	'colorRendering',
+	'dominantBaseline',
+	'enableBackground',
+	'fillOpacity',
+	'fillRule',
+	'floodColor',
+	'floodOpacity',
+	'fontFamily',
+	'fontSize',
+	'fontSizeAdjust',
+	'fontStretch',
+	'fontStyle',
+	'fontVariant',
+	'fontWeight',
+	'glyphName',
+	'glyphOrientationHorizontal',
+	'glyphOrientationVertical',
+	'horizAdvX',
+	'horizOriginX',
+	'imageRendering',
+	'letterSpacing',
+	'lightingColor',
+	'markerEnd',
+	'markerMid',
+	'markerStart',
+	'overlinePosition',
+	'overlineThickness',
+	'paintOrder',
+	'panose-1',
+	'pointerEvents',
+	'renderingIntent',
+	'shapeRendering',
+	'stopColor',
+	'stopOpacity',
+	'strikethroughPosition',
+	'strikethroughThickness',
+	'strokeDasharray',
+	'strokeDashoffset',
+	'strokeLinecap',
+	'strokeLinejoin',
+	'strokeMiterlimit',
+	'strokeOpacity',
+	'strokeWidth',
+	'textAnchor',
+	'textDecoration',
+	'textRendering',
+	'underlinePosition',
+	'underlineThickness',
+	'unicodeBidi',
+	'unicodeRange',
+	'unitsPerEm',
+	'vAlphabetic',
+	'vHanging',
+	'vIdeographic',
+	'vMathematical',
+	'vectorEffect',
+	'vertAdvY',
+	'vertOriginX',
+	'vertOriginY',
+	'wordSpacing',
+	'writingMode',
+	'xmlnsXlink',
+	'xHeight',
+] );
 
 /**
  * Returns the normal form of the element's attribute name for HTML.
@@ -289,6 +370,7 @@ function getNormalAttributeValue( attribute, value ) {
  *
  * @return {string} Normalized attribute name.
  */
+
 function getNormalAttributeName( attribute ) {
 	switch ( attribute ) {
 		case 'htmlFor':
@@ -297,7 +379,9 @@ function getNormalAttributeName( attribute ) {
 		case 'className':
 			return 'class';
 	}
-
+	if ( SVG_ATTRIBUTE_LIST.has( attribute ) ) {
+		return kebabCase( attribute );
+	}
 	return attribute.toLowerCase();
 }
 

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -181,6 +181,18 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'hello<div></div>' );
 	} );
 
+	it( 'SVG attributes with dashes should be rendered as such', () => {
+		const result = renderElement(
+			<svg>
+				<rect x="0" y="0" strokeWidth="5"></rect>
+			</svg>
+		);
+
+		expect( result ).toBe(
+			'<svg><rect x="0" y="0" stroke-width="5"></rect></svg>'
+		);
+	} );
+
 	it( 'renders escaped string element', () => {
 		const result = renderElement( 'hello & world &amp; friends <img/>' );
 

--- a/packages/element/src/test/serialize.js
+++ b/packages/element/src/test/serialize.js
@@ -181,15 +181,39 @@ describe( 'renderElement()', () => {
 		expect( result ).toBe( 'hello<div></div>' );
 	} );
 
-	it( 'SVG attributes with dashes should be rendered as such', () => {
+	it( 'SVG attributes with dashes should be rendered as such - even with wrong casing', () => {
 		const result = renderElement(
 			<svg>
-				<rect x="0" y="0" strokeWidth="5"></rect>
+				<rect x="0" y="0" strokeWidth="5" STROKELinejoin="miter"></rect>
 			</svg>
 		);
 
 		expect( result ).toBe(
-			'<svg><rect x="0" y="0" stroke-width="5"></rect></svg>'
+			'<svg><rect x="0" y="0" stroke-width="5" stroke-linejoin="miter"></rect></svg>'
+		);
+	} );
+
+	it( 'Case sensitive attributes should have the right casing - even with wrong casing', () => {
+		const result = renderElement(
+			<svg ViEWBOx="0 0 1 1" preserveAsPECTRatio="slice"></svg>
+		);
+
+		expect( result ).toBe(
+			'<svg viewBox="0 0 1 1" preserveAspectRatio="slice"></svg>'
+		);
+	} );
+
+	it( 'SVG attributes with colons should be rendered as such - even with wrong casing', () => {
+		const result = renderElement(
+			<svg
+				viewBox="0 0 1 1"
+				XLINKROLE="some-role"
+				xlinkShow="hello"
+			></svg>
+		);
+
+		expect( result ).toBe(
+			'<svg viewBox="0 0 1 1" xlink:role="some-role" xlink:show="hello"></svg>'
 		);
 	} );
 


### PR DESCRIPTION
## Description
This PR fixes rendering SVG attributes that have dashes, before the dashes were omitted, and now they are rendered properly. This required hard-coding a list of all dashed SVG attributes. Luckily, they're not too many.

Fixes https://github.com/WordPress/gutenberg/issues/38553

The first commit should have a failing test on purpose, and the second commit has the fix.

## Testing Instructions

```jsx
import { renderToString } from '@wordpress/element'
const theString = renderToString(<svg><path fillOpacity={1}></path></svg>)
// before 
console.log(theString) // --> <svg><path fillopacity="1"></path></svg>
// after
console.log(theString) // --> <svg><path fill-opacity="1"></path></svg>
```

## Types of changes
Bugfix.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
