### PR TITLE
File block: Try refreshing styles

### DIFF
--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -27,15 +27,23 @@
 	.wp-block-file__content-wrapper {
 		display: flex;
 		flex: 1;
+		align-items: center;
 	}
 
-	// Apply a min-width to the text-editable link.
+	// This is the editable filename on the left.
+	// Make sure it matches the styling on the frontend.
+	// Except for flex-grow, it is useful to have an easily selectable block.
 	a {
-		min-width: 1em !important;
+		min-width: 2em !important;
 	}
 
 	// This element maps to the Download button link on the right.
 	.wp-block-file__button-richtext-wrapper {
 		margin-left: auto;
+	}
+
+	// The file block already has a border, so don't show the extra border of the placceholder.
+	.components-placeholder.components-placeholder {
+		box-shadow: none;
 	}
 }

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -5,12 +5,6 @@
 		height: auto;
 	}
 
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	align-items: center;
-	margin-bottom: 0;
-
 	.components-resizable-box__container {
 		margin-bottom: 1em;
 	}
@@ -29,16 +23,19 @@
 		left: 0;
 	}
 
+	// This is an extra container present only in the editor view.
 	.wp-block-file__content-wrapper {
-		flex-grow: 1;
+		display: flex;
+		flex: 1;
 	}
 
+	// Apply a min-width to the text-editable link.
 	a {
-		min-width: 1em;
+		min-width: 1em !important;
 	}
 
+	// This element maps to the Download button link on the right.
 	.wp-block-file__button-richtext-wrapper {
-		display: inline-block;
-		margin-left: 0.75em;
+		margin-left: auto;
 	}
 }

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -76,7 +76,7 @@ export default function FileBlockInspector( {
 						onChange={ changeLinkDestinationOption }
 					/>
 					<ToggleControl
-						label={ __( 'Open link in new tab' ) }
+						label={ __( 'Open in new tab' ) }
 						checked={ openInNewWindow }
 						onChange={ changeOpenInNewWindow }
 					/>

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -68,7 +68,7 @@ export default function FileBlockInspector( {
 						) }
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Text link settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<SelectControl
 						label={ __( 'Link to' ) }
 						value={ textLinkHref }
@@ -76,12 +76,10 @@ export default function FileBlockInspector( {
 						onChange={ changeLinkDestinationOption }
 					/>
 					<ToggleControl
-						label={ __( 'Open in new tab' ) }
+						label={ __( 'Open link in new tab' ) }
 						checked={ openInNewWindow }
 						onChange={ changeOpenInNewWindow }
 					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Download button settings' ) }>
 					<ToggleControl
 						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -4,6 +4,24 @@
 	justify-content: space-between;
 	align-items: center;
 	margin-bottom: 1em;
+	box-sizing: border-box;
+
+	// Basic styles meant to be easily overridden by block supports and theme.json.
+	border: 1px solid;
+	padding: 0.5em;
+
+	// Link/text.
+	> a {
+		flex: 1;
+	}
+
+	// Separate download button.
+	.wp-block-file__button {
+		margin-left: auto;
+		text-decoration: none;
+		color: currentColor;
+		flex-grow: 0;
+	}
 
 	&.aligncenter {
 		text-align: center;
@@ -16,9 +34,5 @@
 
 	.wp-block-file__embed {
 		margin-bottom: 1em;
-	}
-
-	.wp-block-file__button {
-		margin-left: auto;
 	}
 }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -1,5 +1,9 @@
 .wp-block-file {
-	margin-bottom: 1.5em;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+	margin-bottom: 1em;
 
 	&.aligncenter {
 		text-align: center;
@@ -15,28 +19,6 @@
 	}
 
 	.wp-block-file__button {
-		background: #32373c;
-		border-radius: 2em;
-		color: $white;
-		font-size: 0.8em;
-		padding: 0.5em 1em;
-	}
-
-	a.wp-block-file__button {
-		text-decoration: none;
-
-		&:hover,
-		&:visited,
-		&:focus,
-		&:active {
-			box-shadow: none;
-			color: $white;
-			opacity: 0.85;
-			text-decoration: none;
-		}
-	}
-
-	* + .wp-block-file__button {
-		margin-left: 0.75em;
+		margin-left: auto;
 	}
 }


### PR DESCRIPTION
## Description

The file block default visuals are a bit out of date:

<img width="1392" alt="before" src="https://user-images.githubusercontent.com/1204802/155957467-21f14dc9-5902-4a82-be4c-bb14d5a0eea6.png">

Although basics can be styled using theme.json, it's not very dark mode or theme aware out of the box. There are also missing focus styles and some baked in very opinionated styles we arguably no longer need. This PR does a few things:

* It simplifies settings in the inspector
* It simplifies and reduces the CSS a great deal, relying on inheritance.
* It adds a new default style that is less specific, easier to override, and inherits more from the theme. 
* It fixes the focus style issue, and should be dark theme aware due to color inheritance.

After:

<img width="1392" alt="after" src="https://user-images.githubusercontent.com/1204802/155957815-26732879-694b-4972-b2a3-baf914a8a014.png">

After in TT2:

<img width="765" alt="tt2" src="https://user-images.githubusercontent.com/1204802/155957865-238fdb4c-6db9-4e0f-914b-c8629ea526d4.png">

The new style should also make it vastly simpler to bring various block supports, such as border, radius, font and more to the block.

Although this fixes and tweaks a few things, it does change a style that has been default for a long time. I'd love your thoughts on the impact of this. I personally think it's worth it, given the benefits it brings, and how simpler it is to style.

## Testing Instructions

Please test the file block with and without a separate download button, with and without a PDF preview (see also #30857), with the various alignments available, with a few themes, and on mobile.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
