### PR TITLE
Use consistent terminology across @wordpress/core-data

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -148,7 +148,7 @@ _Returns_
 
 ### getEntitiesByKind
 
-> **Deprecated** since ??. Use getEntitiesConfig instead
+> **Deprecated** since WordPress 6.0. Use getEntitiesConfig instead
 
 Returns the loaded entities for the given kind.
 
@@ -176,7 +176,7 @@ _Returns_
 
 ### getEntity
 
-> **Deprecated** since ??. Use getEntityConfig instead
+> **Deprecated** since WordPress 6.0. Use getEntityConfig instead
 
 Returns the entity config given its kind and name.
 

--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -148,7 +148,22 @@ _Returns_
 
 ### getEntitiesByKind
 
-Returns whether the entities for the give kind are loaded.
+> **Deprecated** since ??. Use getEntitiesConfig instead
+
+Returns the loaded entities for the given kind.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _kind_ `string`: Entity kind.
+
+_Returns_
+
+-   `Array<Object>`: Array of entities with config matching kind.
+
+### getEntitiesConfig
+
+Returns the loaded entities for the given kind.
 
 _Parameters_
 
@@ -161,7 +176,9 @@ _Returns_
 
 ### getEntity
 
-Returns the entity object given its kind and name.
+> **Deprecated** since ??. Use getEntityConfig instead
+
+Returns the entity config given its kind and name.
 
 _Parameters_
 
@@ -171,7 +188,21 @@ _Parameters_
 
 _Returns_
 
--   `Object`: Entity
+-   `Object`: Entity config
+
+### getEntityConfig
+
+Returns the entity config given its kind and name.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+
+_Returns_
+
+-   `Object`: Entity config
 
 ### getEntityRecord
 
@@ -530,9 +561,9 @@ Action triggered to delete an entity record.
 
 _Parameters_
 
--   _kind_ `string`: Kind of the deleted entity.
--   _name_ `string`: Name of the deleted entity.
--   _recordId_ `string`: Record ID of the deleted entity.
+-   _kind_ `string`: Kind of the deleted entity record.
+-   _name_ `string`: Name of the deleted entity record.
+-   _recordId_ `string`: Record ID of the deleted entity record.
 -   _query_ `?Object`: Special query parameters for the DELETE API call.
 -   _options_ `[Object]`: Delete options.
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
@@ -613,8 +644,8 @@ Returns an action object used in signalling that entity records have been receiv
 
 _Parameters_
 
--   _kind_ `string`: Kind of the received entity.
--   _name_ `string`: Name of the received entity.
+-   _kind_ `string`: Kind of the received entity record.
+-   _name_ `string`: Name of the received entity record.
 -   _records_ `Array|Object`: Records received.
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -393,7 +393,7 @@ _Returns_
 
 ### getEntitiesByKind
 
-> **Deprecated** since ??. Use getEntitiesConfig instead
+> **Deprecated** since WordPress 6.0. Use getEntitiesConfig instead
 
 Returns the loaded entities for the given kind.
 
@@ -421,7 +421,7 @@ _Returns_
 
 ### getEntity
 
-> **Deprecated** since ??. Use getEntityConfig instead
+> **Deprecated** since WordPress 6.0. Use getEntityConfig instead
 
 Returns the entity config given its kind and name.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -64,9 +64,9 @@ Action triggered to delete an entity record.
 
 _Parameters_
 
--   _kind_ `string`: Kind of the deleted entity.
--   _name_ `string`: Name of the deleted entity.
--   _recordId_ `string`: Record ID of the deleted entity.
+-   _kind_ `string`: Kind of the deleted entity record.
+-   _name_ `string`: Name of the deleted entity record.
+-   _recordId_ `string`: Record ID of the deleted entity record.
 -   _query_ `?Object`: Special query parameters for the DELETE API call.
 -   _options_ `[Object]`: Delete options.
 -   _options.\_\_unstableFetch_ `[Function]`: Internal use only. Function to call instead of `apiFetch()`. Must return a promise.
@@ -147,8 +147,8 @@ Returns an action object used in signalling that entity records have been receiv
 
 _Parameters_
 
--   _kind_ `string`: Kind of the received entity.
--   _name_ `string`: Name of the received entity.
+-   _kind_ `string`: Kind of the received entity record.
+-   _name_ `string`: Name of the received entity record.
 -   _records_ `Array|Object`: Records received.
 -   _query_ `?Object`: Query Object.
 -   _invalidateCache_ `?boolean`: Should invalidate query caches.
@@ -393,7 +393,22 @@ _Returns_
 
 ### getEntitiesByKind
 
-Returns whether the entities for the give kind are loaded.
+> **Deprecated** since ??. Use getEntitiesConfig instead
+
+Returns the loaded entities for the given kind.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _kind_ `string`: Entity kind.
+
+_Returns_
+
+-   `Array<Object>`: Array of entities with config matching kind.
+
+### getEntitiesConfig
+
+Returns the loaded entities for the given kind.
 
 _Parameters_
 
@@ -406,7 +421,9 @@ _Returns_
 
 ### getEntity
 
-Returns the entity object given its kind and name.
+> **Deprecated** since ??. Use getEntityConfig instead
+
+Returns the entity config given its kind and name.
 
 _Parameters_
 
@@ -416,7 +433,21 @@ _Parameters_
 
 _Returns_
 
