### PR TITLE
Try allowing tab into block placeholder

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -118,13 +118,16 @@ export default function useTabNav() {
 				return;
 			}
 
-			// Allow tabbing between form elements rendered in a block,
+			// Allow tabbing from the block wrapper to a form element,
+			// and between form elements rendered in a block,
 			// such as inside a placeholder. Form elements are generally
 			// meant to be UI rather than part of the content. Ideally
 			// these are not rendered in the content and perhaps in the
 			// future they can be rendered in an iframe or shadow DOM.
 			if (
-				isFormElement( event.target ) &&
+				( isFormElement( event.target ) ||
+					event.target.getAttribute( 'data-block' ) ===
+						getSelectedBlockClientId() ) &&
 				isFormElement( focus.tabbable[ direction ]( event.target ) )
 			) {
 				return;


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Fixes #36710; possible alternative to #37934. 

When focus is on a block with a placeholder (e.g. Image or Columns block) and we are in Edit mode, we should be able to Tab into the placeholder controls. This makes the placeholder controls keyboard accessible when the "Contain text cursor inside block" preference is enabled (arrow key navigation in or out of a block doesn't work with that preference). It also makes it possible to tab into a block that only contains a block inserter, such as an empty Group block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a post, add a Columns block.
2. Check that pressing Tab moves focus to the first control in the placeholder.
3. Select an option from the placeholder, e.g. "Two columns; equal split".
4. Focus should now be on the first column. 
5. Check that pressing Tab moves focus to the block inserter inside the first column.
6. Add a Group block.
7. Check that pressing Tab moves focus to the block inserter inside the Group block.

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
