### PR TITLE
Block settings dropdown: use block display title in remove label

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -231,7 +231,7 @@ _Parameters_
 
 -   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
--   _props.maximumLength_ `number`: The maximum length that the block title string may be before truncated.
+-   _props.maximumLength_ `number|undefined`: The maximum length that the block title string may be before truncated.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -228,10 +228,11 @@ _Parameters_
 
 -   _props_ `Object`:
 -   _props.clientId_ `string`: Client ID of block.
+-   _props.maximumLength_ `number`: The maximum length that the block title string may be before truncated.
 
 _Returns_
 
--   `?string`: Block title.
+-   `JSX.Element`: Block title.
 
 ### BlockToolbar
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -221,7 +221,10 @@ cannot be determined.
 _Usage_
 
 ```jsx
-<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+<BlockTitle
+	clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1"
+	maximumLength={ 17 }
+/>
 ```
 
 _Parameters_

--- a/packages/block-editor/src/components/block-breadcrumb/index.js
+++ b/packages/block-editor/src/components/block-breadcrumb/index.js
@@ -80,7 +80,10 @@ function BlockBreadcrumb( { rootLabelText } ) {
 						variant="tertiary"
 						onClick={ () => selectBlock( parentClientId ) }
 					>
-						<BlockTitle clientId={ parentClientId } />
+						<BlockTitle
+							clientId={ parentClientId }
+							maximumLength={ 35 }
+						/>
 					</Button>
 					<Icon
 						icon={ chevronRightSmall }
@@ -93,7 +96,7 @@ function BlockBreadcrumb( { rootLabelText } ) {
 					className="block-editor-block-breadcrumb__current"
 					aria-current="true"
 				>
-					<BlockTitle clientId={ clientId } />
+					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
 				</li>
 			) }
 		</ul>

