### PR TITLE
Components: update framer motion to 6.2.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16008,7 +16008,7 @@
 				"colord": "^2.7.0",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^6.0.15",
-				"framer-motion": "^6.2.7",
+				"framer-motion": "^6.2.8",
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"lodash": "^4.17.21",
@@ -16043,47 +16043,6 @@
 					"version": "3.0.10",
 					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
 					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
-				},
-				"framer-motion": {
-					"version": "6.2.7",
-					"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.2.7.tgz",
-					"integrity": "sha512-RExmZCFpJ3OCakoXmZz8iW8ZI5MoaHmVadydetvTSrNaKmZ7ZC/JDQpNyw1NoDG+fchRGP86lXoiTFSQuin+Cg==",
-					"requires": {
-						"@emotion/is-prop-valid": "^0.8.2",
-						"framesync": "6.0.1",
-						"hey-listen": "^1.0.8",
-						"popmotion": "11.0.3",
-						"style-value-types": "5.0.0",
-						"tslib": "^2.1.0"
-					}
-				},
-				"framesync": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-					"integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-					"requires": {
-						"tslib": "^2.1.0"
-					}
-				},
-				"popmotion": {
-					"version": "11.0.3",
-					"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-					"integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-					"requires": {
-						"framesync": "6.0.1",
-						"hey-listen": "^1.0.8",
-						"style-value-types": "5.0.0",
-						"tslib": "^2.1.0"
-					}
-				},
-				"style-value-types": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-					"integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-					"requires": {
-						"hey-listen": "^1.0.8",
-						"tslib": "^2.1.0"
-					}
 				}
 			}
 		},
@@ -20439,6 +20398,15 @@
 					"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
 					"dev": true
 				},
+				"axios": {
+					"version": "0.21.1",
+					"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+					"integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+					"dev": true,
+					"requires": {
+						"follow-redirects": "^1.10.0"
+					}
+				},
 				"babel-runtime": {
 					"version": "6.26.0",
 					"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
@@ -21490,7 +21458,8 @@
 				"follow-redirects": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-					"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+					"integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+					"dev": true
 				},
 				"forever-agent": {
 					"version": "0.6.1",
@@ -21825,7 +21794,8 @@
 				"immediate": {
 					"version": "3.0.6",
 					"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-					"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+					"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+					"dev": true
 				},
 				"inflight": {
 					"version": "1.0.6",
@@ -22077,6 +22047,35 @@
 						"verror": "1.10.0"
 					}
 				},
+				"jszip": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+					"integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
+					"dev": true,
+					"requires": {
+						"lie": "~3.3.0",
+						"pako": "~1.0.2",
+						"readable-stream": "~2.3.6",
+						"set-immediate-shim": "~1.0.1"
+					},
+					"dependencies": {
+						"readable-stream": {
+							"version": "2.3.7",
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+							"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+							"dev": true,
+							"requires": {
+								"core-util-is": "~1.0.0",
+								"inherits": "~2.0.3",
+								"isarray": "~1.0.0",
+								"process-nextick-args": "~2.0.0",
+								"safe-buffer": "~5.1.1",
+								"string_decoder": "~1.1.1",
+								"util-deprecate": "~1.0.1"
+							}
+						}
+					}
+				},
 				"keypather": {
 					"version": "1.10.2",
 					"resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
@@ -22149,6 +22148,7 @@
 					"version": "3.3.0",
 					"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
 					"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+					"dev": true,
 					"requires": {
 						"immediate": "~3.0.5"
 					}
@@ -23499,7 +23499,8 @@
 				"set-immediate-shim": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+					"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+					"dev": true
 				},
 				"setprototypeof": {
 					"version": "1.1.1",
@@ -25321,15 +25322,6 @@
 			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz",
 			"integrity": "sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.26.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
-			"integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
-			"dev": true,
-			"requires": {
-				"follow-redirects": "^1.14.8"
-			}
 		},
 		"axobject-query": {
 			"version": "2.2.0",
@@ -34506,6 +34498,27 @@
 				"map-cache": "^0.2.2"
 			}
 		},
