### PR TITLE
[Global Styles]: Fix header panel height

### DIFF
--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -20,7 +20,7 @@
 .edit-site-global-styles-sidebar {
 	display: flex;
 	flex-direction: column;
-	height: 100%;
+	min-height: 100%;
 
 	&__panel,
 	&__navigator-provider {


### PR DESCRIPTION
While working on: https://github.com/WordPress/gutenberg/pull/39117, I noticed that the height of Global Styles header panel isn't working properly and this has to do with the css `stickiness` of it. In order for `sticky` to work properly we should avoid `height` setting.

This PR changes this to `min-height: 100%`.

#### Before

https://user-images.githubusercontent.com/16275880/155958712-a8c5ad60-e082-40e0-bb78-87a06ca6d54e.mov




#### After

https://user-images.githubusercontent.com/16275880/155958722-68631566-0499-4535-894f-985603e24661.mov

## Testing instructions
1. Check the height of the header panel by just clicking `blocks` to see the list of blocks
2. scroll down the blocks list and observe that the header stops being sticky after reaching the `height: 100%`.
