### PR TITLE
Update drag handle footprint.

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Changed `dragHandle` footprint from 18x18 to 24x24 to match other icons.
+
 ## 7.0.0 (2022-02-23)
 
 ### New Features

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Changes
 
--   Changed `dragHandle` footprint from 18x18 to 24x24 to match other icons.
+-   Changed `dragHandle` footprint from 18x18 to 24x24 to match other icons.  ([#39342](https://github.com/WordPress/gutenberg/pull/39342))
 
 ## 7.0.0 (2022-02-23)
 

--- a/packages/icons/src/library/drag-handle.js
+++ b/packages/icons/src/library/drag-handle.js
@@ -5,12 +5,12 @@ import { SVG, Path } from '@wordpress/primitives';
 
 const dragHandle = (
 	<SVG
-		width="18"
-		height="18"
+		width="24"
+		height="24"
 		xmlns="http://www.w3.org/2000/svg"
-		viewBox="0 0 18 18"
+		viewBox="0 0 24 24"
 	>
-		<Path d="M5 4h2V2H5v2zm6-2v2h2V2h-2zm-6 8h2V8H5v2zm6 0h2V8h-2v2zm-6 6h2v-2H5v2zm6 0h2v-2h-2v2z" />
+		<Path d="M8 7h2V5H8v2zm0 6h2v-2H8v2zm0 6h2v-2H8v2zm6-14v2h2V5h-2zm0 8h2v-2h-2v2zm0 6h2v-2h-2v2z" />
 	</SVG>
 );
 


### PR DESCRIPTION
## What?

The `dragHandle` icon is 18x18px. As part of the icon library, it should be 24x24.

## Why?

The icon library is meant to be in sync with the WordPress Figma Design Library, so it's important it stays in sync.

## How?

This PR updates the footprint to match the Figma, and to be 24x24.

## Testing Instructions

Check all the instances of the dragHandle icon, most notably by selecting a block and looking at the block toolbar. Before and after should look identical.

## Screenshots or screencast <!-- if applicable -->

Before, footprint:
![before](https://user-images.githubusercontent.com/1204802/157633040-e3facd4c-d6ef-4957-8b2b-9359a37f8f9f.gif)

After, footprint:

![after](https://user-images.githubusercontent.com/1204802/157633074-64c30ca9-921b-4038-9a8f-62d60f5026a5.gif)

A before and after comparison screenshot:

![before-after](https://user-images.githubusercontent.com/1204802/157633119-f1a00a36-c306-4fa9-9b93-a179ec0f6244.png)

As it turns out, 24px was already reserved for the drag handle, so changing the footprint of the icon didn't require any CSS changes.