+		"framer-motion": {
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.2.8.tgz",
+			"integrity": "sha512-4PtBWFJ6NqR350zYVt9AsFDtISTqsdqna79FvSYPfYDXuuqFmiKtZdkTnYPslnsOMedTW0pEvaQ7eqjD+sA+HA==",
+			"requires": {
+				"@emotion/is-prop-valid": "^0.8.2",
+				"framesync": "6.0.1",
+				"hey-listen": "^1.0.8",
+				"popmotion": "11.0.3",
+				"style-value-types": "5.0.0",
+				"tslib": "^2.1.0"
+			}
+		},
+		"framesync": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+			"integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+			"requires": {
+				"tslib": "^2.1.0"
+			}
+		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -36606,12 +36619,6 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
 			"integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
-		},
-		"immediate": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-			"integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-			"dev": true
 		},
 		"immer": {
 			"version": "8.0.1",
@@ -41437,18 +41444,6 @@
 				}
 			}
 		},
-		"jszip": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
-			"integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
-			"dev": true,
-			"requires": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"set-immediate-shim": "~1.0.1"
-			}
-		},
 		"junk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
@@ -41585,15 +41580,6 @@
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
-			}
-		},
-		"lie": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
-			"requires": {
-				"immediate": "~3.0.5"
 			}
 		},
 		"lilconfig": {
@@ -47236,6 +47222,17 @@
 				}
 			}
 		},
+		"popmotion": {
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+			"integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+			"requires": {
+				"framesync": "6.0.1",
+				"hey-listen": "^1.0.8",
+				"style-value-types": "5.0.0",
+				"tslib": "^2.1.0"
+			}
+		},
 		"portfinder": {
 			"version": "1.0.28",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -52044,12 +52041,6 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-			"dev": true
-		},
 		"set-value": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -54247,6 +54238,15 @@
 			"dev": true,
 			"requires": {
 				"inline-style-parser": "0.1.1"
+			}
+		},
+		"style-value-types": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+			"integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+			"requires": {
+				"hey-listen": "^1.0.8",
+				"tslib": "^2.1.0"
 			}
 		},
 		"stylehacks": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16008,7 +16008,7 @@
 				"colord": "^2.7.0",
 				"dom-scroll-into-view": "^1.2.1",
 				"downshift": "^6.0.15",
-				"framer-motion": "^4.1.17",
+				"framer-motion": "^6.2.7",
 				"gradient-parser": "^0.1.5",
 				"highlight-words-core": "^1.2.2",
 				"lodash": "^4.17.21",
@@ -16043,6 +16043,47 @@
 					"version": "3.0.10",
 					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
 					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"framer-motion": {
+					"version": "6.2.7",
+					"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.2.7.tgz",
+					"integrity": "sha512-RExmZCFpJ3OCakoXmZz8iW8ZI5MoaHmVadydetvTSrNaKmZ7ZC/JDQpNyw1NoDG+fchRGP86lXoiTFSQuin+Cg==",
+					"requires": {
+						"@emotion/is-prop-valid": "^0.8.2",
+						"framesync": "6.0.1",
+						"hey-listen": "^1.0.8",
+						"popmotion": "11.0.3",
+						"style-value-types": "5.0.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"framesync": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+					"integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+					"requires": {
+						"tslib": "^2.1.0"
+					}
+				},
+				"popmotion": {
+					"version": "11.0.3",
+					"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+					"integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+					"requires": {
+						"framesync": "6.0.1",
+						"hey-listen": "^1.0.8",
+						"style-value-types": "5.0.0",
+						"tslib": "^2.1.0"
+					}
+				},
+				"style-value-types": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+					"integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+					"requires": {
+						"hey-listen": "^1.0.8",
+						"tslib": "^2.1.0"
+					}
 				}
 			}
 		},
@@ -34465,27 +34506,6 @@
 				"map-cache": "^0.2.2"
 			}
 		},
