### PR TITLE
Image: Display errors after failed upload

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -293,7 +293,7 @@ export function ImageEdit( {
 		} );
 	}
 
-	const isTemp = isTemporaryImage( id, url );
+	let isTemp = isTemporaryImage( id, url );
 
 	// Upload a temporary image on mount.
 	useEffect( () => {
@@ -310,7 +310,10 @@ export function ImageEdit( {
 					onSelectImage( img );
 				},
 				allowedTypes: ALLOWED_MEDIA_TYPES,
-				onError: onUploadError,
+				onError: ( message ) => {
+					isTemp = false;
+					onUploadError( message );
+				},
 			} );
 		}
 	}, [] );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -171,11 +171,6 @@ export function ImageEdit( {
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
-		setAttributes( {
-			src: undefined,
-			id: undefined,
-			url: undefined,
-		} );
 		setTemporaryURL( undefined );
 	}
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -171,6 +171,11 @@ export function ImageEdit( {
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
+		setAttributes( {
+			src: undefined,
+			id: undefined,
+			url: undefined,
+		} );
 		setTemporaryURL( undefined );
 	}
 

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -171,6 +171,12 @@ export function ImageEdit( {
 	function onUploadError( message ) {
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
+		setAttributes( {
+			src: undefined,
+			id: undefined,
+			url: undefined,
+		} );
+		setTemporaryURL( undefined );
 	}
 
 	function onSelectImage( media ) {
@@ -287,7 +293,7 @@ export function ImageEdit( {
 		} );
 	}
 
-	let isTemp = isTemporaryImage( id, url );
+	const isTemp = isTemporaryImage( id, url );
 
 	// Upload a temporary image on mount.
 	useEffect( () => {
@@ -304,15 +310,7 @@ export function ImageEdit( {
 					onSelectImage( img );
 				},
 				allowedTypes: ALLOWED_MEDIA_TYPES,
-				onError: ( message ) => {
-					isTemp = false;
-					noticeOperations.createErrorNotice( message );
-					setAttributes( {
-						src: undefined,
-						id: undefined,
-						url: undefined,
-					} );
-				},
+				onError: onUploadError,
 			} );
 		}
 	}, [] );


### PR DESCRIPTION
## Description
Resolves #39116

PR ixes the issue when the upload error message wasn't displayed. Also re-uses `onUploadError` callback for error messages.

## Testing Instructions
1. Open a Post or Page
2. Insert an Image Block.
3. Fake upload error (see code below).
4. Confirm that the upload error message is displayed and the image isn't stuck in the upload state.

### Example

```php
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'Image files must be smaller than 10kb';
	return $file;
} );
```

## Screenshots <!-- if applicable -->
**Before**

https://user-images.githubusercontent.com/240569/156501201-c88eb097-55c7-4500-9148-4660217d14a5.mp4

**After**

https://user-images.githubusercontent.com/240569/156501218-d3daf46b-52be-4c8f-bc76-291698071ec2.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
