### PR TITLE
Webfonts API: expose enqueueing method instead of directly enqueueing fonts on registration

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-gutenberg.php
@@ -35,14 +35,14 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_5_9 {
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
 			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );
+			$theme_json_data = gutenberg_add_webfonts_to_theme_json( $theme_json_data );
 			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
 			if ( wp_get_theme()->parent() ) {
 				// Get parent theme.json.
 				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
 				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $parent_theme_json_data );
+				$parent_theme_json_data = gutenberg_add_webfonts_to_theme_json( $parent_theme_json_data );
 				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
 
 				// Merge the child theme.json into the parent theme.json.

--- a/lib/compat/wordpress-6.0/class-wp-webfonts-provider-local.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts-provider-local.php
@@ -227,9 +227,9 @@ class WP_Webfonts_Provider_Local extends WP_Webfonts_Provider {
 		$src = "local($font_family)";
 
 		foreach ( $value as $item ) {
-
-			if ( 0 === strpos( $item['url'], get_site_url() ) ) {
-				$item['url'] = wp_make_link_relative( $item['url'] );
+			if ( 0 === strpos( $item['url'], 'file:./' ) ) {
+				$absolute_path_to_url = get_stylesheet_directory_uri() . '/' . str_replace( 'file:./', '', $item['url'] );
+				$item['url']          = wp_make_link_relative( $absolute_path_to_url );
 			}
 
 			$src .= ( 'data' === $item['format'] )

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -78,7 +78,7 @@ class WP_Webfonts {
 	 * @return array
 	 */
 	public function get_enqueued_fonts() {
-		return self::$enqueued_webfonts;
+		return $this->enqueued_webfonts;
 	}
 
 	/**
@@ -130,13 +130,13 @@ class WP_Webfonts {
 
 		if ( $font ) {
 			$font                           = $this->validate_font( $font );
-			self::$enqueued_webfonts[ $id ] = $font;
+			$this->enqueued_webfonts[ $id ] = $font;
 
 			if ( isset( $this->registered_webfonts[ $id ] ) ) {
 				unset( $this->registered_webfonts[ $id ] );
 			}
 		} elseif ( isset( $this->registered_webfonts[ $id ] ) ) {
-			self::$enqueued_webfonts[ $id ] = $this->registered_webfonts[ $id ];
+			$this->enqueued_webfonts[ $id ] = $this->registered_webfonts[ $id ];
 
 			unset( $this->registered_webfonts[ $id ] );
 		} else {

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -286,6 +286,7 @@ class WP_Webfonts {
 			return;
 		}
 
+		wp_enqueue_style( 'wp-block-library' );
 		wp_add_inline_style( 'wp-block-library', $styles );
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -69,7 +69,7 @@ class WP_Webfonts {
 	 * @return array
 	 */
 	public function get_registered_fonts() {
-		return self::$registered_webfonts;
+		return $this->registered_webfonts;
 	}
 
 	/**
@@ -108,7 +108,7 @@ class WP_Webfonts {
 
 		$font = $this->validate_font( $font );
 		if ( $font ) {
-			self::$registered_webfonts[ $id ] = $font;
+			$this->registered_webfonts[ $id ] = $font;
 		}
 	}
 
@@ -132,13 +132,13 @@ class WP_Webfonts {
 			$font                           = $this->validate_font( $font );
 			self::$enqueued_webfonts[ $id ] = $font;
 
-			if ( isset( self::$registered_webfonts[ $id ] ) ) {
-				unset( self::$registered_webfonts[ $id ] );
+			if ( isset( $this->registered_webfonts[ $id ] ) ) {
+				unset( $this->registered_webfonts[ $id ] );
 			}
-		} elseif ( isset( self::$registered_webfonts[ $id ] ) ) {
-			self::$enqueued_webfonts[ $id ] = self::$registered_webfonts[ $id ];
+		} elseif ( isset( $this->registered_webfonts[ $id ] ) ) {
+			self::$enqueued_webfonts[ $id ] = $this->registered_webfonts[ $id ];
 
-			unset( self::$registered_webfonts[ $id ] );
+			unset( $this->registered_webfonts[ $id ] );
 		} else {
 			trigger_error( __( 'The given webfont ID is not registered, therefore the webfont cannot be enqueued.', 'gutenberg' ) );
 		}

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -16,16 +16,15 @@ class WP_Webfonts {
 	 * @access private
 	 * @var array
 	 */
-	private static $registered_webfonts = array();
+	private $registered_webfonts = array();
 
 	/**
 	 * An array of enqueued webfonts.
 	 *
-	 * @static
 	 * @access private
 	 * @var array
 	 */
-	private static $enqueued_webfonts = array();
+	private $enqueued_webfonts = array();
 
 	/**
 	 * An array of registered providers.

--- a/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
+++ b/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
@@ -6,6 +6,16 @@
  */
 
 /**
+ * Generates a font id based on the provided font object.
+ *
+ * @param array $font The font object.
+ * @return string
+ */
+function gutenberg_generate_font_id( $font ) {
+	return sanitize_title( "{$font['font-family']}-{$font['font-weight']}-{$font['font-style']}-{$font['provider']}" );
+}
+
+/**
  * Register webfonts defined in theme.json.
  */
 function gutenberg_register_webfonts_from_theme_json() {
@@ -58,7 +68,8 @@ function gutenberg_register_webfonts_from_theme_json() {
 		}
 	}
 	foreach ( $webfonts as $webfont ) {
-		wp_webfonts()->register_font( $webfont );
+		$id = isset( $webfont['id'] ) ? $webfont['id'] : gutenberg_generate_font_id( $webfont );
+		wp_register_webfont( $id, $webfont );
 	}
 }
 

--- a/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
+++ b/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
@@ -41,19 +41,6 @@ function gutenberg_register_webfonts_from_theme_json() {
 			$font_family['fontFace'] = (array) $font_family['fontFace'];
 
 			foreach ( $font_family['fontFace'] as $font_face ) {
-				// Check if webfonts have a "src" param, and if they do account for the use of "file:./".
-				if ( ! empty( $font_face['src'] ) ) {
-					$font_face['src'] = (array) $font_face['src'];
-
-					foreach ( $font_face['src'] as $src_key => $url ) {
-						// Tweak the URL to be relative to the theme root.
-						if ( 0 !== strpos( $url, 'file:./' ) ) {
-							continue;
-						}
-						$font_face['src'][ $src_key ] = get_theme_file_uri( str_replace( 'file:./', '', $url ) );
-					}
-				}
-
 				// Convert keys to kebab-case.
 				foreach ( $font_face as $property => $value ) {
 					$kebab_case               = _wp_to_kebab_case( $property );

--- a/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
+++ b/lib/compat/wordpress-6.0/register-webfonts-from-theme-json.php
@@ -69,8 +69,8 @@ function gutenberg_register_webfonts_from_theme_json() {
  *
  * @return array The global styles with missing fonts data.
  */
-function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
-	$font_families_registered = wp_webfonts()->get_fonts();
+function gutenberg_add_webfonts_to_theme_json( $data ) {
+	$webfonts                 = wp_webfonts()->get_all_webfonts();
 	$font_families_from_theme = array();
 	if ( ! empty( $data['settings'] ) && ! empty( $data['settings']['typography'] ) && ! empty( $data['settings']['typography']['fontFamilies'] ) ) {
 		$font_families_from_theme = $data['settings']['typography']['fontFamilies'];
@@ -101,7 +101,7 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 
 	// Diff the arrays to find the missing fonts.
 	$to_add = array_diff(
-		$get_families( $font_families_registered ),
+		$get_families( $webfonts ),
 		$get_families( $font_families_from_theme )
 	);
 
@@ -125,7 +125,7 @@ function gutenberg_add_registered_webfonts_to_theme_json( $data ) {
 	// Add missing fonts.
 	foreach ( $to_add as $family ) {
 		$font_face = array();
-		foreach ( $font_families_registered as $font_family ) {
+		foreach ( $webfonts as $font_family ) {
 			if ( $family !== $font_family['font-family'] ) {
 				continue;
 			}

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -102,6 +102,57 @@ function wp_register_webfont( $id, $webfont ) {
 }
 
 /**
+ * Enqueues a collection of webfonts.
+ *
+ * Example of how to enqueue Source Serif Pro font with font-weight range of 200-900
+ * and font-style of normal and italic:
+ *
+ * <code>
+ * wp_enqueue_webfonts(
+ *      array(
+ *          'some-already-registered-font', // This requires the font to be registered beforehand.
+ *          array(
+ *              'id'          => 'source-serif-200-900-normal',
+ *              'provider'    => 'local',
+ *              'font_family' => 'Source Serif Pro',
+ *              'font_weight' => '200 900',
+ *              'font_style'  => 'normal',
+ *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+ *          ),
+ *          array(
+ *              'id'          => 'source-serif-200-900-italic',
+ *              'provider'    => 'local',
+ *              'font_family' => 'Source Serif Pro',
+ *              'font_weight' => '200 900',
+ *              'font_style'  => 'italic',
+ *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
+ *          ),
+ *      )
+ * );
+ * </code>
+ *
+ * Webfonts should be enqueued in the `after_setup_theme` hook.
+ *
+ * @since 6.0.0
+ *
+ * @param array $webfonts Webfonts to be enqueued.
+ *                        This contains an array of webfonts to be enqueued.
+ *                        Each webfont is an array.
+ *                        See {@see WP_Webfonts_Registry::register()} for a list of
+ *                        supported arguments for each webfont.
+ */
+function wp_enqueue_webfonts( $webfonts = array() ) {
+	foreach ( $webfonts as $webfont ) {
+		if ( is_string( $webfont ) ) {
+			wp_enqueue_webfont( $webfont );
+			continue;
+		}
+
+		wp_enqueue_webfont( $webfont['id'], $webfont );
+	}
+}
+
+/**
  * Enqueue a single webfont.
  *
  * Register the webfont if $webfont is provided and enqueues.

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -63,8 +63,6 @@ function wp_webfonts() {
  * @param array $webfonts Webfonts to be registered.
  *                        This contains an array of webfonts to be registered.
  *                        Each webfont is an array.
- *                        See {@see WP_Webfonts_Registry::register()} for a list of
- *                        supported arguments for each webfont.
  */
 function wp_register_webfonts( $webfonts = array() ) {
 	foreach ( $webfonts as $webfont ) {
@@ -95,7 +93,6 @@ function wp_register_webfonts( $webfonts = array() ) {
  *
  * @param string $id The webfont id.
  * @param array  $webfont Webfont to be registered.
- *                        See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
  */
 function wp_register_webfont( $id, $webfont ) {
 	wp_webfonts()->register_font( $id, $webfont );
@@ -138,8 +135,6 @@ function wp_register_webfont( $id, $webfont ) {
  * @param array $webfonts Webfonts to be enqueued.
  *                        This contains an array of webfonts to be enqueued.
  *                        Each webfont is an array.
- *                        See {@see WP_Webfonts_Registry::register()} for a list of
- *                        supported arguments for each webfont.
  */
 function wp_enqueue_webfonts( $webfonts = array() ) {
 	foreach ( $webfonts as $webfont ) {
@@ -177,7 +172,6 @@ function wp_enqueue_webfonts( $webfonts = array() ) {
  *
  * @param string     $id The webfont id.
  * @param array|null $webfont Webfont to be enqueued. Can be omitted if the font was registered beforehand.
- *                       See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
  */
 function wp_enqueue_webfont( $id, $webfont = null ) {
 	wp_webfonts()->enqueue_font( $id, $webfont );

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -37,6 +37,7 @@ function wp_webfonts() {
  * wp_register_webfonts(
  *      array(
  *          array(
+ *              'id'          => 'source-serif-200-900-normal',
  *              'provider'    => 'local',
  *              'font_family' => 'Source Serif Pro',
  *              'font_weight' => '200 900',
@@ -44,6 +45,7 @@ function wp_webfonts() {
  *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
  *          ),
  *          array(
+ *              'id'          => 'source-serif-200-900-italic',
  *              'provider'    => 'local',
  *              'font_family' => 'Source Serif Pro',
  *              'font_weight' => '200 900',
@@ -64,9 +66,9 @@ function wp_webfonts() {
  *                        See {@see WP_Webfonts_Registry::register()} for a list of
  *                        supported arguments for each webfont.
  */
-function wp_register_webfonts( array $webfonts = array() ) {
+function wp_register_webfonts( $webfonts = array() ) {
 	foreach ( $webfonts as $webfont ) {
-		wp_register_webfont( $webfont );
+		wp_register_webfont( $webfont['id'], $webfont );
 	}
 }
 
@@ -90,11 +92,12 @@ function wp_register_webfonts( array $webfonts = array() ) {
  *
  * @since 6.0.0
  *
- * @param array $webfont Webfont to be registered.
- *                       See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
+ * @param string $id The webfont id.
+ * @param array  $webfont Webfont to be registered.
+ *                        See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
  */
-function wp_register_webfont( array $webfont ) {
-	wp_webfonts()->register_font( $webfont );
+function wp_register_webfont( $id, $webfont ) {
+	wp_webfonts()->register_font( $id, $webfont );
 }
 
 /**

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -80,6 +80,7 @@ function wp_register_webfonts( $webfonts = array() ) {
  * If the font file is contained within the theme:
  * ```
  * wp_register_webfont(
+ *      'source-serif-pro-normal',
  *      array(
  *          'provider'    => 'local',
  *          'font_family' => 'Source Serif Pro',
@@ -98,6 +99,37 @@ function wp_register_webfonts( $webfonts = array() ) {
  */
 function wp_register_webfont( $id, $webfont ) {
 	wp_webfonts()->register_font( $id, $webfont );
+}
+
+/**
+ * Enqueue a single webfont.
+ *
+ * Register the webfont if $webfont is provided and enqueues.
+ *
+ * Example of how to register Source Serif Pro font with font-weight range of 200-900:
+ *
+ * If the font file is contained within the theme:
+ * ```
+ * wp_enqueue_webfont(
+ *      'source-serif-pro-normal',
+ *      array(
+ *          'provider'    => 'local',
+ *          'font_family' => 'Source Serif Pro',
+ *          'font_weight' => '200 900',
+ *          'font_style'  => 'normal',
+ *          'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+ *      )
+ * );
+ * ```
+ *
+ * @since 6.0.0
+ *
+ * @param string     $id The webfont id.
+ * @param array|null $webfont Webfont to be enqueued. Can be omitted if the font was registered beforehand.
+ *                       See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
+ */
+function wp_enqueue_webfont( $id, $webfont = null ) {
+	wp_webfonts()->enqueue_font( $id, $webfont );
 }
 
 /**

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -26,14 +26,17 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wp_register_webfonts() bulk register webfonts.
+	 *
 	 * @covers wp_register_webfonts
 	 * @covers WP_Webfonts::register_font
-	 * @covers WP_Webfonts::get_fonts
-	 * @covers WP_Webfonts::get_font_id
+	 * @covers WP_Webfonts::get_registered_fonts
+	 * @covers WP_Webfonts::get_enqueued_fonts
 	 */
-	public function test_get_fonts() {
+	public function test_wp_register_webfonts() {
 		$fonts = array(
 			array(
+				'id'           => 'source-serif-pro-200-900-normal-local',
 				'provider'     => 'local',
 				'font-family'  => 'Source Serif Pro',
 				'font-style'   => 'normal',
@@ -43,6 +46,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 				'font-display' => 'fallback',
 			),
 			array(
+				'id'           => 'source-serif-pro-200-900-italic-local',
 				'provider'     => 'local',
 				'font-family'  => 'Source Serif Pro',
 				'font-style'   => 'italic',
@@ -54,12 +58,73 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			'source-serif-pro-200-900-normal-local' => $fonts[0],
-			'source-serif-pro-200-900-italic-local' => $fonts[1],
+			$fonts[0]['id'] => array_filter( $fonts[0], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
+			$fonts[1]['id'] => array_filter( $fonts[1], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
 		);
 
 		wp_register_webfonts( $fonts );
-		$this->assertEquals( $expected, wp_webfonts()->get_fonts() );
+		$this->assertEquals( $expected, wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( array(), wp_webfonts()->get_enqueued_fonts() );
+	}
+
+	/**
+	 * Test wp_register_webfont() register a single webfont.
+	 *
+	 * @covers wp_register_webfont
+	 * @covers WP_Webfonts::register_font
+	 * @covers WP_Webfonts::get_registered_fonts
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 */
+	public function test_wp_register_webfont() {
+		$id = 'source-serif-pro-200-900-normal-local';
+
+		$font = array(
+			'provider'     => 'local',
+			'font-family'  => 'Source Serif Pro',
+			'font-style'   => 'normal',
+			'font-weight'  => '200 900',
+			'font-stretch' => 'normal',
+			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'font-display' => 'fallback',
+		);
+
+		$expected = array(
+			$id => $font,
+		);
+
+		wp_register_webfont( $id, $font );
+		$this->assertEquals( $expected, wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( array(), wp_webfonts()->get_enqueued_fonts() );
+	}
+
+	/**
+	 * Test wp_register_webfont() does not enqueue the webfont on registration.
+	 *
+	 * @covers wp_register_webfont
+	 * @covers WP_Webfonts::register_font
+	 * @covers WP_Webfonts::get_registered_fonts
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 */
+	public function test_wp_register_webfont_does_not_enqueue_on_registration() {
+		$id = 'source-serif-pro-200-900-normal-local';
+
+		$font = array(
+			'provider'     => 'local',
+			'font-family'  => 'Source Serif Pro',
+			'font-style'   => 'normal',
+			'font-weight'  => '200 900',
+			'font-stretch' => 'normal',
+			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'font-display' => 'fallback',
+		);
+
+		$expected = array(
+			$id => $font,
+		);
+
+		wp_register_webfont( $id, $font );
+		$this->assertEquals( $expected, wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( array(), wp_webfonts()->get_enqueued_fonts() );
 	}
 
 	/**

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -350,4 +350,49 @@ EOF;
 			get_echo( 'wp_print_styles' )
 		);
 	}
+
+	/**
+	 * Test generate_and_enqueue_editor_styles outputs registered and enqueued webfonts.
+	 * Both are necessary so the editor correctly loads webfonts picked while in the editor.
+	 *
+	 * @covers WP_Webfonts::generate_and_enqueue_editor_styles
+	 */
+	public function test_generate_and_enqueue_editor_styles() {
+		wp_register_webfont(
+			'source-serif-pro-200-900-italic-local',
+			array(
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'italic',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+				'font-display' => 'fallback',
+			)
+		);
+
+		wp_enqueue_webfont(
+			'source-serif-pro-200-900-normal-local', // This is different from the webfont registered above.
+			array(
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'normal',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+				'font-display' => 'fallback',
+			)
+		);
+
+		wp_webfonts()->generate_and_enqueue_editor_styles();
+
+		$expected = <<<EOF
+@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+EOF;
+
+		$this->assertContains(
+			$expected,
+			get_echo( 'wp_print_styles' )
+		);
+	}
 }

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -128,6 +128,127 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test wp_enqueue_webfonts() bulk enqueue webfonts.
+	 *
+	 * @covers wp_enqueue_webfonts
+	 * @covers WP_Webfonts::enqueue_font
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 * @covers WP_Webfonts::get_registered_fonts
+	 */
+	public function test_wp_enqueue_webfonts() {
+		$fonts = array(
+			array(
+				'id'           => 'source-serif-pro-200-900-normal-local',
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'normal',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+				'font-display' => 'fallback',
+			),
+			array(
+				'id'           => 'source-serif-pro-200-900-italic-local',
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'italic',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+				'font-display' => 'fallback',
+			),
+		);
+
+		$expected = array(
+			$fonts[0]['id'] => array_filter( $fonts[0], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
+			$fonts[1]['id'] => array_filter( $fonts[1], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
+		);
+
+		wp_enqueue_webfonts( $fonts );
+		$this->assertEquals( $expected, wp_webfonts()->get_enqueued_fonts() );
+		$this->assertEquals( array(), wp_webfonts()->get_registered_fonts() );
+	}
+
+	/**
+	 * Test wp_enqueue_font() enqueues a registered webfont.
+	 *
+	 * @covers wp_enqueue_webfont
+	 * @covers WP_Webfonts::enqueued_font
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 * @covers WP_Webfonts::get_registered_fonts
+	 */
+	public function test_wp_enqueue_webfont_enqueues_registered_webfont() {
+		$id = 'source-serif-pro-200-900-normal-local';
+
+		$font = array(
+			'provider'     => 'local',
+			'font-family'  => 'Source Serif Pro',
+			'font-style'   => 'normal',
+			'font-weight'  => '200 900',
+			'font-stretch' => 'normal',
+			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'font-display' => 'fallback',
+		);
+
+		$expected = array(
+			$id => $font,
+		);
+
+		wp_register_webfont( $id, $font );
+		wp_enqueue_webfont( $id );
+
+		$this->assertEquals( array(), wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( $expected, wp_webfonts()->get_enqueued_fonts() );
+	}
+
+	/**
+	 * Test wp_enqueue_font() register and enqueues a webfont if given as an argument.
+	 *
+	 * @covers wp_enqueue_webfont
+	 * @covers WP_Webfonts::enqueued_font
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 */
+	public function test_wp_enqueue_webfont_register_and_enqueues_if_webfont_given_as_argument() {
+		$id = 'source-serif-pro-200-900-normal-local';
+
+		$font = array(
+			'provider'     => 'local',
+			'font-family'  => 'Source Serif Pro',
+			'font-style'   => 'normal',
+			'font-weight'  => '200 900',
+			'font-stretch' => 'normal',
+			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'font-display' => 'fallback',
+		);
+
+		$expected = array(
+			$id => $font,
+		);
+
+		wp_enqueue_webfont( $id, $font );
+
+		$this->assertEquals( array(), wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( $expected, wp_webfonts()->get_enqueued_fonts() );
+	}
+
+	/**
+	 * Test wp_enqueue_font() does not enqueue a webfont that was not registered.
+	 *
+	 * @covers wp_enqueue_webfont
+	 * @covers WP_Webfonts::enqueued_font
+	 * @covers WP_Webfonts::get_enqueued_fonts
+	 * @covers WP_Webfonts::get_registered_fonts
+	 */
+	public function test_wp_enqueue_webfont_does_not_enqueue_unregistered_webfont() {
+		$id = 'source-serif-pro-200-900-normal-local';
+
+		wp_enqueue_webfont( $id );
+
+		$this->assertEquals( array(), wp_webfonts()->get_registered_fonts() );
+		$this->assertEquals( array(), wp_webfonts()->get_enqueued_fonts() );
+	}
+
+	/**
 	 * @covers wp_register_webfont
 	 * @covers WP_Webfonts::register_provider
 	 * @covers WP_Webfonts::get_providers

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -308,24 +308,46 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test generate_and_enqueue_styles outputs only enqueued webfonts.
+	 *
 	 * @covers WP_Webfonts::generate_styles
 	 */
 	public function test_generate_styles() {
-		$font = array(
-			'provider'     => 'local',
-			'font-family'  => 'Source Serif Pro',
-			'font-style'   => 'normal',
-			'font-weight'  => '200 900',
-			'font-stretch' => 'normal',
-			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
-			'font-display' => 'fallback',
+		wp_register_webfont(
+			'source-serif-pro-200-900-italic-local',
+			array(
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'italic',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2',
+				'font-display' => 'fallback',
+			)
 		);
 
-		wp_register_webfont( $font );
+		wp_enqueue_webfont(
+			'source-serif-pro-200-900-normal-local', // This is different from the webfont registered above.
+			array(
+				'provider'     => 'local',
+				'font-family'  => 'Source Serif Pro',
+				'font-style'   => 'normal',
+				'font-weight'  => '200 900',
+				'font-stretch' => 'normal',
+				'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+				'font-display' => 'fallback',
+			)
+		);
 
-		$this->assertEquals(
-			'@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url(\'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2\') format(\'woff2\');}',
-			wp_webfonts()->generate_styles()
+		wp_webfonts()->generate_and_enqueue_styles();
+
+		$expected = <<<EOF
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+EOF;
+
+		$this->assertContains(
+			$expected,
+			get_echo( 'wp_print_styles' )
 		);
 	}
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/39332. Read https://github.com/WordPress/gutenberg/issues/39332#issuecomment-1065614371 to gather more context about the whole picture regarding the implementation.

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, the webfonts API automatically enqueues **_all_** registered webfonts. In this PR, we separate webfont registration from webfont enqueuing into two different processes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. By introducing these changes, we more closely match the behavior of wp scripts and styles and accommodate functionality that WordPress developers are already familiar with.
2. We allow API consumers more flexibility in how and when they enqueue webfonts, rather than forcing them to enqueue all fonts indiscriminately.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Create state to track registered webfonts _and_ enqueued webfonts 
- Create methods to access and manually enqueue webfonts

We're also adding the possibility to register custom `id`s now. We're actually enforcing it when registering through `wp_register_webfont` or `wp_enqueue_webfont`.

Naming what you're registering and enqueueing makes the whole API more predictable. You know exactly which fonts you are registering and you can be sure that the font you want to enqueue by id is the exact same font you registered. That's the same principle defined in `wp_scripts` and `wp_styles`, for example, where you must pass the `$handle`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Register a webfont via theme.json or programmatically through the `wp_register_webfont` php function (See below for examples)
2. Enqueue the webfont by calling `wp_enqueue_webfont`
3. Activate the theme in the local WordPress development environment
4. Verify that the webfont is selectable in block settings for certain blocks (button, site title, site tag, etc.) in the post editor and template editor
5. Verify that the webfont is available in the global styles menu for the full site editor
6. Verify that the webfont is displayed in the frontend of the site*

*For now, we're not enqueueing any font if solely picked in the editor without programmatically enqueueing, so no fonts will be loaded in the front-end, even if selected. To test this, you need to programmatically enqueue the font until https://github.com/WordPress/gutenberg/pull/39399 gets merged.

For the examples below, the Roboto font can be downloaded from https://fonts.google.com/specimen/Roboto. Unzip the package and place the .ttf file in the `bennett/assets/fonts` theme directory.

### Testing a webfont loaded via `theme.json`:
Using the Bennett theme as an example, we edit its `theme.json` file and replace `fontFamilies` with the following:
```json

"fontFamilies": [
    {
        "id": "roboto-regular",
        "fontFamily": "Roboto",
        "fontFace": [
            {
                "fontFamily": "Roboto",
                "fontWeight": "900",
                "fontStyle": "normal",
                "fontStretch": "normal",
                "src": [ "file:./assets/fonts/Roboto-Regular.ttf" ]
            },
        ]
    }
],
```
Then, we create a `functions.php` in the `bennett` theme directory and add the following:
```php
<?php

add_action( 'after_setup_theme', function() {
	wp_enqueue_webfont( 'roboto-regular' );
} );
```

### Testing a webfont programmatically through PHP:

Next, to test the PHP registration using the `wp_register_webfont` function, in `functions.php` add the following:

```php
add_action( 'after_setup_theme', function() {
	wp_register_webfont(
		'roboto-regular',
		array(
			'font-family'  => 'Roboto',
			'font-style'   => 'normal',
			'font-stretch' => 'normal',
			"font-weight" => "900",
			'src'          => array( 'file:./assets/fonts/Roboto-Regular.ttf' ),
		)
	);

        wp_enqueue_webfont( 'roboto-regular' );
} );
```

Like WordPress, we can also directly enqueue a webfont without registering it like so:

```php
add_action( 'after_setup_theme', function() {
	wp_enqueue_webfont(
		'roboto-regular',
		array(
			'font-family'  => 'Roboto',
			'font-style'   => 'normal',
			'font-stretch' => 'normal',
			"font-weight" => "900",
			'src'          => array( 'file:./assets/fonts/Roboto-Regular.ttf' ),
		)
	);
} );
```