### PR TITLE
Show tooltip on toggle custom size in FontSizePicker.

### DIFF
--- a/packages/components/src/font-size-picker/index.js
+++ b/packages/components/src/font-size-picker/index.js
@@ -144,7 +144,6 @@ function FontSizePicker(
 									? __( 'Use size preset' )
 									: __( 'Set custom size' )
 							}
-							showTooltip={ false }
 							icon={ settings }
 							onClick={ () => {
 								setShowCustomValueControl(


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/38931

>There's no tooltip displayed when you hover over the Set custom size icon so there's no indication what the icon actually does.

## Testing instructions
1. Click on a paragraph
2. Hover over the `set custom size` toggle button in Font Size Picker
3. Observe that a tooltip is shown with a proper message depending on what controls are displayed.

#### Notes
Your theme should have custom font sizes support.