### PR TITLE
Add e2e testing for experimental nav menu deletion

### DIFF
--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -13,6 +13,7 @@ import {
 	deleteAllMenus,
 	pressKeyTimes,
 	pressKeyWithModifier,
+	setBrowserViewport,
 	setUpResponseMocking,
 	visitAdminPage,
 	__experimentalRest as rest,
@@ -680,122 +681,142 @@ describe.skip( 'Navigation editor', () => {
 		} );
 	} );
 	describe( 'Delete menu button', () => {
-		it( 'should retain menu when confirmation is canceled', async () => {
-			const menuName = 'Menu delete test';
-
-			await createMenu( { name: menuName }, menuItemsFixture );
-			expect( true ).toBe( true );
-			await visitNavigationEditor();
-
-			// Wait for the header to show the menu name.
-			await page.waitForXPath(
-				`//h2[contains(text(), "${ menuName }")]`
-			);
-
-			const deleteMenuButton = await page.waitForXPath(
-				'//button[text()="Delete menu"]'
-			);
-			await deleteMenuButton.click();
-
-			const cancelButton = await page.waitForXPath(
-				'//*[@role="dialog"]//button[text()="Cancel"]'
-			);
-			await cancelButton.click();
-
-			const element = await page.waitForXPath(
-				`//*[contains(@class,"edit-navigation-menu-actions")]//h2[text()="${ menuName }"]`
-			);
-			const currentSelectedMenu = await page.evaluate(
-				( el ) => el.textContent,
-				element
-			);
-
-			expect( currentSelectedMenu ).toBe( menuName );
+		afterEach( async () => {
+			await setBrowserViewport( 'large' );
 		} );
-		it( 'should delete menu when confirmation is confirmed and there are no other menus', async () => {
-			const menuName = 'Menu delete test';
+		it.each( [ 'large', 'small' ] )(
+			`should retain menu when confirmation is canceled and the viewport is %s`,
+			async ( viewport ) => {
+				const menuName = 'Menu delete test';
+				await createMenu( { name: menuName }, menuItemsFixture );
+				await visitNavigationEditor();
+				await setBrowserViewport( viewport );
+				// Wait for the header to show the menu name.
+				await page.waitForXPath(
+					`//h2[contains(text(), "${ menuName }")]`
+				);
 
-			await createMenu( { name: menuName }, menuItemsFixture );
-			await visitNavigationEditor();
-
-			// Wait for the header to show the menu name.
-			await page.waitForXPath(
-				`//h2[contains(text(), "${ menuName }")]`
-			);
-
-			const deleteMenuButton = await page.waitForXPath(
-				'//button[text()="Delete menu"]'
-			);
-			await deleteMenuButton.click();
-
-			const confirmButton = await page.waitForXPath(
-				'//*[@role="dialog"]//button[text()="OK"]'
-			);
-			await confirmButton.click();
-
-			await page.waitForXPath(
-				`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
-			);
-
-			// If the "Create your first menu" prompt appears, we know there are no remaining menus,
-			// so our test menu must have been deleted successfully.
-			const createFirstMenuPrompt = await page.waitForXPath(
-				'//h3[.="Create your first menu"]',
-				{
-					visible: true,
+				if ( viewport === 'small' ) {
+					const openSettingsSidebar = await page.waitForXPath(
+						'//button[@aria-label="Settings"][@aria-expanded="false"]'
+					);
+					await openSettingsSidebar.click();
 				}
-			);
-			const noMenusRemaining = createFirstMenuPrompt ? true : false;
-			expect( noMenusRemaining ).toBe( true );
-		} );
 
-		it( 'should delete menu when confirmation is confirmed and there are other existing menus', async () => {
-			const menuName = 'Menu delete test';
+				const deleteMenuButton = await page.waitForXPath(
+					'//button[text()="Delete menu"]'
+				);
+				await deleteMenuButton.click();
 
-			await createMenu( { name: menuName }, menuItemsFixture );
-			await createMenu( { name: `${ menuName } 2` }, menuItemsFixture );
-			await visitNavigationEditor();
-			// Wait for the header to show the menu name.
-			await page.waitForXPath(
-				`//h2[contains(text(), "${ menuName }")]`
-			);
+				const cancelButton = await page.waitForXPath(
+					'//*[@role="dialog"]//button[text()="Cancel"]'
+				);
+				await cancelButton.click();
 
-			const deleteMenuButton = await page.waitForXPath(
-				'//button[text()="Delete menu"]'
-			);
-			await deleteMenuButton.click();
+				const menuActionsDropdown = await page.waitForXPath(
+					`//*[contains(@class,"edit-navigation-menu-actions")]//h2[text()="${ menuName }"]`
+				);
+				const currentSelectedMenu = await page.evaluate(
+					( el ) => el.textContent,
+					menuActionsDropdown
+				);
 
-			const confirmButton = await page.waitForXPath(
-				'//*[@role="dialog"]//button[text()="OK"]'
-			);
-			await confirmButton.click();
-
-			await page.waitForXPath(
-				`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
-			);
-
-			const menuActionsDropdown = await page.waitForXPath(
-				'//*[@class="edit-navigation-menu-actions"]//button[@aria-expanded="false"]'
-			);
-
-			await menuActionsDropdown.click();
-
-			const menuElementHandles = await page.$x(
-				'//*[@role="group"]//*[@role="menuitemradio"]/span'
-			);
-			const existingMenus = [];
-			for ( const elem of menuElementHandles ) {
-				const elemName = await elem.getProperty( 'textContent' );
-				const existingMenuName = await elemName.jsonValue();
-				existingMenus.push( existingMenuName );
+				expect( currentSelectedMenu ).toBe( menuName );
 			}
-			expect( existingMenus.includes( `${ menuName }` ) ).toBe( false );
-		} );
+		);
+		it.each( [ 'large', 'small' ] )(
+			`should delete menu when confirmation is confirmed and there are no other menus and the viewport is %s`,
+			async ( viewport ) => {
+				const menuName = 'Menu delete test';
+				await createMenu( { name: menuName }, menuItemsFixture );
+				await visitNavigationEditor();
+				await setBrowserViewport( viewport );
+				// Wait for the header to show the menu name.
+				await page.waitForXPath(
+					`//h2[contains(text(), "${ menuName }")]`
+				);
+				if ( viewport === 'small' ) {
+					const openSettingsSidebar = await page.waitForXPath(
+						'//button[@aria-label="Settings"][@aria-expanded="false"]'
+					);
+					await openSettingsSidebar.click();
+				}
 
-		// it.only( 'test', async () => {
-		// 	expect( true ).toBe( true );
-		// } );
+				const deleteMenuButton = await page.waitForXPath(
+					'//button[text()="Delete menu"]'
+				);
+				await deleteMenuButton.click();
+
+				const confirmButton = await page.waitForXPath(
+					'//*[@role="dialog"]//button[text()="OK"]'
+				);
+				await confirmButton.click();
+
+				await page.waitForXPath(
+					`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
+				);
+
+				// If the "Create your first menu" prompt appears, we know there are no remaining menus,
+				// so our test menu must have been deleted successfully.
+				const createFirstMenuPrompt = await page.waitForXPath(
+					'//h3[.="Create your first menu"]',
+					{
+						visible: true,
+					}
+				);
+				const noMenusRemaining = createFirstMenuPrompt ? true : false;
+				expect( noMenusRemaining ).toBe( true );
+			}
+		);
+
+		it.each( [ 'large', 'small' ] )(
+			`should delete menu when confirmation is confirmed and there are other existing menus and the viewport is %s`,
+			async () => {
+				const menuName = 'Menu delete test';
+				await createMenu( { name: menuName }, menuItemsFixture );
+				await createMenu(
+					{ name: `${ menuName } 2` },
+					menuItemsFixture
+				);
+				await visitNavigationEditor();
+				// Wait for the header to show the menu name.
+				await page.waitForXPath(
+					`//h2[contains(text(), "${ menuName }")]`
+				);
+
+				const deleteMenuButton = await page.waitForXPath(
+					'//button[text()="Delete menu"]'
+				);
+				await deleteMenuButton.click();
+
+				const confirmButton = await page.waitForXPath(
+					'//*[@role="dialog"]//button[text()="OK"]'
+				);
+				await confirmButton.click();
+
+				await page.waitForXPath(
+					`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
+				);
+
+				const menuActionsDropdown = await page.waitForXPath(
+					'//*[@class="edit-navigation-menu-actions"]//button[@aria-expanded="false"]'
+				);
+
+				await menuActionsDropdown.click();
+
+				const menuElementHandles = await page.$x(
+					'//*[@role="group"]//*[@role="menuitemradio"]/span'
+				);
+				const existingMenus = [];
+				for ( const elem of menuElementHandles ) {
+					const elemName = await elem.getProperty( 'textContent' );
+					const existingMenuName = await elemName.jsonValue();
+					existingMenus.push( existingMenuName );
+				}
+				expect( existingMenus.includes( `${ menuName }` ) ).toBe(
+					false
+				);
+			}
+		);
 	} );
 } );
-
-//TODO: Resolve unhandled asyncs and investigate testing viewports. hint: check 'await' appilcations

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -701,139 +701,147 @@ describe.skip( 'Navigation editor', () => {
 			expect( lastItemAttributes.isTopLevelLink ).toBeTruthy();
 		} );
 	} );
-	describe( 'Delete menu button', () => {
-		afterEach( async () => {
-			await setBrowserViewport( 'large' );
-		} );
-		it.each( [ 'large', 'small' ] )(
-			`should retain menu when confirmation is canceled and the viewport is %s`,
-			async ( viewport ) => {
-				const menuName = 'Menu delete test';
-				await createMenu( { name: menuName }, menuItemsFixture );
-				await visitNavigationEditor();
-				await setBrowserViewport( viewport );
-				// Wait for the header to show the menu name.
-				await page.waitForXPath(
-					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
-				);
+} );
 
-				if ( viewport === 'small' ) {
-					const openSettingsSidebar = await page.waitForXPath(
-						'//button[@aria-label="Settings"][@aria-expanded="false"]'
-					);
-					await openSettingsSidebar.click();
-				}
+describe( 'Delete menu button', () => {
+	useExperimentalFeatures( [ '#gutenberg-navigation' ] );
 
-				const deleteMenuButton = await page.waitForXPath(
-					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
-				);
-				await deleteMenuButton.click();
-
-				const cancelButton = await page.waitForXPath(
-					'//*[@role="dialog"]//button[text()="Cancel"]'
-				);
-				await cancelButton.click();
-
-				const menuActionsDropdown = await page.waitForXPath(
-					`//*[contains(@class,"edit-navigation-menu-actions")]//h2[text()="${ menuName }"]`
-				);
-				const currentSelectedMenu = await page.evaluate(
-					( el ) => el.textContent,
-					menuActionsDropdown
-				);
-
-				expect( currentSelectedMenu ).toBe( menuName );
-			}
-		);
-		it.each( [ 'large', 'small' ] )(
-			`should delete menu when confirmation is confirmed and there are no other menus and the viewport is %s`,
-			async ( viewport ) => {
-				const menuName = 'Menu delete test';
-				await createMenu( { name: menuName }, menuItemsFixture );
-				await visitNavigationEditor();
-				await setBrowserViewport( viewport );
-				// Wait for the header to show the menu name.
-				await page.waitForXPath(
-					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
-				);
-				if ( viewport === 'small' ) {
-					const openSettingsSidebar = await page.waitForXPath(
-						'//button[@aria-label="Settings"][@aria-expanded="false"]'
-					);
-					await openSettingsSidebar.click();
-				}
-
-				const deleteMenuButton = await page.waitForXPath(
-					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
-				);
-				await deleteMenuButton.click();
-
-				const confirmButton = await page.waitForXPath(
-					'//*[@role="dialog"]//button[text()="OK"]'
-				);
-				await confirmButton.click();
-
-				await page.waitForXPath(
-					`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
-				);
-
-				// If the "Create your first menu" prompt appears, we know there are no remaining menus,
-				// so our test menu must have been deleted successfully.
-				const createFirstMenuPrompt = await page.waitForXPath(
-					'//h3[.="Create your first menu"]',
-					{
-						visible: true,
-					}
-				);
-				const noMenusRemaining = createFirstMenuPrompt ? true : false;
-				expect( noMenusRemaining ).toBe( true );
-			}
-		);
-
-		it.each( [ 'large', 'small' ] )(
-			`should delete menu when confirmation is confirmed and there are other existing menus and the viewport is %s`,
-			async () => {
-				const menuName = 'Menu delete test';
-				await createMenu( { name: menuName }, menuItemsFixture );
-				await createMenu(
-					{ name: `${ menuName } 2` },
-					menuItemsFixture
-				);
-				await visitNavigationEditor();
-				// Wait for the header to show the menu name
-				await page.waitForXPath(
-					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
-				);
-
-				// Confirm both test menus are present
-				openMenuActionsDropdown();
-				const firstTestMenuItem = await getMenuItem( menuName );
-				const secondTestMenuItem = await getMenuItem(
-					`${ menuName } 2`
-				);
-
-				expect( firstTestMenuItem ).not.toBeNull();
-				expect( secondTestMenuItem ).not.toBeNull();
-
-				// Delete the first test menu
-				const deleteMenuButton = await page.waitForXPath(
-					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
-				);
-				await deleteMenuButton.click();
-
-				const confirmButton = await page.waitForXPath(
-					'//*[@role="dialog"]//button[text()="OK"]'
-				);
-				await confirmButton.click();
-
-				await page.waitForXPath(
-					`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
-				);
-
-				openMenuActionsDropdown();
-				const deletedTestMenuItem = await getMenuItem( menuName );
-				expect( deletedTestMenuItem ).toBeNull();
-			}
-		);
+	beforeAll( async () => {
+		await deleteAllMenus();
+		await deleteAllLinkedResources();
 	} );
+
+	afterEach( async () => {
+		await deleteAllMenus();
+		await deleteAllLinkedResources();
+	} );
+
+	afterEach( async () => {
+		await setBrowserViewport( 'large' );
+	} );
+	it.each( [ 'large', 'small' ] )(
+		`should retain menu when confirmation is canceled and the viewport is %s`,
+		async ( viewport ) => {
+			const menuName = 'Menu delete test';
+			await createMenu( { name: menuName }, menuItemsFixture );
+			await visitNavigationEditor();
+			await setBrowserViewport( viewport );
+			// Wait for the header to show the menu name.
+			await page.waitForXPath(
+				`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
+			);
+
+			if ( viewport === 'small' ) {
+				const openSettingsSidebar = await page.waitForXPath(
+					'//button[@aria-label="Settings"][@aria-expanded="false"]'
+				);
+				await openSettingsSidebar.click();
+			}
+
+			const deleteMenuButton = await page.waitForXPath(
+				'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
+			);
+			await deleteMenuButton.click();
+
+			const cancelButton = await page.waitForXPath(
+				'//*[@role="dialog"]//button[text()="Cancel"]'
+			);
+			await cancelButton.click();
+
+			const menuActionsDropdown = await page.waitForXPath(
+				`//*[contains(@class,"edit-navigation-menu-actions")]//h2[text()="${ menuName }"]`
+			);
+			const currentSelectedMenu = await page.evaluate(
+				( el ) => el.textContent,
+				menuActionsDropdown
+			);
+
+			expect( currentSelectedMenu ).toBe( menuName );
+		}
+	);
+	it.each( [ 'large', 'small' ] )(
+		`should delete menu when confirmation is confirmed and there are no other menus and the viewport is %s`,
+		async ( viewport ) => {
+			const menuName = 'Menu delete test';
+			await createMenu( { name: menuName }, menuItemsFixture );
+			await visitNavigationEditor();
+			await setBrowserViewport( viewport );
+			// Wait for the header to show the menu name.
+			await page.waitForXPath(
+				`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
+			);
+			if ( viewport === 'small' ) {
+				const openSettingsSidebar = await page.waitForXPath(
+					'//button[@aria-label="Settings"][@aria-expanded="false"]'
+				);
+				await openSettingsSidebar.click();
+			}
+
+			const deleteMenuButton = await page.waitForXPath(
+				'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
+			);
+			await deleteMenuButton.click();
+
+			const confirmButton = await page.waitForXPath(
+				'//*[@role="dialog"]//button[text()="OK"]'
+			);
+			await confirmButton.click();
+
+			await page.waitForXPath(
+				`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
+			);
+
+			// If the "Create your first menu" prompt appears, we know there are no remaining menus,
+			// so our test menu must have been deleted successfully.
+			const createFirstMenuPrompt = await page.waitForXPath(
+				'//h3[.="Create your first menu"]',
+				{
+					visible: true,
+				}
+			);
+			const noMenusRemaining = createFirstMenuPrompt ? true : false;
+			expect( noMenusRemaining ).toBe( true );
+		}
+	);
+
+	it.each( [ 'large', 'small' ] )(
+		`should delete menu when confirmation is confirmed and there are other existing menus and the viewport is %s`,
+		async () => {
+			const menuName = 'Menu delete test';
+			await createMenu( { name: menuName }, menuItemsFixture );
+			await createMenu( { name: `${ menuName } 2` }, menuItemsFixture );
+			await visitNavigationEditor();
+			// Wait for the header to show the menu name
+			await page.waitForXPath(
+				`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
+			);
+
+			// Confirm both test menus are present
+			openMenuActionsDropdown();
+			const firstTestMenuItem = await getMenuItem( menuName );
+			const secondTestMenuItem = await getMenuItem( `${ menuName } 2` );
+
+			expect( firstTestMenuItem ).not.toBeNull();
+			expect( secondTestMenuItem ).not.toBeNull();
+
+			// Delete the first test menu
+			const deleteMenuButton = await page.waitForXPath(
+				'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
+			);
+			await deleteMenuButton.click();
+
+			const confirmButton = await page.waitForXPath(
+				'//*[@role="dialog"]//button[text()="OK"]'
+			);
+			await confirmButton.click();
+
+			await page.waitForXPath(
+				`//*[@role="button"][@aria-label="Dismiss this notice"]//*[text()='"${ menuName }" menu has been deleted']`
+			);
+
+			openMenuActionsDropdown();
+			const deletedTestMenuItem = await getMenuItem( menuName );
+			expect( deletedTestMenuItem ).toBeNull();
+		}
+	);
 } );

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -711,7 +711,7 @@ describe.skip( 'Navigation editor', () => {
 				}
 
 				const deleteMenuButton = await page.waitForXPath(
-					'//button[text()="Delete menu"]'
+					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
 				);
 				await deleteMenuButton.click();
 
@@ -750,7 +750,7 @@ describe.skip( 'Navigation editor', () => {
 				}
 
 				const deleteMenuButton = await page.waitForXPath(
-					'//button[text()="Delete menu"]'
+					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
 				);
 				await deleteMenuButton.click();
 
@@ -821,7 +821,7 @@ describe.skip( 'Navigation editor', () => {
 
 				// Delete the first test menu
 				const deleteMenuButton = await page.waitForXPath(
-					'//button[text()="Delete menu"]'
+					'//*[@role="region"][@aria-label="Navigation settings"]//button[text()="Delete menu"]'
 				);
 				await deleteMenuButton.click();
 

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -185,6 +185,20 @@ async function openMenuActionsDropdown() {
 	await menuActionsDropdown.click();
 }
 
+async function getMenuItem( menuItemName ) {
+	return await page
+		.waitForXPath(
+			`//*[@role="group"]//*[@role="menuitemradio"]/span[text()="${ menuItemName }"]`
+		)
+		.catch( ( error ) => {
+			if ( error.name !== 'TimeoutError' ) {
+				throw error;
+			} else {
+				return null;
+			}
+		} );
+}
+
 describe.skip( 'Navigation editor', () => {
 	useExperimentalFeatures( [ '#gutenberg-navigation' ] );
 
@@ -793,28 +807,10 @@ describe.skip( 'Navigation editor', () => {
 
 				// Confirm both test menus are present
 				openMenuActionsDropdown();
-				const firstTestMenuItem = await page
-					.waitForXPath(
-						`//*[@role="group"]//*[@role="menuitemradio"]/span[text()="${ menuName }"]`
-					)
-					.catch( ( error ) => {
-						if ( error.name !== 'TimeoutError' ) {
-							throw error;
-						} else {
-							return null;
-						}
-					} );
-				const secondTestMenuItem = await page
-					.waitForXPath(
-						`//*[@role="group"]//*[@role="menuitemradio"]/span[text()="${ menuName } 2"]`
-					)
-					.catch( ( error ) => {
-						if ( error.name !== 'TimeoutError' ) {
-							throw error;
-						} else {
-							return null;
-						}
-					} );
+				const firstTestMenuItem = await getMenuItem( menuName );
+				const secondTestMenuItem = await getMenuItem(
+					`${ menuName } 2`
+				);
 
 				expect( firstTestMenuItem ).not.toBeNull();
 				expect( secondTestMenuItem ).not.toBeNull();
@@ -835,17 +831,7 @@ describe.skip( 'Navigation editor', () => {
 				);
 
 				openMenuActionsDropdown();
-				const deletedTestMenuItem = await page
-					.waitForXPath(
-						`//*[@role="group"]//*[@role="menuitemradio"]/span[text()="${ menuName }"]`
-					)
-					.catch( ( error ) => {
-						if ( error.name !== 'TimeoutError' ) {
-							throw error;
-						} else {
-							return null;
-						}
-					} );
+				const deletedTestMenuItem = await getMenuItem( menuName );
 				expect( deletedTestMenuItem ).toBeNull();
 			}
 		);

--- a/packages/e2e-tests/specs/experiments/navigation-editor.test.js
+++ b/packages/e2e-tests/specs/experiments/navigation-editor.test.js
@@ -693,7 +693,7 @@ describe.skip( 'Navigation editor', () => {
 				await setBrowserViewport( viewport );
 				// Wait for the header to show the menu name.
 				await page.waitForXPath(
-					`//h2[contains(text(), "${ menuName }")]`
+					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
 				);
 
 				if ( viewport === 'small' ) {
@@ -733,7 +733,7 @@ describe.skip( 'Navigation editor', () => {
 				await setBrowserViewport( viewport );
 				// Wait for the header to show the menu name.
 				await page.waitForXPath(
-					`//h2[contains(text(), "${ menuName }")]`
+					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
 				);
 				if ( viewport === 'small' ) {
 					const openSettingsSidebar = await page.waitForXPath(
@@ -781,7 +781,7 @@ describe.skip( 'Navigation editor', () => {
 				await visitNavigationEditor();
 				// Wait for the header to show the menu name.
 				await page.waitForXPath(
-					`//h2[contains(text(), "${ menuName }")]`
+					`//*[@role="region"][@aria-label="Navigation top bar"]//h2[contains(text(), "${ menuName }")]`
 				);
 
 				const deleteMenuButton = await page.waitForXPath(
@@ -799,7 +799,7 @@ describe.skip( 'Navigation editor', () => {
 				);
 
 				const menuActionsDropdown = await page.waitForXPath(
-					'//*[@class="edit-navigation-menu-actions"]//button[@aria-expanded="false"]'
+					'//*[@role="region"][@aria-label="Navigation top bar"]//*[@class="edit-navigation-menu-actions"]//button[@aria-expanded="false"]'
 				);
 
 				await menuActionsDropdown.click();


### PR DESCRIPTION
## Description
Follow up to #37492

This PR adds e2e tests for menu deletion, and the newly migrated ConfirmDialog, in the experimental nav editor. It tests:
- canceling the deletion
- confirming the deletion when there are no other existing menus
- confirming the deletion when there still _are_ other existing menus

The above are all tested twice, once for large and once for small viewports.

The confirmation test happens in two different contexts because the flow is different. With no other menus, we're shown the "Create your first menu" prompt, while if additional menus remain after deletion, we should simply see one of the other menus instead.

_**Edited to add:**_
I initially forgot to mention, I do see frequent (not constant, but on a lot of test runs) warnings from Jest:

> Jest did not exit one second after the test run has completed.
> 
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

In troubleshooting, I've found this comes up inconsistently with existing tests in the suite as well. The more tests you run the more likely you are to see it, so with this PR's six tests it comes up a lot.

I _think_ it's being triggered by something in the timing of the `createMenu()` method's API call, but that's just a theory. Either way it feels like something best pursued in a separate PR.

## Testing Instructions
1. This is an experimental feature, so the main suite is currently skipped. Remove the `.skip` from `packages/e2e-tests/specs/experiments/navigation-editor.test.js` line 181.
2. On line 683 of the same file, add a `.only` to the `describe` call. This is both to speed up testing and also to skip over issues that appear to be present in some of the existing tests.
3. Run the new tests: `npx wp-scripts test-e2e --config packages/e2e-tests/jest.config.js packages/e2e-tests/specs/experiments/navigation-editor.test.js`
4. All 6 tests should pass

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->

cc @ciampo @fullofcaffeine 