### PR TITLE
Bind featured image to cover and image blocks

### DIFF
--- a/packages/edit-post/src/hooks/components/index.js
+++ b/packages/edit-post/src/hooks/components/index.js
@@ -58,14 +58,17 @@ const addFeaturedImageToolbarItem = createHigherOrderComponent(
 				}
 			}, [ mediaUrl ] );
 
-			if ( 'core/image' !== blockName && 'core/cover' !== blockName ) {
+			if (
+				( 'core/image' !== blockName && 'core/cover' !== blockName ) ||
+				! mediaUrl
+			) {
 				return <BlockEdit { ...props } />;
 			}
 			return (
 				<>
 					<BlockControls group="other">
 						<ToolbarButton
-							icon={ group }
+							icon={ group /*this is temporary*/ }
 							label={ __( 'Use featured image' ) }
 							onClick={ () => {
 								setBindFeaturedImage( ! bindFeaturedImage );

--- a/packages/edit-post/src/hooks/components/index.js
+++ b/packages/edit-post/src/hooks/components/index.js
@@ -1,8 +1,16 @@
 /**
  * WordPress dependencies
  */
+import { useEffect, useState } from '@wordpress/element';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
 import { MediaUpload } from '@wordpress/media-utils';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { group } from '@wordpress/icons';
+import { BlockControls } from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 const replaceMediaUpload = () => MediaUpload;
 
@@ -10,4 +18,71 @@ addFilter(
 	'editor.MediaUpload',
 	'core/edit-post/replace-media-upload',
 	replaceMediaUpload
+);
+
+function getMediaSourceUrlBySizeSlug( media, slug ) {
+	return (
+		media?.media_details?.sizes?.[ slug ]?.source_url || media?.source_url
+	);
+}
+
+const addFeaturedImageToolbarItem = createHigherOrderComponent(
+	( BlockEdit ) => {
+		return ( props ) => {
+			const { attributes, setAttributes, name: blockName } = props;
+
+			const [ bindFeaturedImage, setBindFeaturedImage ] = useState(
+				false
+			);
+
+			const { sizeSlug } = attributes;
+			const [ featuredImage ] = useEntityProp(
+				'postType',
+				'post',
+				'featured_media'
+			);
+
+			const media = useSelect(
+				( select ) =>
+					featuredImage &&
+					select( coreStore ).getMedia( featuredImage, {
+						context: 'view',
+					} ),
+				[ featuredImage ]
+			);
+			const mediaUrl = getMediaSourceUrlBySizeSlug( media, sizeSlug );
+
+			useEffect( () => {
+				if ( bindFeaturedImage ) {
+					setAttributes( { url: mediaUrl } );
+				}
+			}, [ mediaUrl ] );
+
+			if ( 'core/image' !== blockName && 'core/cover' !== blockName ) {
+				return <BlockEdit { ...props } />;
+			}
+			return (
+				<>
+					<BlockControls group="other">
+						<ToolbarButton
+							icon={ group }
+							label={ __( 'Use featured image' ) }
+							onClick={ () => {
+								setBindFeaturedImage( ! bindFeaturedImage );
+								setAttributes( { url: mediaUrl } );
+							} }
+						/>
+					</BlockControls>
+					<BlockEdit { ...props } />
+				</>
+			);
+		};
+	},
+	'addFeaturedImageToolbarItem'
+);
+
+addFilter(
+	'editor.BlockEdit',
+	'my-plugin/with-inspector-controls',
+	addFeaturedImageToolbarItem
 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #13795 and advances #37753.

## Why?
We need ways to use featured image when doing page building, as well as site building, via core blocks.

## How?
I implemented an extension via a block edit filter in the edit post package for the cover and image blocks. Doing it this way preserves the agnostic behavior of blocks in the block library (not WordPress specific) and gives us easy access to the entity data of the current post.

It is yet unclear:

- if we want to also SET the featured image from these blocks
- if we want to also update the rendering when the featured image is changed from 3rd party sources (like a plugin updating it). Currently if updated via the post editor the connected blocks auto-update.

## Testing Instructions

1. Switch to this PR
2. In a new post
3. Insert an image and/or a cover block
4. Set them to some image
5. From the inspector click on the top "Post" tab
6. Scroll down to Advanced and click on it
7. From the Set featured .. button set a featured image
8. Select the block(s) you added at (3)
9. In the Block toolbar next to Replace a new button (with a group icon for now) wills show
10. Click this button
11. The featured image should appear in the block

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/107534/158062391-07e015cf-e7a4-43f6-96cd-fac22724d053.mp4