-		"framer-motion": {
-			"version": "4.1.17",
-			"resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-4.1.17.tgz",
-			"integrity": "sha512-thx1wvKzblzbs0XaK2X0G1JuwIdARcoNOW7VVwjO8BUltzXPyONGAElLu6CiCScsOQRI7FIk/45YTFtJw5Yozw==",
-			"requires": {
-				"@emotion/is-prop-valid": "^0.8.2",
-				"framesync": "5.3.0",
-				"hey-listen": "^1.0.8",
-				"popmotion": "9.3.6",
-				"style-value-types": "4.1.4",
-				"tslib": "^2.1.0"
-			}
-		},
-		"framesync": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/framesync/-/framesync-5.3.0.tgz",
-			"integrity": "sha512-oc5m68HDO/tuK2blj7ZcdEBRx3p1PjrgHazL8GYEpvULhrtGIFbQArN6cQS2QhW8mitffaB+VYzMjDqBxxQeoA==",
-			"requires": {
-				"tslib": "^2.1.0"
-			}
-		},
 		"fresh": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -47216,17 +47236,6 @@
 				}
 			}
 		},
-		"popmotion": {
-			"version": "9.3.6",
-			"resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
-			"integrity": "sha512-ZTbXiu6zIggXzIliMi8LGxXBF5ST+wkpXGEjeTUDUOCdSQ356hij/xjeUdv0F8zCQNeqB1+PR5/BB+gC+QLAPw==",
-			"requires": {
-				"framesync": "5.3.0",
-				"hey-listen": "^1.0.8",
-				"style-value-types": "4.1.4",
-				"tslib": "^2.1.0"
-			}
-		},
 		"portfinder": {
 			"version": "1.0.28",
 			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -54238,22 +54247,6 @@
 			"dev": true,
 			"requires": {
 				"inline-style-parser": "0.1.1"
-			}
-		},
-		"style-value-types": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-4.1.4.tgz",
-			"integrity": "sha512-LCJL6tB+vPSUoxgUBt9juXIlNJHtBMy8jkXzUJSBzeHWdBu6lhzHqCvLVkXFGsFIlNa2ln1sQHya/gzaFmB2Lg==",
-			"requires": {
-				"hey-listen": "^1.0.8",
-				"tslib": "^2.1.0"
-			},
-			"dependencies": {
-				"tslib": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-					"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
-				}
 			}
 		},
 		"stylehacks": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
 		"colord": "^2.7.0",
 		"dom-scroll-into-view": "^1.2.1",
 		"downshift": "^6.0.15",
-		"framer-motion": "^6.2.7",
+		"framer-motion": "^6.2.8",
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"lodash": "^4.17.21",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,7 +56,7 @@
 		"colord": "^2.7.0",
 		"dom-scroll-into-view": "^1.2.1",
 		"downshift": "^6.0.15",
-		"framer-motion": "^4.1.17",
+		"framer-motion": "^6.2.7",
 		"gradient-parser": "^0.1.5",
 		"highlight-words-core": "^1.2.2",
 		"lodash": "^4.17.21",

--- a/packages/components/src/animation/index.js
+++ b/packages/components/src/animation/index.js
@@ -10,5 +10,4 @@
 export {
 	motion as __unstableMotion,
 	AnimatePresence as __unstableAnimatePresence,
-	AnimateSharedLayout as __unstableAnimateSharedLayout,
 } from 'framer-motion';


### PR DESCRIPTION
Framer motion is currently used in the components package and is used to animate areas of the block editor, like the snackbar, navigation toggle in the site editor (w logo), and animations in drop zone.

This PR updates framer from 4.1.17 to 6.2.7 (the latest release).

In terms of migration https://www.framer.com/docs/guide-upgrade/ the main difference to highlight is that `AnimateSharedLayout` has been removed. 

In 5+ the `layoutId` prop and components will animate from one to another without the need for the AnimateSharedLayout wrapper. Similarly, components that affect each other's layout can be grouped [with LayoutGroup](https://www.framer.com/docs/layout-group/).

No internal references used this yet. It's also safe to change since the `AnimateSharedLayout` was previously exported under an `__unstable` prefix.

### Testing Instructions

Verify that there are no regressions in animation for:

* Snackbar
* Insertion Point
* Drop zone
* Navigation Toggle
* Preview modes in the post-editor

https://user-images.githubusercontent.com/1270189/155215668-17679a74-b16f-4074-90ac-c777b2ec126f.mp4

Example action we can dispatch in console to have a snackbar appear:
```
wp.data.dispatch('core/notices').createNotice(
		'info',
		'Post published.',
		{
			type: 'snackbar',
			actions: [
				{
					onClick: () => {},
					label: 'View post'
				}
			]
		}
	);
```