### PR TITLE
Documentation: Removing comma so that the code snippet of theme.json represents standard JSON.

### DIFF
--- a/docs/how-to-guides/themes/theme-json.md
+++ b/docs/how-to-guides/themes/theme-json.md
@@ -408,7 +408,7 @@ The naming schema for the classes and the custom properties is as follows:
 							"slug": "white",
 							"color": "#ffffff",
 							"name": "White"
-						},
+						}
 					]
 				}
 			}


### PR DESCRIPTION
## Description

When I'm loafing and weary I copy and paste a lot.

I was using the theme.json snippet over at https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#presets and noticed there was a trailing comma in the JSON.

This PR removes it.

This change will save you a second of your time, but maybe minutes of developer time throughout the world!

## Screenshots <!-- if applicable -->

<img width="567" alt="Screen Shot 2022-02-21 at 1 18 04 pm" src="https://user-images.githubusercontent.com/6458278/154878811-d1fbc009-fbba-4bca-bf59-017fea05cd66.png">


## Types of changes
Documentation quality.


