### PR TITLE
[data] Fill out type definition for data registry

### DIFF
--- a/docs/contributors/code/coding-guidelines.md
+++ b/docs/contributors/code/coding-guidelines.md
@@ -269,7 +269,7 @@ Use the [TypeScript `import` function](https://www.typescriptlang.org/docs/handb
 Since an imported type declaration can occupy an excess of the available line length and become verbose when referenced multiple times, you are encouraged to create an alias of the external type using a `@typedef` declaration at the top of the file, immediately following [the `import` groupings](/docs/contributors/code/coding-guidelines.md#imports).
 
 ```js
-/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
+/** @typedef {import('@wordpress/rich-text').RichTextValue} RichTextValue */
 ```
 
 Note that all custom types defined in another file can be imported.
@@ -277,9 +277,9 @@ Note that all custom types defined in another file can be imported.
 When considering which types should be made available from a WordPress package, the `@typedef` statements in the package's entry point script should be treated as effectively the same as its public API. It is important to be aware of this, both to avoid unintentionally exposing internal types on the public interface, and as a way to expose the public types of a project.
 
 ```js
-// packages/data/src/index.js
+// packages/rich-text/src/can-indent-list-items.js
 
-/** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
+/** @typedef {import('./create').RichTextValue} RichTextValue */
 ```
 
 In this snippet, the `@typedef` will support the usage of the previous example's `import('@wordpress/data')`.

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -12,8 +12,6 @@ import useBlockSync from './use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import { BlockRefsProvider } from './block-refs-provider';
 
-/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
-
 function BlockEditorProvider( props ) {
 	const { children, settings } = props;
 

--- a/packages/block-editor/src/components/provider/index.native.js
+++ b/packages/block-editor/src/components/provider/index.native.js
@@ -12,8 +12,6 @@ import useBlockSync from './use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import { BlockRefsProvider } from './block-refs-provider';
 
-/** @typedef {import('@wordpress/data').WPDataRegistry} WPDataRegistry */
-
 function BlockEditorProvider( props ) {
 	const { children, settings } = props;
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -387,7 +387,7 @@ _Parameters_
 
 _Returns_
 
--   `DataRegistry`: Data registry.
+-   `WPDataRegistry`: Data registry.
 
 ### createRegistryControl
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -387,7 +387,7 @@ _Parameters_
 
 _Returns_
 
--   `WPDataRegistry`: Data registry.
+-   `DataRegistry`: Data registry.
 
 ### createRegistryControl
 

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -9,7 +9,7 @@ import { merge, isPlainObject } from 'lodash';
 import defaultStorage from './storage/default';
 import { combineReducers } from '../../';
 
-/** @typedef {import('../../registry').WPDataRegistry} WPDataRegistry */
+/** @typedef {import('../../types').DataRegistry} DataRegistry */
 
 /** @typedef {import('../../registry').WPDataPlugin} WPDataPlugin */
 
@@ -116,7 +116,7 @@ export function createPersistenceInterface( options ) {
 /**
  * Data plugin to persist store state into a single storage key.
  *
- * @param {WPDataRegistry}                  registry      Data registry.
+ * @param {DataRegistry}                  registry      Data registry.
  * @param {?WPDataPersistencePluginOptions} pluginOptions Plugin options.
  *
  * @return {WPDataPlugin} Data plugin.

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -16,7 +16,7 @@ import coreDataStore from './store';
 import { createEmitter } from './utils/emitter';
 
 /** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
-/** @typedef {import('./types').DataRegistry} DataRegistry */
+/** @typedef {import('./types').DataRegistry} WPDataRegistry */
 
 /**
  * @typedef {Object} WPDataPlugin An object of registry function overrides.
@@ -31,7 +31,7 @@ import { createEmitter } from './utils/emitter';
  * @param {Object}  storeConfigs Initial store configurations.
  * @param {Object?} parent       Parent registry.
  *
- * @return {DataRegistry} Data registry.
+ * @return {WPDataRegistry} Data registry.
  */
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -16,7 +16,7 @@ import coreDataStore from './store';
 import { createEmitter } from './utils/emitter';
 
 /** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
-/** @typedef {import('./types').DataRegistry} WPDataRegistry */
+/** @typedef {import('./types').DataRegistry} DataRegistry */
 
 /**
  * @typedef {Object} WPDataPlugin An object of registry function overrides.
@@ -31,7 +31,7 @@ import { createEmitter } from './utils/emitter';
  * @param {Object}  storeConfigs Initial store configurations.
  * @param {Object?} parent       Parent registry.
  *
- * @return {WPDataRegistry} Data registry.
+ * @return {DataRegistry} Data registry.
  */
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};

--- a/packages/data/src/registry.js
+++ b/packages/data/src/registry.js
@@ -16,26 +16,7 @@ import coreDataStore from './store';
 import { createEmitter } from './utils/emitter';
 
 /** @typedef {import('./types').StoreDescriptor} StoreDescriptor */
-
-/**
- * @typedef {Object} WPDataRegistry An isolated orchestrator of store registrations.
- *
- * @property {Function} registerGenericStore Given a namespace key and settings
- *                                           object, registers a new generic
- *                                           store.
- * @property {Function} registerStore        Given a namespace key and settings
- *                                           object, registers a new namespace
- *                                           store.
- * @property {Function} subscribe            Given a function callback, invokes
- *                                           the callback on any change to state
- *                                           within any registered store.
- * @property {Function} select               Given a namespace key, returns an
- *                                           object of the  store's registered
- *                                           selectors.
- * @property {Function} dispatch             Given a namespace key, returns an
- *                                           object of the store's registered
- *                                           action dispatchers.
- */
+/** @typedef {import('./types').DataRegistry} DataRegistry */
 
 /**
  * @typedef {Object} WPDataPlugin An object of registry function overrides.
@@ -50,7 +31,7 @@ import { createEmitter } from './utils/emitter';
  * @param {Object}  storeConfigs Initial store configurations.
  * @param {Object?} parent       Parent registry.
  *
- * @return {WPDataRegistry} Data registry.
+ * @return {DataRegistry} Data registry.
  */
 export function createRegistry( storeConfigs = {}, parent = null ) {
 	const stores = {};

--- a/packages/data/src/resolvers-cache-middleware.js
+++ b/packages/data/src/resolvers-cache-middleware.js
@@ -8,12 +8,12 @@ import { get } from 'lodash';
  */
 import coreDataStore from './store';
 
-/** @typedef {import('./registry').WPDataRegistry} WPDataRegistry */
+/** @typedef {import('./types').DataRegistry} DataRegistry */
 
 /**
  * Creates a middleware handling resolvers cache invalidation.
  *
- * @param {WPDataRegistry} registry   The registry reference for which to create
+ * @param {DataRegistry} registry   The registry reference for which to create
  *                                    the middleware.
  * @param {string}         reducerKey The namespace for which to create the
  *                                    middleware.

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -1,3 +1,9 @@
+/**
+ * External dependencies
+ */
+import type { MutableRefObject } from 'react';
+import type { Store as ReduxStore } from 'redux';
+
 type MapOf< T > = { [ name: string ]: T };
 
 export type ActionCreator = Function | Generator;
@@ -37,13 +43,96 @@ export interface ReduxStoreConfig<
 	controls?: MapOf< Function >;
 }
 
+/** Unsubscribes from a registered listener. */
+export interface Unsubscriber {
+	(): void;
+}
+
 export interface DataRegistry {
-	register: ( store: StoreDescriptor< any > ) => void;
+	/** Apply multiple store updates without calling store listeners until all have finished */
+	batch( executor: () => void ): void;
+
+	/** Returns the available actions for a given store. */
+	dispatch( store: StoreDescriptor< any > | string ): MapOf< ActionCreator >;
+
+	/** Registers a new store into the registry. */
+	register( store: StoreDescriptor< any > ): void;
+
+	/** Given a namespace key and store description, registers a new Redux store into the registry. */
+	registerStore< Store extends StoreDescriptor< any > >(
+		name: string,
+		store: Store
+	): ReduxStore;
+
+	/**
+	 * Returns a version of the available selectors for a given store that returns
+	 * a Promise which resolves after all associated resolvers have finished.
+	 */
+	resolveSelect(
+		store: StoreDescriptor< any > | string
+	): MapOf< ( ...args: any[] ) => Promise< any > >;
+
+	/** Returns the available selectors for a given store. */
+	select(
+		store: StoreDescriptor< any > | string
+	): MapOf< ( ...args: any[] ) => any >;
+
+	/** Raw access to the underlying store instances in the registry. */
+	stores: Readonly< Record< string, StoreInstance< any > > >;
+
+	/** Subscribe to changes from all registered stores. */
+	subscribe( listener: () => void ): Unsubscriber;
+
+	// Unstable and/or experimental methods
+
+	/** Used internally by useSelect to track which stores are queried by `select` calls. */
+	__experimentalMarkListeningStores<
+		Callback extends ( ...args: any[] ) => any
+	>(
+		callback: Callback,
+		listeners: MutableRefObject< string[] >
+	): ReturnType< Callback >;
+
+	/** Subscribe to changes in stores that are currently queried by useSelect. */
+	__experimentalSubscribeStore(
+		name: string,
+		listener: () => void
+	): Unsubscriber;
+
+	// Deprecated methods and properties
+
+	/**
+	 * Legacy reference to set of store isntances in the registry.
+	 *
+	 * @deprecated Use registry.stores instead.
+	 */
+	namespaces: Readonly< Record< string, StoreInstance< any > > >;
+
+	/**
+	 * Given a namespace key and settings object, registers a new store into the registry.
+	 *
+	 * @deprecated Use register( store ) instead.
+	 */
+	registerGenericStore( name: string, store: StoreDescriptor< any > ): void;
+
+	/**
+	 * Returns an enhanced version of the given registry.
+	 *
+	 * @deprecated
+	 */
+	use<
+		Source extends DataRegistry,
+		Enhancement extends Partial< Source > & Record< string, any >,
+		Options
+	>(
+		plugin: ( registry: Source, options?: Options ) => Enhancement,
+		options?: Options
+	): Source & Enhancement;
 }
 
 export interface DataEmitter {
 	emit: () => void;
-	subscribe: ( listener: () => void ) => () => void;
+	subscribe: ( listener: () => void ) => Unsubscriber;
 	pause: () => void;
 	resume: () => void;
 	isPaused: boolean;

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -60,10 +60,7 @@ type Store<
 	? Stores[ StoreRef ]
 	: never;
 
-type CurriedState< F extends ( ...args: any[] ) => any > = F extends (
-	state: any,
-	...args: infer P
-) => infer R
+type CurriedState< F > = F extends ( state: any, ...args: infer P ) => infer R
 	? ( ...args: P ) => R
 	: F;
 
@@ -72,6 +69,13 @@ type Resolvable<
 > = ReturnType< F > extends Promise< any >
 	? F
 	: ( ...args: Parameters< F > ) => Promise< ReturnType< F > >;
+
+type NonResolveSelectFields =
+	| 'getIsResolving'
+	| 'hasStartedResolution'
+	| 'hasFinishedResolution'
+	| 'isResolving'
+	| 'getCachedResolvers';
 
 export interface DataRegistry {
 	/** Apply multiple store updates without calling store listeners until all have finished */
@@ -86,10 +90,7 @@ export interface DataRegistry {
 	register( store: StoreDescriptor< any > ): void;
 
 	/** Given a namespace key and store description, registers a new Redux store into the registry. */
-	registerStore(
-		name: string,
-		store: StoreDescriptor<any>
-	): ReduxStore;
+	registerStore( name: string, store: StoreDescriptor< any > ): ReduxStore;
 
 	/**
 	 * Returns a version of the available selectors for a given store that returns
@@ -102,9 +103,10 @@ export interface DataRegistry {
 		store: StoreRef
 	): NonNullable<
 		{
-			[ Name in keyof Selectors ]: Resolvable<
-				CurriedState< Selectors[ Name ] >
-			>;
+			[ Name in keyof Selectors as Exclude<
+				Name,
+				NonResolveSelectFields
+			> ]: Resolvable< CurriedState< Selectors[ Name ] > >;
 		}
 	>;
 

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -52,6 +52,21 @@ export interface DataStores {}
 
 export interface Stores extends DataStores {}
 
+/**
+ * Returns a store config given a store name or an actual store config.
+ *
+ * Functions in the data registry typically accept either the name of
+ * a store, e.g. 'core/editor', or they accept the actual store
+ * configuration object, e.g. 'import { storeConfig } from '@wordpress/editor'`.
+ *
+ * This type is a convenience wrapper for turning that reference into
+ * an actual store regardless of what was passed.
+ *
+ * Warning! Will fail if given a name not already registered. In such a
+ * case add an ambient declaration for `@wordpress/data` with the store
+ * name and configuration so that it can merge into the catalog of
+ * registered stores.
+ */
 type Store<
 	StoreRef extends Stores[ keyof Stores ] | keyof Stores
 > = StoreRef extends AnyConfig
@@ -60,16 +75,39 @@ type Store<
 	? Stores[ StoreRef ]
 	: never;
 
+/**
+ * Removes the first argument from a function
+ *
+ * This is designed to remove the `state` parameter from
+ * registered selectors since that argument is supplied
+ * by the editor when calling `select(…)`.
+ *
+ * For functions with no arguments, which some selectors
+ * are free to define, returns the original function.
+ */
 type CurriedState< F > = F extends ( state: any, ...args: infer P ) => infer R
 	? ( ...args: P ) => R
 	: F;
 
+/**
+ * Returns a function whose return type is a Promise of the given return type.
+ *
+ * This is designed to take existing selectors and return a resolveSelector
+ * version of it which returns a Promise of the original return type. Promises
+ * flatten naturally and so if the original function already returned a Promise
+ * we can reuse the existing function type.
+ */
 type Resolvable<
 	F extends ( ...args: any[] ) => any
 > = ReturnType< F > extends Promise< any >
 	? F
 	: ( ...args: Parameters< F > ) => Promise< ReturnType< F > >;
 
+/**
+ * These fields are excluded from the resolveSelect mapping.
+ *
+ * @see mapResolveSelectors
+ */
 type NonResolveSelectFields =
 	| 'getIsResolving'
 	| 'hasStartedResolution'

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -103,6 +103,14 @@ type Resolvable<
 	? F
 	: ( ...args: Parameters< F > ) => Promise< ReturnType< F > >;
 
+type ResolvedThunks< Actions extends AnyConfig[ 'actions' ] > = {
+	[ Action in keyof Actions ]: Actions[ Action ] extends (
+		...args: infer P
+	) => ( thunkArgs: { select?: () => any; dispatch?: () => any } ) => infer R
+		? ( ...args: P ) => R
+		: Actions[ Action ];
+};
+
 /**
  * These fields are excluded from the resolveSelect mapping.
  *
@@ -122,7 +130,7 @@ export interface DataRegistry {
 	/** Returns the available actions for a given store. */
 	dispatch< StoreRef extends Stores[ keyof Stores ] | keyof Stores >(
 		store: StoreRef
-	): NonNullable< Store< StoreRef >[ 'actions' ] >;
+	): ResolvedThunks< NonNullable< Store< StoreRef >[ 'actions' ] > >;
 
 	/** Registers a new store into the registry. */
 	register( store: StoreDescriptor< any > ): void;

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -76,18 +76,74 @@ type Store<
 	: never;
 
 /**
- * Removes the first argument from a function
+ * Removes the first argument from a function.
  *
- * This is designed to remove the `state` parameter from
+ * By default, it removes the `state` parameter from
  * registered selectors since that argument is supplied
  * by the editor when calling `select(…)`.
  *
  * For functions with no arguments, which some selectors
  * are free to define, returns the original function.
+ *
+ * It is possible to manually provide a custom curried signature
+ * and avoid the automatic inference. When the
+ * F generic argument passed to this helper extends the
+ * SelectorWithCustomCurrySignature type, the F['CurriedSignature']
+ * property is used verbatim.
+ *
+ * This is useful because TypeScript does not correctly remove
+ * arguments from complex function signatures constrained by
+ * interdependent generic parameters.
+ * For more context, see https://github.com/WordPress/gutenberg/pull/41578
  */
-type CurriedState< F > = F extends ( state: any, ...args: infer P ) => infer R
+type CurriedState< F > = F extends SelectorWithCustomCurrySignature
+	? F[ 'CurriedSignature' ]
+	: F extends ( state: any, ...args: infer P ) => infer R
 	? ( ...args: P ) => R
 	: F;
+/**
+ * Utility to manually specify curried selector signatures.
+ *
+ * It comes handy when TypeScript can't automatically produce the
+ * correct curried function signature. For example:
+ *
+ * ```ts
+ * type BadlyInferredSignature = CurriedState<
+ *     <K extends string | number>(
+ *         state: any,
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ) => K
+ * >
+ * // BadlyInferredSignature evaluates to:
+ * // (kind: string number, key: false "one value") => string number
+ * ```
+ *
+ * With SelectorWithCustomCurrySignature, we can provide a custom
+ * signature and avoid relying on TypeScript inference:
+ * ```ts
+ * interface MySelectorSignature extends SelectorWithCustomCurrySignature {
+ *     <K extends string | number>(
+ *         state: any,
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ): K;
+ *
+ *     CurriedSignature: <K extends string | number>(
+ *         kind: K,
+ *         key: K extends string ? 'one value' : false
+ *     ): K;
+ * }
+ * type CorrectlyInferredSignature = CurriedState<MySelectorSignature>
+ * // <K extends string | number>(kind: K, key: K extends string ? 'one value' : false): K;
+ *
+ * For even more context, see https://github.com/WordPress/gutenberg/pull/41578
+ * ```
+ */
+export interface SelectorWithCustomCurrySignature {
+	__isCurryContainer: true;
+	CurriedSignature: Function;
+}
 
 /**
  * Returns a function whose return type is a Promise of the given return type.


### PR DESCRIPTION
## Description
The type for the data registry created with `createRegistry()` has lived a
split and minimal life: split across a basic type declaration in `types.ts`
and the associated JSDoc `@typedef` in `registry.js`; and minimal because
neither definition comprehensively describes the structure.

In this patch we're unifying the type into the TypeScript declaration and
also filling it out to comprehensively describe the registry. The complicated
type in this patch is the result of several different attempts to provide the
following goals:

 - Ultimately provide auto-complete for the core data stores in `select()` and
   `dispatch()` calls.
 - Require minimal effort to bring existing core data stores into the default
   core registry: no new type annotations in packages outside of `@wordpress/data`
   and no duplicating type information about other packages inside of `@wordpress/data`.
 - Provide an interface that third-party developers can extend with their own
   stores and not be required to give up any of the core store information.

In this patch the data registry is empty because I want to focus on the type itself.
I believe that adding additional core stores will require at a minimum, renaming some files to end in `.ts` and activating TypeScript for that package if it isn't already.

## Testing Instructions

As a type-only change there should be no impact on the built files.
For testing and review please audit the code and types.

## Screenshots

While not enabled in this PR itself, by using `typeof storeConfig` in other packages we can get the list of actions and selectors (with the `state` parameter curried away) for that store. The arguments and return types won't be typed because they only exist as JS, but we still get their names and the names of their argument and as we add typing to them we'll benefit through the registry.


https://user-images.githubusercontent.com/5431237/155627230-db1f9645-5660-4606-93dd-3076b28e7384.mov


https://user-images.githubusercontent.com/5431237/155627244-a26b170e-cf2c-45cc-9f95-fa3033079ee5.mov




## Types of changes

Updating an existing type definition and merging a JSDoc `@typedef` into it.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
