### PR TITLE
Core Data: Resolve getCurrentUser on API error

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -35,8 +35,12 @@ export const getAuthors = ( query ) => async ( { dispatch } ) => {
  * Requests the current user from the REST API.
  */
 export const getCurrentUser = () => async ( { dispatch } ) => {
-	const currentUser = await apiFetch( { path: '/wp/v2/users/me' } );
-	dispatch.receiveCurrentUser( currentUser );
+	try {
+		const currentUser = await apiFetch( { path: '/wp/v2/users/me' } );
+		dispatch.receiveCurrentUser( currentUser );
+	} catch ( error ) {
+		// Catching the error ensures the resolver is marked as resolved.
+	}
 };
 
 /**

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -454,4 +454,16 @@ describe( 'getCurrentUser', () => {
 			SUCCESSFUL_RESPONSE
 		);
 	} );
+
+	it( 'does nothing when there is an API error', async () => {
+		const dispatch = Object.assign( jest.fn(), {
+			receiveCurrentUser: jest.fn(),
+		} );
+
+		triggerFetch.mockRejectedValue( { status: 401 } );
+
+		await getCurrentUser()( { dispatch } );
+
+		expect( dispatch.receiveCurrentUser ).not.toHaveBeenCalled();
+	} );
 } );


### PR DESCRIPTION
## Description
See #37682.

Add `try/catch` to `getCurrentUser`. Even if we do nothing, catching an error ensures the resolver is marked as resolved.

## Testing Instructions
I couldn't figure out how to test this manually, so I included unit tests.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
