### PR TITLE
Style Engine: Try approach for consolidating styles into a single style tag and de-dupe styles

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -165,7 +165,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		1
 	);
 
-	gutenberg_enqueue_block_support_styles( $style );
+	WP_Style_Engine_Gutenberg::get_instance()->add_style( $class_name, $style );
 
 	return $content;
 }

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -50,26 +50,26 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 	$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
 	// Add universal styles for all default layouts.
-	// Add left align rule;
+	// Add left align rule.
 	$class_names[] = $style_engine->add_style(
 		'wp-layout-default',
 		array(
 			'selector' => '.alignleft',
 			'rules'    => array(
-				'float' => 'left',
+				'float'        => 'left',
 				'margin-right' => '2em',
 				'margin-left'  => '0',
 			),
 		)
 	);
 
-	// Add right align rule:
+	// Add right align rule.
 	$class_names[] = $style_engine->add_style(
 		'wp-layout-default',
 		array(
 			'selector' => '.alignright',
 			'rules'    => array(
-				'float' => 'right',
+				'float'        => 'right',
 				'margin-left'  => '2em',
 				'margin-right' => '0',
 			),
@@ -83,11 +83,11 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 			array(
 				'suffix'   => $all_max_width_value,
 				'selector' => '> :where(:not(.alignleft):not(.alignright))',
-				'rules' => array(
+				'rules'    => array(
 					'max-width'    => esc_html( $all_max_width_value ),
 					'margin-left'  => 'auto !important',
 					'margin-right' => 'auto !important',
-				)
+				),
 			)
 		);
 
@@ -97,9 +97,9 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 			array(
 				'suffix'   => $wide_max_width_value,
 				'selector' => '> .alignwide',
-				'rules' => array(
+				'rules'    => array(
 					'max-width' => esc_html( $wide_max_width_value ),
-				)
+				),
 			)
 		);
 
@@ -110,7 +110,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 				'selector' => '> .alignfull',
 				'rules'    => array(
 					'max-width' => 'none',
-				)
+				),
 			)
 		);
 	}
