### PR TITLE
Webfonts API: Output only used fonts

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -82,7 +82,7 @@ class WP_Webfonts {
 		add_action( 'init', array( $this, 'register_filter_for_current_template_webfonts_collector' ) );
 		add_action( 'init', array( $this, 'collect_webfonts_used_in_global_styles' ) );
 		add_action( 'switch_theme', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
-
+		add_action( 'switch_theme', array( $this, 'invalidate_webfonts_used_in_templates_cache' ) );
 		add_action( 'save_post_wp_template', array( $this, 'invalidate_webfonts_used_in_templates_cache' ) );
 		add_action( 'save_post_wp_template_part', array( $this, 'invalidate_webfonts_used_in_templates_cache' ) );
 		add_action( 'save_post_wp_global_styles', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -71,6 +71,7 @@ class WP_Webfonts {
 		}
 
 		add_action( 'init', array( $this, 'collect_webfonts_used_in_global_styles' ) );
+		add_action( 'switch_theme', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
 		add_action( 'save_post_wp_global_styles', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
 
 		add_action( $hook, array( $this, 'generate_and_enqueue_styles' ) );

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -29,6 +29,15 @@ class WP_Webfonts {
 	private static $providers = array();
 
 	/**
+	 * An array of fonts actually used in the front-end.
+	 *
+	 * @static
+	 * @access private
+	 * @var array
+	 */
+	private static $webfonts_used_in_front_end = array();
+
+	/**
 	 * Stylesheet handle.
 	 *
 	 * @var string
@@ -199,9 +208,33 @@ class WP_Webfonts {
 	}
 
 	/**
+	 * Filter out webfonts that are not being used by the front-end.
+	 *
+	 * @return void
+	 */
+	private function filter_out_webfonts_unused_in_front_end() {
+		$all_registered_fonts = $this->get_fonts();
+		$picked_webfonts      = array();
+
+		self::$webfonts_used_in_front_end = apply_filters( 'gutenberg_webfonts_used_in_front_end', self::$webfonts_used_in_front_end );
+
+		foreach ( $all_registered_fonts as $id => $webfont ) {
+			$font_name = _wp_to_kebab_case( $webfont['font-family'] );
+
+			if ( isset( self::$webfonts_used_in_front_end[ $font_name ] ) ) {
+				$picked_webfonts[ $id ] = $webfont;
+			}
+		}
+
+		self::$webfonts = $picked_webfonts;
+	}
+
+	/**
 	 * Generate and enqueue webfonts styles.
 	 */
 	public function generate_and_enqueue_styles() {
+		$this->filter_out_webfonts_unused_in_front_end();
+
 		// Generate the styles.
 		$styles = $this->generate_styles();
 

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -71,11 +71,22 @@ class WP_Webfonts {
 		}
 
 		add_action( 'init', array( $this, 'collect_webfonts_used_in_global_styles' ) );
+		add_action( 'save_post_wp_global_styles', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
 
 		add_action( $hook, array( $this, 'generate_and_enqueue_styles' ) );
 
 		// Enqueue webfonts in the block editor.
 		add_action( 'admin_init', array( $this, 'generate_and_enqueue_editor_styles' ) );
+	}
+
+	/**
+	 * Update webfonts used in global styles cache.
+	 */
+	public function update_webfonts_used_in_global_styles_cache() {
+		$webfonts_used_in_global_styles = $this->get_webfonts_used_in_global_styles();
+		update_option( self::$webfonts_used_in_global_styles_cache_option, $webfonts_used_in_global_styles );
+
+		return $webfonts_used_in_global_styles;
 	}
 
 	/**
@@ -86,8 +97,7 @@ class WP_Webfonts {
 		$webfonts_used_in_global_styles = get_option( self::$webfonts_used_in_global_styles_cache_option );
 
 		if ( ! $webfonts_used_in_global_styles ) {
-			$webfonts_used_in_global_styles = $this->get_webfonts_used_in_global_styles();
-			update_option( self::$webfonts_used_in_global_styles_cache_option, $webfonts_used_in_global_styles );
+			$webfonts_used_in_global_styles = $this->update_webfonts_used_in_global_styles_cache();
 		}
 
 		self::$webfonts_used_in_front_end = array_merge( self::$webfonts_used_in_front_end, $webfonts_used_in_global_styles );

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -82,12 +82,26 @@ class WP_Webfonts {
 		add_action( 'init', array( $this, 'register_filter_for_current_template_webfonts_collector' ) );
 		add_action( 'init', array( $this, 'collect_webfonts_used_in_global_styles' ) );
 		add_action( 'switch_theme', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
+
+		add_action( 'save_post_wp_template', array( $this, 'invalidate_webfonts_used_in_templates_cache' ) );
+		add_action( 'save_post_wp_template_part', array( $this, 'invalidate_webfonts_used_in_templates_cache' ) );
 		add_action( 'save_post_wp_global_styles', array( $this, 'update_webfonts_used_in_global_styles_cache' ) );
 
 		add_action( $hook, array( $this, 'generate_and_enqueue_styles' ) );
 
 		// Enqueue webfonts in the block editor.
 		add_action( 'admin_init', array( $this, 'generate_and_enqueue_editor_styles' ) );
+	}
+
+	/**
+	 * Invalidate webfonts used in templates cache.
+	 * We need to do that because there's no indication on which templates uses which template parts,
+	 * so we're throwing everything away and lazily reconstructing the cache whenever a template gets loaded.
+	 *
+	 * @return void
+	 */
+	public function invalidate_webfonts_used_in_templates_cache() {
+		delete_option( self::$webfonts_used_in_templates_cache_option );
 	}
 
 	/**


### PR DESCRIPTION
## What

In https://github.com/WordPress/gutenberg/pull/37140, we finally introduced the Webfonts API. The initial implementation has a pitfall: it includes every registered font, even if it's not being used, to the output.

This PR addresses exactly that: it introduces a mechanism to remove webfonts that are not used by the providers when emitting inline CSS that's sent to the front-end.

## Why

A single `@font-face` declaration could add up to 2kb to every request. Imagine someone registering 100 fonts to a provider so one single font could be picked up in FSE. Without this filtering mechanism, we'd add a lot of useless information per request. It can -- and probably will -- become a problem very quickly.

## How

I'm looking up the contents of the current template for every request and saving its used webfonts as an option. This happens for every template, lazily.

Fonts used in the global styles settings are also cached. We're caching because this is an expensive operation.

The cache is invalidated on every update of:
- template;
- template part;
- global styles...

And also when the current theme changes.

The content (post/page content) is also processed, per request, to include webfonts used by the blocks inside the current post or page. There is no cache for this type of content, but there might be if someone requests it.

It also includes a filter called `gutenberg_used_webfonts` so one can override the decision of the mechanism, either by adding or removing fonts as needed. This is a concern raised by @justintadlock regarding a few blocks that do not have the font-family attribute yet. It's a workaround until all blocks get the possibility to change the font family inside the block editor instead of working around it by using additional CSS classes.

## Testing

You should check only the used fonts are included as inline CSS when the webfont is picked as:

- an element, block, or typography setting in global styles;
- the font family on any block that supports it in any active template;
- the font family on any block that supports it in any template part and that template part is used by any active template;
- the font family on any block that supports it in any post or page in the block editor.

## TODO

- [ ] Use WP Cache instead of option to save stuff?