### PR TITLE
Block Conversion: Fix Image and Video to Cover block transformations

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -33,6 +33,7 @@ const transforms = {
 						createBlock( 'core/paragraph', {
 							content: caption,
 							fontSize: 'large',
+							align: 'center',
 						} ),
 					]
 				),
@@ -55,6 +56,7 @@ const transforms = {
 						createBlock( 'core/paragraph', {
 							content: caption,
 							fontSize: 'large',
+							align: 'center',
 						} ),
 					]
 				),


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/38869

Cover block uses a default `template` to match the legacy `title` attribute, that existed before supporting innerBlocks. That template also includes a `text-align:center` for the first innerblock(a paragraph).

When we transform a Video or Image block to Cover we don't use the default template, as we pass a new paragraph block and this can create confusion because the result isn't the same.

This PR adds the text-align:center to these transformations.