### PR TITLE
Storybook: Add webpack loader for easier story descriptions

### DIFF
--- a/packages/components/src/font-size-picker/stories/index.js
+++ b/packages/components/src/font-size-picker/stories/index.js
@@ -91,20 +91,19 @@ WithSlider.args = {
 	withSlider: true,
 };
 
+/**
+ * With custom font sizes disabled via the `disableCustomFontSizes` prop, the user will
+ * only be able to pick one of the predefined sizes passed in `fontSizes`.
+ */
 export const WithCustomSizesDisabled = FontSizePickerWithState.bind( {} );
 WithCustomSizesDisabled.args = {
 	...Default.args,
 	disableCustomFontSizes: true,
 };
-WithCustomSizesDisabled.parameters = {
-	docs: {
-		description: {
-			story:
-				'With custom font sizes disabled via the `disableCustomFontSizes` prop, the user will only be able to pick one of the predefined sizes passed in `fontSizes`.',
-		},
-	},
-};
 
+/**
+ * When there are more than 5 font size options, the UI is no longer a toggle group.
+ */
 export const WithMoreFontSizes = FontSizePickerWithState.bind( {} );
 WithMoreFontSizes.args = {
 	...Default.args,
@@ -142,15 +141,10 @@ WithMoreFontSizes.args = {
 	],
 	initialValue: 8,
 };
-WithMoreFontSizes.parameters = {
-	docs: {
-		description: {
-			story:
-				'When there are more than 5 font size options, the UI is no longer a toggle group.',
-		},
-	},
-};
 
+/**
+ * When units like `px` are specified explicitly, it will be shown as a label hint.
+ */
 export const WithUnits = TwoFontSizePickersWithState.bind( {} );
 WithUnits.args = {
 	...WithMoreFontSizes.args,
@@ -160,15 +154,11 @@ WithUnits.args = {
 	} ) ),
 	initialValue: '8px',
 };
-WithUnits.parameters = {
-	docs: {
-		description: {
-			story:
-				'When units like `px` are specified explicitly, it will be shown as a label hint.',
-		},
-	},
-};
 
+/**
+ * The label hint will not be shown if it is a complex CSS value. Some examples of complex CSS values
+ * in this context are CSS functions like `calc()`, `clamp()`, and `var()`.
+ */
 export const WithComplexCSSValues = TwoFontSizePickersWithState.bind( {} );
 WithComplexCSSValues.args = {
 	...Default.args,
@@ -206,12 +196,4 @@ WithComplexCSSValues.args = {
 		},
 	],
 	initialValue: '1.125rem',
-};
-WithComplexCSSValues.parameters = {
-	docs: {
-		description: {
-			story:
-				'The label hint will not be shown if it is a complex CSS value. Some examples of complex CSS values in this context are CSS functions like `calc()`, `clamp()`, and `var()`.',
-		},
-	},
 };

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -29,9 +29,20 @@ const scssLoaders = ( { isLazy } ) => [
 module.exports = ( { config } ) => {
 	config.module.rules.push(
 		{
-			test: /\/stories\/.+\.js$/,
+			// Currently does not work with our tsx stories
+			// See https://github.com/storybookjs/storybook/issues/17275
+			test: /\/stories\/.+\.(j|t)sx?$/,
 			loader: require.resolve( '@storybook/source-loader' ),
 			enforce: 'pre',
+		},
+		{
+			// Allows a story description to be written as a doc comment above the exported story
+			test: /\/stories\/.+\.(j|t)sx?$/,
+			loader: path.resolve(
+				__dirname,
+				'./webpack/description-loader.js'
+			),
+			enforce: 'post',
 		},
 		{
 			test: /\.scss$/,

--- a/storybook/webpack/description-loader.js
+++ b/storybook/webpack/description-loader.js
@@ -1,0 +1,94 @@
+/**
+ * Allows a story description to be written as a doc comment above the exported story.
+ *
+ * Based on https://github.com/izhan/storybook-description-loader
+ *
+ * @example
+ * ```jsx
+ * // This comment will become the description for the story in the generated docs.
+ * export const MyStory = Template.bind({});
+ * ```
+ */
+
+/**
+ * External dependencies
+ */
+const babel = require( '@babel/core' );
+
+function createDescriptionNode( name, description ) {
+	return babel.types.expressionStatement(
+		babel.types.assignmentExpression(
+			'=',
+			babel.types.memberExpression(
+				babel.types.identifier( name ),
+				babel.types.identifier( 'story' )
+			),
+			babel.types.objectExpression( [
+				babel.types.objectProperty(
+					babel.types.identifier( 'parameters' ),
+					babel.types.objectExpression( [
+						babel.types.objectProperty(
+							babel.types.identifier( 'docs' ),
+							babel.types.objectExpression( [
+								babel.types.objectProperty(
+									babel.types.identifier(
+										'storyDescription'
+									),
+									babel.types.stringLiteral( description )
+								),
+							] )
+						),
+					] )
+				),
+			] )
+		)
+	);
+}
+
+function annotateDescriptionPlugin() {
+	return {
+		visitor: {
+			ExportNamedDeclaration( path ) {
+				if ( path.node.leadingComments ) {
+					const commentValues = path.node.leadingComments.map(
+						( node ) => {
+							if ( node.type === 'CommentLine' ) {
+								return node.value.trimLeft();
+							}
+							// else, node.type === 'CommentBlock'
+							return node.value
+								.split( '\n' )
+								.map( ( line ) => {
+									// stripping out the whitespace and * from comment blocks
+									return line.replace(
+										/^(\s+)?(\*+)?(\s+)?/,
+										''
+									);
+								} )
+								.join( '\n' )
+								.trim();
+						}
+					);
+					const description = commentValues.join( '\n' );
+					const declaration = path.node.declaration.declarations[ 0 ];
+
+					path.insertAfter(
+						createDescriptionNode(
+							declaration.id.name,
+							description
+						)
+					);
+				}
+			},
+		},
+	};
+}
+
+module.exports = function ( source ) {
+	const output = babel.transform( source, {
+		plugins: [ annotateDescriptionPlugin ],
+		filename: __filename,
+		sourceType: 'module',
+	} );
+	return output.code;
+};


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/38727#discussion_r810284529

## Description

This adds a simple webpack loader (based on [`story-description-loader`](https://github.com/izhan/storybook-description-loader)) that will allow us to write story descriptions more easily as doc comments, rather than as a deep parameter:

### Before

```js
export const MyStory = Template.bind({});
MyStory.parameters = {
	docs: {
		description: {
			story:
				'This is the description.',
		},
	},
};
```

### After

```js
/**
 * This is the description.
 */
export const MyStory = Template.bind({});
```

The deep parameter path is way too hard to remember, so I imagine people (including me) will have to search for a code snippet every time they want to add a description. The doc comment way is much more intuitive for everyone, and will [possibly become](https://github.com/storybookjs/storybook/issues/8527) a built-in Storybook feature. Given that we will be adding a lot more story descriptions as part of our doc improvement efforts, I think this loader will be a huge help.

### Additional benefits

- More readable in source file, as the description will precede the story rather than follow it. And for longer descriptions, a hard wrapped doc comment is generally more readable regardless of editor soft wrap settings.
- Less fuss with escaping (descriptions also support markdown, so it can get messy when dealing with a bunch of backticks and quotes).

## Testing Instructions

1. `npm run storybook:dev`
2. Check the stories for `FontSizePicker` and their descriptions.
3. Try adding a story description for a component of your choice.

## Types of changes

Storybook only.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
