### PR TITLE
`ColorPalette`: refine custom color button's label

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -37,8 +37,8 @@ $grid-unit-30: 3 * $grid-unit;		// 24px
 $grid-unit-40: 4 * $grid-unit;		// 32px
 $grid-unit-50: 5 * $grid-unit;		// 40px
 $grid-unit-60: 6 * $grid-unit;		// 48px
-$grid-unit-70: 7 * $grid-unit;    // 56px
-$grid-unit-80: 8 * $grid-unit;    // 64px
+$grid-unit-70: 7 * $grid-unit;		// 56px
+$grid-unit-80: 8 * $grid-unit;		// 64px
 
 /**
  * Dimensions.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -37,7 +37,8 @@ $grid-unit-30: 3 * $grid-unit;		// 24px
 $grid-unit-40: 4 * $grid-unit;		// 32px
 $grid-unit-50: 5 * $grid-unit;		// 40px
 $grid-unit-60: 6 * $grid-unit;		// 48px
-
+$grid-unit-70: 7 * $grid-unit;    // 56px
+$grid-unit-80: 8 * $grid-unit;    // 64px
 
 /**
  * Dimensions.

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -74,10 +74,10 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -69,13 +69,64 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
   min-height: 0;
 }
 
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-10>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-10>* {
+  min-width: 0;
+}
+
+.emotion-13 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-15 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
 <div
   className="components-base-control block-editor-color-gradient-control emotion-0 emotion-1"
 >
   <div
     className="components-base-control__field emotion-2 emotion-3"
   >
-    <fieldset>
+    <fieldset
+      className="block-editor-color-gradient-control__fieldset"
+    >
       <div
         className="components-flex components-h-stack components-v-stack emotion-4 emotion-5"
         data-wp-c16t={true}
@@ -105,7 +156,9 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
               aria-expanded={false}
               aria-haspopup="true"
               aria-label="Custom color picker"
-              className="components-color-palette__custom-color"
+              className="components-flex components-color-palette__custom-color emotion-10 emotion-5"
+              data-wp-c16t={true}
+              data-wp-component="Flex"
               onClick={[Function]}
               style={
                 Object {
@@ -114,7 +167,20 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
                 }
               }
             >
-              #f00
+              <span
+                className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-13 emotion-5"
+                data-wp-c16t={true}
+                data-wp-component="FlexItem"
+              >
+                red
+              </span>
+              <span
+                className="components-flex-item components-color-palette__custom-color-value emotion-15 emotion-5"
+                data-wp-c16t={true}
+                data-wp-component="FlexItem"
+              >
+                f00
+              </span>
             </button>
           </div>
           <div

--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -155,7 +155,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             <button
               aria-expanded={false}
               aria-haspopup="true"
-              aria-label="Custom color picker"
+              aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
               className="components-flex components-color-palette__custom-color emotion-10 emotion-5"
               data-wp-c16t={true}
               data-wp-component="Flex"

--- a/packages/block-editor/src/components/colors-gradients/control.js
+++ b/packages/block-editor/src/components/colors-gradients/control.js
@@ -66,7 +66,7 @@ function ColorGradientControlInner( {
 				className
 			) }
 		>
-			<fieldset>
+			<fieldset className="block-editor-color-gradient-control__fieldset">
 				<VStack spacing={ 1 }>
 					{ showTitle && (
 						<legend>

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -4,6 +4,12 @@
 	}
 }
 
+.block-editor-color-gradient-control__fieldset {
+	// Prevents the `fieldset` from growing beyond its parent's size
+	// in order to fit its content.
+	min-width: 0;
+}
+
 .block-editor-panel-color-gradient-settings {
 	.block-editor-panel-color-gradient-settings__panel-title {
 		display: flex;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   `BaseControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#39325](https://github.com/WordPress/gutenberg/pull/39325)).
 -   `Divider`: Make the divider visible by default (`display: inline`) in flow layout containers when the divider orientation is vertical ([#39316](https://github.com/WordPress/gutenberg/pull/39316)).
 -   Stop using deprecated `event.keyCode` in favor of `event.key` for keyboard events in `UnitControl` and `InputControl`.  ([#39360](https://github.com/WordPress/gutenberg/pull/39360))
+-   `ColorPalette`: : refine custom color button's label. ([#39386](https://github.com/WordPress/gutenberg/pull/39386))
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,7 +7,7 @@
 -   `BaseControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#39325](https://github.com/WordPress/gutenberg/pull/39325)).
 -   `Divider`: Make the divider visible by default (`display: inline`) in flow layout containers when the divider orientation is vertical ([#39316](https://github.com/WordPress/gutenberg/pull/39316)).
 -   Stop using deprecated `event.keyCode` in favor of `event.key` for keyboard events in `UnitControl` and `InputControl`.  ([#39360](https://github.com/WordPress/gutenberg/pull/39360))
--   `ColorPalette`: : refine custom color button's label. ([#39386](https://github.com/WordPress/gutenberg/pull/39386))
+-   `ColorPalette`: refine custom color button's label. ([#39386](https://github.com/WordPress/gutenberg/pull/39386))
 
 ### Internal
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -196,14 +196,16 @@ export default function ColorPalette( {
 		[ value, colors, showMultiplePalettes ]
 	);
 
-	const customColorAccessibleLabel = sprintf(
-		// translators: %1$s: The name of the color e.g: "vivid red". %2$s: The color's hex code e.g: "#f00".
-		__(
-			'Custom color picker. The currently selected color is called "%1$s" and has a value of "%2$s".'
-		),
-		buttonLabelName,
-		valueWithoutLeadingHash
-	);
+	const customColorAccessibleLabel = !! valueWithoutLeadingHash
+		? sprintf(
+				// translators: %1$s: The name of the color e.g: "vivid red". %2$s: The color's hex code e.g: "#f00".
+				__(
+					'Custom color picker. The currently selected color is called "%1$s" and has a value of "%2$s".'
+				),
+				buttonLabelName,
+				valueWithoutLeadingHash
+		  )
+		: __( 'Custom color picker.' );
 
 	return (
 		<VStack spacing={ 3 } className={ className }>

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -136,22 +136,10 @@ const extractColorNameFromCurrentValue = (
 		return '';
 	}
 
-	if ( showMultiplePalettes ) {
-		for ( const { colors: colorPaletteColors } of colors ) {
-			for ( const {
-				name: colorName,
-				color: colorValue,
-			} of colorPaletteColors ) {
-				if (
-					colord( currentValue ).toHex() ===
-					colord( colorValue ).toHex()
-				) {
-					return colorName;
-				}
-			}
-		}
-	} else {
-		for ( const { name: colorName, color: colorValue } of colors ) {
+	// Normalize format of `colors` to simplify the following loop
+	const colorPalettes = showMultiplePalettes ? colors : [ { colors } ];
+	for ( const { colors: paletteColors } of colorPalettes ) {
+		for ( const { name: colorName, color: colorValue } of paletteColors ) {
 			if (
 				colord( currentValue ).toHex() === colord( colorValue ).toHex()
 			) {

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -196,6 +196,15 @@ export default function ColorPalette( {
 		[ value, colors, showMultiplePalettes ]
 	);
 
+	const customColorAccessibleLabel = sprintf(
+		// translators: %1$s: The name of the color e.g: "vivid red". %2$s: The color's hex code e.g: "#f00".
+		__(
+			'Custom color picker. The currently selected color is called "%1$s" and has a value of "%2$s".'
+		),
+		buttonLabelName,
+		valueWithoutLeadingHash
+	);
+
 	return (
 		<VStack spacing={ 3 } className={ className }>
 			{ ! disableCustomColors && (
@@ -212,7 +221,7 @@ export default function ColorPalette( {
 							aria-expanded={ isOpen }
 							aria-haspopup="true"
 							onClick={ onToggle }
-							aria-label={ __( 'Custom color picker' ) }
+							aria-label={ customColorAccessibleLabel }
 							style={ {
 								background: value,
 								color:

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -211,10 +211,14 @@ export default function ColorPalette( {
 	const buttonLabelValue = value?.startsWith( '#' )
 		? value.substring( 1 )
 		: value ?? '';
-	const buttonLabelName = extractColorNameFromCurrentValue(
-		value,
-		colors,
-		showMultiplePalettes
+	const buttonLabelName = useMemo(
+		() =>
+			extractColorNameFromCurrentValue(
+				value,
+				colors,
+				showMultiplePalettes
+			),
+		[ value, colors, showMultiplePalettes ]
 	);
 
 	return (

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -151,25 +151,19 @@ const extractColorNameFromCurrentValue = (
 					colord( currentValue ).toHex() ===
 					colord( colorValue ).toHex()
 				) {
-					return sprintf(
-						// translators: %1$s: The name of the color e.g: "vivid red"; %2$s: the color palette name (e.g. 'Theme', 'Default', 'Custom'...).
-						__( '%1$s (%2$s)' ),
-						colorName,
-						colorPaletteName
-					);
+					return `${ colorName }${
+						colorPaletteName ? ` (${ colorPaletteName })` : ''
+					}`;
 				}
 			}
 		}
 	} else {
 		for ( const { name: colorName, color: colorValue } of colors ) {
-			/* eslint-disable @wordpress/i18n-no-placeholders-only */
 			if (
 				colord( currentValue ).toHex() === colord( colorValue ).toHex()
 			) {
-				// translators: %s: The name of the color e.g: "vivid red".
-				return sprintf( __( '%s' ), colorName );
+				return colorName;
 			}
