### PR TITLE
Block Editor: Check all ancestors inside `canInsertBlockTypeUnmemoized` selector

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1255,11 +1255,20 @@ const canInsertBlockTypeUnmemoized = (
 	);
 
 	const blockAllowedParentBlocks = blockType.parent;
-	const parentName = getBlockName( state, rootClientId );
-	const hasBlockAllowedParent = checkAllowList(
-		blockAllowedParentBlocks,
-		parentName
-	);
+	let hasBlockAllowedParent = null;
+	if ( blockAllowedParentBlocks ) {
+		const parents = [
+			rootClientId,
+			...getBlockParents( state, rootClientId ),
+		];
+
+		hasBlockAllowedParent = some( parents, ( parentClientId ) =>
+			checkAllowList(
+				blockAllowedParentBlocks,
+				getBlockName( state, parentClientId )
+			)
+		);
+	}
 
 	const canInsert =
 		( hasParentAllowedBlock === null && hasBlockAllowedParent === null ) ||

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2248,6 +2248,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: {},
 					attributes: {},
+					parents: {},
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2284,6 +2285,7 @@ describe( 'selectors', () => {
 					attributes: {
 						block1: {},
 					},
+					parents: {},
 				},
 				blockListSettings: {
 					block1: {},
@@ -2304,6 +2306,7 @@ describe( 'selectors', () => {
 					attributes: {
 						block1: {},
 					},
+					parents: {},
 				},
 				blockListSettings: {
 					block1: {},
@@ -2368,6 +2371,7 @@ describe( 'selectors', () => {
 					attributes: {
 						block1: {},
 					},
+					parents: {},
 				},
 				blockListSettings: {
 					block1: {
@@ -2404,6 +2408,7 @@ describe( 'selectors', () => {
 				blocks: {
 					byClientId: {},
 					attributes: {},
+					parents: {},
 				},
 				blockListSettings: {},
 				settings: {},
@@ -2428,6 +2433,7 @@ describe( 'selectors', () => {
 						2: {},
 						3: {},
 					},
+					parents: {},
 				},
 				blockListSettings: {
 					1: {
@@ -2464,6 +2470,32 @@ describe( 'selectors', () => {
 				settings: {},
 			};
 			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( false );
+		} );
+
+		it( 'should allow blocks to be inserted into any parent if an ancestor allows it', () => {
+			const state = {
+				blocks: {
+					byClientId: {
+						block1: { name: 'core/test-block-b' },
+						block2: { name: 'core/test-block-a' },
+					},
+					attributes: {
+						block1: {},
+						block2: {},
+					},
+					parents: {
+						block2: 'block1',
+					},
+				},
+				blockListSettings: {
+					block1: {},
+					block2: {},
+				},
+				settings: {},
+			};
+			expect(
+				canInsertBlockType( state, 'core/test-block-c', 'block2' )
+			).toBe( true );
 		} );
 	} );
 
@@ -2664,6 +2696,7 @@ describe( 'selectors', () => {
 						},
 					},
 					controlledInnerBlocks: {},
+					parents: {},
 				},
 				preferences: {
 					insertUsage: {},
@@ -2872,6 +2905,7 @@ describe( 'selectors', () => {
 						},
 					},
 					controlledInnerBlocks: {},
+					parents: {},
 				},
 				preferences: {
 					insertUsage: {},


### PR DESCRIPTION
## Description

This PR introduces minor changes inside `canInsertBlockTypeUnmemoized` to check if any of all the block's ancestors match any of the block types specified in its `parent` attribute (inside `block.json`), returning `true` if it's the case.

The change would allow blocks to be inserted inside any block, as long as one of the ancestors' type is included in `parent`. 

Although the purpose of this PR is to solve #37181, which is related to comment blocks, I think it could be useful in more cases. For context, see https://github.com/WordPress/gutenberg/issues/37181#issuecomment-1057983367.

## Testing Instructions
1. In Single Post template, add a Comments Query Loop block.
2. Add a Columns block inside the Comment Template, with a two-columns layout.
3. Move, for example, the Comment Author Avatar to the first column and the Comment Content to the second one.
4. You should be allowed to do that in this PR. However, if you try to place any of those blocks outside the Comment Template, you won't be able to move them.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
