### PR TITLE
Storybook: Ensure rerender for RTL switcher

### DIFF
--- a/storybook/decorators/with-rtl.js
+++ b/storybook/decorators/with-rtl.js
@@ -1,13 +1,13 @@
 /**
- * External dependencies
- */
-import { forceReRender } from '@storybook/react';
-
-/**
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
-import { useEffect, useLayoutEffect, useRef } from '@wordpress/element';
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import ltrStyles from '../style-ltr.lazy.scss';
 import rtlStyles from '../style-rtl.lazy.scss';
 
 export const WithRTL = ( Story, context ) => {
+	const [ rerenderKey, setRerenderKey ] = useState( 0 );
 	const ref = useRef();
 
 	useEffect( () => {
@@ -36,7 +37,7 @@ export const WithRTL = ( Story, context ) => {
 			context.globals.direction
 		);
 
-		forceReRender();
+		setRerenderKey( ( prevValue ) => prevValue + 1 );
 
 		return () => removeFilter( 'i18n.gettext_with_context', 'storybook' );
 	}, [ context.globals.direction ] );
@@ -55,7 +56,7 @@ export const WithRTL = ( Story, context ) => {
 	}, [ context.globals.direction ] );
 
 	return (
-		<div ref={ ref }>
+		<div ref={ ref } key={ rerenderKey }>
 			<Story { ...context } />
 		</div>
 	);


### PR DESCRIPTION
## Description

Fixes a re-rendering issue in the Storybook RTL switcher that @ciampo noticed in https://github.com/WordPress/gutenberg/pull/37769#pullrequestreview-887082422.

### Background

The Storybook RTL switcher requires a forced rerender after switching. This is because RTL styles in Emotion have to actively call `i18n.isRTL()` to get the current RTL value, rather than getting it from props or context.

The original RTL switcher used the `forceReRender()` function exported from `@storybook/react`, which is basically undocumented. It worked in most cases but apparently not all. The standard `key` approach seems to be more reliable.

## Testing Instructions

1. `npm run storybook:dev`
2. Open the Vertical story for the `Divider` component.
3. Set `marginStart` to `20`.
4. Toggle the RTL switcher and see that the margin moves to the correct side of the divider.

Some other RTL'ed Emotion component stories (e.g. `RangeControl`) should not have regressed.

I also tried to break it by memoizing `Divider`, but it didn't break:

```diff
- const ConnectedDivider = contextConnect( Divider, 'Divider' );
+ const ConnectedDivider = contextConnect( Divider, 'Divider', { memo: true } );
```

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/555336/155002187-381bbf5c-9030-498e-9932-fb9206e3835a.mp4

## Types of changes

Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
