### PR TITLE
Media & Text: Display media while uploading

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -29,6 +29,7 @@ import {
 	ExternalLink,
 	FocalPointPicker,
 } from '@wordpress/components';
+import { isBlobURL, getBlobTypeByURL } from '@wordpress/blob';
 import { pullLeft, pullRight } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -83,6 +84,10 @@ function attributesFromMedia( {
 				focalPoint: undefined,
 			} );
 			return;
+		}
+
+		if ( isBlobURL( media.url ) ) {
+			media.type = getBlobTypeByURL( media.url );
 		}
 
 		let mediaType;


### PR DESCRIPTION
## Description
PR updates Media & Text block to extract media type from blob URL. It will allow us to call a media-type renderer while the upload is still in progress.

This matches the behavior of Image and [Cover](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/cover/shared.js#L42-L44) blocks.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Media & Text block.
3. Upload file (maybe throttle network here).
4. Confirm that file is displayed while the upload is in progress.

## Screenshots <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/157199022-a51fd195-ddaf-44c1-88f0-d2238a048897.mp4

**After**

https://user-images.githubusercontent.com/240569/157199052-2a414fc5-b14e-4820-97a1-7a55462db3a8.mp4

## Types of changes
Enhancement
