### PR TITLE
[Components - ToggleGroupControlOption]: Calculate width from button content and remove `LabelPlaceholderView` 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `ConfirmDialog`: Add support for custom label text on the confirmation and cancelation buttons ([#38994](https://github.com/WordPress/gutenberg/pull/38994))
 -   `InputControl`: Allow `onBlur` for empty values to commit the change when `isPressEnterToChange` is true, and move reset behavior to the ESCAPE key. ([#39109](https://github.com/WordPress/gutenberg/pull/39109)).
 -   `TreeGrid`: Add tests for Home/End keyboard navigation. Add `onFocusRow` callback for Home/End keyboard navigation, this was missed in the implementation PR. Modify test for expanding/collapsing a row as row 1 implements this now. Update README with latest changes. ([#39302](https://github.com/WordPress/gutenberg/pull/39302))
+-   `ToggleGroupControlOption`: Calculate width from button content and remove `LabelPlaceholderView` ([#39345](https://github.com/WordPress/gutenberg/pull/39345))
 
 ### Bug Fix
 

--- a/packages/components/src/font-size-picker/test/index.js
+++ b/packages/components/src/font-size-picker/test/index.js
@@ -203,7 +203,6 @@ describe( 'FontSizePicker', () => {
 				);
 				const element = screen.getByLabelText( 'Large' );
 				expect( element ).toBeInTheDocument();
-				expect( element.children ).toHaveLength( 2 );
 				expect( element.children[ 0 ].textContent ).toBe( '1.7' );
 			} );
 			it( 'should use incremental sequence of numbers as labels if we have complex css', () => {
@@ -223,7 +222,6 @@ describe( 'FontSizePicker', () => {
 				);
 				const element = screen.getByLabelText( 'Large' );
 				expect( element ).toBeInTheDocument();
-				expect( element.children ).toHaveLength( 2 );
 				expect( element.children[ 0 ].textContent ).toBe( '3' );
 			} );
 		} );

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -122,21 +122,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
 .emotion-11 {
   font-size: 13px;
   line-height: 1;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate( -50%, -50% );
-  -moz-transform: translate( -50%, -50% );
-  -ms-transform: translate( -50%, -50% );
-  transform: translate( -50%, -50% );
-}
-
-.emotion-13 {
-  font-size: 13px;
-  font-weight: bold;
-  height: 0;
-  overflow: hidden;
-  visibility: hidden;
 }
 
 <div
@@ -180,12 +165,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
           >
             R
           </div>
-          <div
-            aria-hidden="true"
-            class="emotion-13 emotion-14"
-          >
-            R
-          </div>
         </button>
       </div>
       <div
@@ -205,12 +184,6 @@ exports[`ToggleGroupControl should render correctly 1`] = `
         >
           <div
             class="emotion-11 emotion-12"
-          >
-            J
-          </div>
-          <div
-            aria-hidden="true"
-            class="emotion-13 emotion-14"
           >
             J
           </div>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/component.tsx
@@ -24,7 +24,7 @@ import * as styles from './styles';
 import { useCx } from '../../utils/hooks';
 import Tooltip from '../../tooltip';
 
-const { ButtonContentView, LabelPlaceholderView, LabelView } = styles;
+const { ButtonContentView, LabelView } = styles;
 
 const WithToolTip = ( { showTooltip, text, children }: WithToolTipProps ) => {
 	if ( showTooltip && text ) {
@@ -88,9 +88,6 @@ function ToggleGroupControlOption(
 					value={ value }
 				>
 					<ButtonContentView>{ label }</ButtonContentView>
-					<LabelPlaceholderView aria-hidden>
-						{ label }
-					</LabelPlaceholderView>
 				</Radio>
 			</WithToolTip>
 		</LabelView>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option/styles.ts
@@ -61,22 +61,10 @@ export const buttonActive = css`
 export const ButtonContentView = styled.div`
 	font-size: ${ CONFIG.fontSize };
 	line-height: 1;
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate( -50%, -50% );
 `;
 
 export const separatorActive = css`
 	background: transparent;
-`;
-
-export const LabelPlaceholderView = styled.div`
-	font-size: ${ CONFIG.fontSize };
-	font-weight: bold;
-	height: 0;
-	overflow: hidden;
-	visibility: hidden;
 `;
 
 export const medium = css`


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I made a POC for adding `icon` support in `ToggleGroupControl` component and saw that we calculate the width of the labels in a weird and not proper way IMO. What we are doing now is having css for the main button that positions `absolute` the element and centers it with a `translate` rule, and we use `LabelPlaceholderView` which is not visible(`visibility: hidden;`) but still in the document label to calculate the width. This seems wrong to me because:
1. We now only support showing the label which has the same content with `LabelPlaceholderView`. If we wanted to change that - like icons support - we cannot do that.
2. In `LabelPlaceholderView` we also have [aria-hidden](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) which means the element is **not** exposed to an accessibility API, so it seems that it was just there for width calculation to me..

So to sum up I think `LabelPlaceholderView` is completely obsolete - but feel free to correct me if I'm missing something.  😄
<!-- In a few words, what is the PR actually doing? -->

## Why?
Code quality change that will also enable us to add `icon` support
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Everything should work just as before with no regressions at all - either visual or a11y.
2. Check existing usages like `FontSizePicker` or in `PostFeaturedImage` when you set a `height`, etc... Also check the stories in storybook.
