### PR TITLE
Migrate post editor `editorMode` to use preferences store and remove `localAutosaveInterval` preference

### DIFF
--- a/lib/compat/wordpress-5.9/block-editor-settings.php
+++ b/lib/compat/wordpress-5.9/block-editor-settings.php
@@ -1,5 +1,11 @@
 <?php
 /**
+ * Adds settings to the block editor.
+ *
+ * @package gutenberg
+ */
+
+/**
  * Extends the block editor with settings that are only in the plugin.
  *
  * This is a temporary solution until the Gutenberg plugin sets

--- a/lib/compat/wordpress-5.9/block-editor-settings.php
+++ b/lib/compat/wordpress-5.9/block-editor-settings.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Extends the block editor with settings that are only in the plugin.
+ *
+ * This is a temporary solution until the Gutenberg plugin sets
+ * the required WordPress version to 5.9.
+ *
+ * @see https://core.trac.wordpress.org/ticket/52920
+ *
+ * @param array $settings Existing editor settings.
+ *
+ * @return array Filtered settings.
+ */
+function gutenberg_get_block_editor_settings_5_9( $settings ) {
+	$settings['__unstableEnableFullSiteEditingBlocks'] = current_theme_supports( 'block-templates' );
+
+	if ( wp_is_block_theme() ) {
+		$settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
+	}
+
+	return $settings;
+}
+add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_5_9' );

--- a/lib/compat/wordpress-6.0/block-editor-settings.php
+++ b/lib/compat/wordpress-6.0/block-editor-settings.php
@@ -159,6 +159,8 @@ function gutenberg_get_block_editor_settings( $settings ) {
 		unset( $settings['__experimentalFeatures']['spacing']['padding'] );
 	}
 
+	$settings['localAutosaveInterval'] = 15;
+
 	return $settings;
 }
 

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -24,6 +24,8 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 		$settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
 	}
 
+	$settings['__experimentalLocalAutosaveInterval'] = 15;
+
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_extend_post_editor_settings' );

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -24,7 +24,7 @@ function gutenberg_extend_post_editor_settings( $settings ) {
 		$settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
 	}
 
-	$settings['__experimentalLocalAutosaveInterval'] = 15;
+	$settings['localAutosaveInterval'] = 15;
 
 	return $settings;
 }

