### PR TITLE
Set $name on WP_Block_Editor_Context

### DIFF
--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -75,7 +75,23 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis
-		$editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
+		switch ( $request['context'] ) {
+			case 'post-editor':
+			default:
+				$editor_context_name = 'core/edit-post';
+				break;
+			case 'widgets-editor':
+				$editor_context_name = 'core/edit-widgets';
+				break;
+			case 'site-editor':
+				$editor_context_name = 'core/edit-site';
+				break;
+			case 'mobile':
+				$editor_context_name = 'core/mobile';
+				break;
+		}
+
+		$editor_context = new WP_Block_Editor_Context( array( 'name' => $editor_context_name ) );
 		$settings       = get_block_editor_settings( array(), $editor_context );
 
 		return rest_ensure_response( $settings );

--- a/lib/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/class-wp-rest-block-editor-settings-controller.php
@@ -75,7 +75,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis
-		$editor_context = new WP_Block_Editor_Context();
+		$editor_context = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 		$settings       = get_block_editor_settings( array(), $editor_context );
 
 		return rest_ensure_response( $settings );

--- a/lib/full-site-editing/edit-site-page.php
+++ b/lib/full-site-editing/edit-site-page.php
@@ -131,7 +131,7 @@ function gutenberg_edit_site_init( $hook ) {
 	 */
 	$current_screen->is_block_editor( true );
 
-	$site_editor_context     = new WP_Block_Editor_Context();
+	$site_editor_context     = new WP_Block_Editor_Context( array( 'name' => 'core/edit-site' ) );
 	$settings                = get_block_editor_settings( $custom_settings, $site_editor_context );
 	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	$active_theme            = wp_get_theme()->get_stylesheet();

--- a/lib/navigation-page.php
+++ b/lib/navigation-page.php
@@ -98,17 +98,15 @@ function gutenberg_navigation_init( $hook ) {
 		$preload_paths[] = gutenberg_navigation_get_menu_items_endpoint( $first_menu_id );
 	}
 
-	$settings = array_merge(
-		get_default_block_editor_settings(),
-		array(
-			'blockNavMenus' => false,
-			// We should uncomment the line below when the block-nav-menus feature becomes stable.
-			// @see https://github.com/WordPress/gutenberg/issues/34265.
-			/*'blockNavMenus' => get_theme_support( 'block-nav-menus' ),*/
-		)
+	$custom_settings = array(
+		'blockNavMenus' => false,
+		// We should uncomment the line below when the block-nav-menus feature becomes stable.
+		// @see https://github.com/WordPress/gutenberg/issues/34265.
+		/*'blockNavMenus' => get_theme_support( 'block-nav-menus' ),*/
 	);
-	$settings = gutenberg_get_block_editor_settings( $settings );
 
+	$context  = new WP_Block_Editor_Context( array( 'name' => 'core/edit-navigation' ) );
+	$settings = get_block_editor_settings( $custom_settings, $context );
 	gutenberg_initialize_editor(
 		'navigation_editor',
 		'edit-navigation',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Compliments https://github.com/WordPress/wordpress-develop/pull/2374 by configuring the Gutenberg plugin to set `$name` on `WP_Block_Editor_Context` wherever the plugin initialises an editor.

## Why?
It's anticipated that `WP_Block_Editor_Context::$name` will land in WP 6.0. See https://github.com/WordPress/wordpress-develop/pull/2374. It was added so that plugins can identify which editor they are customising when using filters such as `allowed_block_types_all`. See https://github.com/WordPress/gutenberg/issues/28517.

## How?
Passes `'name'` to the constructor of `WP_Block_Editor_Context`. This is a safe no-op in versions of WordPress prior to 6.0 
which won't have `WP_Block_Editor_Context::$name`.

## Testing Instructions
Here's some code you can put into e.g. `wp-content/mu-plugins/allowed-blocks.php`:

```php
<?php
add_filter(
	'allowed_block_types_all',
	function( $allowed_block_types, $block_editor_context ) {
		if ( 'core/edit-site' === $block_editor_context->name ) {
			return array( 'core/paragraph' );
		}
		if ( 'core/edit-widgets' === $block_editor_context->name ) {
			return array( 'core/heading' );
		}
		if ( 'core/customize-widgets' === $block_editor_context->name ) {
			return array( 'core/image' );
		}
		if ( 'core/edit-post' === $block_editor_context->name ) {
			return array( 'core/separator' );
		}
		return $allowed_block_types;
	},
	10,
	2
);
```

With the above plugin running, activate the plugin and navigate to Appearance → Editor. You should only be allowed to add a Paragraph block.