### PR TITLE
Fix file block validation error by not outputting aria-describedby if there's no description

### DIFF
--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -25,6 +25,12 @@ export default function save( { attributes } ) {
 				fileName
 		  );
 
+	const hasFilename = ! RichText.isEmpty( fileName );
+
+	// Only output an `aria-describedby` when the element it's referring to is
+	// actually rendered.
+	const describedById = hasFilename ? fileId : undefined;
+
 	return (
 		href && (
 			<div { ...useBlockProps.save() }>
@@ -42,9 +48,9 @@ export default function save( { attributes } ) {
 						/>
 					</>
 				) }
-				{ ! RichText.isEmpty( fileName ) && (
+				{ hasFilename && (
 					<a
-						id={ fileId }
+						id={ describedById }
 						href={ textLinkHref }
 						target={ textLinkTarget }
 						rel={
@@ -59,7 +65,7 @@ export default function save( { attributes } ) {
 						href={ href }
 						className="wp-block-file__button"
 						download={ true }
-						aria-describedby={ fileId }
+						aria-describedby={ describedById }
 					>
 						<RichText.Content value={ downloadButtonText } />
 					</a>


### PR DESCRIPTION
## Description
Fixes #39057

There's a logic flaw in the file block. It always adds an `aria-describedby` id to the download button when saving. The problem is that the matching id for this is the filename `<a>` element, which isn't saved when there's no text. When reloading the saved content, the block tries to source this id from the filename element, but it can't because that element doesn't exist. That causes a validation error.

It doesn't make sense for the block to have an `aria-describedby` that references nothing, so the best solution seems to be to only add `aria-describedby` when there's a filename.

## Testing Instructions
1. Add a file block and upload a file
2. Delete all of the filename text
3. Save and reload
4. The block should still be valid

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
