### PR TITLE
Webfonts: change class properties from static to instance members

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -13,20 +13,18 @@ class WP_Webfonts {
 	/**
 	 * An array of registered webfonts.
 	 *
-	 * @static
 	 * @access private
 	 * @var array
 	 */
-	private static $webfonts = array();
+	private $webfonts = array();
 
 	/**
 	 * An array of registered providers.
 	 *
-	 * @static
 	 * @access private
 	 * @var array
 	 */
-	private static $providers = array();
+	private $providers = array();
 
 	/**
 	 * Stylesheet handle.
@@ -63,7 +61,7 @@ class WP_Webfonts {
 	 * @return array
 	 */
 	public function get_fonts() {
-		return self::$webfonts;
+		return $this->webfonts;
 	}
 
 	/**
@@ -72,7 +70,7 @@ class WP_Webfonts {
 	 * @return array
 	 */
 	public function get_providers() {
-		return self::$providers;
+		return $this->providers;
 	}
 
 	/**
@@ -84,7 +82,7 @@ class WP_Webfonts {
 		$font = $this->validate_font( $font );
 		if ( $font ) {
 			$id                    = $this->get_font_id( $font );
-			self::$webfonts[ $id ] = $font;
+			$this->webfonts[ $id ] = $font;
 		}
 	}
 
@@ -194,7 +192,7 @@ class WP_Webfonts {
 		if ( empty( $provider ) || empty( $class ) ) {
 			return false;
 		}
-		self::$providers[ $provider ] = $class;
+		$this->providers[ $provider ] = $class;
 		return true;
 	}
 

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -16,14 +16,14 @@
  * @return WP_Webfonts Instance of the controller.
  */
 function wp_webfonts() {
-	static $instance;
+	global $wp_webfonts;
 
-	if ( ! $instance instanceof WP_Webfonts ) {
-		$instance = new WP_Webfonts();
-		$instance->init();
+	if ( ! $wp_webfonts instanceof WP_Webfonts ) {
+		$wp_webfonts = new WP_Webfonts();
+		$wp_webfonts->init();
 	}
 
-	return $instance;
+	return $wp_webfonts;
 }
 
 /**

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -5,6 +5,25 @@
  * @covers WP_Webfonts_Test
  */
 class WP_Webfonts_Test extends WP_UnitTestCase {
+	/**
+	 * WP_Webfonts instance reference
+	 *
+	 * @var WP_Webfonts
+	 */
+	private $old_wp_webfonts;
+
+	function setUp() {
+		global $wp_webfonts;
+		$this->old_wp_webfonts = $wp_webfonts;
+
+		$wp_webfonts = null;
+	}
+
+	function tearDown() {
+		global $wp_webfonts;
+
+		$wp_webfonts = $this->old_wp_webfonts;
+	}
 
 	/**
 	 * @covers wp_register_webfonts
@@ -106,8 +125,20 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 	 * @covers WP_Webfonts::generate_styles
 	 */
 	public function test_generate_styles() {
+		$font = array(
+			'provider'     => 'local',
+			'font-family'  => 'Source Serif Pro',
+			'font-style'   => 'normal',
+			'font-weight'  => '200 900',
+			'font-stretch' => 'normal',
+			'src'          => 'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2',
+			'font-display' => 'fallback',
+		);
+
+		wp_register_webfont( $font );
+
 		$this->assertEquals(
-			'@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url(\'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2\') format(\'woff2\');}@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url(\'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2\') format(\'woff2\');}',
+			'@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url(\'https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2\') format(\'woff2\');}',
 			wp_webfonts()->generate_styles()
 		);
 	}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/39332.

## What?

Having static variables in the `WP_Webfonts` class makes the class share state between instances. This is not needed in a lot of cases and @jeyip and I couldn't figure out why it was done like that.

## Why?

That are several problems with that approach, including shared state issues. The tests become aware of each other and order starts to matter. Other instances of `WP_Webfonts` might appear in the codebase, and that might lead to confusing and unexpected behavior. It's even impossible to test features of the `wp_webfonts_*` API in the current state of things.

I wonder why we decided to take this route 🤔 

## How?

By moving `$webfonts` and `$providers` variables to instance members, whenever someone creates a new instance of `WP_Webfonts`, they'll start with a fresh copy.

We're also moving from `static` to `global` inside `wp_webfonts` so the instance can be accessed and reset before running a new test case.

## Testing Instructions

Nothing should change at the implementation level. You should notice the test's expectations are a little different, but the tests are still passing.