### PR TITLE
Change copying PHP files to dist directory to opt-in via a CLI  flag.

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+
+### New Feature
+
 -   Add `--webpack-copy-php` CLI flag to opt-in to copying php files from `src` and its subfolders to the output directory (`build` by default) ([#39171](https://github.com/WordPress/gutenberg/pull/39171)).
 
 ## 22.0.0 (2022-02-22)

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+-   Add `--webpack-copy-php` CLI flag to opt-in to copying php files from `src` and its subfolders to the output directory (`build` by default).
 
 ## 22.0.0 (2022-02-22)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
--   Add `--webpack-copy-php` CLI flag to opt-in to copying php files from `src` and its subfolders to the output directory (`build` by default).
+-   Add `--webpack-copy-php` CLI flag to opt-in to copying php files from `src` and its subfolders to the output directory (`build` by default) ([#39171](https://github.com/WordPress/gutenberg/pull/39171)).
 
 ## 22.0.0 (2022-02-22)
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -88,14 +88,14 @@ _Example:_
 This is how you execute the script with presented setup:
 
 -   `npm run build` - builds the code for production.
--   `npm run build:custom` - builds the code for production with two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
--   `npm run build:copy-php` - builds the code for production and opts into copying PHP files from src src and its subfolders to the dist directory.
+-   `npm run build:custom` - builds the code for production with two entry points and a custom output directory. Paths for custom entry points are relative to the project root.
+-   `npm run build:copy-php` - builds the code for production and opts into copying PHP files from the `src` directory and its subfolders to the output directory.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
--   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
--   `--webpack-copy-php` – enables copying PHP files from src and its subfolders to the dist directory.
+-   `--webpack-copy-php` – enables copying PHP files from the `src` directory and its subfolders to the output directory.
+-   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 
 #### Advanced information
 
@@ -380,16 +380,16 @@ This is how you execute the script with presented setup:
 
 -   `npm start` - starts the build for development.
 -   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the files.
--   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
--   `npm run start:copy-php` - starts the build for development and opts into copying PHP files from src src and its subfolders to the dist directory.
+-   `npm run start:custom` - starts the build for development which contains two entry points and a custom output directory. Paths for custom entry points are relative to the project root.
+-   `npm run start:copy-php` - starts the build for development and opts into copying PHP files from the `src` directory and its subfolders to the output directory.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
 -   `--hot` – enables "Fast Refresh". The page will automatically reload if you make changes to the code. _For now, it requires that WordPress has the [`SCRIPT_DEBUG`](https://wordpress.org/support/article/debugging-in-wordpress/#script_debug) flag enabled and the [Gutenberg](https://wordpress.org/plugins/gutenberg/) plugin installed._
--   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
--   `--webpack--devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.
--   `--webpack-copy-php` – enables copying PHP files from src and its subfolders to the dist directory.
+-   `--webpack-copy-php` – enables copying PHP files from the `src` directory and its subfolders to the output directory.
+-   `--webpack-devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.
+-   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 
 #### Advanced information
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -79,7 +79,8 @@ _Example:_
 {
 	"scripts": {
 		"build": "wp-scripts build",
-		"build:custom": "wp-scripts build entry-one.js entry-two.js --output-path=custom"
+		"build:custom": "wp-scripts build entry-one.js entry-two.js --output-path=custom",
+		"build:copy-php": "wp-scripts build --webpack-copy-php"
 	}
 }
 ```
@@ -88,11 +89,13 @@ This is how you execute the script with presented setup:
 
 -   `npm run build` - builds the code for production.
 -   `npm run build:custom` - builds the code for production with two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
+-   `npm run build:copy-php` - builds the code for production and opts into copying PHP files from src src and its subfolders to the dist directory.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
 -   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
+-   `--webpack-copy-php` – enables copying PHP files from src and its subfolders to the dist directory.
 
 #### Advanced information
 
@@ -367,7 +370,8 @@ _Example:_
 	"scripts": {
 		"start": "wp-scripts start",
 		"start:hot": "wp-scripts start --hot",
-		"start:custom": "wp-scripts start entry-one.js entry-two.js --output-path=custom"
+		"start:custom": "wp-scripts start entry-one.js entry-two.js --output-path=custom",
+		"start:copy-php": "wp-scripts start"
 	}
 }
 ```
@@ -377,6 +381,7 @@ This is how you execute the script with presented setup:
 -   `npm start` - starts the build for development.
 -   `npm run start:hot` - starts the build for development with "Fast Refresh". The page will automatically reload if you make changes to the files.
 -   `npm run start:custom` - starts the build for development which contains two entry points and a custom output folder. Paths for custom entry points are relative to the project root.
+-   `npm run start:copy-php` - starts the build for development and opts into copying PHP files from src src and its subfolders to the dist directory.
 
 This script automatically use the optimized config but sometimes you may want to specify some custom options:
 
@@ -384,6 +389,7 @@ This script automatically use the optimized config but sometimes you may want to
 -   `--webpack-no-externals` – disables scripts' assets generation, and omits the list of default externals.
 -   `--webpack-bundle-analyzer` – enables visualization for the size of webpack output files with an interactive zoomable treemap.
 -   `--webpack--devtool` – controls how source maps are generated. See options at https://webpack.js.org/configuration/devtool/#devtool.
+-   `--webpack-copy-php` – enables copying PHP files from src and its subfolders to the dist directory.
 
 #### Advanced information
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -36,6 +36,10 @@ if ( ! browserslist.findConfig( '.' ) ) {
 }
 const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 
+const copyWebPackPattens = process.env.WP_COPY_PHP_FILES_TO_DIST
+	? '**/{block.json,*.php}'
+	: '**/block.json';
+
 const cssLoaders = [
 	{
 		loader: MiniCSSExtractPlugin.loader,
@@ -228,12 +232,7 @@ const config = {
 		new CopyWebpackPlugin( {
 			patterns: [
 				{
-					from: '**/block.json',
-					context: 'src',
-					noErrorOnMissing: true,
-				},
-				{
-					from: '**/**.php',
+					from: copyWebPackPattens,
 					context: 'src',
 					noErrorOnMissing: true,
 				},

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -19,6 +19,10 @@ if ( hasArgInCLI( '--webpack-bundle-analyzer' ) ) {
 	process.env.WP_BUNDLE_ANALYZER = true;
 }
 
+if ( hasArgInCLI( '--webpack-copy-php' ) ) {
+	process.env.WP_COPY_PHP_FILES_TO_DIST = true;
+}
+
 const { status } = spawn( resolveBin( 'webpack' ), getWebpackArgs(), {
 	stdio: 'inherit',
 } );

--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -21,6 +21,10 @@ if ( hasArgInCLI( '--webpack--devtool' ) ) {
 	process.env.WP_DEVTOOL = getArgFromCLI( '--webpack--devtool' );
 }
 
+if ( hasArgInCLI( '--webpack-copy-php' ) ) {
+	process.env.WP_COPY_PHP_FILES_TO_DIST = true;
+}
+
 const { status } = spawn(
 	resolveBin( 'webpack' ),
 	[ hasArgInCLI( '--hot' ) ? 'serve' : 'watch', ...getWebpackArgs() ],


### PR DESCRIPTION
## Description
Based on feedback post #38715 being merged, this PR changes the approach around copying PHP files by moving to an opt-in approach via providing a `--webpack-copy-php` flag to either the `start` or `build` commands. By moving to opt-in, we should be able to avoid more unintentional issues with existing projects while still allowing the functionality to be accessed.

## Testing Instructions
I created a block using npx @wordpress/create-block@ my-first-dynamic-block --template=@ryanwelcher/dynamic-block-template ( this contains an template.php file in the `src` directory )
Then ran node {FULLPATH}/gutenberg/packages/scripts/bin/wp-scripts.js -- build --webpack-copy-php

## Types of changes
Changes the approach for copying PHP files to be opt-in via a CLI flag.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
