### PR TITLE
Image Block: Move any is-style and custom classnames up to deprecated alignment wrapper

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -237,11 +237,11 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {
-	$image_with_align = '/(^\s*<figure\b[^>]*)\bwp-block-image\b([^"]*\b(?:alignleft|alignright|aligncenter)\b[^>]*>.*<\/figure>)/U';
+	$image_with_align = '/(^\s*<figure.*?class=["\'])(.*\bwp-block-image\b[^"\']*\b(?:alignleft|alignright|aligncenter)\b[^"\']*)(["\'][^>]*>.*<\/figure>)/U';
 
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() ||
-		0 === preg_match( $image_with_align, $block_content )
+		0 === preg_match( $image_with_align, $block_content, $matches )
 	) {
 		return $block_content;
 	}
@@ -253,17 +253,10 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 	if ( isset( $block['attrs']['className'] ) && ! empty( $block['attrs']['className'] ) ) {
 		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
 	}
+	$content_classnames          = explode( ' ', $matches[2] );
+	$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
 
-	$updated_content = preg_replace_callback(
-		'/(<figure.*?class=")(.*)?(">.*<\/figure>)/U',
-		static function( $matches ) use ( $wrapper_classnames ) {
-			$content_classnames          = explode( ' ', $matches[2] );
-			$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
-			return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
-		},
-		$block_content
-	);
-	return $updated_content;
+	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
 }
 
 if ( function_exists( 'wp_restore_image_outer_container' ) ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -245,12 +245,16 @@ function gutenberg_restore_image_outer_container( $block_content ) {
 		return $block_content;
 	}
 
+	$block_classnames                 = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
+	$remove_classnames_pattern        = '/(<figure.*?class=".*)' . $block_classnames . '(.*?">)/';
+	$content_without_block_classnames = preg_replace( $remove_classnames_pattern, '$1 $2', $block_content );
+
 	$updated_content = preg_replace_callback(
 		$image_with_align,
-		static function( $matches ) {
-			return '<div class="wp-block-image">' . $matches[1] . $matches[2] . '</div>';
+		static function( $matches ) use ( $block_classnames ) {
+			return '<div class="wp-block-image ' . $block_classnames . '">' . $matches[1] . $matches[2] . '</div>';
 		},
-		$block_content
+		$content_without_block_classnames
 	);
 	return $updated_content;
 }

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -235,8 +235,9 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * @param string $block_content Rendered block content.
  * @return string Filtered block content.
  */
-function gutenberg_restore_image_outer_container( $block_content ) {
-	$image_with_align = '/(^\s*<figure\b[^>]*)\bwp-block-image\b([^"]*\b(?:alignleft|alignright|aligncenter)\b[^>]*>.*<\/figure>)/U';
+function gutenberg_restore_image_outer_container( $block_content, $block ) {
+	$block_classnames = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
+	$image_with_align = '/(^\s*<figure\b[^>]*)\bwp-block-image\b([^"]*\b(?:alignleft|alignright|aligncenter).*)\b(?:' . $block_classnames . ')([^>]*>.*<\/figure>)/U';
 
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() ||
@@ -245,16 +246,12 @@ function gutenberg_restore_image_outer_container( $block_content ) {
 		return $block_content;
 	}
 
-	$block_classnames                 = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
-	$remove_classnames_pattern        = '/(<figure.*?class=".*)\s' . $block_classnames . '(.*?">)/';
-	$content_without_block_classnames = preg_replace( $remove_classnames_pattern, '$1 $2', $block_content );
-
 	$updated_content = preg_replace_callback(
 		$image_with_align,
 		static function( $matches ) use ( $block_classnames ) {
-			return '<div class="wp-block-image ' . $block_classnames . '">' . $matches[1] . $matches[2] . '</div>';
+			return '<div class="wp-block-image ' . $block_classnames . '">' . $matches[1] . $matches[2] . $matches[3] . '</div>';
 		},
-		$content_without_block_classnames
+		$block_content
 	);
 	return $updated_content;
 }

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -246,7 +246,7 @@ function gutenberg_restore_image_outer_container( $block_content ) {
 	}
 
 	$block_classnames                 = isset( $block['attrs']['className'] ) ? $block['attrs']['className'] : '';
-	$remove_classnames_pattern        = '/(<figure.*?class=".*)' . $block_classnames . '(.*?">)/';
+	$remove_classnames_pattern        = '/(<figure.*?class=".*)\s' . $block_classnames . '(.*?">)/';
 	$content_without_block_classnames = preg_replace( $remove_classnames_pattern, '$1 $2', $block_content );
 
 	$updated_content = preg_replace_callback(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -237,7 +237,7 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {
-	$image_with_align = '/(^\s*<figure.*?class=["\'])(.*\bwp-block-image\b[^"\']*\b(?:alignleft|alignright|aligncenter)\b[^"\']*)(["\'][^>]*>.*<\/figure>)/U';
+	$image_with_align = '/(^\s*<figure.*?class=["\'])(.*\bwp-block-image\b[^"\']*\b(?:alignleft|alignright|aligncenter)\b[^"\']*)(["\'][^>]*>.*<\/figure>)/iU';
 
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() ||

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -250,7 +250,7 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 
 	// If the block has a classNames attribute these classnames need to be removed from the content and added back
 	// to the new wrapper div also.
-	if ( isset( $block['attrs']['className'] ) && ! empty( $block['attrs']['className'] ) ) {
+	if ( ! empty( $block['attrs']['className'] ) ) {
 		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
 	}
 	$content_classnames          = explode( ' ', $matches[2] );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -237,7 +237,31 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {
-	$image_with_align = '/(^\s*<figure.*?class=["\'])(.*\bwp-block-image\b[^"\']*\b(?:alignleft|alignright|aligncenter)\b[^"\']*)(["\'][^>]*>.*<\/figure>)/iU';
+	$image_with_align = "
+/# 1) everything up to the class attribute contents
+(
+	^\s*
+	<figure\b
+	[^>]*
+	\bclass=
+	[\"']
+)
+# 2) the class attribute contents
+(
+	[^\"']*
+	\bwp-block-image\b
+	[^\"']*
+	\b(?:alignleft|alignright|aligncenter)\b
+	[^\"']*
+)
+# 3) everything after the class attribute contents
+(
+	[\"']
+	[^>]*
+	>
+	.*
+	<\/figure>
+)/iUx";
 
 	if (
 		WP_Theme_JSON_Resolver::theme_has_support() ||

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -267,6 +267,6 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 }
 
 if ( function_exists( 'wp_restore_image_outer_container' ) ) {
-	remove_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10, 1 );
+	remove_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10, 2 );
 }
-add_filter( 'render_block_core/image', 'gutenberg_restore_image_outer_container', 10, 1 );
+add_filter( 'render_block_core/image', 'gutenberg_restore_image_outer_container', 10, 2 );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -233,6 +233,7 @@ add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container'
  * to avoid breaking styles relying on that div.
  *
  * @param string $block_content Rendered block content.
+ * @param  array  $block        Block object.
  * @return string Filtered block content.
  */
 function gutenberg_restore_image_outer_container( $block_content, $block ) {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -81,6 +81,11 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_start_placement, $block ) );
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_middle_placement, $block ) );
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_random_placement, $block ) );
+
+		$block_classes_other_attributes = '<figure style="color: red" class="is-style-round wp-block-image alignright my-custom-classname size-full" data-random-tag=">"><img src="/my-image.jpg"/></figure>';
+		$expected_other_attributes      = '<div class="wp-block-image is-style-round my-custom-classname"><figure style="color: red" class="alignright size-full" data-random-tag=">"><img src="/my-image.jpg"/></figure></div>';
+
+		$this->assertSame( $expected_other_attributes, gutenberg_restore_image_outer_container( $block_classes_other_attributes, $block ) );
 	}
 
 	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -35,17 +35,28 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		return $this->theme_root;
 	}
 
+	function test_outer_container_not_restored_for_non_aligned_image_block_with_non_themejson_theme() {
+		// The "default" theme doesn't have theme.json support.
+		switch_theme( 'default' );
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(),
+		);
+		$block_content = '<figure class="wp-block-image size-full"><img src="/my-image.jpg"/></figure>';
+		$expected      = '<figure class="wp-block-image size-full"><img src="/my-image.jpg"/></figure>';
+
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
+	}
+
 	function test_outer_container_restored_for_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
 		$block         = array(
 			'blockName' => 'core/image',
-			'attrs'     => array(
-				'className' => '',
-			),
+			'attrs'     => array(),
 		);
 		$block_content = '<figure class="wp-block-image alignright size-full"><img src="/my-image.jpg"/></figure>';
-		$expected      = '<div class="wp-block-image "><figure class=" alignright size-full"><img src="/my-image.jpg"/></figure></div>';
+		$expected      = '<div class="wp-block-image"><figure class="alignright size-full"><img src="/my-image.jpg"/></figure></div>';
 
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
@@ -59,10 +70,17 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 				'className' => 'is-style-round my-custom-classname',
 			),
 		);