-			/* eslint-enable @wordpress/i18n-no-placeholders-only */
 		}
 	}
 

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -202,7 +202,7 @@ export default function ColorPalette( {
 
 	const colordColor = colord( value );
 
-	const buttonLabelValue = value?.startsWith( '#' )
+	const valueWithoutLeadingHash = value?.startsWith( '#' )
 		? value.substring( 1 )
 		: value ?? '';
 	const buttonLabelName = useMemo(
@@ -251,7 +251,7 @@ export default function ColorPalette( {
 								as="span"
 								className="components-color-palette__custom-color-value"
 							>
-								{ buttonLabelValue }
+								{ valueWithoutLeadingHash }
 							</FlexItem>
 						</Flex>
 					) }

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -147,7 +147,10 @@ const extractColorNameFromCurrentValue = (
 				name: colorName,
 				color: colorValue,
 			} of colorPaletteColors ) {
-				if ( currentValue === colorValue ) {
+				if (
+					colord( currentValue ).toHex() ===
+					colord( colorValue ).toHex()
+				) {
 					return sprintf(
 						// translators: %1$s: The name of the color e.g: "vivid red"; %2$s: the color palette name (e.g. 'Theme', 'Default', 'Custom'...).
 						__( '%1$s (%2$s)' ),
@@ -160,7 +163,9 @@ const extractColorNameFromCurrentValue = (
 	} else {
 		for ( const { name: colorName, color: colorValue } of colors ) {
 			/* eslint-disable @wordpress/i18n-no-placeholders-only */
-			if ( currentValue === colorValue ) {
+			if (
+				colord( currentValue ).toHex() === colord( colorValue ).toHex()
+			) {
 				// translators: %s: The name of the color e.g: "vivid red".
 				return sprintf( __( '%s' ), colorName );
 			}

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -136,8 +136,6 @@ const extractColorNameFromCurrentValue = (
 		return '';
 	}
 
-	let colorNameToReturn;
-
 	if ( showMultiplePalettes ) {
 		for ( const { colors: colorPaletteColors } of colors ) {
 			for ( const {
@@ -163,7 +161,7 @@ const extractColorNameFromCurrentValue = (
 	}
 
 	// translators: shown when the user has picked a custom color (i.e not in the palette of colors).
-	return colorNameToReturn ?? __( 'Custom' );
+	return __( 'Custom' );
 };
 
 export default function ColorPalette( {

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -127,14 +127,6 @@ export function CustomColorPickerDropdown( { isRenderedInSidebar, ...props } ) {
 	);
 }
 
-const formatValueForCustomColorButton = ( value = '' ) => {
-	const withoutStartingHash = value.startsWith( '#' )
-		? value.substring( 1 )
-		: value;
-
-	return withoutStartingHash.toUpperCase();
-};
-
 const extractColorNameFromCurrentValue = (
 	currentValue,
 	colors = [],
@@ -211,7 +203,9 @@ export default function ColorPalette( {
 
 	const colordColor = colord( value );
 
-	const buttonLabelValue = formatValueForCustomColorButton( value );
+	const buttonLabelValue = value?.startsWith( '#' )
+		? value.substring( 1 )
+		: value ?? '';
 	const buttonLabelName = extractColorNameFromCurrentValue(
 		value,
 		colors,

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -139,10 +139,7 @@ const extractColorNameFromCurrentValue = (
 	let colorNameToReturn;
 
 	if ( showMultiplePalettes ) {
-		for ( const {
-			name: colorPaletteName,
-			colors: colorPaletteColors,
-		} of colors ) {
+		for ( const { colors: colorPaletteColors } of colors ) {
 			for ( const {
 				name: colorName,
 				color: colorValue,
@@ -151,9 +148,7 @@ const extractColorNameFromCurrentValue = (
 					colord( currentValue ).toHex() ===
 					colord( colorValue ).toHex()
 				) {
-					return `${ colorName }${
-						colorPaletteName ? ` (${ colorPaletteName })` : ''
-					}`;
+					return colorName;
 				}
 			}
 		}

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -226,6 +226,7 @@ export default function ColorPalette( {
 						<Flex
 							as={ 'button' }
 							justify="space-between"
+							align="flex-start"
 							className="components-color-palette__custom-color"
 							aria-expanded={ isOpen }
 							aria-haspopup="true"

--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { object } from '@storybook/addon-knobs';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -13,35 +8,76 @@ import { useState } from '@wordpress/element';
  */
 import ColorPalette from '../';
 
-export default {
+const meta = {
 	title: 'Components/ColorPalette',
 	component: ColorPalette,
+	argTypes: {
+		__experimentalHasMultipleOrigins: {
+			control: {
+				type: null,
+			},
+		},
+		__experimentalIsRenderedInSidebar: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		clearable: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		disableCustomColors: {
+			control: {
+				type: 'boolean',
+			},
+		},
+	},
 	parameters: {
-		knobs: { disable: false },
+		controls: { expanded: true },
+		docs: { source: { state: 'open' } },
 	},
 };
+export default meta;
 
-const ColorPaletteWithState = ( props ) => {
-	const [ color, setColor ] = useState( '#F00' );
-	return <ColorPalette { ...props } value={ color } onChange={ setColor } />;
+const Template = ( args ) => {
+	const [ color, setColor ] = useState( '#f00' );
+	return <ColorPalette { ...args } value={ color } onChange={ setColor } />;
 };
 
-export const _default = () => {
-	const colors = [
-		{ name: 'red', color: '#f00' },
-		{ name: 'white', color: '#fff' },
-		{ name: 'blue', color: '#00f' },
-	];
-
-	return <ColorPaletteWithState colors={ colors } />;
+export const Default = Template.bind( {} );
+Default.args = {
+	colors: [
+		{ name: 'Red', color: '#f00' },
+		{ name: 'White', color: '#fff' },
+		{ name: 'Blue', color: '#00f' },
+	],
 };
 
-export const withKnobs = () => {
-	const colors = [
-		object( 'Red', { name: 'red', color: '#f00' } ),
-		object( 'White', { name: 'white', color: '#fff' } ),
-		object( 'Blue', { name: 'blue', color: '#00f' } ),
-	];
-
-	return <ColorPaletteWithState colors={ colors } />;
+/**
+ * When setting the `__experimentalHasMultipleOrigins` prop to `true`,
+ * the `colors` prop is expected to be an array of color palettes, rather
+ * than an array of color objects.
+ */
+export const MultipleOrigins = Template.bind( {} );
+MultipleOrigins.args = {
+	__experimentalHasMultipleOrigins: true,
+	colors: [
+		{
+			name: 'Primary colors',
+			colors: [
+				{ name: 'Red', color: '#f00' },
+				{ name: 'Yellow', color: '#ff0' },
+				{ name: 'Blue', color: '#00f' },
+			],
+		},
+		{
+			name: 'Primary colors',
+			colors: [
+				{ name: 'Orange', color: '#f60' },
+				{ name: 'Green', color: '#0f0' },
+				{ name: 'Purple', color: '#60f' },
+			],
+		},
+	],
 };

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -62,4 +62,5 @@
 
 .components-color-palette__custom-color-value {
 	margin-left: $grid-unit-20;
+	text-transform: uppercase;
 }

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -3,7 +3,8 @@
 	border: none;
 	background: none;
 	border-radius: $radius-block-ui;
-	height: $grid-unit-60;
+	height: $grid-unit-80;
+	padding: $grid-unit-15;
 	font-family: inherit;
 	width: 100%;
 	background-image:

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -55,3 +55,11 @@
 		}
 	}
 }
+
+.components-color-palette__custom-color-name {
+	text-align: left;
+}
+
+.components-color-palette__custom-color-value {
+	margin-left: $grid-unit-20;
+}

--- a/packages/components/src/color-palette/style.scss
+++ b/packages/components/src/color-palette/style.scss
@@ -2,11 +2,9 @@
 	position: relative;
 	border: none;
 	background: none;
-	display: block;
 	border-radius: $radius-block-ui;
 	height: $grid-unit-60;
 	font-family: inherit;
-	text-align: right;
 	width: 100%;
 	background-image:
 		repeating-linear-gradient(45deg, $gray-200 25%, transparent 25%, transparent 75%, $gray-200 75%, $gray-200),

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -8,11 +8,123 @@ exports[`ColorPalette Dropdown .renderContent should render dropdown content 1`]
 `;
 
 exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] = `
-<button
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-2>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-3>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-4>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-4>* {
+  min-width: 0;
+}
+
+.emotion-6 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-9 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-11 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emotion-15 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-19 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+<Flex
   aria-expanded={true}
   aria-haspopup="true"
   aria-label="Custom color picker"
+  as="button"
   className="components-color-palette__custom-color"
+  justify="space-between"
   onClick={[MockFunction]}
   style={
     Object {
@@ -21,11 +133,227 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
     }
   }
 >
-  #f00
-</button>
+  <View
+    aria-expanded={true}
+    aria-haspopup="true"
+    aria-label="Custom color picker"
+    as="button"
+    className="emotion-0 emotion-1 emotion-2 emotion-3 components-flex components-color-palette__custom-color"
+    data-wp-c16t={true}
+    data-wp-component="Flex"
+    onClick={[MockFunction]}
+    style={
+      Object {
+        "background": "#f00",
+        "color": "#000",
+      }
+    }
+  >
+    <Noop />
+    <button
+      aria-expanded={true}
+      aria-haspopup="true"
+      aria-label="Custom color picker"
+      className="components-flex components-color-palette__custom-color emotion-4 emotion-5"
+      data-wp-c16t={true}
+      data-wp-component="Flex"
+      onClick={[MockFunction]}
+      style={
+        Object {
+          "background": "#f00",
+          "color": "#000",
+        }
+      }
+    >
+      <FlexItem
+        as={
+          Object {
+            "$$typeof": Symbol(react.forward_ref),
+            "__contextSystemKey__": Array [
+              "Truncate",
+            ],
+            "render": [Function],
+            "selector": ".components-truncate",
+          }
+        }
+        className="components-color-palette__custom-color-name"
+        isBlock={true}
+      >
+        <View
+          as={
+            Object {
+              "$$typeof": Symbol(react.forward_ref),
+              "__contextSystemKey__": Array [
+                "Truncate",
+              ],
+              "render": [Function],
+              "selector": ".components-truncate",
+            }
+          }
+          className="emotion-6 emotion-7 emotion-8 components-flex-item components-color-palette__custom-color-name"
+          data-wp-c16t={true}
+          data-wp-component="FlexItem"
+        >
+          <Noop />
+          <Truncate
+            className="components-flex-item components-color-palette__custom-color-name emotion-9 emotion-5"
+            data-wp-c16t={true}
+            data-wp-component="FlexItem"
+          >
+            <View
+              as="span"
+              className="emotion-11 components-truncate components-flex-item components-color-palette__custom-color-name emotion-9 emotion-5"
+              data-wp-c16t={true}
+              data-wp-component="FlexItem"
+            >
+              <Noop />
+              <span
+                className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-15 emotion-5"
+                data-wp-c16t={true}
+                data-wp-component="FlexItem"
+              >
+                red
+              </span>
+            </View>
+          </Truncate>
+        </View>
+      </FlexItem>
+      <FlexItem
+        as="span"
+        className="components-color-palette__custom-color-value"
+      >
+        <View
+          as="span"
+          className="emotion-6 emotion-7 components-flex-item components-color-palette__custom-color-value"
+          data-wp-c16t={true}
+          data-wp-component="FlexItem"
+        >
+          <Noop />
+          <span
+            className="components-flex-item components-color-palette__custom-color-value emotion-19 emotion-5"
+            data-wp-c16t={true}
+            data-wp-component="FlexItem"
+          >
+            f00
+          </span>
+        </View>
+      </FlexItem>
+    </button>
+  </View>
+</Flex>
 `;
 
 exports[`ColorPalette Dropdown should render it correctly 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.emotion-1 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-2>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-3>* {
+  min-width: 0;
+}
+
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-4>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-4>* {
+  min-width: 0;
+}
+
+.emotion-6 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-8 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-9 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-11 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emotion-15 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-19 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
 <Dropdown
   contentClassName="components-color-palette__custom-color-dropdown-content"
   renderContent={[Function]}
@@ -35,11 +363,13 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
     className="components-dropdown"
     tabIndex="-1"
   >
-    <button
+    <Flex
       aria-expanded={false}
       aria-haspopup="true"
       aria-label="Custom color picker"
+      as="button"
       className="components-color-palette__custom-color"
+      justify="space-between"
       onClick={[Function]}
       style={
         Object {
@@ -48,8 +378,114 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
         }
       }
     >
-      #f00
-    </button>
+      <View
+        aria-expanded={false}
+        aria-haspopup="true"
+        aria-label="Custom color picker"
+        as="button"
+        className="emotion-0 emotion-1 emotion-2 emotion-3 components-flex components-color-palette__custom-color"
+        data-wp-c16t={true}
+        data-wp-component="Flex"
+        onClick={[Function]}
+        style={
+          Object {
+            "background": "#f00",
+            "color": "#000",
+          }
+        }
+      >
+        <Noop />
+        <button
+          aria-expanded={false}
+          aria-haspopup="true"
+          aria-label="Custom color picker"
+          className="components-flex components-color-palette__custom-color emotion-4 emotion-5"
+          data-wp-c16t={true}
+          data-wp-component="Flex"
+          onClick={[Function]}
+          style={
+            Object {
+              "background": "#f00",
+              "color": "#000",
+            }
+          }
+        >
+          <FlexItem
+            as={
+              Object {
+                "$$typeof": Symbol(react.forward_ref),
+                "__contextSystemKey__": Array [
+                  "Truncate",
+                ],
+                "render": [Function],
+                "selector": ".components-truncate",
+              }
+            }
+            className="components-color-palette__custom-color-name"
+            isBlock={true}
+          >
+            <View
+              as={
+                Object {
+                  "$$typeof": Symbol(react.forward_ref),
+                  "__contextSystemKey__": Array [
+                    "Truncate",
+                  ],
+                  "render": [Function],
+                  "selector": ".components-truncate",
+                }
+              }
+              className="emotion-6 emotion-7 emotion-8 components-flex-item components-color-palette__custom-color-name"
+              data-wp-c16t={true}
+              data-wp-component="FlexItem"
+            >
+              <Noop />
+              <Truncate
+                className="components-flex-item components-color-palette__custom-color-name emotion-9 emotion-5"
+                data-wp-c16t={true}
+                data-wp-component="FlexItem"
+              >
+                <View
+                  as="span"
+                  className="emotion-11 components-truncate components-flex-item components-color-palette__custom-color-name emotion-9 emotion-5"
+                  data-wp-c16t={true}
+                  data-wp-component="FlexItem"
+                >
+                  <Noop />
+                  <span
+                    className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-15 emotion-5"
+                    data-wp-c16t={true}
+                    data-wp-component="FlexItem"
+                  >
+                    red
+                  </span>
+                </View>
+              </Truncate>
+            </View>
+          </FlexItem>
+          <FlexItem
+            as="span"
+            className="components-color-palette__custom-color-value"
+          >
+            <View
+              as="span"
+              className="emotion-6 emotion-7 components-flex-item components-color-palette__custom-color-value"
+              data-wp-c16t={true}
+              data-wp-component="FlexItem"
+            >
+              <Noop />
+              <span
+                className="components-flex-item components-color-palette__custom-color-value emotion-19 emotion-5"
+                data-wp-c16t={true}
+                data-wp-component="FlexItem"
+              >
+                f00
+              </span>
+            </View>
+          </FlexItem>
+        </button>
+      </View>
+    </Flex>
   </div>
 </Dropdown>
 `;
@@ -144,6 +580,109 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   min-height: 0;
 }
 
+.emotion-7 {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-8>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-9>* {
+  min-width: 0;
+}
+
+.emotion-10 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.emotion-10>*+*:not( marquee ) {
+  margin-left: calc(4px * 2);
+}
+
+.emotion-10>* {
+  min-width: 0;
+}
+
+.emotion-12 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
+.emotion-14 {
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-15 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-17 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.emotion-21 {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.emotion-25 {
+  display: block;
+  max-height: 100%;
+  max-width: 100%;
+  min-height: 0;
+  min-width: 0;
+}
+
 <ColorPalette
   colors={
     Array [
@@ -194,11 +733,13 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               className="components-dropdown"
               tabIndex="-1"
             >
-              <button
+              <Flex
                 aria-expanded={false}
                 aria-haspopup="true"
                 aria-label="Custom color picker"
+                as="button"
                 className="components-color-palette__custom-color"
+                justify="space-between"
                 onClick={[Function]}
                 style={
                   Object {
@@ -207,8 +748,114 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                   }
                 }
               >
-                #f00
-              </button>
+                <View
+                  aria-expanded={false}
+                  aria-haspopup="true"
+                  aria-label="Custom color picker"
+                  as="button"
+                  className="emotion-0 emotion-7 emotion-8 emotion-9 components-flex components-color-palette__custom-color"
+                  data-wp-c16t={true}
+                  data-wp-component="Flex"
+                  onClick={[Function]}
+                  style={
+                    Object {
+                      "background": "#f00",
+                      "color": "#000",
+                    }
+                  }
+                >
+                  <Noop />
+                  <button
+                    aria-expanded={false}
+                    aria-haspopup="true"
+                    aria-label="Custom color picker"
+                    className="components-flex components-color-palette__custom-color emotion-10 emotion-5"
+                    data-wp-c16t={true}
+                    data-wp-component="Flex"
+                    onClick={[Function]}
+                    style={
+                      Object {
+                        "background": "#f00",
+                        "color": "#000",
+                      }
+                    }
+                  >
+                    <FlexItem
+                      as={
+                        Object {
+                          "$$typeof": Symbol(react.forward_ref),
+                          "__contextSystemKey__": Array [
+                            "Truncate",
+                          ],
+                          "render": [Function],
+                          "selector": ".components-truncate",
+                        }
+                      }
+                      className="components-color-palette__custom-color-name"
+                      isBlock={true}
+                    >
+                      <View
+                        as={
+                          Object {
+                            "$$typeof": Symbol(react.forward_ref),
+                            "__contextSystemKey__": Array [
+                              "Truncate",
+                            ],
+                            "render": [Function],
+                            "selector": ".components-truncate",
+                          }
+                        }
+                        className="emotion-12 emotion-13 emotion-14 components-flex-item components-color-palette__custom-color-name"
+                        data-wp-c16t={true}
+                        data-wp-component="FlexItem"
+                      >
+                        <Noop />
+                        <Truncate
+                          className="components-flex-item components-color-palette__custom-color-name emotion-15 emotion-5"
+                          data-wp-c16t={true}
+                          data-wp-component="FlexItem"
+                        >
+                          <View
+                            as="span"
+                            className="emotion-17 components-truncate components-flex-item components-color-palette__custom-color-name emotion-15 emotion-5"
+                            data-wp-c16t={true}
+                            data-wp-component="FlexItem"
+                          >
+                            <Noop />
+                            <span
+                              className="components-truncate components-flex-item components-color-palette__custom-color-name emotion-5 emotion-21 emotion-5"
+                              data-wp-c16t={true}
+                              data-wp-component="FlexItem"
+                            >
+                              red
+                            </span>
+                          </View>
+                        </Truncate>
+                      </View>
+                    </FlexItem>
+                    <FlexItem
+                      as="span"
+                      className="components-color-palette__custom-color-value"
+                    >
+                      <View
+                        as="span"
+                        className="emotion-12 emotion-13 components-flex-item components-color-palette__custom-color-value"
+                        data-wp-c16t={true}
+                        data-wp-component="FlexItem"
+                      >
+                        <Noop />
+                        <span
+                          className="components-flex-item components-color-palette__custom-color-value emotion-25 emotion-5"
+                          data-wp-c16t={true}
+                          data-wp-component="FlexItem"
+                        >
+                          f00
+                        </span>
+                      </View>
+                    </FlexItem>
+                  </button>
+                </View>
+              </Flex>
             </div>
           </Dropdown>
         </CustomColorPickerDropdown>

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -122,7 +122,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
   align="flex-start"
   aria-expanded={true}
   aria-haspopup="true"
-  aria-label="Custom color picker"
+  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
   as="button"
   className="components-color-palette__custom-color"
   justify="space-between"
@@ -137,7 +137,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
   <View
     aria-expanded={true}
     aria-haspopup="true"
-    aria-label="Custom color picker"
+    aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
     as="button"
     className="emotion-0 emotion-1 emotion-2 emotion-3 components-flex components-color-palette__custom-color"
     data-wp-c16t={true}
@@ -154,7 +154,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
     <button
       aria-expanded={true}
       aria-haspopup="true"
-      aria-label="Custom color picker"
+      aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
       className="components-flex components-color-palette__custom-color emotion-4 emotion-5"
       data-wp-c16t={true}
       data-wp-component="Flex"
@@ -368,7 +368,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
       align="flex-start"
       aria-expanded={false}
       aria-haspopup="true"
-      aria-label="Custom color picker"
+      aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
       as="button"
       className="components-color-palette__custom-color"
       justify="space-between"
@@ -383,7 +383,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
       <View
         aria-expanded={false}
         aria-haspopup="true"
-        aria-label="Custom color picker"
+        aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
         as="button"
         className="emotion-0 emotion-1 emotion-2 emotion-3 components-flex components-color-palette__custom-color"
         data-wp-c16t={true}
@@ -400,7 +400,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
         <button
           aria-expanded={false}
           aria-haspopup="true"
-          aria-label="Custom color picker"
+          aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
           className="components-flex components-color-palette__custom-color emotion-4 emotion-5"
           data-wp-c16t={true}
           data-wp-component="Flex"
@@ -739,7 +739,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 align="flex-start"
                 aria-expanded={false}
                 aria-haspopup="true"
-                aria-label="Custom color picker"
+                aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
                 as="button"
                 className="components-color-palette__custom-color"
                 justify="space-between"
@@ -754,7 +754,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 <View
                   aria-expanded={false}
                   aria-haspopup="true"
-                  aria-label="Custom color picker"
+                  aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
                   as="button"
                   className="emotion-0 emotion-7 emotion-8 emotion-9 components-flex components-color-palette__custom-color"
                   data-wp-c16t={true}
@@ -771,7 +771,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                   <button
                     aria-expanded={false}
                     aria-haspopup="true"
-                    aria-label="Custom color picker"
+                    aria-label="Custom color picker. The currently selected color is called \\"red\\" and has a value of \\"f00\\"."
                     className="components-flex components-color-palette__custom-color emotion-10 emotion-5"
                     data-wp-c16t={true}
                     data-wp-component="Flex"

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -16,10 +16,10 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
 }
 
 .emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -42,10 +42,10 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -119,6 +119,7 @@ exports[`ColorPalette Dropdown .renderToggle should render dropdown content 1`] 
 }
 
 <Flex
+  align="flex-start"
   aria-expanded={true}
   aria-haspopup="true"
   aria-label="Custom color picker"
@@ -252,10 +253,10 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
 }
 
 .emotion-1 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -278,10 +279,10 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -364,6 +365,7 @@ exports[`ColorPalette Dropdown should render it correctly 1`] = `
     tabIndex="-1"
   >
     <Flex
+      align="flex-start"
       aria-expanded={false}
       aria-haspopup="true"
       aria-label="Custom color picker"
@@ -581,10 +583,10 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
 }
 
 .emotion-7 {
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -607,10 +609,10 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
@@ -734,6 +736,7 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
               tabIndex="-1"
             >
               <Flex
+                align="flex-start"
                 aria-expanded={false}
                 aria-haspopup="true"
                 aria-label="Custom color picker"

--- a/packages/components/src/color-palette/test/index.js
+++ b/packages/components/src/color-palette/test/index.js
@@ -92,7 +92,7 @@ describe( 'ColorPalette', () => {
 			const isOpen = true;
 			const onToggle = jest.fn();
 
-			const renderedToggleButton = shallow(
+			const renderedToggleButton = mount(
 				dropdown.props().renderToggle( { isOpen, onToggle } )
 			);
 

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -88,7 +88,7 @@ describe( 'Heading', () => {
 		await pressKeyWithModifier( 'primary', 'A' );
 		await page.keyboard.type( '0782f6' );
 		await page.click( 'h3[data-type="core/heading"]' );
-		await page.waitForXPath( '//button[text()="#0782f6"]' );
+		await page.waitForXPath( '//button[contains(text(), "0782f6")]' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 

--- a/packages/e2e-tests/specs/editor/blocks/heading.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/heading.test.js
@@ -88,7 +88,7 @@ describe( 'Heading', () => {
 		await pressKeyWithModifier( 'primary', 'A' );
 		await page.keyboard.type( '0782f6' );
 		await page.click( 'h3[data-type="core/heading"]' );
-		await page.waitForXPath( '//button[contains(text(), "0782f6")]' );
+		await page.waitForXPath( '//button//span[contains(text(), "0782f6")]' );
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Change the label for the custom color button in the `ColorPalette` component:

- format the color value to always be upper case, and hide the starting `#` character
- display the color name

<details>

<summary>See more details</summary>

For reference, this is how this button looks like in `trunk`

![image (1)](https://user-images.githubusercontent.com/1083581/157872196-f4909cc3-8309-4407-abd2-4a175294b9ed.png)

And this is how it _should_ look like:

![image](https://user-images.githubusercontent.com/1083581/157872416-0a80dc50-d8ac-4c8f-875f-3a2ac7e30595.png)
</details>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Iterating and refining our UIs

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Added a utility function that is able to find the color name, given its hex value, by matching it against the color palette(s)
2. Used the `Flex` and `Truncate` components (and a couple of custom styles) to implement the layout changes
3. Added a fix to `fieldset` to make sure that it does't grow larger than its container.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Check the component in Storybook / Global Styles (in the theme editor) / Post editor (e.g. by setting a background color for a group block)
- Focus your attention on the custom color button, in the `ColorPalette` component:
    - The color value should be uppercase and stripped from the leading `#` character
    - The color name should be displayed. If the current color can't be matched against the current paletted of predefined named colors, the text `Custom` should be displayed instead
    - Make sure that, in case of a color with a very long name, the text is truncated correctly.

## Screenshots or screencast <!-- if applicable -->

**In Storybook:**

https://user-images.githubusercontent.com/1083581/157878761-41d43388-b72b-4ed1-9921-95815e1e3c77.mp4

**In the theme editor:**

https://user-images.githubusercontent.com/1083581/157874005-6f997ffc-43d3-4b0c-894e-12114aa88a6f.mp4

**In the post editor:**

https://user-images.githubusercontent.com/1083581/157875711-94cb9db8-7f80-4f8e-99ce-0b9d2d34cd60.mp4
