### PR TITLE
Dom: Avoid RangeError in findPrevious method

### DIFF
--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -166,7 +166,7 @@ export function findPrevious( element ) {
 	const index = focusables.indexOf( element );
 
 	// Remove all focusables after and including `element`.
-	focusables.length = index;
+	focusables.length = index !== -1 ? index : 0;
 
 	return last( filterTabbable( focusables ) );
 }

--- a/packages/dom/src/tabbable.js
+++ b/packages/dom/src/tabbable.js
@@ -160,13 +160,19 @@ export function find( context ) {
  *
  * @param {Element} element The focusable element before which to look. Defaults
  *                          to the active element.
+ *
+ * @return {Element|undefined} Preceding tabbable element.
  */
 export function findPrevious( element ) {
 	const focusables = findFocusable( element.ownerDocument.body );
 	const index = focusables.indexOf( element );
 
+	if ( index === -1 ) {
+		return undefined;
+	}
+
 	// Remove all focusables after and including `element`.
-	focusables.length = index !== -1 ? index : 0;
+	focusables.length = index;
 
 	return last( filterTabbable( focusables ) );
 }


### PR DESCRIPTION
## Description
I noticed this error while running e2e tests.

The `findPrevious` uses return value from `Array.indexOf` to set length focusables, which can be `-1` when the element isn't in an array and cause `RangeError: Invalid array length` error.

## Testing Instructions
It is a little hard to reproduce this error manually. However, you can run the following e2e test and confirm it doesn't throw an error:

```
npm run test-e2e -- packages/e2e-tests/specs/editor/various/keyboard-navigable-blocks.test.js
```

The error happens during the "allows tabbing in navigation mode if no block is selected (reverse)" test.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