--   `Object`: Entity
+-   `Object`: Entity config
+
+### getEntityConfig
+
+Returns the entity config given its kind and name.
+
+_Parameters_
+
+-   _state_ `Object`: Data state.
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+
+_Returns_
+
+-   `Object`: Entity config
 
 ### getEntityRecord
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -236,7 +236,7 @@ export const deleteEntityRecord = (
 
 	const lock = await dispatch.__unstableAcquireStoreLock(
 		STORE_NAME,
-		[ 'entities', 'data', kind, name, recordId ],
+		[ 'entities', 'records', kind, name, recordId ],
 		{ exclusive: true }
 	);
 
@@ -411,7 +411,7 @@ export const saveEntityRecord = (
 
 	const lock = await dispatch.__unstableAcquireStoreLock(
 		STORE_NAME,
-		[ 'entities', 'data', kind, name, recordId || uuid() ],
+		[ 'entities', 'records', kind, name, recordId || uuid() ],
 		{ exclusive: true }
 	);
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -66,8 +66,8 @@ export function addEntities( entities ) {
 /**
  * Returns an action object used in signalling that entity records have been received.
  *
- * @param {string}       kind            Kind of the received entity.
- * @param {string}       name            Name of the received entity.
+ * @param {string}       kind            Kind of the received entity record.
+ * @param {string}       name            Name of the received entity record.
  * @param {Array|Object} records         Records received.
  * @param {?Object}      query           Query Object.
  * @param {?boolean}     invalidateCache Should invalidate query caches.
@@ -209,9 +209,9 @@ export function receiveEmbedPreview( url, preview ) {
 /**
  * Action triggered to delete an entity record.
  *
- * @param {string}   kind                      Kind of the deleted entity.
- * @param {string}   name                      Name of the deleted entity.
- * @param {string}   recordId                  Record ID of the deleted entity.
+ * @param {string}   kind                      Kind of the deleted entity record.
+ * @param {string}   name                      Name of the deleted entity record.
+ * @param {string}   recordId                  Record ID of the deleted entity record.
  * @param {?Object}  query                     Special query parameters for the
  *                                             DELETE API call.
  * @param {Object}   [options]                 Delete options.

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -15,7 +15,7 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import { receiveItems, removeItems, receiveQueriedItems } from './queried-data';
-import { getKindEntities, DEFAULT_ENTITY_KEY } from './entities';
+import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 import { createBatch } from './batch';
 import { STORE_NAME } from './name';
 
@@ -226,7 +226,7 @@ export const deleteEntityRecord = (
 	query,
 	{ __unstableFetch = apiFetch } = {}
 ) => async ( { dispatch } ) => {
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	let error;
 	let deletedRecord = false;
@@ -401,7 +401,7 @@ export const saveEntityRecord = (
 	record,
 	{ isAutosave = false, __unstableFetch = apiFetch } = {}
 ) => async ( { select, resolveSelect, dispatch } ) => {
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
@@ -659,7 +659,7 @@ export const saveEditedEntityRecord = (
 	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 		return;
 	}
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -299,7 +299,7 @@ export const editEntityRecord = (
 	edits,
 	options = {}
 ) => ( { select, dispatch } ) => {
-	const entity = select.getEntity( kind, name );
+	const entity = select.getEntityConfig( kind, name );
 	if ( ! entity ) {
 		throw new Error(
 			`The entity being edited (${ kind }, ${ name }) does not have a loaded config.`

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -226,11 +226,11 @@ export const deleteEntityRecord = (
 	query,
 	{ __unstableFetch = apiFetch } = {}
 ) => async ( { dispatch } ) => {
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
 	let error;
 	let deletedRecord = false;
-	if ( ! entity || entity?.__experimentalNoFetch ) {
+	if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 		return;
 	}
 
@@ -249,7 +249,7 @@ export const deleteEntityRecord = (
 		} );
 
 		try {
-			let path = `${ entity.baseURL }/${ recordId }`;
+			let path = `${ entityConfig.baseURL }/${ recordId }`;
 
 			if ( query ) {
 				path = addQueryArgs( path, query );
@@ -299,13 +299,13 @@ export const editEntityRecord = (
 	edits,
 	options = {}
 ) => ( { select, dispatch } ) => {
-	const entity = select.getEntityConfig( kind, name );
-	if ( ! entity ) {
+	const entityConfig = select.getEntityConfig( kind, name );
+	if ( ! entityConfig ) {
 		throw new Error(
 			`The entity being edited (${ kind }, ${ name }) does not have a loaded config.`
 		);
 	}
-	const { transientEdits = {}, mergedEdits = {} } = entity;
+	const { transientEdits = {}, mergedEdits = {} } = entityConfig;
 	const record = select.getRawEntityRecord( kind, name, recordId );
 	const editedRecord = select.getEditedEntityRecord( kind, name, recordId );
 
@@ -401,12 +401,12 @@ export const saveEntityRecord = (
 	record,
 	{ isAutosave = false, __unstableFetch = apiFetch } = {}
 ) => async ( { select, resolveSelect, dispatch } ) => {
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
-	if ( ! entity || entity?.__experimentalNoFetch ) {
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
+	if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 		return;
 	}
-	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;
+	const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
 	const recordId = record[ entityIdKey ];
 
 	const lock = await dispatch.__unstableAcquireStoreLock(
@@ -446,7 +446,7 @@ export const saveEntityRecord = (
 		let updatedRecord;
 		let error;
 		try {
-			const path = `${ entity.baseURL }${
+			const path = `${ entityConfig.baseURL }${
 				recordId ? '/' + recordId : ''
 			}`;
 			const persistedRecord = select.getRawEntityRecord(
@@ -543,10 +543,10 @@ export const saveEntityRecord = (
 				}
 			} else {
 				let edits = record;
-				if ( entity.__unstablePrePersist ) {
+				if ( entityConfig.__unstablePrePersist ) {
 					edits = {
 						...edits,
-						...entity.__unstablePrePersist(
+						...entityConfig.__unstablePrePersist(
 							persistedRecord,
 							edits
 						),
@@ -659,12 +659,12 @@ export const saveEditedEntityRecord = (
 	if ( ! select.hasEditsForEntityRecord( kind, name, recordId ) ) {
 		return;
 	}
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
+	if ( ! entityConfig ) {
 		return;
 	}
-	const entityIdKey = entity.key || DEFAULT_ENTITY_KEY;
+	const entityIdKey = entityConfig.key || DEFAULT_ENTITY_KEY;
 
 	const edits = select.getEntityRecordNonTransientEdits(
 		kind,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -301,9 +301,9 @@ export const getOrLoadEntitiesConfig = ( kind ) => async ( {
 	select,
 	dispatch,
 } ) => {
-	let entities = select.getEntitiesConfig( kind );
-	if ( entities && entities.length !== 0 ) {
-		return entities;
+	let configs = select.getEntitiesConfig( kind );
+	if ( configs && configs.length !== 0 ) {
+		return configs;
 	}
 
 	const loader = find( additionalEntityConfigLoaders, { kind } );
@@ -311,8 +311,8 @@ export const getOrLoadEntitiesConfig = ( kind ) => async ( {
 		return [];
 	}
 
-	entities = await loader.loadEntities();
-	dispatch( addEntities( entities ) );
+	configs = await loader.loadEntities();
+	dispatch( addEntities( configs ) );
 
-	return entities;
+	return configs;
 };

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -279,13 +279,13 @@ export const getMethodName = (
 	prefix = 'get',
 	usePlural = false
 ) => {
-	const entity = find( rootEntitiesConfig, { kind, name } );
+	const entityConfig = find( rootEntitiesConfig, { kind, name } );
 	const kindPrefix = kind === 'root' ? '' : upperFirst( camelCase( kind ) );
 	const nameSuffix =
 		upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
 	const suffix =
-		usePlural && entity.plural
-			? upperFirst( camelCase( entity.plural ) )
+		usePlural && entityConfig.plural
+			? upperFirst( camelCase( entityConfig.plural ) )
 			: nameSuffix;
 	return `${ prefix }${ kindPrefix }${ suffix }`;
 };

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -301,7 +301,7 @@ export const getOrLoadEntitiesConfig = ( kind ) => async ( {
 	select,
 	dispatch,
 } ) => {
-	let entities = select.getEntitiesByKind( kind );
+	let entities = select.getEntitiesConfig( kind );
 	if ( entities && entities.length !== 0 ) {
 		return entities;
 	}

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -61,7 +61,7 @@ const getEntity = ( kind, type ) => {
  *                   the entity's context provider.
  */
 export default function EntityProvider( { kind, type, id, children } ) {
-	const Provider = getEntity( kind, type ).context.Provider;
+	const Provider = getEntityConfig( kind, type ).context.Provider;
 	return <Provider value={ id }>{ children }</Provider>;
 }
 
@@ -73,7 +73,7 @@ export default function EntityProvider( { kind, type, id, children } ) {
  * @param {string} type The entity type.
  */
 export function useEntityId( kind, type ) {
-	return useContext( getEntity( kind, type ).context );
+	return useContext( getEntityConfig( kind, type ).context );
 }
 
 /**

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -23,15 +23,15 @@ const EMPTY_ARRAY = [];
 import { rootEntitiesConfig, additionalEntityConfigLoaders } from './entities';
 
 const entityContexts = {
-	...rootEntitiesConfig.reduce( ( acc, entity ) => {
-		if ( ! acc[ entity.kind ] ) {
-			acc[ entity.kind ] = {};
+	...rootEntitiesConfig.reduce( ( acc, loader ) => {
+		if ( ! acc[ loader.kind ] ) {
+			acc[ loader.kind ] = {};
 		}
-		acc[ entity.kind ][ entity.name ] = { context: createContext() };
+		acc[ loader.kind ][ loader.name ] = { context: createContext() };
 		return acc;
 	}, {} ),
-	...additionalEntityConfigLoaders.reduce( ( acc, kind ) => {
-		acc[ kind.kind ] = {};
+	...additionalEntityConfigLoaders.reduce( ( acc, loader ) => {
+		acc[ loader.kind ] = {};
 		return acc;
 	}, {} ),
 };
@@ -102,12 +102,12 @@ export function useEntityProp( kind, type, prop, _id ) {
 			const { getEntityRecord, getEditedEntityRecord } = select(
 				STORE_NAME
 			);
-			const entity = getEntityRecord( kind, type, id ); // Trigger resolver.
-			const editedEntity = getEditedEntityRecord( kind, type, id );
-			return entity && editedEntity
+			const record = getEntityRecord( kind, type, id ); // Trigger resolver.
+			const editedRecord = getEditedEntityRecord( kind, type, id );
+			return record && editedRecord
 				? {
-						value: editedEntity[ prop ],
-						fullValue: entity[ prop ],
+						value: editedRecord[ prop ],
+						fullValue: record[ prop ],
 				  }
 				: {};
 		},
@@ -150,10 +150,10 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 	const { content, blocks } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( STORE_NAME );
-			const editedEntity = getEditedEntityRecord( kind, type, id );
+			const editedRecord = getEditedEntityRecord( kind, type, id );
 			return {
-				blocks: editedEntity.blocks,
-				content: editedEntity.content,
+				blocks: editedRecord.blocks,
+				content: editedRecord.content,
 			};
 		},
 		[ kind, type, id ]

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -22,7 +22,7 @@ const EMPTY_ARRAY = [];
  */
 import { rootEntitiesConfig, additionalEntityConfigLoaders } from './entities';
 
-const entities = {
+const entityContexts = {
 	...rootEntitiesConfig.reduce( ( acc, entity ) => {
 		if ( ! acc[ entity.kind ] ) {
 			acc[ entity.kind ] = {};
@@ -35,16 +35,16 @@ const entities = {
 		return acc;
 	}, {} ),
 };
-const getEntity = ( kind, type ) => {
-	if ( ! entities[ kind ] ) {
+const getEntityContext = ( kind, type ) => {
+	if ( ! entityContexts[ kind ] ) {
 		throw new Error( `Missing entity config for kind: ${ kind }.` );
 	}
 
-	if ( ! entities[ kind ][ type ] ) {
-		entities[ kind ][ type ] = { context: createContext() };
+	if ( ! entityContexts[ kind ][ type ] ) {
+		entityContexts[ kind ][ type ] = { context: createContext() };
 	}
 
-	return entities[ kind ][ type ];
+	return entityContexts[ kind ][ type ].context;
 };
 
 /**
@@ -61,7 +61,7 @@ const getEntity = ( kind, type ) => {
  *                   the entity's context provider.
  */
 export default function EntityProvider( { kind, type, id, children } ) {
-	const Provider = getEntityConfig( kind, type ).context.Provider;
+	const Provider = getEntityContext( kind, type ).Provider;
 	return <Provider value={ id }>{ children }</Provider>;
 }
 
@@ -72,8 +72,8 @@ export default function EntityProvider( { kind, type, id, children } ) {
  * @param {string} kind The entity kind.
  * @param {string} type The entity type.
  */
-export function useEntityId( kind, type ) {
-	return useContext( getEntityConfig( kind, type ).context );
+export function useEntityProviderId( kind, type ) {
+	return useContext( getEntityContext( kind, type ) );
 }
 
 /**
@@ -94,7 +94,7 @@ export function useEntityId( kind, type ) {
  * 							  `protected` props.
  */
 export function useEntityProp( kind, type, prop, _id ) {
-	const providerId = useEntityId( kind, type );
+	const providerId = useEntityProviderId( kind, type );
 	const id = _id ?? providerId;
 
 	const { value, fullValue } = useSelect(
@@ -145,7 +145,7 @@ export function useEntityProp( kind, type, prop, _id ) {
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
 export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
-	const providerId = useEntityId( kind, type );
+	const providerId = useEntityProviderId( kind, type );
 	const id = _id ?? providerId;
 	const { content, blocks } = useSelect(
 		( select ) => {

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -20,18 +20,18 @@ const EMPTY_ARRAY = [];
 /**
  * Internal dependencies
  */
-import { defaultEntities, kinds } from './entities';
+import { rootEntitiesConfig, additionalEntityConfigLoaders } from './entities';
 
 const entities = {
-	...defaultEntities.reduce( ( acc, entity ) => {
+	...rootEntitiesConfig.reduce( ( acc, entity ) => {
 		if ( ! acc[ entity.kind ] ) {
 			acc[ entity.kind ] = {};
 		}
 		acc[ entity.kind ][ entity.name ] = { context: createContext() };
 		return acc;
 	}, {} ),
-	...kinds.reduce( ( acc, kind ) => {
-		acc[ kind.name ] = {};
+	...additionalEntityConfigLoaders.reduce( ( acc, kind ) => {
+		acc[ kind.kind ] = {};
 		return acc;
 	}, {} ),
 };

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -35,33 +35,33 @@ const entityContexts = {
 		return acc;
 	}, {} ),
 };
-const getEntityContext = ( kind, type ) => {
+const getEntityContext = ( kind, name ) => {
 	if ( ! entityContexts[ kind ] ) {
 		throw new Error( `Missing entity config for kind: ${ kind }.` );
 	}
 
-	if ( ! entityContexts[ kind ][ type ] ) {
-		entityContexts[ kind ][ type ] = { context: createContext() };
+	if ( ! entityContexts[ kind ][ name ] ) {
+		entityContexts[ kind ][ name ] = { context: createContext() };
 	}
 
-	return entityContexts[ kind ][ type ].context;
+	return entityContexts[ kind ][ name ].context;
 };
 
 /**
  * Context provider component for providing
- * an entity for a specific entity type.
+ * an entity for a specific entity.
  *
  * @param {Object} props          The component's props.
  * @param {string} props.kind     The entity kind.
- * @param {string} props.type     The entity type.
+ * @param {string} props.type     The entity name.
  * @param {number} props.id       The entity ID.
  * @param {*}      props.children The children to wrap.
  *
  * @return {Object} The provided children, wrapped with
  *                   the entity's context provider.
  */
-export default function EntityProvider( { kind, type, id, children } ) {
-	const Provider = getEntityContext( kind, type ).Provider;
+export default function EntityProvider( { kind, type: name, id, children } ) {
+	const Provider = getEntityContext( kind, name ).Provider;
 	return <Provider value={ id }>{ children }</Provider>;
 }
 
@@ -70,10 +70,10 @@ export default function EntityProvider( { kind, type, id, children } ) {
  * provided entity of the specified type.
  *
  * @param {string} kind The entity kind.
- * @param {string} type The entity type.
+ * @param {string} name The entity name.
  */
-export function useEntityProviderId( kind, type ) {
-	return useContext( getEntityContext( kind, type ) );
+export function useEntityProviderId( kind, name ) {
+	return useContext( getEntityContext( kind, name ) );
 }
 
 /**
@@ -82,7 +82,7 @@ export function useEntityProviderId( kind, type ) {
  * entity of the specified type.
  *
  * @param {string} kind  The entity kind.
- * @param {string} type  The entity type.
+ * @param {string} name  The entity name.
  * @param {string} prop  The property name.
  * @param {string} [_id] An entity ID to use instead of the context-provided one.
  *
@@ -93,8 +93,8 @@ export function useEntityProviderId( kind, type ) {
  * 							  information like `raw`, `rendered` and
  * 							  `protected` props.
  */
-export function useEntityProp( kind, type, prop, _id ) {
-	const providerId = useEntityProviderId( kind, type );
+export function useEntityProp( kind, name, prop, _id ) {
+	const providerId = useEntityProviderId( kind, name );
 	const id = _id ?? providerId;
 
 	const { value, fullValue } = useSelect(
@@ -102,8 +102,8 @@ export function useEntityProp( kind, type, prop, _id ) {
 			const { getEntityRecord, getEditedEntityRecord } = select(
 				STORE_NAME
 			);
-			const record = getEntityRecord( kind, type, id ); // Trigger resolver.
-			const editedRecord = getEditedEntityRecord( kind, type, id );
+			const record = getEntityRecord( kind, name, id ); // Trigger resolver.
+			const editedRecord = getEditedEntityRecord( kind, name, id );
 			return record && editedRecord
 				? {
 						value: editedRecord[ prop ],
@@ -111,16 +111,16 @@ export function useEntityProp( kind, type, prop, _id ) {
 				  }
 				: {};
 		},
-		[ kind, type, id, prop ]
+		[ kind, name, id, prop ]
 	);
 	const { editEntityRecord } = useDispatch( STORE_NAME );
 	const setValue = useCallback(
 		( newValue ) => {
-			editEntityRecord( kind, type, id, {
+			editEntityRecord( kind, name, id, {
 				[ prop ]: newValue,
 			} );
 		},
-		[ kind, type, id, prop ]
+		[ kind, name, id, prop ]
 	);
 
 	return [ value, setValue, fullValue ];
@@ -138,25 +138,25 @@ export function useEntityProp( kind, type, prop, _id ) {
  * or similar components or hooks.
  *
  * @param {string} kind         The entity kind.
- * @param {string} type         The entity type.
+ * @param {string} name         The entity name.
  * @param {Object} options
  * @param {string} [options.id] An entity ID to use instead of the context-provided one.
  *
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
-export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
-	const providerId = useEntityProviderId( kind, type );
+export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
+	const providerId = useEntityProviderId( kind, name );
 	const id = _id ?? providerId;
 	const { content, blocks } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( STORE_NAME );
-			const editedRecord = getEditedEntityRecord( kind, type, id );
+			const editedRecord = getEditedEntityRecord( kind, name, id );
 			return {
 				blocks: editedRecord.blocks,
 				content: editedRecord.content,
 			};
 		},
-		[ kind, type, id ]
+		[ kind, name, id ]
 	);
 	const { __unstableCreateUndoLevel, editEntityRecord } = useDispatch(
 		STORE_NAME
@@ -170,7 +170,7 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 			const parsedContent = parse( content );
 			editEntityRecord(
 				kind,
-				type,
+				name,
 				id,
 				{
 					blocks: parsedContent,
@@ -187,7 +187,7 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 
 			const noChange = blocks === edits.blocks;
 			if ( noChange ) {
-				return __unstableCreateUndoLevel( kind, type, id );
+				return __unstableCreateUndoLevel( kind, name, id );
 			}
 
 			// We create a new function here on every persistent edit
@@ -196,18 +196,18 @@ export function useEntityBlockEditor( kind, type, { id: _id } = {} ) {
 			edits.content = ( { blocks: blocksForSerialization = [] } ) =>
 				__unstableSerializeAndClean( blocksForSerialization );
 
-			editEntityRecord( kind, type, id, edits );
+			editEntityRecord( kind, name, id, edits );
 		},
-		[ kind, type, id, blocks ]
+		[ kind, name, id, blocks ]
 	);
 
 	const onInput = useCallback(
 		( newBlocks, options ) => {
 			const { selection } = options;
 			const edits = { blocks: newBlocks, selection };
-			editEntityRecord( kind, type, id, edits );
+			editEntityRecord( kind, name, id, edits );
 		},
-		[ kind, type, id ]
+		[ kind, name, id ]
 	);
 
 	return [ blocks ?? EMPTY_ARRAY, onInput, onChange ];

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -11,7 +11,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import * as resolvers from './resolvers';
 import createLocksActions from './locks/actions';
-import { defaultEntities, getMethodName } from './entities';
+import { rootEntitiesConfig, getMethodName } from './entities';
 import { STORE_NAME } from './name';
 
 // The entity selectors/resolvers and actions are shortcuts to their generic equivalents
@@ -19,7 +19,7 @@ import { STORE_NAME } from './name';
 // Instead of getEntityRecord, the consumer could use more user-frieldly named selector: getPostType, getTaxonomy...
 // The "kind" and the "name" of the entity are combined to generate these shortcuts.
 
-const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
+const entitySelectors = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
 		selectors.getEntityRecord( state, kind, name, key, query );
@@ -28,7 +28,7 @@ const entitySelectors = defaultEntities.reduce( ( result, entity ) => {
 	return result;
 }, {} );
 
-const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
+const entityResolvers = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( key, query ) =>
 		resolvers.getEntityRecord( kind, name, key, query );
@@ -45,7 +45,7 @@ const entityResolvers = defaultEntities.reduce( ( result, entity ) => {
 	return result;
 }, {} );
 
-const entityActions = defaultEntities.reduce( ( result, entity ) => {
+const entityActions = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name, 'save' ) ] = ( key ) =>
 		actions.saveEntityRecord( kind, name, key );

--- a/packages/core-data/src/locks/test/selectors.js
+++ b/packages/core-data/src/locks/test/selectors.js
@@ -116,7 +116,7 @@ describe( 'isLockAvailable', () => {
 													store: 'core',
 													path: [
 														'entities',
-														'data',
+														'records',
 														'postType',
 														'post',
 														16,
@@ -163,7 +163,7 @@ describe( 'isLockAvailable', () => {
 								entities: {
 									locks: [],
 									children: {
-										data: {
+										records: {
 											locks: [],
 											children: {
 												postType: {
@@ -178,7 +178,7 @@ describe( 'isLockAvailable', () => {
 																			path: [
 																				'core',
 																				'entities',
-																				'data',
+																				'records',
 																				'postType',
 																				'book',
 																				67,
@@ -205,7 +205,7 @@ describe( 'isLockAvailable', () => {
 				isLockAvailable(
 					deepFreeze( subState ),
 					'core',
-					[ 'entities', 'data', 'postType', 'book', 67 ],
+					[ 'entities', 'records', 'postType', 'book', 67 ],
 					{ exclusive: false }
 				)
 			).toBe( false );

--- a/packages/core-data/src/queried-data/reducer.js
+++ b/packages/core-data/src/queried-data/reducer.js
@@ -130,7 +130,7 @@ export function itemIsComplete( state = {}, action ) {
 			// An item is considered complete if it is received without an associated
 			// fields query. Ideally, this would be implemented in such a way where the
 			// complete aggregate of all fields would satisfy completeness. Since the
-			// fields are not consistent across all entity types, this would require
+			// fields are not consistent across all entities, this would require
 			// introspection on the REST schema for each entity to know which fields
 			// compose a complete item for that entity.
 			const queryParts = query ? getQueryParts( query ) : {};

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -14,7 +14,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
  */
 import { ifMatchingAction, replaceAction } from './utils';
 import { reducer as queriedDataReducer } from './queried-data';
-import { defaultEntities, DEFAULT_ENTITY_KEY } from './entities';
+import { rootEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 
 /**
  * Reducer managing terms state. Keyed by taxonomy slug, the value is either
@@ -335,7 +335,7 @@ function entity( entityConfig ) {
  *
  * @return {Object} Updated state.
  */
-export function entitiesConfig( state = defaultEntities, action ) {
+export function entitiesConfig( state = rootEntitiesConfig, action ) {
 	switch ( action.type ) {
 		case 'ADD_ENTITIES':
 			return [ ...state, ...action.entities ];

--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -380,10 +380,10 @@ export const entities = ( state = {}, action ) => {
 		);
 	}
 
-	const newData = entitiesDataReducer( state.data, action );
+	const newData = entitiesDataReducer( state.records, action );
 
 	if (
-		newData === state.data &&
+		newData === state.records &&
 		newConfig === state.config &&
 		entitiesDataReducer === state.reducer
 	) {
@@ -392,7 +392,7 @@ export const entities = ( state = {}, action ) => {
 
 	return {
 		reducer: entitiesDataReducer,
-		data: newData,
+		records: newData,
 		config: newConfig,
 	};
 };

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -60,7 +60,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 
 	const lock = await dispatch.__unstableAcquireStoreLock(
 		STORE_NAME,
-		[ 'entities', 'data', kind, name, key ],
+		[ 'entities', 'records', kind, name, key ],
 		{ exclusive: false }
 	);
 
@@ -141,7 +141,7 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 
 	const lock = await dispatch.__unstableAcquireStoreLock(
 		STORE_NAME,
-		[ 'entities', 'data', kind, name ],
+		[ 'entities', 'records', kind, name ],
 		{ exclusive: false }
 	);
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -52,9 +52,9 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 	select,
 	dispatch,
 } ) => {
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
-	if ( ! entity || entity?.__experimentalNoFetch ) {
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
+	if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 		return;
 	}
 
@@ -73,7 +73,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 				...query,
 				_fields: uniq( [
 					...( getNormalizedCommaSeparable( query._fields ) || [] ),
-					entity.key || DEFAULT_ENTITY_KEY,
+					entityConfig.key || DEFAULT_ENTITY_KEY,
 				] ).join(),
 			};
 		}
@@ -85,10 +85,13 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 		// for how the request is made to the REST API.
 
 		// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-		const path = addQueryArgs( entity.baseURL + ( key ? '/' + key : '' ), {
-			...entity.baseURLParams,
-			...query,
-		} );
+		const path = addQueryArgs(
+			entityConfig.baseURL + ( key ? '/' + key : '' ),
+			{
+				...entityConfig.baseURLParams,
+				...query,
+			}
+		);
 
 		if ( query !== undefined ) {
 			query = { ...query, include: [ key ] };
@@ -133,9 +136,9 @@ export const getEditedEntityRecord = forwardResolver( 'getEntityRecord' );
 export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 	dispatch,
 } ) => {
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
-	if ( ! entity || entity?.__experimentalNoFetch ) {
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
+	if ( ! entityConfig || entityConfig?.__experimentalNoFetch ) {
 		return;
 	}
 
@@ -154,13 +157,13 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 				...query,
 				_fields: uniq( [
 					...( getNormalizedCommaSeparable( query._fields ) || [] ),
-					entity.key || DEFAULT_ENTITY_KEY,
+					entityConfig.key || DEFAULT_ENTITY_KEY,
 				] ).join(),
 			};
 		}
 
-		const path = addQueryArgs( entity.baseURL, {
-			...entity.baseURLParams,
+		const path = addQueryArgs( entityConfig.baseURL, {
+			...entityConfig.baseURLParams,
 			...query,
 		} );
 
@@ -186,7 +189,7 @@ export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 		// resolve the `getEntityRecord` selector in addition to `getEntityRecords`.
 		// See https://github.com/WordPress/gutenberg/pull/26575
 		if ( ! query?._fields && ! query.context ) {
-			const key = entity.key || DEFAULT_ENTITY_KEY;
+			const key = entityConfig.key || DEFAULT_ENTITY_KEY;
 			const resolutionsArgs = records
 				.filter( ( record ) => record[ key ] )
 				.map( ( record ) => [ kind, name, record[ key ] ] );
@@ -312,13 +315,13 @@ export const canUser = ( action, resource, id ) => async ( { dispatch } ) => {
 export const canUserEditEntityRecord = ( kind, name, recordId ) => async ( {
 	dispatch,
 } ) => {
-	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
-	const entity = find( entities, { kind, name } );
-	if ( ! entity ) {
+	const configs = await dispatch( getOrLoadEntitiesConfig( kind ) );
+	const entityConfig = find( configs, { kind, name } );
+	if ( ! entityConfig ) {
 		return;
 	}
 
-	const resource = entity.__unstable_rest_base;
+	const resource = entityConfig.__unstable_rest_base;
 	await dispatch( canUser( 'update', resource, recordId ) );
 };
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -13,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { STORE_NAME } from './name';
-import { getKindEntities, DEFAULT_ENTITY_KEY } from './entities';
+import { getOrLoadEntitiesConfig, DEFAULT_ENTITY_KEY } from './entities';
 import { forwardResolver, getNormalizedCommaSeparable } from './utils';
 
 /**
@@ -52,7 +52,7 @@ export const getEntityRecord = ( kind, name, key = '', query ) => async ( {
 	select,
 	dispatch,
 } ) => {
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
@@ -133,7 +133,7 @@ export const getEditedEntityRecord = forwardResolver( 'getEntityRecord' );
 export const getEntityRecords = ( kind, name, query = {} ) => async ( {
 	dispatch,
 } ) => {
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity || entity?.__experimentalNoFetch ) {
 		return;
@@ -312,7 +312,7 @@ export const canUser = ( action, resource, id ) => async ( { dispatch } ) => {
 export const canUserEditEntityRecord = ( kind, name, recordId ) => async ( {
 	dispatch,
 } ) => {
-	const entities = await dispatch( getKindEntities( kind ) );
+	const entities = await dispatch( getOrLoadEntitiesConfig( kind ) );
 	const entity = find( entities, { kind, name } );
 	if ( ! entity ) {
 		return;

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -124,7 +124,7 @@ export function getEntitiesConfig( state, kind ) {
 }
 
 /**
- * Returns the entity object given its kind and name.
+ * Returns the entity config given its kind and name.
  *
  * @deprecated since ??. Use getEntityConfig instead
  * @param {Object} state Data state.
@@ -142,7 +142,7 @@ export function getEntity( state, kind, name ) {
 }
 
 /**
- * Returns the entity object given its kind and name.
+ * Returns the entity config given its kind and name.
  *
  * @param {Object} state Data state.
  * @param {string} kind  Entity kind.
@@ -226,7 +226,7 @@ export const getEntityRecord = createSelector(
 );
 
 /**
- * Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity from the API if the entity record isn't available in the local state.
+ * Returns the Entity's record object by key. Doesn't trigger a resolver nor requests the entity records from the API if the entity record isn't available in the local state.
  *
  * @param {Object} state State tree
  * @param {string} kind  Entity kind.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -383,7 +383,8 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 								entityRecord[
 									entityConfig.key || DEFAULT_ENTITY_KEY
 								],
-							title: entityConfig?.getTitle?.( entityRecord ) || '',
+							title:
+								entityConfig?.getTitle?.( entityRecord ) || '',
 							name,
 							kind,
 						} );
@@ -434,7 +435,8 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 								entityRecord[
 									entityConfig.key || DEFAULT_ENTITY_KEY
 								],
-							title: entityConfig?.getTitle?.( entityRecord ) || '',
+							title:
+								entityConfig?.getTitle?.( entityRecord ) || '',
 							name,
 							kind,
 						} );

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -368,7 +368,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 				);
 
 				if ( primaryKeys.length ) {
-					const entity = getEntityConfig( state, kind, name );
+					const entityConfig = getEntityConfig( state, kind, name );
 					primaryKeys.forEach( ( primaryKey ) => {
 						const entityRecord = getEditedEntityRecord(
 							state,
@@ -381,9 +381,9 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 							// when it's used as an object key.
 							key:
 								entityRecord[
-									entity.key || DEFAULT_ENTITY_KEY
+									entityConfig.key || DEFAULT_ENTITY_KEY
 								],
-							title: entity?.getTitle?.( entityRecord ) || '',
+							title: entityConfig?.getTitle?.( entityRecord ) || '',
 							name,
 							kind,
 						} );
@@ -419,7 +419,7 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 				);
 
 				if ( primaryKeys.length ) {
-					const entity = getEntityConfig( state, kind, name );
+					const entityConfig = getEntityConfig( state, kind, name );
 					primaryKeys.forEach( ( primaryKey ) => {
 						const entityRecord = getEditedEntityRecord(
 							state,
@@ -432,9 +432,9 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 							// when it's used as an object key.
 							key:
 								entityRecord[
-									entity.key || DEFAULT_ENTITY_KEY
+									entityConfig.key || DEFAULT_ENTITY_KEY
 								],
-							title: entity?.getTitle?.( entityRecord ) || '',
+							title: entityConfig?.getTitle?.( entityRecord ) || '',
 							name,
 							kind,
 						} );
@@ -817,11 +817,11 @@ export function canUser( state, action, resource, id ) {
  * or `undefined` if the OPTIONS request is still being made.
  */
 export function canUserEditEntityRecord( state, kind, name, recordId ) {
-	const entity = getEntityConfig( state, kind, name );
-	if ( ! entity ) {
+	const entityConfig = getEntityConfig( state, kind, name );
+	if ( ! entityConfig ) {
 		return false;
 	}
-	const resource = entity.__unstable_rest_base;
+	const resource = entityConfig.__unstable_rest_base;
 
 	return canUser( state, 'update', resource, recordId );
 }

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -109,13 +109,31 @@ export function getEntitiesByKind( state, kind ) {
 /**
  * Returns the entity object given its kind and name.
  *
+ * @deprecated since ??. Use getEntityConfig instead
  * @param {Object} state Data state.
  * @param {string} kind  Entity kind.
  * @param {string} name  Entity name.
  *
- * @return {Object} Entity
+ * @return {Object} Entity config
  */
 export function getEntity( state, kind, name ) {
+	deprecated( "wp.data.select( 'core' ).getEntity()", {
+		since: '6.0',
+		alternative: "wp.data.select( 'core' ).getEntityConfig()",
+	} );
+	return getEntityConfig( state, kind, name );
+}
+
+/**
+ * Returns the entity object given its kind and name.
+ *
+ * @param {Object} state Data state.
+ * @param {string} kind  Entity kind.
+ * @param {string} name  Entity name.
+ *
+ * @return {Object} Entity config
+ */
+export function getEntityConfig( state, kind, name ) {
 	return find( state.entities.config, { kind, name } );
 }
 
@@ -226,7 +244,9 @@ export const getRawEntityRecord = createSelector(
 		return (
 			record &&
 			Object.keys( record ).reduce( ( accumulator, _key ) => {
-				if ( isRawAttribute( getEntity( state, kind, name ), _key ) ) {
+				if (
+					isRawAttribute( getEntityConfig( state, kind, name ), _key )
+				) {
 					// Because edits are the "raw" attribute values,
 					// we return those from record selectors to make rendering,
 					// comparisons, and joins with edits easier.
@@ -331,7 +351,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 				);
 
 				if ( primaryKeys.length ) {
-					const entity = getEntity( state, kind, name );
+					const entity = getEntityConfig( state, kind, name );
 					primaryKeys.forEach( ( primaryKey ) => {
 						const entityRecord = getEditedEntityRecord(
 							state,
@@ -382,7 +402,7 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 				);
 
 				if ( primaryKeys.length ) {
-					const entity = getEntity( state, kind, name );
+					const entity = getEntityConfig( state, kind, name );
 					primaryKeys.forEach( ( primaryKey ) => {
 						const entityRecord = getEditedEntityRecord(
 							state,
@@ -440,7 +460,7 @@ export function getEntityRecordEdits( state, kind, name, recordId ) {
  */
 export const getEntityRecordNonTransientEdits = createSelector(
 	( state, kind, name, recordId ) => {
-		const { transientEdits } = getEntity( state, kind, name ) || {};
+		const { transientEdits } = getEntityConfig( state, kind, name ) || {};
 		const edits = getEntityRecordEdits( state, kind, name, recordId ) || {};
 		if ( ! transientEdits ) {
 			return edits;
@@ -780,7 +800,7 @@ export function canUser( state, action, resource, id ) {
  * or `undefined` if the OPTIONS request is still being made.
  */
 export function canUserEditEntityRecord( state, kind, name, recordId ) {
-	const entity = getEntity( state, kind, name );
+	const entity = getEntityConfig( state, kind, name );
 	if ( ! entity ) {
 		return false;
 	}

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -97,7 +97,7 @@ export const getUserQueryResults = createSelector(
 /**
  * Returns the loaded entities for the given kind.
  *
- * @deprecated since ??. Use getEntitiesConfig instead
+ * @deprecated since WordPress 6.0. Use getEntitiesConfig instead
  * @param {Object} state Data state.
  * @param {string} kind  Entity kind.
  *
@@ -126,7 +126,7 @@ export function getEntitiesConfig( state, kind ) {
 /**
  * Returns the entity config given its kind and name.
  *
- * @deprecated since ??. Use getEntityConfig instead
+ * @deprecated since WordPress 6.0. Use getEntityConfig instead
  * @param {Object} state Data state.
  * @param {string} kind  Entity kind.
  * @param {string} name  Entity name.

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -95,14 +95,31 @@ export const getUserQueryResults = createSelector(
 );
 
 /**
- * Returns whether the entities for the give kind are loaded.
+ * Returns the loaded entities for the given kind.
  *
+ * @deprecated since ??. Use getEntitiesConfig instead
  * @param {Object} state Data state.
  * @param {string} kind  Entity kind.
  *
  * @return {Array<Object>} Array of entities with config matching kind.
  */
 export function getEntitiesByKind( state, kind ) {
+	deprecated( "wp.data.select( 'core' ).getEntitiesByKind()", {
+		since: '6.0',
+		alternative: "wp.data.select( 'core' ).getEntitiesConfig()",
+	} );
+	return getEntitiesConfig( state, kind );
+}
+
+/**
+ * Returns the loaded entities for the given kind.
+ *
+ * @param {Object} state Data state.
+ * @param {string} kind  Entity kind.
+ *
+ * @return {Array<Object>} Array of entities with config matching kind.
+ */
+export function getEntitiesConfig( state, kind ) {
 	return filter( state.entities.config, { kind } );
 }
 

--- a/packages/core-data/src/selectors.js
+++ b/packages/core-data/src/selectors.js
@@ -134,7 +134,7 @@ export function getEntity( state, kind, name ) {
  */
 export const getEntityRecord = createSelector(
 	( state, kind, name, key, query ) => {
-		const queriedState = get( state.entities.data, [
+		const queriedState = get( state.entities.records, [
 			kind,
 			name,
 			'queriedData',
@@ -170,7 +170,7 @@ export const getEntityRecord = createSelector(
 	( state, kind, name, recordId, query ) => {
 		const context = query?.context ?? 'default';
 		return [
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -178,7 +178,7 @@ export const getEntityRecord = createSelector(
 				context,
 				recordId,
 			] ),
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -246,7 +246,7 @@ export const getRawEntityRecord = createSelector(
 		const context = query?.context ?? 'default';
 		return [
 			state.entities.config,
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -254,7 +254,7 @@ export const getRawEntityRecord = createSelector(
 				context,
 				recordId,
 			] ),
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -294,7 +294,7 @@ export function hasEntityRecords( state, kind, name, query ) {
 export function getEntityRecords( state, kind, name, query ) {
 	// Queried data state is prepopulated for all known entities. If this is not
 	// assigned for the given parameters, then it is known to not exist.
-	const queriedState = get( state.entities.data, [
+	const queriedState = get( state.entities.records, [
 		kind,
 		name,
 		'queriedData',
@@ -315,13 +315,13 @@ export function getEntityRecords( state, kind, name, query ) {
 export const __experimentalGetDirtyEntityRecords = createSelector(
 	( state ) => {
 		const {
-			entities: { data },
+			entities: { records },
 		} = state;
 		const dirtyRecords = [];
-		Object.keys( data ).forEach( ( kind ) => {
-			Object.keys( data[ kind ] ).forEach( ( name ) => {
+		Object.keys( records ).forEach( ( kind ) => {
+			Object.keys( records[ kind ] ).forEach( ( name ) => {
 				const primaryKeys = Object.keys(
-					data[ kind ][ name ].edits
+					records[ kind ][ name ].edits
 				).filter(
 					( primaryKey ) =>
 						// The entity record must exist (not be deleted),
@@ -357,7 +357,7 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 
 		return dirtyRecords;
 	},
-	( state ) => [ state.entities.data ]
+	( state ) => [ state.entities.records ]
 );
 
 /**
@@ -370,13 +370,13 @@ export const __experimentalGetDirtyEntityRecords = createSelector(
 export const __experimentalGetEntitiesBeingSaved = createSelector(
 	( state ) => {
 		const {
-			entities: { data },
+			entities: { records },
 		} = state;
 		const recordsBeingSaved = [];
-		Object.keys( data ).forEach( ( kind ) => {
-			Object.keys( data[ kind ] ).forEach( ( name ) => {
+		Object.keys( records ).forEach( ( kind ) => {
+			Object.keys( records[ kind ] ).forEach( ( name ) => {
 				const primaryKeys = Object.keys(
-					data[ kind ][ name ].saving
+					records[ kind ][ name ].saving
 				).filter( ( primaryKey ) =>
 					isSavingEntityRecord( state, kind, name, primaryKey )
 				);
@@ -407,7 +407,7 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
 		} );
 		return recordsBeingSaved;
 	},
-	( state ) => [ state.entities.data ]
+	( state ) => [ state.entities.records ]
 );
 
 /**
@@ -421,7 +421,7 @@ export const __experimentalGetEntitiesBeingSaved = createSelector(
  * @return {Object?} The entity record's edits.
  */
 export function getEntityRecordEdits( state, kind, name, recordId ) {
-	return get( state.entities.data, [ kind, name, 'edits', recordId ] );
+	return get( state.entities.records, [ kind, name, 'edits', recordId ] );
 }
 
 /**
@@ -454,7 +454,7 @@ export const getEntityRecordNonTransientEdits = createSelector(
 	},
 	( state, kind, name, recordId ) => [
 		state.entities.config,
-		get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+		get( state.entities.records, [ kind, name, 'edits', recordId ] ),
 	]
 );
 
@@ -497,7 +497,7 @@ export const getEditedEntityRecord = createSelector(
 		const context = query?.context ?? 'default';
 		return [
 			state.entities.config,
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -505,7 +505,7 @@ export const getEditedEntityRecord = createSelector(
 				context,
 				recordId,
 			] ),
-			get( state.entities.data, [
+			get( state.entities.records, [
 				kind,
 				name,
 				'queriedData',
@@ -513,7 +513,7 @@ export const getEditedEntityRecord = createSelector(
 				context,
 				recordId,
 			] ),
-			get( state.entities.data, [ kind, name, 'edits', recordId ] ),
+			get( state.entities.records, [ kind, name, 'edits', recordId ] ),
 		];
 	}
 );
@@ -530,7 +530,7 @@ export const getEditedEntityRecord = createSelector(
  */
 export function isAutosavingEntityRecord( state, kind, name, recordId ) {
 	const { pending, isAutosave } = get(
-		state.entities.data,
+		state.entities.records,
 		[ kind, name, 'saving', recordId ],
 		{}
 	);
@@ -549,7 +549,7 @@ export function isAutosavingEntityRecord( state, kind, name, recordId ) {
  */
 export function isSavingEntityRecord( state, kind, name, recordId ) {
 	return get(
-		state.entities.data,
+		state.entities.records,
 		[ kind, name, 'saving', recordId, 'pending' ],
 		false
 	);
@@ -567,7 +567,7 @@ export function isSavingEntityRecord( state, kind, name, recordId ) {
  */
 export function isDeletingEntityRecord( state, kind, name, recordId ) {
 	return get(
-		state.entities.data,
+		state.entities.records,
 		[ kind, name, 'deleting', recordId, 'pending' ],
 		false
 	);
@@ -584,7 +584,7 @@ export function isDeletingEntityRecord( state, kind, name, recordId ) {
  * @return {Object?} The entity record's save error.
  */
 export function getLastEntitySaveError( state, kind, name, recordId ) {
-	return get( state.entities.data, [
+	return get( state.entities.records, [
 		kind,
 		name,
 		'saving',
@@ -604,7 +604,7 @@ export function getLastEntitySaveError( state, kind, name, recordId ) {
  * @return {Object?} The entity record's save error.
  */
 export function getLastEntityDeleteError( state, kind, name, recordId ) {
-	return get( state.entities.data, [
+	return get( state.entities.records, [
 		kind,
 		name,
 		'deleting',

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -32,7 +32,7 @@ describe( 'editEntityRecord', () => {
 	it( 'throws when the edited entity does not have a loaded config.', async () => {
 		const entity = { kind: 'someKind', name: 'someName', id: 'someId' };
 		const select = {
-			getEntity: jest.fn(),
+			getEntityConfig: jest.fn(),
 		};
 		const fulfillment = () =>
 			editEntityRecord(
@@ -44,7 +44,7 @@ describe( 'editEntityRecord', () => {
 		expect( fulfillment ).toThrow(
 			`The entity being edited (${ entity.kind }, ${ entity.name }) does not have a loaded config.`
 		);
-		expect( select.getEntity ).toHaveBeenCalledTimes( 1 );
+		expect( select.getEntityConfig ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -30,19 +30,19 @@ jest.mock( '../batch', () => {
 
 describe( 'editEntityRecord', () => {
 	it( 'throws when the edited entity does not have a loaded config.', async () => {
-		const entity = { kind: 'someKind', name: 'someName', id: 'someId' };
+		const entityConfig = { kind: 'someKind', name: 'someName', id: 'someId' };
 		const select = {
 			getEntityConfig: jest.fn(),
 		};
 		const fulfillment = () =>
 			editEntityRecord(
-				entity.kind,
-				entity.name,
-				entity.id,
+				entityConfig.kind,
+				entityConfig.name,
+				entityConfig.id,
 				{}
 			)( { select } );
 		expect( fulfillment ).toThrow(
-			`The entity being edited (${ entity.kind }, ${ entity.name }) does not have a loaded config.`
+			`The entity being edited (${ entityConfig.kind }, ${ entityConfig.name }) does not have a loaded config.`
 		);
 		expect( select.getEntityConfig ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -30,7 +30,11 @@ jest.mock( '../batch', () => {
 
 describe( 'editEntityRecord', () => {
 	it( 'throws when the edited entity does not have a loaded config.', async () => {
-		const entityConfig = { kind: 'someKind', name: 'someName', id: 'someId' };
+		const entityConfig = {
+			kind: 'someKind',
+			name: 'someName',
+			id: 'someId',
+		};
 		const select = {
 			getEntityConfig: jest.fn(),
 		};

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -56,7 +56,7 @@ describe( 'deleteEntityRecord', () => {
 
 	it( 'triggers a DELETE request for an existing record', async () => {
 		const deletedRecord = { title: 'new post', id: 10 };
-		const entities = [
+		const configs = [
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 
@@ -66,7 +66,7 @@ describe( 'deleteEntityRecord', () => {
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		apiFetch.mockImplementation( () => deletedRecord );
@@ -116,7 +116,7 @@ describe( 'saveEditedEntityRecord', () => {
 
 	it( 'Uses "id" as a key when no entity key is provided', async () => {
 		const area = { id: 1, menu: 0 };
-		const entities = [
+		const configs = [
 			{
 				kind: 'root',
 				name: 'navigationArea',
@@ -132,7 +132,7 @@ describe( 'saveEditedEntityRecord', () => {
 			saveEntityRecord: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		const updatedRecord = { ...area, menu: 10 };
@@ -156,7 +156,7 @@ describe( 'saveEditedEntityRecord', () => {
 
 	it( 'Uses the entity key when provided', async () => {
 		const area = { area: 'primary', menu: 0 };
-		const entities = [
+		const configs = [
 			{
 				kind: 'root',
 				name: 'navigationArea',
@@ -173,7 +173,7 @@ describe( 'saveEditedEntityRecord', () => {
 			saveEntityRecord: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		const updatedRecord = { ...area, menu: 10 };
@@ -204,7 +204,7 @@ describe( 'saveEntityRecord', () => {
 
 	it( 'triggers a POST request for a new record', async () => {
 		const post = { title: 'new post' };
-		const entities = [
+		const configs = [
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 		const select = {
@@ -217,7 +217,7 @@ describe( 'saveEntityRecord', () => {
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		const updatedRecord = { ...post, id: 10 };
@@ -276,7 +276,7 @@ describe( 'saveEntityRecord', () => {
 
 	it( 'triggers a PUT request for an existing record', async () => {
 		const post = { id: 10, title: 'new post' };
-		const entities = [
+		const configs = [
 			{ name: 'post', kind: 'postType', baseURL: '/wp/v2/posts' },
 		];
 		const select = {
@@ -289,7 +289,7 @@ describe( 'saveEntityRecord', () => {
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		const updatedRecord = { ...post, id: 10 };
@@ -348,7 +348,7 @@ describe( 'saveEntityRecord', () => {
 
 	it( 'triggers a PUT request for an existing record with a custom key', async () => {
 		const postType = { slug: 'page', title: 'Pages' };
-		const entities = [
+		const configs = [
 			{
 				name: 'postType',
 				kind: 'root',
@@ -366,7 +366,7 @@ describe( 'saveEntityRecord', () => {
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
 		// Provide entities
-		dispatch.mockReturnValueOnce( entities );
+		dispatch.mockReturnValueOnce( configs );
 
 		// Provide response
 		apiFetch.mockImplementation( () => postType );

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -9,8 +9,8 @@ jest.mock( '@wordpress/api-fetch' );
  */
 import {
 	getMethodName,
-	defaultEntities,
-	getKindEntities,
+	rootEntitiesConfig,
+	getOrLoadEntitiesConfig,
 	prePersistPostType,
 } from '../entities';
 
@@ -40,10 +40,10 @@ describe( 'getMethodName', () => {
 	} );
 
 	it( 'should include the kind in the method name', () => {
-		const id = defaultEntities.length;
-		defaultEntities[ id ] = { name: 'book', kind: 'postType' };
+		const id = rootEntitiesConfig.length;
+		rootEntitiesConfig[ id ] = { name: 'book', kind: 'postType' };
 		const methodName = getMethodName( 'postType', 'book' );
-		delete defaultEntities[ id ];
+		delete rootEntitiesConfig[ id ];
 
 		expect( methodName ).toEqual( 'getPostTypeBook' );
 	} );
@@ -61,7 +61,7 @@ describe( 'getKindEntities', () => {
 			getEntitiesByKind: jest.fn( () => entities ),
 		};
 		const entities = [ { kind: 'postType' } ];
-		await getKindEntities( 'postType' )( { dispatch, select } );
+		await getOrLoadEntitiesConfig( 'postType' )( { dispatch, select } );
 		expect( dispatch ).not.toHaveBeenCalled();
 	} );
 
@@ -70,7 +70,7 @@ describe( 'getKindEntities', () => {
 		const select = {
 			getEntitiesByKind: jest.fn( () => [] ),
 		};
-		await getKindEntities( 'unknownKind' )( { dispatch, select } );
+		await getOrLoadEntitiesConfig( 'unknownKind' )( { dispatch, select } );
 		expect( dispatch ).not.toHaveBeenCalled();
 	} );
 
@@ -89,7 +89,7 @@ describe( 'getKindEntities', () => {
 		};
 		triggerFetch.mockImplementation( () => fetchedEntities );
 
-		await getKindEntities( 'postType' )( { dispatch, select } );
+		await getOrLoadEntitiesConfig( 'postType' )( { dispatch, select } );
 		expect( dispatch ).toHaveBeenCalledTimes( 1 );
 		expect( dispatch.mock.calls[ 0 ][ 0 ].type ).toBe( 'ADD_ENTITIES' );
 		expect( dispatch.mock.calls[ 0 ][ 0 ].entities.length ).toBe( 1 );

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -58,7 +58,7 @@ describe( 'getKindEntities', () => {
 	it( 'shouldn’t do anything if the entities have already been resolved', async () => {
 		const dispatch = jest.fn();
 		const select = {
-			getEntitiesByKind: jest.fn( () => entities ),
+			getEntitiesConfig: jest.fn( () => entities ),
 		};
 		const entities = [ { kind: 'postType' } ];
 		await getOrLoadEntitiesConfig( 'postType' )( { dispatch, select } );
@@ -68,7 +68,7 @@ describe( 'getKindEntities', () => {
 	it( 'shouldn’t do anything if there no defined kind config', async () => {
 		const dispatch = jest.fn();
 		const select = {
-			getEntitiesByKind: jest.fn( () => [] ),
+			getEntitiesConfig: jest.fn( () => [] ),
 		};
 		await getOrLoadEntitiesConfig( 'unknownKind' )( { dispatch, select } );
 		expect( dispatch ).not.toHaveBeenCalled();
@@ -85,7 +85,7 @@ describe( 'getKindEntities', () => {
 		];
 		const dispatch = jest.fn();
 		const select = {
-			getEntitiesByKind: jest.fn( () => [] ),
+			getEntitiesConfig: jest.fn( () => [] ),
 		};
 		triggerFetch.mockImplementation( () => fetchedEntities );
 

--- a/packages/core-data/src/test/reducer.js
+++ b/packages/core-data/src/test/reducer.js
@@ -46,7 +46,7 @@ describe( 'entities', () => {
 	it( 'returns the default state for all defined entities', () => {
 		const state = entities( undefined, {} );
 
-		expect( state.data.root.postType.queriedData ).toEqual( {
+		expect( state.records.root.postType.queriedData ).toEqual( {
 			items: {},
 			queries: {},
 			itemIsComplete: {},
@@ -65,7 +65,7 @@ describe( 'entities', () => {
 			name: 'postType',
 		} );
 
-		expect( state.data.root.postType.queriedData ).toEqual( {
+		expect( state.records.root.postType.queriedData ).toEqual( {
 			items: {
 				default: {
 					b: { slug: 'b', title: 'beach' },
@@ -84,7 +84,7 @@ describe( 'entities', () => {
 
 	it( 'appends the received post types by slug', () => {
 		const originalState = deepFreeze( {
-			data: {
+			records: {
 				root: {
 					postType: {
 						queriedData: {
@@ -111,7 +111,7 @@ describe( 'entities', () => {
 			name: 'postType',
 		} );
 
-		expect( state.data.root.postType.queriedData ).toEqual( {
+		expect( state.records.root.postType.queriedData ).toEqual( {
 			items: {
 				default: {
 					w: { slug: 'w', title: 'water' },

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -393,14 +393,14 @@ describe( 'getAutosaves', () => {
 		const postType = 'post';
 		const postId = 1;
 		const restBase = 'posts';
-		const postEntity = { rest_base: restBase };
+		const postEntityConfig = { rest_base: restBase };
 
 		triggerFetch.mockImplementation( () => SUCCESSFUL_RESPONSE );
 		const dispatch = Object.assign( jest.fn(), {
 			receiveAutosaves: jest.fn(),
 		} );
 		const resolveSelect = Object.assign( jest.fn(), {
-			getPostType: jest.fn( () => postEntity ),
+			getPostType: jest.fn( () => postEntityConfig ),
 		} );
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 
@@ -417,14 +417,14 @@ describe( 'getAutosaves', () => {
 		const postType = 'post';
 		const postId = 1;
 		const restBase = 'posts';
-		const postEntity = { rest_base: restBase };
+		const postEntityConfig = { rest_base: restBase };
 
 		triggerFetch.mockImplementation( () => [] );
 		const dispatch = Object.assign( jest.fn(), {
 			receiveAutosaves: jest.fn(),
 		} );
 		const resolveSelect = Object.assign( jest.fn(), {
-			getPostType: jest.fn( () => postEntity ),
+			getPostType: jest.fn( () => postEntityConfig ),
 		} );
 		await getAutosaves( postType, postId )( { dispatch, resolveSelect } );
 

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -201,7 +201,7 @@ describe( 'getEntityRecords', () => {
 			dispatch.__unstableAcquireStoreLock
 		).toHaveBeenCalledWith(
 			'core',
-			[ 'entities', 'data', 'root', 'postType' ],
+			[ 'entities', 'records', 'root', 'postType' ],
 			{ exclusive: false }
 		);
 		expect( dispatch.__unstableReleaseStoreLock ).toHaveBeenCalledTimes(

--- a/packages/core-data/src/test/selectors.js
+++ b/packages/core-data/src/test/selectors.js
@@ -32,7 +32,7 @@ describe.each( [
 	it( 'should return undefined for unknown entity kind, name', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -51,7 +51,7 @@ describe.each( [
 	it( 'should return undefined for unknown record’s key', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -70,7 +70,7 @@ describe.each( [
 	it( 'should return a record by key', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -105,7 +105,7 @@ describe.each( [
 	it( 'should return filtered item if complete item received, filtered item requested', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					postType: {
 						post: {
 							queriedData: {
@@ -142,7 +142,7 @@ describe( 'hasEntityRecords', () => {
 	it( 'returns false if entity records have not been received', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -162,7 +162,7 @@ describe( 'hasEntityRecords', () => {
 	it( 'returns false if the entity configuration is not known', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {},
+				records: {},
 			},
 		} );
 
@@ -172,7 +172,7 @@ describe( 'hasEntityRecords', () => {
 	it( 'returns true if entity records have been received', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -239,7 +239,7 @@ describe( 'getRawEntityRecord', () => {
 						name: 'someName',
 					},
 				],
-				data: { ...data },
+				records: { ...data },
 			},
 		} );
 		expect(
@@ -261,7 +261,7 @@ describe( 'getRawEntityRecord', () => {
 						rawAttributes: [ 'title' ],
 					},
 				],
-				data: { ...data },
+				records: { ...data },
 			},
 		} );
 		expect(
@@ -278,7 +278,7 @@ describe( 'getEntityRecords', () => {
 	it( 'should return null by default', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -297,7 +297,7 @@ describe( 'getEntityRecords', () => {
 	it( 'should return null for an unknown entity configuration', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {},
+				records: {},
 			},
 		} );
 
@@ -307,7 +307,7 @@ describe( 'getEntityRecords', () => {
 	it( 'should return all the records', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {
@@ -343,7 +343,7 @@ describe( 'getEntityRecords', () => {
 	it( 'should return filtered items', () => {
 		const state = deepFreeze( {
 			entities: {
-				data: {
+				records: {
 					postType: {
 						post: {
 							queriedData: {
@@ -382,7 +382,7 @@ describe( 'getEntityRecords', () => {
 	it( 'should return the same instance with the same arguments', () => {
 		let state = deepFreeze( {
 			entities: {
-				data: {},
+				records: {},
 			},
 		} );
 
@@ -427,7 +427,7 @@ describe( '__experimentalGetDirtyEntityRecords', () => {
 						transientEdits: { someTransientEditProperty: true },
 					},
 				],
-				data: {
+				records: {
 					someKind: {
 						someName: {
 							queriedData: {
@@ -476,7 +476,7 @@ describe( '__experimentalGetDirtyEntityRecords', () => {
 						transientEdits: { someTransientEditProperty: true },
 					},
 				],
-				data: {
+				records: {
 					someKind: {
 						someName: {
 							queriedData: {
@@ -533,7 +533,7 @@ describe( '__experimentalGetEntitiesBeingSaved', () => {
 						transientEdits: { someTransientEditProperty: true },
 					},
 				],
-				data: {
+				records: {
 					someKind: {
 						someName: {
 							queriedData: {
@@ -573,7 +573,7 @@ describe( '__experimentalGetEntitiesBeingSaved', () => {
 describe( 'getEntityRecordNonTransientEdits', () => {
 	it( 'should return an empty object when the entity does not have a loaded config.', () => {
 		const state = deepFreeze( {
-			entities: { config: [], data: {} },
+			entities: { config: [], records: {} },
 		} );
 		expect(
 			getEntityRecordNonTransientEdits(
@@ -597,11 +597,11 @@ describe( 'getEmbedPreview()', () => {
 
 		state = deepFreeze( {
 			embedPreviews: {
-				'http://example.com/': { data: 42 },
+				'http://example.com/': { records: 42 },
 			},
 		} );
 		expect( getEmbedPreview( state, 'http://example.com/' ) ).toEqual( {
-			data: 42,
+			records: 42,
 		} );
 	} );
 } );
@@ -653,7 +653,7 @@ describe( 'canUserEditEntityRecord', () => {
 	it( 'returns false by default', () => {
 		const state = deepFreeze( {
 			userPermissions: {},
-			entities: { data: {} },
+			entities: { records: {} },
 		} );
 		expect( canUserEditEntityRecord( state, 'postType', 'post' ) ).toBe(
 			false
@@ -674,7 +674,7 @@ describe( 'canUserEditEntityRecord', () => {
 						__unstable_rest_base: 'posts',
 					},
 				],
-				data: {
+				records: {
 					root: {
 						postType: {
 							queriedData: {

--- a/packages/core-data/src/utils/conservative-map-item.js
+++ b/packages/core-data/src/utils/conservative-map-item.js
@@ -4,7 +4,7 @@
 import { isEqual } from 'lodash';
 
 /**
- * Given the current and next item entity, returns the minimally "modified"
+ * Given the current and next item entity record, returns the minimally "modified"
  * result of the next item, preferring value references from the original item
  * if equal. If all values match, the original item is returned.
  *

--- a/packages/core-data/src/utils/is-raw-attribute.js
+++ b/packages/core-data/src/utils/is-raw-attribute.js
@@ -1,7 +1,7 @@
 /**
  * Checks whether the attribute is a "raw" attribute or not.
  *
- * @param {Object} entity    Entity data.
+ * @param {Object} entity    Entity record.
  * @param {string} attribute Attribute name.
  *
  * @return {boolean} Is the attribute raw

--- a/packages/core-data/src/utils/test/is-raw-attribute.js
+++ b/packages/core-data/src/utils/test/is-raw-attribute.js
@@ -5,18 +5,18 @@ import { isRawAttribute } from '../';
 
 describe( 'isRawAttribute', () => {
 	it( 'should correctly assess that the attribute is not raw', () => {
-		const entity = {
+		const entityConfig = {
 			kind: 'someKind',
 			name: 'someName',
 		};
-		expect( isRawAttribute( entity, 'title' ) ).toBe( false );
+		expect( isRawAttribute( entityConfig, 'title' ) ).toBe( false );
 	} );
 	it( 'should correctly assess that the attribute is raw', () => {
-		const entity = {
+		const entityConfig = {
 			kind: 'someKind',
 			name: 'someName',
 			rawAttributes: [ 'title' ],
 		};
-		expect( isRawAttribute( entity, 'title' ) ).toBe( true );
+		expect( isRawAttribute( entityConfig, 'title' ) ).toBe( true );
 	} );
 } );

--- a/packages/edit-site/src/store/actions.js
+++ b/packages/edit-site/src/store/actions.js
@@ -333,11 +333,11 @@ export const revertTemplate = (
 	}
 
 	try {
-		const templateEntity = registry
+		const templateEntityConfig = registry
 			.select( coreStore )
-			.getEntity( 'postType', template.type );
+			.getEntityConfig( 'postType', template.type );
 
-		if ( ! templateEntity ) {
+		if ( ! templateEntityConfig ) {
 			registry
 				.dispatch( noticesStore )
 				.createErrorNotice(
@@ -350,7 +350,7 @@ export const revertTemplate = (
 		}
 
 		const fileTemplatePath = addQueryArgs(
-			`${ templateEntity.baseURL }/${ template.id }`,
+			`${ templateEntityConfig.baseURL }/${ template.id }`,
 			{ context: 'edit', source: 'theme' }
 		);
 

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -45,7 +45,10 @@ export default function EntityTypeList( {
 	const firstRecord = list[ 0 ];
 	const entityConfig = useSelect(
 		( select ) =>
-			select( coreStore ).getEntityConfig( firstRecord.kind, firstRecord.name ),
+			select( coreStore ).getEntityConfig(
+				firstRecord.kind,
+				firstRecord.name
+			),
 		[ firstRecord.kind, firstRecord.name ]
 	);
 	const { name } = firstRecord;

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -43,16 +43,16 @@ export default function EntityTypeList( {
 	closePanel,
 } ) {
 	const firstRecord = list[ 0 ];
-	const entity = useSelect(
+	const entityConfig = useSelect(
 		( select ) =>
-			select( coreStore ).getEntity( firstRecord.kind, firstRecord.name ),
+			select( coreStore ).getEntityConfig( firstRecord.kind, firstRecord.name ),
 		[ firstRecord.kind, firstRecord.name ]
 	);
 	const { name } = firstRecord;
 	const entityLabel =
 		name === 'wp_template_part'
 			? _n( 'Template Part', 'Template Parts', list.length )
-			: entity.label;
+			: entityConfig.label;
 	// Set description based on type of entity.
 	const description = getEntityDescription( name, list.length );
 


### PR DESCRIPTION
## What?
This PR unifies the language used in core-data, leaving only one term for each concept. The most prominent changes are:

* `Entity loader` replaced `kind`, `kind config`, and `entity`
* `Entity config` replaced `entity` and `kind entity` (in actions, selectors, and resolvers)
* `Entity context` replaced `entity` (in the entity provider)
* `Entity name` replaced `entity name` and `entity type` (in the entity provider)
* `state.records` replaced `state.data` 

Other than two deprecations in `selectors.js`, this PR aims to keep the public API of the core-data package the same. Every consumer of this package should continue to work in the exact same way.

## Why?
I walked through that code with @dmsnell a few days ago, and we both got super confused by all the different terms imprecisely referring sometimes to the same ideas, and sometimes to completely different ones. My intention in this PR is to make the immersion easier.

## Testing Instructions
* Comment with your opinion on whether the changes make sense
* Confirm all the tests are green – this matters less for now, let's make sure we're aligned around the idea first.

cc @gziolo @youknowriad @ellatrix @noisysocks @talldan @getdave @kevin940726 @Mamaduka 