### PR TITLE
Expose plugin area to site editor's List page

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -3,6 +3,10 @@
  */
 import { SlotFillProvider } from '@wordpress/components';
 import { UnsavedChangesWarning } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { PluginArea } from '@wordpress/plugins';
 
 /**
  * Internal dependencies
@@ -14,6 +18,20 @@ import NavigationSidebar from '../navigation-sidebar';
 import getIsListPage from '../../utils/get-is-list-page';
 
 export default function EditSiteApp( { reboot } ) {
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	function onPluginAreaError( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
+
 	return (
 		<SlotFillProvider>
 			<UnsavedChangesWarning />
@@ -29,6 +47,7 @@ export default function EditSiteApp( { reboot } ) {
 							) : (
 								<Editor onError={ reboot } />
 							) }
+							<PluginArea onError={ onPluginAreaError } />
 							{ /* Keep the instance of the sidebar to ensure focus will not be lost
 							 * when navigating to other pages. */ }
 							<NavigationSidebar

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -16,13 +16,11 @@ import {
 	EditorSnackbars,
 	EntitiesSavedStates,
 } from '@wordpress/editor';
-import { __, sprintf } from '@wordpress/i18n';
-import { PluginArea } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 import {
 	ShortcutProvider,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -111,7 +109,6 @@ function Editor( { onError } ) {
 	}, [] );
 	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const [
 		isEntitiesSavedStatesOpen,
@@ -182,18 +179,6 @@ function Editor( { onError } ) {
 		}
 		return null;
 	};
-
-	function onPluginAreaError( name ) {
-		createErrorNotice(
-			sprintf(
-				/* translators: %s: plugin name */
-				__(
-					'The "%s" plugin has encountered an error and cannot be rendered.'
-				),
-				name
-			)
-		);
-	}
 
 	// Only announce the title once the editor is ready to prevent "Replace"
 	// action in <URlQueryController> from double-announcing.
