### PR TITLE
Fix Image block link rel handling

### DIFF
--- a/packages/block-editor/src/components/url-popover/image-url-input-ui.js
+++ b/packages/block-editor/src/components/url-popover/image-url-input-ui.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { find, isEmpty, each, map } from 'lodash';
+import { find, map } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -80,38 +80,25 @@ const ImageURLInputUI = ( {
 		setIsOpen( false );
 	} );
 
-	const removeNewTabRel = ( currentRel ) => {
-		let newRel = currentRel;
-
-		if ( currentRel !== undefined && ! isEmpty( newRel ) ) {
-			if ( ! isEmpty( newRel ) ) {
-				each( NEW_TAB_REL, ( relVal ) => {
-					const regExp = new RegExp( '\\b' + relVal + '\\b', 'gi' );
-					newRel = newRel.replace( regExp, '' );
-				} );
-
-				// Only trim if NEW_TAB_REL values was replaced.
-				if ( newRel !== currentRel ) {
-					newRel = newRel.trim();
-				}
-
-				if ( isEmpty( newRel ) ) {
-					newRel = undefined;
-				}
-			}
-		}
-
-		return newRel;
-	};
-
 	const getUpdatedLinkTargetSettings = ( value ) => {
 		const newLinkTarget = value ? '_blank' : undefined;
 
 		let updatedRel;
-		if ( ! newLinkTarget && ! rel ) {
-			updatedRel = undefined;
+		if ( newLinkTarget ) {
+			const rels = ( rel ?? '' ).split( ' ' );
+			NEW_TAB_REL.forEach( ( relVal ) => {
+				if ( ! rels.includes( relVal ) ) {
+					rels.push( relVal );
+				}
+			} );
+			updatedRel = rels.join( ' ' );
 		} else {
-			updatedRel = removeNewTabRel( rel );
+			const rels = ( rel ?? '' )
+				.split( ' ' )
+				.filter(
+					( relVal ) => NEW_TAB_REL.includes( relVal ) === false
+				);
+			updatedRel = rels.length ? rels.join( ' ' ) : undefined;
 		}
 
 		return {
@@ -232,7 +219,7 @@ const ImageURLInputUI = ( {
 			/>
 			<TextControl
 				label={ __( 'Link Rel' ) }
-				value={ removeNewTabRel( rel ) || '' }
+				value={ rel ?? '' }
 				onChange={ onSetLinkRel }
 			/>
 			<TextControl


### PR DESCRIPTION
closes #9731 

## What?

When adding a link to the image block and marking it as an external link, the "rel" of the link is not being updated properly.
This doesn't have any visible impact in the image block because when saving and loading the page, the ref attribute get filled again (by parsing the DOM after the server side filter adding the rel="noreferrer noopener" does its job). That said, it's not idea, the block is not idempotent.

## Why?
It's mostly a code quality to change to make the image block "link" behave similarly to the RichText links.

## How?
I'm just assigning the "noreferrer noopener" rel attribute when the "open in new tab" is triggered and remove these two rel attributes when the "open in new tab" is removed.

## Testing Instructions

- Add an image block
- Add a link to the image block
- Set it to "open in new tab"
- Check that the "rel" is filled in the code editor

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/272444/157480322-fd30276e-419f-4c55-979a-9d1fb2d11bba.mov

