### PR TITLE
CopyHandler: use new shouldDismissPastedFiles helper

### DIFF
--- a/packages/block-editor/src/utils/pasting.js
+++ b/packages/block-editor/src/utils/pasting.js
@@ -29,9 +29,10 @@ export function getPasteEventData( { clipboardData } ) {
 		clipboardData
 	).filter( ( { type } ) => /^image\/(?:jpe?g|png|gif|webp)$/.test( type ) );
 
-	// Only process files if no HTML is present.
-	// A pasted file may have the URL as plain text.
-	if ( files.length && ! html ) {
+	if (
+		files.length &&
+		! shouldDismissPastedFiles( files, html, plainText )
+	) {
 		html = files
 			.map( ( file ) => `<img src="${ createBlobURL( file ) }">` )
 			.join( '' );


### PR DESCRIPTION
Follows #38992.

## Description

This PR brings the fix introduced in #38992 to `getPasteEventData`, which is used by the `CopyHandler` component of the block editor. Props @ellatrix for the reminder.

## Testing Instructions

Perform the same paste operations as mentioned in the original PR, but this time, instead of pasting into a RichText component, paste into an Image placeholder block.

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