@@ -314,9 +299,6 @@ function Editor( { onError } ) {
 										/>
 										<WelcomeGuide />
 										<Popover.Slot />
-										<PluginArea
-											onError={ onPluginAreaError }
-										/>
 									</ErrorBoundary>
 								</BlockContextProvider>
 							</GlobalStylesProvider>

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -7,11 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
+import { PluginArea } from '@wordpress/plugins';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { EditorSnackbars } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -30,6 +32,8 @@ export default function List() {
 	} = useLocation();
 
 	useRegisterShortcuts();
+
+	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const { previousShortcut, nextShortcut, isNavigationOpen } = useSelect(
 		( select ) => {
@@ -73,23 +77,38 @@ export default function List() {
 		  }
 		: undefined;
 
+	function onPluginAreaError( name ) {
+		createErrorNotice(
+			sprintf(
+				/* translators: %s: plugin name */
+				__(
+					'The "%s" plugin has encountered an error and cannot be rendered.'
+				),
+				name
+			)
+		);
+	}
+
 	return (
-		<InterfaceSkeleton
-			className={ classnames( 'edit-site-list', {
-				'is-navigation-open': isNavigationOpen,
-			} ) }
-			labels={ {
-				drawer: __( 'Navigation Sidebar' ),
-				...detailedRegionLabels,
-			} }
-			header={ <Header templateType={ templateType } /> }
-			drawer={ <NavigationSidebar.Slot /> }
-			notices={ <EditorSnackbars /> }
-			content={ <Table templateType={ templateType } /> }
-			shortcuts={ {
-				previous: previousShortcut,
-				next: nextShortcut,
-			} }
-		/>
+		<>
+			<InterfaceSkeleton
+				className={ classnames( 'edit-site-list', {
+					'is-navigation-open': isNavigationOpen,
+				} ) }
+				labels={ {
+					drawer: __( 'Navigation Sidebar' ),
+					...detailedRegionLabels,
+				} }
+				header={ <Header templateType={ templateType } /> }
+				drawer={ <NavigationSidebar.Slot /> }
+				notices={ <EditorSnackbars /> }
+				content={ <Table templateType={ templateType } /> }
+				shortcuts={ {
+					previous: previousShortcut,
+					next: nextShortcut,
+				} }
+			/>
+			<PluginArea onError={ onPluginAreaError } />
+		</>
 	);
 }

--- a/packages/edit-site/src/components/list/index.js
+++ b/packages/edit-site/src/components/list/index.js
@@ -7,13 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { InterfaceSkeleton } from '@wordpress/interface';
 import { __, sprintf } from '@wordpress/i18n';
-import { PluginArea } from '@wordpress/plugins';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { EditorSnackbars } from '@wordpress/editor';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -32,8 +30,6 @@ export default function List() {
 	} = useLocation();
 
 	useRegisterShortcuts();
-
-	const { createErrorNotice } = useDispatch( noticesStore );
 
 	const { previousShortcut, nextShortcut, isNavigationOpen } = useSelect(
 		( select ) => {
@@ -77,38 +73,23 @@ export default function List() {
 		  }
 		: undefined;
 
-	function onPluginAreaError( name ) {
-		createErrorNotice(
-			sprintf(
-				/* translators: %s: plugin name */
-				__(
-					'The "%s" plugin has encountered an error and cannot be rendered.'
-				),
-				name
-			)
-		);
-	}
-
 	return (
-		<>
-			<InterfaceSkeleton
-				className={ classnames( 'edit-site-list', {
-					'is-navigation-open': isNavigationOpen,
-				} ) }
-				labels={ {
-					drawer: __( 'Navigation Sidebar' ),
-					...detailedRegionLabels,
-				} }
-				header={ <Header templateType={ templateType } /> }
-				drawer={ <NavigationSidebar.Slot /> }
-				notices={ <EditorSnackbars /> }
-				content={ <Table templateType={ templateType } /> }
-				shortcuts={ {
-					previous: previousShortcut,
-					next: nextShortcut,
-				} }
-			/>
-			<PluginArea onError={ onPluginAreaError } />
-		</>
+		<InterfaceSkeleton
+			className={ classnames( 'edit-site-list', {
+				'is-navigation-open': isNavigationOpen,
+			} ) }
+			labels={ {
+				drawer: __( 'Navigation Sidebar' ),
+				...detailedRegionLabels,
+			} }
+			header={ <Header templateType={ templateType } /> }
+			drawer={ <NavigationSidebar.Slot /> }
+			notices={ <EditorSnackbars /> }
+			content={ <Table templateType={ templateType } /> }
+			shortcuts={ {
+				previous: previousShortcut,
+				next: nextShortcut,
+			} }
+		/>
 	);
 }


### PR DESCRIPTION
## Description

This PR adds parity between the editor and the list page inside the site editor regarding the `PluginArea`. Without it, it's not possible to fill the provided slots by using the `registerPlugin` API.

The absence of the plugin area [caused a bug in Calypso](https://github.com/Automattic/wp-calypso/issues/60110) where the slots were only being filled in the editor's navigation drawer.

## Testing Instructions

Open the site editor and run this code in the DevTools after the page is loaded:

```js
var el = wp.element.createElement;
var Fill = wp.components.Fill;
var registerPlugin = wp.plugins.registerPlugin;

registerPlugin( 'test', {
  render: function() {
    return el(
      Fill,
      { name: '__experimentalMainDashboardButton' },
      el('span', {}, 'hello, world')
    );
  }
} );
```

Click the W button and check that `hello, world` message appears at the top instead of the `< Dashboard` button on both the editor page and the list by clicking on `Templates` or `Template Parts` inside the navigation drawer.

## Screenshots

| Editor | List |
| ------ | --- |
| ![image](https://user-images.githubusercontent.com/26530524/155606989-d1b75d1d-7741-4691-aad1-92824cc828a7.png) | ![image](https://user-images.githubusercontent.com/26530524/155607004-8645b7db-f23c-4081-93ff-94ff2fd823f5.png) |


## Types of changes

Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
