### PR TITLE
[core-data] Do not suppress errors in the getEntityRecord and getEntityRecords resolvers

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -8,6 +8,7 @@ import { find, includes, get, compact, uniq } from 'lodash';
  */
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -104,6 +105,17 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 
 		const record = await apiFetch( { path } );
 		dispatch.receiveEntityRecords( kind, name, record, query );
+	} catch ( error ) {
+		deprecated(
+			'Wordpress silently hid the errors for getEntityRecord and getEntityRecords resolvers. ' +
+				'These resolved even if error occurred. This has changed in 6.0 and starting 6.1 the errors ' +
+				'will be thrown.',
+			{
+				since: '6.0',
+			}
+		);
+		// eslint-disable-next-line no-console
+		console.error( error );
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}
@@ -198,6 +210,17 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 				args: resolutionsArgs,
 			} );
 		}
+	} catch ( error ) {
+		deprecated(
+			'Wordpress silently hid the errors for getEntityRecord and getEntityRecords resolvers. ' +
+				'These resolved even if error occurred. This has changed in 6.0 and starting 6.1 the errors ' +
+				'will be thrown.',
+			{
+				since: '6.0',
+			}
+		);
+		// eslint-disable-next-line no-console
+		console.error( error );
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -104,10 +104,6 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 
 		const record = await apiFetch( { path } );
 		dispatch.receiveEntityRecords( kind, name, record, query );
-	} catch ( error ) {
-		// We need a way to handle and access REST API errors in state
-		// Until then, catching the error ensures the resolver is marked as resolved.
-		// See similar implementation in `getEntityRecords()`.
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}
@@ -202,10 +198,6 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 				args: resolutionsArgs,
 			} );
 		}
-	} catch ( error ) {
-		// We need a way to handle and access REST API errors in state
-		// Until then, catching the error ensures the resolver is marked as resolved.
-		// See similar implementation in `getEntityRecord()`.
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -8,7 +8,6 @@ import { find, includes, get, compact, uniq } from 'lodash';
  */
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
-import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -105,17 +104,6 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 
 		const record = await apiFetch( { path } );
 		dispatch.receiveEntityRecords( kind, name, record, query );
-	} catch ( error ) {
-		deprecated(
-			'Wordpress silently hid the errors for getEntityRecord and getEntityRecords resolvers. ' +
-				'These resolved even if error occurred. This has changed in 6.0 and starting 6.1 the errors ' +
-				'will be thrown.',
-			{
-				since: '6.0',
-			}
-		);
-		// eslint-disable-next-line no-console
-		console.error( error );
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}
@@ -210,17 +198,6 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 				args: resolutionsArgs,
 			} );
 		}
-	} catch ( error ) {
-		deprecated(
-			'Wordpress silently hid the errors for getEntityRecord and getEntityRecords resolvers. ' +
-				'These resolved even if error occurred. This has changed in 6.0 and starting 6.1 the errors ' +
-				'will be thrown.',
-			{
-				since: '6.0',
-			}
-		);
-		// eslint-disable-next-line no-console
-		console.error( error );
 	} finally {
 		dispatch.__unstableReleaseStoreLock( lock );
 	}

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -84,6 +84,8 @@ describe( 'Post actions', () => {
 				) {
 					return { ...post, ...data };
 				} else if (
+					// This URL is requested by the actions dispatched in this test.
+					// They are safe to ignore and are only listed here to avoid triggeringan error.
 					method === 'GET' &&
 					path.startsWith( '/wp/v2/types/post' )
 				) {
@@ -169,9 +171,11 @@ describe( 'Post actions', () => {
 						return [];
 					}
 				} else if ( method === 'GET' ) {
+					// These URLs are requested by the actions dispatched in this test.
+					// They are safe to ignore and are only listed here to avoid triggeringan error.
 					if (
 						path.startsWith( '/wp/v2/types/post' ) ||
-						path.startsWith( '/wp/v2/posts/44' )
+						path.startsWith( `/wp/v2/posts/${ postId }` )
 					) {
 						return {};
 					}
@@ -251,6 +255,8 @@ describe( 'Post actions', () => {
 							...data,
 						};
 					}
+					// This URL is requested by the actions dispatched in this test.
+					// They are safe to ignore and are only listed here to avoid triggeringan error.
 				} else if (
 					method === 'GET' &&
 					path.startsWith( '/wp/v2/types/post' )

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -83,6 +83,11 @@ describe( 'Post actions', () => {
 					path.startsWith( `/wp/v2/posts/${ postId }` )
 				) {
 					return { ...post, ...data };
+				} else if (
+					method === 'GET' &&
+					path.startsWith( '/wp/v2/types/post' )
+				) {
+					return {};
 				}
 
 				throw {
@@ -163,6 +168,13 @@ describe( 'Post actions', () => {
 					} else if ( method === 'GET' ) {
 						return [];
 					}
+				} else if ( method === 'GET' ) {
+					if (
+						path.startsWith( '/wp/v2/types/post' ) ||
+						path.startsWith( '/wp/v2/posts/44' )
+					) {
+						return {};
+					}
 				}
 
 				throw {
@@ -239,6 +251,11 @@ describe( 'Post actions', () => {
 							...data,
 						};
 					}
+				} else if (
+					method === 'GET' &&
+					path.startsWith( '/wp/v2/types/post' )
+				) {
+					return {};
 				}
 
 				throw {


### PR DESCRIPTION
## What?
Now that the [resolution errors are handled by our redux store](https://github.com/WordPress/gutenberg/pull/38669), core-data resolvers may stop silencing them.

Note this is a breaking change in that the promises returned by resolveSelect( coreStore ).getEntityRecord/Records will now be rejected on failure whereas previously they were resolved without any possible way of learning that an error occurred.

## Testing Instructions
Check if all the checks below this PR are green.

cc @kevin940726 @jsnajdr @youknowriad @gziolo @Mamaduka @draganescu 