### PR TITLE
Add Home/End keyboard E2E test for List View

### DIFF
--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -149,4 +149,50 @@ describe( 'List view', () => {
 
 		expect( selectedElementText ).toContain( 'Paragraph' );
 	} );
+
+	// Test keyboard Home/End keys.
+	it( 'ensures the Home/End keyboard keys move focus to start/end of list', async () => {
+		// Insert some blocks of different types.
+		await insertBlock( 'Image' );
+		await insertBlock( 'Heading' );
+		await insertBlock( 'Paragraph' );
+		await insertBlock( 'Columns' );
+		await insertBlock( 'Group' );
+
+		// Open list view.
+		await pressKeyWithModifier( 'access', 'o' );
+
+		// The last inserted group block should be selected in list view.
+		await page.waitForXPath( '//a[contains(., "Group(selected block)")]' );
+
+		// Press Home to go to the first inserted block (image).
+		await page.keyboard.press( 'Home' );
+		const listViewImageBlock = await page.waitForXPath(
+			'//a[contains(., "Image")]'
+		);
+		await expect( listViewImageBlock ).toHaveFocus();
+
+		// Press End followed by Arrow Up to go to the second to last block (columns).
+		await page.keyboard.press( 'End' );
+		await page.keyboard.press( 'ArrowUp' );
+		const listViewColumnsBlock = await page.waitForXPath(
+			'//a[contains(., "Columns")]'
+		);
+		await expect( listViewColumnsBlock ).toHaveFocus();
+
+		// Try navigating the right column to image block options button via Home key.
+		await page.keyboard.press( 'ArrowRight' );
+		await page.keyboard.press( 'Home' );
+		const listViewImageBlockRight = await page.waitForSelector(
+			'button[aria-label="Options for Image block"]'
+		);
+		await expect( listViewImageBlockRight ).toHaveFocus();
+
+		// Try navigating the right column to group block options button.
+		await page.keyboard.press( 'End' );
+		const listViewGroupBlockRight = await page.waitForSelector(
+			'button[aria-label="Options for Group block"]'
+		);
+		await expect( listViewGroupBlockRight ).toHaveFocus();
+	} );
 } );


### PR DESCRIPTION
<!-- Learn the overall process and best practices for pull requests at https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/repository-management.md#pull-requests. -->

<!-- Gutenberg's license is in the process of updating to be dual-licensed under the GPL and MPL. As part of that transition, all new contributions are dual-licensed. For more information, see: https://github.com/WordPress/gutenberg/blob/trunk/LICENSE.md -->

## Description
<!-- Please describe what you have changed or added -->

Add an E2E test to ensure Home/End keyboard keys take you to start/end of List View left/right columns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Enhancement.

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [x] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [x] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [x] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
