### PR TITLE
Image: Restore baseline responsiveness in the block.

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -2,6 +2,8 @@
 	margin: 0 0 1em 0;
 
 	img {
+		height: auto;
+		max-width: 100%;
 		vertical-align: bottom;
 	}
 


### PR DESCRIPTION
## What?

Followup to #38399 and feedback in https://github.com/WordPress/gutenberg/pull/39045#issuecomment-1059071650. While the new responsive rules from 39045 work for images inserted, they don't work for images in patterns. As a result, you might see this cropped bird in the Patterns tab:

<img width="383" alt="Screenshot 2022-03-10 at 09 51 31" src="https://user-images.githubusercontent.com/1204802/157626043-ecbf87e4-3f31-45ee-b42b-a3cd4b192f16.png">

This PR restores the image specific rule, fixing it:

<img width="367" alt="Screenshot 2022-03-10 at 09 53 59" src="https://user-images.githubusercontent.com/1204802/157626077-2971d8e6-dc28-4cbf-83a8-1e2c6a7cac10.png">

The basic responsive rule is still kept intact, as it still serves a purpose for targetting images inserted in the classic editor.

## Testing Instructions

Test the pattern library of TwentyTwentyTwo before and after this PR, and observe the "Wide image" pattern scaling its image properly.
