### PR TITLE
File: Don't display loading animation on upload error

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -112,11 +112,11 @@ function FileEdit( {
 	}, [] );
 
 	useEffect( () => {
-		if ( ! fileId ) {
+		if ( ! fileId && href ) {
 			// Add a unique fileId to each file block.
 			setAttributes( { fileId: `wp-block-file--media-${ clientId }` } );
 		}
-	}, [ fileId, clientId ] );
+	}, [ href, fileId, clientId ] );
 
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -112,11 +112,11 @@ function FileEdit( {
 	}, [] );
 
 	useEffect( () => {
-		if ( ! fileId && href ) {
+		if ( ! fileId ) {
 			// Add a unique fileId to each file block.
 			setAttributes( { fileId: `wp-block-file--media-${ clientId }` } );
 		}
-	}, [ href, fileId, clientId ] );
+	}, [ fileId, clientId ] );
 
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -23,7 +23,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { useCopyToClipboard } from '@wordpress/compose';
 import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
@@ -79,7 +79,6 @@ function FileEdit( {
 		displayPreview,
 		previewHeight,
 	} = attributes;
-	const [ hasError, setHasError ] = useState( false );
 	const { media, mediaUpload } = useSelect(
 		( select ) => ( {
 			media:
@@ -101,10 +100,7 @@ function FileEdit( {
 			mediaUpload( {
 				filesList: [ file ],
 				onFileChange: ( [ newMedia ] ) => onSelectFile( newMedia ),
-				onError: ( message ) => {
-					setHasError( true );
-					noticeOperations.createErrorNotice( message );
-				},
+				onError: onUploadError,
 			} );
 
 			revokeBlobURL( href );
@@ -124,7 +120,6 @@ function FileEdit( {
 
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {
-			setHasError( false );
 			const isPdf = newMedia.url.endsWith( '.pdf' );
 			setAttributes( {
 				href: newMedia.url,
@@ -138,7 +133,7 @@ function FileEdit( {
 	}
 
 	function onUploadError( message ) {
-		setHasError( true );
+		setAttributes( { href: undefined } );
 		noticeOperations.removeAllNotices();
 		noticeOperations.createErrorNotice( message );
 	}
@@ -197,7 +192,7 @@ function FileEdit( {
 
 	const displayPreviewInEditor = browserSupportsPdfs() && displayPreview;
 
-	if ( ! href || hasError ) {
+	if ( ! href ) {
 		return (
 			<div { ...blockProps }>
 				<MediaPlaceholder


### PR DESCRIPTION
## Description
File block was still displaying loading animation after upload error.

I also refactored the error state handler to reuse the `onUploadError` method. In addition, a block is reverted to a placeholder state by removing the `href` attribute instead of storing errors in the local state. There's no need to keep URL blob if upload fails.

## Testing Instructions
1. Open a Post or Page.
2. Add File block.
3. Try uploading an unsupported file type, like JSON.
4. Confirm that the error message is displayed and there's no loading animation.

## Screenshots <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/240569/156709919-135e492d-58aa-45b3-97e6-91132c66685d.mp4

After:

https://user-images.githubusercontent.com/240569/156709909-4e719944-7ad5-4863-8e0f-fb7791f753f8.mp4

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
