### PR TITLE
Resolve peer dependency warnings

### DIFF
--- a/packages/annotations/package.json
+++ b/packages/annotations/package.json
@@ -34,6 +34,9 @@
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/block-directory/package.json
+++ b/packages/block-directory/package.json
@@ -46,6 +46,10 @@
 		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -67,6 +67,10 @@
 		"micromodal": "^0.4.10",
 		"moment": "^2.22.1"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -50,6 +50,9 @@
 		"simple-html-tokenizer": "^0.5.7",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -45,6 +45,9 @@
 		"rememo": "^3.0.0",
 		"uuid": "^8.3.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/customize-widgets/package.json
+++ b/packages/customize-widgets/package.json
@@ -45,6 +45,10 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/data-controls/package.json
+++ b/packages/data-controls/package.json
@@ -31,6 +31,9 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -55,6 +55,10 @@
 		"memize": "^1.1.0",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -59,6 +59,10 @@
 		"react-autosize-textarea": "^7.1.0",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -52,6 +52,10 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -39,6 +39,10 @@
 		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/interface/package.json
+++ b/packages/interface/package.json
@@ -44,6 +44,10 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/keyboard-shortcuts/package.json
+++ b/packages/keyboard-shortcuts/package.json
@@ -32,6 +32,9 @@
 		"lodash": "^4.17.21",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/list-reusable-blocks/package.json
+++ b/packages/list-reusable-blocks/package.json
@@ -33,6 +33,10 @@
 		"@wordpress/i18n": "file:../i18n",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/notices/package.json
+++ b/packages/notices/package.json
@@ -30,6 +30,9 @@
 		"@wordpress/data": "file:../data",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/nux/package.json
+++ b/packages/nux/package.json
@@ -41,6 +41,10 @@
 		"lodash": "^4.17.21",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -33,6 +33,9 @@
 		"lodash": "^4.17.21",
 		"memize": "^1.1.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/reusable-blocks/package.json
+++ b/packages/reusable-blocks/package.json
@@ -40,6 +40,10 @@
 		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/rich-text/package.json
+++ b/packages/rich-text/package.json
@@ -41,6 +41,9 @@
 		"memize": "^1.1.0",
 		"rememo": "^3.0.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -90,6 +90,10 @@
 		"webpack-cli": "^4.9.1",
 		"webpack-dev-server": "^4.4.0"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/server-side-render/package.json
+++ b/packages/server-side-render/package.json
@@ -38,6 +38,10 @@
 		"@wordpress/url": "file:../url",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -30,6 +30,9 @@
 		"@wordpress/data": "file:../data",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}

--- a/packages/widgets/package.json
+++ b/packages/widgets/package.json
@@ -35,6 +35,10 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21"
 	},
+	"peerDependencies": {
+		"react": "^17.0.0",
+		"react-dom": "^17.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
Resolves #39041. See that for more info, but the TLDR is that certain packages in gutenberg (like `@wordpress/compose`) have peer dependencies for react, but internal packages (like `@wordpress/annotations`) which depend on compose don't provide those peer dependencies. This causes a lot of errors and warnings when installing close to all of the WordPress dependencies in environments with strict peer dependency reporting (like yarn 3 or more recent versions of npm).

## Testing Instructions
AFAIK, this doesn't have any impact on shipped code, just on published npm packages.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
