### PR TITLE
Image block: Add additional selector to account for the move of is-style classes 

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -69,7 +69,8 @@
 	}
 
 	// Variations
-	&.is-style-rounded img {
+	&.is-style-rounded img,
+	.is-style-rounded img {
 		// We use an absolute pixel to prevent the oval shape that a value of 50% would give
 		// to rectangular images. A pill-shape is better than otherwise.
 		border-radius: 9999px;


### PR DESCRIPTION
## What?
This PR adds an additional selector for the Image blocks core `is-style-rounded` style. Fixes: #39242

## Why?
In https://github.com/WordPress/gutenberg/pull/38657 the additional wrapper that was added to allow for image alignment was removed and all of the classes were moved to the `figure` element. For non theme.json themes the wrapper `div` was added back in the frontend, but the `is-style-` classes are not moved to this div, so the styling is lost on the frontend.

## How?
The addition of `.wp-block-image .is-style-rounded img` as well as `.wp-block-image.is-style-rounded img` makes sure that both instances are accounted for.

**N.B.** - this only fixes the image `is-style-rounded` core style. Any image styles set within a theme that rely on the style class being on the same element as `.wp-block-image`  will still be broken.

## Testing Instructions

- In a non theme.json theme, eg TwentyTwentyOne add an image and apply the Rounded style and also specify an alignment for the image
- Check that the style is applied as expected in the editor and the frontend

## Screenshots
Before:

https://user-images.githubusercontent.com/3629020/157328622-0a64fae6-b132-491f-850f-39259a63b478.mp4

After:

https://user-images.githubusercontent.com/3629020/157328688-65d4031d-8afb-44f7-9067-536b514bd87f.mp4