--- a/lib/editor-settings.php
+++ b/lib/editor-settings.php
@@ -6,31 +6,6 @@
  */
 
 /**
- * Extends the block editor with settings that are only in the plugin.
- *
- * This is a temporary solution until the Gutenberg plugin sets
- * the required WordPress version to 5.9.
- *
- * @see https://core.trac.wordpress.org/ticket/52920
- *
- * @param array $settings Existing editor settings.
- *
- * @return array Filtered settings.
- */
-function gutenberg_extend_post_editor_settings( $settings ) {
-	$settings['__unstableEnableFullSiteEditingBlocks'] = current_theme_supports( 'block-templates' );
-
-	if ( wp_is_block_theme() ) {
-		$settings['defaultTemplatePartAreas'] = get_allowed_block_template_part_areas();
-	}
-
-	$settings['localAutosaveInterval'] = 15;
-
-	return $settings;
-}
-add_filter( 'block_editor_settings_all', 'gutenberg_extend_post_editor_settings' );
-
-/**
  * Initialize a block-based editor.
  *
  * @param string $editor_name          Editor name.

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -414,11 +414,6 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 	migrateIndividualPreferenceToPreferencesStore(
 		persistence,
 		'core/edit-post',
-		'localAutosaveInterval'
-	);
-	migrateIndividualPreferenceToPreferencesStore(
-		persistence,
-		'core/edit-post',
 		'editorMode'
 	);
 	migrateFeaturePreferencesToPreferencesStore(

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -411,6 +411,16 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 		'core/edit-post',
 		'hiddenBlockTypes'
 	);
+	migrateIndividualPreferenceToPreferencesStore(
+		persistence,
+		'core/edit-post',
+		'localAutosaveInterval'
+	);
+	migrateIndividualPreferenceToPreferencesStore(
+		persistence,
+		'core/edit-post',
+		'editorMode'
+	);
 	migrateFeaturePreferencesToPreferencesStore(
 		persistence,
 		'core/edit-site'

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -56,9 +56,9 @@ async function getCurrentPostId() {
 
 async function setLocalAutosaveInterval( value ) {
 	return page.evaluate( ( _value ) => {
-		window.wp.data
-			.dispatch( 'core/preferences' )
-			.set( 'core/edit-post', 'localAutosaveInterval', _value );
+		window.wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
+			__experimentalLocalAutosaveInterval: _value,
+		} );
 	}, value );
 }
 

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -57,8 +57,8 @@ async function getCurrentPostId() {
 async function setLocalAutosaveInterval( value ) {
 	return page.evaluate( ( _value ) => {
 		window.wp.data
-			.dispatch( 'core/edit-post' )
-			.__experimentalUpdateLocalAutosaveInterval( _value );
+			.dispatch( 'core/preferences' )
+			.set( 'core/edit-post', 'localAutosaveInterval', _value );
 	}, value );
 }
 

--- a/packages/e2e-tests/specs/editor/various/autosave.test.js
+++ b/packages/e2e-tests/specs/editor/various/autosave.test.js
@@ -57,7 +57,7 @@ async function getCurrentPostId() {
 async function setLocalAutosaveInterval( value ) {
 	return page.evaluate( ( _value ) => {
 		window.wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
-			__experimentalLocalAutosaveInterval: _value,
+			localAutosaveInterval: _value,
 		} );
 	}, value );
 }

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -87,8 +87,8 @@ describe( 'Post Editor Performance', () => {
 		// Disable auto-save to avoid impacting the metrics.
 		await page.evaluate( () => {
 			window.wp.data
-				.dispatch( 'core/edit-post' )
-				.__experimentalUpdateLocalAutosaveInterval( 100000000000 );
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-post', 'localAutosaveInterval', 100000000000 );
 			window.wp.data
 				.dispatch( 'core/editor' )
 				.updateEditorSettings( { autosaveInterval: 100000000000 } );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -88,7 +88,7 @@ describe( 'Post Editor Performance', () => {
 		await page.evaluate( () => {
 			window.wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
 				autosaveInterval: 100000000000,
-				__experimentalLocalAutosaveInterval: 100000000000,
+				localAutosaveInterval: 100000000000,
 			} );
 		} );
 	} );

--- a/packages/e2e-tests/specs/performance/post-editor.test.js
+++ b/packages/e2e-tests/specs/performance/post-editor.test.js
@@ -86,12 +86,10 @@ describe( 'Post Editor Performance', () => {
 	beforeEach( async () => {
 		// Disable auto-save to avoid impacting the metrics.
 		await page.evaluate( () => {
-			window.wp.data
-				.dispatch( 'core/preferences' )
-				.set( 'core/edit-post', 'localAutosaveInterval', 100000000000 );
-			window.wp.data
-				.dispatch( 'core/editor' )
-				.updateEditorSettings( { autosaveInterval: 100000000000 } );
+			window.wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
+				autosaveInterval: 100000000000,
+				__experimentalLocalAutosaveInterval: 100000000000,
+			} );
 		} );
 	} );
 

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -18,6 +18,7 @@ import { StrictMode, useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -51,7 +52,7 @@ function Editor( {
 		( select ) => {
 			const {
 				isFeatureActive,
-				getPreference,
+				getPreference: getEditorPreference,
 				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
@@ -61,6 +62,7 @@ function Editor( {
 				coreStore
 			);
 			const { getEditorSettings } = select( editorStore );
+			const { get: getPreference } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
 			const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 				postType
@@ -87,12 +89,13 @@ function Editor( {
 				focusMode: isFeatureActive( 'focusMode' ),
 				hasReducedUI: isFeatureActive( 'reducedUI' ),
 				hasThemeStyles: isFeatureActive( 'themeStyles' ),
-				preferredStyleVariations: getPreference(
+				preferredStyleVariations: getEditorPreference(
 					'preferredStyleVariations'
 				),
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
 				__experimentalLocalAutosaveInterval: getPreference(
+					'core/edit-post',
 					'localAutosaveInterval'
 				),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -18,7 +18,6 @@ import { StrictMode, useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -44,7 +43,6 @@ function Editor( {
 		preferredStyleVariations,
 		hiddenBlockTypes,
 		blockTypes,
-		__experimentalLocalAutosaveInterval,
 		keepCaretInsideBlock,
 		isTemplateMode,
 		template,
@@ -52,7 +50,7 @@ function Editor( {
 		( select ) => {
 			const {
 				isFeatureActive,
-				getPreference: getEditorPreference,
+				getPreference,
 				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
@@ -62,7 +60,6 @@ function Editor( {
 				coreStore
 			);
 			const { getEditorSettings } = select( editorStore );
-			const { get: getPreference } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
 			const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 				postType
@@ -89,15 +86,11 @@ function Editor( {
 				focusMode: isFeatureActive( 'focusMode' ),
 				hasReducedUI: isFeatureActive( 'reducedUI' ),
 				hasThemeStyles: isFeatureActive( 'themeStyles' ),
-				preferredStyleVariations: getEditorPreference(
+				preferredStyleVariations: getPreference(
 					'preferredStyleVariations'
 				),
 				hiddenBlockTypes: getHiddenBlockTypes(),
 				blockTypes: getBlockTypes(),
-				__experimentalLocalAutosaveInterval: getPreference(
-					'core/edit-post',
-					'localAutosaveInterval'
-				),
 				keepCaretInsideBlock: isFeatureActive( 'keepCaretInsideBlock' ),
 				isTemplateMode: isEditingTemplate(),
 				template:
@@ -124,7 +117,6 @@ function Editor( {
 			hasFixedToolbar,
 			focusMode,
 			hasReducedUI,
-			__experimentalLocalAutosaveInterval,
 
 			// This is marked as experimental to give time for the quick inserter to mature.
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
@@ -159,7 +151,6 @@ function Editor( {
 		hiddenBlockTypes,
 		blockTypes,
 		preferredStyleVariations,
-		__experimentalLocalAutosaveInterval,
 		setIsInserterOpened,
 		updatePreferredStyleVariations,
 		keepCaretInsideBlock,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -107,6 +107,7 @@ export function initializeEditor(
 	);
 
 	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
+		editorMode: 'visual',
 		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -111,7 +111,6 @@ export function initializeEditor(
 		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
-		localAutosaveInterval: 15,
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		themeStyles: true,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -110,6 +110,7 @@ export function initializeEditor(
 		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
+		localAutosaveInterval: 15,
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		themeStyles: true,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -3,6 +3,8 @@
  */
 import '@wordpress/core-data';
 import '@wordpress/format-library';
