### PR TITLE
Page List: Simplify loading state

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -12,12 +12,7 @@ import {
 	useBlockProps,
 	getColorClassName,
 } from '@wordpress/block-editor';
-import {
-	ToolbarButton,
-	Placeholder,
-	Spinner,
-	Notice,
-} from '@wordpress/components';
+import { ToolbarButton, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
@@ -77,9 +72,7 @@ export default function PageListEdit( { context, clientId } ) {
 			) }
 			{ ! hasResolvedPages && (
 				<div { ...blockProps }>
-					<Placeholder>
-						<Spinner />
-					</Placeholder>
+					<Spinner />
 				</div>
 			) }
 

--- a/packages/block-library/src/page-list/editor.scss
+++ b/packages/block-library/src/page-list/editor.scss
@@ -27,16 +27,6 @@
 	pointer-events: none;
 }
 
-.wp-block-page-list .components-placeholder {
-	min-height: 0;
-	padding: 0;
-	background-color: inherit;
-
-	.components-spinner {
-		margin: 0.5em;
-	}
-}
-
 // Modal that shows conversion option.
 .wp-block-page-list-modal {
 	@include break-small() {


### PR DESCRIPTION
## Description
Resolves #38981.
Similar to #37548.

Removes placeholder wrapper from loading state.

## Testing Instructions
1. Open a Post or Page
2. Insert a Page List block
3. Confirm that Spinner isn't wrapped inside the placeholder component.

## Screenshots <!-- if applicable -->
https://user-images.githubusercontent.com/240569/155135762-ae5cde6b-1539-4358-b82d-c8274ef4a8da.mp4

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
