### PR TITLE
e2e-tests: update preview test to wait for publish panel to appear before closing it

### DIFF
--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -273,9 +273,11 @@ describe( 'Preview', () => {
 
 		// Close the panel.
 		await page.waitForSelector(
-			'.editor-post-publish-panel__header button'
+			'.editor-post-publish-panel button[aria-label="Close panel"]'
 		);
-		await page.click( '.editor-post-publish-panel__header button' );
+		await page.click(
+			'.editor-post-publish-panel button[aria-label="Close panel"]'
+		);
 
 		// Change the title and preview again.
 		await editorPage.type( '[aria-label="Add title"]', ' Ipsum' );

--- a/packages/e2e-tests/specs/editor/various/preview.test.js
+++ b/packages/e2e-tests/specs/editor/various/preview.test.js
@@ -272,7 +272,9 @@ describe( 'Preview', () => {
 		await publishPost();
 
 		// Close the panel.
-		await page.waitForSelector( '.editor-post-publish-panel' );
+		await page.waitForSelector(
+			'.editor-post-publish-panel__header button'
+		);
 		await page.click( '.editor-post-publish-panel__header button' );
 
 		// Change the title and preview again.


### PR DESCRIPTION
I noticed that trunk sometimes had red E2E runs. Failures would sometimes occur in the preview test suite, since the test would get stuck with the post-publish panel being open. This PR updates the test to wait for the actual close button to appear before attempting to click it.

Here's an example bad run: https://github.com/WordPress/gutenberg/runs/5337988645?check_suite_focus=true

| trunk runs | e2e log | stuck screen artifact |
|-----|-----|-----|
|  <img width="1224" alt="CleanShot 2022-02-25 at 12 35 36@2x" src="https://user-images.githubusercontent.com/1270189/155799233-1f827d8a-2657-4419-977b-02fe1c6108de.png"> | <img width="892" alt="CleanShot 2022-02-25 at 12 36 09@2x" src="https://user-images.githubusercontent.com/1270189/155799388-cdf14861-a6c1-4773-8a92-2512d663be12.png"> | ![should display the correct preview when switching between published and draft statuses 2022-02-25T18](https://user-images.githubusercontent.com/1270189/155799413-9705441b-aa4f-4e82-8390-89856cdad70d.jpg) |

 ### Testing Instructions
- Multiple E2E runs on this branch should remain green and not sometimes fail