### PR TITLE
Improve create new UI feedback in Nav block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -61,7 +61,11 @@ import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_PENDING,
 	CLASSIC_MENU_CONVERSION_SUCCESS,
 } from './use-convert-classic-menu-to-block-menu';
-import useCreateNavigationMenu from './use-create-navigation-menu';
+import useCreateNavigationMenu, {
+	CREATE_NAVIGATION_MENU_ERROR,
+	CREATE_NAVIGATION_MENU_PENDING,
+	CREATE_NAVIGATION_MENU_SUCCESS,
+} from './use-create-navigation-menu';
 
 const EMPTY_ARRAY = [];
 
@@ -180,11 +184,11 @@ function Navigation( {
 	useEffect( () => {
 		hideNavigationMenuCreateNotice();
 
-		if ( createNavigationMenuStatus === 'pending' ) {
+		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING ) {
 			speak( __( `Creating Navigation Menu.` ) );
 		}
 
-		if ( createNavigationMenuStatus === 'success' ) {
+		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_SUCCESS ) {
 			setRef( createNavigationMenuPost.id );
 			selectBlock( clientId );
 
@@ -193,7 +197,7 @@ function Navigation( {
 			);
 		}
 
-		if ( createNavigationMenuStatus === 'error' ) {
+		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_ERROR ) {
 			showNavigationMenuCreateNotice(
 				__( 'Failed to create Navigation Menu.' )
 			);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -290,7 +290,7 @@ function Navigation( {
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =
-createNavigationMenuStatus === 'pending' ||
+		createNavigationMenuStatus === 'pending' ||
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -163,6 +163,13 @@ function Navigation( {
 	// the Select Menu dropdown.
 	useNavigationEntities();
 
+	const [
+		showNavigationMenuCreateNotice,
+		hideNavigationMenuCreateNotice,
+	] = useNavigationNotice( {
+		name: 'block-library/core/navigation/create',
+	} );
+
 	const {
 		create: createNavigationMenu,
 		status: createNavigationMenuStatus,
@@ -171,9 +178,25 @@ function Navigation( {
 	} = useCreateNavigationMenu( clientId );
 
 	useEffect( () => {
+		hideNavigationMenuCreateNotice();
+
+		if ( createNavigationMenuStatus === 'pending' ) {
+			speak( __( `Creating Navigation Menu.` ) );
+		}
+
 		if ( createNavigationMenuStatus === 'success' ) {
 			setRef( createNavigationMenuPost.id );
 			selectBlock( clientId );
+
+			showNavigationMenuCreateNotice(
+				__( `Navigation Menu successfully created.` )
+			);
+		}
+
+		if ( createNavigationMenuStatus === 'error' ) {
+			showNavigationMenuCreateNotice(
+				__( 'Failed to create Navigation Menu.' )
+			);
 		}
 	}, [
 		createNavigationMenu,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -181,6 +181,9 @@ function Navigation( {
 		value: createNavigationMenuPost,
 	} = useCreateNavigationMenu( clientId );
 
+	const isCreatingNavigationMenu =
+		createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING;
+
 	useEffect( () => {
 		hideNavigationMenuCreateNotice();
 
@@ -298,13 +301,14 @@ function Navigation( {
 	const TagName = 'nav';
 
 	// "placeholder" shown if:
-	// - we don't have a ref attribute pointing to a Navigation Post.
-	// - we are not running a menu conversion process.
-	// - we don't have uncontrolled blocks.
-	// - (legacy) we have a Navigation Area without a ref attribute pointing to a Navigation Post.
+	// - there is no ref attribute pointing to a Navigation Post.
+	// - there is no classic menu conversion process in progress.
+	// - there is no menu creation process in progress.
+	// - there are no uncontrolled blocks.
+	// - (legacy) there is a Navigation Area without a ref attribute pointing to a Navigation Post.
 	const isPlaceholder =
-		createNavigationMenuStatus !== 'pending' &&
 		! ref &&
+		! isCreatingNavigationMenu &&
 		! isConvertingClassicMenu &&
 		( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
 
@@ -312,12 +316,13 @@ function Navigation( {
 		! isNavigationMenuMissing && isNavigationMenuResolved;
 
 	// "loading" state:
-	// - we are running the Classic Menu conversion process.
+	// - there is a menu creation process in progress.
+	// - there is a classic menu conversion process in progress.
 	// OR
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =
-		createNavigationMenuStatus === 'pending' ||
+		isCreatingNavigationMenu ||
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -61,6 +61,7 @@ import useConvertClassicToBlockMenu, {
 	CLASSIC_MENU_CONVERSION_PENDING,
 	CLASSIC_MENU_CONVERSION_SUCCESS,
 } from './use-convert-classic-menu-to-block-menu';
+import useCreateNavigationMenu from './use-create-navigation-menu';
 
 const EMPTY_ARRAY = [];
 
@@ -163,6 +164,25 @@ function Navigation( {
 	useNavigationEntities();
 
 	const {
+		create: createNavigationMenu,
+		status: createNavigationMenuStatus,
+		error: createNavigationMenuError,
+		value: createNavigationMenuPost,
+	} = useCreateNavigationMenu( clientId );
+
+	useEffect( () => {
+		if ( createNavigationMenuStatus === 'success' ) {
+			setRef( createNavigationMenuPost.id );
+			selectBlock( clientId );
+		}
+	}, [
+		createNavigationMenu,
+		createNavigationMenuStatus,
+		createNavigationMenuError,
+		createNavigationMenuPost,
+	] );
+
+	const {
 		hasUncontrolledInnerBlocks,
 		uncontrolledInnerBlocks,
 		isInnerBlockSelected,
@@ -256,6 +276,7 @@ function Navigation( {
 	// - we don't have uncontrolled blocks.
 	// - (legacy) we have a Navigation Area without a ref attribute pointing to a Navigation Post.
 	const isPlaceholder =
+		createNavigationMenuStatus !== 'pending' &&
 		! ref &&
 		! isConvertingClassicMenu &&
 		( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
@@ -269,6 +290,7 @@ function Navigation( {
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =
+createNavigationMenuStatus === 'pending' ||
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );
 
@@ -569,6 +591,7 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onFinish={ handleSelectNavigation }
+					onCreateEmpty={ createNavigationMenu }
 				/>
 			</TagName>
 		);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -515,7 +515,7 @@ function Navigation( {
 		[ convert, handleUpdateMenu ]
 	);
 
-	const startWithEmptyMenu = useCallback( () => {
+	const resetToEmptyBlock = useCallback( () => {
 		registry.batch( () => {
 			if ( navigationArea ) {
 				setAreaMenu( 0 );
@@ -577,7 +577,7 @@ function Navigation( {
 					{ __(
 						'Navigation menu has been deleted or is unavailable. '
 					) }
-					<Button onClick={ startWithEmptyMenu } variant="link">
+					<Button onClick={ resetToEmptyBlock } variant="link">
 						{ __( 'Create a new menu?' ) }
 					</Button>
 				</Warning>
@@ -634,7 +634,7 @@ function Navigation( {
 								currentMenuId={ ref }
 								clientId={ clientId }
 								onSelect={ handleSelectNavigation }
-								onCreateNew={ startWithEmptyMenu }
+								onCreateNew={ resetToEmptyBlock }
 								/* translators: %s: The name of a menu. */
 								actionLabel={ __( "Switch to '%s'" ) }
 								showManageActions
@@ -789,7 +789,7 @@ function Navigation( {
 						{ hasResolvedCanUserDeleteNavigationMenu &&
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
-									onDelete={ startWithEmptyMenu }
+									onDelete={ resetToEmptyBlock }
 								/>
 							) }
 					</InspectorControls>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -591,7 +591,7 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onFinish={ handleSelectNavigation }
-					onCreateEmpty={ createNavigationMenu }
+					onCreateEmpty={ () => createNavigationMenu( [] ) }
 				/>
 			</TagName>
 		);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -614,7 +614,7 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onFinish={ handleSelectNavigation }
-					onCreateEmpty={ () => createNavigationMenu( [] ) }
+					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
 				/>
 			</TagName>
 		);

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -40,6 +40,10 @@ export default function NavigationMenuSelector( {
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
+	const { create: createNavigationMenu } = useCreateNavigationMenu(
+		clientId
+	);
+
 	const handleSelect = useCallback(
 		( _onClose ) => ( selectedId ) => {
 			_onClose();

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -40,10 +40,6 @@ export default function NavigationMenuSelector( {
 		canSwitchNavigationMenu,
 	} = useNavigationMenu();
 
-	const { create: createNavigationMenu } = useCreateNavigationMenu(
-		clientId
-	);
-
 	const handleSelect = useCallback(
 		( _onClose ) => ( selectedId ) => {
 			_onClose();

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -12,7 +12,6 @@ import { useEffect } from '@wordpress/element';
  */
 import useNavigationEntities from '../../use-navigation-entities';
 import PlaceholderPreview from './placeholder-preview';
-import useCreateNavigationMenu from '../use-create-navigation-menu';
 import NavigationMenuSelector from '../navigation-menu-selector';
 
 export default function NavigationPlaceholder( {
@@ -22,26 +21,12 @@ export default function NavigationPlaceholder( {
 	canUserCreateNavigationMenu = false,
 	isResolvingCanUserCreateNavigationMenu,
 	onFinish,
+	onCreateEmpty,
 } ) {
-	const { create: createNavigationMenu } = useCreateNavigationMenu(
-		clientId
-	);
-
-	const onFinishMenuCreation = async (
-		blocks,
-		navigationMenuTitle = null
-	) => {
-		const navigationMenu = await createNavigationMenu(
-			navigationMenuTitle,
-			blocks
-		);
-		onFinish( navigationMenu, blocks );
-	};
-
 	const { isResolvingMenus, hasResolvedMenus } = useNavigationEntities();
 
 	const onCreateEmptyMenu = () => {
-		onFinishMenuCreation( [] );
+		onCreateEmpty( [] );
 	};
 
 	useEffect( () => {

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -23,7 +23,9 @@ export default function NavigationPlaceholder( {
 	isResolvingCanUserCreateNavigationMenu,
 	onFinish,
 } ) {
-	const createNavigationMenu = useCreateNavigationMenu( clientId );
+	const { create: createNavigationMenu } = useCreateNavigationMenu(
+		clientId
+	);
 
 	const onFinishMenuCreation = async (
 		blocks,

--- a/packages/block-library/src/navigation/edit/placeholder/index.js
+++ b/packages/block-library/src/navigation/edit/placeholder/index.js
@@ -25,10 +25,6 @@ export default function NavigationPlaceholder( {
 } ) {
 	const { isResolvingMenus, hasResolvedMenus } = useNavigationEntities();
 
-	const onCreateEmptyMenu = () => {
-		onCreateEmpty( [] );
-	};
-
 	useEffect( () => {
 		if ( ! isSelected ) {
 			return;
@@ -85,7 +81,7 @@ export default function NavigationPlaceholder( {
 						{ canUserCreateNavigationMenu && (
 							<Button
 								variant="tertiary"
-								onClick={ onCreateEmptyMenu }
+								onClick={ onCreateEmpty }
 							>
 								{ __( 'Start empty' ) }
 							</Button>

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -72,7 +72,9 @@ export default function UnsavedInnerBlocks( {
 
 	const { hasResolvedNavigationMenus, navigationMenus } = useNavigationMenu();
 
-	const createNavigationMenu = useCreateNavigationMenu( clientId );
+	const { create: createNavigationMenu } = useCreateNavigationMenu(
+		clientId
+	);
 
 	// Automatically save the uncontrolled blocks.
 	useEffect( async () => {

--- a/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
+++ b/packages/block-library/src/navigation/edit/use-convert-classic-menu-to-block-menu.js
@@ -18,7 +18,9 @@ export const CLASSIC_MENU_CONVERSION_PENDING = 'pending';
 export const CLASSIC_MENU_CONVERSION_IDLE = 'idle';
 
 function useConvertClassicToBlockMenu( clientId ) {
-	const createNavigationMenu = useCreateNavigationMenu( clientId );
+	const { create: createNavigationMenu } = useCreateNavigationMenu(
+		clientId
+	);
 	const registry = useRegistry();
 
 	const [ status, setStatus ] = useState( CLASSIC_MENU_CONVERSION_IDLE );

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -28,6 +28,19 @@ export default function useCreateNavigationMenu( clientId ) {
 	// a new navigation menu when the user completes the final step.
 	const create = useCallback(
 		async ( title = null, blocks = [] ) => {
+			// Guard against creating Navigations without a title.
+			// Note you can pass no title, but if one is passed it must be
+			// a string otherwise the title may end up being empty.
+			if ( title && typeof title !== 'string' ) {
+				setError(
+					'Invalid title supplied when creating Navigation Menu.'
+				);
+				setStatus( ERROR );
+				throw new Error(
+					`Value of supplied title argument was not a string.`
+				);
+			}
+
 			setStatus( PENDING );
 			setValue( null );
 			setError( null );

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -11,13 +11,13 @@ import { useState, useCallback } from '@wordpress/element';
  */
 import useGenerateDefaultNavigationTitle from './use-generate-default-navigation-title';
 
-const SUCCESS = 'success';
-const ERROR = 'error';
-const PENDING = 'pending';
-const IDLE = 'idle';
+export const CREATE_NAVIGATION_MENU_SUCCESS = 'success';
+export const CREATE_NAVIGATION_MENU_ERROR = 'error';
+export const CREATE_NAVIGATION_MENU_PENDING = 'pending';
+export const CREATE_NAVIGATION_MENU_IDLE = 'idle';
 
 export default function useCreateNavigationMenu( clientId ) {
-	const [ status, setStatus ] = useState( IDLE );
+	const [ status, setStatus ] = useState( CREATE_NAVIGATION_MENU_IDLE );
 	const [ value, setValue ] = useState( null );
 	const [ error, setError ] = useState( null );
 
@@ -35,20 +35,20 @@ export default function useCreateNavigationMenu( clientId ) {
 				setError(
 					'Invalid title supplied when creating Navigation Menu.'
 				);
-				setStatus( ERROR );
+				setStatus( CREATE_NAVIGATION_MENU_ERROR );
 				throw new Error(
 					`Value of supplied title argument was not a string.`
 				);
 			}
 
-			setStatus( PENDING );
+			setStatus( CREATE_NAVIGATION_MENU_PENDING );
 			setValue( null );
 			setError( null );
 
 			if ( ! title ) {
 				title = await generateDefaultTitle().catch( ( err ) => {
 					setError( err?.message );
-					setStatus( ERROR );
+					setStatus( CREATE_NAVIGATION_MENU_ERROR );
 					throw new Error(
 						'Failed to create title when saving new Navigation Menu.',
 						{
@@ -67,12 +67,12 @@ export default function useCreateNavigationMenu( clientId ) {
 			return saveEntityRecord( 'postType', 'wp_navigation', record )
 				.then( ( response ) => {
 					setValue( response );
-					setStatus( SUCCESS );
+					setStatus( CREATE_NAVIGATION_MENU_SUCCESS );
 					return response;
 				} )
 				.catch( ( err ) => {
 					setError( err?.message );
-					setStatus( ERROR );
+					setStatus( CREATE_NAVIGATION_MENU_ERROR );
 					throw new Error( 'Unable to save new Navigation Menu', {
 						cause: err,
 					} );

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -4,23 +4,39 @@
 import { serialize } from '@wordpress/blocks';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import useGenerateDefaultNavigationTitle from './use-generate-default-navigation-title';
 
+const SUCCESS = 'success';
+const ERROR = 'error';
+const PENDING = 'pending';
+const IDLE = 'idle';
+
 export default function useCreateNavigationMenu( clientId ) {
+	const [ status, setStatus ] = useState( IDLE );
+	const [ value, setValue ] = useState( null );
+	const [ error, setError ] = useState( null );
+
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const generateDefaultTitle = useGenerateDefaultNavigationTitle( clientId );
 
 	// This callback uses data from the two placeholder steps and only creates
 	// a new navigation menu when the user completes the final step.
-	return useCallback(
-		async ( title = null, blocks = [] ) => {
+	const create = useCallback(
+		( title = null, blocks = [] ) => {
+			setStatus( PENDING );
+			setValue( null );
+			setError( null );
+
 			if ( ! title ) {
-				title = await generateDefaultTitle();
+				title = generateDefaultTitle().catch( ( e ) => {
+					setError( e?.message );
+					setStatus( ERROR );
+				} );
 			}
 			const record = {
 				title,
@@ -28,12 +44,25 @@ export default function useCreateNavigationMenu( clientId ) {
 				status: 'publish',
 			};
 
-			return await saveEntityRecord(
-				'postType',
-				'wp_navigation',
-				record
-			);
+			return saveEntityRecord( 'postType', 'wp_navigation', record )
+				.then( ( response ) => {
+					setValue( response );
+					setStatus( SUCCESS );
+					return response;
+				} )
+				.catch( ( e ) => {
+					setError( e?.message );
+					setStatus( ERROR );
+					return e;
+				} );
 		},
 		[ serialize, saveEntityRecord ]
 	);
+
+	return {
+		create,
+		status,
+		value,
+		error,
+	};
 }

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -33,9 +33,15 @@ export default function useCreateNavigationMenu( clientId ) {
 			setError( null );
 
 			if ( ! title ) {
-				title = generateDefaultTitle().catch( ( e ) => {
-					setError( e?.message );
+				title = generateDefaultTitle().catch( ( err ) => {
+					setError( err?.message );
 					setStatus( ERROR );
+					throw new Error(
+						'Failed to create title when saving new Navigation Menu.',
+						{
+							cause: err,
+						}
+					);
 				} );
 			}
 			const record = {
@@ -44,16 +50,19 @@ export default function useCreateNavigationMenu( clientId ) {
 				status: 'publish',
 			};
 
+			// Return affords ability to await on this function directly
 			return saveEntityRecord( 'postType', 'wp_navigation', record )
 				.then( ( response ) => {
 					setValue( response );
 					setStatus( SUCCESS );
 					return response;
 				} )
-				.catch( ( e ) => {
-					setError( e?.message );
+				.catch( ( err ) => {
+					setError( err?.message );
 					setStatus( ERROR );
-					return e;
+					throw new Error( 'Unable to save new Navigation Menu', {
+						cause: err,
+					} );
 				} );
 		},
 		[ serialize, saveEntityRecord ]

--- a/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
+++ b/packages/block-library/src/navigation/edit/use-create-navigation-menu.js
@@ -27,13 +27,13 @@ export default function useCreateNavigationMenu( clientId ) {
 	// This callback uses data from the two placeholder steps and only creates
 	// a new navigation menu when the user completes the final step.
 	const create = useCallback(
-		( title = null, blocks = [] ) => {
+		async ( title = null, blocks = [] ) => {
 			setStatus( PENDING );
 			setValue( null );
 			setError( null );
 
 			if ( ! title ) {
-				title = generateDefaultTitle().catch( ( err ) => {
+				title = await generateDefaultTitle().catch( ( err ) => {
 					setError( err?.message );
 					setStatus( ERROR );
 					throw new Error(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -513,6 +513,11 @@ describe( 'Navigation', () => {
 		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
 		await startEmptyButton.click();
 
+		// Await "success" notice.
+		await page.waitForXPath(
+			'//div[@class="components-snackbar__content"][contains(text(), "Navigation Menu successfully created.")]'
+		);
+
 		const appender = await page.waitForSelector(
 			'.wp-block-navigation .block-list-appender'
 		);

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -357,9 +357,9 @@ describe( 'Navigation', () => {
 				// Check for unconfigured Placeholder state to display
 				await page.waitForXPath( START_EMPTY_XPATH );
 
-				// Deselect the Nav block.
-				await page.keyboard.press( 'Escape' );
-				await page.keyboard.press( 'Escape' );
+				// Deselect the Nav block by inserting a new block at the root level
+				// outside of the Nav block.
+				await insertBlock( 'Paragraph' );
 
 				const navBlock = await waitForBlock( 'Navigation' );
 
@@ -386,11 +386,15 @@ describe( 'Navigation', () => {
 				);
 				await startEmptyButton.click();
 
-				const navBlock = await waitForBlock( 'Navigation' );
+				// Wait for block to resolve
+				let navBlock = await waitForBlock( 'Navigation' );
 
-				// Deselect the Nav block.
-				await page.keyboard.press( 'Escape' );
-				await page.keyboard.press( 'Escape' );
+				// Deselect the Nav block by inserting a new block at the root level
+				// outside of the Nav block.
+				await insertBlock( 'Paragraph' );
+
+				// Aquire fresh reference to block
+				navBlock = await waitForBlock( 'Navigation' );
 
 				// Check Placeholder Preview is visible.
 				await navBlock.waitForSelector(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -340,6 +340,53 @@ describe( 'Navigation', () => {
 			// Resolve the controlled mocked API request.
 			resolveNavigationRequest();
 		} );
+
+		it( 'shows a loading indicator whilst empty Navigation menu is being created', async () => {
+			const testNavId = 1;
+
+			let resolveNavigationRequest;
+
+			// Mock the request for the single Navigation post in order to fully
+			// control the resolution of the request. This will enable the ability
+			// to assert on how the UI responds during the API resolution without
+			// relying on variable factors such as network conditions.
+			await setUpResponseMocking( [
+				{
+					match: ( request ) =>
+						request.url().includes( `rest_route` ) &&
+						request.url().includes( `navigation` ) &&
+						request.url().includes( testNavId ),
+					onRequestMatch: () => {
+						// The Promise simulates a REST API request whose resolultion
+						// the test has full control over.
+						return new Promise( ( resolve ) => {
+							// Assign the resolution function to the var in the
+							// upper scope to afford control over resolution.
+							resolveNavigationRequest = resolve;
+						} );
+					},
+				},
+			] );
+
+			await createNewPost();
+			await insertBlock( 'Navigation' );
+
+			let navBlock = await waitForBlock( 'Navigation' );
+
+			// Create empty Navigation block with no items
+			const startEmptyButton = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+			await startEmptyButton.click();
+
+			navBlock = await waitForBlock( 'Navigation' );
+
+			// Check for the spinner to be present whilst loading.
+			await navBlock.waitForSelector( '.components-spinner' );
+
+			// Resolve the controlled mocked API request.
+			resolveNavigationRequest();
+		} );
 	} );
 
 	describe( 'Placeholder', () => {


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Builds on work in https://github.com/WordPress/gutenberg/pull/38858 to address part of https://github.com/WordPress/gutenberg/issues/37190.

This PR improves the UI feedback provided when creating a new menu using the `Start empty` button.

On `trunk` when you click the `Start empty` button in the placeholder, the block UI provides little or no feedback that anything is happening and can even feel like it's "frozen". 

This PR changes things so that

- the UI provides _immediate_ visual feedback that an action is taking place
- provides accessible _auditory_ feedback on the changes of state as they happen via `speak()` and/or the `<Notice>` component.
- provides a clear notice that a new empty menu has been successfully created and is ready for editing in the block - previously the empty menu would be created and you would only know by looking at the empty block. It wasn't very clear that a successful operation had occurred.

This is principally achieved by improving the utility of the `useCreateNavigationMenu` hook in order that:

- it exposes it's internal resolution state for consuming components
- it improves handling of error and exposes them to consuming components
- it provides a dual API of direct or indirect usage (for example you can choose to `await` on the `create` hook property directly or you can call it and use the `state` property to handle the resolution status. This is important for this hook as it is used in both ways in different areas of the codebase.



## Testing Instructions

### Testing feedback in UI

1. New Post.
2. Add Nav block.
3. Click `Start empty` in the placeholder.
4. See _immediate_ UI feedback that a Nav is being created.
5. See a "success" message when the empty Nav is created. 
6. Check there is a `ref` pointing to a `wp_navigation` - switch to Code view to validate.
7. Repeat steps above but this time with a screen reader ("Hey Siri start Voiceover"). Check there is accessible auditory feedback on the nav creation process.


### Check classic Menu conversion process

As the classic menu conversion relies on the create menu hook we need to validate the conversion still works with the new API for the `useCreateNavigationMenu` hook.

- Create classic Menus.
- Switch to block Theme.
- New Post.
- Add Nav block.
- `Select menu` -> pick a classic menu.
- See conversion process occur with immediate UI feedback as per `trunk`.

### Testing Uncontrolled Inner Blocks

A Navigation can exist that has uncontrolled inner blocks (for example a pattern or a legacy block). In this case the contents are auto-converted to a `wp_navigation` post and the uncontrolled inner blocks are removed. We need to validate that continues to work.

1. New Post.
9. Code Editor mode.
10. Paste `<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->`.
11. Exit code editor mode.
12. See Nav block created which now has a `ref` to a new `wp_navigation`. The uncontrolled inner blocks you pasted are no longer present when switching back to Code View.

## Screenshots <!-- if applicable -->

### Before

Notice how even though I'm on a super fast fibre connection, the UI seems to "lock up" when I click `Start empty`. The feedback only happens once the request to create the menu resolves.


https://user-images.githubusercontent.com/444434/156773218-ea73e35e-0ee5-4af4-8fb1-bc9317dfa246.mov



### After

Notice how the UI immediately reflects the "working" state:

https://user-images.githubusercontent.com/444434/156772895-192c7f77-a8f9-49aa-af05-deff973b8d97.mov



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
