### PR TITLE
Add block button overlap fixed #39304

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -52,6 +52,21 @@
  * These styles apply to all in-canvas inserters that exist inside nesting containers.
  */
 
+.items-justified-right .is-menu-open .wp-block-navigation__responsive-container-content * .block-list-appender {
+	left: -30px;
+	right: unset;
+}
+
+.items-justified-center .is-menu-open .wp-block-navigation__responsive-container-content * .block-list-appender {
+	right: -30px;
+	left: unset;
+}
+
+.items-justified-left .is-menu-open .wp-block-navigation__responsive-container-content * .block-list-appender {
+	right: -30px;
+	left: unset;
+}
+
 .block-editor-block-list__block .block-list-appender {
 	position: absolute;
 	list-style: none;


### PR DESCRIPTION
## What?
This PR will fix the overlapping issue of the add button.

## Why?
It will add a few lines of new CSS which sets the proper alignment of the add button of the header menu.

## How?

When the alignment is set the add button is positioned according to the text and alignment.

## Testing Instructions

To test this follow the below steps: 
1. Go to the page editor
2. Selecting mobile view using the preview button
3. On a mobile device click on the hamburger button and slide-out navigation
4. Click on menus to add a new menu and also same time selection navigation block alignment in the center and right end at the time add block button will not overlap.


## Screenshots or screencast <!-- if applicable -->

Here is the video showing solution.

https://www.loom.com/share/d68b687267a74b47840364d578467415

