### PR TITLE
Fix `NumberControl` validation

### DIFF
--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -47,7 +47,7 @@ function InputField(
 		onValidate = noop,
 		size = 'default',
 		setIsFocused,
-		stateReducer = ( state: any ) => state,
+		stateReducer,
 		value: valueProp,
 		type,
 		...props
@@ -75,42 +75,41 @@ function InputField(
 		isPressEnterToChange,
 	} );
 
-	const { _event, value, isDragging, isDirty } = state;
-	const wasDirtyOnBlur = useRef( false );
+	const { _event, value, isDragging, isDirty, error } = state;
+	const wasPendentOnBlur = useRef( false );
 
 	const dragCursor = useDragCursor( isDragging, dragDirection );
 
 	/*
-	 * Handles synchronization of external and internal value state.
-	 * If not focused and did not hold a dirty value[1] on blur
-	 * updates the value from the props. Otherwise if not holding
-	 * a dirty value[1] propagates the value and event through onChange.
-	 * [1] value is only made dirty if isPressEnterToChange is true
+	 * Handles switching modes between controlled – while not focused – and
+	 * self-controlled – while focused. Exceptions are made when the internal
+	 * value is either dirty or invalid. In such cases, the value does not
+	 * propagate while focused and the first render while not focused ignores
+	 * the value from props and instead propagates the internal value.
 	 */
 	useUpdateEffect( () => {
 		if ( valueProp === value ) {
 			return;
 		}
-		if ( ! isFocused && ! wasDirtyOnBlur.current ) {
+		if ( ! isFocused && ! wasPendentOnBlur.current ) {
 			update( valueProp, _event as SyntheticEvent );
-		} else if ( ! isDirty ) {
+		} else if ( ! isDirty && ! error ) {
 			onChange( value, {
 				event: _event as ChangeEvent< HTMLInputElement >,
 			} );
-			wasDirtyOnBlur.current = false;
+			wasPendentOnBlur.current = false;
 		}
-	}, [ value, isDirty, isFocused, valueProp ] );
+	}, [ value, isDirty, isFocused, valueProp, error ] );
 
 	const handleOnBlur = ( event: FocusEvent< HTMLInputElement > ) => {
 		onBlur( event );
 		setIsFocused?.( false );
-
-		/**
-		 * If isPressEnterToChange is set, this commits the value to
-		 * the onChange callback.
+		/*
+		 * Commits the value when it's either dirty or invalid as such values
+		 * will have not yet propagated.
 		 */
-		if ( isPressEnterToChange && isDirty ) {
-			wasDirtyOnBlur.current = true;
+		if ( isDirty || error ) {
+			wasPendentOnBlur.current = true;
 			handleOnCommit( event );
 		}
 	};

--- a/packages/components/src/input-control/reducer/actions.ts
+++ b/packages/components/src/input-control/reducer/actions.ts
@@ -33,6 +33,11 @@ interface ValuePayload {
 	value: string;
 }
 
+interface ErrorPayload {
+	value: string;
+	error: unknown;
+}
+
 export type ChangeAction = Action< typeof CHANGE, ValuePayload >;
 export type CommitAction = Action< typeof COMMIT, ValuePayload >;
 export type PressUpAction = Action< typeof PRESS_UP >;
@@ -43,7 +48,7 @@ export type DragEndAction = Action< typeof DRAG_END, DragProps >;
 export type DragAction = Action< typeof DRAG, DragProps >;
 export type ResetAction = Action< typeof RESET, Partial< ValuePayload > >;
 export type UpdateAction = Action< typeof UPDATE, ValuePayload >;
-export type InvalidateAction = Action< typeof INVALIDATE, { error: unknown } >;
+export type InvalidateAction = Action< typeof INVALIDATE, ErrorPayload >;
 
 export type ChangeEventAction =
 	| ChangeAction

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isEmpty } from 'lodash';
-import type { SyntheticEvent } from 'react';
+import type { ChangeEvent, KeyboardEvent, FocusEvent } from 'react';
 
 /**
  * WordPress dependencies
@@ -132,6 +132,7 @@ function inputControlStateReducer(
 			 */
 			case actions.INVALIDATE:
 				nextState.error = action.payload.error;
+				nextState.value = action.payload.value;
 				break;
 		}
 
