### PR TITLE
[Blocks]: Add flag in `parse` to skip logging migration details from patterns parsing

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1914,7 +1914,9 @@ export const __experimentalGetParsedPattern = createSelector(
 		}
 		return {
 			...pattern,
-			blocks: parse( pattern.content ),
+			blocks: parse( pattern.content, {
+				__unstableSkipMigrationLogs: true,
+			} ),
 		};
 	},
 	( state ) => [ state.settings.__experimentalBlockPatterns ]

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -631,6 +631,7 @@ _Related_
 _Parameters_
 
 -   _content_ `string`: The post content.
+-   _options_ `ParseOptions`: Extra options for handling block parsing.
 
 _Returns_
 

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -51,6 +51,11 @@ import { applyBuiltInValidationFixes } from './apply-built-in-validation-fixes';
  */
 
 /**
+ * @typedef  {Object}  ParseOptions
+ * @property {boolean} __unstableSkipMigrationLogs If a block is migrated from a deprecated version, skip logging the migration details.
+ */
+
+/**
  * Convert legacy blocks to their canonical form. This function is used
  * both in the parser level for previous content and to convert such blocks
  * used in Custom Post Types templates.
@@ -179,11 +184,12 @@ function applyBlockValidation( unvalidatedBlock, blockType ) {
 /**
  * Given a raw block returned by grammar parsing, returns a fully parsed block.
  *
- * @param {WPRawBlock} rawBlock The raw block object.
+ * @param {WPRawBlock}   rawBlock The raw block object.
+ * @param {ParseOptions} options  Extra options for handling block parsing.
  *
  * @return {WPBlock} Fully parsed block.
  */
-export function parseRawBlock( rawBlock ) {
+export function parseRawBlock( rawBlock, options ) {
 	let normalizedBlock = normalizeRawBlock( rawBlock );
 
 	// During the lifecycle of the project, we renamed some old blocks
@@ -214,7 +220,7 @@ export function parseRawBlock( rawBlock ) {
 
 	// Parse inner blocks recursively.
 	const parsedInnerBlocks = normalizedBlock.innerBlocks
-		.map( parseRawBlock )
+		.map( ( innerBlock ) => parseRawBlock( innerBlock, options ) )
 		// See https://github.com/WordPress/gutenberg/pull/17164.
 		.filter( ( innerBlock ) => !! innerBlock );
 
@@ -253,7 +259,11 @@ export function parseRawBlock( rawBlock ) {
 		updatedBlock.__unstableBlockSource = rawBlock;
 	}
 
-	if ( ! validatedBlock.isValid && updatedBlock.isValid ) {
+	if (
+		! validatedBlock.isValid &&
+		updatedBlock.isValid &&
+		! options?.__unstableSkipMigrationLogs
+	) {
 		/* eslint-disable no-console */
 		console.groupCollapsed( 'Updated Block: %s', blockType.name );
 		console.info(
@@ -288,13 +298,14 @@ export function parseRawBlock( rawBlock ) {
  * @see
  * https://developer.wordpress.org/block-editor/packages/packages-block-serialization-default-parser/
  *
- * @param {string} content The post content.
+ * @param {string}       content The post content.
+ * @param {ParseOptions} options Extra options for handling block parsing.
  *
  * @return {Array} Block list.
  */
-export default function parse( content ) {
+export default function parse( content, options ) {
 	return grammarParse( content ).reduce( ( accumulator, rawBlock ) => {
-		const block = parseRawBlock( rawBlock );
+		const block = parseRawBlock( rawBlock, options );
 		if ( block ) {
 			accumulator.push( block );
 		}

--- a/packages/blocks/src/api/parser/test/index.js
+++ b/packages/blocks/src/api/parser/test/index.js
@@ -107,7 +107,7 @@ describe( 'block parser', () => {
 			} );
 			expect( block ).toBeUndefined();
 		} );
-		describe( 'fallback to an older version of the block if the current one is invalid', () => {
+		describe( 'fall back to an older version of the block if the current one is invalid', () => {
 			beforeEach( () => {
 				registerBlockType( 'core/test-block', {
 					...defaultBlockSettings,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently we pre parse the registered block patterns(in browsers idle time) when the editor loads and that often leads to many log messages with migration details for included deprecated versions of blocks. This has been discussed in some other issues and I think @gziolo ' [comment](https://github.com/WordPress/gutenberg/pull/33153#issuecomment-901678163) is spot on:

>Thinking a bit more about it, it’s inevitable that with block patterns we will see more and more of those logs. Maybe, we should be less concerned about successful migrations.

>I see a ton of console.info logs when developing Gutenberg. It's inevitable to see the growing number of (successful) validation logs with the growing number of block patterns in the directory. I doubt that those patterns are going to be updated often after they get submitted. Well, I think it's great that they work fine even when core blocks update the output format.

>What worries me here, that those logs come from the preview in the block inserter the block patterns parsing that isn't related to the content used on the site. I don't think we should be really reporting those issues on production as they bring only confusion. What matters here is if they get correctly inserted into the content/template. 

<!-- In a few words, what is the PR actually doing? -->

## How?
This PR introduces a flag (`__unstableSkipMigrationLogs`) for `parse` function to be able to skip the logs from migrations and is used when patterns are parsed. I intentionally made it `unstable` to 'discourage' its usage, as I think this information is valuable, but with patterns it's a special case because their content is usually out of the control of the end user.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Load the editor and observe that the migration logs from patterns are not shown
2. Migration logs from existing content or by pasting a deprecated version of a block should be created

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="1256" alt="Screenshot 2022-03-12 at 10 32 55 AM" src="https://user-images.githubusercontent.com/16275880/158011644-5b361252-60ec-4c00-b78b-85f744b216c0.png">



### After

https://user-images.githubusercontent.com/16275880/158011647-1073a028-de36-46dc-b515-56164f757a25.mov


