### PR TITLE
Compose: avoid memory leak in use-drop-zone

### DIFF
--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -12,7 +12,7 @@ import useRefEffect from '../use-ref-effect';
 /**
  * @template T
  * @param {T} value
- * @return {import('react').MutableRefObject<T>} A ref with the value.
+ * @return {import('react').MutableRefObject<T|null>} A ref with the value.
  */
 function useFreshRef( value ) {
 	/* eslint-enable jsdoc/valid-types */
@@ -219,6 +219,12 @@ export default function useDropZone( {
 			ownerDocument.addEventListener( 'dragenter', maybeDragStart );
 
 			return () => {
+				onDropRef.current = null;
+				onDragStartRef.current = null;
+				onDragEnterRef.current = null;
+				onDragLeaveRef.current = null;
+				onDragEndRef.current = null;
+				onDragOverRef.current = null;
 				delete element.dataset.isDropZone;
 				element.removeEventListener( 'drop', onDrop );
 				element.removeEventListener( 'dragenter', onDragEnter );


### PR DESCRIPTION
While testing https://github.com/WordPress/gutenberg/pull/38999 @ciampo found that DropZone was triggering a "Can't perform React state update on an unmounted component." warning

<img width="1345" alt="CleanShot 2022-02-23 at 14 38 29@2x" src="https://user-images.githubusercontent.com/1270189/155421332-b76d7520-1e44-45b8-b225-504e5d33b4e4.png">

This PR fixes the issue by setting refs with callback functions to null when the cleanup function is called. Let me know if there is a more elegant way of working around this.

Before:

https://user-images.githubusercontent.com/1270189/155421579-052dbba3-614e-4b51-99b4-c4eb3b414055.mp4

After:

https://user-images.githubusercontent.com/1270189/155421602-48cb6192-407f-494e-be79-10c5cfe6feac.mp4

### Testing Instructions

- No regressions to dropzone components used in blocks like image/gallery
- verify that the React warning no longer fires.

 