### PR TITLE
Packages: Ensure that `@wordpress/preferences` gets published to npm

### DIFF
--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ## Unreleased
 
-## 1.0.0
-
 -   Initial version of the package.

--- a/packages/preferences/package.json
+++ b/packages/preferences/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/preferences",
 	"version": "1.0.0-prerelease",
-	"private": true,
 	"description": "Utilities for managing WordPress preferences.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 22.2.0 (2022-03-11)
+
+### Enhancement
+
+-   The bundled `@wordpress/eslint-plugin` package got updated to the new major version, but the breaking changes included don't affect this package ([#39244](https://github.com/WordPress/gutenberg/pull/39244)).
+
 ## 22.1.0 (2022-03-03)
 
 ### New Feature


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for #38873 that added a new `@wordpress/preferences` package but marked it as private.

Raised on WordPress Slack (requires registration at https://make.wordpress.org/chat):

https://wordpress.slack.com/archives/C02QB2JS7/p1647001592635239

> Got a problem with `@wordpress/preferences` while compiling assets.
> ```
> error Couldn't find package "@wordpress/preferences@^1.0.0-prerelease" required by "@wordpress/edit-post@^6.0.2" on the "npm" registry.
> ```
> Looks like the package has not been released.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Having `@wordpress/preferences` as a private package prevented it from publishing to npm. Other packages depend on it so it isn't possible to download them anymore.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR marks `@wordpress/preferences` as public.

I also included a changelog entry for `@wordpress/scripts` to include when publishing packages to npm.