### PR TITLE
Block Test Fixtures: Add additional error message for serialized test fixtures that reserialize identically

### DIFF
--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -209,7 +209,7 @@ describe( 'full post content fixture', () => {
 				) {
 					throw new Error(
 						format(
-							"File '%s' does not match expected value (however, the block re-serializes identically):\n\n%s",
+							"File '%s' does not match expected value (however, the block re-serializes identically so you may need to run 'npm run fixtures:regenerate'):\n\n%s",
 							serializedHTMLFileName,
 							err.message
 						)

--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -203,13 +203,26 @@ describe( 'full post content fixture', () => {
 			try {
 				expect( serializedActual ).toEqual( serializedExpected );
 			} catch ( err ) {
-				throw new Error(
-					format(
-						"File '%s' does not match expected value:\n\n%s",
-						serializedHTMLFileName,
-						err.message
-					)
-				);
+				if (
+					serialize( blocksActual ) ===
+					serialize( parse( serializedExpected ) )
+				) {
+					throw new Error(
+						format(
+							"File '%s' does not match expected value (however, the block re-serializes identically):\n\n%s",
+							serializedHTMLFileName,
+							err.message
+						)
+					);
+				} else {
+					throw new Error(
+						format(
+							"File '%s' does not match expected value:\n\n%s",
+							serializedHTMLFileName,
+							err.message
+						)
+					);
+				}
 			}
 		} );
 	} );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

While testing #36293 we attempted to debug an odd issue where the block attributes were being serialized in a different order than expected. This caused the fixture tests to fail (even though the blocks re-serialize in an otherwise identical way). An argument could be made whether or not blocks in this state should still pass the tests — but rather than make a decision on that, I thought I'd put up this PR to explore adding an extra error message that makes it clear that the results of re-serializing the test fixture match the actual block. The hope is that this additional error message might help debugging in the event of a future test failure.

I'm not _too_ sure whether or not folks will find this useful, so I'm very happy for feedback on whether or not the change is worth it!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Checkout the following commit from https://github.com/WordPress/gutenberg/pull/36293 where the order of block attributes in the block comment changed: https://github.com/WordPress/gutenberg/pull/36293/commits/7bdb4113c40f3430a9de10acd55ca60d53da2a46

Apply the changes from this PR to that commit and run the following to run the block test fixture tests:

```
npm run test-unit test/integration/full-content/
```

Note that the tests should fail, but the error message should indicate that the test fixture when parsed and re-serialized is identical to the actual block.

## Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/14988353/155441799-fda8cd11-0d7d-4baa-8399-106660a67d96.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Code quality / testing quality.

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
