### PR TITLE
Add end-to-end test for merging paragraphs and soft line break afterwards.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -457,6 +457,24 @@ describe( 'Writing Flow', () => {
 	` );
 	} );
 
+	it( 'should merge and then soft line break', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '1' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( '2' );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.press( 'Delete' );
+		await page.keyboard.down( 'Shift' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.up( 'Shift' );
+
+		expect( await getEditedPostContent() ).toMatchInlineSnapshot( `
+		"<!-- wp:paragraph -->
+		<p>1<br>2</p>
+		<!-- /wp:paragraph -->"
+	` );
+	} );
+
 	it( 'should merge forwards', async () => {
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( '1' );


### PR DESCRIPTION
This PR: https://github.com/WordPress/gutenberg/pull/38991 actually resolved this issue: https://github.com/WordPress/gutenberg/issues/38322 too.

Here I added an extra e2e test to cover that case.