### PR TITLE
useBlockEditorSettings: remove unused unstableBase fetch

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -39,20 +39,9 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	} = useSelect( ( select ) => {
 		const { canUserUseUnfilteredHTML } = select( editorStore );
 		const isWeb = Platform.OS === 'web';
-		const {
-			canUser,
-			getUnstableBase,
-			hasFinishedResolution,
-			getEntityRecord,
-		} = select( coreStore );
+		const { canUser, getEntityRecord } = select( coreStore );
 
 		const siteSettings = getEntityRecord( 'root', 'site' );
-
-		const siteData = getUnstableBase();
-
-		const hasFinishedResolvingSiteData = hasFinishedResolution(
-			'getUnstableBase'
-		);
 
 		return {
 			canUseUnfilteredHTML: canUserUseUnfilteredHTML(),
@@ -67,8 +56,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				canUser( 'create', 'media' ),
 				true
 			),
-			hasResolvedLocalSiteData: hasFinishedResolvingSiteData,
-			baseUrl: siteData?.url || '',
 			userCanCreatePages: canUser( 'create', 'pages' ),
 			pageOnFront: siteSettings?.page_on_front,
 		};


### PR DESCRIPTION
Removes usage of `getUnstableBase` and related selectors from `useBlockEditorSettings`. Note that the caller of `useSelect` doesn't use (destructure) some of the returned fields.

The usage of `baseUrl` et al was removed in #33086 but not completely. This PR finished the cleanup.

Removes a place that triggers fetch of the `/` REST endpoint. We'd like to stop preloading that endpoint.