### PR TITLE
Update submenu font-size inheritance to fix scaling of top level submenu parent

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -284,6 +284,7 @@ $navigation-icon-size: 24px;
 .wp-block-navigation-submenu {
 	position: relative;
 	display: flex;
+	font-size: inherit;
 
 	.wp-block-navigation__submenu-icon svg {
 		stroke: currentColor;


### PR DESCRIPTION
## Description
Resizing the font variable on a submenu will affect the top-level menu item (parent of submenu). This fix changes the .wp-block-navigation-submenu to inherit its font-size properly, and only scale the submenu itself to the variable set in theme.json.



Closes https://github.com/WordPress/gutenberg/issues/39263

## Testing Instructions
1. Go to theme.json
2. Under styles { block }, and set a font-size for core/navigation-submenu that differs from the top level menu
3. See the font-size change in the submenu, and its parent anchor.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 


## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run lint`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/javascript/ -->
- [ ] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [ ] I've tested my changes with keyboard and screen readers. <!-- Instructions: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/accessibility-testing.md -->
- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/javascript/ -->
- [ ] I've included developer documentation if appropriate. <!-- Handbook: https://developer.wordpress.org/block-editor/ -->
- [ ] I've updated all React Native files affected by any refactorings/renamings in this PR (please manually search all `*.native.js` files for terms that need renaming or removal). <!-- React Native mobile Gutenberg guidelines: https://github.com/WordPress/gutenberg/blob/HEAD/docs/contributors/code/native-mobile.md -->
- [ ] I've updated related schemas if appropriate. <!-- Reference: https://github.com/WordPress/gutenberg/tree/trunk/schemas -->
