### PR TITLE
Style Engine: server side rendering of CSS

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -166,7 +166,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		1
 	);
 
-	gutenberg_enqueue_block_support_styles( $style );
+	WP_Style_Engine_Gutenberg::get_instance()->add_style( $class_name, $style );
 
 	return $content;
 }

--- a/lib/class-wp-style-engine.php
+++ b/lib/class-wp-style-engine.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * WP_Style_Engine class
+ *
+ * @package Gutenberg
+
+ */
+
+/**
+ * Singleton class representing the style engine.
+ *
+ * Consolidates rendering block styles to reduce duplication and streamline
+ * CSS styles generation.
+ *
+ * @since 6.0.0
+ */
+class WP_Style_Engine_Gutenberg {
+	/**
+	 * Registered CSS styles.
+	 *
+	 * @since 5.5.0
+	 * @var array
+	 */
+	private $registered_styles = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @since 5.5.0
+	 * @var WP_Style_Engine_Gutenberg|null
+	 */
+	private static $instance = null;
+
+	public function __construct() {
+		// Borrows the logic from `gutenberg_enqueue_block_support_styles`.
+		$action_hook_name = 'wp_footer';
+		if ( wp_is_block_theme() ) {
+			$action_hook_name = 'wp_enqueue_scripts';
+		}
+		add_action(
+			$action_hook_name,
+			array( $this, 'output_styles' )
+		);
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return WP_Style_Engine_Gutenberg The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function add_style( $key, $value ) {
+		$this->registered_styles[ $key ] = $value;
+	}
+
+	public function output_styles() {
+		$style = implode( "\n", $this->registered_styles );
+		echo "<style>$style</style>\n";
+	}
+}

--- a/lib/class-wp-style-engine.php
+++ b/lib/class-wp-style-engine.php
@@ -3,7 +3,6 @@
  * WP_Style_Engine class
  *
  * @package Gutenberg
-
  */
 
 /**
@@ -58,12 +57,56 @@ class WP_Style_Engine_Gutenberg {
 		return self::$instance;
 	}
 
-	public function add_style( $key, $value ) {
-		$this->registered_styles[ $key ] = $value;
+	public function add_styles( $styles ) {
+		if ( ! is_array( $styles ) ) {
+			return array();
+		}
+
+		foreach ( $styles as $key => $value ) {
+			$value = is_array( $value ) ? $value : array();
+			if ( isset( $this->registered_styles[ $key ] ) ) {
+				$this->registered_styles[ $key ] = array_merge( $this->registered_styles[ $key ], $value );
+			} else {
+				$this->registered_styles[ $key ] = $value;
+			}
+		}
+	}
+
+	protected function deduplicate_styles() {
+		$result        = array();
+		$unique_styles = array();
+		array_walk(
+			$this->registered_styles,
+			function( $value, $key ) use ( &$result, &$unique_styles ) {
+				$stringified_value = json_encode( $value );
+				if ( array_key_exists( $stringified_value, $unique_styles ) ) {
+					$new_key = $unique_styles[ $stringified_value ] . ",\n" . $key;
+					unset( $result[ $unique_styles[ $stringified_value ] ] );
+					$unique_styles[ $stringified_value ] = $new_key;
+					$result[ $new_key ] = $value;
+				} else {
+					$unique_styles[ $stringified_value ] = $key;
+					$result[ $key ]                      = $value;
+				}
+			}
+		);
+		return $result;
 	}
 
 	public function output_styles() {
-		$style = implode( "\n", $this->registered_styles );
-		echo "<style>$style</style>\n";
+		$deduped_styles = $this->deduplicate_styles();
+		$callback = function( $css_selector, $css_ruleset ) {
+			$style = "{$css_selector} {\n";
+			foreach ( $css_ruleset as $css_property => $css_value ) {
+				$style .= "    {$css_property}: {$css_value};\n";
+			}
+			$style .= "}\n";
+			return $style;
+		};
+
+		$output = array_map( $callback, array_keys( $deduped_styles ), array_values( $deduped_styles ) );
+		$output = implode( "\n", $output );
+
+		echo "<style>\n$output</style>\n";
 	}
 }

--- a/lib/load.php
+++ b/lib/load.php
@@ -112,6 +112,11 @@ require __DIR__ . '/experiments-page.php';
 require __DIR__ . '/global-styles.php';
 require __DIR__ . '/pwa.php';
 
+// TODO: Before this PR merges, move this to be a part of the style engine package.
+// Part of the build process should be to copy the PHP file to the correct location,
+// similar to the loading behaviour in `blocks.php`.
+require __DIR__ . '/class-wp-style-engine.php';
+
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/typography.php';


### PR DESCRIPTION
## Description

Experimenting with approaches based on https://github.com/WordPress/gutenberg/pull/38974

Picking on the layout abstraction to register and render styles on the frontend.

Styles are rendered at top of page for now while testing.


## Testing Instructions

Paste in the test content into the code editor and publish the post:

<details><summary>Test content</summary>


```html
<!-- wp:group {"style":{"color":{"background":"#aad3ee"}}} -->
<div class="wp-block-group has-background" style="background-color:#aad3ee"><!-- wp:paragraph -->
<p>This is a test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"style":{"color":{"background":"#cce5f8"}}} -->
<div class="wp-block-group has-background" style="background-color:#cce5f8"><!-- wp:paragraph -->
<p>This is a test 2</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test 3</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test 2</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>This is a test 2</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph {"style":{"color":{"background":"#f2e8dd"}}} -->
<p class="has-background" style="background-color:#f2e8dd">This is a test column</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph {"style":{"color":{"background":"#f7ede2"}}} -->
<p class="has-background" style="background-color:#f7ede2">This is a test column</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

Check that the page layout looks as it should and that the styles are rendered in the page.

```css
<style>
.wp-container-3 {
    justify-content: flex-end;
}

.wp-container-1,
.wp-container-9,
.wp-container-11 {
    align-items: center;
}

.wp-container-4,
.wp-container-14 {
    justify-content: space-between;
}

.wp-container-1 > *,
.wp-container-3 > *,
.wp-container-4 > *,
.wp-container-9 > *,
.wp-container-11 > *,
.wp-container-14 > * {
    margin: 0;
}

.wp-container-5 > :where(:not(.alignleft):not(.alignright)),
.wp-container-6 > :where(:not(.alignleft):not(.alignright)),
.wp-container-10 > :where(:not(.alignleft):not(.alignright)),
.wp-container-12 > :where(:not(.alignleft):not(.alignright)),
.wp-container-15 > :where(:not(.alignleft):not(.alignright)),
.wp-container-16 > :where(:not(.alignleft):not(.alignright)) {
    max-width: 650px;
    margin-left: auto !important;
    margin-right: auto !important;
}
...

```


## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
