### PR TITLE
Buttons: Don't set a placeholder text color

### DIFF
--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -13,11 +13,6 @@
 	position: relative;
 	cursor: text;
 
-	// Make placeholder text white unless custom colors or outline versions are chosen.
-	&:not(.has-text-color):not(.is-style-outline) [data-rich-text-placeholder]::after {
-		color: $white;
-	}
-
 	// Add outline to button on focus to indicate focus-state
 	&:focus {
 		box-shadow: 0 0 0 1px $white, 0 0 0 3px var(--wp-admin-theme-color);


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
This reverts https://github.com/WordPress/gutenberg/pull/10160/files, since it's no longer needed. The problem with this fix is that it doesn't account for light buttons in a dark theme. Since now the placeholder inherits the block colors we don't need to set a placeholder color at all, so I think we can just remove these lines.

## Testing Instructions
Use remote: https://github.com/Automattic/themes/pull/5574
Add a Button block to a post
Confirm that the placeholder text is still legible.

## Screenshots
Before
<img width="713" alt="Screenshot 2022-02-23 at 18 16 34" src="https://user-images.githubusercontent.com/275961/155385157-2f6cff76-56da-4083-87c6-0ef0be23a670.png">

After
<img width="394" alt="Screenshot 2022-02-23 at 18 28 20" src="https://user-images.githubusercontent.com/275961/155385434-e2442752-33ec-4726-8abd-f56fec6b9274.png">

TT2 is unaffected by this change:
<img width="366" alt="Screenshot 2022-02-23 at 18 27 47" src="https://user-images.githubusercontent.com/275961/155385435-bc956a98-ca80-4e2d-a7e3-143ae753b997.png">

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
