### PR TITLE
WIP: lower specificity to max width on post template

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -7,7 +7,6 @@
 .wp-block-query-loop {
 	margin-top: 0;
 	margin-bottom: 0;
-	max-width: 100%;
 	list-style: none;
 	padding: 0;
 
@@ -35,4 +34,10 @@
 			}
 		}
 	}
+}
+
+//lower specificity so it doesn't interfere with alignment rules
+:where(.wp-block-post-template),
+:where(.wp-block-query-loop) {
+	max-width: 100%;
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

When we lowered specificity to the alignment CSS they started following behind other block rules that affect the same properties. In this case the max-width of the post content block styles is more specific than the new layout rules in some cases (in my testing, this shows up on query blocks that have layout inherit and a tagName attribute).

I'm not sure if the correct fix is to lower specificity to the offending CSS or raising it up to the layout styles and then fixing it a different way for alignleft and right. I'm going to keep tinkering but I leave this here for others to chime in.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

 To test this, use this block markup on empty theme, use it as index.html:

```
<!-- wp:template-part {"slug":"header","tagName":"header"} /-->

<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":3},"tagName":"main","displayLayout":{"inherit":true},"layout":{"inherit":true}} -->
<main class="wp-block-query"><!-- wp:post-template -->
<!-- wp:post-title {"isLink":true} /-->

<!-- wp:post-excerpt /-->
<!-- /wp:post-template --></main>
<!-- /wp:query -->
```

The post content shows as 100% width without the fix. 



## Screenshots <!-- if applicable -->

Before:

<img width="1329" alt="Screenshot 2022-02-23 at 11 25 21" src="https://user-images.githubusercontent.com/3593343/155301342-773f22e6-84d8-49aa-bb4c-e67cebb32c9f.png">
<img width="507" alt="Screenshot 2022-02-23 at 11 25 36" src="https://user-images.githubusercontent.com/3593343/155301338-44d5e786-458b-4810-aacb-b35611713f77.png">

After:
<img width="1611" alt="Screenshot 2022-02-23 at 11 27 04" src="https://user-images.githubusercontent.com/3593343/155301523-973664e1-b658-402c-9f28-4e408515b0d3.png">



## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
