### PR TITLE
Fix `npm run docs:build` crashing when a `block.json` lacks `supports` key.

### DIFF
--- a/bin/api-docs/gen-block-lib-list.js
+++ b/bin/api-docs/gen-block-lib-list.js
@@ -147,8 +147,10 @@ function readBlockJSON( filename ) {
 	const blockjson = require( filename );
 
 	const sourcefile = getSourceFromFile( filename );
-	const supportsAugmented = augmentSupports( blockjson.supports );
-	const supportsList = processObjWithInnerKeys( supportsAugmented );
+	const supportsList =
+		blockjson.supports !== undefined
+			? processObjWithInnerKeys( augmentSupports( blockjson.supports ) )
+			: [];
 	const attributes = getTruthyKeys( blockjson.attributes );
 
 	return `


### PR DESCRIPTION
## Description
While working on a new PR to finish the [`<details>` block](https://github.com/WordPress/gutenberg/pull/23940), I discovered a bug when running `npm run docs:build`:

```
> gutenberg@12.7.0 docs:build /[...]/gutenberg
> npm-run-all docs:gen api-docs:*


> gutenberg@12.7.0 docs:gen /[...]/gutenberg
> node ./docs/tool/index.js


> gutenberg@12.7.0 api-docs:blocks /[...]/gutenberg
> node ./bin/api-docs/gen-block-lib-list.js

/[...]/gutenberg/bin/api-docs/gen-block-lib-list.js:112
        if ( 'color' in supports ) {
                     ^

TypeError: Cannot use 'in' operator to search for 'color' in undefined
    at augmentSupports (/[...]/gutenberg/bin/api-docs/gen-block-lib-list.js:112:15)
    at readBlockJSON (/[...]/gutenberg/bin/api-docs/gen-block-lib-list.js:150:28)
    at /[...]/gutenberg/bin/api-docs/gen-block-lib-list.js:175:17
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/[...]/gutenberg/bin/api-docs/gen-block-lib-list.js:174:7)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
```

Turns out that a `block.json` without a `supports` key causes the doc-gen command to throw. The [`block.json` schema](https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/block.json) does not require that key, so I decided to whip up a quick PR to fix the issue. I've confirmed that the fix in this PR works by rebasing my WIP `<details>` block branch on this PR's branch and verifying that `npm run docs:build` works as intended.

## Testing Instructions
1. Remove the `supports` key from a core block's `block.json`.
2. Run `npm run docs:build` and ensure that no errors are thrown.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
