### PR TITLE
Env: Fix PHP unit tests for "non-standard" cloned directories

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -5,6 +5,7 @@
 	"env": {
 		"tests": {
 			"mappings": {
+				"wp-content/plugins/gutenberg": ".",
 				"wp-content/mu-plugins": "./packages/e2e-tests/mu-plugins",
 				"wp-content/plugins/gutenberg-test-plugins": "./packages/e2e-tests/plugins",
 				"wp-content/themes/gutenberg-test-themes": "./packages/e2e-tests/themes"

--- a/packages/env/lib/build-docker-compose-config.js
+++ b/packages/env/lib/build-docker-compose-config.js
@@ -45,7 +45,14 @@ function getMounts( config, wordpressDefault = 'wordpress' ) {
 		config.coreSource ? config.coreSource.path : wordpressDefault
 	}:/var/www/html`;
 
-	return [ coreMount, ...directoryMounts, ...pluginMounts, ...themeMounts ];
+	return [
+		...new Set( [
+			coreMount,
+			...directoryMounts,
+			...pluginMounts,
+			...themeMounts,
+		] ),
+	];
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
It updates the `wp-env` config file so the PHP unit tests work as expected on a non-standard cloned directory.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The PHP unit tests fail if our local copy is cloned into a "non-standard" directory.

For example:
```
$ git clone https://github.com/WordPress/gutenberg wp-gutenberg
$ npm ci; npm run build
$ npm run test-unit-php

Could not read "/var/www/html/wp-content/plugins/gutenberg/phpunit.xml.dist".
ERROR: 1
```
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It updates the `.wp-env.json` config file to map the volume `wp-content/plugins/gutenberg` to the current directory.

This is required because we have a few hardcoded paths in the `package.json` file.

https://github.com/WordPress/gutenberg/blob/2396f3a095d2dcf6248d60eae262a0564d13e2d9/package.json#L286

## Testing Instructions
Run the PHP unit tests.
```
npm run wp-env destroy
npm run wp-env start
npm run prelint-php
npm run test-unit-php
```
## Screenshots or screencast <!-- if applicable -->
