### PR TITLE
Templates page: reduce z-index of content area

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -34,6 +34,7 @@ $z-layers: (
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 91,
+	".edit-site-list.interface-interface-skeleton__content": 29, // The content area needs to be lower than the header so tools dropdowns appear over the content.
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -46,6 +46,7 @@
 			background: $white;
 			align-items: center;
 			padding: $grid-unit-20;
+			z-index: z-index(".edit-site-list.interface-interface-skeleton__content");
 
 			@include break-medium() {
 				padding: $grid-unit * 9;


### PR DESCRIPTION
## What?
This PR demotes the content area's z-index for `edit-site-list` (the Templates list) so that popovers in the header sit over the content.

## Why?

The z-index of `.interface-interface-skeleton__content` was bumped to `91` from `20` in https://github.com/WordPress/gutenberg/pull/38893.

The result, for the Templates list page, is that the **Add New** dropdown sits underneath the content area.

<img width="500" alt="Screen Shot 2022-03-10 at 1 39 53 pm" src="https://user-images.githubusercontent.com/6458278/157578147-ca3be7a3-147a-4e28-8101-bc5c4d9b011c.png">

## How?

This PR reduces the z-index of `.edit-site-list.interface-interface-skeleton__content` to `29`. 

<img width="405" alt="Screen Shot 2022-03-10 at 1 27 35 pm" src="https://user-images.githubusercontent.com/6458278/157579679-1d5e83dc-213e-4635-8b30-edaf01be6462.png">

## Testing Instructions
1. With a block theme activated, header over to `/wp-admin/themes.php?page=gutenberg-edit-site&postType=wp_template`
2. You should be able to see and use the **Add New** dropdown
3. Also check that the Template Part modal still works as it should just in case.


