### PR TITLE
File: Fix the undo trap

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -90,7 +90,10 @@ function FileEdit( {
 		[ id ]
 	);
 
-	const { toggleSelection } = useDispatch( blockEditorStore );
+	const {
+		toggleSelection,
+		__unstableMarkNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 
 	useEffect( () => {
 		// Upload a file drag-and-dropped into the editor.
@@ -112,11 +115,12 @@ function FileEdit( {
 	}, [] );
 
 	useEffect( () => {
-		if ( ! fileId ) {
+		if ( ! fileId && href ) {
 			// Add a unique fileId to each file block.
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { fileId: `wp-block-file--media-${ clientId }` } );
 		}
-	}, [ fileId, clientId ] );
+	}, [ href, fileId, clientId ] );
 
 	function onSelectFile( newMedia ) {
 		if ( newMedia && newMedia.url ) {


### PR DESCRIPTION
## Description
Fixes File block "undo trap" by marking the `fileId` attribute update as non-persistent. Props to @talldan - https://github.com/WordPress/gutenberg/pull/39213#discussion_r819296924. 

P.S. I noticed an extra undo step for the transient state because the blob URL is stored in the attribute. It is a documented issue (#8119) and probably affects other media upload blocks.

## Testing Instructions
1. Add a file block
2. Drag a valid file type
3. Pressing undo should revert to the block's initial state.

## Types of changes
Bugfix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
