### PR TITLE
Block editor: fix iframe rendering mode

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -199,6 +199,14 @@ function Iframe(
 			contentDocument.dir = ownerDocument.dir;
 			documentElement.removeChild( contentDocument.head );
 			documentElement.removeChild( contentDocument.body );
+			contentDocument.insertBefore(
+				contentDocument.implementation.createDocumentType(
+					'html',
+					'',
+					''
+				),
+				documentElement
+			);
 
 			return true;
 		}

--- a/packages/e2e-tests/specs/site-editor/iframe-rendering-mode.test.js
+++ b/packages/e2e-tests/specs/site-editor/iframe-rendering-mode.test.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { activateTheme, visitSiteEditor } from '@wordpress/e2e-test-utils';
+
+describe( 'Site editor iframe rendering mode', () => {
+	beforeAll( async () => {
+		await activateTheme( 'emptytheme' );
+	} );
+
+	afterAll( async () => {
+		await activateTheme( 'twentytwentyone' );
+	} );
+
+	it( 'Should render editor in standards mode.', async () => {
+		await visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+		} );
+
+		const compatMode = await page.evaluate(
+			() =>
+				document.querySelector( `iframe[name='editor-canvas']` )
+					.contentDocument.compatMode
+		);
+
+		// CSS1Compat = expected standards mode.
+		// BackCompat = quirks mode.
+		expect( compatMode ).toBe( 'CSS1Compat' );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Same as #38855, but without using srcDoc.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
