### PR TITLE
Fix performance tests - attempt 2

### DIFF
--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -98,6 +98,7 @@ export async function disableSiteEditorWelcomeGuide() {
 				wp.data
 					.dispatch( 'core/edit-site' )
 					.toggleFeature( 'welcomeGuide' );
+				return;
 			}
 
 			wp.data
@@ -113,6 +114,7 @@ export async function disableSiteEditorWelcomeGuide() {
 				wp.data
 					.dispatch( 'core/edit-site' )
 					.toggleFeature( 'welcomeGuideStyles' );
+				return;
 			}
 			wp.data
 				.dispatch( 'core/preferences' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the performance tests that run on `trunk`.

This is a follow up to https://github.com/WordPress/gutenberg/pull/39300.

## Why?
I missed an early `return` to avoid the dispatch to preferences. 🤦 