### PR TITLE
Try: Fix image responsive rules.

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -125,7 +125,7 @@ html :where([style*="border-width"]) {
 /**
  * Provide baseline responsiveness for images.
  */
-html :where(img) {
+html :where(img[class^="wp-image-"]) {
 	height: auto;
 	max-width: 100%;
 }

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -125,7 +125,7 @@ html :where([style*="border-width"]) {
 /**
  * Provide baseline responsiveness for images.
  */
-html :where(img[class^="wp-image-"]) {
+html :where(img[class*="wp-image-"]) {
 	height: auto;
 	max-width: 100%;
 }


### PR DESCRIPTION
## Description

Changes the approach to image responsive from #38399, and should fix issues outlined in the comments. Props @nasif-co for the [suggestion](https://github.com/WordPress/gutenberg/pull/38399#issuecomment-1049267123).

38399 moved a CSS rule intended to help add responsive guardrails to images, so that it would apply across the frontend. This had side effects for images that weren't meant to be responsive.

This PR fixes it by scoping those styles to just images inserted manually in the editor, either block or classic.

See also #39046 for a revert alternative.

## Testing Instructions

Insert an image in an editor, observe that it's responsive on the frontend.

Note that images that weren't manually inserted should not be targetted by these rules.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
