### PR TITLE
Fix navigation menu error when menus are not yet fetched

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -43,7 +43,7 @@ export default function NavigationMenuSelector( {
 
 	// Avoid showing any currently active menu in the list of
 	// menus that can be selected.
-	const navigationMenusOmitCurrent = navigationMenus.filter(
+	const navigationMenusOmitCurrent = navigationMenus?.filter(
 		( menu ) => ! currentMenuId || menu.id !== currentMenuId
 	);
 


### PR DESCRIPTION
## Description
This is a little bug that was noticed in [#39087](https://github.com/WordPress/gutenberg/pull/39087#issuecomment-1050659139).

I think this will be fixed in #38907, but it'd be good to get this small fix in first as that one is a slightly bigger change and may not make the cut for the next plugin release. This one can be cherry picked into the 12.7 release

## Testing Instructions
1. Add a navigation block and select or create a menu
2. Reload and quickly select the navigation block while it's loading

In this branch: Everything works ok
In `trunk`: The block throws an error

Quick explanation - this bug only happens while the menus are still being fetched, the render function tries to call `filter` on `null`.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
