### PR TITLE
[create-block] Make case consistent for block functions

### DIFF
--- a/packages/create-block/lib/templates/block/edit.js.mustache
+++ b/packages/create-block/lib/templates/block/edit.js.mustache
@@ -29,7 +29,7 @@ import './editor.scss';
  *
  * @return {WPElement} Element to render.
  */
-export default function Edit() {
+export default function edit() {
 	return (
 		<p { ...useBlockProps() }>
 			{ __( '{{title}} – hello from the editor!', '{{textdomain}}' ) }

--- a/packages/create-block/lib/templates/block/index.js.mustache
+++ b/packages/create-block/lib/templates/block/index.js.mustache
@@ -17,7 +17,7 @@ import './style.scss';
 /**
  * Internal dependencies
  */
-import Edit from './edit';
+import edit from './edit';
 import save from './save';
 
 /**
@@ -29,9 +29,9 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
 	 * @see ./edit.js
 	 */
-	edit: Edit,
+	edit: edit,
 	/**
 	 * @see ./save.js
 	 */
-	save,
+	save: save,
 } );


### PR DESCRIPTION
## What?

When scaffolding a block plugin with the `@wordpress/create-block` package, the block functions are currently using inconsistent casing: `Edit` vs `save`.

They should be consistent in case.

## Why?

Consistency is a sign of quality. Having the casing be inconsistent makes me wonder what else might be "off".

## How?

This PR makes these consistent, as well as makes their use consistent in the block registration.

## Testing Instructions

1. Scaffold a new block plugin using `npx @wordpress/create-block new-block-plugin`.
2. Open the `index.js` file in the newly create plugin.

## Screenshots or screencast <!-- if applicable -->

![index js - awesome-carousel  WSL_ Ubuntu-20 2022-03-11 at 9 51 49 AM 04  - Visual Studio Code](https://user-images.githubusercontent.com/83631/157922952-ab78b1ef-0839-41c6-8de1-ca587dde72bf.jpeg)
