### PR TITLE
Experiment: try using inner blocks for the page list block

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -176,7 +176,7 @@ function getTemplatedPageBlocks(
 		const hasChildren = pagesByParentId.has( page.id );
 		// const isNavigationChild = 'showSubmenuIcon' in context;
 		const block = [
-			'core/navigation-link',
+			hasChildren ? 'core/navigation-submenu' : 'core/navigation-link',
 			{
 				id: page.id,
 				kind: 'post-type',
@@ -193,7 +193,7 @@ function getTemplatedPageBlocks(
 				? getTemplatedPageBlocks(
 						context,
 						pagesByParentId,
-						parentId,
+						page.id,
 						depth + 1
 				  )
 				: [],


### PR DESCRIPTION
## Description
This is a fairly simple experiment that attempts to use inner blocks for the Page List block in the editor. It does so by creating a locked template of Navigation Link blocks. Each block is also locked to prevent removal or moving.

The thing that prompted me to explore this is #38600, which looks at using List View to display site navigation. A shortcoming of Page List in this context is that it doesn't show its child pages in List View because they're not blocks. This resolves that, now we get to see the full page hierarchy in List View:
![Screen Shot 2022-02-25 at 3 17 03 pm](https://user-images.githubusercontent.com/677833/155671698-0a2ae7bd-8479-4a14-8240-4ba8019a0ee5.png)

I think there are also advantages in code reuse. The Navigation Block is now using the defacto nav link blocks instead of reproducing their markup. It should avoid any issues with code or style drift.

It also fixes https://github.com/WordPress/gutenberg/issues/38733.

There are some problems to solve:
- [ ] The inner blocks are still editable, you can still change text, use formatting and change other attributes. I think there's a chance to explore more block locking tools to prevent any modifications to a block.
- [ ] Page List is contextual and displays differently depending on whether it's used inside or outside of the navigation block. We might consider introducing a new Page List Item block type for code separation.
- [ ] We could consider making it clearer in List View which blocks are locked
- [ ] Page List still reproduces Navigation Submenu/Link markup in its render_callback, though we could investigate using other blocks there too.

## Testing Instructions
1. In wp-admin, publish some pages and arrange them into a hierarchy
2. In the post editor, add a Page List to a nav block

## Screenshots
![Screen Shot 2022-02-25 at 3 30 24 pm](https://user-images.githubusercontent.com/677833/155673523-54db4640-0276-4303-98f4-ba8a33be7637.png)

## Types of changes
Experiment
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
