### PR TITLE
Fix how the Handbook renders the Create your First App with Gutenberg Data tutorial

### DIFF
--- a/docs/how-to-guides/data-basics/1-data-basics-setup.md
+++ b/docs/how-to-guides/data-basics/1-data-basics-setup.md
@@ -178,7 +178,7 @@ Once all the dependencies are in place, all that's left is to run `npm start` an
 
 If you now go to the Plugins page, you should see a plugin called **My first Gutenberg App**. Go ahead and activate it. A new menu item labeled _My first Gutenberg app_ should show up. Once you click it, you will see a page that says _Hello from JavaScript!_:
 
-![](/docs/how-to-guides/data-basics/media/setup/hello-from-js.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/setup/hello-from-js.jpg)
 
 Congratulations! You are now ready to start building the app!
 

--- a/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
+++ b/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
@@ -3,7 +3,7 @@
 In this part, we will build a filterable list of all WordPress pages. This is what the app will look like at the end of
 this section:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/part1-finished.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/part1-finished.jpg)
 
 Let’s see how we can get there step by step.
 
@@ -33,7 +33,7 @@ function PagesList( { pages } ) {
 Note that this component does not fetch any data yet, only presents the hardcoded list of pages. When you refresh the page,
 you should see the following:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/simple-list.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/simple-list.jpg)
 
 ## Step 2: Fetch the data
 
@@ -43,7 +43,7 @@ list of pages from the [WordPress REST API](https://developer.wordpress.org/rest
 Before we start, let’s confirm we actually have some pages to fetch. Within WPAdmin, Navigate to Pages using the sidebar menu and
 ensure it shows at least four or five Pages:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/pages-list.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/pages-list.jpg)
 
 If it doesn’t, go ahead and create a few pages – you can use the same titles as on the screenshot above. Be sure to _
 publish_ and not just _save_ them.
@@ -120,7 +120,7 @@ Note that post title may contain HTML entities like `&aacute;`, so we need to us
 
 Refreshing the page should display a list similar to this one:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/fetch-the-data.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/fetch-the-data.jpg)
 
 ## Step 3: Turn it into a table
 
@@ -145,7 +145,7 @@ function PagesList( { pages } ) {
 }
 ```
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/make-a-table.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/make-a-table.jpg)
 
 ## Step 4: Add a search box
 
@@ -177,7 +177,7 @@ Note that instead of using an `input` tag, we took advantage of
 the [SearchControl](https://developer.wordpress.org/block-editor/reference-guides/components/search-control/) component.
 This is what it looks like:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/filter-field.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/filter-field.jpg)
 
 The field starts empty, and the contents are stored in the `searchTerm` state value. If you aren’t familiar with
 the [useState](https://reactjs.org/docs/hooks-state.html) hook, you can learn more
@@ -254,7 +254,7 @@ function MyFirstApp() {
 
 Voila! We can now filter the results:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/filter.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/filter.jpg)
 
 ### Using core-data instead vs calling the API directly
 
@@ -296,7 +296,7 @@ instead.
 
 There is one problem with our search feature. We can’t be quite sure whether it’s still searching or showing no results:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/unclear-status.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/unclear-status.jpg)
 
 A few messages like  _Loading…_ or _No results_ would clear it up. Let’s implement them! First,  `PagesList` has to be
 aware of the current status:
@@ -458,8 +458,8 @@ window.addEventListener(
 
 All that’s left is to refresh the page and enjoy the brand new status indicator:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/indicator.jpg)
-![](/docs/how-to-guides/data-basics/media/list-of-pages/no-results.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/indicator.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/no-results.jpg)
 
 ## What's next?
 

--- a/docs/how-to-guides/data-basics/README.md
+++ b/docs/how-to-guides/data-basics/README.md
@@ -2,7 +2,7 @@
 
 This tutorial aims to get you comfortable with the Gutenberg data layer. It guides you through building a simple React application that enables the user to manage their WordPress pages. The finished app will look like this:
 
-![](/docs/how-to-guides/data-basics/media/list-of-pages/part1-finished.jpg)
+![](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/how-to-guides/data-basics/media/list-of-pages/part1-finished.jpg)
 
 You may review the [finished app](https://github.com/WordPress/gutenberg-examples/tree/trunk/09-code-data-basics-esnext) in the gutenberg-examples repository.
 

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -92,6 +92,9 @@
 					},
 					{
 					  "docs/how-to-guides/data-basics/2-building-a-list-of-pages.md": []
+					},
+					{
+					  "docs/how-to-guides/data-basics/3-building-an-edit-form.md": []
 					}
 				]
 			},


### PR DESCRIPTION
## What?

This PR solves two issues with the handbook version of the [**Create your First App with Gutenberg Data** tutorial](https://developer.wordpress.org/block-editor/how-to-guides/data-basics/):

1. The link to part three is broken, because the markdown file is missing from toc.json
2. The images are missing, because they are sourced from a relative path instead of raw.githubusercontent

![CleanShot 2022-03-11 at 14 38 59](https://user-images.githubusercontent.com/205419/157878670-48770087-6ac4-4ae8-8e6f-91f801bda1c8.png)

## Testing Instructions
There is nothing to test, just confirm the changes make sense. 
