### PR TITLE
[RNMobile] Increase editor ready timeout in Android e2e tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -46,6 +46,8 @@ const strToKeycode = {
 	[ backspace ]: 67,
 };
 
+const editorReadyTimeout = 8000;
+
 const timer = ( ms ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
 const isAndroid = () => {
@@ -157,8 +159,8 @@ const setupDriver = async () => {
 	// eslint-disable-next-line no-console
 	console.log( status );
 
-	await driver.setImplicitWaitTimeout( 5000 );
-	await timer( 5000 );
+	await driver.setImplicitWaitTimeout( editorReadyTimeout );
+	await timer( editorReadyTimeout );
 
 	await driver.setOrientation( 'PORTRAIT' );
 	return driver;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce failure rate of the `React Native E2E Tests (Android)` PR check.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
After merging https://github.com/WordPress/gutenberg/pull/39098, I noticed that several commits merged into `trunk` have the PR check `React Native E2E Tests (Android)` marked as failed (around 42% of recent commits). This PR should reduce the flakiness and hopefully prevent that PR check to fail. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
As far as I investigated, the issue looks related to the tests not waiting enough time before acting over the app. Currently, the Android E2E tests wait 5 seconds, this PR increases the timeout to 8 seconds in order to give enough time to let the editor be ready.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
This fix has been tested in https://github.com/WordPress/gutenberg/pull/39247 by running several times the CI job and checking that all of them passed. 

- [Latest succeeded CI job 🟢 ](https://github.com/WordPress/gutenberg/runs/5477987874?check_suite_focus=true)

<img width="600" alt="Screenshot 2022-03-09 at 14 36 27" src="https://user-images.githubusercontent.com/14905380/157452446-d3b1fa6d-d604-4672-8c01-ebeee04622fc.png">

As you can see in the screenshot, a couple of runs failed but were not related to e2e tests:
- Job 8 failed in the post step "Post Restore Gradle cache" which is not really related to e2e tests, probably this is an eventual error.
- Job 1 failed due to "Connection refused" error when setting up the Android emulator, again, probably this is an eventual error.

## Screenshots or screencast <!-- if applicable -->