+import { dispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -19,5 +21,13 @@ import Editor from './editor';
  * @param {Object} postId   ID of the post to edit (unused right now)
  */
 export function initializeEditor( id, postType, postId ) {
+	dispatch( preferencesStore ).setDefaults( 'core/edit-post', {
+		editorMode: 'visual',
+		fixedToolbar: false,
+		fullscreenMode: true,
+		hiddenBlockTypes: [],
+		welcomeGuide: true,
+	} );
+
 	return <Editor postId={ postId } postType={ postType } />;
 }

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -155,11 +155,10 @@ export const toggleFeature = ( feature ) => ( { registry } ) =>
  *
  * @param {string} mode The editor mode.
  */
-export const switchEditorMode = ( mode ) => ( { dispatch, registry } ) => {
-	dispatch( {
-		type: 'SWITCH_MODE',
-		mode,
-	} );
+export const switchEditorMode = ( mode ) => ( { registry } ) => {
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/edit-post', 'editorMode', mode );
 
 	// Unselect blocks when we switch to the code editor.
 	if ( mode !== 'visual' ) {

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -205,20 +205,6 @@ export function updatePreferredStyleVariations( blockName, blockStyle ) {
 }
 
 /**
- * Returns an action object used in signalling that the editor should attempt
- * to locally autosave the current post every `interval` seconds.
- *
- * @param {number} interval The new interval, in seconds.
- * @return {Object} Action object.
- */
-export function __experimentalUpdateLocalAutosaveInterval( interval ) {
-	return {
-		type: 'UPDATE_LOCAL_AUTOSAVE_INTERVAL',
-		interval,
-	};
-}
-
-/**
  * Update the provided block types to be visible.
  *
  * @param {string[]} blockNames Names of block types to show.

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -7,5 +7,4 @@ export const PREFERENCES_DEFAULTS = {
 	},
 	hiddenBlockTypes: [],
 	preferredStyleVariations: {},
-	localAutosaveInterval: 15,
 };

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -1,5 +1,4 @@
 export const PREFERENCES_DEFAULTS = {
-	editorMode: 'visual',
 	panels: {
 		'post-status': {
 			opened: true,

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -102,14 +102,6 @@ export const preferences = flow( [
 		}
 		return state;
 	},
-	localAutosaveInterval( state, action ) {
-		switch ( action.type ) {
-			case 'UPDATE_LOCAL_AUTOSAVE_INTERVAL':
-				return action.interval;
-		}
-
-		return state;
-	},
 } );
 
 /**

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -78,13 +78,6 @@ export const preferences = flow( [
 
 		return state;
 	},
-	editorMode( state, action ) {
-		if ( action.type === 'SWITCH_MODE' ) {
-			return action.mode;
-		}
-
-		return state;
-	},
 	preferredStyleVariations( state, action ) {
 		switch ( action.type ) {
 			case 'UPDATE_PREFERRED_STYLE_VARIATIONS': {

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -91,7 +91,7 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
 
 // The current list of preference keys that have been migrated to the
 // preferences package.
-const MIGRATED_KEYS = [ 'hiddenBlockTypes' ];
+const MIGRATED_KEYS = [ 'hiddenBlockTypes', 'localAutosaveInterval' ];
 
 /**
  * Returns the preferences (these preferences are persisted locally).

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -22,9 +22,9 @@ const EMPTY_ARRAY = [];
  *
  * @return {string} Editing mode.
  */
-export function getEditorMode( state ) {
-	return getPreference( state, 'editorMode', 'visual' );
-}
+export const getEditorMode = createRegistrySelector( ( select ) => () =>
+	select( preferencesStore ).get( 'core/edit-post', 'editorMode' )
+);
 
 /**
  * Returns true if the editor sidebar is opened.
@@ -91,7 +91,11 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
 
 // The current list of preference keys that have been migrated to the
 // preferences package.
-const MIGRATED_KEYS = [ 'hiddenBlockTypes', 'localAutosaveInterval' ];
+const MIGRATED_KEYS = [
+	'hiddenBlockTypes',
+	'localAutosaveInterval',
+	'editorMode',
+];
 
 /**
  * Returns the preferences (these preferences are persisted locally).

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -23,7 +23,7 @@ const EMPTY_ARRAY = [];
  * @return {string} Editing mode.
  */
 export const getEditorMode = createRegistrySelector( ( select ) => () =>
-	select( preferencesStore ).get( 'core/edit-post', 'editorMode' )
+	select( preferencesStore ).get( 'core/edit-post', 'editorMode' ) ?? 'visual'
 );
 
 /**

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -91,11 +91,7 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
 
 // The current list of preference keys that have been migrated to the
 // preferences package.
-const MIGRATED_KEYS = [
-	'hiddenBlockTypes',
-	'localAutosaveInterval',
-	'editorMode',
-];
+const MIGRATED_KEYS = [ 'hiddenBlockTypes', 'editorMode' ];
 
 /**
  * Returns the preferences (these preferences are persisted locally).

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -196,21 +196,6 @@ describe( 'actions', () => {
 		} );
 	} );
 
-	describe( '__experimentalUpdateLocalAutosaveInterval', () => {
-		it( 'sets the local autosave interval', () => {
-			registry
-				.dispatch( editPostStore )
-				.__experimentalUpdateLocalAutosaveInterval( 42 );
-
-			// TODO - remove once `getPreference` is deprecated.
-			expect(
-				registry
-					.select( editPostStore )
-					.getPreference( 'localAutosaveInterval' )
-			).toBe( 42 );
-		} );
-	} );
-
 	describe( 'toggleEditorPanelEnabled', () => {
 		it( 'toggles panels to be enabled and not enabled', () => {
 			const defaultState = {

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -71,6 +71,11 @@ describe( 'actions', () => {
 
 	describe( 'switchEditorMode', () => {
 		it( 'to visual', () => {
+			// Switch to text first, since the default is visual.
+			registry.dispatch( editPostStore ).switchEditorMode( 'text' );
+			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
+				'text'
+			);
 			registry.dispatch( editPostStore ).switchEditorMode( 'visual' );
 			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
 				'visual'
@@ -78,6 +83,10 @@ describe( 'actions', () => {
 		} );
 
 		it( 'to text', () => {
+			// It defaults to visual.
+			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
+				'visual'
+			);
 			// Add a selected client id and make sure it's there.
 			const clientId = 'clientId_1';
 			registry.dispatch( blockEditorStore ).selectionChange( clientId );
@@ -89,6 +98,9 @@ describe( 'actions', () => {
 			expect(
 				registry.select( blockEditorStore ).getSelectedBlockClientId()
 			).toBeNull();
+			expect( registry.select( editPostStore ).getEditorMode() ).toEqual(
+				'text'
+			);
 		} );
 	} );
 

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -142,15 +142,6 @@ describe( 'state', () => {
 				'post-status': { opened: false },
 			} );
 		} );
-
-		it( 'should return switched mode', () => {
-			const state = preferences( deepFreeze( { editorMode: 'visual' } ), {
-				type: 'SWITCH_MODE',
-				mode: 'text',
-			} );
-
-			expect( state.editorMode ).toBe( 'text' );
-		} );
 	} );
 
 	describe( 'activeModal', () => {

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -7,7 +7,6 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getEditorMode,
 	getPreference,
 	isEditorPanelOpened,
 	isModalActive,
@@ -22,24 +21,6 @@ import {
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( 'getEditorMode', () => {
-		it( 'should return the selected editor mode', () => {
-			const state = {
-				preferences: { editorMode: 'text' },
-			};
-
-			expect( getEditorMode( state ) ).toEqual( 'text' );
-		} );
-
-		it( 'should fallback to visual if not set', () => {
-			const state = {
-				preferences: {},
-			};
-
-			expect( getEditorMode( state ) ).toEqual( 'visual' );
-		} );
-	} );
-
 	describe( 'getPreference', () => {
 		it( 'should return the preference value if set', () => {
 			const state = {

--- a/packages/editor/src/components/local-autosave-monitor/README.md
+++ b/packages/editor/src/components/local-autosave-monitor/README.md
@@ -11,7 +11,7 @@
 The interval used for the local autosave can be modified by updating the editor settings
 ```js
 wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
-	__experimentalLocalAutosaveInterval: 100000000000,
+	localAutosaveInterval: 100000000000,
 } );
 ```
 

--- a/packages/editor/src/components/local-autosave-monitor/README.md
+++ b/packages/editor/src/components/local-autosave-monitor/README.md
@@ -6,7 +6,7 @@
 -   warn the user upon loading a post that there is a local copy that can be loaded;
 -   defer to remote autosaves, if any is available.
 
-`LocalAutosaveMonitor` observes a saving interval defined specifically for local autosaves, in contrast with remote (server-side) autosaving. See editor setting `__experimentalLocalAutosaveInterval` and setter `__experimentalUpdateLocalAutosaveInterval`.
+`LocalAutosaveMonitor` observes a saving interval defined specifically for local autosaves, in contrast with remote (server-side) autosaving. See the preference `localAutosaveInterval`.
 
 ## Example
 

--- a/packages/editor/src/components/local-autosave-monitor/README.md
+++ b/packages/editor/src/components/local-autosave-monitor/README.md
@@ -6,7 +6,16 @@
 -   warn the user upon loading a post that there is a local copy that can be loaded;
 -   defer to remote autosaves, if any is available.
 
-`LocalAutosaveMonitor` observes a saving interval defined specifically for local autosaves, in contrast with remote (server-side) autosaving. See the preference `localAutosaveInterval`.
+`LocalAutosaveMonitor` observes a saving interval defined specifically for local autosaves, in contrast with remote (server-side) autosaving.
+
+The interval used for the local autosave can be modified using the preferences store:
+```js
+// Set the interval.
+wp.data.dispatch( 'core/preferences' ).set( 'core/edit-post', 'localAutosaveInterval', 100 );
+
+// Get the interval.
+wp.data.select( 'core/preferences' ).get( 'core/edit-post', 'localAutosaveInterval' ); // 100
+```
 
 ## Example
 

--- a/packages/editor/src/components/local-autosave-monitor/README.md
+++ b/packages/editor/src/components/local-autosave-monitor/README.md
@@ -8,13 +8,11 @@
 
 `LocalAutosaveMonitor` observes a saving interval defined specifically for local autosaves, in contrast with remote (server-side) autosaving.
 
-The interval used for the local autosave can be modified using the preferences store:
+The interval used for the local autosave can be modified by updating the editor settings
 ```js
-// Set the interval.
-wp.data.dispatch( 'core/preferences' ).set( 'core/edit-post', 'localAutosaveInterval', 100 );
-
-// Get the interval.
-wp.data.select( 'core/preferences' ).get( 'core/edit-post', 'localAutosaveInterval' ); // 100
+wp.data.dispatch( 'core/editor' ).updateEditorSettings( {
+	__experimentalLocalAutosaveInterval: 100000000000,
+} );
 ```
 
 ## Example

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -178,7 +178,7 @@ function LocalAutosaveMonitor() {
 	const { localAutosaveInterval } = useSelect(
 		( select ) => ( {
 			localAutosaveInterval: select( editorStore ).getEditorSettings()
-				.__experimentalLocalAutosaveInterval,
+				.localAutosaveInterval,
 		} ),
 		[]
 	);

--- a/packages/editor/src/store/defaults.js
+++ b/packages/editor/src/store/defaults.js
@@ -9,23 +9,22 @@ export const PREFERENCES_DEFAULTS = {
 };
 
 /**
- * The default post editor settings
+ * The default post editor settings.
  *
- *  allowedBlockTypes  boolean|Array Allowed block types
- *  richEditingEnabled boolean       Whether rich editing is enabled or not
- *  codeEditingEnabled boolean       Whether code editing is enabled or not
- *  enableCustomFields boolean       Whether the WordPress custom fields are enabled or not.
- *                                     true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
- *                                     false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
- *                                     undefined = the current environment does not support Custom Fields,
- *                                                 so the option toggle in Preferences -> Panels to
- *                                                 enable the Custom Fields panel is not displayed.
- *  autosaveInterval   number        Autosave Interval
- *  availableTemplates array?        The available post templates
- *  disablePostFormats boolean       Whether or not the post formats are disabled
- *  allowedMimeTypes   array?        List of allowed mime types and file extensions
- *  maxUploadFileSize  number        Maximum upload file size
- *  supportsLayout     boolean      Whether the editor supports layouts.
+ * @property {boolean|Array} allowedBlockTypes     Allowed block types
+ * @property {boolean}       richEditingEnabled    Whether rich editing is enabled or not
+ * @property {boolean}       codeEditingEnabled    Whether code editing is enabled or not
+ * @property {boolean}       enableCustomFields    Whether the WordPress custom fields are enabled or not.
+ *                                                 true  = the user has opted to show the Custom Fields panel at the bottom of the editor.
+ *                                                 false = the user has opted to hide the Custom Fields panel at the bottom of the editor.
+ *                                                 undefined = the current environment does not support Custom Fields, so the option toggle in Preferences -> Panels to enable the Custom Fields panel is not displayed.
+ * @property {number}        autosaveInterval      How often in seconds the post will be auto-saved via the REST API.
+ * @property {number}        localAutosaveInterval How often in seconds the post will be backed up to sessionStorage.
+ * @property {Array?}        availableTemplates    The available post templates
+ * @property {boolean}       disablePostFormats    Whether or not the post formats are disabled
+ * @property {Array?}        allowedMimeTypes      List of allowed mime types and file extensions
+ * @property {number}        maxUploadFileSize     Maximum upload file size
+ * @property {boolean}       supportsLayout        Whether the editor supports layouts.
  */
 export const EDITOR_SETTINGS_DEFAULTS = {
 	...SETTINGS_DEFAULTS,


### PR DESCRIPTION
## Description
Addresses some of https://github.com/WordPress/gutenberg/issues/31965

This migrates the post editor's `editorMode` preferences to use the new preferences store. This preference is. used for determining whether the visual or code editor is shown.

`localAutosaveInterval` has also been changed via some code review feedback. It's now now no longer an editor preference, instead this value is set or updated via editor settings alone. The setting is now stable, it's been around for a few years, so seems like a good time to make this happen.

## Testing Instructions
#### Code editor
1. Delete your WP localstorage data
2. Using `trunk` open the post editor and dismiss the welcome guide
3. Switch from the Visual Editor to the Code editor
4. Checkout this branch and rebuild
5. Reload the site editor
6. The welcome guide should not show and the code editor should still be shown (preference changes were migrated correctly)
7. Switch back to Visual editor
8. Reload
9. The visual editor should be shown (preference changes are still persisted)

#### Autosave Interval
No need to switch branches for this test, just build this branch.
1. Open the post editor to a new post.
2. Add some initial content and save it as a draft.
3. Open the browser dev tools and inspect the Session Storage. This is where the local autosave is saved. To do this in Chrome go to the Application tab, click Session Storage from the right panel, and choose the URL that corresponds to your test site.
4. Make some changes to the post title and then wait.
5. You should see an entry for your post (in the format wp-autosave-_postid_) appear or be updated.

Another option is to add a console log to this line - [packages/editor/src/components/local-autosave-monitor/index.js](https://github.com/WordPress/gutenberg/blob/trunk/packages%2Feditor%2Fsrc%2Fcomponents%2Flocal-autosave-monitor%2Findex.js#L185) to log out the value of `localAutosaveInterval`. It should be `15` by default.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
