### PR TITLE
(explorations) Parsing API responses based on the JSON schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19249,16 +19249,6 @@
 						"yauzl": "^2.7.0"
 					},
 					"dependencies": {
-						"are-we-there-yet": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
-							"integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
-							"dev": true,
-							"requires": {
-								"delegates": "^1.0.0",
-								"readable-stream": "^3.6.0"
-							}
-						},
 						"gauge": {
 							"version": "3.0.1",
 							"resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz",
@@ -21338,6 +21328,12 @@
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
 					"integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+					"dev": true
+				},
+				"follow-redirects": {
+					"version": "1.14.1",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+					"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
 					"dev": true
 				},
 				"forever-agent": {

--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -14,6 +14,7 @@ import namespaceEndpointMiddleware from './middlewares/namespace-endpoint';
 import httpV1Middleware from './middlewares/http-v1';
 import userLocaleMiddleware from './middlewares/user-locale';
 import mediaUploadMiddleware from './middlewares/media-upload';
+import jsonSchemaMiddleware from './middlewares/json-schema';
 import {
 	parseResponseAndNormalizeError,
 	parseAndThrowError,
@@ -53,6 +54,7 @@ const middlewares = [
 	userLocaleMiddleware,
 	namespaceEndpointMiddleware,
 	httpV1Middleware,
+	jsonSchemaMiddleware,
 	fetchAllMiddleware,
 ];
 

--- a/packages/api-fetch/src/middlewares/json-schema.js
+++ b/packages/api-fetch/src/middlewares/json-schema.js
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import Ajv from 'ajv';
+
+/**
+ * Internal dependencies
+ */
+import apiFetch from '..';
+
+const ajv = new Ajv( {
+	strict: false,
+} );
+
+/**
+ * The REST API enforces an upper limit on the per_page option. To handle large
+ * collections, apiFetch consumers can pass `per_page=-1`; this middleware will
+ * then recursively assemble a full response array from all available pages.
+ *
+ * @type {import('../types').APIFetchMiddleware}
+ */
+const jsonSchemaMiddleware = async ( options, next ) => {
+	if ( options.parse === false ) {
+		// If a consumer has opted out of parsing, do not apply middleware.
+		return next( options );
+	}
+
+	if ( options.method === 'OPTIONS' ) {
+		return next( options );
+	}
+
+	// Retrieve requested page of results.
+	const schemaResponse = await apiFetch( {
+		...options,
+		method: 'OPTIONS',
+	} );
+
+	if ( ! ( 'schema' in schemaResponse ) ) {
+		return next( options );
+	}
+
+	const { schema } = schemaResponse;
+	const response = await next( options );
+
+	delete schema.$schema;
+	const validate = ajv.compile( schema );
+	const valid = validate( response );
+	if ( ! valid ) {
+		setTimeout( () => {
+			console.log( schema );
+			throw validate.errors;
+		} );
+	}
+
+	return response;
+};
+
+export default jsonSchemaMiddleware;

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -39,9 +39,10 @@
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/is-shallow-equal": "file:../is-shallow-equal",
 		"@wordpress/url": "file:../url",
+		"ajv": "8.10.0",
 		"equivalent-key-map": "^0.2.2",
 		"lodash": "^4.17.21",
-	  	"memize": "^1.1.0",
+		"memize": "^1.1.0",
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},


### PR DESCRIPTION
As discussed extensively in [TypeScript definitions for core-data entity records](https://github.com/WordPress/gutenberg/pull/38666), the API responses are currently accepted on the face value and not parsed at all. WordPress REST API does expose the JSON schema definitions, though, so we theoretically could parse anything the API returns. This PR explores how an implementation could look like.

The implementation is super naive ATM: it merely requests the schema using an OPTIONS request and uses it to validate the data. The upside is that it can work regardless of the API version. The downside is that that schema can easily get out of sync with the TypeScript types.

It seems like we'd have to bundle the data shapes with the Gutenberg plugin and strongly couple it with the Typescript definitions. I also wonder what should happen in case of inconsistencies, e.g. numbers transmitted as strings. Should it throw an error? Should it try to type-cast the data and issue a warning if the result seems sensible or issue an error if there is no sane way to perform the cast?

cc @jsnajdr @dmsnell 