-		$block_content = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
-		$expected      = '<div class="wp-block-image is-style-round my-custom-classname"><figure class=" alignright size-full "><img src="/my-image.jpg"/></figure></div>';
 
-		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
+		$block_classes_end_placement    = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
+		$block_classes_start_placement  = '<figure class="is-style-round my-custom-classname wp-block-image alignright size-full"><img src="/my-image.jpg"/></figure>';
+		$block_classes_middle_placement = '<figure class="wp-block-image is-style-round my-custom-classname alignright size-full"><img src="/my-image.jpg"/></figure>';
+		$block_classes_random_placement = '<figure class="is-style-round wp-block-image alignright my-custom-classname size-full"><img src="/my-image.jpg"/></figure>';
+		$expected                       = '<div class="wp-block-image is-style-round my-custom-classname"><figure class="alignright size-full"><img src="/my-image.jpg"/></figure></div>';
+
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_end_placement, $block ) );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_start_placement, $block ) );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_middle_placement, $block ) );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_random_placement, $block ) );
 	}
 
 	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -45,10 +45,9 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 		$block_content = '<figure class="wp-block-image alignright size-full"><img src="/my-image.jpg"/></figure>';
-		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
 		$expected      = '<div class="wp-block-image "><figure class=" alignright size-full"><img src="/my-image.jpg"/></figure></div>';
 