@@ -215,8 +216,21 @@ export function useInputControlStateReducer(
 	 * Actions for the reducer
 	 */
 	const change = createChangeEvent( actions.CHANGE );
-	const invalidate = ( error: unknown, event: SyntheticEvent ) =>
-		dispatch( { type: actions.INVALIDATE, payload: { error, event } } );
+	const invalidate = (
+		error: unknown,
+		event:
+			| ChangeEvent< HTMLInputElement >
+			| KeyboardEvent< HTMLInputElement >
+			| FocusEvent< HTMLInputElement >
+	) =>
+		dispatch( {
+			type: actions.INVALIDATE,
+			payload: {
+				error,
+				event,
+				value: event.currentTarget.value,
+			},
+		} );
 	const reset = createChangeEvent( actions.RESET );
 	const commit = createChangeEvent( actions.COMMIT );
 	const update = createChangeEvent( actions.UPDATE );

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -90,3 +90,7 @@ export interface InputControlLabelProps {
 	labelPosition?: BaseProps[ 'labelPosition' ];
 	size?: BaseProps[ 'size' ];
 }
+
+export interface KeyedValidityState extends ValidityState {
+	[ key: string ]: boolean;
+}

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -167,6 +167,13 @@ export function NumberControl(
 		return state;
 	};
 
+	const onValidate = ( nextValue, event ) => {
+		props.onValidate?.( nextValue, event );
+		if ( ! event.target.validity.valid ) {
+			throw new Error( event.target.validationMessage );
+		}
+	};
+
 	return (
 		<Input
 			autoComplete={ autoComplete }
@@ -179,6 +186,7 @@ export function NumberControl(
 			label={ label }
 			max={ max }
 			min={ min }
+			onValidate={ onValidate }
 			ref={ ref }
 			required={ required }
 			step={ step }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -147,10 +147,12 @@ export function NumberControl(
 		}
 
 		/**
-		 * Handles commit (ENTER key press or on blur if isPressEnterToChange)
+		 * Handles ENTER key press or commits. The latter originates from blur
+		 * events or ENTER key presses when isPressEnterToChange is true).
 		 */
 		if (
-			type === inputControlActionTypes.PRESS_ENTER ||
+			( type === inputControlActionTypes.PRESS_ENTER &&
+				! state.isPressEnterToChange ) ||
 			type === inputControlActionTypes.COMMIT
 		) {
 			const applyEmptyValue = required === false && currentValue === '';
@@ -158,6 +160,8 @@ export function NumberControl(
 			state.value = applyEmptyValue
 				? currentValue
 				: constrainValue( currentValue );
+
+			state.error = null;
 		}
 
 		return state;

--- a/packages/components/src/number-control/test/index.js
+++ b/packages/components/src/number-control/test/index.js
@@ -60,8 +60,26 @@ describe( 'NumberControl', () => {
 			const input = getInput();
 			input.focus();
 			fireEvent.change( input, { target: { value: 10 } } );
-
 			expect( spy ).toHaveBeenCalledWith( '10' );
+		} );
+
+		it( 'should not call onChange callback with invalid values', () => {
+			const spy = jest.fn();
+
+			render(
+				<NumberControl
+					value={ 5 }
+					min={ 2 }
+					max={ 10 }
+					onChange={ ( v ) => spy( v ) }
+				/>
+			);
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: 1 } } );
+			expect( input.value ).toBe( '1' );
+			expect( spy ).not.toHaveBeenCalled();
 		} );
 	} );
 
@@ -78,8 +96,18 @@ describe( 'NumberControl', () => {
 			 * This is zero because the value has been adjusted to
 			 * respect the min/max range of the input.
 			 */
-
 			expect( input.value ).toBe( '0' );
+		} );
+
+		it( 'should clamp value within range on blur', () => {
+			render( <NumberControl value={ 0 } min={ -5 } max={ 5 } /> );
+
+			const input = getInput();
+			input.focus();
+			fireEvent.change( input, { target: { value: -10 } } );
+			input.blur();
+
+			expect( input.value ).toBe( '-5' );
 		} );
 
 		it( 'should parse to number value on ENTER keypress when required', () => {

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -128,7 +128,6 @@ function RangeControl(
 		setValue( nextValue );
 		onChange( nextValue );
 	};
-
 	const handleOnChange = ( nextValue ) => {
 		nextValue = parseFloat( nextValue );
 		setValue( nextValue );
@@ -144,6 +143,14 @@ function RangeControl(
 			isResetPendent.current = false;
 		} else if ( allowReset ) {
 			isResetPendent.current = true;
+		}
+	};
+
+	// Handles invalid values from the number input that would otherwise be
+	// missed because they aren't sent through its onChange.
+	const handleOnInputNumberValidate = ( nextValue, event ) => {
+		if ( ! event.target.validity.valid ) {
+			handleOnChange( nextValue );
 		}
 	};
 
@@ -289,6 +296,7 @@ function RangeControl(
 						min={ min }
 						onBlur={ handleOnInputNumberBlur }
 						onChange={ handleOnChange }
+						onValidate={ handleOnInputNumberValidate }
 						shiftStep={ shiftStep }
 						step={ step }
 						value={ inputSliderValue }


### PR DESCRIPTION
Keeping this drafted as it would be important to first correct the stepping behavior of `NumberControl` so that it does not step to invalid values #34566.

---- 

## What
This PR enables consumers of `NumberControl` to expect that values received by its `onChange` handler will be valid according to its `min`, `max`, `step` and `required` props.

It adds unit tests to cover the new behavior.

It also includes a small change to `RangeControl` needed to maintain its current behavior on top of the changed behavior of `NumberControl`.

## Why
To fix #33291

## How
Primarily (on a high-level) by changes to `NumberControl` so that it
 *  does not call `onChange` with invalid values
 *  clamps invalid values to within range on blur

Much of the changes required to support that were in `InputControl` since the behavior of `NumberControl` is rooted there. The changes to `InputControl` make it so that it
 * does not call `onChange` with invalid values (like it already does for dirty values)
 * when the value entered is invalid, dispatches `commit` on `blur` (like it already does for dirty values)
 * calls `onValidate` before changes (when `isPressEnterToChange` is `false`)
 * puts the invalid value of the input into the payload during `invalidate` actions

## Testing Instructions
will update…

## Screenshots <!-- if applicable -->

## Types of changes
* Bug fix
* Enhancement

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
