### PR TITLE
add test case for post locking feature saving

### DIFF
--- a/packages/e2e-tests/specs/editor/various/publishing.test.js
+++ b/packages/e2e-tests/specs/editor/various/publishing.test.js
@@ -10,6 +10,7 @@ import {
 	arePrePublishChecksEnabled,
 	setBrowserViewport,
 	openPublishPanel,
+	pressKeyWithModifier,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Publishing', () => {
@@ -51,9 +52,7 @@ describe( 'Publishing', () => {
 						.dispatch( 'core/editor' )
 						.lockPostSaving( 'futurelock' )
 				);
-
-				await page.keyboard.press( 'ControlLeft' );
-				await page.keyboard.press( 'KeyS' );
+				await pressKeyWithModifier( 'primary', 'S' );
 
 				expect( await page.$( '.editor-post-saved-state' ) ).toBeNull();
 				expect(

--- a/packages/e2e-tests/specs/editor/various/publishing.test.js
+++ b/packages/e2e-tests/specs/editor/various/publishing.test.js
@@ -35,11 +35,10 @@ describe( 'Publishing', () => {
 				await openPublishPanel();
 
 				expect(
-					await page.$eval(
-						'.editor-post-publish-button',
-						( element ) => element.getAttribute( 'aria-disabled' )
+					await page.$(
+						'.editor-post-publish-button[aria-disabled="true"]'
 					)
-				).toBe( 'true' );
+				).not.toBeNull();
 			} );
 
 			it( `disables the save shortcut when a ${ postType } is locked`, async () => {
@@ -57,7 +56,7 @@ describe( 'Publishing', () => {
 				expect( await page.$( '.editor-post-saved-state' ) ).toBeNull();
 				expect(
 					await page.$( '.editor-post-save-draft' )
-				).toBeTruthy();
+				).not.toBeNull();
 			} );
 		}
 	);


### PR DESCRIPTION

<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->
As mentioned in the issue #35377, I have implemented both the scenarios
and tested them in interactive mode. Test cases are passing.

Closes #35377.

- it disables the publish button when a post is locked
- it disables the save shortcut when a post is locked
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Checkout this PR
2. Run ```npm run test-e2e```

To explore more options on how to run test cases, follow the given link instructions:
https://github.com/WordPress/gutenberg/blob/8c3ca76906ddb61f1e7639442815e70fa068cc85/docs/contributors/code/testing-overview.md#end-to-end-testing
## Screenshots <!-- if applicable -->
<img width="1792" alt="Screenshot 2022-02-23 at 7 15 23 PM" src="https://user-images.githubusercontent.com/21127788/155332829-703e7747-baba-45d5-8329-8f652459e400.png">

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Code quality/testing
## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
