### PR TITLE
Refactor `FocalPointPicker` to function component

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Refactor `FocalPointPicker` to function component ([#39168](https://github.com/WordPress/gutenberg/pull/39168)).
+
 ## 20.0.0 (2022-08-24)
 
 ### Breaking Changes

--- a/packages/components/src/focal-point-picker/README.md
+++ b/packages/components/src/focal-point-picker/README.md
@@ -18,10 +18,6 @@ const Example = () => {
 	} );
 
 	const url = '/path/to/image';
-	const dimensions = {
-		width: 400,
-		height: 100,
-	};
 
 	/* Example function to render the CSS styles based on Focal Point Picker value */
 	const style = {
@@ -33,9 +29,10 @@ const Example = () => {
 		<>
 			<FocalPointPicker
 				url={ url }
-				dimensions={ dimensions }
 				value={ focalPoint }
-				onChange={ ( focalPoint ) => setFocalPoint( { focalPoint } ) }
+				onDragStart={ setFocalPoint }
+				onDrag={ setFocalPoint }
+				onChange={ setFocalPoint }
 			/>
 			<div style={ style } />
 		</>

--- a/packages/components/src/focal-point-picker/controls.js
+++ b/packages/components/src/focal-point-picker/controls.js
@@ -18,19 +18,19 @@ const noop = () => {};
 
 export default function FocalPointPickerControls( {
 	onChange = noop,
-	percentages = {
+	point = {
 		x: 0.5,
 		y: 0.5,
 	},
 } ) {
-	const valueX = fractionToPercentage( percentages.x );
-	const valueY = fractionToPercentage( percentages.y );
+	const valueX = fractionToPercentage( point.x );
+	const valueY = fractionToPercentage( point.y );
 
 	const handleChange = ( value, axis ) => {
 		const num = parseInt( value, 10 );
 
 		if ( ! isNaN( num ) ) {
-			onChange( { ...percentages, [ axis ]: num / 100 } );
+			onChange( { ...point, [ axis ]: num / 100 } );
 		}
 	};
 

--- a/packages/components/src/focal-point-picker/focal-point.js
+++ b/packages/components/src/focal-point-picker/focal-point.js
@@ -13,15 +13,12 @@ import {
  */
 import classnames from 'classnames';
 
-export default function FocalPoint( {
-	coordinates = { left: '50%', top: '50%' },
-	...props
-} ) {
+export default function FocalPoint( { left = '50%', top = '50%', ...props } ) {
 	const classes = classnames(
 		'components-focal-point-picker__icon_container'
 	);
 
-	const style = { ...coordinates };
+	const style = { left, top };
 
 	return (
 		<FocalPointWrapper { ...props } className={ classes } style={ style }>

--- a/packages/components/src/focal-point-picker/focal-point.js
+++ b/packages/components/src/focal-point-picker/focal-point.js
@@ -21,10 +21,7 @@ export default function FocalPoint( {
 		'components-focal-point-picker__icon_container'
 	);
 
-	const style = {
-		left: coordinates.left,
-		top: coordinates.top,
-	};
+	const style = { ...coordinates };
 
 	return (
 		<FocalPointWrapper { ...props } className={ classes } style={ style }>

--- a/packages/components/src/focal-point-picker/grid.js
+++ b/packages/components/src/focal-point-picker/grid.js
@@ -13,11 +13,7 @@ import {
 } from './styles/focal-point-picker-style';
 import { useUpdateEffect } from '../utils/hooks';
 
-export default function FocalPointPickerGrid( {
-	bounds = {},
-	value,
-	...props
-} ) {
+export default function FocalPointPickerGrid( { bounds, value, ...props } ) {
 	const animationProps = useRevealAnimation( value );
 	const style = {
 		width: bounds.width,

--- a/packages/components/src/focal-point-picker/grid.js
+++ b/packages/components/src/focal-point-picker/grid.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import {
@@ -11,21 +6,16 @@ import {
 	GridLineX,
 	GridLineY,
 } from './styles/focal-point-picker-style';
-import { useUpdateEffect } from '../utils/hooks';
 
-export default function FocalPointPickerGrid( { bounds, value, ...props } ) {
-	const animationProps = useRevealAnimation( value );
-	const style = {
-		width: bounds.width,
-		height: bounds.height,
-	};
-
+export default function FocalPointPickerGrid( { bounds, ...props } ) {
 	return (
 		<GridView
 			{ ...props }
-			{ ...animationProps }
 			className="components-focal-point-picker__grid"
-			style={ style }
+			style={ {
+				width: bounds.width,
+				height: bounds.height,
+			} }
 		>
 			<GridLineX style={ { top: '33%' } } />
 			<GridLineX style={ { top: '66%' } } />
@@ -33,26 +23,4 @@ export default function FocalPointPickerGrid( { bounds, value, ...props } ) {
 			<GridLineY style={ { left: '66%' } } />
 		</GridView>
 	);
-}
-
-/**
- * Custom hook that renders the "flash" animation whenever the value changes.
- *
- * @param {string} value Value of (box) side.
- */
-function useRevealAnimation( value ) {
-	const [ isActive, setIsActive ] = useState( false );
-
-	useUpdateEffect( () => {
-		setIsActive( true );
-		const timeout = window.setTimeout( () => {
-			setIsActive( false );
-		}, 600 );
-
-		return () => window.clearTimeout( timeout );
-	}, [ value ] );
-
-	return {
-		isActive,
-	};
 }

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -170,7 +170,9 @@ export default function FocalPointPicker( {
 					className="components-focal-point-picker"
 					onKeyDown={ arrowKeyStep }
 					onMouseDown={ startDrag }
-					onBlur={ endDrag }
+					onBlur={ () => {
+						if ( isDragging ) endDrag();
+					} }
 					ref={ dragAreaRef }
 					role="button"
 					tabIndex="-1"

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -27,6 +27,9 @@ import {
 	MediaContainer,
 } from './styles/focal-point-picker-style';
 import { INITIAL_BOUNDS } from './utils';
+import { useUpdateEffect } from '../utils/hooks';
+
+const GRID_OVERLAY_TIMEOUT = 600;
 
 export default function FocalPointPicker( {
 	autoPlay = true,
@@ -45,6 +48,7 @@ export default function FocalPointPicker( {
 	},
 } ) {
 	const [ point, setPoint ] = useState( valueProp );
+	const [ showGridOverlay, setShowGridOverlay ] = useState( false );
 
 	const { startDrag, endDrag, isDragging } = useDragging( {
 		onDragStart: ( event ) => {
@@ -146,6 +150,15 @@ export default function FocalPointPicker( {
 	const instanceId = useInstanceId( FocalPointPicker );
 	const id = `inspector-focal-point-picker-control-${ instanceId }`;
 
+	useUpdateEffect( () => {
+		setShowGridOverlay( true );
+		const timeout = window.setTimeout( () => {
+			setShowGridOverlay( false );
+		}, GRID_OVERLAY_TIMEOUT );
+
+		return () => window.clearTimeout( timeout );
+	}, [ x, y ] );
+
 	return (
 		<BaseControl
 			label={ label }
@@ -165,7 +178,7 @@ export default function FocalPointPicker( {
 					role="button"
 					tabIndex="-1"
 				>
-					<Grid bounds={ bounds } value={ `${ x }${ y }` } />
+					<Grid bounds={ bounds } showOverlay={ showGridOverlay } />
 					<Media
 						alt={ __( 'Media preview' ) }
 						autoPlay={ autoPlay }

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -44,18 +44,18 @@ export default function FocalPointPicker( {
 	},
 } ) {
 	const [ point, setPoint ] = useState( valueProp );
-	// Tracks whether the internal point value has not propagated.
-	const isPointHeld = useRef();
-	const { current: keepPoint } = useRef( ( value ) => {
+	// Tracks the internal point value when it’s yet to be propagated.
+	const refPoint = useRef();
+	const keepPoint = ( value ) => {
 		setPoint( value );
-		isPointHeld.current = true;
-	} );
-	const sendPoint = ( value = point ) => {
+		refPoint.current = value;
+	};
+	const sendPoint = ( value = refPoint.current ) => {
 		onChange?.( value );
-		isPointHeld.current = false;
+		refPoint.current = undefined;
 	};
 	// Uses the internal point if it is held or else the value from props.
-	const { x, y } = isPointHeld.current ? point : valueProp;
+	const { x, y } = refPoint.current !== undefined ? point : valueProp;
 
 	const dragAreaRef = useRef();
 	const [ bounds, setBounds ] = useState( INITIAL_BOUNDS );
@@ -94,13 +94,9 @@ export default function FocalPointPicker( {
 		},
 		onDragEnd: ( event ) => {
 			onDragEnd?.( event );
+			sendPoint();
 		},
 	} );
-
-	// Propagates the value when a drag gesture has ended.
-	useEffect( () => {
-		if ( ! isDragging && isPointHeld.current ) sendPoint();
-	}, [ isDragging ] );
 
 	const getValueWithinDragArea = ( { clientX, clientY, shiftKey } ) => {
 		const { top, left } = dragAreaRef.current.getBoundingClientRect();

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import {
 	__experimentalUseDragging as useDragging,
 	useInstanceId,
+	useIsomorphicLayoutEffect,
 } from '@wordpress/compose';
 
 /**
@@ -77,12 +78,8 @@ export default function FocalPointPicker( {
 		return () => defaultView.removeEventListener( 'resize', updateBounds );
 	}, [] );
 
-	useEffect( () => {
-		// Updates bounds if there’s no media (and thus no load event to trigger
-		// a bounds update). Even then, this will only have an effect if the
-		// component is styled to non-default dimensions.
-		if ( ! url ) refUpdateBounds.current();
-	}, [ url ] );
+	// Updates the bounds to cover cases of unspecified media or load failures.
+	useIsomorphicLayoutEffect( () => void refUpdateBounds.current(), [] );
 
 	const { startDrag, endDrag, isDragging } = useDragging( {
 		onDragStart: ( event ) => {

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -7,8 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import {
+	__experimentalUseDragging as useDragging,
+	useInstanceId,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -24,150 +27,104 @@ import {
 } from './styles/focal-point-picker-style';
 import { INITIAL_BOUNDS } from './utils';
 
-export class FocalPointPicker extends Component {
-	constructor( props ) {
-		super( ...arguments );
+export default function FocalPointPicker( {
+	autoPlay = true,
+	className,
+	help,
+	label,
+	onChange,
+	onDrag,
+	onDragEnd,
+	onDragStart,
+	resolvePoint,
+	url,
+	value: valueProp = {
+		x: 0.5,
+		y: 0.5,
+	},
+} ) {
+	const [ point, setPoint ] = useState( valueProp );
+	// Tracks whether the internal point value has not propagated.
+	const isPointHeld = useRef();
+	const { current: keepPoint } = useRef( ( value ) => {
+		setPoint( value );
+		isPointHeld.current = true;
+	} );
+	const sendPoint = ( value = point ) => {
+		onChange?.( value );
+		isPointHeld.current = false;
+	};
+	// Uses the internal point if it is held or else the value from props.
+	const { x, y } = isPointHeld.current ? point : valueProp;
 
-		this.state = {
-			isDragging: false,
-			bounds: INITIAL_BOUNDS,
-			percentages: props.value,
-		};
-
-		this.containerRef = createRef();
-		this.mediaRef = createRef();
-
-		this.onMouseDown = this.startDrag.bind( this );
-		this.onMouseUp = this.stopDrag.bind( this );
-		this.onKeyDown = this.onKeyDown.bind( this );
-		this.onMouseMove = this.doDrag.bind( this );
-		this.ifDraggingStop = () => {
-			if ( this.state.isDragging ) {
-				this.stopDrag();
-			}
-		};
-		this.onChangeAtControls = ( value ) => {
-			this.updateValue( value, () => {
-				this.props.onChange( this.state.percentages );
-			} );
-		};
-
-		this.updateBounds = this.updateBounds.bind( this );
-		this.updateValue = this.updateValue.bind( this );
-	}
-	componentDidMount() {
-		const { defaultView } = this.containerRef.current.ownerDocument;
-		defaultView.addEventListener( 'resize', this.updateBounds );
-
-		/*
-		 * Set initial bound values.
-		 *
-		 * This is necessary for Safari:
-		 * https://github.com/WordPress/gutenberg/issues/25814
-		 */
-		this.updateBounds();
-	}
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.url !== this.props.url ) {
-			this.ifDraggingStop();
-		}
-		/*
-		 * Handles cases where the incoming value changes.
-		 * An example is the values resetting based on an UNDO action.
-		 */
-		const {
-			isDragging,
-			percentages: { x, y },
-		} = this.state;
-		const { value } = this.props;
-		if ( ! isDragging && ( value.x !== x || value.y !== y ) ) {
-			this.setState( { percentages: value } );
-		}
-	}
-	componentWillUnmount() {
-		const { defaultView } = this.containerRef.current.ownerDocument;
-		defaultView.removeEventListener( 'resize', this.updateBounds );
-		this.ifDraggingStop();
-	}
-	calculateBounds() {
-		const bounds = INITIAL_BOUNDS;
-
-		if ( ! this.mediaRef.current ) {
-			return bounds;
-		}
-
-		// Prevent division by zero when updateBounds runs in componentDidMount
-		if (
-			this.mediaRef.current.clientWidth === 0 ||
-			this.mediaRef.current.clientHeight === 0
-		) {
-			return bounds;
-		}
-
-		const dimensions = {
-			width: this.mediaRef.current.clientWidth,
-			height: this.mediaRef.current.clientHeight,
-		};
-
-		const pickerDimensions = this.pickerDimensions();
-
-		const widthRatio = pickerDimensions.width / dimensions.width;
-		const heightRatio = pickerDimensions.height / dimensions.height;
-
-		if ( heightRatio >= widthRatio ) {
-			bounds.width = bounds.right = pickerDimensions.width;
-			bounds.height = dimensions.height * widthRatio;
-			bounds.top = ( pickerDimensions.height - bounds.height ) / 2;
-			bounds.bottom = bounds.top + bounds.height;
-		} else {
-			bounds.height = bounds.bottom = pickerDimensions.height;
-			bounds.width = dimensions.width * heightRatio;
-			bounds.left = ( pickerDimensions.width - bounds.width ) / 2;
-			bounds.right = bounds.left + bounds.width;
-		}
-		return bounds;
-	}
-	updateValue( nextValue, callback ) {
-		const resolvedValue =
-			this.props.resolvePoint?.( nextValue ) ?? nextValue;
-
-		const { x, y } = resolvedValue;
-
-		const nextPercentage = {
-			x: parseFloat( x ).toFixed( 2 ),
-			y: parseFloat( y ).toFixed( 2 ),
-		};
-
-		this.setState( { percentages: nextPercentage }, callback );
-	}
-	updateBounds() {
-		this.setState( {
-			bounds: this.calculateBounds(),
-		} );
-	}
-	startDrag( event ) {
-		this.containerRef.current.focus();
-		this.setState( { isDragging: true } );
-		const { ownerDocument } = this.containerRef.current;
-		ownerDocument.addEventListener( 'mouseup', this.onMouseUp );
-		ownerDocument.addEventListener( 'mousemove', this.onMouseMove );
-		const value = this.getValueFromPoint(
-			{ x: event.pageX, y: event.pageY },
-			event.shiftKey
+	const dragAreaRef = useRef();
+	const [ bounds, setBounds ] = useState( INITIAL_BOUNDS );
+	const { current: updateBounds } = useRef( () => {
+		const { clientWidth: width, clientHeight: height } =
+			dragAreaRef.current;
+		// Falls back to initial bounds if the ref has no size. Since styles
+		// give the drag area dimensions even when the media has not loaded
+		// this should only happen in unit tests (jsdom).
+		setBounds(
+			width > 0 && height > 0 ? { width, height } : { ...INITIAL_BOUNDS }
 		);
-		this.updateValue( value );
-		this.props.onDragStart?.( value, event );
-	}
-	stopDrag( event ) {
-		const { ownerDocument } = this.containerRef.current;
-		ownerDocument.removeEventListener( 'mouseup', this.onMouseUp );
-		ownerDocument.removeEventListener( 'mousemove', this.onMouseMove );
-		this.setState( { isDragging: false }, () => {
-			this.props.onChange( this.state.percentages );
-		} );
-		this.props.onDragEnd?.( event );
-	}
-	onKeyDown( event ) {
+	} );
+
+	useEffect( () => {
+		const { defaultView } = dragAreaRef.current.ownerDocument;
+		defaultView.addEventListener( 'resize', updateBounds );
+		return () => {
+			defaultView.removeEventListener( 'resize', updateBounds );
+		};
+	}, [] );
+
+	const { startDrag, endDrag, isDragging } = useDragging( {
+		onDragStart: ( event ) => {
+			dragAreaRef.current.focus();
+			const value = getValueWithinDragArea( event );
+			onDragStart?.( value, event );
+			keepPoint( value );
+		},
+		onDragMove: ( event ) => {
+			// Prevents text-selection when dragging.
+			event.preventDefault();
+			const value = getValueWithinDragArea( event );
+			onDrag?.( value, event );
+			keepPoint( value );
+		},
+		onDragEnd: ( event ) => {
+			onDragEnd?.( event );
+		},
+	} );
+
+	// Propagates the value when a drag gesture has ended.
+	useEffect( () => {
+		if ( ! isDragging && isPointHeld.current ) sendPoint();
+	}, [ isDragging ] );
+
+	const getValueWithinDragArea = ( { clientX, clientY, shiftKey } ) => {
+		const { top, left } = dragAreaRef.current.getBoundingClientRect();
+		let nextX = ( clientX - left ) / bounds.width;
+		let nextY = ( clientY - top ) / bounds.height;
+		// Enables holding shift to jump values by 10%.
+		if ( shiftKey ) {
+			nextX = Math.round( nextX / 0.1 ) * 0.1;
+			nextY = Math.round( nextY / 0.1 ) * 0.1;
+		}
+		return getFinalValue( { x: nextX, y: nextY } );
+	};
+
+	const getFinalValue = ( value ) => {
+		const resolvedValue = resolvePoint?.( value ) ?? value;
+		resolvedValue.x = Math.max( 0, Math.min( resolvedValue.x, 1 ) );
+		resolvedValue.y = Math.max( 0, Math.min( resolvedValue.y, 1 ) );
+		return {
+			x: parseFloat( resolvedValue.x ).toFixed( 2 ),
+			y: parseFloat( resolvedValue.y ).toFixed( 2 ),
+		};
+	};
+
+	const arrowKeyStep = ( event ) => {
 		const { code, shiftKey } = event;
 		if (
 			! [ 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight' ].includes(
@@ -177,162 +134,64 @@ export class FocalPointPicker extends Component {
 			return;
 
 		event.preventDefault();
-
-		const next = { ...this.state.percentages };
+		const value = { x, y };
 		const step = shiftKey ? 0.1 : 0.01;
 		const delta =
 			code === 'ArrowUp' || code === 'ArrowLeft' ? -1 * step : step;
 		const axis = code === 'ArrowUp' || code === 'ArrowDown' ? 'y' : 'x';
-		const value = parseFloat( next[ axis ] ) + delta;
+		value[ axis ] = parseFloat( value[ axis ] ) + delta;
+		sendPoint( getFinalValue( value ) );
+	};
 
-		next[ axis ] = value;
+	const focalPointPosition = {
+		left: x * bounds.width,
+		top: y * bounds.height,
+	};
 
-		this.updateValue( next, () => {
-			this.props.onChange( this.state.percentages );
-		} );
-	}
-	doDrag( event ) {
-		// Prevents text-selection when dragging.
-		event.preventDefault();
-		const value = this.getValueFromPoint(
-			{ x: event.pageX, y: event.pageY },
-			event.shiftKey
-		);
-		this.updateValue( value );
-		this.props.onDrag?.( value, event );
-	}
-	getValueFromPoint( point, byTenths ) {
-		const { bounds } = this.state;
+	const classes = classnames(
+		'components-focal-point-picker-control',
+		className
+	);
 
-		const pickerDimensions = this.pickerDimensions();
-		const relativePoint = {
-			left: point.x - pickerDimensions.left,
-			top: point.y - pickerDimensions.top,
-		};
+	const instanceId = useInstanceId( FocalPointPicker );
+	const id = `inspector-focal-point-picker-control-${ instanceId }`;
 
-		const left = Math.max(
-			bounds.left,
-			Math.min( relativePoint.left, bounds.right )
-		);
-		const top = Math.max(
-			bounds.top,
-			Math.min( relativePoint.top, bounds.bottom )
-		);
-
-		let nextX =
-			( left - bounds.left ) /
-			( pickerDimensions.width - bounds.left * 2 );
-		let nextY =
-			( top - bounds.top ) / ( pickerDimensions.height - bounds.top * 2 );
-
-		// Enables holding shift to jump values by 10%
-		if ( byTenths ) {
-			nextX = Math.round( nextX / 0.1 ) * 0.1;
-			nextY = Math.round( nextY / 0.1 ) * 0.1;
-		}
-
-		return { x: nextX, y: nextY };
-	}
-	pickerDimensions() {
-		const containerNode = this.containerRef.current;
-
-		if ( ! containerNode ) {
-			return {
-				width: 0,
-				height: 0,
-				left: 0,
-				top: 0,
-			};
-		}
-
-		const { clientHeight, clientWidth } = containerNode;
-		const { top, left } = containerNode.getBoundingClientRect();
-
-		return {
-			width: clientWidth,
-			height: clientHeight,
-			top: top + document.body.scrollTop,
-			left,
-		};
-	}
-	iconCoordinates() {
-		const {
-			bounds,
-			percentages: { x, y },
-		} = this.state;
-
-		if ( bounds.left === undefined || bounds.top === undefined ) {
-			return;
-		}
-
-		const { width, height } = this.pickerDimensions();
-		return {
-			left: x * ( width - bounds.left * 2 ) + bounds.left,
-			top: y * ( height - bounds.top * 2 ) + bounds.top,
-		};
-	}
-	render() {
-		const { autoPlay, className, help, instanceId, label, url } =
-			this.props;
-		const { bounds, isDragging, percentages } = this.state;
-
-		const classes = classnames(
-			'components-focal-point-picker-control',
-			className
-		);
-
-		const id = `inspector-focal-point-picker-control-${ instanceId }`;
-
-		return (
-			<BaseControl
-				label={ label }
-				id={ id }
-				help={ help }
-				className={ classes }
-			>
-				<MediaWrapper className="components-focal-point-picker-wrapper">
-					<MediaContainer
-						className="components-focal-point-picker"
-						onKeyDown={ this.onKeyDown }
-						onMouseDown={ this.onMouseDown }
-						onBlur={ this.ifDraggingStop }
-						ref={ this.containerRef }
-						role="button"
-						tabIndex="-1"
-					>
-						<Grid
-							bounds={ bounds }
-							value={ percentages.x + percentages.y }
-						/>
-						<Media
-							alt={ __( 'Media preview' ) }
-							autoPlay={ autoPlay }
-							mediaRef={ this.mediaRef }
-							onLoad={ this.updateBounds }
-							src={ url }
-						/>
-						<FocalPoint
-							coordinates={ this.iconCoordinates() }
-							isDragging={ isDragging }
-						/>
-					</MediaContainer>
-				</MediaWrapper>
-				<Controls
-					percentages={ percentages }
-					onChange={ this.onChangeAtControls }
-				/>
-			</BaseControl>
-		);
-	}
+	return (
+		<BaseControl
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ classes }
+		>
+			<MediaWrapper className="components-focal-point-picker-wrapper">
+				<MediaContainer
+					className="components-focal-point-picker"
+					onKeyDown={ arrowKeyStep }
+					onMouseDown={ startDrag }
+					onBlur={ endDrag }
+					ref={ dragAreaRef }
+					role="button"
+					tabIndex="-1"
+				>
+					<Grid bounds={ bounds } value={ `${ x }${ y }` } />
+					<Media
+						alt={ __( 'Media preview' ) }
+						autoPlay={ autoPlay }
+						onLoad={ updateBounds }
+						src={ url }
+					/>
+					<FocalPoint
+						{ ...focalPointPosition }
+						isDragging={ isDragging }
+					/>
+				</MediaContainer>
+			</MediaWrapper>
+			<Controls
+				point={ { x, y } }
+				onChange={ ( value ) => {
+					sendPoint( getFinalValue( value ) );
+				} }
+			/>
+		</BaseControl>
+	);
 }
-
-FocalPointPicker.defaultProps = {
-	autoPlay: true,
-	value: {
-		x: 0.5,
-		y: 0.5,
-	},
-	url: null,
-};
-
-export default withInstanceId( FocalPointPicker );

--- a/packages/components/src/focal-point-picker/index.js
+++ b/packages/components/src/focal-point-picker/index.js
@@ -22,7 +22,6 @@ import {
 	MediaWrapper,
 	MediaContainer,
 } from './styles/focal-point-picker-style';
-import { roundClamp } from '../utils/math';
 import { INITIAL_BOUNDS } from './utils';
 
 export class FocalPointPicker extends Component {
@@ -82,7 +81,7 @@ export class FocalPointPicker extends Component {
 		} = this.state;
 		const { value } = this.props;
 		if ( ! isDragging && ( value.x !== x || value.y !== y ) ) {
-			this.setState( { percentages: this.props.value } );
+			this.setState( { percentages: value } );
 		}
 	}
 	componentWillUnmount() {
@@ -128,7 +127,7 @@ export class FocalPointPicker extends Component {
 		}
 		return bounds;
 	}
-	updateValue( nextValue = {}, callback ) {
+	updateValue( nextValue, callback ) {
 		const resolvedValue =
 			this.props.resolvePoint?.( nextValue ) ?? nextValue;
 
@@ -147,7 +146,6 @@ export class FocalPointPicker extends Component {
 		} );
 	}
 	startDrag( event ) {
-		event.persist();
 		this.containerRef.current.focus();
 		this.setState( { isDragging: true } );
 		const { ownerDocument } = this.containerRef.current;
@@ -187,7 +185,7 @@ export class FocalPointPicker extends Component {
 		const axis = code === 'ArrowUp' || code === 'ArrowDown' ? 'y' : 'x';
 		const value = parseFloat( next[ axis ] ) + delta;
 
-		next[ axis ] = roundClamp( value, 0, 1, step );
+		next[ axis ] = value;
 
 		this.updateValue( next, () => {
 			this.props.onChange( this.state.percentages );
@@ -228,10 +226,10 @@ export class FocalPointPicker extends Component {
 			( top - bounds.top ) / ( pickerDimensions.height - bounds.top * 2 );
 
 		// Enables holding shift to jump values by 10%
-		const step = byTenths ? 0.1 : 0.01;
-
-		nextX = roundClamp( nextX, 0, 1, step );
-		nextY = roundClamp( nextY, 0, 1, step );
+		if ( byTenths ) {
+			nextX = Math.round( nextX / 0.1 ) * 0.1;
+			nextY = Math.round( nextY / 0.1 ) * 0.1;
+		}
 
 		return { x: nextX, y: nextY };
 	}
@@ -264,10 +262,7 @@ export class FocalPointPicker extends Component {
 		} = this.state;
 
 		if ( bounds.left === undefined || bounds.top === undefined ) {
-			return {
-				left: '50%',
-				top: '50%',
-			};
+			return;
 		}
 
 		const { width, height } = this.pickerDimensions();
@@ -280,7 +275,6 @@ export class FocalPointPicker extends Component {
 		const { autoPlay, className, help, instanceId, label, url } =
 			this.props;
 		const { bounds, isDragging, percentages } = this.state;
-		const iconCoordinates = this.iconCoordinates();
 
 		const classes = classnames(
 			'components-focal-point-picker-control',
@@ -318,7 +312,7 @@ export class FocalPointPicker extends Component {
 							src={ url }
 						/>
 						<FocalPoint
-							coordinates={ iconCoordinates }
+							coordinates={ this.iconCoordinates() }
 							isDragging={ isDragging }
 						/>
 					</MediaContainer>

--- a/packages/components/src/focal-point-picker/media.js
+++ b/packages/components/src/focal-point-picker/media.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useLayoutEffect } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { MediaPlaceholder } from './styles/focal-point-picker-style';
@@ -22,10 +17,10 @@ export default function Media( {
 } ) {
 	if ( ! src ) {
 		return (
-			<MediaPlaceholderElement
+			<MediaPlaceholder
 				className="components-focal-point-picker__media components-focal-point-picker__media--placeholder"
-				onLoad={ onLoad }
-				mediaRef={ mediaRef }
+				ref={ mediaRef }
+				{ ...props }
 			/>
 		);
 	}
@@ -53,17 +48,4 @@ export default function Media( {
 			src={ src }
 		/>
 	);
-}
-
-function MediaPlaceholderElement( { mediaRef, onLoad, ...props } ) {
-	/**
-	 * This async callback mimics the onLoad (img) / onLoadedData (video) callback
-	 * for media elements. It is used in the main <FocalPointPicker /> component
-	 * to calculate the dimensions + boundaries for positioning.
-	 */
-	useLayoutEffect( () => {
-		window.requestAnimationFrame( () => onLoad() );
-	}, [] );
-
-	return <MediaPlaceholder ref={ mediaRef } { ...props } />;
 }

--- a/packages/components/src/focal-point-picker/media.js
+++ b/packages/components/src/focal-point-picker/media.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useLayoutEffect } from '@wordpress/element';
+import { useLayoutEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,13 +9,11 @@ import { useRef, useLayoutEffect } from '@wordpress/element';
 import { MediaPlaceholder } from './styles/focal-point-picker-style';
 import { isVideoType } from './utils';
 
-const noop = () => {};
-
 export default function Media( {
 	alt,
 	autoPlay,
 	src,
-	onLoad = noop,
+	onLoad,
 	mediaRef,
 	// Exposing muted prop for test rendering purposes
 	// https://github.com/testing-library/react-testing-library/issues/470
@@ -57,18 +55,14 @@ export default function Media( {
 	);
 }
 
-function MediaPlaceholderElement( { mediaRef, onLoad = noop, ...props } ) {
-	const onLoadRef = useRef( onLoad );
-
+function MediaPlaceholderElement( { mediaRef, onLoad, ...props } ) {
 	/**
 	 * This async callback mimics the onLoad (img) / onLoadedData (video) callback
 	 * for media elements. It is used in the main <FocalPointPicker /> component
 	 * to calculate the dimensions + boundaries for positioning.
 	 */
 	useLayoutEffect( () => {
-		window.requestAnimationFrame( () => {
-			onLoadRef.current();
-		} );
+		window.requestAnimationFrame( () => onLoad() );
 	}, [] );
 
 	return <MediaPlaceholder ref={ mediaRef } { ...props } />;

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.js
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.js
@@ -61,7 +61,6 @@ export const ControlWrapper = styled( Flex )`
 
 export const GridView = styled.div`
 	left: 50%;
-	opacity: 0;
 	overflow: hidden;
 	pointer-events: none;
 	position: absolute;
@@ -70,11 +69,7 @@ export const GridView = styled.div`
 	transition: opacity 120ms linear;
 	z-index: 1;
 
-	${ ( { isActive } ) =>
-		isActive &&
-		`
-		opacity: 1;
-	` }
+	opacity: ${ ( { showOverlay } ) => ( showOverlay ? 1 : 0 ) };
 `;
 
 export const GridLine = styled.div`

--- a/packages/components/src/focal-point-picker/styles/focal-point-picker-style.js
+++ b/packages/components/src/focal-point-picker/styles/focal-point-picker-style.js
@@ -9,6 +9,7 @@ import styled from '@emotion/styled';
 import { Flex } from '../../flex';
 import BaseUnitControl from '../../unit-control';
 import { COLORS } from '../../utils';
+import { INITIAL_BOUNDS } from '../utils';
 
 export const MediaWrapper = styled.div`
 	background-color: transparent;
@@ -42,9 +43,10 @@ export const MediaContainer = styled.div`
 
 export const MediaPlaceholder = styled.div`
 	background: ${ COLORS.lightGray[ 300 ] };
-	height: 170px;
+	box-sizing: border-box;
+	height: ${ INITIAL_BOUNDS.height }px;
 	max-width: 280px;
-	min-width: 200px;
+	min-width: ${ INITIAL_BOUNDS.width }px;
 	width: 100%;
 `;
 

--- a/packages/components/src/focal-point-picker/test/index.js
+++ b/packages/components/src/focal-point-picker/test/index.js
@@ -137,7 +137,7 @@ describe( 'FocalPointPicker', () => {
 			render(
 				<Picker value={ { x: 0.14, y: 0.62 } } onChange={ spyChange } />
 			);
-			// Click and press arrow up
+			// Focus and press arrow up
 			const dragArea = screen.getByRole( 'button' );
 
 			await user.click( dragArea );

--- a/packages/components/src/focal-point-picker/utils.js
+++ b/packages/components/src/focal-point-picker/utils.js
@@ -1,10 +1,6 @@
 export const INITIAL_BOUNDS = {
-	top: 0,
-	left: 0,
-	bottom: 0,
-	right: 0,
-	width: 0,
-	height: 0,
+	width: 200,
+	height: 170,
 };
 
 const VIDEO_EXTENSIONS = [


### PR DESCRIPTION
Part of #22890.

When starting on this I first looked for some small things that could be simplified and put them in the first commit since they would be hard to spot within the rewrite as a function component.  Once I got into the rewrite, I found more things to simplify:
- Mainly that the logic and state handling the drag area boundaries was crufty from before #22531 where the image area was a fixed aspect and the drag area had variable margins around it (see https://github.com/WordPress/gutenberg/pull/22531#issuecomment-632824022).
- Additionally, there was some code for handling drag gestures that has been obviated by `useDragging` from the compose package.

## Testing Instructions
Make sure the `FocalPointPicker` works as expected. Especially in the Media & Text block and Cover blocks.

## Screenshots <!-- if applicable -->

## Types of changes
Refactor

## Checklist:
- [x] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
