### PR TITLE
Webfonts: Preload fonts in the head to stop a flash of unstyled content

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -301,10 +301,16 @@ class WP_Webfonts {
 	 * @return void
 	 */
 	function preload_webfonts() {
+		$allowed_types = array( 'woff', 'woff2', 'ttf', 'eot', 'otf' );
 		foreach ( $this->get_fonts() as $font ) {
+			var_dump( $font );
 			foreach( $font['src'] as $src ) {
 				$srcAsArray = explode( '.', $src );
-				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . end( $srcAsArray ) . '" crossorigin />';
+				$file_type = end( $srcAsArray );
+				if ( ! in_array( $file_type, $allowed_types ) ) {
+					$file_type = '';
+				}
+				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . $type . '" crossorigin />';
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -55,6 +55,9 @@ class WP_Webfonts {
 
 		// Enqueue webfonts in the block editor.
 		add_action( 'admin_init', array( $this, 'generate_and_enqueue_editor_styles' ) );
+
+		// Preload the font files.
+		add_action( 'wp_head', array( $this, 'preload_webfonts' ) );
 	}
 
 	/**
@@ -290,5 +293,19 @@ class WP_Webfonts {
 		}
 
 		return $styles;
+	}
+
+	/**
+	 * Preload webfonts to improve performance
+	 *
+	 * @return void
+	 */
+	function preload_webfonts() {
+		foreach ( $this->get_fonts() as $font ) {
+			foreach( $font['src'] as $src ) {
+				$srcAsArray = explode( '.', $src );
+				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . end( $srcAsArray ) . '" crossorigin />';
+			}
+		}
 	}
 }

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -310,8 +310,8 @@ class WP_Webfonts {
 		foreach ( $this->get_fonts() as $font ) {
 			if ( $font['preload'] ) {
 				foreach( $font['src'] as $src ) {
-					$srcAsArray = explode( '.', $src );
-					$file_type = end( $srcAsArray );
+					$src_as_array = explode( '.', $src );
+					$file_type    = end( $src_as_array );
 					if ( ! in_array( $file_type, self::$allowed_types ) ) {
 						$file_type = '';
 					}

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -36,6 +36,11 @@ class WP_Webfonts {
 	private $stylesheet_handle = '';
 
 	/**
+	 * Allowed file types
+	 */
+	private static $allowed_types = array( 'woff', 'woff2', 'ttf', 'eot', 'otf' );
+
+	/**
 	 * Init.
 	 */
 	public function init() {
@@ -300,17 +305,15 @@ class WP_Webfonts {
 	 *
 	 * @return void
 	 */
-	function preload_webfonts() {
-		$allowed_types = array( 'woff', 'woff2', 'ttf', 'eot', 'otf' );
+	public function preload_webfonts() {
 		foreach ( $this->get_fonts() as $font ) {
-			var_dump( $font );
 			foreach( $font['src'] as $src ) {
 				$srcAsArray = explode( '.', $src );
 				$file_type = end( $srcAsArray );
-				if ( ! in_array( $file_type, $allowed_types ) ) {
+				if ( ! in_array( $file_type, self::$allowed_types ) ) {
 					$file_type = '';
 				}
-				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . $type . '" crossorigin />';
+				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . $file_type . '" crossorigin />';
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -308,7 +308,7 @@ class WP_Webfonts {
 	 */
 	public function preload_webfonts() {
 		foreach ( $this->get_fonts() as $font ) {
-			if ( $font['preload'] ) {
+			if ( ! empty( $font['preload'] ) && $font['preload'] ) {
 				foreach( $font['src'] as $src ) {
 					$src_as_array = explode( '.', $src );
 					$file_type    = end( $src_as_array );

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -173,6 +173,7 @@ class WP_Webfonts {
 			'font-feature-settings',
 			'font-variation-settings',
 			'line-gap-override',
+			'preload',
 			'size-adjust',
 			'src',
 			'unicode-range',
@@ -307,13 +308,15 @@ class WP_Webfonts {
 	 */
 	public function preload_webfonts() {
 		foreach ( $this->get_fonts() as $font ) {
-			foreach( $font['src'] as $src ) {
-				$srcAsArray = explode( '.', $src );
-				$file_type = end( $srcAsArray );
-				if ( ! in_array( $file_type, self::$allowed_types ) ) {
-					$file_type = '';
+			if ( $font['preload'] ) {
+				foreach( $font['src'] as $src ) {
+					$srcAsArray = explode( '.', $src );
+					$file_type = end( $srcAsArray );
+					if ( ! in_array( $file_type, self::$allowed_types ) ) {
+						$file_type = '';
+					}
+					echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . $file_type . '" crossorigin />';
 				}
-				echo '<link rel="preload" href="' . $src . '" as="font" type="font/' . $file_type . '" crossorigin />';
 			}
 		}
 	}


### PR DESCRIPTION
## What?
This adds a preload for each Webfont that is loaded in theme.json so that the fonts load before the text is displayed

## Why?
Without this PR the text on the site that uses these fonts is displayed in the default font until the font files load. If the font files load slowly they aren't used until the subsequent page views.

## How?
This adds a `link` tag to the header for each font file of the form:
`'<link rel="preload" href="' . $src . '" as="font" type="font/' . end( $srcAsArray ) . '" crossorigin />'`

## Testing Instructions
This is quite tricky to test.
1. Use a theme that loads webfonts in theme.json (you can use one from [this PR](https://github.com/Automattic/themes/pull/5609))
2. If necessary remove any code that preloads webfonts  (there is some in the themes in the PR above)
3. Also add `preload: true` to one of the font files
4. Open you developer console and go to the network tab
5. Disable cache
6. Set your connection to be slow
7. Load the frontend of your site. With this PR you'll notice that the text doesn't load until the font files have loaded. On trunk you'll notice that you see the text in the default font.
8. Check the markup and you'll see that the font file you specified has been loaded in a link element with a `rel` attribute of `preload`.

## Screenshots or screencast <!-- if applicable -->
Before:
![before](https://user-images.githubusercontent.com/275961/157904438-e8e8abb1-b0b3-4546-b35a-f4873e305969.gif)

After:
![after](https://user-images.githubusercontent.com/275961/157904445-e9ae8312-09d2-49b2-9a09-4de59abf04c4.gif)

