### PR TITLE
[Try]: Style Engine: Alternative approach to rendering common layout styles from presets

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -25,106 +25,31 @@ function gutenberg_register_layout_support( $block_type ) {
 	}
 }
 
-function gutenberg_generate_common_flow_layout_styles() {
-	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
-
-	$style_engine->add_style(
-		'wp-layout-flow',
-		array(
-			'selector' => '.alignleft',
-			'rules'    => array(
-				'float'        => 'left',
-				'margin-right' => '2em',
-				'margin-left'  => '0',
-			),
-		)
-	);
-
-	$style_engine->add_style(
-		'wp-layout-flow',
-		array(
-			'selector' => '.alignright',
-			'rules'    => array(
-				'float'        => 'right',
-				'margin-left'  => '2em',
-				'margin-right' => '0',
-			),
-		)
-	);
-
-	$style_engine->add_style(
-		'wp-layout-flow',
-		array(
-			'selector' => '> .alignfull',
-			'rules'    => array(
-				'max-width' => 'none',
-			),
-		)
-	);
-
-	$style_engine->add_style(
-		'wp-layout-flow--global-gap',
-		array(
-			'selector' => '> *',
-			'rules'    => array(
-				'margin-top'    => '0',
-				'margin-bottom' => '0',
-			),
-		)
-	);
-
-	$style_engine->add_style(
-		'wp-layout-flow--global-gap',
-		array(
-			'selector' => '> * + *',
-			'rules'    => array(
-				'margin-top'    => 'var( --wp--style--block-gap )',
-				'margin-bottom' => '0',
-			),
-		)
-	);
-}
-
-function gutenberg_generate_common_flex_layout_styles() {
-	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
-
-	$style_engine->add_style(
-		'wp-layout-flex',
-		array(
-			'rules' => array(
-				'display' => 'flex',
-				'gap'     => '0.5em',
-			),
-		)
-	);
-
-	$style_engine->add_style(
-		'wp-layout-flex',
-		array(
-			'selector' => '> *',
-			'rules'    => array(
-				'margin' => '0',
-			),
-		)
-	);
-}
-
 function gutenberg_get_layout_preset_styles( $preset_metadata, $presets_by_origin ) {
-	WP_Style_Engine_Gutenberg::get_instance()->reset();
+	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
+	$style_engine->reset();
 
 	$presets = end( $presets_by_origin );
 
 	foreach ( $presets as $preset ) {
-		if ( isset( $preset['type'] ) ) {
-			if ( 'flow' === $preset['type'] ) {
-				$output_styles = gutenberg_generate_common_flow_layout_styles();
-			} else if ( 'flex' === $preset['type'] ) {
-				$output_styles = gutenberg_generate_common_flex_layout_styles();
+		if ( ! empty( $preset['type'] ) && ! empty( $preset['styles'] ) ) {
+			$slug       = ! empty( $preset['slug'] ) ? $preset['slug'] : $preset['type'];
+			$base_class = 'wp-layout-' . sanitize_title( $slug );
+
+			foreach ( $preset['styles'] as $style ) {
+				if ( ! empty( $style['rules'] ) && is_array( $style['rules'] ) ) {
+					$options = array(
+						'selector' => ! empty( $style['selector'] ) ? $style['selector'] : null,
+						'suffix'   => ! empty( $style['suffix'] ) ? sanitize_title( $style['suffix'] ) : null,
+						'rules'    => $style['rules'],
+					);
+					$style_engine->add_style( $base_class, $options );
+				}
 			}
 		}
 	}
 
-	return WP_Style_Engine_Gutenberg::get_instance()->get_generated_styles();
+	return $style_engine->get_generated_styles();
 }
 
 /**

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -25,6 +25,108 @@ function gutenberg_register_layout_support( $block_type ) {
 	}
 }
 
+function gutenberg_generate_common_flow_layout_styles() {
+	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
+
+	$style_engine->add_style(
+		'wp-layout-flow',
+		array(
+			'selector' => '.alignleft',
+			'rules'    => array(
+				'float'        => 'left',
+				'margin-right' => '2em',
+				'margin-left'  => '0',
+			),
+		)
+	);
+
+	$style_engine->add_style(
+		'wp-layout-flow',
+		array(
+			'selector' => '.alignright',
+			'rules'    => array(
+				'float'        => 'right',
+				'margin-left'  => '2em',
+				'margin-right' => '0',
+			),
+		)
+	);
+
+	$style_engine->add_style(
+		'wp-layout-flow',
+		array(
+			'selector' => '> .alignfull',
+			'rules'    => array(
+				'max-width' => 'none',
+			),
+		)
+	);
+
+	$style_engine->add_style(
+		'wp-layout-flow--global-gap',
+		array(
+			'selector' => '> *',
+			'rules'    => array(
+				'margin-top'    => '0',
+				'margin-bottom' => '0',
+			),
+		)
+	);
+
+	$style_engine->add_style(
+		'wp-layout-flow--global-gap',
+		array(
+			'selector' => '> * + *',
+			'rules'    => array(
+				'margin-top'    => 'var( --wp--style--block-gap )',
+				'margin-bottom' => '0',
+			),
+		)
+	);
+}
+
+function gutenberg_generate_common_flex_layout_styles() {
+	$style_engine = WP_Style_Engine_Gutenberg::get_instance();
+
+	$style_engine->add_style(
+		'wp-layout-flex',
+		array(
+			'rules' => array(
+				'display' => 'flex',
+				'gap'     => '0.5em',
+			),
+		)
+	);
+
+	$style_engine->add_style(
+		'wp-layout-flex',
+		array(
+			'selector' => '> *',
+			'rules'    => array(
+				'margin' => '0',
+			),
+		)
+	);
+}
+
+function gutenberg_get_layout_preset_styles( $preset_metadata, $presets_by_origin ) {
+	WP_Style_Engine_Gutenberg::get_instance()->reset();
+
+	$presets = end( $presets_by_origin );
+
+	foreach ( $presets as $preset ) {
+		if ( isset( $preset['type'] ) ) {
+			if ( 'flow' === $preset['type'] ) {
+				$output_styles = gutenberg_generate_common_flow_layout_styles();
+			} else if ( 'flex' === $preset['type'] ) {
+				$output_styles = gutenberg_generate_common_flex_layout_styles();
+			}
+		}
+	}
+
+	return WP_Style_Engine_Gutenberg::get_instance()->get_generated_styles();
+}
+
 /**
  * Generates the CSS corresponding to the provided layout.
  *

--- a/lib/class-wp-style-engine-gutenberg.php
+++ b/lib/class-wp-style-engine-gutenberg.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * WP_Style_Engine class
+ *
+ * @package Gutenberg
+ */
+
+/**
+ * Singleton class representing the style engine.
+ *
+ * Consolidates rendering block styles to reduce duplication and streamline
+ * CSS styles generation.
+ *
+ * @since 6.0.0
+ */
+class WP_Style_Engine_Gutenberg {
+	/**
+	 * Registered CSS styles.
+	 *
+	 * @since 5.5.0
+	 * @var array
+	 */
+	private $registered_styles = array();
+
+	/**
+	 * Container for the main instance of the class.
+	 *
+	 * @since 5.5.0
+	 * @var WP_Style_Engine_Gutenberg|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Register action for outputting styles when the class is constructed.
+	 */
+	public function __construct() {
+		// Borrows the logic from `gutenberg_enqueue_block_support_styles`.
+		// $action_hook_name = 'wp_footer';
+		// if ( wp_is_block_theme() ) {
+		// 	$action_hook_name = 'wp_enqueue_scripts';
+		// }
+		// add_action(
+		// 	$action_hook_name,
+		// 	array( $this, 'output_styles' )
+		// );
+	}
+
+	/**
+	 * Utility method to retrieve the main instance of the class.
+	 *
+	 * The instance will be created if it does not exist yet.
+	 *
+	 * @return WP_Style_Engine_Gutenberg The main instance.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	public function reset() {
+		$this->registered_styles = array();
+	}
+
+	public function get_generated_styles() {
+		$output = '';
+		foreach ( $this->registered_styles as $selector => $rules ) {
+			$output .= "{$selector} {\n";
+
+			if ( is_string( $rules ) ) {
+				$output .= '  ';
+				$output .= $rules;
+			} else {
+				foreach ( $rules as $rule => $value ) {
+					$output .= "  {$rule}: {$value};\n";
+				}
+			}
+			$output .= "}\n";
+		}
+		return $output;
+	}
+
+	/**
+	 * Stores style rules for a given CSS selector (the key) and returns an associated classname.
+	 *
+	 * @param string $key     A class name used to construct a key.
+	 * @param array  $options An array of options, rules, and selector for constructing the rules.
+	 *
+	 * @return string The class name for the added style.
+	 */
+	public function add_style( $key, $options ) {
+		$class    = ! empty( $options['suffix'] ) ? $key . '-' . sanitize_title( $options['suffix'] ) : $key;
+		$selector = ! empty( $options['selector'] ) ? ' ' . trim( $options['selector'] ) : '';
+		$rules    = ! empty( $options['rules'] ) ? $options['rules'] : array();
+		$prefix   = ! empty( $options['prefix'] ) ? $options['prefix'] : '.';
+
+		if ( ! $class ) {
+			return;
+		}
+
+		$this->registered_styles[ $prefix . $class . $selector ] = $rules;
+
+		return $class;
+	}
+
+	/**
+	 * Render registered styles as key { ...rules }  for final output.
+	 */
+	public function output_styles() {
+		$output = $this->get_generated_styles();
+		echo "<style>\n$output</style>\n";
+	}
+}

--- a/lib/class-wp-style-engine-gutenberg.php
+++ b/lib/class-wp-style-engine-gutenberg.php
@@ -91,7 +91,7 @@ class WP_Style_Engine_Gutenberg {
 	 * @return string The class name for the added style.
 	 */
 	public function add_style( $key, $options ) {
-		$class    = ! empty( $options['suffix'] ) ? $key . '-' . sanitize_title( $options['suffix'] ) : $key;
+		$class    = ! empty( $options['suffix'] ) ? $key . '--' . sanitize_title( $options['suffix'] ) : $key;
 		$selector = ! empty( $options['selector'] ) ? ' ' . trim( $options['selector'] ) : '';
 		$rules    = ! empty( $options['rules'] ) ? $options['rules'] : array();
 		$prefix   = ! empty( $options['prefix'] ) ? $options['prefix'] : '.';

--- a/lib/class-wp-style-engine-gutenberg.php
+++ b/lib/class-wp-style-engine-gutenberg.php
@@ -91,7 +91,8 @@ class WP_Style_Engine_Gutenberg {
 	 * @return string The class name for the added style.
 	 */
 	public function add_style( $key, $options ) {
-		$class    = ! empty( $options['suffix'] ) ? $key . '--' . sanitize_title( $options['suffix'] ) : $key;
+		$suffix   = ! empty( $options['suffix'] ) && is_array( $options['suffix'] ) ? implode( '--', $options['suffix'] ) : $options['suffix'];
+		$class    = ! empty( $suffix ) ? $key . '--' . sanitize_key( $suffix ) : $key;
 		$selector = ! empty( $options['selector'] ) ? ' ' . trim( $options['selector'] ) : '';
 		$rules    = ! empty( $options['rules'] ) ? $options['rules'] : array();
 		$prefix   = ! empty( $options['prefix'] ) ? $options['prefix'] : '.';

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -948,7 +948,7 @@ class WP_Theme_JSON_5_9 {
 
 		$stylesheet = '';
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
-			if ( isset( $preset_metadata['type'] ) && 'layout' === $preset_metadata['type'] ) {
+			if ( ! empty( $preset_metadata['path'] ) && 'layout' === $preset_metadata['path'][0] ) {
 
 				$preset_per_origin = _wp_array_get( $settings, $preset_metadata['path'], array() );
 

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -948,6 +948,20 @@ class WP_Theme_JSON_5_9 {
 
 		$stylesheet = '';
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+			if ( isset( $preset_metadata['type'] ) && 'layout' === $preset_metadata['type'] ) {
+
+				$preset_per_origin = _wp_array_get( $settings, $preset_metadata['path'], array() );
+
+				if ( ! empty( $preset_per_origin ) ) {
+					if ( isset( $preset_metadata['value_func'] ) &&
+						is_callable( $preset_metadata['value_func'] )
+					) {
+						$value_func  = $preset_metadata['value_func'];
+						$stylesheet .= call_user_func( $value_func, $preset_metadata, $preset_per_origin );
+						continue;
+					}
+				}
+			}
 			$slugs = static::get_settings_slugs( $settings, $preset_metadata, $origins );
 			foreach ( $preset_metadata['classes'] as $class => $property ) {
 				foreach ( $slugs as $slug ) {
@@ -1135,6 +1149,9 @@ class WP_Theme_JSON_5_9 {
 	protected static function compute_preset_vars( $settings, $origins ) {
 		$declarations = array();
 		foreach ( static::PRESETS_METADATA as $preset_metadata ) {
+			if ( isset( $preset_metadata['type'] ) && 'layout' === $preset_metadata['type'] ) {
+				continue;
+			}
 			$values_by_slug = static::get_settings_values_by_slug( $settings, $preset_metadata, $origins );
 			foreach ( $values_by_slug as $slug => $value ) {
 				$declarations[] = array(

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -186,8 +186,8 @@
 			"text": true
 		},
 		"layout": {
-			"types": [
-				{
+			"types": {
+				"flow": {
 					"slug": "flow",
 					"type": "flow",
 					"styles": [
@@ -238,7 +238,7 @@
 						}
 					]
 				},
-				{
+				"flex": {
 					"slug": "flex",
 					"type": "flex",
 					"styles": [
@@ -253,10 +253,45 @@
 							"rules": {
 								"margin": "0"
 							}
+						},
+						{
+							"suffix": "h-justify",
+							"rules": {
+								"align-items": "center"
+							}
 						}
-					]
+					],
+					"controlledSets": {
+						"flexWrap": {
+							"suffix": "wrap",
+							"property": "flex-wrap",
+							"options": {
+								"wrap": "wrap",
+								"nowrap": "nowrap"
+							}
+						},
+						"horizontalJustification": {
+							"suffix": "h-justify",
+							"property": "justify-content",
+							"options": {
+								"left": "flex-start",
+								"right": "flex-end",
+								"center": "center",
+								"space-between": "space-between"
+							}
+						},
+						"verticalJustification": {
+							"suffix": "v-justify",
+							"property": "align-items",
+							"options": {
+								"left": "flex-start",
+								"right": "flex-end",
+								"center": "center"
+							}
+						}
+					}
 				}
-			]
+			}
 		},
 		"spacing": {
 			"blockGap": null,

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -185,6 +185,18 @@
 			],
 			"text": true
 		},
+		"layout": {
+			"types": [
+				{
+					"slug": "flow",
+					"type": "flow"
+				},
+				{
+					"slug": "flex",
+					"type": "flex"
+				}
+			]
+		},
 		"spacing": {
 			"blockGap": null,
 			"margin": false,

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -192,19 +192,26 @@
 					"type": "flow",
 					"styles": [
 						{
-							"selector": ".alignleft",
+							"selector": "> .alignleft",
 							"rules": {
 								"float": "left",
-								"margin-right": "2em",
-								"margin-left": "0"
+								"margin-inline-end": "2em",
+								"margin-inline-start": "0"
 							}
 						},
 						{
-							"selector": ".alignright",
+							"selector": "> .alignright",
 							"rules": {
 								"float": "right",
-								"margin-left": "2em",
-								"margin-right": "0"
+								"margin-inline-start": "2em",
+								"margin-inline-end": "0"
+							}
+						},
+						{
+							"selector": "> .aligncenter",
+							"rules": {
+								"margin-left": "auto !important",
+								"margin-right": "auto !important"
 							}
 						},
 						{

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -189,11 +189,65 @@
 			"types": [
 				{
 					"slug": "flow",
-					"type": "flow"
+					"type": "flow",
+					"styles": [
+						{
+							"selector": ".alignleft",
+							"rules": {
+								"float": "left",
+								"margin-right": "2em",
+								"margin-left": "0"
+							}
+						},
+						{
+							"selector": ".alignright",
+							"rules": {
+								"float": "right",
+								"margin-left": "2em",
+								"margin-right": "0"
+							}
+						},
+						{
+							"selector": "> .alignfull",
+							"rules": {
+								"max-width": "none"
+							}
+						},
+						{
+							"suffix": "global-gap",
+							"selector": "> *",
+							"rules": {
+								"margin-top": "0",
+								"margin-bottom": "0"
+							}
+						},
+						{
+							"suffix": "global-gap",
+							"selector": "> * + *",
+							"rules": {
+								"margin-top": "var( --wp--style--block-gap )",
+								"margin-bottom": 0
+							}
+						}
+					]
 				},
 				{
 					"slug": "flex",
-					"type": "flex"
+					"type": "flex",
+					"styles": [
+						{
+							"rules": {
+								"display": "flex",
+								"gap": "0.5em"
+							}
+						},
+						{
+							"selector": "> *",
+							"rules": {
+								"margin": "0"
+							}
+						}
+					]
 				}
 			]
 		},

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -259,6 +259,13 @@
 							"rules": {
 								"align-items": "center"
 							}
+						},
+						{
+							"suffix": "v-justify",
+							"rules": {
+								"align-items": "flex-start",
+								"flex-direction": "column"
+							}
 						}
 					],
 					"controlledSets": {

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -15,6 +15,175 @@
  * @access private
  */
 class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
+	/**
+	 * Presets are a set of values that serve
+	 * to bootstrap some styles: colors, font sizes, etc.
+	 *
+	 * They are a unkeyed array of values such as:
+	 *
+	 * ```php
+	 * array(
+	 *   array(
+	 *     'slug'      => 'unique-name-within-the-set',
+	 *     'name'      => 'Name for the UI',
+	 *     <value_key> => 'value'
+	 *   ),
+	 * )
+	 * ```
+	 *
+	 * This contains the necessary metadata to process them:
+	 *
+	 * - path             => Where to find the preset within the settings section.
+	 * - prevent_override => Whether a theme preset with the same slug as a default preset
+	 *                       should not override it or the path to a setting for the same
+	 *                       When defaults.
+	 *                       The relationship between whether to override the defaults
+	 *                       and whether the defaults are enabled is inverse:
+	 *                         - If defaults are enabled  => theme presets should not be overriden
+	 *                         - If defaults are disabled => theme presets should be overriden
+	 *                       For example, a theme sets defaultPalette to false,
+	 *                       making the default palette hidden from the user.
+	 *                       In that case, we want all the theme presets to be present,
+	 *                       so they should override the defaults by setting this false.
+	 * - value_key        => the key that represents the value
+	 * - value_func       => optionally, instead of value_key, a function to generate
+	 *                       the value that takes a preset as an argument
+	 *                       (either value_key or value_func should be present)
+	 * - css_vars         => template string to use in generating the CSS Custom Property.
+	 *                       Example output: "--wp--preset--duotone--blue: <value>" will generate as many CSS Custom Properties as presets defined
+	 *                       substituting the $slug for the slug's value for each preset value.
+	 * - classes          => array containing a structure with the classes to
+	 *                       generate for the presets, where for each array item
+	 *                       the key is the class name and the value the property name.
+	 *                       The "$slug" substring will be replaced by the slug of each preset.
+	 *                       For example:
+	 *                       'classes' => array(
+	 *                         '.has-$slug-color'            => 'color',
+	 *                         '.has-$slug-background-color' => 'background-color',
+	 *                         '.has-$slug-border-color'     => 'border-color',
+	 *                       )
+	 * - properties       => array of CSS properties to be used by kses to
+	 *                       validate the content of each preset
+	 *                       by means of the remove_insecure_properties method.
+	 */
+	const PRESETS_METADATA = array(
+		array(
+			'path'                => array( 'color', 'palette' ),
+			'prevent_override'    => array( 'color', 'defaultPalette' ),
+			'use_default_presets' => array( 'color', 'defaultPalette' ),
+			'use_default_names'   => false,
+			'value_key'           => 'color',
+			'css_vars'            => '--wp--preset--color--$slug',
+			'classes'             => array(
+				'.has-$slug-color'            => 'color',
+				'.has-$slug-background-color' => 'background-color',
+				'.has-$slug-border-color'     => 'border-color',
+			),
+			'properties'          => array( 'color', 'background-color', 'border-color' ),
+		),
+		array(
+			'path'                => array( 'color', 'gradients' ),
+			'prevent_override'    => array( 'color', 'defaultGradients' ),
+			'use_default_presets' => array( 'color', 'defaultGradients' ),
+			'use_default_names'   => false,
+			'value_key'           => 'gradient',
+			'css_vars'            => '--wp--preset--gradient--$slug',
+			'classes'             => array( '.has-$slug-gradient-background' => 'background' ),
+			'properties'          => array( 'background' ),
+		),
+		array(
+			'path'                => array( 'color', 'duotone' ),
+			'prevent_override'    => array( 'color', 'defaultDuotone' ),
+			'use_default_presets' => array( 'color', 'defaultDuotone' ),
+			'use_default_names'   => false,
+			'value_func'          => 'gutenberg_get_duotone_filter_property',
+			'css_vars'            => '--wp--preset--duotone--$slug',
+			'classes'             => array(),
+			'properties'          => array( 'filter' ),
+		),
+		array(
+			'path'                => array( 'typography', 'fontSizes' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => true,
+			'value_key'           => 'size',
+			'css_vars'            => '--wp--preset--font-size--$slug',
+			'classes'             => array( '.has-$slug-font-size' => 'font-size' ),
+			'properties'          => array( 'font-size' ),
+		),
+		array(
+			'path'                => array( 'typography', 'fontFamilies' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'fontFamily',
+			'css_vars'            => '--wp--preset--font-family--$slug',
+			'classes'             => array( '.has-$slug-font-family' => 'font-family' ),
+			'properties'          => array( 'font-family' ),
+		),
+		array(
+			'type'                => 'layout',
+			'path'                => array( 'layout', 'types' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_func'          => 'gutenberg_get_layout_preset_styles',
+			'classes'             => array(),
+		),
+	);
+
+	/**
+	 * The valid properties under the settings key.
+	 *
+	 * @var array
+	 */
+	const VALID_SETTINGS = array(
+		'appearanceTools' => null,
+		'border'          => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+		),
+		'color'           => array(
+			'background'       => null,
+			'custom'           => null,
+			'customDuotone'    => null,
+			'customGradient'   => null,
+			'defaultDuotone'   => null,
+			'defaultGradients' => null,
+			'defaultPalette'   => null,
+			'duotone'          => null,
+			'gradients'        => null,
+			'link'             => null,
+			'palette'          => null,
+			'text'             => null,
+		),
+		'custom'          => null,
+		'layout'          => array(
+			'contentSize' => null,
+			'wideSize'    => null,
+			'types'       => null,
+		),
+		'spacing'         => array(
+			'blockGap' => null,
+			'margin'   => null,
+			'padding'  => null,
+			'units'    => null,
+		),
+		'typography'      => array(
+			'customFontSize' => null,
+			'dropCap'        => null,
+			'fontFamilies'   => null,
+			'fontSizes'      => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
 
 	/**
 	 * The top-level keys a theme.json can have.

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -122,7 +122,6 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			'properties'          => array( 'font-family' ),
 		),
 		array(
-			'type'                => 'layout',
 			'path'                => array( 'layout', 'types' ),
 			'prevent_override'    => false,
 			'use_default_presets' => true,

--- a/lib/load.php
+++ b/lib/load.php
@@ -121,6 +121,11 @@ require __DIR__ . '/experiments-page.php';
 require __DIR__ . '/global-styles.php';
 require __DIR__ . '/pwa.php';
 
+// TODO: Before this PR merges, move this to be a part of the style engine package.
+// Part of the build process should be to copy the PHP file to the correct location,
+// similar to the loading behaviour in `blocks.php`.
+require __DIR__ . '/class-wp-style-engine-gutenberg.php';
+
 require __DIR__ . '/block-supports/elements.php';
 require __DIR__ . '/block-supports/colors.php';
 require __DIR__ . '/block-supports/typography.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

🚧 🚧 🚧 🚧 🚧 ***WIP: This is a messy exploratory PR that is highly likely to change*** 🚧 🚧 🚧 🚧 🚧 

This is a very early draft exploration alternative to #38974 to look at potentially trying to generate common layout styles via presets in `theme.json`.

The main objective is to hook into the `theme.json` style generation for invoking generating styles for layouts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Based on discussion in #38974, we'd like to look into a presets approach for generating common layout styles, that individual blocks can then link to via classname.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Currently it adds an additional preset metadata item for layouts, and then iterates over those layout types — there's an escape hatch from the usual global styles generation that then goes to call a function from the Layout block support to generate the styles. This then uses a similar mechanism as to #38974 to generate the styling rules, and then passes it back to the theme JSON class, so that those styling rules can be included in the global stylesheet.

This is a very naive approach at the moment, and it is not close to a working example.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->

Styles included in the global styles sheet:

<img width="803" alt="image" src="https://user-images.githubusercontent.com/14988353/157814400-39692704-72f7-4603-a2f6-fcd10016225e.png">

