### PR TITLE
Don't filter 'theme_templates' when running WP 5.9

### DIFF
--- a/lib/compat/wordpress-5.9/wp-theme-get-post-templates.php
+++ b/lib/compat/wordpress-5.9/wp-theme-get-post-templates.php
@@ -5,25 +5,29 @@
  * @package gutenberg
  */
 
-/**
- * Load the page templates in Gutenberg.
- *
- * @param string[] $templates Page templates.
- * @param WP_Theme $theme     WP_Theme instance.
- * @param WP_Post  $post      The post being edited, provided for context, or null.
- * @param string   $post_type Post type to get the templates for.
- * @return array (Maybe) modified page templates array.
- */
-function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
-	if ( ! current_theme_supports( 'block-templates' ) ) {
+// Only run any of the code in this file if the version is less than 5.9.
+// wp_list_users was introduced in 5.9.
+if ( ! function_exists( 'wp_list_users' ) ) {
+	/**
+	 * Load the page templates in Gutenberg.
+	 *
+	 * @param string[] $templates Page templates.
+	 * @param WP_Theme $theme     WP_Theme instance.
+	 * @param WP_Post  $post      The post being edited, provided for context, or null.
+	 * @param string   $post_type Post type to get the templates for.
+	 * @return array (Maybe) modified page templates array.
+	 */
+	function gutenberg_load_block_page_templates( $templates, $theme, $post, $post_type ) {
+		if ( ! current_theme_supports( 'block-templates' ) ) {
+			return $templates;
+		}
+
+		$block_templates = gutenberg_get_block_templates( array( 'post_type' => $post_type ), 'wp_template' );
+		foreach ( $block_templates as $template ) {
+			$templates[ $template->slug ] = $template->title;
+		}
+
 		return $templates;
 	}
-
-	$block_templates = gutenberg_get_block_templates( array( 'post_type' => $post_type ), 'wp_template' );
-	foreach ( $block_templates as $template ) {
-		$templates[ $template->slug ] = $template->title;
-	}
-
-	return $templates;
+	add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );
 }
-add_filter( 'theme_templates', 'gutenberg_load_block_page_templates', 10, 4 );


### PR DESCRIPTION
## Description
This filter is no longer necessary when using Gutenberg plugin with WP 5.9

## Testing Instructions
1. Open a Post or Page
2. Confirm same templates are displayed in the Template dropdown with and without the plugin.

## Types of changes
Code Quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
