### PR TITLE
RichText: Add test for merging and then splitting paragraphs

### DIFF
--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -437,6 +437,26 @@ describe( 'Writing Flow', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should merge and then split paragraphs', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'abc' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '123' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.press( 'Enter' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>abc</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>123</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
+
 	it( 'should merge forwards', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );


### PR DESCRIPTION
## Description
Closes #34213.

The bug was resolved via #38991, this PR just adds e2e test coverage to avoid regressions.

@ntsekouras, I just realized I linked the wrong PR in the [comment](https://github.com/WordPress/gutenberg/pull/38991#issuecomment-1048145411), so went ahead and added e2e tests :)

## Testing Instructions
Running tests locally:

```
npm run test-e2e -- packages/e2e-tests/specs/editor/various/writing-flow.test.js
```

## Types of changes
Testing

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
