### PR TITLE
Element: add changelog notes for serialize attribute casing

### DIFF
--- a/packages/element/CHANGELOG.md
+++ b/packages/element/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+- Serialize will now keep correct casing for SVG attributes ([#38936](https://github.com/WordPress/gutenberg/pull/38936)).
+
 ## 4.1.0 (2022-01-27)
 
 ### Bug Fix


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/38936 this PR adds a bug fix changelog note.