### PR TITLE
Pullquote block: Fix citation markup in Editor

### DIFF
--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -69,7 +69,7 @@ function PullQuoteEdit( {
 					{ shouldShowCitation && (
 						<RichText
 							identifier="citation"
-					 		tagName={ isWebPlatform ? 'cite' : undefined }
+							tagName={ isWebPlatform ? 'cite' : undefined }
 							style={ { display: 'block' } }
 							value={ citation }
 							aria-label={ __( 'Pullquote citation text' ) }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -14,6 +14,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
+import { Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,9 +22,7 @@ import { createBlock } from '@wordpress/blocks';
 import { Figure } from './figure';
 import { BlockQuote } from './blockquote';
 
-/**
- * Internal dependencies
- */
+const isWebPlatform = Platform.OS === 'web';
 
 function PullQuoteEdit( {
 	attributes,
@@ -70,6 +69,8 @@ function PullQuoteEdit( {
 					{ shouldShowCitation && (
 						<RichText
 							identifier="citation"
+					 		tagName={ isWebPlatform ? 'cite' : undefined }
+							style={ { display: 'block' } }
 							value={ citation }
 							aria-label={ __( 'Pullquote citation text' ) }
 							placeholder={


### PR DESCRIPTION
## What?
This PR changes the pullquote citation markup in the Editor from `<div>` to `<cite>` to improve consistency between the Editor and Frontend. The Frontend already uses `<cite>`.

## Why?
This bug appears to have been an oversight, the quote block already has this fix. This PR copies the quote block implementation exactly. 

## Testing Instructions
1. Add a pullquote block to a page/post. 
2. Confirm the citation markup in the Editor is `<cite>`, and so is the Frontend. 

Props to @mrleemon for the original PR: #38610