@@ -230,7 +230,7 @@ function gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support =
 			$class_names[] = $style_engine->add_style(
 				'wp-layout-flex-global-gap',
 				array(
-					'rules'  => array(
+					'rules' => array(
 						'gap' => 'var( --wp--style--block-gap, 0.5em )',
 					),
 				)
@@ -252,8 +252,8 @@ function gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support =
 		$class_names[] = $style_engine->add_style(
 			'wp-layout-flex-orientation-horizontal',
 			array(
-				'rules'  => array(
-					'align-items'    => 'center',
+				'rules' => array(
+					'align-items' => 'center',
 				),
 			)
 		);
@@ -278,7 +278,7 @@ function gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support =
 		$class_names[] = $style_engine->add_style(
 			'wp-layout-flex-orientation-vertical',
 			array(
-				'rules'  => array(
+				'rules' => array(
 					'flex-direction' => 'column',
 				),
 			)
@@ -321,8 +321,6 @@ function gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support =
  */
 function gutenberg_get_layout_style( $layout, $has_block_gap_support = false, $gap_value = null ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
-
-	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
 	$class_names = array();
 
 	if ( 'default' === $layout_type ) {
@@ -361,7 +359,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$used_layout = $default_layout;
 	}
 
-	$gap_value  = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
+	$gap_value = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) );
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -52,7 +52,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 	// Add universal styles for all default layouts.
 	// Add left align rule.
 	$class_names[] = $style_engine->add_style(
-		'wp-layout-default',
+		'wp-layout-flow',
 		array(
 			'selector' => '.alignleft',
 			'rules'    => array(
@@ -65,7 +65,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 
 	// Add right align rule.
 	$class_names[] = $style_engine->add_style(
-		'wp-layout-default',
+		'wp-layout-flow',
 		array(
 			'selector' => '.alignright',
 			'rules'    => array(
@@ -79,7 +79,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 	if ( $content_size || $wide_size ) {
 		// Add value specific content size.
 		$class_names[] = $style_engine->add_style(
-			'wp-layout-default-content-size',
+			'wp-layout-flow-content-size',
 			array(
 				'suffix'   => $all_max_width_value,
 				'selector' => '> :where(:not(.alignleft):not(.alignright))',
@@ -93,7 +93,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 
 		// Add value specific wide size.
 		$class_names[] = $style_engine->add_style(
-			'wp-layout-default-wide-size',
+			'wp-layout-flow-wide-size',
 			array(
 				'suffix'   => $wide_max_width_value,
 				'selector' => '> .alignwide',
@@ -105,7 +105,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 
 		// Add universal full width.
 		$class_names[] = $style_engine->add_style(
-			'wp-layout-default',
+			'wp-layout-flow',
 			array(
 				'selector' => '> .alignfull',
 				'rules'    => array(
@@ -118,7 +118,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 	if ( $has_block_gap_support ) {
 		if ( ! $gap_value ) {
 			$class_names[] = $style_engine->add_style(
-				'wp-layout-default-global-gap',
+				'wp-layout-flow-global-gap',
 				array(
 					'selector' => '> *',
 					'rules'    => array(
@@ -128,7 +128,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 				)
 			);
 			$class_names[] = $style_engine->add_style(
-				'wp-layout-default-global-gap',
+				'wp-layout-flow-global-gap',
 				array(
 					'selector' => '> * + *',
 					'rules'    => array(
@@ -139,7 +139,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 			);
 		} else {
 			$class_names[] = $style_engine->add_style(
-				'wp-layout-default-custom-gap',
+				'wp-layout-flow-custom-gap',
 				array(
 					'suffix'   => $gap_value,
 					'selector' => '> *',
@@ -150,7 +150,7 @@ function gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support =
 				)
 			);
 			$class_names[] = $style_engine->add_style(
-				'wp-layout-default-custom-gap',
+				'wp-layout-flow-custom-gap',
 				array(
 					'suffix'   => $gap_value,
 					'selector' => '> * + *',
@@ -320,10 +320,10 @@ function gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support =
  * @return array An array of class names corresponding to the generated layout CSS.
  */
 function gutenberg_get_layout_style( $layout, $has_block_gap_support = false, $gap_value = null ) {
-	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
+	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'flow';
 	$class_names = array();
 
-	if ( 'default' === $layout_type ) {
+	if ( 'flow' === $layout_type ) {
 		$class_names = gutenberg_generate_layout_style_flow( $layout, $has_block_gap_support, $gap_value );
 	} elseif ( 'flex' === $layout_type ) {
 		$class_names = gutenberg_generate_layout_style_flex( $layout, $has_block_gap_support, $gap_value );

--- a/lib/class-wp-style-engine-gutenberg.php
+++ b/lib/class-wp-style-engine-gutenberg.php
@@ -3,7 +3,6 @@
  * WP_Style_Engine class
  *
  * @package Gutenberg
-
  */
 
 /**
@@ -31,6 +30,9 @@ class WP_Style_Engine_Gutenberg {
 	 */
 	private static $instance = null;
 
+	/**
+	 * Register action for outputting styles when the class is constructed.
+	 */
 	public function __construct() {
 		// Borrows the logic from `gutenberg_enqueue_block_support_styles`.
 		$action_hook_name = 'wp_footer';
@@ -83,7 +85,7 @@ class WP_Style_Engine_Gutenberg {
 			$style .= '  ';
 			$style .= $rules;
 		} else {
-			foreach( $rules as $rule => $value ) {
+			foreach ( $rules as $rule => $value ) {
 				$style .= "  {$rule}: {$value};\n";
 			}
 		}
@@ -94,6 +96,9 @@ class WP_Style_Engine_Gutenberg {
 		return $class;
 	}
 
+	/**
+	 * Render registered styles for final output.
+	 */
 	public function output_styles() {
 		$style = implode( "\n", $this->registered_styles );
 		echo "<style>\n$style</style>\n";

--- a/lib/class-wp-style-engine-gutenberg.php
+++ b/lib/class-wp-style-engine-gutenberg.php
@@ -61,8 +61,7 @@ class WP_Style_Engine_Gutenberg {
 	}
 
 	/**
-	 * Assemble the style rule from a list of rules, and store based on a key
-	 * generated from the class name, the selector, and any values used as a suffix.
+	 * Stores style rules for a given CSS selector (the key) and returns an associated classname.
 	 *
 	 * @param string $key     A class name used to construct a key.
 	 * @param array  $options An array of options, rules, and selector for constructing the rules.
@@ -79,28 +78,29 @@ class WP_Style_Engine_Gutenberg {
 			return;
 		}
 
-		$style = "{$prefix}{$class}{$selector} {\n";
-
-		if ( is_string( $rules ) ) {
-			$style .= '  ';
-			$style .= $rules;
-		} else {
-			foreach ( $rules as $rule => $value ) {
-				$style .= "  {$rule}: {$value};\n";
-			}
-		}
-		$style .= "}\n";
-
-		$this->registered_styles[ $class . $selector ] = $style;
+		$this->registered_styles[ $prefix . $class . $selector ] = $rules;
 
 		return $class;
 	}
 
 	/**
-	 * Render registered styles for final output.
+	 * Render registered styles as key { ...rules }  for final output.
 	 */
 	public function output_styles() {
-		$style = implode( "\n", $this->registered_styles );
-		echo "<style>\n$style</style>\n";
+		$output = '';
+		foreach ( $this->registered_styles as $selector => $rules ) {
+			$output .= "{$selector} {\n";
+
+			if ( is_string( $rules ) ) {
+				$output .= '  ';
+				$output .= $rules;
+			} else {
+				foreach ( $rules as $rule => $value ) {
+					$output .= "  {$rule}: {$value};\n";
+				}
+			}
+			$output .= "}\n";
+		}
+		echo "<style>\n$output</style>\n";
 	}
 }

--- a/lib/class-wp-style-engine.php
+++ b/lib/class-wp-style-engine.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WP_Style_Engine class
+ *
+ * @package Gutenberg
+
+ */
+
+/**
+ * Singleton class representing the style engine.
+ *
+ * Consolidates rendering block styles to reduce duplication and streamline
+ * CSS styles generation.
+ *
+ * @since 6.0.0
+ */
+class WP_Style_Engine_Gutenberg {
+	/**
+	 * Registered CSS styles.
+	 *
+	 * @since 5.5.0
+	 * @var array
+	 */
+	private $registered_styles = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @since 5.5.0
+	 * @var WP_Style_Engine_Gutenberg|null
+	 */
+	private static $instance = null;
+
+	public function __construct() {
+		// Borrows the logic from `gutenberg_enqueue_block_support_styles`.
+		$action_hook_name = 'wp_footer';
+		if ( wp_is_block_theme() ) {
+			$action_hook_name = 'wp_enqueue_scripts';
+		}
+		add_action(
+			$action_hook_name,
+			array( $this, 'output_styles' )
+		);
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return WP_Style_Engine_Gutenberg The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function add_style( $key, $value ) {
+		$this->registered_styles[ $key ] = $value;
+	}
+
+	public function output_styles() {
+		$style = implode( "\n", $this->registered_styles );
+		echo "<style>$style</style>\n";
+	}
+}

--- a/lib/class-wp-style-engine.php
+++ b/lib/class-wp-style-engine.php
@@ -58,12 +58,44 @@ class WP_Style_Engine_Gutenberg {
 		return self::$instance;
 	}
 
-	public function add_style( $key, $value ) {
-		$this->registered_styles[ $key ] = $value;
+	/**
+	 * Assemble the style rule from a list of rules, and store based on a key
+	 * generated from the class name, the selector, and any values used as a suffix.
+	 *
+	 * @param string $key     A class name used to construct a key.
+	 * @param array  $options An array of options, rules, and selector for constructing the rules.
+	 *
+	 * @return string The class name for the added style.
+	 */
+	public function add_style( $key, $options ) {
+		$class    = ! empty( $options['suffix'] ) ? $key . '-' . sanitize_title( $options['suffix'] ) : $key;
+		$selector = ! empty( $options['selector'] ) ? ' ' . trim( $options['selector'] ) : '';
+		$rules    = ! empty( $options['rules'] ) ? $options['rules'] : array();
+		$prefix   = ! empty( $options['prefix'] ) ? $options['prefix'] : '.';
+
+		if ( ! $class ) {
+			return;
+		}
+
+		$style = "{$prefix}{$class}{$selector} {\n";
+
+		if ( is_string( $rules ) ) {
+			$style .= '  ';
+			$style .= $rules;
+		} else {
+			foreach( $rules as $rule => $value ) {
+				$style .= "  {$rule}: {$value};\n";
+			}
+		}
+		$style .= "}\n";
+
+		$this->registered_styles[ $class . $selector ] = $style;
+
+		return $class;
 	}
 
 	public function output_styles() {
 		$style = implode( "\n", $this->registered_styles );
-		echo "<style>$style</style>\n";
+		echo "<style>\n$style</style>\n";
 	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -123,7 +123,7 @@ require __DIR__ . '/pwa.php';
 // TODO: Before this PR merges, move this to be a part of the style engine package.
 // Part of the build process should be to copy the PHP file to the correct location,
 // similar to the loading behaviour in `blocks.php`.
-require __DIR__ . '/class-wp-style-engine.php';
+require __DIR__ . '/class-wp-style-engine-gutenberg.php';
 
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -120,6 +120,11 @@ require __DIR__ . '/experiments-page.php';
 require __DIR__ . '/global-styles.php';
 require __DIR__ . '/pwa.php';
 
+// TODO: Before this PR merges, move this to be a part of the style engine package.
+// Part of the build process should be to copy the PHP file to the correct location,
+// similar to the loading behaviour in `blocks.php`.
+require __DIR__ . '/class-wp-style-engine.php';
+
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/typography.php';


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

🚧 🚧 🚧 🚧 ___Note: this is an exploratory PR just to try out some ideas for server-rendering styles___ 🚧 🚧 🚧 🚧 

At the moment, the idea of this PR is to take a look at a couple of areas that we hope to improve via server-rendering using the style engine:

1. Consolidating style tags for layout support
2. Explore whether we can de-dupe class names by generating class names based on values used in constructing the styles instead of using a random class name. E.g. `wp-container-1` becomes `wp-layout-default wp-layout-default-content-size-650px wp-layout-default-wide-size-1000px wp-layout-default-global-gap`

Related work:

There is another similar / alternate exploration in #39086 

Related:
- https://github.com/WordPress/gutenberg/issues/38167


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

Currently this PR looks at consolidating style generation for the layout support into a single style tag, and generating class names based on style values instead of a randomly assigned number.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/155071784-bda7328c-fcd2-4eb9-94ab-56f84b51f776.png) | ![image](https://user-images.githubusercontent.com/14988353/155657832-c96d19db-02b1-4aa0-8fe3-4eb884066b89.png) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Exploratory

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
