### PR TITLE
MediaReplaceFlow: Add 'onError' prop to handle error notifications

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -56,25 +56,18 @@ Callback used when media is replaced with an URL. It is called with one argument
 -   Type: `func`
 -   Required: Yes
 
+### onError
+
+Callback called when an upload error happens and receives an error message as an argument.
+
+-   Type: `func`
+-   Required: Yes
+
 ### name
 
 The label of the replace button.
 
 -   Type: `string`
--   Required: No
-
-### createNotice
-
-Creates a media replace notice.
-
--   Type: `func`
--   Required: No
-
-### removeNotice
-
-Removes a media replace notice.
-
--   Type: `func`
 -   Required: No
 
 ### children

--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -61,7 +61,7 @@ Callback used when media is replaced with an URL. It is called with one argument
 Callback called when an upload error happens and receives an error message as an argument.
 
 -   Type: `func`
--   Required: Yes
+-   Required: No
 
 ### name
 

--- a/packages/block-editor/src/components/media-replace-flow/README.md
+++ b/packages/block-editor/src/components/media-replace-flow/README.md
@@ -70,6 +70,20 @@ The label of the replace button.
 -   Type: `string`
 -   Required: No
 
+### createNotice
+
+Creates a media replace notice.
+
+-   Type: `func`
+-   Required: No
+
+### removeNotice
+
+Removes a media replace notice.
+
+-   Type: `func`
+-   Required: No
+
 ### children
 
 -   Type: `Element`

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -6,7 +6,7 @@ import { noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, createRef } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import {
@@ -50,7 +50,7 @@ const MediaReplaceFlow = ( {
 	const mediaUpload = useSelect( ( select ) => {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
-	const editMediaButtonRef = createRef();
+	const editMediaButtonRef = useRef();
 
 	const selectMedia = ( media, closeMenu ) => {
 		closeMenu();

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -90,10 +90,6 @@ const MediaReplaceFlow = ( {
 		removeNotice( errorNoticeID );
 	};
 
-	const selectURL = ( newURL ) => {
-		onSelectURL( newURL );
-	};
-
 	const uploadFiles = ( event, closeMenu ) => {
 		const files = event.target.files;
 		if ( ! handleUpload ) {
@@ -204,7 +200,7 @@ const MediaReplaceFlow = ( {
 								showSuggestions={ false }
 								onChange={ ( { url } ) => {
 									setMediaURLValue( url );
-									selectURL( url );
+									onSelectURL( url );
 									editMediaButtonRef.current.focus();
 								} }
 							/>


### PR DESCRIPTION
## Description
PR adds the `onError` prop to the `MediaReplaceFlow` component, letting blocks handle error notifications. It also makes it possible to update block attributes on an error and display them in a placeholder state.

Note: Some blocks are already passing this prop, but it was doing nothing.

## Testing Instructions
1. Open a Post or Page.
2. Add the File block and select file.
3. Emulate upload error using the example code below.
4. Click on "Replace" in the block toolbar and replace the file using the "Upload" action.
5. Confirm that the error message is displayed.

```php
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'Image files must be smaller than 10kb';
	return $file;
} );
```

## Types of changes
Enhancement

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
