### PR TITLE
InputControl: Allow onBlur for empty values to commit the change, move reset behaviour to ESCAPE key

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 -   `TreeGrid`: Add tests for `onCollapseRow`, `onExpandRow`, and `onFocusRow` callback functions. ([#38942](https://github.com/WordPress/gutenberg/pull/38942)).
 -   `TreeGrid`: Update callback tests to use `TreeGridRow` and `TreeGridCell` sub-components. ([#39002](https://github.com/WordPress/gutenberg/pull/39002)).
+-   InputControl: Allow `onBlur` for empty values to commit the change when `isPressEnterToChange` is true, and move reset behavior to the ESCAPE key. ([#39109](https://github.com/WordPress/gutenberg/pull/39109)).
 
 ## 19.4.0 (2022-02-10)
 

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -124,6 +124,24 @@ describe( 'BoxControl', () => {
 			expect( input.value ).toBe( '' );
 			expect( unitSelect.value ).toBe( 'px' );
 		} );
+
+		it( 'should persist cleared value when focus changes', () => {
+			const { container } = render( <BoxControl /> );
+			const input = container.querySelector( 'input' );
+			const unitSelect = container.querySelector( 'select' );
+
+			input.focus();
+			fireEvent.change( input, { target: { value: '100%' } } );
+			fireEvent.keyDown( input, { keyCode: ENTER } );
+
+			expect( input.value ).toBe( '100' );
+			expect( unitSelect.value ).toBe( '%' );
+
+			fireEvent.change( input, { target: { value: '' } } );
+			fireEvent.blur( input );
+
+			expect( input.value ).toBe( '' );
+		} );
 	} );
 
 	describe( 'Unlinked Sides', () => {

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -126,9 +126,11 @@ describe( 'BoxControl', () => {
 		} );
 
 		it( 'should persist cleared value when focus changes', () => {
-			const { container } = render( <BoxControl /> );
-			const input = container.querySelector( 'input' );
-			const unitSelect = container.querySelector( 'select' );
+			render( <BoxControl /> );
+			const input = screen.getByLabelText( 'Box Control', {
+				selector: 'input',
+			} );
+			const unitSelect = screen.getByLabelText( 'Select unit' );
 
 			input.focus();
 			fireEvent.change( input, { target: { value: '100%' } } );

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -38,7 +38,7 @@ export default function BoxUnitControl( {
 					isFirst={ isFirst }
 					isLast={ isLast }
 					isOnly={ isOnly }
-					isPressEnterToChange
+					isPressEnterToChange={ false }
 					isResetValueOnUnitChange={ false }
 					value={ value }
 					{ ...props }

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -38,7 +38,7 @@ export default function BoxUnitControl( {
 					isFirst={ isFirst }
 					isLast={ isLast }
 					isOnly={ isOnly }
-					isPressEnterToChange={ false }
+					isPressEnterToChange={ true }
 					isResetValueOnUnitChange={ false }
 					value={ value }
 					{ ...props }

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -38,7 +38,7 @@ export default function BoxUnitControl( {
 					isFirst={ isFirst }
 					isLast={ isLast }
 					isOnly={ isOnly }
-					isPressEnterToChange={ true }
+					isPressEnterToChange
 					isResetValueOnUnitChange={ false }
 					value={ value }
 					{ ...props }

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -17,7 +17,7 @@ import type {
  * WordPress dependencies
  */
 import { forwardRef, useRef } from '@wordpress/element';
-import { UP, DOWN, ENTER } from '@wordpress/keycodes';
+import { UP, DOWN, ENTER, ESCAPE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
@@ -25,7 +25,6 @@ import type { WordPressComponentProps } from '../ui/context';
 import { useDragCursor } from './utils';
 import { Input } from './styles/input-control-styles';
 import { useInputControlStateReducer } from './reducer/reducer';
-import { isValueEmpty } from '../utils/values';
 import { useUpdateEffect } from '../utils';
 import type { InputFieldProps } from './types';
 
@@ -112,11 +111,7 @@ function InputField(
 		 */
 		if ( isPressEnterToChange && isDirty ) {
 			wasDirtyOnBlur.current = true;
-			if ( ! isValueEmpty( value ) ) {
-				handleOnCommit( event );
-			} else {
-				reset( valueProp, event );
-			}
+			handleOnCommit( event );
 		}
 	};
 
@@ -160,6 +155,13 @@ function InputField(
 				if ( isPressEnterToChange ) {
 					event.preventDefault();
 					handleOnCommit( event );
+				}
+				break;
+
+			case ESCAPE:
+				if ( isPressEnterToChange ) {
+					event.preventDefault();
+					reset( valueProp, event );
 				}
 				break;
 		}

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -159,7 +159,7 @@ function InputField(
 				break;
 
 			case ESCAPE:
-				if ( isPressEnterToChange ) {
+				if ( isPressEnterToChange && isDirty ) {
 					event.preventDefault();
 					reset( valueProp, event );
 				}

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -6,7 +6,7 @@ import { render, fireEvent } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import { UP, DOWN, ENTER } from '@wordpress/keycodes';
+import { UP, DOWN, ENTER, ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -125,6 +125,32 @@ describe( 'UnitControl', () => {
 			fireKeyDown( { keyCode: DOWN, shiftKey: true } );
 
 			expect( state ).toBe( '40px' );
+		} );
+
+		it( 'should cancel change when ESCAPE key is pressed', () => {
+			let state = 50;
+			const setState = ( nextState ) => ( state = nextState );
+
+			render(
+				<UnitControl
+					value={ state }
+					onChange={ setState }
+					isPressEnterToChange
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+
+			fireEvent.change( input, { target: { value: '300px' } } );
+
+			expect( input.value ).toBe( '300px' );
+			expect( state ).toBe( 50 );
+
+			fireKeyDown( { keyCode: ESCAPE } );
+
+			expect( input.value ).toBe( '50' );
+			expect( state ).toBe( 50 );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

As reported in #39090, the existing default behaviour of the BoxControl (as used in Padding and Margin dimensions controls) where you need to press Enter to commit a value change such as clearing out the padding value, can be confusing for users when it comes to clearing out the value.

Prior to this PR, when you blur (e.g. tab or click) out of the UnitControl (with `isPressEnterToChange` set to true) when it contains no value, this will be treated as cancelling / resetting the current change.

After this PR, we treat any change to the input field (even it's empty) as a change to commit when tabbing or clicking out of the field.

To preserve the ability to cancel the current change, the `reset()` behaviour is moved to the ESCAPE key, which has some consistency with the [W3C WAI recommendations](https://www.w3.org/TR/wai-aria-practices-1.1/#gridNav_inside) for editing within a data cell (namely `Escape`: if content was being edited, it may also undo edits) — it's not an exact match to the use case of this component, but I think there's a close enough parallel.

The proposed change here is an opinionated one, but hopefully it helps alleviate some of the frustration with editing Padding and Margin values as in the initial report.

## Changes included:

* When `isPressEnterToChange` is set on the InputField, commit empty values
* When `isPressEnterToChange` is set on the InputField, allow the `ESCAPE` key to cancel the current (not-yet-committed) change

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

* Add a group or row block to a post or in the site editor.
* Adjust the padding and/or margin so that it has a value.
* Save and reload the editor.
* Go to clear out the value by pressing backspace in the field.
* Click outside of the field — the cleared value should persist.
* Save and reload the editor — the cleared value should persist.
* Also check that you're still able to enter a value + unit to switch the unit in the control. E.g. try entering `10px` or `2rem` or `5%` and then press enter and check that it still works correctly.

Confirm existing tests pass (you can look at the CI job, but I ran the following locally to confirm the tests were passing):

```
npm run test-unit packages/components/src/box-control/test
npm run test-unit packages/components/src/input-control/test
npm run test-unit packages/components/src/unit-control/test
```

Also check that the components still behave correctly in Storybook (via `npm run storybook:dev`). Test the BoxControl component in particular: http://localhost:50240/?path=/story/components-experimental-boxcontrol--default

## Screenshots <!-- if applicable -->

| Before | After |
| --- | --- |
| ![box-control-before](https://user-images.githubusercontent.com/14988353/155905644-ff8eed17-282f-41a6-9ef3-ac33c9ea7625.gif) | ![box-control-after](https://user-images.githubusercontent.com/14988353/155905651-ffff5356-1d7f-448f-8b0d-04cacc5866a8.gif) |

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