--- a/packages/block-editor/src/components/block-list/block-selection-button.native.js
+++ b/packages/block-editor/src/components/block-list/block-selection-button.native.js
@@ -72,7 +72,7 @@ const BlockSelectionButton = ( {
 					numberOfLines={ 1 }
 					style={ styles.selectionButtonTitle }
 				>
-					<BlockTitle clientId={ clientId } />
+					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
 				</Text>
 			</TouchableOpacity>
 		</View>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -10,9 +10,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
-
 import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize, store as blocksStore } from '@wordpress/blocks';
+import { serialize } from '@wordpress/blocks';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -25,6 +24,7 @@ import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
+import useBlockDisplayTitle from '../block-title/use-block-display-title';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -46,14 +46,11 @@ export function BlockSettingsDropdown( {
 	const blockClientIds = castArray( clientIds );
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
-	const { onlyBlock, title } = useSelect(
+	const { onlyBlock } = useSelect(
 		( select ) => {
-			const { getBlockCount, getBlockName } = select( blockEditorStore );
-			const { getBlockType } = select( blocksStore );
+			const { getBlockCount } = select( blockEditorStore );
 			return {
 				onlyBlock: 1 === getBlockCount(),
-				title: getBlockType( getBlockName( firstBlockClientId ) )
-					?.title,
 			};
 		},
 		[ firstBlockClientId ]
@@ -87,10 +84,12 @@ export function BlockSettingsDropdown( {
 		[ __experimentalSelectBlock ]
 	);
 
+	const blockTitle = useBlockDisplayTitle( firstBlockClientId, 25 );
+
 	const label = sprintf(
 		/* translators: %s: block name */
 		__( 'Remove %s' ),
-		title
+		blockTitle
 	);
 	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -158,7 +158,10 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 								/>
 								{ ( isReusable || isTemplate ) && (
 									<span className="block-editor-block-switcher__toggle-text">
-										<BlockTitle clientId={ clientIds } />
+										<BlockTitle
+											clientId={ clientIds }
+											maximumLength={ 35 }
+										/>
 									</span>
 								) }
 							</>

--- a/packages/block-editor/src/components/block-title/README.md
+++ b/packages/block-editor/src/components/block-title/README.md
@@ -19,7 +19,7 @@ The client ID of a block.
 
 #### maximumLength
 
-The maximum length that the block title string may be before truncated. The default is stored in `MAXIMUM_TITLE_LENGTH`.
+The maximum length that the block title string may be before truncated. If `undefined` no truncation will take place.
 
 -   Type: `Number`
 -   Required: No

--- a/packages/block-editor/src/components/block-title/README.md
+++ b/packages/block-editor/src/components/block-title/README.md
@@ -5,5 +5,21 @@ Renders the block's configured title as a string, or empty if the title cannot b
 ## Usage
 
 ```jsx
-<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+<BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" maximumLength={ 12 }/>
 ```
+
+### Props
+
+#### clientId
+
+The client ID of a block.
+
+-   Type: `String`
+-   Required: Yes
+
+#### maximumLength
+
+The maximum length that the block title string may be before truncated. The default is stored in `MAXIMUM_TITLE_LENGTH`.
+
+-   Type: `Number`
+-   Required: No

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -1,23 +1,10 @@
 /**
- * External dependencies
- */
-import { truncate } from 'lodash';
-
-/**
- * WordPress dependencies
- */
-import { useSelect } from '@wordpress/data';
-import {
-	getBlockType,
-	__experimentalGetBlockLabel as getBlockLabel,
-	isReusableBlock,
-} from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
-import useBlockDisplayInformation from '../use-block-display-information';
-import { store as blockEditorStore } from '../../store';
+
+import useBlockDisplayTitle, {
+	MAXIMUM_TITLE_LENGTH,
+} from './use-block-display-title';
 
 /**
  * Renders the block's configured title as a string, or empty if the title
@@ -31,50 +18,13 @@ import { store as blockEditorStore } from '../../store';
  *
  * @param {Object} props
  * @param {string} props.clientId Client ID of block.
+ * @param {number} props.maximumLength The maximum length that the block title string may be before truncated.
  *
- * @return {?string} Block title.
+ * @return {JSX.Element} Block title.
  */
-export default function BlockTitle( { clientId } ) {
-	const { attributes, name, reusableBlockTitle } = useSelect(
-		( select ) => {
-			if ( ! clientId ) {
-				return {};
-			}
-			const {
-				getBlockName,
-				getBlockAttributes,
-				__experimentalGetReusableBlockTitle,
-			} = select( blockEditorStore );
-			const blockName = getBlockName( clientId );
-			if ( ! blockName ) {
-				return {};
-			}
-			const isReusable = isReusableBlock( getBlockType( blockName ) );
-			return {
-				attributes: getBlockAttributes( clientId ),
-				name: blockName,
-				reusableBlockTitle:
-					isReusable &&
-					__experimentalGetReusableBlockTitle(
-						getBlockAttributes( clientId ).ref
-					),
-			};
-		},
-		[ clientId ]
-	);
-
-	const blockInformation = useBlockDisplayInformation( clientId );
-	if ( ! name || ! blockInformation ) return null;
-	const blockType = getBlockType( name );
-	const blockLabel = blockType
-		? getBlockLabel( blockType, attributes )
-		: null;
-	const label = reusableBlockTitle || blockLabel;
-	// Label will fallback to the title if no label is defined for the current
-	// label context. If the label is defined we prioritize it over possible
-	// possible block variation title match.
-	if ( label && label !== blockType.title ) {
-		return truncate( label, { length: 35 } );
-	}
-	return blockInformation.title;
+export default function BlockTitle( {
+	clientId,
+	maximumLength = MAXIMUM_TITLE_LENGTH,
+} ) {
+	return useBlockDisplayTitle( clientId, maximumLength );
 }

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -2,9 +2,7 @@
  * Internal dependencies
  */
 
-import useBlockDisplayTitle, {
-	MAXIMUM_TITLE_LENGTH,
-} from './use-block-display-title';
+import useBlockDisplayTitle from './use-block-display-title';
 
 /**
  * Renders the block's configured title as a string, or empty if the title
@@ -18,13 +16,10 @@ import useBlockDisplayTitle, {
  *
  * @param {Object} props
  * @param {string} props.clientId Client ID of block.
- * @param {number} props.maximumLength The maximum length that the block title string may be before truncated.
+ * @param {number|undefined} props.maximumLength The maximum length that the block title string may be before truncated.
  *
  * @return {JSX.Element} Block title.
  */
-export default function BlockTitle( {
-	clientId,
-	maximumLength = MAXIMUM_TITLE_LENGTH,
-} ) {
+export default function BlockTitle( { clientId, maximumLength } ) {
 	return useBlockDisplayTitle( clientId, maximumLength );
 }

--- a/packages/block-editor/src/components/block-title/index.js
+++ b/packages/block-editor/src/components/block-title/index.js
@@ -13,7 +13,7 @@ import useBlockDisplayTitle, {
  * @example
  *
  * ```jsx
- * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+ * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" maximumLength={ 17 }/>
  * ```
  *
  * @param {Object} props

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -106,7 +106,7 @@ describe( 'BlockTitle', () => {
 		expect( wrapper.text() ).toBe( 'Test Label' );
 	} );
 
-	it( 'truncates the label if it is too long', () => {
+	it( 'truncates the label at the default value if it is too long', () => {
 		useSelect.mockImplementation( () => ( {
 			name: 'name-with-long-label',
 			attributes: null,
@@ -114,6 +114,38 @@ describe( 'BlockTitle', () => {
 
 		const wrapper = shallow(
 			<BlockTitle clientId="id-name-with-long-label" />
+		);
+
+		expect( wrapper.text() ).toBe( 'This is a longer label than typi...' );
+	} );
+
+	it( 'truncates the label if it is too long with custom truncate length', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-long-label',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow(
+			<BlockTitle
+				clientId="id-name-with-long-label"
+				maximumLength={ 12 }
+			/>
+		);
+
+		expect( wrapper.text() ).toBe( 'This is a...' );
+	} );
+
+	it( 'truncates the label at the default value if maximum length is not a number', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-long-label',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow(
+			<BlockTitle
+				clientId="id-name-with-long-label"
+				maximumLength={ false }
+			/>
 		);
 
 		expect( wrapper.text() ).toBe( 'This is a longer label than typi...' );

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -106,20 +106,7 @@ describe( 'BlockTitle', () => {
 		expect( wrapper.text() ).toBe( 'Test Label' );
 	} );
 
-	it( 'truncates the label at the default value if it is too long', () => {
-		useSelect.mockImplementation( () => ( {
-			name: 'name-with-long-label',
-			attributes: null,
-		} ) );
-
-		const wrapper = shallow(
-			<BlockTitle clientId="id-name-with-long-label" />
-		);
-
-		expect( wrapper.text() ).toBe( 'This is a longer label than typi...' );
-	} );
-
-	it( 'truncates the label if it is too long with custom truncate length', () => {
+	it( 'truncates the label with custom truncate length', () => {
 		useSelect.mockImplementation( () => ( {
 			name: 'name-with-long-label',
 			attributes: null,
@@ -135,19 +122,18 @@ describe( 'BlockTitle', () => {
 		expect( wrapper.text() ).toBe( 'This is a...' );
 	} );
 
-	it( 'truncates the label at the default value if maximum length is not a number', () => {
+	it( 'should not truncate the label if maximum length is undefined', () => {
 		useSelect.mockImplementation( () => ( {
 			name: 'name-with-long-label',
 			attributes: null,
 		} ) );
 
 		const wrapper = shallow(
-			<BlockTitle
-				clientId="id-name-with-long-label"
-				maximumLength={ false }
-			/>
+			<BlockTitle clientId="id-name-with-long-label" />
 		);
 
-		expect( wrapper.text() ).toBe( 'This is a longer label than typi...' );
+		expect( wrapper.text() ).toBe(
+			'This is a longer label than typical for blocks to have.'
+		);
 	} );
 } );

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -19,8 +19,6 @@ import {
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
-export const MAXIMUM_TITLE_LENGTH = 35;
-
 /**
  * Returns the block's configured title as a string, or empty if the title
  * cannot be determined.
@@ -32,14 +30,10 @@ export const MAXIMUM_TITLE_LENGTH = 35;
  * ```
  *
  * @param {string} clientId Client ID of block.
- * @param {number} maximumLength The maximum length that the block title string may be before truncated.
+ * @param {number|undefined} maximumLength The maximum length that the block title string may be before truncated.
  * @return {?string} Block title.
  */
 export default function useBlockDisplayTitle( clientId, maximumLength ) {
-	maximumLength = Number.isInteger( maximumLength )
-		? maximumLength
-		: MAXIMUM_TITLE_LENGTH;
-
 	const { attributes, name, reusableBlockTitle } = useSelect(
 		( select ) => {
 			if ( ! clientId ) {
@@ -81,7 +75,9 @@ export default function useBlockDisplayTitle( clientId, maximumLength ) {
 	// label context. If the label is defined we prioritize it over possible
 	// possible block variation title match.
 	if ( label && label !== blockType.title ) {
-		return truncate( label, { length: maximumLength } );
+		return maximumLength && maximumLength > 0
+			? truncate( label, { length: maximumLength } )
+			: label;
 	}
 	return blockInformation.title;
 }

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -27,8 +27,8 @@ export const MAXIMUM_TITLE_LENGTH = 35;
  *
  * @example
  *
- * ```jsx
- * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+ * ```js
+ * useBlockDisplayTitle( 'afd1cb17-2c08-4e7a-91be-007ba7ddc3a1', 17 );
  * ```
  *
  * @param {string} clientId Client ID of block.

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { truncate } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import {
+	getBlockType,
+	__experimentalGetBlockLabel as getBlockLabel,
+	isReusableBlock,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import useBlockDisplayInformation from '../use-block-display-information';
+import { store as blockEditorStore } from '../../store';
+
+export const MAXIMUM_TITLE_LENGTH = 35;
+
+/**
+ * Returns the block's configured title as a string, or empty if the title
+ * cannot be determined.
+ *
+ * @example
+ *
+ * ```jsx
+ * <BlockTitle clientId="afd1cb17-2c08-4e7a-91be-007ba7ddc3a1" />
+ * ```
+ *
+ * @param {string} clientId Client ID of block.
+ * @param {number} maximumLength The maximum length that the block title string may be before truncated.
+ * @return {?string} Block title.
+ */
+export default function useBlockDisplayTitle( clientId, maximumLength ) {
+	maximumLength = Number.isInteger( maximumLength )
+		? maximumLength
+		: MAXIMUM_TITLE_LENGTH;
+
+	const { attributes, name, reusableBlockTitle } = useSelect(
+		( select ) => {
+			if ( ! clientId ) {
+				return {};
+			}
+			const {
+				getBlockName,
+				getBlockAttributes,
+				__experimentalGetReusableBlockTitle,
+			} = select( blockEditorStore );
+			const blockName = getBlockName( clientId );
+			if ( ! blockName ) {
+				return {};
+			}
+			const isReusable = isReusableBlock( getBlockType( blockName ) );
+			return {
+				attributes: getBlockAttributes( clientId ),
+				name: blockName,
+				reusableBlockTitle:
+					isReusable &&
+					__experimentalGetReusableBlockTitle(
+						getBlockAttributes( clientId ).ref
+					),
+			};
+		},
+		[ clientId ]
+	);
+
+	const blockInformation = useBlockDisplayInformation( clientId );
+	if ( ! name || ! blockInformation ) {
+		return null;
+	}
+	const blockType = getBlockType( name );
+	const blockLabel = blockType
+		? getBlockLabel( blockType, attributes )
+		: null;
+	const label = reusableBlockTitle || blockLabel;
+	// Label will fallback to the title if no label is defined for the current
+	// label context. If the label is defined we prioritize it over possible
+	// possible block variation title match.
+	if ( label && label !== blockType.title ) {
+		return truncate( label, { length: maximumLength } );
+	}
+	return blockInformation.title;
+}

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -262,7 +262,10 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 						label={ label }
 						className="block-selection-button_select-button"
 					>
-						<BlockTitle clientId={ clientId } />
+						<BlockTitle
+							clientId={ clientId }
+							maximumLength={ 35 }
+						/>
 					</Button>
 				</FlexItem>
 			</Flex>

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -85,7 +85,7 @@ function ListViewBlockSelectButton(
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
-				<BlockTitle clientId={ clientId } />
+				<BlockTitle clientId={ clientId } maximumLength={ 35 } />
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">
 						{ blockInformation.anchor }

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -27,7 +27,8 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			}
+			},
+			"__experimentalSkipSerialization": [ "gradients", "link", "background", "text" ]
 		},
 		"spacing": {
 			"margin": [ "top", "bottom" ],
@@ -36,7 +37,8 @@
 			"__experimentalDefaultControls": {
 				"padding": true,
 				"blockGap": true
-			}
+			},
+			"__experimentalSkipSerialization": [ "blockGap", "margin", "padding" ]
 		},
 		"__experimentalBorder": {
 			"color": true,
@@ -48,7 +50,8 @@
 				"radius": true,
 				"style": true,
 				"width": true
-			}
+			},
+			"__experimentalSkipSerialization": [ "color", "radius", "style", "width" ]
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -27,8 +27,7 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			},
-			"__experimentalSkipSerialization": [ "gradients", "link", "background", "text" ]
+			}
 		},
 		"spacing": {
 			"margin": [ "top", "bottom" ],
@@ -37,8 +36,7 @@
 			"__experimentalDefaultControls": {
 				"padding": true,
 				"blockGap": true
-			},
-			"__experimentalSkipSerialization": [ "blockGap", "margin", "padding" ]
+			}
 		},
 		"__experimentalBorder": {
 			"color": true,
@@ -50,8 +48,7 @@
 				"radius": true,
 				"style": true,
 				"width": true
-			},
-			"__experimentalSkipSerialization": [ "color", "radius", "style", "width" ]
+			}
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
## Description
This PR employs a block display title in the block settings dropdown rather than the default core block name in the drop down label "Remove `x` block".

A "block display title" might be a specific block variation title, or a reusable block group name. 

This makes the label consistent with the block list view.

## Changes
- Gutting `<BlockTitle />` and turning it into a hook that we use independently of JSX
- Truncating long block display names to 25 chars (negotiable) ONLY for `BlockSettingsDropdown`, which appears in the [block settings toolbar](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/block-toolbar/index.js#L145) and the [block list view](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/list-view/block.js#L248). This is to maintain (roughly) the dropdown container's current width proportions.
- Making truncation of the block title optional. I've passed the current default value of `35` for all existing usages to maintain the status quo for now.

## Room for improvement

We might like to refactor `<Blocktitle />` to use the `<Text />` component, which has truncation built in, e.g., 

```jsx
<Text
    as="span"
    limit={ 25 }
    ellipsizeMode="tail"
    truncate
    >
   { someLabel }
</Text>
```

Also, maybe an aria-label with the full value might be appropriate where there is a truncation?

## Testing Instructions

1. Add a Group Block to a post.
2. Add a Row Block to a post.
3. Add another random block to a post, and turn it into a reusable block.
4. When removing the block via the block settings drop down, either via the Block List Tree ellipsis, or via the block's own toolbar,  you should see the name of either the block, or its variation or the reusable group.
5. Check that other instances of `<BlockTitle />` appear as they do on trunk (max 35 chars), e.g., bread crumb, block switcher...


Run `npm run test-unit packages/block-editor/src/components/block-title/test/index.js`

<details><summary>Some test code</summary>

```html
<!-- wp:group {"layout":{"type":"flex","allowOrientation":false}} -->
<div class="wp-block-group"></div>
<!-- /wp:group -->

<!-- wp:group -->
<div class="wp-block-group"></div>
<!-- /wp:group -->
```

</details>

## Screenshots <!-- if applicable -->
### Before

Remove a "Row" Block (a Group variation)

<img width="555" alt="Screen Shot 2022-02-28 at 1 52 29 pm" src="https://user-images.githubusercontent.com/6458278/155916226-ee65b20b-c5b3-4dbc-8603-561d178f1c5e.png">

Remove a reusable block 
<img width="537" alt="Screen Shot 2022-02-28 at 1 52 25 pm" src="https://user-images.githubusercontent.com/6458278/155916231-6d5a55ad-1563-45b1-9a54-84545720d378.png">


### After
<img width="578" alt="Screen Shot 2022-02-28 at 1 13 04 pm" src="https://user-images.githubusercontent.com/6458278/155916137-5e1c73ce-4f93-49b2-b52a-aa1cd23e149d.png">

<img width="675" alt="Screen Shot 2022-02-28 at 1 47 43 pm" src="https://user-images.githubusercontent.com/6458278/155916116-5c3ffc17-06e8-4131-ada7-015a3a7458f0.png">




## Types of changes
Enhancement to the block settings dropdown.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
