### PR TITLE
`theme.json` Update version section docs to v2

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -150,7 +150,7 @@ This specification is the same for the three different origins that use this for
 ### Version
 This field describes the format of the `theme.json` file. The current version is [v2](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/), [introduced in WordPress 5.9](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). It also works with the current Gutenberg plugin.
 
-As of now, WordPress will ignore any version that is not the current one.  If you have used v1 previously, you don’t need to update the version in the v1 file to v2, as it’ll be transformed into v2 at runtime for you. Each version potentially introduces new keys and might rename the old ones. In that case, the old key name becomes invalid and will need to be updated to the new key name.
+If you have used [v1](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-v1/) previously, you don’t need to update the version in the v1 file to v2, as it’ll be [migrated](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-migrations/) into v2 at runtime for you.
 
 
 ### Settings

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -148,10 +148,10 @@ This specification is the same for the three different origins that use this for
 ```
 
 ### Version
+This field describes the format of the `theme.json` file. Previously, the version used was only 1. With WordPress 5.9 introduced a new v2 with new keys. Follow [this](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/) link to find out more on v2.
 
-This field describes the format of the `theme.json` file. The current and only version is 1.
+As of now, WordPress will ignore any version that is not the current one.  If you have used v1 previously, you don’t need to update the version in the v1 file to v2, as it’ll be transformed into v2 at runtime for you. Each version potentially introduces new keys and might rename the old ones. In that case, the old key name becomes invalid and will need to be updated to the new key name.
 
-WordPress 5.8 will ignore the contents of any `theme.json` whose version is not equals to the current. Should the Gutenberg plugin need it, it'll update the version and will add the corresponding migration mechanisms from older versions.
 
 ### Settings
 

--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -148,7 +148,7 @@ This specification is the same for the three different origins that use this for
 ```
 
 ### Version
-This field describes the format of the `theme.json` file. Previously, the version used was only 1. With WordPress 5.9 introduced a new v2 with new keys. Follow [this](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/) link to find out more on v2.
+This field describes the format of the `theme.json` file. The current version is [v2](https://developer.wordpress.org/block-editor/reference-guides/theme-json-reference/theme-json-living/), [introduced in WordPress 5.9](https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/). It also works with the current Gutenberg plugin.
 
 As of now, WordPress will ignore any version that is not the current one.  If you have used v1 previously, you don’t need to update the version in the v1 file to v2, as it’ll be transformed into v2 at runtime for you. Each version potentially introduces new keys and might rename the old ones. In that case, the old key name becomes invalid and will need to be updated to the new key name.
 


### PR DESCRIPTION
Added a little bit more information on the version section. Currently, it only discusses the v1 which is not valid anymore.

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
