### PR TITLE
Media & Text: Display errors after failed upload

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -72,6 +72,19 @@ function attributesFromMedia( {
 	setAttributes,
 } ) {
 	return ( media ) => {
+		if ( ! media || ! media.url ) {
+			setAttributes( {
+				mediaAlt: undefined,
+				mediaId: undefined,
+				mediaType: undefined,
+				mediaUrl: undefined,
+				mediaLink: undefined,
+				href: undefined,
+				focalPoint: undefined,
+			} );
+			return;
+		}
+
 		let mediaType;
 		let src;
 		// For media selections originated from a file upload.


### PR DESCRIPTION
## Description
Media & Text block wasn't displaying failed upload notices and got stuck in loading state. PR fixes this issue by resetting attributes if `media` is undefined, which only happens if there's an error.

Resolves #21741.
Similar to #39178.

## Testing Instructions
1. Open a Post or Page
2. Insert a Media & Text block.
3. Fake upload error (see code below).
4. Confirm that the upload error message is displayed and the image isn't stuck in the upload state.

```php
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'Image files must be smaller than 10kb';
	return $file;
} );
```

## Screenshots <!-- if applicable -->

Before

https://user-images.githubusercontent.com/240569/156992961-94f5ba30-ffe8-43c9-93c5-5240f1b3ad24.mp4

After

https://user-images.githubusercontent.com/240569/156993013-3a6461d7-0294-411e-bfc3-37606374f2cf.mp4

## Types of changes
Bugfix