-		$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 
 	function test_additional_styles_moved_to_restored_outer_container_for_aligned_image_block_with_non_themejson_theme() {
@@ -61,10 +60,9 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 		$block_content = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
-		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
 		$expected      = '<div class="wp-block-image is-style-round my-custom-classname"><figure class=" alignright size-full "><img src="/my-image.jpg"/></figure></div>';
 
-		$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 
 	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {
@@ -76,9 +74,8 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 			),
 		);
 		$block_content = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
-		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
 		$expected      = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
 
-		$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_content, $block ) );
 	}
 }

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Test the block layout support.
+ *
+ * @package Gutenberg
+ */
+
+class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		$this->theme_root     = realpath( __DIR__ . '/../data/themedir1' );
+		$this->orig_theme_dir = $GLOBALS['wp_theme_directories'];
+
+		// /themes is necessary as theme.php functions assume /themes is the root if there is only one root.
+		$GLOBALS['wp_theme_directories'] = array( WP_CONTENT_DIR . '/themes', $this->theme_root );
+
+		add_filter( 'theme_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'stylesheet_root', array( $this, 'filter_set_theme_root' ) );
+		add_filter( 'template_root', array( $this, 'filter_set_theme_root' ) );
+		$this->queries = array();
+		// Clear caches.
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+	}
+
+	function tearDown() {
+		$GLOBALS['wp_theme_directories'] = $this->orig_theme_dir;
+		wp_clean_themes_cache();
+		unset( $GLOBALS['wp_themes'] );
+		parent::tearDown();
+	}
+
+	function filter_set_theme_root() {
+		return $this->theme_root;
+	}
+
+	function test_outer_container_restored_for_aligned_image_block_with_non_themejson_theme() {
+		// The "default" theme doesn't have theme.json support.
+		switch_theme( 'default' );
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'className' => 'is-style-round my-custom-classname',
+			),
+		);
+		$block_content = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
+		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
+		$expected      = '<div class="wp-block-image is-style-round my-custom-classname"><figure class=" alignright size-full "><img src="/my-image.jpg"/></figure></div>';
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	function test_outer_container_not_restored_for_aligned_image_block_with_themejson_theme() {
+		switch_theme( 'block-theme' );
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
+				'className' => 'is-style-round my-custom-classname',
+			),
+		);
+		$block_content = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
+		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
+		$expected      = '<figure class="wp-block-image alignright size-full is-style-round my-custom-classname"><img src="/my-image.jpg"/></figure>';
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -64,7 +64,7 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 	function test_additional_styles_moved_to_restored_outer_container_for_aligned_image_block_with_non_themejson_theme() {
 		// The "default" theme doesn't have theme.json support.
 		switch_theme( 'default' );
-		$block         = array(
+		$block = array(
 			'blockName' => 'core/image',
 			'attrs'     => array(
 				'className' => 'is-style-round my-custom-classname',
@@ -82,8 +82,8 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_middle_placement, $block ) );
 		$this->assertSame( $expected, gutenberg_restore_image_outer_container( $block_classes_random_placement, $block ) );
 
-		$block_classes_other_attributes = '<figure style="color: red" class="is-style-round wp-block-image alignright my-custom-classname size-full" data-random-tag=">"><img src="/my-image.jpg"/></figure>';
-		$expected_other_attributes      = '<div class="wp-block-image is-style-round my-custom-classname"><figure style="color: red" class="alignright size-full" data-random-tag=">"><img src="/my-image.jpg"/></figure></div>';
+		$block_classes_other_attributes = '<figure style="color: red" class=\'is-style-round wp-block-image alignright my-custom-classname size-full\' data-random-tag=">"><img src="/my-image.jpg"/></figure>';
+		$expected_other_attributes      = '<div class="wp-block-image is-style-round my-custom-classname"><figure style="color: red" class=\'alignright size-full\' data-random-tag=">"><img src="/my-image.jpg"/></figure></div>';
 
 		$this->assertSame( $expected_other_attributes, gutenberg_restore_image_outer_container( $block_classes_other_attributes, $block ) );
 	}

--- a/phpunit/block-supports/layout-test.php
+++ b/phpunit/block-supports/layout-test.php
@@ -41,6 +41,22 @@ class WP_Block_Supports_Layout_Test extends WP_UnitTestCase {
 		$block         = array(
 			'blockName' => 'core/image',
 			'attrs'     => array(
+				'className' => '',
+			),
+		);
+		$block_content = '<figure class="wp-block-image alignright size-full"><img src="/my-image.jpg"/></figure>';
+		$actual        = gutenberg_restore_image_outer_container( $block_content, $block );
+		$expected      = '<div class="wp-block-image "><figure class=" alignright size-full"><img src="/my-image.jpg"/></figure></div>';
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	function test_additional_styles_moved_to_restored_outer_container_for_aligned_image_block_with_non_themejson_theme() {
+		// The "default" theme doesn't have theme.json support.
+		switch_theme( 'default' );
+		$block         = array(
+			'blockName' => 'core/image',
+			'attrs'     => array(
 				'className' => 'is-style-round my-custom-classname',
 			),
 		);


### PR DESCRIPTION
## What?
For non theme.json themes any `is-style` or custom classnames added to an image block in combination with a specified alignment will be copied to the deprecated `div` alignment wrapper that is added back to the frontend.

## Why?
There are many themes/plugins that are relying on these custom classnames being on the same element as the `wp-block-image` class which is also moved to this deprecated wrapper div.

## How?
The block className attribute is applied to the `<div>` wrapper that is added.

## Testing Instructions

- Add an image to a site with TwentyTwentyOne theme running and select one of the border styles and also set the block to align right
- Check that the image style displays as expected in the frontend.
- Check that `phpunit/block-supports/layout-test.php` tests pass

## Screenshots

Before:
<img width="537" alt="Screen Shot 2022-03-14 at 3 47 06 PM" src="https://user-images.githubusercontent.com/3629020/158096265-15f572c3-7d74-434d-b899-be1bae3d2573.png">

After:
<img width="592" alt="Screen Shot 2022-03-14 at 3 35 42 PM" src="https://user-images.githubusercontent.com/3629020/158096286-7cc2abd9-6dde-43de-a77f-fe274fe53480.png">

