### PR TITLE
Block Editor: Use default layout type when block specifies unknown value

### DIFF
--- a/packages/block-editor/src/layouts/index.js
+++ b/packages/block-editor/src/layouts/index.js
@@ -14,7 +14,10 @@ const layoutTypes = [ flow, flex, constrained ];
  * @return {Object} Layout type.
  */
 export function getLayoutType( name = 'default' ) {
-	return layoutTypes.find( ( layoutType ) => layoutType.name === name );
+	return (
+		layoutTypes.find( ( layoutType ) => layoutType.name === name ) ??
+		layoutTypes.find( ( layoutType ) => layoutType.name === 'default' )
+	);
 }
 
 /**


### PR DESCRIPTION
## Description

While working on #38923 with invalid blocks it happened that a JavaScript
error surfaced when working with a block that specified an incorrect layout
type. In the case at hand the block asked for the `flerx` alignment instead
of the `flex` alignment.

It's reasonable to expect blocks to call for unrecognized layouts,
especially if a plugin introduces new layouts and then blocks are loaded
without that plugin's support.

When `getLayoutType` is unable to find a recognized layout it returns
`undefined` which causes numerous issues with calling code that expects
a valid layout.

In this patch we're guarding for those cases and if no known layout can
be found for the specified layout type then we return the default layout
instead. This introduces data corruption so it could be that this solution
is more of a coverup than a fix. There is no way however to ignore that
layout and preserve the behavior while still editing the block. On the
other hand a block should not fail validation due to an implementation bug
in the core editor and if this fix truly resolves the issue we should find
invalidated blocks and prevent editing anyway (unfortunately this is not
the case in this patch).

**Can you provide some insight into how this kind of problem should be resolved?**
If this is a "right" approach I can finish the PR and make sure it's ready
to merge. If I'm handling this improperly I'm fine taking a different approach.

## Testing Instructions

Edit a post and paste the following contents into the text editor to produce invalid markup.

```html
<!-- wp:group {"layout":{"type":"flerx","allowOrientation":false}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Nested!</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

Notice in `trunk` that the block has been replaced with an error message while in this branch it loads fine, though the rendering should be using the default layout type/alignemnt instead of the non-existent `flerx` as incorrectly specified in the block comment.

## Screenshots

The JS error produces the "This block has encountered an error and cannot be previewed" message. It's not a failure to validate the block; instead it's a JS exception thrown when rendering the block and that's the exception isolation boundary replacing the contents with that message.

![](https://user-images.githubusercontent.com/275961/156359078-696e1cbd-a684-43f4-b2cb-89bd79c674f0.png)

Thanks to @scruffian for calling this error out


![](https://user-images.githubusercontent.com/275961/156414678-7001b999-64bc-4862-9e33-f0c74c70308c.png)


## Types of changes

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
