### PR TITLE
Add an "enabled" option to useEntityRecord and useEntityRecords

### DIFF
--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -30,6 +30,7 @@ export default function useNavigationEntities( menuId ) {
 		isResolving: isResolvingMenus,
 		hasResolved: hasResolvedMenus,
 	} = useEntityRecords( 'root', 'menu', { per_page: -1, context: 'view' } );
+
 	const {
 		records: pages,
 		isResolving: isResolvingPages,

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -54,7 +54,7 @@ export default function useNavigationEntities( menuId ) {
 			per_page: -1,
 			context: 'view',
 		},
-		{ __experimentalEnabled: !! menuId }
+		{ enabled: !! menuId }
 	);
 
 	return {

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
-import {
-	store as coreStore,
-	__experimentalUseEntityRecords as useEntityRecords,
-} from '@wordpress/core-data';
+import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData
@@ -29,82 +25,49 @@ import {
  * @return { NavigationEntitiesData } the entity data.
  */
 export default function useNavigationEntities( menuId ) {
-	return {
-		...usePageEntities(),
-		...useMenuEntities(),
-		...useMenuItemEntities( menuId ),
-	};
-}
+	const {
+		records: menus,
+		isResolving: isResolvingMenus,
+		hasResolved: hasResolvedMenus,
+	} = useEntityRecords( 'root', 'menu', { per_page: -1, context: 'view' } );
+	const {
+		records: pages,
+		isResolving: isResolvingPages,
+		hasResolved: hasResolvedPages,
+	} = useEntityRecords( 'postType', 'page', {
+		parent: 0,
+		order: 'asc',
+		orderby: 'id',
+		per_page: -1,
+		context: 'view',
+	} );
 
-function useMenuEntities() {
-	const { records, isResolving, hasResolved } = useEntityRecords(
+	const {
+		records: menuItems,
+		hasResolved: hasResolvedMenuItems,
+	} = useEntityRecords(
 		'root',
-		'menu',
-		{ per_page: -1, context: 'view' }
-	);
-
-	return {
-		menus: records,
-		isResolvingMenus: isResolving,
-		hasResolvedMenus: hasResolved,
-		hasMenus: !! ( hasResolved && records?.length ),
-	};
-}
-
-function useMenuItemEntities( menuId ) {
-	const { menuItems, hasResolvedMenuItems } = useSelect(
-		( select ) => {
-			const { getMenuItems, hasFinishedResolution } = select( coreStore );
-
-			const hasSelectedMenu = menuId !== undefined;
-			const menuItemsParameters = hasSelectedMenu
-				? [
-						{
-							menus: menuId,
-							per_page: -1,
-							context: 'view',
-						},
-				  ]
-				: undefined;
-
-			return {
-				menuItems: hasSelectedMenu
-					? getMenuItems( ...menuItemsParameters )
-					: undefined,
-				hasResolvedMenuItems: hasSelectedMenu
-					? hasFinishedResolution(
-							'getMenuItems',
-							menuItemsParameters
-					  )
-					: false,
-			};
-		},
-		[ menuId ]
-	);
-
-	return {
-		menuItems,
-		hasResolvedMenuItems,
-	};
-}
-
-function usePageEntities() {
-	const { records, isResolving, hasResolved } = useEntityRecords(
-		'postType',
-		'page',
+		'menuItem',
 		{
-			parent: 0,
-			order: 'asc',
-			orderby: 'id',
+			menus: menuId,
 			per_page: -1,
 			context: 'view',
-		}
+		},
+		{ execute: ! menuId }
 	);
 
 	return {
-		pages: records,
-		isResolvingPages: isResolving,
-		hasResolvedPages: hasResolved,
-		hasPages: !! ( hasResolved && records?.length ),
+		pages,
+		isResolvingPages,
+		hasResolvedPages,
+		hasPages: !! ( hasResolvedPages && pages?.length ),
+
+		menus,
+		isResolvingMenus,
+		hasResolvedMenus,
+		hasMenus: !! ( hasResolvedMenus && menus?.length ),
+
+		menuItems,
+		hasResolvedMenuItems,
 	};
 }

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -54,7 +54,7 @@ export default function useNavigationEntities( menuId ) {
 			per_page: -1,
 			context: 'view',
 		},
-		{ execute: !! menuId }
+		{ __experimentalExecute: !! menuId }
 	);
 
 	return {

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -53,7 +53,7 @@ export default function useNavigationEntities( menuId ) {
 			per_page: -1,
 			context: 'view',
 		},
-		{ execute: ! menuId }
+		{ execute: !! menuId }
 	);
 
 	return {

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -54,7 +54,7 @@ export default function useNavigationEntities( menuId ) {
 			per_page: -1,
 			context: 'view',
 		},
-		{ __experimentalExecute: !! menuId }
+		{ __experimentalEnabled: !! menuId }
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -24,16 +24,17 @@ interface EntityRecordResolution< RecordType > {
 }
 
 interface Options {
-	__experimentalEnabled: boolean;
+	enabled: boolean;
 }
 
 /**
  * Resolves the specified entity record.
  *
- * @param  kind     Kind of the requested entity.
- * @param  name     Name of the requested  entity.
- * @param  recordId Record ID of the requested entity.
- * @param  options
+ * @param  kind                                 Kind of the requested entity.
+ * @param  name                                 Name of the requested  entity.
+ * @param  recordId                             Record ID of the requested entity.
+ * @param  options                              Hook options.
+ * @param  [options.enabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -63,16 +64,16 @@ export default function __experimentalUseEntityRecord< RecordType >(
 	kind: string,
 	name: string,
 	recordId: string | number,
-	options: Options = { __experimentalEnabled: true }
+	options: Options = { enabled: true }
 ): EntityRecordResolution< RecordType > {
 	const { data: record, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.__experimentalEnabled ) {
+			if ( ! options.enabled ) {
 				return null;
 			}
 			return query( coreStore ).getEntityRecord( kind, name, recordId );
 		},
-		[ kind, name, recordId, options.__experimentalEnabled ]
+		[ kind, name, recordId, options.enabled ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -24,7 +24,7 @@ interface EntityRecordResolution< RecordType > {
 }
 
 interface Options {
-	__experimentalExecute: boolean;
+	__experimentalEnabled: boolean;
 }
 
 /**
@@ -64,16 +64,16 @@ export default function __experimentalUseEntityRecord< RecordType >(
 	kind: string,
 	name: string,
 	recordId: string | number,
-	options: Options = { __experimentalExecute: true }
+	options: Options = { __experimentalEnabled: true }
 ): EntityRecordResolution< RecordType > {
 	const { data: record, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.__experimentalExecute ) {
+			if ( ! options.__experimentalEnabled ) {
 				return null;
 			}
 			return query( coreStore ).getEntityRecord( kind, name, recordId );
 		},
-		[ kind, name, recordId, options.__experimentalExecute ]
+		[ kind, name, recordId, options.__experimentalEnabled ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -23,6 +23,10 @@ interface EntityRecordResolution< RecordType > {
 	status: Status;
 }
 
+interface Options {
+	execute: boolean;
+}
+
 /**
  * Resolves the specified entity record.
  *
@@ -30,6 +34,7 @@ interface EntityRecordResolution< RecordType > {
  * @param  name     Name of the requested  entity.
  * @param  recordId Record ID of the requested entity.
  *
+ * @param  options
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -58,10 +63,16 @@ interface EntityRecordResolution< RecordType > {
 export default function __experimentalUseEntityRecord< RecordType >(
 	kind: string,
 	name: string,
-	recordId: string | number
+	recordId: string | number,
+	options: Options = { execute: true }
 ): EntityRecordResolution< RecordType > {
 	const { data: record, ...rest } = useQuerySelect(
-		( query ) => query( coreStore ).getEntityRecord( kind, name, recordId ),
+		( query ) => {
+			if ( ! options.execute ) {
+				return {};
+			}
+			query( coreStore ).getEntityRecord( kind, name, recordId );
+		},
 		[ kind, name, recordId ]
 	);
 

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -30,11 +30,12 @@ interface Options {
 /**
  * Resolves the specified entity record.
  *
- * @param  kind     Kind of the requested entity.
- * @param  name     Name of the requested  entity.
- * @param  recordId Record ID of the requested entity.
+ * @param  kind                                 Kind of the requested entity.
+ * @param  name                                 Name of the requested  entity.
+ * @param  recordId                             Record ID of the requested entity.
+ * @param  options                              Hook options.
+ * @param  [options.__experimentalEnabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
  *
- * @param  options
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -24,7 +24,7 @@ interface EntityRecordResolution< RecordType > {
 }
 
 interface Options {
-	execute: boolean;
+	__experimentalExecute: boolean;
 }
 
 /**
@@ -64,16 +64,16 @@ export default function __experimentalUseEntityRecord< RecordType >(
 	kind: string,
 	name: string,
 	recordId: string | number,
-	options: Options = { execute: true }
+	options: Options = { __experimentalExecute: true }
 ): EntityRecordResolution< RecordType > {
 	const { data: record, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.execute ) {
-				return {};
+			if ( ! options.__experimentalExecute ) {
+				return null;
 			}
-			query( coreStore ).getEntityRecord( kind, name, recordId );
+			return query( coreStore ).getEntityRecord( kind, name, recordId );
 		},
-		[ kind, name, recordId ]
+		[ kind, name, recordId, options.__experimentalExecute ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -30,12 +30,10 @@ interface Options {
 /**
  * Resolves the specified entity record.
  *
- * @param  kind                                 Kind of the requested entity.
- * @param  name                                 Name of the requested  entity.
- * @param  recordId                             Record ID of the requested entity.
- * @param  options                              Hook options.
- * @param  [options.__experimentalEnabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
- *
+ * @param  kind     Kind of the requested entity.
+ * @param  name     Name of the requested  entity.
+ * @param  recordId Record ID of the requested entity.
+ * @param  options
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -29,7 +29,7 @@ interface EntityRecordsResolution< RecordType > {
 }
 
 interface Options {
-	__experimentalEnabled: boolean;
+	enabled: boolean;
 }
 
 /**
@@ -39,8 +39,7 @@ interface Options {
  * @param  name                                 Name of the requested entities.
  * @param  queryArgs                            HTTP query for the requested entities.
  * @param  options                              Hook options.
- * @param  [options.__experimentalEnabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
- *
+ * @param  [options.enabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -76,7 +75,7 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
 	queryArgs: unknown = {},
-	options: Options = { __experimentalEnabled: true }
+	options: Options = { enabled: true }
 ): EntityRecordsResolution< RecordType > {
 	// Serialize queryArgs to a string that can be safely used as a React dep.
 	// We can't just pass queryArgs as one of the deps, because if it is passed
@@ -86,12 +85,12 @@ export default function __experimentalUseEntityRecords< RecordType >(
 
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.__experimentalEnabled ) {
+			if ( ! options.enabled ) {
 				return {};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );
 		},
-		[ kind, name, queryAsString, options.__experimentalEnabled ]
+		[ kind, name, queryAsString, options.enabled ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -86,7 +86,9 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) => {
 			if ( ! options.enabled ) {
-				return {};
+				return {
+					data: []
+				};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );
 		},

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -29,7 +29,7 @@ interface EntityRecordsResolution< RecordType > {
 }
 
 interface Options {
-	execute: boolean;
+	__experimentalExecute: boolean;
 }
 
 /**
@@ -74,7 +74,7 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
 	queryArgs: unknown = {},
-	options: Options = { execute: true }
+	options: Options = { __experimentalExecute: true }
 ): EntityRecordsResolution< RecordType > {
 	// Serialize queryArgs to a string that can be safely used as a React dep.
 	// We can't just pass queryArgs as one of the deps, because if it is passed
@@ -84,12 +84,12 @@ export default function __experimentalUseEntityRecords< RecordType >(
 
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.execute ) {
+			if ( ! options.__experimentalExecute ) {
 				return {};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );
 		},
-		[ kind, name, queryAsString, options.execute ]
+		[ kind, name, queryAsString, options.__experimentalExecute ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -87,7 +87,7 @@ export default function __experimentalUseEntityRecords< RecordType >(
 		( query ) => {
 			if ( ! options.enabled ) {
 				return {
-					data: []
+					data: [],
 				};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -28,12 +28,17 @@ interface EntityRecordsResolution< RecordType > {
 	status: Status;
 }
 
+interface Options {
+	execute: boolean;
+}
+
 /**
  * Resolves the specified entity records.
  *
  * @param  kind      Kind of the requested entities.
  * @param  name      Name of the requested entities.
  * @param  queryArgs HTTP query for the requested entities.
+ * @param  options
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -68,7 +73,8 @@ interface EntityRecordsResolution< RecordType > {
 export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
-	queryArgs: unknown = {}
+	queryArgs: unknown = {},
+	options: Options = { execute: true }
 ): EntityRecordsResolution< RecordType > {
 	// Serialize queryArgs to a string that can be safely used as a React dep.
 	// We can't just pass queryArgs as one of the deps, because if it is passed
@@ -77,9 +83,16 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	const queryAsString = addQueryArgs( '', queryArgs );
 
 	const { data: records, ...rest } = useQuerySelect(
-		( query ) =>
-			query( coreStore ).getEntityRecords( kind, name, queryArgs ),
-		[ kind, name, queryAsString ]
+		( query ) => {
+			if ( options.execute ) {
+				return query( coreStore ).getEntityRecords(
+					kind,
+					name,
+					queryArgs
+				);
+			}
+		},
+		[ kind, name, queryAsString, options.execute ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -84,13 +84,10 @@ export default function __experimentalUseEntityRecords< RecordType >(
 
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( options.execute ) {
-				return query( coreStore ).getEntityRecords(
-					kind,
-					name,
-					queryArgs
-				);
+			if ( ! options.execute ) {
+				return {};
 			}
+			return query( coreStore ).getEntityRecords( kind, name, queryArgs );
 		},
 		[ kind, name, queryAsString, options.execute ]
 	);

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -29,7 +29,7 @@ interface EntityRecordsResolution< RecordType > {
 }
 
 interface Options {
-	__experimentalExecute: boolean;
+	__experimentalEnabled: boolean;
 }
 
 /**
@@ -74,7 +74,7 @@ export default function __experimentalUseEntityRecords< RecordType >(
 	kind: string,
 	name: string,
 	queryArgs: unknown = {},
-	options: Options = { __experimentalExecute: true }
+	options: Options = { __experimentalEnabled: true }
 ): EntityRecordsResolution< RecordType > {
 	// Serialize queryArgs to a string that can be safely used as a React dep.
 	// We can't just pass queryArgs as one of the deps, because if it is passed
@@ -84,12 +84,12 @@ export default function __experimentalUseEntityRecords< RecordType >(
 
 	const { data: records, ...rest } = useQuerySelect(
 		( query ) => {
-			if ( ! options.__experimentalExecute ) {
+			if ( ! options.__experimentalEnabled ) {
 				return {};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );
 		},
-		[ kind, name, queryAsString, options.__experimentalExecute ]
+		[ kind, name, queryAsString, options.__experimentalEnabled ]
 	);
 
 	return {

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -35,10 +35,12 @@ interface Options {
 /**
  * Resolves the specified entity records.
  *
- * @param  kind      Kind of the requested entities.
- * @param  name      Name of the requested entities.
- * @param  queryArgs HTTP query for the requested entities.
- * @param  options
+ * @param  kind                                 Kind of the requested entities.
+ * @param  name                                 Name of the requested entities.
+ * @param  queryArgs                            HTTP query for the requested entities.
+ * @param  options                              Hook options.
+ * @param  [options.__experimentalEnabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
+ *
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';


### PR DESCRIPTION
## Description

A part of #38135

Following up on an excellent discussion from https://github.com/WordPress/gutenberg/pull/38827, this PR takes a closer look at the conditional execution of `getEntityRecords` to make it a viable tool in cases such as this one:

```js
	const { menuItems, hasResolvedMenuItems = false } = useSelect(
		( select ) => {
			if ( ! menuId ) {
				return {};
			}

			const { getMenuItems, hasFinishedResolution } = select( coreStore );
			const query = {
				menus: menuId,
				per_page: -1,
				context: 'view',
			};
			return {
				menuItems: getMenuItems( query ),
				hasResolvedMenuItems: hasFinishedResolution( 'getMenuItems', [
					query,
				] ),
			};
		},
		[ menuId ]
	);
```

With the new option proposed in this PR, the snippet above would look like this instead:

```js
	const { records, hasResolved } = useEntityRecords(
		'root',
		'menuItem',
		{
			menus: menuId,
			per_page: -1,
			context: 'view',
		},
		{ enabled: !! menuId }
	);
```

As demonstrated in the update made to `use-navigation-entities.js`.

## Test plan

Confirm the tests are green. The relevant navigation block use-cases are covered by e2e so there should be no additional testing required.

## Alternatives

@kevin940726 suggested opening `useQuerySelect` API as an alternative:

```js
useQuerySelect((query) => {
  if (enabled) {
    return query(coreStore).selectAll('root', 'menu', { per_page: -1, context: 'view' });
  }
});
```

It has a few upsides, such as enabling the use of conditional, loops, infinite loading, etc.

It could make a great follow-up discussion – I still think this PR has merit on its own.

cc @gziolo @getdave @kevin940726 @noisysocks 

