### PR TITLE
Create Block: Add confirm prompt before showing the plugin options

### DIFF
--- a/packages/create-block/lib/index.js
+++ b/packages/create-block/lib/index.js
@@ -96,19 +96,55 @@ program
 					};
 					await scaffold( pluginTemplate, answers );
 				} else {
-					const prompts = getPrompts( pluginTemplate ).filter(
-						( { name } ) =>
-							! Object.keys( optionsValues ).includes( name )
-					);
 					log.info( '' );
 					log.info(
 						"Let's customize your WordPress plugin with blocks:"
 					);
-					const answers = await inquirer.prompt( prompts );
+
+					const filterOptionsProvided = ( { name } ) =>
+						! Object.keys( optionsValues ).includes( name );
+					const blockPrompts = getPrompts( pluginTemplate, [
+						'slug',
+						'namespace',
+						'title',
+						'description',
+						'dashicon',
+						'category',
+					] ).filter( filterOptionsProvided );
+					const blockAnswers = await inquirer.prompt( blockPrompts );
+
+					const pluginAnswers = await inquirer
+						.prompt( {
+							type: 'confirm',
+							name: 'configurePlugin',
+							message:
+								'Do you want to customize the WordPress plugin?',
+							default: false,
+						} )
+						.then( async ( { configurePlugin } ) => {
+							if ( ! configurePlugin ) {
+								return {};
+							}
+
+							const pluginPrompts = getPrompts( pluginTemplate, [
+								'pluginURI',
+								'version',
+								'author',
+								'license',
+								'licenseURI',
+								'domainPath',
+								'updateURI',
+							] ).filter( filterOptionsProvided );
+							const result = await inquirer.prompt(
+								pluginPrompts
+							);
+							return result;
+						} );
 					await scaffold( pluginTemplate, {
 						...defaultValues,
 						...optionsValues,
-						...answers,
+						...blockAnswers,
+						...pluginAnswers,
 					} );
 				}
 			} catch ( error ) {

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -220,9 +220,9 @@ const getDefaultValues = ( pluginTemplate ) => {
 	};
 };
 
-const getPrompts = ( pluginTemplate ) => {
+const getPrompts = ( pluginTemplate, keys ) => {
 	const defaultValues = getDefaultValues( pluginTemplate );
-	return Object.keys( prompts ).map( ( promptName ) => {
+	return keys.map( ( promptName ) => {
 		return {
 			...prompts[ promptName ],
 			default: defaultValues[ promptName ],


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

There were 3 more CLI prompts added for the plugin header fields in https://github.com/WordPress/gutenberg/pull/39096 when scaffolding a block with `@wordpress/create-block`. The part related to the WordPress plugin is less important so the proposal is to let the users decide whether they want to customize them. This split will make it also easier to update the workflow to scaffold only a block as the next step.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Tested locally with two project templates in interactive mode:

```bash
npx wp-create-block -t es5
npx wp-create-block --no-wp-scripts
```

## Screenshots <!-- if applicable -->


https://user-images.githubusercontent.com/699132/155840306-849bf1a5-b3f3-4516-9158-17e3ea74ce39.mov


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Improving developer experience when scaffolding block.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [-] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
