### PR TITLE
Add aria label to Nav block on front of site

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -361,6 +361,8 @@ function block_core_navigation_get_fallback_blocks() {
  */
 function render_block_core_navigation( $attributes, $content, $block ) {
 
+	static $seen_menu_names = array();
+
 	// Flag used to indicate whether the rendered output is considered to be
 	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
@@ -431,6 +433,12 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		}
 
 		$nav_menu_name = $navigation_post->post_title;
+
+		if ( isset( $seen_menu_names[ $nav_menu_name ] ) ) {
+			$seen_menu_names[ $nav_menu_name ] = $seen_menu_names[ $nav_menu_name ] + 1;
+		} else {
+			$seen_menu_names[ $nav_menu_name ] = 1;
+		}
 
 		$parsed_blocks = parse_blocks( $navigation_post->post_content );
 
@@ -511,6 +519,13 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	}
 
 	$block_styles = isset( $attributes['styles'] ) ? $attributes['styles'] : '';
+
+	// If the menu name has been used previously then append an ID
+	// to the name to ensure uniqueness across a given post.
+	if ( isset( $seen_menu_names[ $nav_menu_name ] ) && $seen_menu_names[ $nav_menu_name ] > 1 ) {
+		$count         = $seen_menu_names[ $nav_menu_name ];
+		$nav_menu_name = $nav_menu_name . ' ' . ( $count - 1 );
+	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -365,6 +365,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// a fallback (i.e. the block has no menu associated with it).
 	$is_fallback = false;
 
+	$nav_menu_name = '';
+
 	/**
 	 * Deprecated:
 	 * The rgbTextColor and rgbBackgroundColor attributes
@@ -427,6 +429,8 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		if ( ! isset( $navigation_post ) ) {
 			return '';
 		}
+
+		$nav_menu_name = $navigation_post->post_title;
 
 		$parsed_blocks = parse_blocks( $navigation_post->post_content );
 
@@ -510,8 +514,9 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => implode( ' ', $classes ),
-			'style' => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
+			'class'      => implode( ' ', $classes ),
+			'style'      => $block_styles . $colors['inline_styles'] . $font_sizes['inline_styles'],
+			'aria-label' => $nav_menu_name,
 		)
 	);
 

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -435,7 +435,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		$nav_menu_name = $navigation_post->post_title;
 
 		if ( isset( $seen_menu_names[ $nav_menu_name ] ) ) {
-			$seen_menu_names[ $nav_menu_name ] = $seen_menu_names[ $nav_menu_name ] + 1;
+			++$seen_menu_names[ $nav_menu_name ];
 		} else {
 			$seen_menu_names[ $nav_menu_name ] = 1;
 		}

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -524,7 +524,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// to the name to ensure uniqueness across a given post.
 	if ( isset( $seen_menu_names[ $nav_menu_name ] ) && $seen_menu_names[ $nav_menu_name ] > 1 ) {
 		$count         = $seen_menu_names[ $nav_menu_name ];
-		$nav_menu_name = $nav_menu_name . ' ' . ( $count - 1 );
+		$nav_menu_name = $nav_menu_name . ' ' . ( $count );
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -910,6 +910,35 @@ describe( 'Navigation', () => {
 		} );
 	} );
 
+	it( 'applies accessible label to block element', async () => {
+		await createNewPost();
+		await insertBlock( 'Navigation' );
+		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
+		await startEmptyButton.click();
+
+		const appender = await page.waitForSelector(
+			'.wp-block-navigation .block-list-appender'
+		);
+		await appender.click();
+
+		// Add a link to the Link block.
+		await updateActiveNavigationLink( {
+			url: 'https://wordpress.org',
+			label: 'WP',
+			type: 'url',
+		} );
+
+		const previewPage = await openPreviewPage();
+		await previewPage.bringToFront();
+		await previewPage.waitForNetworkIdle();
+
+		const isAccessibleLabelPresent = await previewPage.$(
+			'nav[aria-label="Navigation"]'
+		);
+
+		expect( isAccessibleLabelPresent ).toBeTruthy();
+	} );
+
 	it( 'does not load the frontend script if no navigation blocks are present', async () => {
 		await createNewPost();
 		await insertBlock( 'Paragraph' );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description

Currently when rendered on the front of the site the Navigation block has no accessible label to identify it. We have a `Menu name` field on the block which is saved to the `post_title` field of the underlying `wp_navigation` post. 

This PR utilises the `Menu name` as the `aria-label` attribute on the main `<nav>` tag on the front of the site (only).

I added an e2e test to provide coverage.


Closes https://github.com/WordPress/gutenberg/issues/24369.

## Limitations

I'm aware of the following:

- Menu names are automatically generated by the block so they may not always be the most descriptive out of the box (although they can be edited in the inspector controls under the `Advanced` section).
- If you reuse the same Navigation Menu (i.e. `wp_navigation) across multiple Navigation block's on the same page then you will have duplicate `aria-label`s. This is probably an edge case. We could add an additional `aria-label` field to the block if necessary but I'm unclear on how we could dedupe names across Nav blocks on a page.



## Testing Instructions

1. New Post.
2. Add Nav block.
3. Add some items.
4. Publish post being sure to save the Navigation Menu in the entity saving flow at the publish step.
5. Switch to front of site.
6. Inspect Nav block `<nav>` tag for presence of `aria-label` attribute.
7. Try renaming the Nav in the editor - under `Advanced` -> `Menu name`.
8. Update the post.
6. Inspect Nav block `<nav>` tag for presence of modified `aria-label` attribute.

## Screenshots <!-- if applicable -->
<img width="900" alt="Screen Shot 2022-03-02 at 13 40 03" src="https://user-images.githubusercontent.com/444434/156372568-24a267a7-54df-48b5-9b33-2ab93e645253.png">

## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
