### PR TITLE
Block supports: fixing empty object in line height control 

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -61,7 +61,7 @@ export default function LineHeightControl( {
 		// For example, Firefox emits an input event with inputType="insertReplacementText"
 		// on spin button clicks, while other browsers do not even emit an input event.
 		const wasTypedOrPasted = [ 'insertText', 'insertFromPaste' ].includes(
-			action.payload.event.nativeEvent.inputType
+			action.payload.event?.nativeEvent?.inputType
 		);
 		state.value = adjustNextValue( state.value, wasTypedOrPasted );
 		return state;


### PR DESCRIPTION
## Description
In the line-height component, `nativeEvent` is not available on the event object for non-synthetic events,

The consequence is that dragging in the line-height control triggers an error.

```
index.js:64 Uncaught TypeError: Cannot read properties of undefined (reading 'inputType')
    at stateReducer (index.js:64:37)
    at reducer.ts:56:20
    at Array.reduceRight (<anonymous>)
    at reducer.ts:52:14
    at reducer.ts:147:10
    at updateReducer (react-dom.860550b4.js:15348:24)
    at Object.useReducer (react-dom.860550b4.js:16455:18)
    at useReducer (react.c58d0bd5.js:1537:23)
    at useInputControlStateReducer (reducer.ts:169:40)
    at InputField (input-field.tsx:73:33)
```

## Testing Instructions

Insert a Paragraph and drag your mouse to change the Typography > Line height value.

The page should not bork and the line height value should be correct in the editor and frontend.

## Screenshots <!-- if applicable -->
![2022-02-23 11 07 47](https://user-images.githubusercontent.com/6458278/155241383-706cfd16-3c67-427e-b390-4d013cc5cc9d.gif)


## Types of changes
Bugfix

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
