### PR TITLE
[Block Library]: Use `UnitControl` from `components` package in Cover and Search blocks

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -26,6 +26,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalBoxControl as BoxControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { compose, useInstanceId } from '@wordpress/compose';
 import {
@@ -41,7 +42,6 @@ import {
 	useInnerBlocksProps,
 	__experimentalUseGradient,
 	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
-	__experimentalUnitControl as UnitControl,
 	__experimentalBlockAlignmentMatrixControl as BlockAlignmentMatrixControl,
 	__experimentalBlockFullHeightAligmentControl as FullHeightAlignmentControl,
 	store as blockEditorStore,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -12,7 +12,6 @@ import {
 	InspectorControls,
 	RichText,
 	__experimentalUseBorderProps as useBorderProps,
-	__experimentalUnitControl as UnitControl,
 	__experimentalUseColorProps as useColorProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -28,6 +27,7 @@ import {
 	PanelBody,
 	BaseControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { Icon, search } from '@wordpress/icons';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/37724
<!-- In a few words, what is the PR actually doing? -->

## Why?
The reported issue is about not showing the `vh` unit in `min height` control in `Cover` block. At first this seemed to me as duplicate of: https://github.com/WordPress/gutenberg/issues/36035 which explains that a theme(through `spacing.units` in `theme.json`) enables support for specific units - so a theme issue and not a GB one. But then I tested to verify the issue, by removing that setting in my `theme.json`. In that case the cover block provides some fallback [units here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/cover/edit.js#L106). 

To my surprise `vh` was not there and after debugging I realized that there is a wrapper `UnitControl` [component in block-editor package](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/unit-control/index.js), which overrides the provided units and doesn't include the `vh` unit.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
This PR changed `Search`(width control) and `Cover`(min height control) blocks to use the `UnitControl` from `@wordpress/components` package. These were the only usages I found that used the wrapper UnitControl.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. The `Search`(width control) and `Cover`(min height control) should work as before with no regressions introduced
2. Remove from `theme.json` the `spacing.units` and observe that in `Cover` block's min height control the `vh` unit is available.

## Notes
Also in case of testing with themes without theme.json, have in mind this:
>The theme doesn't need to have theme.json (Twenty-One has none, I think). The theme needs support for custom units:
>add_theme_support( 'custom-units' );


## Questions

I can't see the point of having such a wrapper in block-editor package in general. Is this something we need to remove/deprecate? --cc @ciampo @mirka 