### PR TITLE
[Components]: Update changelog follow up for #38985

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fix
 
 -   Fix spin buttons of number inputs in Safari ([#38840](https://github.com/WordPress/gutenberg/pull/38840))
+-   Show tooltip on toggle custom size button in FontSizePicker ([#38985](https://github.com/WordPress/gutenberg/pull/38985))
 
 ### Enhancements
 


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/38985 that adds the changelog entry in components package.
