### PR TITLE
Fix Global styles overriding block's element styles

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -122,8 +122,11 @@ function compileElementsStyles( selector, elements = {} ) {
 	return map( elements, ( styles, element ) => {
 		const elementStyles = getInlineStyles( styles );
 		if ( ! isEmpty( elementStyles ) ) {
+			// The .editor-styles-wrapper selctor is required on elements styles. As it is
+			// added to all other editor styles, not providing it causes reset and global
+			// styles to override element styles because of higher specificity.
 			return [
-				`.${ selector } ${ ELEMENTS[ element ] }{`,
+				`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ element ] }{`,
 				...map(
 					elementStyles,
 					( value, property ) =>

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -122,7 +122,7 @@ function compileElementsStyles( selector, elements = {} ) {
 	return map( elements, ( styles, element ) => {
 		const elementStyles = getInlineStyles( styles );
 		if ( ! isEmpty( elementStyles ) ) {
-			// The .editor-styles-wrapper selctor is required on elements styles. As it is
+			// The .editor-styles-wrapper selector is required on elements styles. As it is
 			// added to all other editor styles, not providing it causes reset and global
 			// styles to override element styles because of higher specificity.
 			return [


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

This fixes #39010

This fixes issue where global styles would override local block level style settings for block element styles (ie. link color). For more details please see #39010. 

Fix is applied by prefixing css selectors with `.editor-styles-wrapper` in the `compileElementsStyles` used by `withElementsStyles` HOC which is used only in the editor.

## Testing Instructions
1. Go to Site Editor.
2. Edit Global Styles for Paragraph block - set custom color for text and link.
3. Add new Page.
4. Create a Paragraph - it should have global styles applied.
5. Create new Paragraph and edit its color styles using different text and link color.

- [ ] Link color should override global styles
- [ ] Text color should override global styles

## Screenshots <!-- if applicable -->

| before | after |
| - | - |
|  ![Screenshot 2022-02-23 at 09 56 57](https://user-images.githubusercontent.com/112270/155289347-03149c65-cd2e-4843-8b89-2d49b260bd14.jpg) |  ![Screenshot 2022-02-23 at 09 18 30](https://user-images.githubusercontent.com/112270/155289972-5ae2be9d-4ccd-4d40-907e-1200787dc9f0.jpg) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is (manually)  tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
