### PR TITLE
Tag Cloud: Use flex for the Outline style

### DIFF
--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -19,12 +19,16 @@
 		text-decoration: none;
 	}
 
-	&.is-style-outline a {
-		border: 1px solid currentColor;
-		font-size: unset !important; // !important Needed to override the inline styles.
-		margin-bottom: 1ch;
-		margin-right: 1ch;
-		padding: 1ch 2ch;
-		text-decoration: none !important; // !important needed to override generic post content link decoration.
+	&.is-style-outline {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1ch;
+
+		a {
+			border: 1px solid currentColor;
+			font-size: unset !important; // !important Needed to override the inline styles.
+			padding: 1ch 2ch;
+			text-decoration: none !important; // !important needed to override generic post content link decoration.
+		}
 	}
 }

--- a/packages/block-library/src/tag-cloud/style.scss
+++ b/packages/block-library/src/tag-cloud/style.scss
@@ -27,6 +27,7 @@
 		a {
 			border: 1px solid currentColor;
 			font-size: unset !important; // !important Needed to override the inline styles.
+			margin-right: 0;
 			padding: 1ch 2ch;
 			text-decoration: none !important; // !important needed to override generic post content link decoration.
 		}


### PR DESCRIPTION
## Description
When we're using the outline style of the tag cloud block, the tags are separated using margins which makes it harder for themes to modify them. This switches the approach to use gap, which is easier for themes to hook into. It also opens the door to having a gap control for this block in the future.

## Testing Instructions
Add a tag cloud block

## Screenshots <!-- if applicable -->
<img width="528" alt="Screenshot 2022-02-22 at 17 50 06" src="https://user-images.githubusercontent.com/275961/155190092-aabc7a3f-66bc-47d4-994b-50b2e9eec669.png">

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
