### PR TITLE
[RichText]: Fix wrong block merging when pressing  `delete` consecutively

### DIFF
--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -449,6 +449,33 @@ describe( 'Writing Flow', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should merge forwards properly on multiple triggers', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '3' );
+		await pressKeyTimes( 'ArrowUp', 2 );
+		await pressKeyTimes( 'Delete', 2 );
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>1</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>3</p>
+		<!-- /wp:paragraph -->"
+	` );
+		await page.keyboard.press( 'Delete' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>13</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
+
 	it( 'should preserve horizontal position when navigating vertically between blocks', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'abc' );

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -204,6 +204,7 @@ export function useRichText( {
 	useLayoutEffect( () => {
 		if ( didMount.current && value !== _value.current ) {
 			applyFromProps();
+			forceRender();
 		}
 	}, [ value ] );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/37534
Fixes https://github.com/WordPress/gutenberg/pull/38991

Currently if you have some `mergeable` blocks like `paragraphs` and you press `delete` at the end of one of them multiple times it doesn't work as expected.

### What is the problem and why this suggested patch
I'm not 100% sure if there is a better fix for this and I've pinged @ellatrix to take a look and share feedback, but from what I understood the reason for this is:
The delete handling happens [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/rich-text/index.js#L264) which takes its value from `useRichText` hook. After debugging I saw that the value wasn't updated on `delete` press and would stop after `three` improper handlings of the `delete`, because in the third press would take another stale previous value, but the selection(start,end) would have changed so it wouldn't qualify to merge blocks.

At first I thought we didn't check the new/previous value inside  `useRichText` hook, but [we actually do here](https://github.com/WordPress/gutenberg/blob/trunk/packages/rich-text/src/component/index.js#L204). That hook on change updates internal `refs` (which do not cause a rerender) and after updating the `refs` we `forceRender` to make consumers take the updated value. So on merge blocks the `onChange` is not called but `applyFromProps` is, which updates the used `ref` without making the hook rerender.

Hope that makes sense and I'm not way off with this solution 😄 

## Reproduction steps
There are two scenarios that are affected by the same problem.
**Scenario 1:**
1. Insert two paragraph blocks
2. At the end of the text of the `first` paragraph press `delete` multiple times
3. Observe that the first `delete` will merge the blocks and all the others are doing nothing

**Scenario 2:**
1. Insert three paragraph blocks
2. At the end of the text of the `first` paragraph press `delete` multiple times
3. Observe that the first `delete` will merge the two blocks and the second one will merge the third one

## Testing instructions
With the reproduction steps everything should work as expected.

