### PR TITLE
Data: normalize selector args when handling metadata selectors/actions

### DIFF
--- a/packages/data/src/redux-store/metadata/actions.js
+++ b/packages/data/src/redux-store/metadata/actions.js
@@ -37,10 +37,10 @@ export function finishResolution( selectorName, args ) {
  * started.
  *
  * @param {string}    selectorName Name of selector for which resolver triggered.
- * @param {unknown[]} args         Array of arguments to associate for uniqueness, each item
+ * @param {unknown[][]} args         Array of arguments to associate for uniqueness, each item
  *                                 is associated to a resolution.
  *
- * @return {{ type: 'START_RESOLUTIONS', selectorName: string, args: unknown[] }} Action object.
+ * @return {{ type: 'START_RESOLUTIONS', selectorName: string, args: unknown[][] }} Action object.
  */
 export function startResolutions( selectorName, args ) {
 	return {
@@ -55,10 +55,10 @@ export function startResolutions( selectorName, args ) {
  * completed.
  *
  * @param {string}    selectorName Name of selector for which resolver triggered.
- * @param {unknown[]} args         Array of arguments to associate for uniqueness, each item
+ * @param {unknown[][]} args         Array of arguments to associate for uniqueness, each item
  *                                 is associated to a resolution.
  *
- * @return {{ type: 'FINISH_RESOLUTIONS', selectorName: string, args: unknown[] }} Action object.
+ * @return {{ type: 'FINISH_RESOLUTIONS', selectorName: string, args: unknown[][] }} Action object.
  */
 export function finishResolutions( selectorName, args ) {
 	return {

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -8,7 +8,7 @@ import type { Reducer } from 'redux';
 /**
  * Internal dependencies
  */
-import { normalizeArgs, onSubKey } from './utils';
+import { selectorArgsToStateKey, onSubKey } from './utils';
 
 type Action =
 	| ReturnType< typeof import('./actions').startResolution >
@@ -38,7 +38,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 		case 'FINISH_RESOLUTION': {
 			const isStarting = action.type === 'START_RESOLUTION';
 			const nextState = new EquivalentKeyMap( state );
-			nextState.set( normalizeArgs( action.args ), isStarting );
+			nextState.set( selectorArgsToStateKey( action.args ), isStarting );
 			return nextState;
 		}
 		case 'START_RESOLUTIONS':
@@ -46,13 +46,16 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 			const isStarting = action.type === 'START_RESOLUTIONS';
 			const nextState = new EquivalentKeyMap( state );
 			for ( const resolutionArgs of action.args ) {
-				nextState.set( normalizeArgs( resolutionArgs ), isStarting );
+				nextState.set(
+					selectorArgsToStateKey( resolutionArgs ),
+					isStarting
+				);
 			}
 			return nextState;
 		}
 		case 'INVALIDATE_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
-			nextState.delete( normalizeArgs( action.args ) );
+			nextState.delete( selectorArgsToStateKey( action.args ) );
 			return nextState;
 		}
 	}

--- a/packages/data/src/redux-store/metadata/reducer.ts
+++ b/packages/data/src/redux-store/metadata/reducer.ts
@@ -8,7 +8,7 @@ import type { Reducer } from 'redux';
 /**
  * Internal dependencies
  */
-import { onSubKey } from './utils';
+import { normalizeArgs, onSubKey } from './utils';
 
 type Action =
 	| ReturnType< typeof import('./actions').startResolution >
@@ -38,7 +38,7 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 		case 'FINISH_RESOLUTION': {
 			const isStarting = action.type === 'START_RESOLUTION';
 			const nextState = new EquivalentKeyMap( state );
-			nextState.set( action.args, isStarting );
+			nextState.set( normalizeArgs( action.args ), isStarting );
 			return nextState;
 		}
 		case 'START_RESOLUTIONS':
@@ -46,13 +46,13 @@ const subKeysIsResolved: Reducer< Record< string, State >, Action > = onSubKey<
 			const isStarting = action.type === 'START_RESOLUTIONS';
 			const nextState = new EquivalentKeyMap( state );
 			for ( const resolutionArgs of action.args ) {
-				nextState.set( resolutionArgs, isStarting );
+				nextState.set( normalizeArgs( resolutionArgs ), isStarting );
 			}
 			return nextState;
 		}
 		case 'INVALIDATE_RESOLUTION': {
 			const nextState = new EquivalentKeyMap( state );
-			nextState.delete( action.args );
+			nextState.delete( normalizeArgs( action.args ) );
 			return nextState;
 		}
 	}

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -3,6 +3,11 @@
  */
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+import { normalizeArgs } from './utils';
+
 /** @typedef {Record<string, import('./reducer').State>} State */
 
 /**
@@ -11,9 +16,9 @@ import { get } from 'lodash';
  * or not resolved for the given set of arguments, otherwise true or false for
  * resolution started and completed respectively.
  *
- * @param {State}     state        Data state.
- * @param {string}    selectorName Selector name.
- * @param {unknown[]} args         Arguments passed to selector.
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
  *
  * @return {boolean | undefined} isResolving value.
  */
@@ -23,20 +28,20 @@ export function getIsResolving( state, selectorName, args ) {
 		return undefined;
 	}
 
-	return map.get( args );
+	return map.get( normalizeArgs( args ) );
 }
 
 /**
  * Returns true if resolution has already been triggered for a given
  * selector name, and arguments set.
  *
- * @param {State}     state        Data state.
- * @param {string}    selectorName Selector name.
- * @param {unknown[]} [args]       Arguments passed to selector (default `[]`).
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
  *
  * @return {boolean} Whether resolution has been triggered.
  */
