### PR TITLE
Fix experimental full site editing blocks not being registered

### DIFF
--- a/lib/load.php
+++ b/lib/load.php
@@ -61,6 +61,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 require __DIR__ . '/compat.php';
 require __DIR__ . '/compat/wordpress-5.9/widget-render-api-endpoint/index.php';
 require __DIR__ . '/compat/wordpress-5.9/blocks.php';
+require __DIR__ . '/compat/wordpress-5.9/block-editor-settings.php';
 require __DIR__ . '/compat/wordpress-5.9/block-patterns.php';
 require __DIR__ . '/compat/wordpress-5.9/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-5.9/default-editor-styles.php';


### PR DESCRIPTION
## What?
Fixes a an issue introduced in #39180 - experimental full site editing blocks were not being registered.

Props to @michalczaplinski for noticing this and finding the PR that introduced the bug.

## Why?
In #39180, some block settings were moved to a new file the wordpress-5.9 folder. 

The issue is that this file wasn't being loaded, so the editor settings (which included `__unstableEnableFullSiteEditingBlocks`) were not being applied.

## How?
Added a new line to the `load.php` to require the file.

## Testing Instructions
1. Open the post editor
2. Try adding a `comments-query-loop` block

Expected: The block should be available and can be added.