### PR TITLE
Gallery block: fix image upload bug

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -156,8 +156,12 @@ function GalleryEdit( props ) {
 			} );
 		} );
 
-		// If new blocks added select the first of these so they scroll into view.
-		if ( newImages?.length ) {
+		// If new blocks added, and no images still uploading, select new images
+		//  so they scroll into view.
+		if (
+			newImages?.length &&
+			! images.find( ( image ) => image.url.startsWith( 'blob' ) )
+		) {
 			multiSelect(
 				newImages[ 0 ].clientId,
 				newImages[ newImages?.length - 1 ].clientId

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -99,7 +99,8 @@ function GalleryEdit( props ) {
 		__unstableMarkNextChangeAsNotPersistent,
 		replaceInnerBlocks,
 		updateBlockAttributes,
-		multiSelect,
+		selectBlock,
+		clearSelectedBlock,
 	} = useDispatch( blockEditorStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
@@ -155,17 +156,8 @@ function GalleryEdit( props ) {
 				align: undefined,
 			} );
 		} );
-
-		// If new blocks added, and no images still uploading, select new images
-		//  so they scroll into view.
-		if (
-			newImages?.length &&
-			! images.find( ( image ) => image.url.startsWith( 'blob' ) )
-		) {
-			multiSelect(
-				newImages[ 0 ].clientId,
-				newImages[ newImages?.length - 1 ].clientId
-			);
+		if ( newImages?.length > 0 ) {
+			clearSelectedBlock();
 		}
 	}, [ newImages ] );
 
@@ -299,6 +291,10 @@ function GalleryEdit( props ) {
 				alt: image.alt,
 			} );
 		} );
+
+		if ( newBlocks?.length > 0 ) {
+			selectBlock( newBlocks[ 0 ].clientId );
+		}
 
 		replaceInnerBlocks(
 			clientId,

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -14,6 +14,7 @@ import {
 	getEditedPostContent,
 	createNewPost,
 	clickButton,
+	openListView,
 } from '@wordpress/e2e-test-utils';
 
 async function upload( selector ) {
@@ -61,7 +62,7 @@ describe( 'Gallery', () => {
 
 		// The Gallery needs to be selected from the List view panel due to the
 		// way that Image uploads take and lose focus.
-		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		await openListView();
 		const galleryListLink = await page.waitForXPath(
 			`//a[contains(text(), 'Gallery')]`
 		);

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -59,11 +59,16 @@ describe( 'Gallery', () => {
 		await upload( '.wp-block-gallery input[type="file"]' );
 		await page.waitForSelector( '.wp-block-gallery .wp-block-image' );
 
-		// The newly added image gets the focus, so refocus parent Gallery
-		// block before trying to edit caption.
-		await clickButton( 'Gallery' );
+		// The Gallery needs to be selected from the List view panel due to the
+		// way that Image uploads take and lose focus.
+		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+		const galleryListLink = await page.waitForXPath(
+			`//a[contains(text(), 'Gallery')]`
+		);
+		await galleryListLink.click();
 
 		await page.click( '.wp-block-gallery .blocks-gallery-caption' );
+
 		await page.keyboard.type( galleryCaption );
 
 		expect( await getEditedPostContent() ).toMatch(

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -47,7 +47,7 @@ describe( 'Gallery', () => {
 		const filename = await upload( '.wp-block-gallery input[type="file"]' );
 
 		const regex = new RegExp(
-			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"full\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image size-full\\"><img src=\\"[^"]+\/${ filename }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
+			`<!-- wp:gallery {\\"linkTo\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-gallery has-nested-images columns-default is-cropped\\"><!-- wp:image {\\"id\\":\\d+,\\"sizeSlug\\":\\"(?:full|large)\\",\\"linkDestination\\":\\"none\\"} -->\\s*<figure class=\\"wp-block-image (?:size-full|size-large)\\"><img src=\\"[^"]+\/${ filename }\.png\\" alt=\\"\\" class=\\"wp-image-\\d+\\"\/><\/figure>\\s*<!-- \/wp:image --><\/figure>\\s*<!-- \/wp:gallery -->`
 		);
 		expect( await getEditedPostContent() ).toMatch( regex );
 	} );


### PR DESCRIPTION
## Description
https://github.com/WordPress/gutenberg/pull/38259 was supposed to fix an issue with all uploading images being switched to the last image being uploaded - but it turned out this fix only works if all images are similar sizes and finish uploaded about the same time. 

There are two possible fixes committed to this PR:

1.  The [first commit](https://github.com/WordPress/gutenberg/pull/39269/commits/026442173f8c5502cd439090e51cb784128ca5b6) checks that no images are still uploading before selecting the latest images. The disadvantage of this is that the selected blocks are not all of the newly uploaded images, but rather just the last image/images to complete uploading. Also, for large images the scroll and selection to the latest can be very delayed, so there may be no indication to the user that anything is happening if upload it taking place off-screen
2. The [second commit](https://github.com/WordPress/gutenberg/pull/39269/commits/bee3177efec1745e281d74e719c08374aee103ab) switched to just selecting the first new images immediately in order to scroll straight to the new images and then deselects it as otherwise, the caption of that image takes focus which is a bit annoying. The disadvantage of this approach is that all of the new images are not selected.

I prefer option 2 personally as selecting all the new images can be a bit annoying as often you want to just edit one image at a time after upload and it takes extra clicks to unselect all the new images.

## Testing Instructions

- Drag and drop a collection of images onto the editor, one of which is considerably larger in size, eg, 2MB compared to 15KB
- Make sure image uploads complete as expected

## Screenshots 
Before:

https://user-images.githubusercontent.com/3629020/157141121-2c86eeb7-3431-402b-81f1-44e1dde9a254.mp4

After with first commit:

https://user-images.githubusercontent.com/3629020/157141219-2ca66c1c-7401-4392-bc35-7a38b543a506.mp4

After with second commit:

https://user-images.githubusercontent.com/3629020/157141272-bf0ded4d-fece-43e8-a91e-94290378fe18.mp4