-export function hasStartedResolution( state, selectorName, args = [] ) {
+export function hasStartedResolution( state, selectorName, args ) {
 	return getIsResolving( state, selectorName, args ) !== undefined;
 }
 
@@ -44,13 +49,13 @@ export function hasStartedResolution( state, selectorName, args = [] ) {
  * Returns true if resolution has completed for a given selector
  * name, and arguments set.
  *
- * @param {State}     state        Data state.
- * @param {string}    selectorName Selector name.
- * @param {unknown[]} [args]       Arguments passed to selector.
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
  *
  * @return {boolean} Whether resolution has completed.
  */
-export function hasFinishedResolution( state, selectorName, args = [] ) {
+export function hasFinishedResolution( state, selectorName, args ) {
 	return getIsResolving( state, selectorName, args ) === false;
 }
 
@@ -58,13 +63,13 @@ export function hasFinishedResolution( state, selectorName, args = [] ) {
  * Returns true if resolution has been triggered but has not yet completed for
  * a given selector name, and arguments set.
  *
- * @param {State}     state        Data state.
- * @param {string}    selectorName Selector name.
- * @param {unknown[]} [args]       Arguments passed to selector.
+ * @param {State}      state        Data state.
+ * @param {string}     selectorName Selector name.
+ * @param {unknown[]?} args         Arguments passed to selector.
  *
  * @return {boolean} Whether resolution is in progress.
  */
-export function isResolving( state, selectorName, args = [] ) {
+export function isResolving( state, selectorName, args ) {
 	return getIsResolving( state, selectorName, args ) === true;
 }
 

--- a/packages/data/src/redux-store/metadata/selectors.js
+++ b/packages/data/src/redux-store/metadata/selectors.js
@@ -6,7 +6,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { normalizeArgs } from './utils';
+import { selectorArgsToStateKey } from './utils';
 
 /** @typedef {Record<string, import('./reducer').State>} State */
 
@@ -28,7 +28,7 @@ export function getIsResolving( state, selectorName, args ) {
 		return undefined;
 	}
 
-	return map.get( normalizeArgs( args ) );
+	return map.get( selectorArgsToStateKey( args ) );
 }
 
 /**

--- a/packages/data/src/redux-store/metadata/test/reducer.js
+++ b/packages/data/src/redux-store/metadata/test/reducer.js
@@ -127,6 +127,22 @@ describe( 'reducer', () => {
 				expect( state.getFoo.get( [ 'post' ] ) ).toBe( false );
 			}
 		);
+
+		it( 'should normalize args array when dispatching actions', () => {
+			const started = reducer( undefined, {
+				type: 'START_RESOLUTION',
+				selectorName: 'getFoo',
+				args: [ 1, undefined ],
+			} );
+			expect( started.getFoo.get( [ 1 ] ) ).toBe( true );
+
+			const finished = reducer( started, {
+				type: 'FINISH_RESOLUTION',
+				selectorName: 'getFoo',
+				args: [ 1, undefined, undefined ],
+			} );
+			expect( finished.getFoo.get( [ 1 ] ) ).toBe( false );
+		} );
 	} );
 
 	describe( 'resolution batch', () => {
@@ -240,5 +256,29 @@ describe( 'reducer', () => {
 				expect( state.getFoo.get( [ 'block' ] ) ).toBe( false );
 			}
 		);
+
+		it( 'should normalize args array when dispatching actions', () => {
+			const started = reducer( undefined, {
+				type: 'START_RESOLUTIONS',
+				selectorName: 'getFoo',
+				args: [
+					[ 1, undefined ],
+					[ 2, undefined, undefined ],
+				],
+			} );
+			expect( started.getFoo.get( [ 1 ] ) ).toBe( true );
+			expect( started.getFoo.get( [ 2 ] ) ).toBe( true );
+
+			const finished = reducer( started, {
+				type: 'FINISH_RESOLUTIONS',
+				selectorName: 'getFoo',
+				args: [
+					[ 1, undefined, undefined ],
+					[ 2, undefined ],
+				],
+			} );
+			expect( finished.getFoo.get( [ 1 ] ) ).toBe( false );
+			expect( finished.getFoo.get( [ 2 ] ) ).toBe( false );
+		} );
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/selectors.js
+++ b/packages/data/src/redux-store/metadata/test/selectors.js
@@ -38,6 +38,17 @@ describe( 'getIsResolving', () => {
 
 		expect( result ).toBe( true );
 	} );
+
+	it( 'should normalize args ard return the right value', () => {
+		const state = {
+			getFoo: new EquivalentKeyMap( [ [ [], true ] ] ),
+		};
+		expect( getIsResolving( state, 'getFoo' ) ).toBe( true );
+		expect( getIsResolving( state, 'getFoo', [ undefined ] ) ).toBe( true );
+		expect(
+			getIsResolving( state, 'getFoo', [ undefined, undefined ] )
+		).toBe( true );
+	} );
 } );
 
 describe( 'hasStartedResolution', () => {

--- a/packages/data/src/redux-store/metadata/test/utils.js
+++ b/packages/data/src/redux-store/metadata/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { onSubKey } from '../utils';
+import { normalizeArgs, onSubKey } from '../utils';
 
 describe( 'onSubKey', () => {
 	function createEnhancedReducer( actionProperty ) {
@@ -37,5 +37,32 @@ describe( 'onSubKey', () => {
 			1: 'Called by 1',
 			2: 'Called by 2',
 		} );
+	} );
+} );
+
+describe( 'normalizeArgs', () => {
+	it( 'should default to an empty array', () => {
+		expect( normalizeArgs( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'should remove trailing undefined values', () => {
+		expect( normalizeArgs( [ 1, 2, undefined ] ) ).toEqual( [ 1, 2 ] );
+		expect( normalizeArgs( [ 1, 2, undefined, undefined ] ) ).toEqual( [
+			1,
+			2,
+		] );
+	} );
+
+	it( 'should leave non-trailing undefined values alone', () => {
+		expect( normalizeArgs( [ 1, undefined, 2, undefined ] ) ).toEqual( [
+			1,
+			undefined,
+			2,
+		] );
+	} );
+
+	it( 'should return already normalized array unchanged', () => {
+		const args = [ 1, 2, 3 ];
+		expect( normalizeArgs( args ) ).toBe( args );
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/test/utils.js
+++ b/packages/data/src/redux-store/metadata/test/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { normalizeArgs, onSubKey } from '../utils';
+import { selectorArgsToStateKey, onSubKey } from '../utils';
 
 describe( 'onSubKey', () => {
 	function createEnhancedReducer( actionProperty ) {
@@ -40,29 +40,29 @@ describe( 'onSubKey', () => {
 	} );
 } );
 
-describe( 'normalizeArgs', () => {
+describe( 'selectorArgsToStateKey', () => {
 	it( 'should default to an empty array', () => {
-		expect( normalizeArgs( undefined ) ).toEqual( [] );
+		expect( selectorArgsToStateKey( undefined ) ).toEqual( [] );
 	} );
 
 	it( 'should remove trailing undefined values', () => {
-		expect( normalizeArgs( [ 1, 2, undefined ] ) ).toEqual( [ 1, 2 ] );
-		expect( normalizeArgs( [ 1, 2, undefined, undefined ] ) ).toEqual( [
+		expect( selectorArgsToStateKey( [ 1, 2, undefined ] ) ).toEqual( [
 			1,
 			2,
 		] );
+		expect(
+			selectorArgsToStateKey( [ 1, 2, undefined, undefined ] )
+		).toEqual( [ 1, 2 ] );
 	} );
 
 	it( 'should leave non-trailing undefined values alone', () => {
-		expect( normalizeArgs( [ 1, undefined, 2, undefined ] ) ).toEqual( [
-			1,
-			undefined,
-			2,
-		] );
+		expect(
+			selectorArgsToStateKey( [ 1, undefined, 2, undefined ] )
+		).toEqual( [ 1, undefined, 2 ] );
 	} );
 
 	it( 'should return already normalized array unchanged', () => {
 		const args = [ 1, 2, 3 ];
-		expect( normalizeArgs( args ) ).toBe( args );
+		expect( selectorArgsToStateKey( args ) ).toBe( args );
 	} );
 } );

--- a/packages/data/src/redux-store/metadata/utils.ts
+++ b/packages/data/src/redux-store/metadata/utils.ts
@@ -43,9 +43,9 @@ export const onSubKey = < TState extends unknown, TAction extends AnyAction >(
  * and removing trailing `undefined` values.
  *
  * @param  args Selector argument array
- * @return Normalized selector argument array
+ * @return Normalized state key array
  */
-export function normalizeArgs( args: unknown[] | null | undefined ) {
+export function selectorArgsToStateKey( args: unknown[] | null | undefined ) {
 	if ( args === undefined || args === null ) {
 		return [];
 	}

--- a/packages/data/src/redux-store/metadata/utils.ts
+++ b/packages/data/src/redux-store/metadata/utils.ts
@@ -37,3 +37,23 @@ export const onSubKey = < TState extends unknown, TAction extends AnyAction >(
 		[ key ]: nextKeyState,
 	};
 };
+
+/**
+ * Normalize selector argument array by defaulting `undefined` value to an empty array
+ * and removing trailing `undefined` values.
+ *
+ * @param  args Selector argument array
+ * @return Normalized selector argument array
+ */
+export function normalizeArgs( args: unknown[] | null | undefined ) {
+	if ( args === undefined || args === null ) {
+		return [];
+	}
+
+	const len = args.length;
+	let idx = len;
+	while ( idx > 0 && args[ idx - 1 ] === undefined ) {
+		idx--;
+	}
+	return idx === len ? args : args.slice( 0, idx );
+}

--- a/packages/data/src/redux-store/metadata/utils.ts
+++ b/packages/data/src/redux-store/metadata/utils.ts
@@ -1,23 +1,25 @@
 /**
+ * External dependencies
+ */
+import type { AnyAction, Reducer } from 'redux';
+
+/**
  * Higher-order reducer creator which creates a combined reducer object, keyed
  * by a property on the action object.
  *
- * @template {any} TState
- * @template {import('redux').AnyAction} TAction
- *
- * @param {string} actionProperty Action property by which to key object.
- *
- * @return {(reducer: import('redux').Reducer<TState, TAction>) => import('redux').Reducer<Record<string, TState>, TAction>} Higher-order reducer.
+ * @param  actionProperty Action property by which to key object.
+ * @return Higher-order reducer.
  */
-export const onSubKey = ( actionProperty ) => ( reducer ) => (
-	/* eslint-disable jsdoc/no-undefined-types */
-	state = /** @type {Record<string, TState>} */ ( {} ),
+export const onSubKey = < TState extends unknown, TAction extends AnyAction >(
+	actionProperty: string
+) => (
+	reducer: Reducer< TState, TAction >
+): Reducer< Record< string, TState >, TAction > => (
+	state: Record< string, TState > = {},
 	action
 ) => {
 	// Retrieve subkey from action. Do not track if undefined; useful for cases
 	// where reducer is scoped by action shape.
-	/** @type {keyof state} */
-	/* eslint-enable jsdoc/no-undefined-types */
 	const key = action[ actionProperty ];
 	if ( key === undefined ) {
 		return state;


### PR DESCRIPTION
The problem: I can call a `getEntityRecord` selector like:
```js
getEntityRecord( 'root', 'site' )
```
and there is also a generated `getSite` selector that calls `getEntityRecord` internally, with optional params:
```js
const getSite = ( key, query ) => getEntityRecord( 'root', 'site', key, query )
```
One would expect that when calling these selector one after another:
```js
await resolveSelect.getSite();
await resolveSelect.getEntityRecord( 'root', 'site' );
```
there would be only one REST request sent because on the second call the selector is already resolved, isn't it? But there will be two requests.

Why? The resolving code asks whether:
```js
hasFinishedResolution( state, 'getEntityRecord', [ 'root', 'site', undefined, undefined ] ) // from getSite
```
and whether
```js
hasFinishedResolution( state, 'getEntityRecord', [ 'root', 'site' ] ) // from getEntityRecord
```
Although both are supposed to be the same selector with the same args, the resolution state treats them as two different invocations. The resolver runs twice.

This patch fixes that by "normalizing" the `args` array that's passed i) to one of the `{START,FINISH}_RESOLUTION(S)` actions, which leads to the Redux state keys to be normalized; ii) to the `isResolving` and other selectors that read the resolution metadata, which leads to always looking up a normalized key in state.

Normalization means that trailing `undefined` values are removed: `[ 1, 2, undefined, undefined ]` is converted to `[ 1, 2 ]`. I'm also normalizing a `null` or `undefined` value to `[]`, and marking the `args` argument as optional, so that calls like `isResolving( state, 'getSite' )` and `isResolving( state, 'getSite', [] )` are equivalent.

**How to test:**
The changes are covered by unit tests.