### PR TITLE
Gallery block: disable edit as html support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -248,7 +248,7 @@ Display multiple images in a rich gallery. ([Source](https://github.com/WordPres
 
 -	**Name:** core/gallery
 -	**Category:** media
--	**Supports:** align, anchor
+-	**Supports:** align, anchor, ~~html~~
 -	**Attributes:** allowResize, caption, columns, fixedHeight, ids, imageCrop, images, linkTarget, linkTo, shortCodeTransforms, sizeSlug
 
 ## Group

--- a/packages/block-library/CHANGELOG.md
+++ b/packages/block-library/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fix
 
+-   Gallery block: disable edit as html support ([#39318](https://github.com/WordPress/gutenberg/pull/39318)).
 -   Removed unused `@wordpress/escape-html` and `@wordpress/is-shallow-equal` dependencies ([#38388](https://github.com/WordPress/gutenberg/pull/38388)).
 
 ## 6.1.0 (2022-01-27)

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -106,7 +106,8 @@
 	},
 	"supports": {
 		"anchor": true,
-		"align": true
+		"align": true,
+		"html": false
 	},
 	"editorStyle": "wp-block-gallery-editor",
 	"style": "wp-block-gallery"


### PR DESCRIPTION
See: #39310

## What?
This PR disables HTML editing support for gallery blocks.

## Why?
In the gallery block, the block is broken when entering HTML edit mode and then returning to visual edit mode.
But gallery blocks with child blocks (`core/image`) should not be edited as HTML, just like group and column blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Insert a gallery block.
2. Make sure that the "Edit as HTML" menu is not displayed in the block toolbar option.