### PR TITLE
[Mobile] `UnitControl`: align component with web counterpart

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.native.js
+++ b/packages/block-editor/src/components/line-height-control/index.native.js
@@ -12,6 +12,8 @@ export default function LineHeightControl( { value: lineHeight, onChange } ) {
 	const isDefined = isLineHeightDefined( lineHeight );
 	const value = isDefined ? lineHeight : BASE_DEFAULT_VALUE;
 	return (
+		// If there's no units, this should be a `NumberControl` ?
+		// Alternatively, use `disableUnits` prop.
 		<UnitControl
 			label={ __( 'Line Height' ) }
 			// Set minimun value of 1 since lower values break on Android
@@ -22,7 +24,8 @@ export default function LineHeightControl( { value: lineHeight, onChange } ) {
 			onChange={ onChange }
 			// TODO: should be updated to avoid using `false`, in order to
 			// align with the web version of `UnitControl`
-			units={ false }
+			units={ [] }
+			disableUnits={ true }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

The `UnitControl` native component's logic is currently out-of-date compared to the web counterparts and the docs.

In particular:
- the native component assumes that `value` only contains the numeric quantity, and the the unit should be passed via the `unit` prop
- the native component has a couple of props that are not documented (`currentInput`, `initialPosition`)
- the native component still accepts a value of `false` for the `units` prop

For reference:
- the `unit` prop is marked as deprecated and should be not used anymore
- the `value` prop is expected to contain both the quantity and the unit (e.g `'34%'`)
- the `units` prop is expected to be only an array of unit objects (and not a boolean)
- if in need of disabling the units via `units = {false}`, a better approach could be to use the `disableUnits` prop

cc @geriux 

---

As a follow-up, once the native `UnitControl` also deprecates the `unit` prop, we should **update all the instances in which native consumers of this component use the `unit` prop** — as a reference, this was tracked in https://github.com/WordPress/gutenberg/pull/39503 for the web version of the component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
