### PR TITLE
Post Terms: Unescape HTML entities in term names

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { unescape } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -88,7 +89,7 @@ export default function PostTermsEdit( {
 								href={ postTerm.link }
 								onClick={ ( event ) => event.preventDefault() }
 							>
-								{ postTerm.name }
+								{ unescape( postTerm.name ) }
 							</a>
 						) )
 						.reduce( ( prev, curr ) => (


### PR DESCRIPTION
## Description
The Post Terms blocks currently displays raw HTML entities.

## Testing Instructions
* Create a post with a tag named "Hello & World"
* Create a post with a query block which includes the above post and add the Post Terms block to it

## Screenshots <!-- if applicable -->

Before:
<img width="465" alt="Bildschirmfoto 2022-03-04 um 09 27 58" src="https://user-images.githubusercontent.com/617637/156727882-7ded0a74-e414-48a9-8397-e2739c7d8817.png">

After:
<img width="461" alt="Bildschirmfoto 2022-03-04 um 09 32 16" src="https://user-images.githubusercontent.com/617637/156727864-accd9b95-2458-4c46-b02d-6f5ea78a6beb.png">



## Types of changes
Bug fix

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [-] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [- I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [-] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [-] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [-] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [-] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
