### PR TITLE
Change location of block support styles in `<head>`

### DIFF
--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -53,8 +53,8 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
  *
  * For block themes, it's loaded in the head.
  * For classic ones, it's loaded in the body
- * because the wp_head action (and wp_enqueue_scripts)
- * happens before the render_block.
+ * because the wp_head action  happens before
+ * the render_block.
  *
  * @link https://core.trac.wordpress.org/ticket/53494.
  *

--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -63,7 +63,7 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
 function gutenberg_enqueue_block_support_styles( $style ) {
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_enqueue_scripts';
+		$action_hook_name = 'wp_head';
 	}
 	add_action(
 		$action_hook_name,


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
https://github.com/WordPress/gutenberg/pull/38750 moved to block support styles to `<head>`, which was great. However these styles were loaded before block/global inline styles. This causes block support styles (which includes user styles set in the Editor) to be potentially overwritten by block/global inline styles.

In this PR, instead of using `wp_enqueue_scripts`, we use `wp_head` instead. This ensures that block support styles are loaded after the block/global inline styles in `<head>`.

_There may be a better option than `wp_head`, but I have so far not been able to find one that works. Any insight would be greatly appreciated!_

## Screenshots
Here are some screenshots looking at the Site Title block. In theme.json, there is a link color applied. Before this change, this color overrides the custom orange color set by the user in the Editor. After the change, the user color takes precedent. 

Before:
![image](https://user-images.githubusercontent.com/4832319/156387466-081974e9-4d20-4617-9a94-3d0fcd35b8da.png)

After:
![image](https://user-images.githubusercontent.com/4832319/156387521-2970319c-df91-473f-b9ab-ad5e57dced97.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [X] My code is tested.
- [X] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [X] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [X] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [X] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
