### PR TITLE
Update 'clickMenuItem' test util to use full label matching

### DIFF
--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Updated `clickMenuItem` method to use complete label matching instead of partial [#39274](https://github.com/WordPress/gutenberg/pull/39274).
+-   Updated `clickMenuItem` method to use exact label matching instead of partial [#39274](https://github.com/WordPress/gutenberg/pull/39274).
 
 ### Enhancement
 

--- a/packages/e2e-test-utils/CHANGELOG.md
+++ b/packages/e2e-test-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Updated `clickMenuItem` method to use complete label matching instead of partial [#39274](https://github.com/WordPress/gutenberg/pull/39274).
+
 ### Enhancement
 
 -   The `toggleMoreMenu` and `clickMoreMenuItem` utilities no longer require a second 'context' parameter.

--- a/packages/e2e-test-utils/src/click-menu-item.js
+++ b/packages/e2e-test-utils/src/click-menu-item.js
@@ -10,9 +10,7 @@ import { first } from 'lodash';
  */
 export async function clickMenuItem( label ) {
 	const elementToClick = first(
-		await page.$x(
-			`//div[@role="menu"]//span[contains(concat(" ", @class, " "), " components-menu-item__item ")][contains(text(), "${ label }")]`
-		)
+		await page.$x( `//*[@role="menu"]//*[text()="${ label }"]` )
 	);
 	await elementToClick.click();
 }


### PR DESCRIPTION
## Description
PR update `clickMenuItem` to use complete label matching. It should prevent clicking incorrect menu items when a label is partially matched.

I've also updated the selector (per @ciampo's suggestion) to avoid relying on DOM structure and classes.

The previous discussion can be found here - https://github.com/WordPress/gutenberg/pull/39183#discussion_r819462805.

## Testing Instructions
All e2e tests should pass.

## Types of changes
Bugfix/Breaking change
