### PR TITLE
Fix performance tests by adding backwards compatibility to welcome guide utility

### DIFF
--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -59,33 +59,65 @@ export async function closeSiteEditorNavigationPanel() {
  * Skips the welcome guide popping up to first time users of the site editor
  */
 export async function disableSiteEditorWelcomeGuide() {
-	const isWelcomeGuideActive = await page.evaluate(
-		() =>
-			!! wp.data
-				.select( 'core/preferences' )
-				.get( 'core/edit-site', 'welcomeGuide' )
-	);
-	const isWelcomeGuideStyesActive = await page.evaluate(
-		() =>
-			!! wp.data
-				.select( 'core/preferences' )
-				.get( 'core/edit-site', 'welcomeGuideStyles' )
-	);
+	// This code prioritizes using the preferences store. However, performance
+	// tests run on older versions of the codebase where the preferences store
+	// doesn't exist. Some backwards compatibility has been built-in so that
+	// those tests continue to work there. This can be removed once WordPress
+	// 6.0 is released, as the older version used by the performance tests will
+	// then include the preferences store.
+	// See https://github.com/WordPress/gutenberg/pull/39300.
+	const isWelcomeGuideActive = await page.evaluate( () => {
+		// TODO - remove if statement after WordPress 6.0 is released.
+		if ( ! wp.data.select( 'core/preferences' ) ) {
+			return wp.data
+				.select( 'core/edit-site' )
+				.isFeatureActive( 'welcomeGuide' );
+		}
+
+		return !! wp.data
+			.select( 'core/preferences' )
+			?.get( 'core/edit-site', 'welcomeGuide' );
+	} );
+	const isWelcomeGuideStyesActive = await page.evaluate( () => {
+		// TODO - remove if statement after WordPress 6.0 is released.
+		if ( ! wp.data.select( 'core/preferences' ) ) {
+			return wp.data
+				.select( 'core/edit-site' )
+				.isFeatureActive( 'welcomeGuideStyles' );
+		}
+
+		return !! wp.data
+			.select( 'core/preferences' )
+			?.get( 'core/edit-site', 'welcomeGuideStyles' );
+	} );
 
 	if ( isWelcomeGuideActive ) {
-		await page.evaluate( () =>
+		await page.evaluate( () => {
+			// TODO - remove if statement after WordPress 6.0 is released.
+			if ( ! wp.data.dispatch( 'core/preferences' ) ) {
+				wp.data
+					.dispatch( 'core/edit-site' )
+					.toggleFeature( 'welcomeGuide' );
+			}
+
 			wp.data
 				.dispatch( 'core/preferences' )
-				.toggle( 'core/edit-site', 'welcomeGuide' )
-		);
+				.toggle( 'core/edit-site', 'welcomeGuide' );
+		} );
 	}
 
 	if ( isWelcomeGuideStyesActive ) {
-		await page.evaluate( () =>
+		await page.evaluate( () => {
+			// TODO - remove if statement after WordPress 6.0 is released.
+			if ( ! wp.data.dispatch( 'core/preferences' ) ) {
+				wp.data
+					.dispatch( 'core/edit-site' )
+					.toggleFeature( 'welcomeGuideStyles' );
+			}
 			wp.data
 				.dispatch( 'core/preferences' )
-				.toggle( 'core/edit-site', 'welcomeGuideStyles' )
-		);
+				.toggle( 'core/edit-site', 'welcomeGuideStyles' );
+		} );
 	}
 }
 


### PR DESCRIPTION
## What?
Fixes the performance tests.

## Why?
The tests are currently failing in `trunk`. 

They fail when comparing performance against an old version of the codebase, we can see in the logs the commit reference being used as the basis for the tests and that the site editor tests fail:
```
Branch: debd225d007f4e441ceec80fbd6fa96653f94737, Suite: site-editor
```

The commit referenced (debd225d007f4e441ceec80fbd6fa96653f94737) is from January, which predates the preferences store being introduced to the site editor in #39158.

The stack trace has this (I've snipped the irrelevant bits):
```
    Evaluation failed: TypeError: Cannot read properties of null (reading 'get')
      at disableSiteEditorWelcomeGuide (../e2e-test-utils/build/@wordpress/e2e-test-utils/src/site-editor.js:62:31)
```

Which shows that when running tests for this old branch, the test is trying to use the preferences store API (`get` function) to turn off the welcome guide, but the preferences store won't exist at that commit reference.

What confuses me is that I would've thought the old performance test would run using a corresponding older version of the test code and test utils. That doesn't seem to be the case though.

## How?
I've added some backwards compatibility to the `disableSiteEditorWelcomeGuide` util.
