### PR TITLE
Conditionally remove duotone filters

### DIFF
--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -192,7 +192,7 @@ if ( ! function_exists( '_wp_maybe_remove_duotone_filters' ) ) {
 		}
 
 		// If there are no duotones, remove the action from `wp_body_open`.
-		if ( false === strpos( 'wp-duotone-', $template_html ) ) {
+		if ( false === stripos( 'wp-duotone-', $template_html ) ) {
 			remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
 		}
 	}

--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -175,3 +175,26 @@ if ( ! function_exists( 'wp_get_global_styles_svg_filters' ) ) {
 		return $svgs;
 	}
 }
+
+if ( ! function_exists( '_wp_maybe_remove_duotone_filters' ) ) {
+	/**
+	 * Checks if the current page uses duotones,
+	 * and if it doesn't then it's safe to remove duotone styles.
+	 *
+	 * Hooks in `wp_head` and only applies to block themes.
+	 */
+	function _wp_maybe_remove_duotone_filters() {
+
+		// Bail if not a block theme.
+		global $template_html;
+		if ( ! $template_html ) {
+			return;
+		}
+
+		// If there are no duotones, remove the action from `wp_body_open`.
+		if ( false === strpos( 'wp-duotone-', $template_html ) ) {
+			remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
+		}
+	}
+}
+add_action( 'wp_head', '_wp_maybe_remove_duotone_filters' );


### PR DESCRIPTION
## Description
There have been a lot of complaints from multiple sources about the amount of inline styles that Gutenberg adds through global-styles.
Most of the complaints focus on the inclusion of the duotone filters, so this PR is an attempt to fix this.

## Testing Instructions
1. Create a new post and add some images with duotone filters. Go the the frontend, view the page source and verify that duotones are properly applied.
2. Create a new post with no duotones in it. Go to the frontend and verify that the duotone filters are not included in the page's source.

## Types of changes
In block themes, we set a `$template_html` var _before the `wp_head` action runs. That var contains all the HTML of rendered blocks. 
In this PR, we're adding a new `_wp_maybe_remove_duotone_filters` function and hook it in `wp_head`. In that function, we're checking if the HTML of the page contains `wp-duotone-` (the prefix for classnames when using a duotone filter). If it doesn't, then we can be sure that there are no duotones used, and we can remove the `wp_global_styles_render_svg_filters` action from `wp_body_open`.

### Notes

Ideally, we'd only add the SVGs and global-styles for duotones used on a page. However, that would be a more involved and complex implementation. In this patch I'm attempting something simple, which is to either remove all duotone filters, or print them all.
It's not the ideal solution, but it's certainly better than what happens now - and can be refined in future implementations.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
