### PR TITLE
Block Library: Fix Comments Pagination Number with no pagination settings

### DIFF
--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -37,12 +37,12 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 
 		$inherit = ! empty( $block->context['comments/inherit'] );
 
-		$per_page       = (int) get_option( 'comments_per_page' );
-		$query_per_page = (int) get_query_var( 'comments_per_page' );
-		if ( 0 !== $query_per_page ) {
-			$per_page = $query_per_page;
+		$per_page = 0;
+		$block_per_page = ! empty( $block->context['comments/perPage'] ) ? (int) $block->context['comments/perPage'] : null;
+		if ( $inherit && get_option( 'page_comments' )  ) {
+			$per_page = get_option( 'comments_per_page' );
 		}
-		$block_per_page = ! empty( $block->context['comments/perPage'] ) ? (int) $block->context['comments/perPage'] : 0;
+
 		if ( ! $inherit && 0 !== $block_per_page ) {
 			$per_page = $block_per_page;
 		}

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -37,6 +37,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 
 		$inherit = ! empty( $block->context['comments/inherit'] );
 
+		$per_page = 0;
 		if ( $inherit && get_option( 'page_comments' ) ) {
 			$per_page = get_option( 'comments_per_page' );
 		}

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -37,7 +37,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 
 		$inherit = ! empty( $block->context['comments/inherit'] );
 
-		if ( $inherit && get_option( 'page_comments' )  ) {
+		if ( $inherit && get_option( 'page_comments' ) ) {
 			$per_page = get_option( 'comments_per_page' );
 		}
 

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -37,14 +37,12 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 
 		$inherit = ! empty( $block->context['comments/inherit'] );
 
-		$per_page = 0;
-		$block_per_page = ! empty( $block->context['comments/perPage'] ) ? (int) $block->context['comments/perPage'] : null;
 		if ( $inherit && get_option( 'page_comments' )  ) {
 			$per_page = get_option( 'comments_per_page' );
 		}
 
-		if ( ! $inherit && 0 !== $block_per_page ) {
-			$per_page = $block_per_page;
+		if ( ! $inherit && ! empty( $block->context['comments/perPage'] ) ) {
+			$per_page = (int) $block->context['comments/perPage'];
 		}
 
 		$default_page = get_option( 'default_comments_page' );

--- a/packages/block-library/src/comments-pagination-numbers/index.php
+++ b/packages/block-library/src/comments-pagination-numbers/index.php
@@ -23,7 +23,7 @@ function render_block_core_comments_pagination_numbers( $attributes, $content, $
 	$comment_vars = build_comment_query_vars_from_block( $block );
 
 	$total   = ( new WP_Comment_Query( $comment_vars ) )->max_num_pages;
-	$current = $comment_vars['paged'];
+	$current = ! empty( $comment_vars['paged'] ) ? $comment_vars['paged'] : null;
 
 	// Render links.
 	$content = paginate_comments_links(

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -120,7 +120,32 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'no_found_rows'             => false,
 				'update_comment_meta_cache' => false,
 				'hierarchical'              => 'threaded',
-				'number'                    => self::$per_page,
+			)
+		);
+	}
+
+	function test_build_comment_query_vars_from_block_with_context_and_pagination() {
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'comments/perPage' => 77,
+			)
+		);
+
+		$this->assertEquals(
+			build_comment_query_vars_from_block( $block ),
+			array(
+				'orderby'                   => 'comment_date_gmt',
+				'order'                     => 'ASC',
+				'status'                    => 'approve',
+				'no_found_rows'             => false,
+				'update_comment_meta_cache' => false,
+				'hierarchical'              => 'threaded',
+				'number'                    => 77,
 				'paged'                     => 1,
 			)
 		);


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes partial #39157 (not fixing anything related with order)

Before the PR, if the `Inherit from Discussion Settings` option is enabled in the Comments Query loop, it did not respect the setting `Break comments into pages with X top level comments per page and the last/first page displayed by default`.

After the fix, the Comments Query Loop, on the frontend, if we have `Inherit from Discussion Settings` enabled, will apply the settings selected by the user on Discussion Settings.

## How to test

In trunk (before)
1. Go to Discussion Settings and disable the "Break comments into pages", set to a number of top level comments.
2. Go to a post with more than the number you put before comments, add the Comments Query Loop block.
3. You can see on the frontend that, even when the setting is disabled, it is still breaking the comments into pages with 1 comment.

On the PR branch
1. Go to Discussion Settings and disable the "Break comments into pages" to 1 top level comments.
2. Go to a post with more than 1 comment, add the Comments Query Loop block.
3. You can see on the frontend that, when the setting is disabled, now it will show all comments, respecting the setting.
4. You can also enable `break comments` settings and, in Comments Query Loop, having inherit setting enabled, it should paginate on frontend with the discussion settings selected.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
