### PR TITLE
Improve switch to draft button e2e test robustness

### DIFF
--- a/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
+++ b/packages/e2e-tests/specs/editor/various/switch-to-draft.test.js
@@ -67,7 +67,9 @@ async function scheduleTestPost( postType, viewport ) {
 	);
 
 	await (
-		await page.$x( '//td[@role="button"]/*[text() = "15"]' )
+		await page.$x(
+			'//*[@role="application"][@aria-label="Calendar"]//td[@role="button"]/*[text() = "15"]'
+		)
 	 )[ 0 ].click();
 
 	await page.click( '.edit-post-post-schedule__toggle' );


### PR DESCRIPTION
## Description
Follow up to https://github.com/WordPress/gutenberg/pull/37491

This PR improves the XPath selector for the post scheduling calendar as discussed in https://github.com/WordPress/gutenberg/pull/38717#pullrequestreview-886560365 to add more specificity and make the test more robust.

cc @ciampo 

## Testing Instructions
all tests should pass

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
