### PR TITLE
Migrate hidden block types (block manager data) to new preferences packages

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -352,16 +352,12 @@ _Returns_
 
 ### hideBlockTypes
 
-Returns an action object used in signalling that block types by the given
-name(s) should be hidden.
+Dispatches an action to update the hidden block types preference with new
+hidden blocks.
 
 _Parameters_
 
 -   _blockNames_ `string[]`: Names of block types to hide.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### initializeMetaBoxes
 
@@ -477,16 +473,12 @@ _Returns_
 
 ### showBlockTypes
 
-Returns an action object used in signalling that block types by the given
-name(s) should be shown.
+Dispatches an action to update the hidden block types preference with new
+visible blocks.
 
 _Parameters_
 
 -   _blockNames_ `string[]`: Names of block types to show.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### switchEditorMode
 

--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -81,6 +81,15 @@ _Returns_
 
 -   `string`: Editing mode.
 
+### getHiddenBlockTypes
+
+Registry selector that gets the hidden block types from the preferences
+store.
+
+_Returns_
+
+-   `Array`: A list of the hidden block types
+
 ### getMetaBoxesPerLocation
 
 Returns the list of all the available meta boxes for a given location.

--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -83,8 +83,7 @@ _Returns_
 
 ### getHiddenBlockTypes
 
-Registry selector that gets the hidden block types from the preferences
-store.
+Returns an array of blocks that are hidden.
 
 _Returns_
 
@@ -361,8 +360,7 @@ _Returns_
 
 ### hideBlockTypes
 
-Dispatches an action to update the hidden block types preference with new
-hidden blocks.
+Update the provided block types to be hidden.
 
 _Parameters_
 
@@ -482,8 +480,7 @@ _Returns_
 
 ### showBlockTypes
 
-Dispatches an action to update the hidden block types preference with new
-visible blocks.
+Update the provided block types to be visible.
 
 _Parameters_
 

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -296,6 +296,54 @@ export function migrateFeaturePreferencesToPreferencesStore(
 	}
 }
 
