### PR TITLE
Components: Normalize font-family

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Normalize `font-family` on `Button`, `ColorPalette`, `ComoboboxControl`, `DateTimePicker`, `FormTokenField`, `InputControl`, `SelectControl`, and `ToggleGroupControl` ([#38969](https://github.com/WordPress/gutenberg/pull/38969)).
+
 ## 19.5.0 (2022-02-23)
 
 ### Bug Fix

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,6 +1,7 @@
 .components-button {
 	display: inline-flex;
 	text-decoration: none;
+	font-family: inherit;
 	font-weight: normal;
 	font-size: $default-font-size;
 	margin: 0;

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -5,6 +5,7 @@
 	display: block;
 	border-radius: $radius-block-ui;
 	height: $grid-unit-60;
+	font-family: inherit;
 	text-align: right;
 	width: 100%;
 	background-image:

--- a/packages/components/src/combobox-control/style.scss
+++ b/packages/components/src/combobox-control/style.scss
@@ -6,6 +6,7 @@ input.components-combobox-control__input[type="text"] {
 	width: 100%;
 	border: none;
 	box-shadow: none;
+	font-family: inherit;
 	font-size: 16px;
 	padding: 2px;
 	margin: 0;

--- a/packages/components/src/date-time/style.scss
+++ b/packages/components/src/date-time/style.scss
@@ -237,6 +237,10 @@
 	}
 }
 
+.components-datetime__time-field-integer-field {
+	font-family: inherit;
+}
+
 .components-datetime__time-field-hours-input,
 .components-datetime__time-field-minutes-input,
 .components-datetime__time-field-day-input {

--- a/packages/components/src/date-time/time.js
+++ b/packages/components/src/date-time/time.js
@@ -36,12 +36,19 @@ function from12hTo24h( hours, isPm ) {
  * <UpdateOnBlurAsIntegerField>
  * A shared component to parse, validate, and handle remounting of the underlying form field element like <input> and <select>.
  *
- * @param {Object}        props          Component props.
- * @param {string}        props.as       Render the component as specific element tag, defaults to "input".
- * @param {number|string} props.value    The default value of the component which will be parsed to integer.
- * @param {Function}      props.onUpdate Call back when blurred and validated.
+ * @param {Object}        props             Component props.
+ * @param {string}        props.as          Render the component as specific element tag, defaults to "input".
+ * @param {number|string} props.value       The default value of the component which will be parsed to integer.
+ * @param {Function}      props.onUpdate    Call back when blurred and validated.
+ * @param {string}        [props.className]
  */
-function UpdateOnBlurAsIntegerField( { as, value, onUpdate, ...props } ) {
+function UpdateOnBlurAsIntegerField( {
+	as,
+	value,
+	onUpdate,
+	className,
+	...props
+} ) {
 	function handleBlur( event ) {
 		const { target } = event;
 
@@ -70,6 +77,10 @@ function UpdateOnBlurAsIntegerField( { as, value, onUpdate, ...props } ) {
 		key: value,
 		defaultValue: value,
 		onBlur: handleBlur,
+		className: classnames(
+			'components-datetime__time-field-integer-field',
+			className
+		),
 		...props,
 	} );
 }

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -22,6 +22,7 @@
 	input[type="text"].components-form-token-field__input {
 		display: inline-block;
 		flex: 1;
+		font-family: inherit;
 		font-size: 16px;
 		width: 100%;
 		max-width: 100%;

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -212,6 +212,7 @@ export const Input = styled.input< InputProps >`
 		box-shadow: none !important;
 		color: ${ COLORS.black };
 		display: block;
+		font-family: inherit;
 		margin: 0;
 		outline: none;
 		width: 100%;

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -98,6 +98,7 @@ export const Select = styled.select< SelectProps >`
 		box-shadow: none !important;
 		color: ${ COLORS.black };
 		display: block;
+		font-family: inherit;
 		margin: 0;
 		width: 100%;
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -84,6 +84,7 @@ exports[`ToggleGroupControl should render correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  font-family: inherit;
   height: 100%;
   -webkit-box-pack: center;
   -ms-flex-pack: center;

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
@@ -29,6 +29,7 @@ export const buttonView = css`
 	color: ${ COLORS.gray[ 700 ] };
 	cursor: pointer;
 	display: flex;
+	font-family: inherit;
 	height: 100%;
 	justify-content: center;
 	line-height: 100%;


### PR DESCRIPTION
Fixes #37555 

## Description

This fixes a `font-family` inconsistency that causes some environments to render certain control elements in an unintended font.

### Directly affected components

- Button
- ColorPalette
- ComboboxControl
- DateTimePicker
- FormTokenField
- InputControl
- SelectControl
- ToggleGroupControl

Anything relying on these components will be fixed as well.

### Background

Chrome has user agent styles that make `input`, `select`, and `button` default to Arial (not sure if this is the same font for everyone). This basically makes these control elements render in a different font from the [surrounding UI](https://github.com/WordPress/gutenberg/blob/f3c95660506f8a2a094471ea0f8c5255b1ed838d/packages/base-styles/_variables.scss#L15).

This problem doesn't manifest in contexts where the core WP `forms.css` is loaded (i.e. wp-admin), since that includes these normalizing rules:

```scss
// forms.css
input, select, textarea, button {
  font-family: inherit;
}
```

The presence of `forms.css` is obviously not guaranteed, as has surfaced in Storybook.

I briefly considered adding some kind of global reset styles for the wp-components package, but I _think_ we should be adding them explicitly in each relevant component because ultimately we're aiming for complete tree-shakeable encapsulation. Thoughts?

## Testing Instructions

1. `npm run storybook:dev`
2. In Chrome, open the story for any one of the fixed components. Compare it to the one on https://wordpress.github.io/gutenberg/.

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/555336/155020983-3d8630ff-ebf2-4524-8d6d-6a17d7294994.mp4

## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
