### PR TITLE
Drop `composeStateReducers`

### DIFF
--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -37,7 +37,7 @@ export default function LineHeightControl( {
 		 * Step up/down actions can be triggered by keydowns of the up/down arrow keys,
 		 * or by clicking the spin buttons.
 		 */
-		switch ( nextValue ) {
+		switch ( `${ nextValue }` ) {
 			case `${ STEP }`:
 				// Increment by step value.
 				return BASE_DEFAULT_VALUE + STEP;
@@ -63,8 +63,8 @@ export default function LineHeightControl( {
 		const wasTypedOrPasted = [ 'insertText', 'insertFromPaste' ].includes(
 			action.payload.event.nativeEvent?.inputType
 		);
-		state.value = adjustNextValue( state.value, wasTypedOrPasted );
-		return state;
+		const value = adjustNextValue( state.value, wasTypedOrPasted );
+		return { ...state, value };
 	};
 
 	const value = isDefined ? lineHeight : RESET_VALUE;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,10 @@
 -   Fix input value selection of `InputControl`-based controls in Firefox and Safari with axial constraint of drag gesture ([#38968](https://github.com/WordPress/gutenberg/pull/38968)).
 -   Fix `UnitControl`'s behavior around updating the unit when a new `value` is passed (i.e. in controlled mode). ([#39148](https://github.com/WordPress/gutenberg/pull/39148)).
 
+### Internal
+
+-   Delete the `composeStateReducers` utility function ([#39262](https://github.com/WordPress/gutenberg/pull/39262)).
+
 ## 19.5.0 (2022-02-23)
 
 ### Bug Fix

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
 import type { SyntheticEvent } from 'react';
 
 /**
@@ -37,27 +36,6 @@ function mergeInitialState(
 		initialValue: value,
 	} as InputState;
 }
-
-/**
- * Composes multiple stateReducers into a single stateReducer, building
- * the pipeline to control the flow for state and actions.
- *
- * @param  fns State reducers.
- * @return The single composed stateReducer.
- */
-export const composeStateReducers = (
-	...fns: StateReducer[]
-): StateReducer => {
-	return ( ...args ) => {
-		return fns.reduceRight( ( state, fn ) => {
-			// TODO: Assess whether this can be replaced with a more standard `compose` implementation
-			// like wp.data.compose() (aka lodash flowRight) or Redux compose().
-			// The current implementation only works by functions mutating the original state object.
-			const fnState = fn( ...args );
-			return isEmpty( fnState ) ? state : { ...state, ...fnState };
-		}, {} as InputState );
-	};
-};
 
 /**
  * Creates a reducer that opens the channel for external state subscription

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -20,7 +20,7 @@ import { isValueEmpty } from '../utils/values';
 
 export function NumberControl(
 	{
-		__unstableStateReducer: stateReducer,
+		__unstableStateReducer: stateReducerProp,
 		className,
 		dragDirection = 'n',
 		hideHTMLArrows = false,
@@ -161,7 +161,7 @@ export function NumberControl(
 				: constrainValue( currentValue );
 		}
 
-		return stateReducer?.( nextState, action ) ?? nextState;
+		return state;
 	};
 
 	return (
@@ -181,7 +181,10 @@ export function NumberControl(
 			step={ step }
 			type={ typeProp }
 			value={ valueProp }
-			__unstableStateReducer={ numberControlStateReducer }
+			__unstableStateReducer={ ( state, action ) => { 
+				const baseState = numberControlStateReducer( state, action );
+				return stateReducerProp?.( baseState, action ) ?? baseState;
+			} }
 		/>
 	);
 }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -161,7 +161,7 @@ export function NumberControl(
 				: constrainValue( currentValue );
 		}
 
-		return state;
+		return nextState;
 	};
 
 	return (
@@ -181,7 +181,7 @@ export function NumberControl(
 			step={ step }
 			type={ typeProp }
 			value={ valueProp }
-			__unstableStateReducer={ ( state, action ) => { 
+			__unstableStateReducer={ ( state, action ) => {
 				const baseState = numberControlStateReducer( state, action );
 				return stateReducerProp?.( baseState, action ) ?? baseState;
 			} }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -61,9 +61,11 @@ export function NumberControl(
 	 * @return {Object} The updated state to apply to InputControl
 	 */
 	const numberControlStateReducer = ( state, action ) => {
+		const nextState = { ...state };
+
 		const { type, payload } = action;
 		const event = payload?.event;
-		const currentValue = state.value;
+		const currentValue = nextState.value;
 
 		/**
 		 * Handles custom UP and DOWN Keyboard events
@@ -93,7 +95,7 @@ export function NumberControl(
 				nextValue = subtract( nextValue, incrementalValue );
 			}
 
-			state.value = constrainValue(
+			nextState.value = constrainValue(
 				nextValue,
 				enableShift ? incrementalValue : null
 			);
@@ -138,7 +140,7 @@ export function NumberControl(
 				delta = Math.ceil( Math.abs( delta ) ) * Math.sign( delta );
 				const distance = delta * modifier * directionModifier;
 
-				state.value = constrainValue(
+				nextState.value = constrainValue(
 					add( currentValue, distance ),
 					enableShift ? modifier : null
 				);
@@ -154,12 +156,12 @@ export function NumberControl(
 		) {
 			const applyEmptyValue = required === false && currentValue === '';
 
-			state.value = applyEmptyValue
+			nextState.value = applyEmptyValue
 				? currentValue
 				: constrainValue( currentValue );
 		}
 
-		return stateReducer?.( state, action ) ?? state;
+		return stateReducer?.( nextState, action ) ?? nextState;
 	};
 
 	return (

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -15,7 +15,6 @@ import { isRTL } from '@wordpress/i18n';
  */
 import { Input } from './styles/number-control-styles';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
-import { composeStateReducers } from '../input-control/reducer/reducer';
 import { add, subtract, roundClamp } from '../utils/math';
 import { isValueEmpty } from '../utils/values';
 
@@ -160,7 +159,7 @@ export function NumberControl(
 				: constrainValue( currentValue );
 		}
 
-		return state;
+		return stateReducer( state, action );
 	};
 
 	return (
@@ -180,10 +179,7 @@ export function NumberControl(
 			step={ step }
 			type={ typeProp }
 			value={ valueProp }
-			__unstableStateReducer={ composeStateReducers(
-				numberControlStateReducer,
-				stateReducer
-			) }
+			__unstableStateReducer={ numberControlStateReducer }
 		/>
 	);
 }

--- a/packages/components/src/number-control/index.js
+++ b/packages/components/src/number-control/index.js
@@ -20,7 +20,7 @@ import { isValueEmpty } from '../utils/values';
 
 export function NumberControl(
 	{
-		__unstableStateReducer: stateReducer = ( state ) => state,
+		__unstableStateReducer: stateReducer,
 		className,
 		dragDirection = 'n',
 		hideHTMLArrows = false,
@@ -159,7 +159,7 @@ export function NumberControl(
 				: constrainValue( currentValue );
 		}
 
-		return stateReducer( state, action );
+		return stateReducer?.( state, action ) ?? state;
 	};
 
 	return (

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -37,7 +37,7 @@ import type { StateReducer } from '../input-control/reducer/state';
 
 function UnitControl(
 	{
-		__unstableStateReducer: stateReducer,
+		__unstableStateReducer: stateReducerProp,
 		autoComplete = 'off',
 		className,
 		disabled = false,
@@ -201,8 +201,16 @@ function UnitControl(
 			}
 		}
 
-		return stateReducer?.( nextState, action ) ?? nextState;
+		return state;
 	};
+
+	let stateReducer: StateReducer = unitControlStateReducer;
+	if ( stateReducerProp ) {
+		stateReducer = ( state, action ) => {
+			const baseState = unitControlStateReducer( state, action );
+			return stateReducerProp( baseState, action );
+		};
+	}
 
 	const inputSuffix = ! disableUnits ? (
 		<UnitSelectControl
@@ -247,7 +255,7 @@ function UnitControl(
 				suffix={ inputSuffix }
 				value={ parsedQuantity ?? '' }
 				step={ step }
-				__unstableStateReducer={ unitControlStateReducer }
+				__unstableStateReducer={ stateReducer }
 			/>
 		</Root>
 	);

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -201,7 +201,7 @@ function UnitControl(
 			}
 		}
 
-		return state;
+		return nextState;
 	};
 
 	let stateReducer: StateReducer = unitControlStateReducer;

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -185,6 +185,8 @@ function UnitControl(
 	 * @return The updated state to apply to InputControl
 	 */
 	const unitControlStateReducer: StateReducer = ( state, action ) => {
+		const nextState = { ...state };
+
 		/*
 		 * On commits (when pressing ENTER and on blur if
 		 * isPressEnterToChange is true), if a parse has been performed
@@ -192,12 +194,14 @@ function UnitControl(
 		 */
 		if ( action.type === inputControlActionTypes.COMMIT ) {
 			if ( refParsedQuantity.current !== undefined ) {
-				state.value = ( refParsedQuantity.current ?? '' ).toString();
+				nextState.value = (
+					refParsedQuantity.current ?? ''
+				).toString();
 				refParsedQuantity.current = undefined;
 			}
 		}
 
-		return stateReducer?.( state, action ) ?? state;
+		return stateReducer?.( nextState, action ) ?? nextState;
 	};
 
 	const inputSuffix = ! disableUnits ? (

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -23,7 +23,6 @@ import { ENTER } from '@wordpress/keycodes';
  */
 import type { WordPressComponentProps } from '../ui/context';
 import * as inputControlActionTypes from '../input-control/reducer/actions';
-import { composeStateReducers } from '../input-control/reducer/reducer';
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
 import {
@@ -38,7 +37,7 @@ import type { StateReducer } from '../input-control/reducer/state';
 
 function UnitControl(
 	{
-		__unstableStateReducer: stateReducer = ( state ) => state,
+		__unstableStateReducer: stateReducer,
 		autoComplete = 'off',
 		className,
 		disabled = false,
@@ -198,7 +197,7 @@ function UnitControl(
 			}
 		}
 
-		return state;
+		return stateReducer?.( state, action ) ?? state;
 	};
 
 	const inputSuffix = ! disableUnits ? (
@@ -244,10 +243,7 @@ function UnitControl(
 				suffix={ inputSuffix }
 				value={ parsedQuantity ?? '' }
 				step={ step }
-				__unstableStateReducer={ composeStateReducers(
-					unitControlStateReducer,
-					stateReducer
-				) }
+				__unstableStateReducer={ unitControlStateReducer }
 			/>
 		</Root>
 	);


### PR DESCRIPTION
## What
Removes `composeStateReducers` and replaces it with direct coupling. That has the effect of changing the order of a couple of reducer stacks. That breaks the one in `LineHeightControl` so a fix is included here too.

## Why
To resolve #38845 and also make the order that the reducers run in the expected order.

## How
Couples the reducers together directly.

## Testing Instructions
Make sure all components with specializing reducers based on `InputControl` work as expected. That is `NumberControl`, `UnitControl`, `LineHeightControl`.

## Screenshots <!-- if applicable -->

## Types of changes
Code-quality

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
