### PR TITLE
Block supports: allow "all" as a value for __experimentalDefaultControls

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -57,10 +57,7 @@ export function BorderPanel( props ) {
 		return null;
 	}
 
-	const defaultBorderControls = getBlockSupport( props.name, [
-		BORDER_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultBorderControls = getDefaultBorderControls( props.name );
 
 	const createResetAllFilter = (
 		borderAttribute,
@@ -212,4 +209,30 @@ export function removeBorderAttribute( style, attribute ) {
 			[ attribute ]: undefined,
 		},
 	} );
+}
+
+/**
+ * Returns an object containing default controls. A control key with a `true` value
+ * means that the control will be shown in the panel by default.
+ *
+ * @param {string|Object} blockType Block name or block type object.
+ *
+ * @return {Object} Default controls key/value pairs.
+ */
+export function getDefaultBorderControls( blockType ) {
+	const defaultBorderControls = getBlockSupport( blockType, [
+		BORDER_SUPPORT_KEY,
+		'__experimentalDefaultControls',
+	] );
+
+	if ( defaultBorderControls === 'all' ) {
+		return {
+			color: true,
+			radius: true,
+			width: true,
+			style: true,
+		};
+	}
+
+	return defaultBorderControls;
 }

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -489,10 +489,7 @@ export function ColorEdit( props ) {
 	const enableContrastChecking =
 		Platform.OS === 'web' && ! gradient && ! style?.color?.gradient;
 
-	const defaultColorControls = getBlockSupport( props.name, [
-		COLOR_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultColorControls = getDefaultColorControls( props.name );
 
 	return (
 		<ColorPanel
@@ -619,6 +616,31 @@ export const withColorPaletteStyles = createHigherOrderComponent(
 		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	}
 );
+
+/**
+ * Returns an object containing default controls. A control key with a `true` value
+ * means that the control will be shown in the panel by default.
+ *
+ * @param {string|Object} blockType Block name or block type object.
+ *
+ * @return {Object} Default controls key/value pairs.
+ */
+export function getDefaultColorControls( blockType ) {
+	const defaultBorderControls = getBlockSupport( blockType, [
+		COLOR_SUPPORT_KEY,
+		'__experimentalDefaultControls',
+	] );
+
+	if ( defaultBorderControls === 'all' ) {
+		return {
+			text: true,
+			background: true,
+			link: true,
+		};
+	}
+
+	return defaultBorderControls;
+}
 
 const MIGRATION_PATHS = {
 	linkColor: [ [ 'style', 'elements', 'link', 'color', 'text' ] ],

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -631,7 +631,7 @@ export function getDefaultColorControls( blockType ) {
 		'__experimentalDefaultControls',
 	] );
 
-	if ( defaultBorderControls === 'all' ) {
+	if ( defaultColorControls === 'all' ) {
 		return {
 			text: true,
 			background: true,
@@ -639,7 +639,7 @@ export function getDefaultColorControls( blockType ) {
 		};
 	}
 
-	return defaultBorderControls;
+	return defaultColorControls;
 }
 
 const MIGRATION_PATHS = {

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -626,7 +626,7 @@ export const withColorPaletteStyles = createHigherOrderComponent(
  * @return {Object} Default controls key/value pairs.
  */
 export function getDefaultColorControls( blockType ) {
-	const defaultBorderControls = getBlockSupport( blockType, [
+	const defaultColorControls = getBlockSupport( blockType, [
 		COLOR_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -208,7 +208,7 @@ export function getDefaultDimensionsControls( blockType ) {
 		'__experimentalDefaultControls',
 	] );
 
-	if ( defaultBorderControls === 'all' ) {
+	if ( defaultDimensionsControls === 'all' ) {
 		return {
 			padding: true,
 			margin: true,
@@ -216,5 +216,5 @@ export function getDefaultDimensionsControls( blockType ) {
 		};
 	}
 
-	return defaultBorderControls;
+	return defaultDimensionsControls;
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -54,10 +54,7 @@ export function DimensionsPanel( props ) {
 		return null;
 	}
 
-	const defaultSpacingControls = getBlockSupport( props.name, [
-		SPACING_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultSpacingControls = getDefaultDimensionsControls( props.name );
 
 	const createResetAllFilter = ( attribute ) => ( newAttributes ) => ( {
 		...newAttributes,
@@ -195,4 +192,29 @@ export function useIsDimensionsSupportValid( blockName, feature ) {
 	}
 
 	return true;
+}
+
+/**
+ * Returns an object containing default controls. A control key with a `true` value
+ * means that the control will be shown in the panel by default.
+ *
+ * @param {string|Object} blockType Block name or block type object.
+ *
+ * @return {Object} Default controls key/value pairs.
+ */
+export function getDefaultDimensionsControls( blockType ) {
+	const defaultBorderControls = getBlockSupport( blockType, [
+		SPACING_SUPPORT_KEY,
+		'__experimentalDefaultControls',
+	] );
+
+	if ( defaultBorderControls === 'all' ) {
+		return {
+			padding: true,
+			margin: true,
+			blockGap: true,
+		};
+	}
+
+	return defaultBorderControls;
 }

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -203,7 +203,7 @@ export function useIsDimensionsSupportValid( blockName, feature ) {
  * @return {Object} Default controls key/value pairs.
  */
 export function getDefaultDimensionsControls( blockType ) {
-	const defaultBorderControls = getBlockSupport( blockType, [
+	const defaultDimensionsControls = getBlockSupport( blockType, [
 		SPACING_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -94,10 +94,7 @@ export function TypographyPanel( props ) {
 
 	if ( isDisabled || ! isSupported ) return null;
 
-	const defaultControls = getBlockSupport( props.name, [
-		TYPOGRAPHY_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultControls = getDefaultTypographyControls( props.name );
 
 	const createResetAllFilter = ( attribute ) => ( newAttributes ) => ( {
 		...newAttributes,
@@ -249,4 +246,32 @@ function useIsTypographyDisabled( props = {} ) {
 	];
 
 	return configs.filter( Boolean ).length === configs.length;
+}
+
+/**
+ * Returns an object containing default controls. A control key with a `true` value
+ * means that the control will be shown in the panel by default.
+ *
+ * @param {string|Object} blockType Block name or block type object.
+ *
+ * @return {Object} Default controls key/value pairs.
+ */
+export function getDefaultTypographyControls( blockType ) {
+	const defaultBorderControls = getBlockSupport( blockType, [
+		TYPOGRAPHY_SUPPORT_KEY,
+		'__experimentalDefaultControls',
+	] );
+
+	if ( defaultBorderControls === 'all' ) {
+		return {
+			fontFamily: true,
+			fontSize: true,
+			fontAppearance: true,
+			lineHeight: true,
+			textDecoration: true,
+			letterSpacing: true,
+		};
+	}
+
+	return defaultBorderControls;
 }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -262,16 +262,17 @@ export function getDefaultTypographyControls( blockType ) {
 		'__experimentalDefaultControls',
 	] );
 
-	if ( defaultBorderControls === 'all' ) {
+	if ( defaultTypographyControls === 'all' ) {
 		return {
 			fontFamily: true,
 			fontSize: true,
 			fontAppearance: true,
 			lineHeight: true,
 			textDecoration: true,
+			textTransform: true,
 			letterSpacing: true,
 		};
 	}
 
-	return defaultBorderControls;
+	return defaultTypographyControls;
 }

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -257,7 +257,7 @@ function useIsTypographyDisabled( props = {} ) {
  * @return {Object} Default controls key/value pairs.
  */
 export function getDefaultTypographyControls( blockType ) {
-	const defaultBorderControls = getBlockSupport( blockType, [
+	const defaultTypographyControls = getBlockSupport( blockType, [
 		TYPOGRAPHY_SUPPORT_KEY,
 		'__experimentalDefaultControls',
 	] );


### PR DESCRIPTION
## Description
This PR introduces a method for each block support that shows all supported controls when  `__experimentalDefaultControls` is `true`.

It will only show the controls where the block.json has opted into the support.

This PR is mainly to test the appetite for such a feature.

Props to @andrewserong for the idea

## Testing Instructions

Where a block's `block.json` opts into a support, swap the object for `"__experimentalDefaultControls" for "all"` to show all controls in the panel by default.

For example:

```json
		"spacing": {
			"margin": [ "top", "bottom" ],
			"padding": true,
			"blockGap": true,
			"__experimentalDefaultControls": "all"
		},
```

Testing using the Group Block is convenient. Here's an example `block.json`:

<details><summary>Group block.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/block.json",
	"apiVersion": 2,
	"name": "core/group",
	"title": "Group",
	"category": "design",
	"description": "Combine blocks into a group.",
	"keywords": [ "container", "wrapper", "row", "section" ],
	"textdomain": "default",
	"attributes": {
		"tagName": {
			"type": "string",
			"default": "div"
		},
		"templateLock": {
			"type": [ "string", "boolean" ],
			"enum": [ "all", "insert", false ]
		}
	},
	"supports": {
		"align": [ "wide", "full" ],
		"anchor": true,
		"html": false,
		"color": {
			"gradients": true,
			"link": true,
			"__experimentalDefaultControls": "all"
		},
		"spacing": {
			"margin": [ "top", "bottom" ],
			"padding": true,
			"blockGap": true,
			"__experimentalDefaultControls": "all"
		},
		"__experimentalBorder": {
			"color": true,
			"radius": true,
			"style": true,
			"width": true,
			"__experimentalDefaultControls": "all"
		},
		"typography": {
			"fontSize": true,
			"lineHeight": true,
			"__experimentalFontStyle": true,
			"__experimentalFontWeight": true,
			"__experimentalLetterSpacing": true,
			"__experimentalTextTransform": true,
			"__experimentalDefaultControls": "all"
		},
		"__experimentalLayout": true
	},
	"editorStyle": "wp-block-group-editor",
	"style": "wp-block-group"
}

```

</details>

## Screenshots <!-- if applicable -->

Opting into all controls for the Group Block:

<img width="286" alt="Screen Shot 2022-02-22 at 3 27 36 pm" src="https://user-images.githubusercontent.com/6458278/155063189-5a41b7d9-c0d0-4c88-845e-f2eccac2a1d9.png">


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
