### PR TITLE
Add safeDispatch util hook

### DIFF
--- a/packages/element/src/index.js
+++ b/packages/element/src/index.js
@@ -5,3 +5,4 @@ export * from './utils';
 export { default as Platform } from './platform';
 export { default as renderToString } from './serialize';
 export { default as RawHTML } from './raw-html';
+export { default as __experimentalUseSafeDispatch } from './use-safe-dispatch';

--- a/packages/element/src/test/use-safe-dispatch.js
+++ b/packages/element/src/test/use-safe-dispatch.js
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { render, act } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import {
+	useState,
+	useEffect,
+	__experimentalUseSafeDispatch as useSafeDispatch,
+} from '@wordpress/element';
+
+function deferred() {
+	let resolve, reject;
+	const promise = new Promise( ( res, rej ) => {
+		resolve = res;
+		reject = rej;
+	} );
+	return { promise, resolve, reject };
+}
+
+describe( '__experimentalUseSafeDispatch', () => {
+	it( 'does not allow dispatch on unmounted component', async () => {
+		jest.spyOn( console, 'error' );
+
+		const { promise, resolve } = deferred();
+
+		jest.useFakeTimers();
+
+		function MyComponent() {
+			const [ msg, setMsg ] = useState();
+
+			const safeSetMsg = useSafeDispatch( setMsg );
+
+			useEffect( () => {
+				async function doAsync() {
+					await promise;
+					safeSetMsg( 'Loaded' );
+				}
+
+				doAsync();
+			}, [ safeSetMsg ] );
+			return <p>Hello from Component: { msg }</p>;
+		}
+
+		const { unmount } = render( <MyComponent /> );
+
+		// Unmount whilst still 'await'ing in component.
+		unmount();
+
+		// Resolve the Promise within the component's effect
+		// that was not cleaned up.
+		await act( async () => {
+			resolve();
+		} );
+
+		// Look for warning:
+		// "Warning: Can't perform a React state update on an unmounted component"
+		// eslint-disable-next-line no-console
+		const badCall = console.error.mock.calls.find( ( args ) =>
+			args.some( ( a ) => a && a.includes && a.includes( 'unmounted' ) )
+		);
+		expect( badCall ).toBe( undefined );
+		// eslint-disable-next-line no-console
+		console.error.mockRestore();
+	} );
+} );

--- a/packages/element/src/use-safe-dispatch.js
+++ b/packages/element/src/use-safe-dispatch.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { useRef, useLayoutEffect, useCallback } from './react';
+
+export default function useSafeDispatch( dispatch ) {
+	const mounted = useRef( false );
+	// @ts-ignore
+	useLayoutEffect( () => {
+		mounted.current = true;
+		return () => ( mounted.current = false );
+	}, [] );
+	return useCallback(
+		( ...args ) => ( mounted.current ? dispatch( ...args ) : void 0 ),
+		[ dispatch ]
+	);
+}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This PR adds a new utility hook called `__experimentalUseSafeDispatch`. I came across this whilst working through the [Epic React course by Kent C Dodds](https://github.com/kentcdodds/bookshelf/blob/c3be72ec9fb01e19a996526c24f9039df85df2d6/src/utils/use-async.js#L3).

The hook accepts a function and returns a handler. If you invoke the handler when the component is _unmounted_, the original function _will not_ be called.

This is very useful for guarding against the common `setState` on unmounted component error which occurs when a component attempts to call `setState` following the resolution of a `Promise`. I've seen this error crop up many times whilst working on the Gutenberg codebase as it's very easily introduced.

Here's an example of the common error pattern:

```jsx
function MyComponent() {
    const [ msg, setMsg ] = useState();

    useEffect( () => {
        async function doAsync() {
            await somePromise();
            setMsg( 'Loaded' ); // ⚠️ error if component has been unmounted.
        }

        doAsync();
    }, [ safeSetMsg ] );
    return <p>Hello from Component: { msg }</p>;
}
```

Here's how `useSafeDispatch` guards against that:

```jsx
function MyComponent() {
    const [ msg, setMsg ] = useState();

    // Wrapped handler function.
    const safeSetMsg = useSafeDispatch( setMsg );

    useEffect( () => {
        async function doAsync() {
            await promise;
            safeSetMsg( 'Loaded' ); // will **not** call `setMsg` if MyComponent has been unmounted.
        }

        doAsync();
    }, [ safeSetMsg ] );
    return <p>Hello from Component: { msg }</p>;
}
```

You can also use this hook to guard any function including `dispatch` from `useReducer` or `useDispatch`.

## Questions

- should the hook log a warning to the console suggesting you need to cancel your handlers in the `useEffect`? 


## Testing Instructions

I would advise reading through the tests to understand how the component works. 

If you had time I would try it out in your own component.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
