### PR TITLE
Add: Page start options (templates and patterns).

### DIFF
--- a/lib/block-patterns.php
+++ b/lib/block-patterns.php
@@ -17,7 +17,7 @@ function gutenberg_register_gutenberg_patterns() {
 	$patterns = array(
 		'query-standard-posts'                 => array(
 			'title'      => _x( 'Standard', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
+			'blockTypes' => array( 'core/query', 'core/post-content' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
@@ -35,7 +35,7 @@ function gutenberg_register_gutenberg_patterns() {
 		),
 		'query-medium-posts'                   => array(
 			'title'      => _x( 'Image at left', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
+			'blockTypes' => array( 'core/query', 'core/post-content' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
@@ -55,7 +55,7 @@ function gutenberg_register_gutenberg_patterns() {
 		),
 		'query-small-posts'                    => array(
 			'title'      => _x( 'Small image and title', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
+			'blockTypes' => array( 'core/query', 'core/post-content' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false}} -->
 							<div class="wp-block-query">
@@ -74,7 +74,7 @@ function gutenberg_register_gutenberg_patterns() {
 		),
 		'query-grid-posts'                     => array(
 			'title'      => _x( 'Grid', 'Block pattern title', 'gutenberg' ),
-			'blockTypes' => array( 'core/query' ),
+			'blockTypes' => array( 'core/query', 'core/post-content' ),
 			'categories' => array( 'query' ),
 			'content'    => '<!-- wp:query {"query":{"perPage":6,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"exclude","inherit":false},"displayLayout":{"type":"flex","columns":3}} -->
 							<div class="wp-block-query">

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -47,6 +47,7 @@ import SettingsSidebar from '../sidebar/settings-sidebar';
 import MetaBoxes from '../meta-boxes';
 import WelcomeGuide from '../welcome-guide';
 import ActionsPanel from './actions-panel';
+import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
 
 const interfaceLabels = {
@@ -286,6 +287,7 @@ function Layout( { styles } ) {
 			<PreferencesModal />
 			<KeyboardShortcutHelpModal />
 			<WelcomeGuide />
+			<StartPageOptions />
 			<Popover.Slot />
 			<PluginArea onError={ onPluginAreaError } />
 		</>

--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -1,0 +1,216 @@
+/**
+ * WordPress dependencies
+ */
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import {
+	store as blockEditorStore,
+	__experimentalBlockPatternsList as BlockPatternsList,
+} from '@wordpress/block-editor';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useAsyncList } from '@wordpress/compose';
+import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { parse } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+function TemplateSelection( { onChooseTemplate } ) {
+	const { availableTemplates, fetchedTemplates, linkedTemplate } = useSelect(
+		( select ) => {
+			const {
+				getEditorSettings,
+				getCurrentPostType,
+				getCurrentPost,
+			} = select( editorStore );
+			const { getEntityRecords } = select( coreStore );
+
+			const currentPostType = getCurrentPostType();
+			const currentPostLink = getCurrentPost().link;
+
+			const templateRecords = getEntityRecords(
+				'postType',
+				'wp_template',
+				{
+					post_type: currentPostType,
+					per_page: -1,
+				}
+			);
+
+			const linkedTemplateRecords = getEntityRecords(
+				'postType',
+				'wp_template',
+				{
+					'find-template': currentPostLink,
+					per_page: 1,
+				}
+			);
+
+			return {
+				availableTemplates: getEditorSettings().availableTemplates,
+				fetchedTemplates: templateRecords,
+				linkedTemplate:
+					linkedTemplateRecords && linkedTemplateRecords[ 0 ],
+			};
+		},
+		[]
+	);
+	const templatesAsPatterns = useMemo( () => {
+		let templates = ( fetchedTemplates || [] ).filter(
+			( { slug } ) => !! availableTemplates[ slug ]
+		);
+		if (
+			linkedTemplate &&
+			! templates.some( ( { id } ) => id === linkedTemplate.id )
+		) {
+			templates = [ linkedTemplate, ...templates ];
+		}
+		return templates.map( ( template ) => ( {
+			name: template.id,
+			title: template.title.rendered,
+			blocks: parse( template.content.raw ),
+			template,
+		} ) );
+	}, [ availableTemplates, fetchedTemplates, linkedTemplate ] );
+	const shownPatterns = useAsyncList( templatesAsPatterns );
+	const { editPost } = useDispatch( editorStore );
+	useEffect( () => {
+		if ( availableTemplates.length <= 1 ) {
+			onChooseTemplate();
+		}
+	}, [ availableTemplates.length ] );
+	return (
+		<BlockPatternsList
+			blockPatterns={ templatesAsPatterns }
+			shownPatterns={ shownPatterns }
+			onClickPattern={ ( { template } ) => {
+				if ( template.id !== linkedTemplate.id ) {
+					editPost( { template: template.slug } );
+				}
+				onChooseTemplate();
+			} }
+		/>
+	);
+}
+
+function PatternSelection( { onChoosePattern } ) {
+	const { blockPatterns } = useSelect( ( select ) => {
+		const { __experimentalGetPatternsByBlockTypes } = select(
+			blockEditorStore
+		);
+		return {
+			blockPatterns: __experimentalGetPatternsByBlockTypes(
+				'core/post-content'
+			),
+		};
+	}, [] );
+	const shownBlockPatterns = useAsyncList( blockPatterns );
+	const { resetEditorBlocks } = useDispatch( editorStore );
+	useEffect( () => {
+		if ( blockPatterns.length <= 1 ) {
+			onChoosePattern();
+		}
+	}, [ blockPatterns.length ] );
+	return (
+		<BlockPatternsList
+			blockPatterns={ blockPatterns }
+			shownPatterns={ shownBlockPatterns }
+			onClickPattern={ ( _pattern, blocks ) => {
+				resetEditorBlocks( blocks );
+				onChoosePattern();
+			} }
+		/>
+	);
+}
+
+const START_PAGE_MODAL_STATES = {
+	INITIAL: 'INITIAL',
+	TEMPLATE: 'TEMPLATE',
+	PATTERN: 'PATTERN',
+	CLOSED: 'CLOSED',
+};
+
+export default function StartPageOptions() {
+	const [ modalState, setModalState ] = useState(
+		START_PAGE_MODAL_STATES.INITIAL
+	);
+	const shouldOpenModel = useSelect(
+		( select ) => {
+			if ( modalState !== START_PAGE_MODAL_STATES.INITIAL ) {
+				return false;
+			}
+			const {
+				getCurrentPostType,
+				getEditedPostContent,
+				getEditedPostAttribute,
+				isEditedPostSaveable,
+			} = select( editorStore );
+			const { isEditingTemplate, isFeatureActive } = select(
+				editPostStore
+			);
+			return (
+				getCurrentPostType() === 'page' &&
+				! isEditedPostSaveable() &&
+				'' === getEditedPostContent() &&
+				'' === getEditedPostAttribute( 'template' ) &&
+				! isEditingTemplate() &&
+				! isFeatureActive( 'welcomeGuide' )
+			);
+		},
+		[ modalState ]
+	);
+
+	useEffect( () => {
+		if ( shouldOpenModel ) {
+			setModalState( START_PAGE_MODAL_STATES.TEMPLATE );
+		}
+	}, [ shouldOpenModel ] );
+
+	if (
+		modalState === START_PAGE_MODAL_STATES.INITIAL ||
+		modalState === START_PAGE_MODAL_STATES.CLOSED
+	) {
+		return null;
+	}
+	return (
+		<Modal
+			className="edit-post-start-page-options__modal"
+			title={
+				modalState === START_PAGE_MODAL_STATES.TEMPLATE
+					? __( 'Choose a template' )
+					: __( 'Choose a pattern' )
+			}
+			closeLabel={ __( 'Cancel' ) }
+			onRequestClose={ () => {
+				switch ( modalState ) {
+					case START_PAGE_MODAL_STATES.TEMPLATE:
+						setModalState( START_PAGE_MODAL_STATES.PATTERN );
+						return;
+					case START_PAGE_MODAL_STATES.PATTERN:
+						setModalState( START_PAGE_MODAL_STATES.CLOSED );
+				}
+			} }
+		>
+			<div className="edit-post-start-page-options__modal-content">
+				{ modalState === START_PAGE_MODAL_STATES.TEMPLATE && (
+					<TemplateSelection
+						onChooseTemplate={ () => {
+							setModalState( START_PAGE_MODAL_STATES.PATTERN );
+						} }
+					/>
+				) }
+				{ modalState === START_PAGE_MODAL_STATES.PATTERN && (
+					<PatternSelection
+						onChoosePattern={ () => {
+							setModalState( START_PAGE_MODAL_STATES.CLOSED );
+						} }
+					/>
+				) }
+			</div>
+		</Modal>
+	);
+}

--- a/packages/edit-post/src/components/start-page-options/style.scss
+++ b/packages/edit-post/src/components/start-page-options/style.scss
@@ -1,0 +1,27 @@
+.edit-post-start-page-options__modal {
+	// To keep modal dimensions consistent as subsections are navigated, width
+	// and height are used instead of max-(width/height).
+	@include break-small() {
+		width: calc(100% - #{ $grid-unit-20 * 2 });
+		height: calc(100% - #{ $header-height * 2 });
+	}
+	@include break-medium() {
+		width: $break-medium - $grid-unit-20 * 2;
+	}
+	@include break-large() {
+		height: 70%;
+	}
+}
+
+.edit-post-start-page-options__modal-content .block-editor-block-patterns-list {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-gap: $grid-unit-10;
+
+	.block-editor-block-patterns-list__list-item {
+		margin-bottom: 0;
+		.block-editor-block-preview__container {
+			min-height: 100px;
+		}
+	}
+}

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -23,6 +23,7 @@
 @import "./components/text-editor/style.scss";
 @import "./components/visual-editor/style.scss";
 @import "./components/welcome-guide/style.scss";
+@import "./components/start-page-options/style.scss";
 
 /**
  * Animations


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/38787

This PR adds a set of options when the user is creating a new page.
The options allow the user to choose a template for the page (with previews) and a pattern to fill the content of the page.
@youknowriad  said:
> Ideally, we'd have ways to mark "patterns" as "full page patterns".

This is done by adding `'blockTypes' => array( 'core/post-content' )`, to the patterns that we say are for the full "post content". We could instead add a new flag. But it seems we can use what we already have to mark that a pattern is for the full content.


Although the implementation is fully functional from the UX perspective there is still lots of work to do. Right now we are just showing two simple modals one for the template and another for the pattern.

### Some questions:
Would a "wizard" with a back next to pick a template and pattern make sense?
Another alternative could we instead show a list of templates at the side of the patterns with the default template already chosen (the user can switch the template) but as soon as the user chooses a pattern we close the modal. When the user switches template we just change the template without close the modal? Basically, a single modal to choose a pattern with a lateral UI to switch the template.
For the pattern previews should we just show the pattern preview like we do now or should we show a full preview e.g: the full template with the chosen pattern as the content?



### Patterns for blank templates
I guess we may have some patterns that just make sense one a blank template e.g: the patterns take control of the full page and only makes sense on a template that just includes: `<!-- wp:post-content /-->`.

Should we have a way to mark these patterns?
`blockTypes' => array( 'core/post-content' )` is different it marks patterns that make sense as the full content of a page. But the page can have a template with headers footers sidebars etc.

But I guess we may have patterns that require a blank template for these patterns when chosen we would use a blank template if the theme provides one (like 2022 does) or we would automatically create a blank template if one does not already exists.




## Testing Instructions
I added `'blockTypes' => array( 'core/post-content' ),` to some patterns of the 2022 theme.
I created a new page and verified there are prompts to choose a template and a pattern of the page.
I verified both the template and the patterns are correctly applied to the page.

## Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/11271197/156228740-91b74920-491e-41e9-aae7-efe0224edabd.png)
![image](https://user-images.githubusercontent.com/11271197/156228761-72767d08-022b-4fef-a3f2-5a23a9de1208.png)
