### PR TITLE
Tooling: Remove unused npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -263,7 +263,6 @@
 		"lint:md-js": "wp-scripts lint-md-js",
 		"lint:md-docs": "wp-scripts lint-md-docs",
 		"native": "npm run --prefix packages/react-native-editor",
-		"pot-to-php": "./bin/pot-to-php.js",
 		"postinstall": "patch-package && node ./patches/patch-xcode.js",
 		"prepublishOnly": "npm run clean:package-types && npm run build:packages",
 		"publish:check": "lerna updated",


### PR DESCRIPTION
I found a script (`php-to-php`) in `package.json` that references a file that does not exist, so I removed it.

I don't know the details of this script, but I suspect that when the built-in tools were removed at #6007, only the scripts remained.