### PR TITLE
Code owners: Remove users without write access and fix typos

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,7 +136,6 @@
 /lib/compat/wordpress-5.9/theme-i18n.json                            @timothybjacobs @spacedmonkey @oandregal
 /lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php          @timothybjacobs @spacedmonkey @oandregal
 /lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php @timothybjacobs @spacedmonkey @oandregal
-/lib/full-site-editing
 /phpunit/class-wp-theme-json-test.php                                @oandregal
 
 # Web App
@@ -148,9 +147,9 @@
 /packages/components/src/mobile/global-styles-context                @geriux @antonis
 
 # Native (Unowned)
-*.native.js                                     @ghost
-*.android.js                                    @ghost
-*.ios.js                                        @ghost
-*.native.scss                                   @ghost
-*.android.scss                                  @ghost
-*.ios.scss                                      @ghost
+*.native.js
+*.android.js
+*.ios.js
+*.native.scss
+*.android.scss
+*.ios.scss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 # Data
 /packages/api-fetch                             @nerrad @mmtr
 /packages/core-data                             @nerrad
-/packages/data                                  @nerrad @coderkevin
+/packages/data                                  @nerrad
 /packages/redux-routine                         @nerrad
 /packages/data-controls                         @nerrad
 
@@ -83,12 +83,12 @@
 /packages/stylelint-config                      @ntwb
 
 # UI Components
-/packages/components                            @ajitbohra @jaymanpandya
-/packages/compose                               @ajitbohra @jaymanpandya
-/packages/element                               @ajitbohra @jaymanpandya
-/packages/notices                               @ajitbohra @jaymanpandya
-/packages/nux                                   @ajitbohra @jaymanpandya
-/packages/viewport                              @ajitbohra @jaymanpandya
+/packages/components                            @ajitbohra
+/packages/compose                               @ajitbohra
+/packages/element                               @ajitbohra
+/packages/notices                               @ajitbohra
+/packages/nux                                   @ajitbohra
+/packages/viewport                              @ajitbohra
 /packages/base-styles
 /packages/icons
 /packages/primitives
@@ -130,13 +130,13 @@
 
 # PHP
 /lib                                                                 @timothybjacobs @spacedmonkey
-/lib/global-styles.php                                               @timothybjabocs @spacedmonkey @oandregal
+/lib/global-styles.php                                               @timothybjacobs @spacedmonkey @oandregal
 /lib/class-wp-rest-block-editor-settings-controller.php              @timothybjacobs @spacedmonkey @geriux @antonis
-/lib/compat/wordpress-5.9/theme.json                                                      @timothybjabocs @spacedmonkey @oandregal
-/lib/compat/wordpress-5.9/theme-i18n.json                                                 @timothybjabocs @spacedmonkey @oandregal
-/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php          @timothybjabocs @spacedmonkey @oandregal
-/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php @timothybjabocs @spacedmonkey @oandregal
-/lib/full-site-editing                                               @janw-me
+/lib/compat/wordpress-5.9/theme.json                                 @timothybjacobs @spacedmonkey @oandregal
+/lib/compat/wordpress-5.9/theme-i18n.json                            @timothybjacobs @spacedmonkey @oandregal
+/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php          @timothybjacobs @spacedmonkey @oandregal
+/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-gutenberg.php @timothybjacobs @spacedmonkey @oandregal
+/lib/full-site-editing
 /phpunit/class-wp-theme-json-test.php                                @oandregal
 
 # Web App


### PR DESCRIPTION
## Description

The current CODEOWNERS files contains a few errors which you should see when [open the file on GitHub](https://github.com/WordPress/gutenberg/blob/446d0012a51795c659971ae33bc0f5a997416c69/.github/CODEOWNERS).

<img width="482" alt="image" src="https://user-images.githubusercontent.com/617637/156922735-871a0307-349b-4948-975a-dc72a3571e0f.png">

<details>
<summary>List of errors</summary>

```
Unknown owner on line 11: make sure @coderkevin exists and has write access to the repository
…                      @nerrad @coderkevin
Unknown owner on line 86: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 87: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 88: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 89: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 90: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 91: make sure @jaymanpandya exists and has write access to the repository
…                   @ajitbohra @jaymanpandya
Unknown owner on line 133: make sure @timothybjabocs exists and has write access to the repository
…                              @timothybjabocs @spacedmonkey @oandregal
Unknown owner on line 135: make sure @timothybjabocs exists and has write access to the repository
…                              @timothybjabocs @spacedmonkey @oandregal
Unknown owner on line 136: make sure @timothybjabocs exists and has write access to the repository
…                              @timothybjabocs @spacedmonkey @oandregal
Unknown owner on line 137: make sure @timothybjabocs exists and has write access to the repository
…e-json-gutenberg.php          @timothybjabocs @spacedmonkey @oandregal
Unknown owner on line 138: make sure @timothybjabocs exists and has write access to the repository
…e-json-resolver-gutenberg.php @timothybjabocs @spacedmonkey @oandregal
Unknown owner on line 139: make sure @janw-me exists and has write access to the repository
…                              @janw-me
Unknown owner on line 151: make sure @ghost exists and has write access to the repository
…                              @ghost
Unknown owner on line 152: make sure @ghost exists and has write access to the repository
…                              @ghost
Unknown owner on line 153: make sure @ghost exists and has write access to the repository
…                              @ghost
Unknown owner on line 154: make sure @ghost exists and has write access to the repository
…                              @ghost
Unknown owner on line 155: make sure @ghost exists and has write access to the repository
…                              @ghost
Unknown owner on line 156: make sure @ghost exists and has write access to the repository
…                              @ghost
```

</details>


This PR removes users which seem to no longer have write access and fixes a typo in `timothybjacobs`. The remaining errors are for the native files which should be unowned. Based on the [example (last line)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file) I'm wondering if keeping it empty would be enough too? It seems like that wasn't clear when introduced in #13675.