+export function migrateIndividualPreferenceToPreferencesStore(
+	persistence,
+	sourceStoreName,
+	key
+) {
+	const preferencesStoreName = 'core/preferences';
+	const state = persistence.get();
+	const sourcePreference = state[ sourceStoreName ]?.preferences?.[ key ];
+
+	// There's nothing to migrate, exit early.
+	if ( ! sourcePreference ) {
+		return;
+	}
+
+	const targetPreference =
+		state[ preferencesStoreName ]?.preferences?.[ sourceStoreName ]?.[
+			key
+		];
+
+	// There's existing data at the target, so don't overwrite it, exit early.
+	if ( targetPreference ) {
+		return;
+	}
+
+	const allPreferences = state[ preferencesStoreName ]?.preferences;
+	const targetPreferences =
+		state[ preferencesStoreName ]?.preferences?.[ sourceStoreName ];
+
+	persistence.set( preferencesStoreName, {
+		preferences: {
+			...allPreferences,
+			[ sourceStoreName ]: {
+				...targetPreferences,
+				[ key ]: sourcePreference,
+			},
+		},
+	} );
+
+	// Remove migrated feature preferences from the source.
+	const allSourcePreferences = state[ sourceStoreName ]?.preferences;
+	persistence.set( sourceStoreName, {
+		preferences: {
+			...allSourcePreferences,
+			[ key ]: undefined,
+		},
+	} );
+}
+
 /**
  * Move the 'features' object in local storage from the sourceStoreName to the
  * interface store.
@@ -357,6 +405,11 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 	migrateFeaturePreferencesToPreferencesStore(
 		persistence,
 		'core/edit-post'
+	);
+	migrateIndividualPreferenceToPreferencesStore(
+		persistence,
+		'core/edit-post',
+		'hiddenBlockTypes'
 	);
 };
 

--- a/packages/edit-post/src/components/block-manager/category.js
+++ b/packages/edit-post/src/components/block-manager/category.js
@@ -23,11 +23,11 @@ function BlockManagerCategory( { title, blockTypes } ) {
 	const { defaultAllowedBlockTypes, hiddenBlockTypes } = useSelect(
 		( select ) => {
 			const { getEditorSettings } = select( editorStore );
-			const { getPreference } = select( editPostStore );
+			const { getHiddenBlockTypes } = select( editPostStore );
 			return {
 				defaultAllowedBlockTypes: getEditorSettings()
 					.defaultAllowedBlockTypes,
-				hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
+				hiddenBlockTypes: getHiddenBlockTypes(),
 			};
 		},
 		[]

--- a/packages/edit-post/src/components/block-manager/index.js
+++ b/packages/edit-post/src/components/block-manager/index.js
@@ -116,8 +116,8 @@ export default withSelect( ( select ) => {
 		hasBlockSupport,
 		isMatchingSearchTerm,
 	} = select( blocksStore );
-	const { getPreference } = select( editPostStore );
-	const hiddenBlockTypes = getPreference( 'hiddenBlockTypes' );
+	const { getHiddenBlockTypes } = select( editPostStore );
+	const hiddenBlockTypes = getHiddenBlockTypes();
 	const numberOfHiddenBlocks =
 		isArray( hiddenBlockTypes ) && hiddenBlockTypes.length;
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -55,6 +55,7 @@ function Editor( {
 				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
+				getHiddenBlockTypes,
 			} = select( editPostStore );
 			const { getEntityRecord, getPostType, getEntityRecords } = select(
 				coreStore
@@ -89,7 +90,7 @@ function Editor( {
 				preferredStyleVariations: getPreference(
 					'preferredStyleVariations'
 				),
-				hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
+				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				__experimentalLocalAutosaveInterval: getPreference(
 					'localAutosaveInterval'

--- a/packages/edit-post/src/editor.native.js
+++ b/packages/edit-post/src/editor.native.js
@@ -187,8 +187,8 @@ export default compose( [
 		const {
 			isFeatureActive,
 			getEditorMode,
-			getPreference,
 			__experimentalGetPreviewDeviceType,
+			getHiddenBlockTypes,
 		} = select( editPostStore );
 		const { getBlockTypes } = select( blocksStore );
 
@@ -198,7 +198,7 @@ export default compose( [
 				__experimentalGetPreviewDeviceType() !== 'Desktop',
 			focusMode: isFeatureActive( 'focusMode' ),
 			mode: getEditorMode(),
-			hiddenBlockTypes: getPreference( 'hiddenBlockTypes' ),
+			hiddenBlockTypes: getHiddenBlockTypes(),
 			blockTypes: getBlockTypes(),
 		};
 	} ),

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -108,11 +108,12 @@ export function initializeEditor(
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
 		fixedToolbar: false,
-		welcomeGuide: true,
 		fullscreenMode: true,
+		hiddenBlockTypes: [],
+		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		themeStyles: true,
-		showBlockBreadcrumbs: true,
+		welcomeGuide: true,
 		welcomeGuideTemplate: true,
 	} );
 

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -225,9 +225,10 @@ export function __experimentalUpdateLocalAutosaveInterval( interval ) {
  * @param {string[]} blockNames Names of block types to show.
  */
 export const showBlockTypes = ( blockNames ) => ( { registry } ) => {
-	const existingBlockNames = registry
-		.select( preferencesStore )
-		.get( 'core/edit-post', 'hiddenBlockTypes' );
+	const existingBlockNames =
+		registry
+			.select( preferencesStore )
+			.get( 'core/edit-post', 'hiddenBlockTypes' ) ?? [];
 
 	const newBlockNames = without(
 		existingBlockNames,
@@ -246,9 +247,10 @@ export const showBlockTypes = ( blockNames ) => ( { registry } ) => {
  * @param {string[]} blockNames Names of block types to hide.
  */
 export const hideBlockTypes = ( blockNames ) => ( { registry } ) => {
-	const existingBlockNames = registry
-		.select( preferencesStore )
-		.get( 'core/edit-post', 'hiddenBlockTypes' );
+	const existingBlockNames =
+		registry
+			.select( preferencesStore )
+			.get( 'core/edit-post', 'hiddenBlockTypes' ) ?? [];
 
 	const mergedBlockNames = new Set( [
 		...existingBlockNames,

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -219,8 +219,7 @@ export function __experimentalUpdateLocalAutosaveInterval( interval ) {
 }
 
 /**
- * Dispatches an action to update the hidden block types preference with new
- * visible blocks.
+ * Update the provided block types to be visible.
  *
  * @param {string[]} blockNames Names of block types to show.
  */
@@ -241,8 +240,7 @@ export const showBlockTypes = ( blockNames ) => ( { registry } ) => {
 };
 
 /**
- * Dispatches an action to update the hidden block types preference with new
- * hidden blocks.
+ * Update the provided block types to be hidden.
  *
  * @param {string[]} blockNames Names of block types to hide.
  */

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { castArray, reduce } from 'lodash';
+import { castArray, reduce, without } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -189,21 +189,6 @@ export const togglePinnedPluginItem = ( pluginName ) => ( { registry } ) => {
 };
 
 /**
- * Returns an action object used in signalling that block types by the given
- * name(s) should be hidden.
- *
- * @param {string[]} blockNames Names of block types to hide.
- *
- * @return {Object} Action object.
- */
-export function hideBlockTypes( blockNames ) {
-	return {
-		type: 'HIDE_BLOCK_TYPES',
-		blockNames: castArray( blockNames ),
-	};
-}
-
-/**
  * Returns an action object used in signaling that a style should be auto-applied when a block is created.
  *
  * @param {string}  blockName  Name of the block.
@@ -234,19 +219,46 @@ export function __experimentalUpdateLocalAutosaveInterval( interval ) {
 }
 
 /**
- * Returns an action object used in signalling that block types by the given
- * name(s) should be shown.
+ * Dispatches an action to update the hidden block types preference with new
+ * visible blocks.
  *
  * @param {string[]} blockNames Names of block types to show.
- *
- * @return {Object} Action object.
  */
-export function showBlockTypes( blockNames ) {
-	return {
-		type: 'SHOW_BLOCK_TYPES',
-		blockNames: castArray( blockNames ),
-	};
-}
+export const showBlockTypes = ( blockNames ) => ( { registry } ) => {
+	const existingBlockNames = registry
+		.select( preferencesStore )
+		.get( 'core/edit-post', 'hiddenBlockTypes' );
+
+	const newBlockNames = without(
+		existingBlockNames,
+		...castArray( blockNames )
+	);
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/edit-post', 'hiddenBlockTypes', newBlockNames );
+};
+
+/**
+ * Dispatches an action to update the hidden block types preference with new
+ * hidden blocks.
+ *
+ * @param {string[]} blockNames Names of block types to hide.
+ */
+export const hideBlockTypes = ( blockNames ) => ( { registry } ) => {
+	const existingBlockNames = registry
+		.select( preferencesStore )
+		.get( 'core/edit-post', 'hiddenBlockTypes' );
+
+	const mergedBlockNames = new Set( [
+		...existingBlockNames,
+		...castArray( blockNames ),
+	] );
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/edit-post', 'hiddenBlockTypes', [ ...mergedBlockNames ] );
+};
 
 /**
  * Returns an action object used in signaling

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flow, get, includes, omit, union, without } from 'lodash';
+import { flow, get, includes, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -81,17 +81,6 @@ export const preferences = flow( [
 	editorMode( state, action ) {
 		if ( action.type === 'SWITCH_MODE' ) {
 			return action.mode;
-		}
-
-		return state;
-	},
-	hiddenBlockTypes( state, action ) {
-		switch ( action.type ) {
-			case 'SHOW_BLOCK_TYPES':
-				return without( state, ...action.blockNames );
-
-			case 'HIDE_BLOCK_TYPES':
-				return union( state, action.blockNames );
 		}
 
 		return state;

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -105,11 +105,20 @@ export function getPreferences( state ) {
  *
  * @return {*} Preference Value.
  */
-export function getPreference( state, preferenceKey, defaultValue ) {
-	const preferences = getPreferences( state );
-	const value = preferences[ preferenceKey ];
-	return value === undefined ? defaultValue : value;
-}
+export const getPreference = createRegistrySelector(
+	( select ) => ( state, preferenceKey, defaultValue ) => {
+		if ( preferenceKey === 'hiddenBlockTypes' ) {
+			return select( preferencesStore ).get(
+				'core/edit-post',
+				preferenceKey
+			);
+		}
+
+		const preferences = getPreferences( state );
+		const value = preferences[ preferenceKey ];
+		return value === undefined ? defaultValue : value;
+	}
+);
 
 /**
  * Returns true if the publish sidebar is opened.

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -148,8 +148,7 @@ export function getPreference( state, preferenceKey, defaultValue ) {
 }
 
 /**
- * Registry selector that gets the hidden block types from the preferences
- * store.
+ * Returns an array of blocks that are hidden.
  *
  * @return {Array} A list of the hidden block types
  */

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -13,10 +13,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-// import { store as editPostStore } from '../store';
+const EMPTY_ARRAY = [];
 
 /**
  * Returns the current editing mode.
@@ -149,6 +146,21 @@ export function getPreference( state, preferenceKey, defaultValue ) {
 	const value = preferences[ preferenceKey ];
 	return value === undefined ? defaultValue : value;
 }
+
+/**
+ * Registry selector that gets the hidden block types from the preferences
+ * store.
+ *
+ * @return {Array} A list of the hidden block types
+ */
+export const getHiddenBlockTypes = createRegistrySelector( ( select ) => () => {
+	return (
+		select( preferencesStore ).get(
+			'core/edit-post',
+			'hiddenBlockTypes'
+		) ?? EMPTY_ARRAY
+	);
+} );
 
 /**
  * Returns true if the publish sidebar is opened.

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -195,4 +195,99 @@ describe( 'actions', () => {
 			).toEqual( expectedB );
 		} );
 	} );
+
+	describe( '__experimentalUpdateLocalAutosaveInterval', () => {
+		it( 'sets the local autosave interval', () => {
+			registry
+				.dispatch( editPostStore )
+				.__experimentalUpdateLocalAutosaveInterval( 42 );
+
+			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry
+					.select( editPostStore )
+					.getPreference( 'localAutosaveInterval' )
+			).toBe( 42 );
+		} );
+	} );
+
+	describe( 'toggleEditorPanelEnabled', () => {
+		it( 'toggles panels to be enabled and not enabled', () => {
+			const defaultState = {
+				'post-status': {
+					opened: true,
+				},
+			};
+
+			// This will switch it off, since the default is on.
+			registry
+				.dispatch( editPostStore )
+				.toggleEditorPanelEnabled( 'control-panel' );
+
+			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry.select( editPostStore ).getPreference( 'panels' )
+			).toEqual( {
+				...defaultState,
+				'control-panel': {
+					enabled: false,
+				},
+			} );
+
+			// Switch it on again.
+			registry
+				.dispatch( editPostStore )
+				.toggleEditorPanelEnabled( 'control-panel' );
+
+			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry.select( editPostStore ).getPreference( 'panels' )
+			).toEqual( {
+				...defaultState,
+				'control-panel': {
+					enabled: true,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'toggleEditorPanelOpened', () => {
+		it( 'toggles panels open and closed', () => {
+			const defaultState = {
+				'post-status': {
+					opened: true,
+				},
+			};
+
+			// This will open it, since the default is closed.
+			registry
+				.dispatch( editPostStore )
+				.toggleEditorPanelOpened( 'control-panel' );
+
+			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry.select( editPostStore ).getPreference( 'panels' )
+			).toEqual( {
+				...defaultState,
+				'control-panel': {
+					opened: true,
+				},
+			} );
+
+			// Close it.
+			registry
+				.dispatch( editPostStore )
+				.toggleEditorPanelOpened( 'control-panel' );
+
+			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry.select( editPostStore ).getPreference( 'panels' )
+			).toEqual( {
+				...defaultState,
+				'control-panel': {
+					opened: false,
+				},
+			} );
+		} );
+	} );
 } );

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -34,6 +34,7 @@ describe( 'actions', () => {
 	beforeEach( () => {
 		registry = createRegistryWithStores();
 	} );
+
 	it( 'openGeneralSidebar/closeGeneralSidebar', () => {
 		registry.dispatch( editPostStore ).openGeneralSidebar( 'test/sidebar' );
 		expect(
@@ -51,6 +52,7 @@ describe( 'actions', () => {
 				.getActiveComplementaryArea( 'core/edit-post' )
 		).toBeNull();
 	} );
+
 	it( 'toggleFeature', () => {
 		registry.dispatch( editPostStore ).toggleFeature( 'welcomeGuide' );
 		expect(
@@ -66,6 +68,7 @@ describe( 'actions', () => {
 				.get( editPostStore.name, 'welcomeGuide' )
 		).toBe( false );
 	} );
+
 	describe( 'switchEditorMode', () => {
 		it( 'to visual', () => {
 			registry.dispatch( editPostStore ).switchEditorMode( 'visual' );
@@ -73,6 +76,7 @@ describe( 'actions', () => {
 				'visual'
 			);
 		} );
+
 		it( 'to text', () => {
 			// Add a selected client id and make sure it's there.
 			const clientId = 'clientId_1';
@@ -87,6 +91,7 @@ describe( 'actions', () => {
 			).toBeNull();
 		} );
 	} );
+
 	it( 'togglePinnedPluginItem', () => {
 		registry.dispatch( editPostStore ).togglePinnedPluginItem( 'rigatoni' );
 		// Sidebars are pinned by default.
@@ -103,6 +108,7 @@ describe( 'actions', () => {
 				.isItemPinned( editPostStore.name, 'rigatoni' )
 		).toBe( true );
 	} );
+
 	describe( '__unstableSwitchToTemplateMode', () => {
 		it( 'welcome guide is active', () => {
 			// Activate `welcomeGuideTemplate` feature.
@@ -116,6 +122,7 @@ describe( 'actions', () => {
 			const notices = registry.select( noticesStore ).getNotices();
 			expect( notices ).toHaveLength( 0 );
 		} );
+
 		it( 'welcome guide is inactive', () => {
 			expect(
 				registry.select( editPostStore ).isEditingTemplate()

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -143,11 +143,18 @@ describe( 'actions', () => {
 				.dispatch( editPostStore )
 				.hideBlockTypes( [ 'core/quote', 'core/table' ] );
 
+			const expected = [ 'core/quote', 'core/table' ];
+
+			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
 					.getPreference( 'hiddenBlockTypes' )
-			).toEqual( [ 'core/quote', 'core/table' ] );
+			).toEqual( expected );
+
+			expect(
+				registry.select( editPostStore ).getHiddenBlockTypes()
+			).toEqual( expected );
 		} );
 	} );
 
@@ -157,21 +164,35 @@ describe( 'actions', () => {
 				.dispatch( editPostStore )
 				.hideBlockTypes( [ 'core/quote', 'core/table' ] );
 
+			const expectedA = [ 'core/quote', 'core/table' ];
+
+			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
 					.getPreference( 'hiddenBlockTypes' )
-			).toEqual( [ 'core/quote', 'core/table' ] );
+			).toEqual( expectedA );
+
+			expect(
+				registry.select( editPostStore ).getHiddenBlockTypes()
+			).toEqual( expectedA );
 
 			registry
 				.dispatch( editPostStore )
 				.showBlockTypes( [ 'core/table' ] );
 
+			const expectedB = [ 'core/quote' ];
+
+			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
 					.getPreference( 'hiddenBlockTypes' )
-			).toEqual( [ 'core/quote' ] );
+			).toEqual( expectedB );
+
+			expect(
+				registry.select( editPostStore ).getHiddenBlockTypes()
+			).toEqual( expectedB );
 		} );
 	} );
 } );

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -136,4 +136,42 @@ describe( 'actions', () => {
 			expect( notices[ 0 ].content ).toMatch( 'template' );
 		} );
 	} );
+
+	describe( 'hideBlockTypes', () => {
+		it( 'adds the hidden block type to the preferences', () => {
+			registry
+				.dispatch( editPostStore )
+				.hideBlockTypes( [ 'core/quote', 'core/table' ] );
+
+			expect(
+				registry
+					.select( editPostStore )
+					.getPreference( 'hiddenBlockTypes' )
+			).toEqual( [ 'core/quote', 'core/table' ] );
+		} );
+	} );
+
+	describe( 'showBlockTypes', () => {
+		it( 'removes the hidden block type from the preferences', () => {
+			registry
+				.dispatch( editPostStore )
+				.hideBlockTypes( [ 'core/quote', 'core/table' ] );
+
+			expect(
+				registry
+					.select( editPostStore )
+					.getPreference( 'hiddenBlockTypes' )
+			).toEqual( [ 'core/quote', 'core/table' ] );
+
+			registry
+				.dispatch( editPostStore )
+				.showBlockTypes( [ 'core/table' ] );
+
+			expect(
+				registry
+					.select( editPostStore )
+					.getPreference( 'hiddenBlockTypes' )
+			).toEqual( [ 'core/quote' ] );
+		} );
+	} );
 } );

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -151,34 +151,6 @@ describe( 'state', () => {
 
 			expect( state.editorMode ).toBe( 'text' );
 		} );
-
-		describe( 'hiddenBlockTypes', () => {
-			it( 'concatenates unique names on disable', () => {
-				const original = deepFreeze( {
-					hiddenBlockTypes: [ 'a', 'b' ],
-				} );
-
-				const state = preferences( original, {
-					type: 'HIDE_BLOCK_TYPES',
-					blockNames: [ 'b', 'c' ],
-				} );
-
-				expect( state.hiddenBlockTypes ).toEqual( [ 'a', 'b', 'c' ] );
-			} );
-
-			it( 'omits present names by enable', () => {
-				const original = deepFreeze( {
-					hiddenBlockTypes: [ 'a', 'b' ],
-				} );
-
-				const state = preferences( original, {
-					type: 'SHOW_BLOCK_TYPES',
-					blockNames: [ 'b', 'c' ],
-				} );
-
-				expect( state.hiddenBlockTypes ).toEqual( [ 'a' ] );
-			} );
-		} );
 	} );
 
 	describe( 'activeModal', () => {


### PR DESCRIPTION
## Description
This PR is the next in a series of PRs migrating our editor preferences to use the new preferences package.

It tackles the `hiddenBlockTypes` state in the post editor that's used to drive the block manager, and should enable the block manager to be used within other editors (if we can figure out a nice way to migrate the component).

While #39115 handles all the boolean 'feature' preferences that are easy to migrate, the `hiddenBlockTypes` state has its own reducer, so I think it makes sense to have a separate PR to give this more scrutiny.

There are probably a few different ways to do this, but I've chosen to keep the code roughly equivalent, basically moving the `hiddenBlockType` reducer logic into the actions.

----

### An alternative I considered

An alternative could be to have an individual preference in the preferences store for each block and use a compound key, something like:
```js
export const hideBlockType = ( blockName ) => ( { registry } ) => {
	registry
		.dispatch( preferencesStore )
		.set( 'core/edit-post', `hiddenBlockTypes/${ blockName }`, true );
};

export const showBlockType = ( blockName ) => ( { registry } ) => {
	registry
		.dispatch( preferencesStore )
		.unset( 'core/edit-post', hiddenBlockTypes/${ blockName }` );
};
```

This would simplify the actions, but where there's a need to get the full list of hidden block types, that becomes harder. The selector would need to filter the preferences down to only those with the 'hiddenBlockTypes' prefix. That might be performance intensive, given selectors are generally called more often than actions.

## Testing Instructions
1. Delete your WP localstorage data
2. Using `trunk` open the post editor and dismiss the welcome guide
3. Open the preferences modal, and in the 'Blocks' tab, hide some of the blocks.
4. Check out this branch and rebuild
5. Reload the post editor
6. Open the preferences modal again and go back to the 'Blocks' tab. The blocks toggled in step 3, should still be the same. (this shows the local storage data migration worked)
7. Toggle a few more blocks
8. Reload
9. Open the preferences modal again and go back to the 'Blocks' tab. The preferences from step 7 (and step 3) should still be the same (the changes are still persisted)