### PR TITLE
Pullquote block: Remove deprecated pullquote style

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -47,11 +47,6 @@
 }
 
 // .is-style-solid-color is deprecated.
-.wp-block-pullquote:not(.is-style-solid-color) {
-	background: none;
-}
-
-// .is-style-solid-color is deprecated.
 .wp-block-pullquote.is-style-solid-color {
 	border: none;
 	blockquote {


### PR DESCRIPTION
The `.is-style-solid-color` pullquote style has been deprecated for some time. However, in the `style.css` file for the pullquote block, there was also a deprecated style for every other pullquote without this class (i.e. `.wp-block-pullquote:not(.is-style-solid-color){...}`). This is problematic and prevents you from setting the background color for pullquotes in `theme.json`.

This PR leaves the deprecated styles for `.is-style-solid-color` intact, but removes any other styling that impacts other pullquote blocks. The `.is-style-solid-color` styling is left untouched in case there are still some users utilizing this. That said, complete removal should be considered in the future. 

## Testing Instructions
1. Use the Twenty Twenty-Two theme.
2. In `theme.json` apply a background color to pullquote blocks. 
3. Navigate to a page/post and add a pull quote. You should see the background color set in `theme.json`.
4. Navigate to the frontend and the background color should also be present (without this PR, the color is missing)
5. Change the background color in the Editor and confirm that it changes both in the Editor and on the Frontend.

Example code for adding a background color in theme.json. 

```
"core/pullquote": {
	"color": {
		"background": "#ff0000"
	}
}
```