### PR TITLE
Simplify Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,11 +5,11 @@
 ## What?
 <!-- In a few words, what is the PR actually doing? -->
 
-## How?
-<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
-
 ## Why?
 <!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
+
+## How?
+<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
 
 ## Testing Instructions
 <!-- Please include step by step instructions on how to test this PR. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,14 @@
-<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->
+<!--
 
-<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
+Hi there! Thanks for contributing to Gutenberg!
+
+If this is your first time contributing, you may find reviewing these guides first to be helpful:
+- Overall process and best practices for pull requests: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests.
+- Coding Standards: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/
+- Accessibility testing: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md
+- Gutenberg licensing: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md
+
+-->
 
 ## What?
 <!-- In a few words, what is the PR actually doing? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,14 @@
 
 <!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->
 
-## Description
-<!-- Please describe what you have changed or added -->
+## What?
+<!-- In a few words, what is the PR actually doing? -->
+
+## How?
+<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
+
+## Why?
+<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
 
 ## Testing Instructions
 <!-- Please include step by step instructions on how to test this PR. -->
@@ -11,20 +17,4 @@
 <!-- 2. Insert a Heading Block. -->
 <!-- 3. etc. -->
 
-## Screenshots <!-- if applicable -->
-
-## Types of changes
-<!-- What types of changes does your code introduce?  -->
-<!-- Bug fix (non-breaking change which fixes an issue) -->
-<!-- New feature (non-breaking change which adds functionality) -->
-<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
-
-## Checklist:
-- [ ] My code is tested.
-- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
-- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
-- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
-- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
-- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
-- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
-- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
+## Screenshots or screencast <!-- if applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,5 @@
-<!--
-
-Hi there! Thanks for contributing to Gutenberg!
-
-If this is your first time contributing, you may find reviewing these guides first to be helpful:
-- Overall process and best practices for pull requests: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests.
-- Coding Standards: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/
-- Accessibility testing: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md
-- Gutenberg licensing: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md
-
--->
+<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
+https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
 
 ## What?
 <!-- In a few words, what is the PR actually doing? -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   Accessibility should be top of mind and thoroughly tested by following the [accessibility testing instructions](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md).
 
+-   Verify that any changes in your PR that affect function/class/variable names are mirrored in the corresponding `.native.js` versions of the files to avoid introducing breaking changes in the [React Native Mobile Editor](https://github.com/WordPress/gutenberg/tree/trunk/docs/contributors/code/react-native).
+
 -   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [Gutenberg's License](/LICENSE.md).
 
 ## Reporting Security Issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ To learn all about contributing to the Gutenberg project, see the [Contributor G
 
 -   As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
+-   Contributors should review the [overall process and best practices for pull requests](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/repository-management.md#pull-requests), adhering to WordPress' [JavaScript coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/) and [accessibility coding standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
+
+-   Accessibility should be top of mind and thoroughly tested by following the [accessibility testing instructions](https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md).
+
 -   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [Gutenberg's License](/LICENSE.md).
 
 ## Reporting Security Issues


### PR DESCRIPTION
## What?
This PR tries to simplify the pull request template for a better contributor experience.

## Why?
Currently, understanding the context and purpose of some PRs can be challenging.

One reason is that the PR template is quite verbose and is not always followed. For example:
- The "types of changes" section can be described with labels.
- The checklist is often omitted, as some steps don't apply or can be checked by linting tools.

On the other hand, **basic information like the purpose of the PR and why it's necessary** is often missing; sometimes, the context is in another issue and hard to find among a long list of comments.

Simplifying the template with a more direct, less frictional form, might help contributors provide more context and homogenize PRs descriptions.

## How?
By:
- Adding basic "What, Why, How" questions, [inspired on other open-source projects like Frontity](https://github.com/frontity/frontity/blob/dev/.github/pull_request_template.md).
- Removing the checklist but adding relevant guidelines at the top of the template.
- Removing the `types of changes` section.

## Testing instructions
1. Head to [this repository](https://github.com/priethor/gutenberg/pulls)
2. Create a new PR and check how the proposed changes would look if approved

This very PR is created following the template, too, so this is how it would look like 🙂 

## Screenshots or screencast <!-- if applicable -->
PR-ception
![image](https://user-images.githubusercontent.com/27339341/156827830-8d7a30ee-3c64-44c5-8390-e1670c973fff.png)