### PR TITLE
Try: extract template metadata from the HTML files directly

### DIFF
--- a/lib/compat/wordpress-5.9/block-template-utils.php
+++ b/lib/compat/wordpress-5.9/block-template-utils.php
@@ -323,7 +323,18 @@ if ( ! function_exists( '_get_block_templates_files' ) ) {
 				);
 
 				if ( 'wp_template_part' === $template_type ) {
-					$template_files[] = _add_block_template_part_area_info( $new_template_item );
+					$default_headers = array(
+						'title' => 'Title',
+						'area'  => 'Area',
+					);
+					$metadata = get_file_data( $template_file, $default_headers );
+					if ( ! empty( $metadata['title'] ) ) {
+						$new_template_item[ 'title' ] = translate_with_gettext_context( $metadata['title'], 'Template part title', $theme_slug );
+					}
+					if ( ! empty( $metadta['area'] ) ) {
+						$new_template_item['area'] = $metadata['area'];
+					}
+					$template_files[] = $new_template_item;
 				}
 
 				if ( 'wp_template' === $template_type ) {


### PR DESCRIPTION
Spin-off from https://github.com/WordPress/gutenberg/pull/36751

The templates & parts of block themes are declared via `.html` files. The metadata for each of those files (translatable title, area, post types, etc) is provided via an external file, the `theme.json` (see `customTemplates` and `templateParts` keys). This PR explores pulling metadata directly from the `.html` files, spinning off from https://github.com/WordPress/gutenberg/pull/36751

Each template & part would add a top-level comment such as:

```html
<!--
	title: Title for the template or part
	area: related-area
-->
```

## How to test

- Use the empty theme and WordPress 5.8.
- Add the following to the `parts/header.html` file in the theme directory:

```html
<!--
	title: Cabeceira
	area: header
-->
```
- Go to the site editor and verify that the part name is now "Cabeceira". In `trunk`, it'd be "header".

## TODO and related work.

- In `wp-cli`: implement extracting the fields available for translation from the `.html` templates.
- Fallback to the existing `theme.json` mechanism if no metadata was found in the template & part.
- Make it work for 5.9 (provide plugin overrides to the core functions, etc).
