### PR TITLE
Update: Keep additional classes during a block transform.

### DIFF
--- a/packages/block-editor/src/hooks/custom-class-name.js
+++ b/packages/block-editor/src/hooks/custom-class-name.js
@@ -112,6 +112,45 @@ export function addSaveProps( extraProps, blockType, attributes ) {
 	return extraProps;
 }
 
+export function addTransforms( result, source, index, results ) {
+	if ( ! hasBlockSupport( result.name, 'customClassName', true ) ) {
+		return result;
+	}
+
+	// If the condition verifies we are probably in the presence of a wrapping transform
+	// e.g: nesting paragraphs in a group or columns and in that case the class should not be kept.
+	if ( results.length === 1 && result.innerBlocks.length === source.length ) {
+		return result;
+	}
+
+	// If we are transforming one block to multiple blocks or multiple blocks to one block,
+	// we ignore the class during the transform.
+	if (
+		( results.length === 1 && source.length > 1 ) ||
+		( results.length > 1 && source.length === 1 )
+	) {
+		return result;
+	}
+
+	// If we are in presence of transform between one or more block in the source
+	// that have one or more blocks in the result
+	// we apply the class on source N to the result N,
+	// if source N does not exists we do nothing.
+	if ( source[ index ] ) {
+		const originClassName = source[ index ]?.attributes.className;
+		if ( originClassName ) {
+			return {
+				...result,
+				attributes: {
+					...result.attributes,
+					className: originClassName,
+				},
+			};
+		}
+	}
+	return result;
+}
+
 addFilter(
 	'blocks.registerBlockType',
 	'core/custom-class-name/attribute',
@@ -126,4 +165,10 @@ addFilter(
 	'blocks.getSaveContent.extraProps',
 	'core/custom-class-name/save-props',
 	addSaveProps
+);
+
+addFilter(
+	'blocks.switchToBlockType.transformedBlock',
+	'core/color/addTransforms',
+	addTransforms
 );


### PR DESCRIPTION
Follows feedback given on comment https://github.com/WordPress/gutenberg/issues/30815#issuecomment-1046110463 and adds functionality to keep the additional class names during a block transform. 

## Testing Instructions
I added one paragraph block with a classname converted it to a heading and verified the classname was kept. I converted the heading back to a paragraph and verified the classname persisted.
I added two headings and a classname to each of the headings converted the headings using the multiselection option to a paragraph and verified the classnames were kept.
I added one paragraph block with a classname converted it to a group and verified the classname was not added to the group.
I added two paragraphs each containing a classname converted both paragraphs to a list and verified the classname was not kept.