### PR TITLE
Add labels to the global styles variations

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
@@ -231,7 +231,11 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Global_Styles_Cont
 			foreach ( $nested_html_files as $path => $file ) {
 				$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
 				if ( is_array( $decoded_file ) ) {
-					$variations[] = ( new WP_Theme_JSON_Gutenberg( $decoded_file ) )->get_raw_data();
+					$variation = ( new WP_Theme_JSON_Gutenberg( $decoded_file ) )->get_raw_data();
+					if ( ! isset( $variation['name'] ) ) {
+						$variation['name'] = basename( $path, '.json' );
+					}
+					$variations[] = $variation;
 				}
 			}
 		}

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
@@ -232,7 +232,7 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Global_Styles_Cont
 				$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
 				if ( is_array( $decoded_file ) ) {
 					$variation = ( new WP_Theme_JSON_Gutenberg( $decoded_file ) )->get_raw_data();
-					if ( ! isset( $variation['name'] ) ) {
+					if ( empty( $variation['name'] ) ) {
 						$variation['name'] = basename( $path, '.json' );
 					}
 					$variations[] = $variation;

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -28,6 +28,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'styles',
 		'templateParts',
 		'version',
+		'name',
 	);
 
 	/**

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -5,12 +5,43 @@ import {
 	__unstableIframe as Iframe,
 	__unstableEditorStyles as EditorStyles,
 } from '@wordpress/block-editor';
+import {
+	__unstableMotion as motion,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { useStyle } from './hooks';
+import { useSetting, useStyle } from './hooks';
 import { useGlobalStylesOutput } from './use-global-styles-output';
+
+const defaultColorVariants = {
+	start: {
+		opacity: 1,
+		display: 'block',
+	},
+	hover: {
+		opacity: 0,
+		display: 'none',
+	},
+};
+
+const paletteMotionVariants = {
+	start: {
+		y: '100%',
+		opacity: 0,
+		display: 'none',
+	},
+	hover: {
+		y: 0,
+		opacity: 1,
+		display: 'block',
+	},
+};
 
 const StylesPreview = ( { height = 150 } ) => {
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
@@ -19,51 +50,89 @@ const StylesPreview = ( { height = 150 } ) => {
 	const [ backgroundColor = 'white' ] = useStyle( 'color.background' );
 	const [ gradientValue ] = useStyle( 'color.gradient' );
 	const [ styles ] = useGlobalStylesOutput();
+	const disableMotion = useReducedMotion();
+	const [ isHovered, setIsHovered ] = useState( false );
+	const [ themeColors ] = useSetting( 'color.palette.theme' );
+	const [ customColors ] = useSetting( 'color.palette.custom' );
 
 	return (
 		<Iframe
 			className="edit-site-global-styles-preview__iframe"
 			head={ <EditorStyles styles={ styles } /> }
 			style={ { height } }
+			onMouseEnter={ () => setIsHovered( true ) }
+			onMouseLeave={ () => setIsHovered( false ) }
 		>
-			<div
+			<motion.div
 				style={ {
-					display: 'flex',
-					gap: 20,
-					alignItems: 'center',
-					justifyContent: 'center',
 					height: '100%',
-					transform: `scale(${ height / 150 })`,
+					width: '100%',
 					background: gradientValue ?? backgroundColor,
 					cursor: 'pointer',
 				} }
+				initial="start"
+				animate={ isHovered && ! disableMotion ? 'hover' : 'start' }
+				layout={ ! disableMotion }
 			>
-				<div style={ { fontFamily, fontSize: '80px' } }>Aa</div>
-				<div
+				<HStack
 					style={ {
-						display: 'flex',
-						gap: 20,
-						flexDirection: 'column',
+						height: '100%',
+						overflow: 'hidden',
 					} }
+					spacing={ 4 }
+					justify="center"
 				>
 					<div
 						style={ {
-							height: 40,
-							width: 40,
-							background: textColor,
-							borderRadius: 20,
+							fontFamily,
+							fontSize: ( 65 * height ) / 150,
 						} }
-					/>{ ' ' }
-					<div
-						style={ {
-							height: 40,
-							width: 40,
-							background: linkColor,
-							borderRadius: 20,
-						} }
-					/>
-				</div>
-			</div>
+					>
+						Aa
+					</div>
+					<motion.div variants={ defaultColorVariants }>
+						<VStack>
+							<div
+								style={ {
+									height: ( 30 * height ) / 150,
+									width: ( 30 * height ) / 150,
+									background: textColor,
+									borderRadius: ( 15 * height ) / 150,
+									border: '1px solid #f0f0f0',
+								} }
+							/>
+							<div
+								style={ {
+									height: ( 30 * height ) / 150,
+									width: ( 30 * height ) / 150,
+									background: linkColor,
+									borderRadius: ( 15 * height ) / 150,
+									border: '1px solid #f0f0f0',
+								} }
+							/>
+						</VStack>
+					</motion.div>
+					<motion.div variants={ paletteMotionVariants }>
+						<VStack>
+							{ themeColors
+								.concat( customColors )
+								.slice( 0, 4 )
+								.map( ( { color }, index ) => (
+									<div
+										key={ index }
+										style={ {
+											height: ( 30 * height ) / 150,
+											width: ( 30 * height ) / 150,
+											background: color,
+											borderRadius: ( 15 * height ) / 150,
+											border: '1px solid #f0f0f0',
+										} }
+									/>
+								) ) }
+						</VStack>
+					</motion.div>
+				</HStack>
+			</motion.div>
 		</Iframe>
 	);
 };

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -19,7 +19,7 @@ import { useState } from '@wordpress/element';
 import { useSetting, useStyle } from './hooks';
 import { useGlobalStylesOutput } from './use-global-styles-output';
 
-const defaultColorVariants = {
+const firstFrame = {
 	start: {
 		opacity: 1,
 		display: 'block',
@@ -30,36 +30,14 @@ const defaultColorVariants = {
 	},
 };
 
-const typographyVariants = {
-	start: {
-		opacity: 1,
-	},
-	hover: {
-		opacity: 0,
-	},
-};
-
-const labelVariants = {
-	start: {
-		opacity: 0,
-		display: 'none',
-	},
+const secondFrame = {
 	hover: {
 		opacity: 1,
 		display: 'block',
 	},
-};
-
-const paletteMotionVariants = {
 	start: {
-		y: '100%',
 		opacity: 0,
 		display: 'none',
-	},
-	hover: {
-		y: 0,
-		opacity: 1,
-		display: 'block',
 	},
 };
 
@@ -67,17 +45,30 @@ const normalizedWidth = 250;
 
 const StylesPreview = ( { label } ) => {
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
+	const [ headingFontFamily = fontFamily ] = useStyle(
+		'elements.h1.typography.fontFamily'
+	);
 	const [ textColor = 'black' ] = useStyle( 'color.text' );
+	const [ headingColor = textColor ] = useStyle( 'elements.h1.color.text' );
 	const [ linkColor = 'blue' ] = useStyle( 'elements.link.color.text' );
 	const [ backgroundColor = 'white' ] = useStyle( 'color.background' );
 	const [ gradientValue ] = useStyle( 'color.gradient' );
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
 	const [ isHovered, setIsHovered ] = useState( false );
+	const [ coreColors ] = useSetting( 'color.palette.core' );
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
 	const [ customColors ] = useSetting( 'color.palette.custom' );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / normalizedWidth : 1;
+
+	const paletteColors = ( themeColors ?? [] )
+		.concat( customColors ?? [] )
+		.concat( coreColors ?? [] );
+	const highlightedColors = paletteColors
+		.filter( ( { color } ) => color !== backgroundColor )
+		.slice( 0, 2 );
+
 	return (
 		<Iframe
 			className="edit-site-global-styles-preview__iframe"
@@ -100,84 +91,113 @@ const StylesPreview = ( { label } ) => {
 				initial="start"
 				animate={ isHovered && ! disableMotion ? 'hover' : 'start' }
 			>
-				{ label && (
-					<motion.div
-						style={ {
-							fontSize: 30 * ratio,
-							position: 'absolute',
-							left: 10 * ratio,
-							bottom: 10 * ratio,
-							zIndex: 1,
-						} }
-						variants={ labelVariants }
-						transition={ { duration: 0.5 } }
-					>
-						{ label }
-					</motion.div>
-				) }
-				<HStack
+				<motion.div
+					variants={ firstFrame }
 					style={ {
 						height: '100%',
 						overflow: 'hidden',
 					} }
-					spacing={ 10 * ratio }
-					justify="center"
 				>
-					<motion.div
+					<HStack
+						spacing={ 10 * ratio }
+						justify="center"
 						style={ {
-							fontFamily,
-							fontSize: 65 * ratio,
+							height: '100%',
+							overflow: 'hidden',
 						} }
-						variants={ label ? typographyVariants : {} }
-						transition={ { duration: 0.5 } }
 					>
-						Aa
-					</motion.div>
-					<motion.div
-						variants={ defaultColorVariants }
-						transition={ { duration: 0.5 } }
-					>
+						<div
+							style={ {
+								fontFamily: headingFontFamily,
+								fontSize: 65 * ratio,
+								color: headingColor,
+							} }
+						>
+							Aa
+						</div>
 						<VStack spacing={ 2 * ratio }>
+							{ highlightedColors.map( ( { color } ) => (
+								<div
+									key={ color }
+									style={ {
+										height: 30 * ratio,
+										width: 30 * ratio,
+										background: color,
+										borderRadius: 15 * ratio,
+									} }
+								/>
+							) ) }
+						</VStack>
+					</HStack>
+				</motion.div>
+				<motion.div
+					variants={ secondFrame }
+					style={ {
+						height: '100%',
+						overflow: 'hidden',
+					} }
+				>
+					<VStack
+						spacing={ 3 * ratio }
+						justify="center"
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+							padding: 10 * ratio,
+							boxSizing: 'border-box',
+						} }
+					>
+						{ label && (
 							<div
 								style={ {
-									height: 30 * ratio,
-									width: 30 * ratio,
-									background: textColor,
-									borderRadius: 15 * ratio,
+									fontSize: 35 * ratio,
+									fontFamily: headingFontFamily,
+									color: headingColor,
+									lineHeight: '1em',
 								} }
-							/>
+							>
+								{ label }
+							</div>
+						) }
+						<HStack spacing={ 2 * ratio } justify="flex-start">
 							<div
 								style={ {
-									height: 30 * ratio,
-									width: 30 * ratio,
-									background: linkColor,
-									borderRadius: 15 * ratio,
+									fontFamily,
+									fontSize: 24 * ratio,
+									color: textColor,
 								} }
-							/>
-						</VStack>
-					</motion.div>
-					<motion.div
-						variants={ paletteMotionVariants }
-						transition={ { duration: 0.5 } }
-					>
-						<VStack spacing={ 2 * ratio }>
-							{ themeColors
-								.concat( customColors )
-								.slice( 0, 4 )
-								.map( ( { color }, index ) => (
-									<div
-										key={ index }
-										style={ {
-											height: 30 * ratio,
-											width: 30 * ratio,
-											background: color,
-											borderRadius: 15 * ratio,
-										} }
-									/>
-								) ) }
-						</VStack>
-					</motion.div>
-				</HStack>
+							>
+								Aa
+							</div>
+							<div
+								style={ {
+									fontFamily,
+									fontSize: 24 * ratio,
+									color: linkColor,
+								} }
+							>
+								Aa
+							</div>
+						</HStack>
+						{ paletteColors && (
+							<HStack spacing={ 0 }>
+								{ paletteColors
+									.slice( 0, 4 )
+									.map( ( { color }, index ) => (
+										<div
+											key={ index }
+											style={ {
+												height: 10 * ratio,
+												width: 30 * ratio,
+												background: color,
+												flexGrow: 1,
+											} }
+										/>
+									) ) }
+							</HStack>
+						) }
+					</VStack>
+				</motion.div>
 			</motion.div>
 		</Iframe>
 	);

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -30,6 +30,26 @@ const defaultColorVariants = {
 	},
 };
 
+const typographyVariants = {
+	start: {
+		opacity: 1,
+	},
+	hover: {
+		opacity: 0,
+	},
+};
+
+const labelVariants = {
+	start: {
+		opacity: 0,
+		display: 'none',
+	},
+	hover: {
+		opacity: 1,
+		display: 'block',
+	},
+};
+
 const paletteMotionVariants = {
 	start: {
 		y: '100%',
@@ -45,7 +65,7 @@ const paletteMotionVariants = {
 
 const normalizedWidth = 250;
 
-const StylesPreview = () => {
+const StylesPreview = ( { label } ) => {
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ textColor = 'black' ] = useStyle( 'color.text' );
 	const [ linkColor = 'blue' ] = useStyle( 'elements.link.color.text' );
@@ -81,22 +101,39 @@ const StylesPreview = () => {
 				animate={ isHovered && ! disableMotion ? 'hover' : 'start' }
 				layout={ ! disableMotion }
 			>
+				{ label && (
+					<motion.div
+						style={ {
+							fontSize: 30 * ratio,
+							position: 'absolute',
+							left: 10 * ratio,
+							bottom: 10 * ratio,
+							zIndex: 1,
+						} }
+						variants={ labelVariants }
+						transition={ { duration: 0.5 } }
+					>
+						{ label }
+					</motion.div>
+				) }
 				<HStack
 					style={ {
 						height: '100%',
 						overflow: 'hidden',
 					} }
-					spacing={ 4 * ratio }
+					spacing={ 10 * ratio }
 					justify="center"
 				>
-					<div
+					<motion.div
 						style={ {
 							fontFamily,
 							fontSize: 65 * ratio,
 						} }
+						variants={ label ? typographyVariants : {} }
+						transition={ { duration: 0.5 } }
 					>
 						Aa
-					</div>
+					</motion.div>
 					<motion.div
 						variants={ defaultColorVariants }
 						transition={ { duration: 0.5 } }

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -99,7 +99,6 @@ const StylesPreview = ( { label } ) => {
 				} }
 				initial="start"
 				animate={ isHovered && ! disableMotion ? 'hover' : 'start' }
-				layout={ ! disableMotion }
 			>
 				{ label && (
 					<motion.div

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -43,10 +43,14 @@ const secondFrame = {
 
 const normalizedWidth = 250;
 
-const StylesPreview = ( { label } ) => {
+const StylesPreview = ( { label, isFocused } ) => {
+	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ headingFontFamily = fontFamily ] = useStyle(
 		'elements.h1.typography.fontFamily'
+	);
+	const [ headingFontWeight = fontWeight ] = useStyle(
+		'elements.h1.typography.fontWeight'
 	);
 	const [ textColor = 'black' ] = useStyle( 'color.text' );
 	const [ headingColor = textColor ] = useStyle( 'elements.h1.color.text' );
@@ -55,10 +59,10 @@ const StylesPreview = ( { label } ) => {
 	const [ gradientValue ] = useStyle( 'color.gradient' );
 	const [ styles ] = useGlobalStylesOutput();
 	const disableMotion = useReducedMotion();
-	const [ isHovered, setIsHovered ] = useState( false );
 	const [ coreColors ] = useSetting( 'color.palette.core' );
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
 	const [ customColors ] = useSetting( 'color.palette.custom' );
+	const [ isHovered, setIsHovered ] = useState( false );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / normalizedWidth : 1;
 
@@ -66,7 +70,10 @@ const StylesPreview = ( { label } ) => {
 		.concat( customColors ?? [] )
 		.concat( coreColors ?? [] );
 	const highlightedColors = paletteColors
-		.filter( ( { color } ) => color !== backgroundColor )
+		.filter(
+			// we exclude these two colors because they are already visible in the preview.
+			( { color } ) => color !== backgroundColor && color !== headingColor
+		)
 		.slice( 0, 2 );
 
 	return (
@@ -79,6 +86,7 @@ const StylesPreview = ( { label } ) => {
 			} }
 			onMouseEnter={ () => setIsHovered( true ) }
 			onMouseLeave={ () => setIsHovered( false ) }
+			tabIndex={ -1 }
 		>
 			{ containerResizeListener }
 			<motion.div
@@ -89,7 +97,11 @@ const StylesPreview = ( { label } ) => {
 					cursor: 'pointer',
 				} }
 				initial="start"
-				animate={ isHovered && ! disableMotion ? 'hover' : 'start' }
+				animate={
+					( isHovered || isFocused ) && ! disableMotion
+						? 'hover'
+						: 'start'
+				}
 			>
 				<motion.div
 					variants={ firstFrame }
@@ -111,14 +123,15 @@ const StylesPreview = ( { label } ) => {
 								fontFamily: headingFontFamily,
 								fontSize: 65 * ratio,
 								color: headingColor,
+								fontWeight: headingFontWeight,
 							} }
 						>
 							Aa
 						</div>
 						<VStack spacing={ 2 * ratio }>
-							{ highlightedColors.map( ( { color } ) => (
+							{ highlightedColors.map( ( { slug, color } ) => (
 								<div
-									key={ color }
+									key={ slug }
 									style={ {
 										height: 30 * ratio,
 										width: 30 * ratio,
@@ -153,6 +166,7 @@ const StylesPreview = ( { label } ) => {
 									fontSize: 35 * ratio,
 									fontFamily: headingFontFamily,
 									color: headingColor,
+									fontWeight: headingFontWeight,
 									lineHeight: '1em',
 								} }
 							>

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -10,7 +10,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useReducedMotion } from '@wordpress/compose';
+import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 import { useState } from '@wordpress/element';
 
 /**
@@ -43,7 +43,9 @@ const paletteMotionVariants = {
 	},
 };
 
-const StylesPreview = ( { height = 150 } ) => {
+const normalizedWidth = 250;
+
+const StylesPreview = () => {
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
 	const [ textColor = 'black' ] = useStyle( 'color.text' );
 	const [ linkColor = 'blue' ] = useStyle( 'elements.link.color.text' );
@@ -54,15 +56,20 @@ const StylesPreview = ( { height = 150 } ) => {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ themeColors ] = useSetting( 'color.palette.theme' );
 	const [ customColors ] = useSetting( 'color.palette.custom' );
-
+	const [ containerResizeListener, { width } ] = useResizeObserver();
+	const ratio = width ? width / normalizedWidth : 1;
 	return (
 		<Iframe
 			className="edit-site-global-styles-preview__iframe"
 			head={ <EditorStyles styles={ styles } /> }
-			style={ { height } }
+			style={ {
+				height: 150 * ratio,
+				visibility: ! width ? 'hidden' : 'visible',
+			} }
 			onMouseEnter={ () => setIsHovered( true ) }
 			onMouseLeave={ () => setIsHovered( false ) }
 		>
+			{ containerResizeListener }
 			<motion.div
 				style={ {
 					height: '100%',
@@ -79,41 +86,45 @@ const StylesPreview = ( { height = 150 } ) => {
 						height: '100%',
 						overflow: 'hidden',
 					} }
-					spacing={ 4 }
+					spacing={ 4 * ratio }
 					justify="center"
 				>
 					<div
 						style={ {
 							fontFamily,
-							fontSize: ( 65 * height ) / 150,
+							fontSize: 65 * ratio,
 						} }
 					>
 						Aa
 					</div>
-					<motion.div variants={ defaultColorVariants }>
-						<VStack>
+					<motion.div
+						variants={ defaultColorVariants }
+						transition={ { duration: 0.5 } }
+					>
+						<VStack spacing={ 2 * ratio }>
 							<div
 								style={ {
-									height: ( 30 * height ) / 150,
-									width: ( 30 * height ) / 150,
+									height: 30 * ratio,
+									width: 30 * ratio,
 									background: textColor,
-									borderRadius: ( 15 * height ) / 150,
-									border: '1px solid #f0f0f0',
+									borderRadius: 15 * ratio,
 								} }
 							/>
 							<div
 								style={ {
-									height: ( 30 * height ) / 150,
-									width: ( 30 * height ) / 150,
+									height: 30 * ratio,
+									width: 30 * ratio,
 									background: linkColor,
-									borderRadius: ( 15 * height ) / 150,
-									border: '1px solid #f0f0f0',
+									borderRadius: 15 * ratio,
 								} }
 							/>
 						</VStack>
 					</motion.div>
-					<motion.div variants={ paletteMotionVariants }>
-						<VStack>
+					<motion.div
+						variants={ paletteMotionVariants }
+						transition={ { duration: 0.5 } }
+					>
+						<VStack spacing={ 2 * ratio }>
 							{ themeColors
 								.concat( customColors )
 								.slice( 0, 4 )
@@ -121,11 +132,10 @@ const StylesPreview = ( { height = 150 } ) => {
 									<div
 										key={ index }
 										style={ {
-											height: ( 30 * height ) / 150,
-											width: ( 30 * height ) / 150,
+											height: 30 * ratio,
+											width: 30 * ratio,
 											background: color,
-											borderRadius: ( 15 * height ) / 150,
-											border: '1px solid #f0f0f0',
+											borderRadius: 15 * ratio,
 										} }
 									/>
 								) ) }

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -82,7 +82,7 @@ function Variation( { variation } ) {
 			>
 				<VStack spacing="2">
 					<div className="edit-site-global-styles-variations_item-preview">
-						<StylesPreview height={ 100 } />
+						<StylesPreview height={ 80 } />
 					</div>
 					<HStack alignment="center">{ variation?.name }</HStack>
 				</VStack>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -13,6 +13,8 @@ import { useMemo, useContext } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import {
 	__experimentalGrid as Grid,
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 	Card,
 	CardBody,
 } from '@wordpress/components';
@@ -78,7 +80,12 @@ function Variation( { variation } ) {
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
 			>
-				<StylesPreview height={ 100 } />
+				<VStack spacing="2">
+					<div className="edit-site-global-styles-variations_item-preview">
+						<StylesPreview height={ 100 } />
+					</div>
+					<HStack alignment="center">{ variation?.name }</HStack>
+				</VStack>
 			</div>
 		</GlobalStylesContext.Provider>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -84,7 +84,12 @@ function Variation( { variation } ) {
 					<div className="edit-site-global-styles-variations_item-preview">
 						<StylesPreview height={ 80 } />
 					</div>
-					<HStack alignment="center">{ variation?.name }</HStack>
+					<HStack
+						className="edit-site-global-styles-variations_item-label"
+						alignment="center"
+					>
+						{ variation?.name }
+					</HStack>
 				</VStack>
 			</div>
 		</GlobalStylesContext.Provider>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -13,8 +13,6 @@ import { useMemo, useContext } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import {
 	__experimentalGrid as Grid,
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	Card,
 	CardBody,
 } from '@wordpress/components';
@@ -79,18 +77,11 @@ function Variation( { variation } ) {
 				onClick={ selectVariation }
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
+				aria-label={ variation?.name }
 			>
-				<VStack spacing="2">
-					<div className="edit-site-global-styles-variations_item-preview">
-						<StylesPreview />
-					</div>
-					<HStack
-						className="edit-site-global-styles-variations_item-label"
-						alignment="center"
-					>
-						{ variation?.name }
-					</HStack>
-				</VStack>
+				<div className="edit-site-global-styles-variations_item-preview">
+					<StylesPreview label={ variation?.name } />
+				</div>
 			</div>
 		</GlobalStylesContext.Provider>
 	);

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useMemo, useContext } from '@wordpress/element';
+import { useMemo, useContext, useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import {
 	__experimentalGrid as Grid,
@@ -31,6 +31,7 @@ function compareVariations( a, b ) {
 }
 
 function Variation( { variation } ) {
+	const [ isFocused, setIsFocused ] = useState( false );
 	const { base, user, setUserConfig } = useContext( GlobalStylesContext );
 	const context = useMemo( () => {
 		return {
@@ -78,9 +79,14 @@ function Variation( { variation } ) {
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
 				aria-label={ variation?.name }
+				onFocus={ () => setIsFocused( true ) }
+				onBlur={ () => setIsFocused( false ) }
 			>
 				<div className="edit-site-global-styles-variations_item-preview">
-					<StylesPreview label={ variation?.name } />
+					<StylesPreview
+						label={ variation?.name }
+						isFocused={ isFocused }
+					/>
 				</div>
 			</div>
 		</GlobalStylesContext.Provider>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -82,7 +82,7 @@ function Variation( { variation } ) {
 			>
 				<VStack spacing="2">
 					<div className="edit-site-global-styles-variations_item-preview">
-						<StylesPreview height={ 80 } />
+						<StylesPreview />
 					</div>
 					<HStack
 						className="edit-site-global-styles-variations_item-label"

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -92,3 +92,7 @@
 		border: var(--wp-admin-theme-color) $border-width solid;
 	}
 }
+
+.edit-site-global-styles-variations_item-label {
+	word-break: break-all;
+}

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -73,19 +73,22 @@
 
 .edit-site-global-styles-variations_item {
 	box-sizing: border-box;
-	padding: $border-width * 2;
-	border-radius: $radius-block-ui;
-	border: $gray-200 $border-width solid;
 
-	&.is-active {
+	.edit-site-global-styles-variations_item-preview {
+		padding: $border-width * 2;
+		border-radius: $radius-block-ui;
+		border: $gray-200 $border-width solid;
+	}
+
+	&.is-active .edit-site-global-styles-variations_item-preview {
 		border: $gray-900 $border-width solid;
 	}
 
-	&:hover {
+	&:hover .edit-site-global-styles-variations_item-preview {
 		border: var(--wp-admin-theme-color) $border-width solid;
 	}
 
-	&:focus {
+	&:focus .edit-site-global-styles-variations_item-preview {
 		border: var(--wp-admin-theme-color) $border-width solid;
 	}
 }

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -93,6 +93,3 @@
 	}
 }
 
-.edit-site-global-styles-variations_item-label {
-	word-break: break-all;
-}

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -110,6 +110,7 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 						),
 					),
 				),
+				'name'     => 'variation',
 			),
 		);
 		$this->assertSameSetsWithIndex( $data, $expected );


### PR DESCRIPTION
## What?

closes #38918

This PR adds "labels" to the global styles variations shown in the site editor sidebar.

## Why?

Something the colors and the previews are not enough to differentiate between the available variations. This PRs allows theme authors to provide a name for each style variation to disambiguate between them.

## How?

Theme authors can add a top level `name` property to the `json` file for each variation. If no name is provided, we fallback to the file name (without the extension).

I'll be needing some help here to make this new property translatable. cc @oandregal @swissspidy 

## Testing Instructions

 - Add a `theme.json` like file (same format as theme.json but different name potentially) to the `styles` folder of your theme
 - Add a top level `name` property in the JSON
 - Open the site editor
 - On the styles sidebar (if it's closed, you should be able to open it by clicking the "Styles" button on the top toolbar), you should be able to click "Other styles".
 - A list of available style variations should be shown corresponding to the alternative theme.json files in the `styles` folder of your theme. Each style variation should have the proper label corresponding to the "name" property in the theme.json file.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/272444/157490447-ea009b38-6d85-4bad-a6e2-648d047596ac.mov

