### PR TITLE
[Block Library - Cover]: Fix keep selected unit on deleting minHeight value

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -125,9 +125,6 @@ function CoverHeightInput( {
 		}
 		setTemporaryInput( null );
 		onChange( inputValue );
-		if ( inputValue === undefined ) {
-			onUnitChange();
-		}
 	};
 
 	const handleOnBlur = () => {
@@ -402,9 +399,10 @@ function CoverEdit( {
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
-	const minHeightWithUnit = minHeightUnit
-		? `${ minHeight }${ minHeightUnit }`
-		: minHeight;
+	const minHeightWithUnit =
+		minHeight && minHeightUnit
+			? `${ minHeight }${ minHeightUnit }`
+			: minHeight;
 
 	const isImgElement = ! ( hasParallax || isRepeated );
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -110,7 +110,7 @@ function CoverHeightInput( {
 			'vw',
 			'vh',
 		],
-		defaultValues: { px: 430, em: 20, rem: 20, vw: 20, vh: 50 },
+		defaultValues: { px: 430, '%': 20, em: 20, rem: 20, vw: 20, vh: 50 },
 	} );
 
 	const handleOnChange = ( unprocessedValue ) => {

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -49,9 +49,10 @@ export default function save( { attributes } ) {
 		overlayColor
 	);
 	const gradientClass = __experimentalGetGradientClass( gradient );
-	const minHeight = minHeightUnit
-		? `${ minHeightProp }${ minHeightUnit }`
-		: minHeightProp;
+	const minHeight =
+		minHeightProp && minHeightUnit
+			? `${ minHeightProp }${ minHeightUnit }`
+			: minHeightProp;
 
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;

--- a/test/integration/fixtures/blocks/core__cover__deprecated-9.html
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-9.html
@@ -1,0 +1,10 @@
+<!-- wp:cover {"overlayColor":"primary","minHeightUnit":"%"} -->
+<div class="wp-block-cover" style="min-height:undefined%">
+	<span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span>
+	<div class="wp-block-cover__inner-container">
+		<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+		<p class="has-text-align-center has-large-font-size"></p>
+		<!-- /wp:paragraph -->
+	</div>
+</div>
+<!-- /wp:cover -->

--- a/test/integration/fixtures/blocks/core__cover__deprecated-9.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-9.json
@@ -1,0 +1,30 @@
+[
+	{
+		"name": "core/cover",
+		"isValid": true,
+		"attributes": {
+			"alt": "",
+			"hasParallax": false,
+			"isRepeated": false,
+			"dimRatio": 100,
+			"overlayColor": "primary",
+			"backgroundType": "image",
+			"minHeightUnit": "%",
+			"isDark": true
+		},
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"isValid": true,
+				"attributes": {
+					"align": "center",
+					"content": "",
+					"dropCap": false,
+					"placeholder": "Write title…",
+					"fontSize": "large"
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__cover__deprecated-9.parsed.json
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-9.parsed.json
@@ -1,0 +1,30 @@
+[
+	{
+		"blockName": "core/cover",
+		"attrs": {
+			"overlayColor": "primary",
+			"minHeightUnit": "%"
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/paragraph",
+				"attrs": {
+					"align": "center",
+					"placeholder": "Write title…",
+					"fontSize": "large"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n\t\t<p class=\"has-text-align-center has-large-font-size\"></p>\n\t\t",
+				"innerContent": [
+					"\n\t\t<p class=\"has-text-align-center has-large-font-size\"></p>\n\t\t"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-cover\" style=\"min-height:undefined%\">\n\t<span aria-hidden=\"true\" class=\"wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t\n\t</div>\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-cover\" style=\"min-height:undefined%\">\n\t<span aria-hidden=\"true\" class=\"wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim\"></span>\n\t<div class=\"wp-block-cover__inner-container\">\n\t\t",
+			null,
+			"\n\t</div>\n</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__cover__deprecated-9.serialized.html
+++ b/test/integration/fixtures/blocks/core__cover__deprecated-9.serialized.html
@@ -1,0 +1,5 @@
+<!-- wp:cover {"overlayColor":"primary","minHeightUnit":"%"} -->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-primary-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+<p class="has-text-align-center has-large-font-size"></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/38872

When you insert a Cover block and change the `min height` unit and then delete the value, the `unit` changes back to `px`.
This PR is part of the issue and is about the `minHeight` control in Cover block. In the issue there is reference to Image block and border radius, that I haven't looked into. 

There was another bug that wasn't impactful and due to the `default` values per unit was only occurring when `%` was selected. In that case we would have a `unit` but no `value` and the markup would include invalid css like `min-height:undefind%`. This PR handles that as well and I added a deprecation.

### Testing instructions

1. Add a cover block. 
2. Open the block settings.
3. Under ‘Min height of cover’ change the dimensions to ’em’ or ‘rem’ or ‘vh’ or ‘vw’ and add in a number.
4. Delete the number and observe the unit is preserved
5. Everything should work as before
6. No invalidation of Cover blocks occurs

### Before

https://user-images.githubusercontent.com/26996883/154400548-27af4579-f49b-4fbb-baf8-fb373e60d442.mov





### After

https://user-images.githubusercontent.com/16275880/156217748-d837c0ae-a6e9-44bc-a45c-af8a7a4c7b12.mov


