### PR TITLE
Webfonts: scan content for webfonts and enqueue them

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -81,9 +81,19 @@ class WP_Webfonts {
 
 		add_action( 'save_post_wp_template', array( $this, 'invalidate_template_webfonts_cache' ) );
 		add_action( 'save_post_wp_template_part', array( $this, 'invalidate_template_webfonts_cache' ) );
+		add_action( 'save_post_wp_global_styles', array( $this, 'invalidate_global_styles_webfonts_cache' ) );
 
 		// Enqueue webfonts in the block editor.
 		add_action( 'admin_init', array( $this, 'generate_and_enqueue_editor_styles' ) );
+	}
+
+	/**
+	 * Invalidate global styles webfonts cache.
+	 */
+	public function invalidate_global_styles_webfonts_cache() {
+		$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+
+		delete_post_meta( $global_styles_post_id, self::$webfonts_cache_meta_attribute );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -69,8 +69,18 @@ class WP_Webfonts {
 
 		add_action( 'init', array( $this, 'register_filter_for_current_template_webfonts_enqueuing' ) );
 
+		add_action( 'save_post_wp_template', array( $this, 'invalidate_template_webfonts_cache' ) );
+		add_action( 'save_post_wp_template_part', array( $this, 'invalidate_template_webfonts_cache' ) );
+
 		// Enqueue webfonts in the block editor.
 		add_action( 'admin_init', array( $this, 'generate_and_enqueue_editor_styles' ) );
+	}
+
+	/**
+	 * Invalidate template webfonts cache.
+	 */
+	public function invalidate_template_webfonts_cache() {
+		remove_theme_mod( self::$template_webfonts_cache_theme_mod );
 	}
 
 	/**

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -106,7 +106,9 @@ class WP_Webfonts {
 			return;
 		}
 
-		$font = $this->validate_font( $font );
+		$font['id'] = $id;
+		$font       = $this->validate_font( $font );
+
 		if ( $font ) {
 			$this->registered_webfonts[ $id ] = $font;
 		}
@@ -129,7 +131,9 @@ class WP_Webfonts {
 		}
 
 		if ( $font ) {
-			$font                           = $this->validate_font( $font );
+			$font['id'] = $id;
+			$font       = $this->validate_font( $font );
+
 			$this->enqueued_webfonts[ $id ] = $font;
 
 			if ( isset( $this->registered_webfonts[ $id ] ) ) {
@@ -216,6 +220,7 @@ class WP_Webfonts {
 			'unicode-range',
 
 			// Exceptions.
+			'id',
 			'provider',
 		);
 

--- a/phpunit/class-wp-webfonts-test.php
+++ b/phpunit/class-wp-webfonts-test.php
@@ -58,8 +58,8 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			$fonts[0]['id'] => array_filter( $fonts[0], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
-			$fonts[1]['id'] => array_filter( $fonts[1], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
+			$fonts[0]['id'] => $fonts[0],
+			$fonts[1]['id'] => $fonts[1],
 		);
 
 		wp_register_webfonts( $fonts );
@@ -79,6 +79,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		$id = 'source-serif-pro-200-900-normal-local';
 
 		$font = array(
+			'id'           => $id,
 			'provider'     => 'local',
 			'font-family'  => 'Source Serif Pro',
 			'font-style'   => 'normal',
@@ -109,6 +110,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		$id = 'source-serif-pro-200-900-normal-local';
 
 		$font = array(
+			'id'           => $id,
 			'provider'     => 'local',
 			'font-family'  => 'Source Serif Pro',
 			'font-style'   => 'normal',
@@ -160,8 +162,8 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		);
 
 		$expected = array(
-			$fonts[0]['id'] => array_filter( $fonts[0], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
-			$fonts[1]['id'] => array_filter( $fonts[1], fn( $key ) => 'id' !== $key, ARRAY_FILTER_USE_KEY ),
+			$fonts[0]['id'] => $fonts[0],
+			$fonts[1]['id'] => $fonts[1],
 		);
 
 		wp_enqueue_webfonts( $fonts );
@@ -181,6 +183,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		$id = 'source-serif-pro-200-900-normal-local';
 
 		$font = array(
+			'id'           => $id,
 			'provider'     => 'local',
 			'font-family'  => 'Source Serif Pro',
 			'font-style'   => 'normal',
@@ -212,6 +215,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		$id = 'source-serif-pro-200-900-normal-local';
 
 		$font = array(
+			'id'           => $id,
 			'provider'     => 'local',
 			'font-family'  => 'Source Serif Pro',
 			'font-style'   => 'normal',
@@ -342,7 +346,7 @@ class WP_Webfonts_Test extends WP_UnitTestCase {
 		wp_webfonts()->generate_and_enqueue_styles();
 
 		$expected = <<<EOF
-@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');id:source-serif-pro-200-900-normal-local;}
 EOF;
 
 		$this->assertContains(
@@ -387,7 +391,7 @@ EOF;
 		wp_webfonts()->generate_and_enqueue_editor_styles();
 
 		$expected = <<<EOF
-@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');}@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');}
+@font-face{font-family:"Source Serif Pro";font-style:italic;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2') format('woff2');id:source-serif-pro-200-900-italic-local;}@font-face{font-family:"Source Serif Pro";font-style:normal;font-weight:200 900;font-display:fallback;font-stretch:normal;src:local("Source Serif Pro"), url('https://example.com/assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2') format('woff2');id:source-serif-pro-200-900-normal-local;}
 EOF;
 
 		$this->assertContains(


### PR DESCRIPTION
**We've since created an alternative approach that we find preferable to this PR. It can be found here. https://github.com/WordPress/gutenberg/pull/39559**

Part of https://github.com/WordPress/gutenberg/issues/39332. Read https://github.com/WordPress/gutenberg/issues/39332#issuecomment-1065614371 to gather more context about the whole picture regarding the implementation.

## What?

Now that we are not outputting all the registered fonts (#39327), we need to scan the content for actually used fonts and enqueue them. We are placing filters for content, global styles, and templates so we can crawl for webfonts and enqueue them. We are scanning all the post types that stock WordPress exposes through its API.

## Why?

Performance. #39332 has more about it.

## How?

We're hooking into every possible post type and enqueueing the webfonts that they are using. The webfonts found are then put in a cache (which is wiped on save) so it doesn't slow down the rendering process.

The process is a little different for templates and template parts since they might or might not be a post entry: if the template is pristine, there's no post, and the template is read from disk. That's why we cannot use meta attributes for them. Instead, they use a theme mod so the cache is wiped when the theme is switched.

## Testing Instructions

1. Follow the steps on https://github.com/WordPress/gutenberg/pull/39327 to register a webfont;
2. Open the block editor and include a block which allows typography customization;
3. Pick the registered webfont and save the content.

Refresh the page and you should see the custom webfont there. It also works for global styles.

## TODO

- [ ] Tests.