### PR TITLE
File: Check if 'fileId' exists before setting the attribute

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -69,6 +69,7 @@ function FileEdit( {
 } ) {
 	const {
 		id,
+		fileId,
 		fileName,
 		href,
 		textLinkHref,
@@ -115,9 +116,11 @@ function FileEdit( {
 	}, [] );
 
 	useEffect( () => {
-		// Add a unique fileId to each file block
-		setAttributes( { fileId: `wp-block-file--media-${ clientId }` } );
-	}, [ clientId ] );
+		if ( ! fileId ) {
+			// Add a unique fileId to each file block
+			setAttributes( { fileId: `wp-block-file--media-${ clientId }` } );
+		}
+	}, [ fileId, clientId ] );
 
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {


### PR DESCRIPTION
## Description
Unconditional `setAttributes` in effect was causing a "You have unsaved changes." warning.

## Testing Instructions
1. Add a file block and upload a file
2. Delete all of the filename text
3. Save and reload
4. Update/Save button should be disabled.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
