### PR TITLE
Post Title: Add support for text decoration

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -50,6 +50,7 @@
 			"__experimentalFontFamily": true,
 			"__experimentalFontWeight": true,
 			"__experimentalFontStyle": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalTextTransform": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -40,8 +40,8 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 			'<%1$s><a href="%2$s" target="%3$s" rel="%4$s" %5$s>%6$s</a></%1$s>',
 			$tag_name,
 			get_the_permalink( $post_ID ),
-			$attributes['linkTarget'],
-			$attributes['rel'],
+			esc_attr( $attributes['linkTarget'] ),
+			esc_attr( $attributes['rel'] ),
 			$wrapper_attributes,
 			$title
 		);

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -33,10 +33,19 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		$tag_name = 0 === $attributes['level'] ? 'p' : 'h' . $attributes['level'];
 	}
 
-	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-		$title = sprintf( '<a href="%1$s" target="%2$s" rel="%3$s">%4$s</a>', get_the_permalink( $post_ID ), esc_attr( $attributes['linkTarget'] ), esc_attr( $attributes['rel'] ), $title );
-	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
+
+	if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+		return sprintf(
+			'<%1$s><a href="%2$s" target="%3$s" rel="%4$s" %5$s>%6$s</a></%1$s>',
+			$tag_name,
+			get_the_permalink( $post_ID ),
+			$attributes['linkTarget'],
+			$attributes['rel'],
+			$wrapper_attributes,
+			$title
+		);
+	}
 
 	return sprintf(
 		'<%1$s %2$s>%3$s</%1$s>',


### PR DESCRIPTION
## Description
We removed support for text decoration from the Post Title block in https://github.com/WordPress/gutenberg/pull/34064, though I'm not quite sure why. This adds back that support, but it makes a few changes to ensure that it is applied to the link, not to the wrapper, if there is a link.

We might want to get https://github.com/WordPress/gutenberg/pull/31768 shipped as part of this change too?

## Testing Instructions
Open a page template that contains a Post Title
Edit the block and confirm that you can add a "strikethrough" text decoration
Also confirm that the setting can be "none" as per https://github.com/Automattic/themes/pull/5573

## Screenshots <!-- if applicable -->
<img width="1440" alt="Screenshot 2022-02-22 at 13 53 02" src="https://user-images.githubusercontent.com/275961/155146092-e940d877-5f4b-474a-9c09-b33606b76ca0.png">


## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
