### PR TITLE
Block Title: remove truncate discrimination

### DIFF
--- a/docs/getting-started/create-block/block-anatomy.md
+++ b/docs/getting-started/create-block/block-anatomy.md
@@ -60,7 +60,7 @@ Most of the properties are set in the `block.json` file.
 }
 ```
 
-The **title** is the title of the block shown in the Inserter.
+The **title** is the title of the block shown in the Inserter and in other areas of the editor.
 
 The **icon** is the icon shown in the Inserter. The icon property expects any Dashicon name as a string, see [list of available icons](https://developer.wordpress.org/resource/dashicons/). You can also provide an SVG object, but for now it's easiest to just pick a Dashicon name.
 

--- a/docs/reference-guides/block-api/block-metadata.md
+++ b/docs/reference-guides/block-api/block-metadata.md
@@ -172,7 +172,9 @@ The name for a block is a unique string that identifies a block. Names have to b
 { "title": "Heading" }
 ```
 
-This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name.
+This is the display title for your block, which can be translated with our translation functions. The title will display in the Inserter and in other areas of the editor.
+
+**Note:** To keep your block titles readable and accessible in the UI, try to avoid very long titles.
 
 ### Category
 

--- a/docs/reference-guides/block-api/block-registration.md
+++ b/docs/reference-guides/block-api/block-registration.md
@@ -35,12 +35,14 @@ A block requires a few properties to be specified before it can be registered su
 
 -   **Type:** `String`
 
-This is the display title for your block, which can be translated with our translation functions. The block inserter will show this name.
+This is the display title for your block, which can be translated with our translation functions. The title will display in the Inserter and in other areas of the editor. 
 
 ```js
 // Our data object
 title: __( 'Book' );
 ```
+
+_Note:_ To keep your block titles readable and accessible in the UI, try to avoid very long titles.
 
 #### description (optional)
 

--- a/packages/block-editor/src/components/block-title/README.md
+++ b/packages/block-editor/src/components/block-title/README.md
@@ -26,7 +26,5 @@ The client ID of a block.
 
 The maximum length that the block title string may be before truncated. If `undefined` no truncation will take place.
 
-Truncation only affects contextual titles, for example block variation and reusable block labels. Display titles specified in the block's metadata will not be truncated even if a valid `maximumLength` value is passed.
-
 -   Type: `Number`
 -   Required: No

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -26,6 +26,9 @@ jest.mock( '@wordpress/blocks', () => {
 				case 'name-with-label':
 					return { title: 'Block With Label' };
 
+				case 'name-with-custom-label':
+					return { title: 'Block With Custom Label' };
+
 				case 'name-with-long-label':
 					return { title: 'Block With Long Label' };
 			}
@@ -37,6 +40,9 @@ jest.mock( '@wordpress/blocks', () => {
 
 				case 'Block With Long Label':
 					return 'This is a longer label than typical for blocks to have.';
+
+				case 'Block With Custom Label':
+					return 'A Custom Label like a Block Variation Label';
 
 				default:
 					return title;
@@ -61,7 +67,7 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 } );
 
 describe( 'BlockTitle', () => {
-	it( 'renders nothing if name is falsey2', () => {
+	it( 'renders nothing if name is falsey', () => {
 		useSelect.mockImplementation( () => ( {
 			name: null,
 			attributes: null,
@@ -104,6 +110,42 @@ describe( 'BlockTitle', () => {
 		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
 
 		expect( wrapper.text() ).toBe( 'Test Label' );
+	} );
+
+	it( 'should prioritize reusable block title over title', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-label',
+			reusableBlockTitle: 'Reuse me!',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+
+		expect( wrapper.text() ).toBe( 'Reuse me!' );
+	} );
+
+	it( 'should prioritize block label over title', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-custom-label',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+
+		expect( wrapper.text() ).toBe(
+			'A Custom Label like a Block Variation Label'
+		);
+	} );
+
+	it( 'should default to block information title if no reusable title or block name is available', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'some-rando-name',
+			attributes: null,
+		} ) );
+
+		const wrapper = shallow( <BlockTitle clientId="id-name-with-label" /> );
+
+		expect( wrapper.text() ).toBe( 'Block With Label' );
 	} );
 
 	it( 'truncates the label with custom truncate length', () => {

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -70,14 +70,17 @@ export default function useBlockDisplayTitle( clientId, maximumLength ) {
 	const blockLabel = blockType
 		? getBlockLabel( blockType, attributes )
 		: null;
+
 	const label = reusableBlockTitle || blockLabel;
 	// Label will fallback to the title if no label is defined for the current
-	// label context. If the label is defined we prioritize it over possible
+	// label context. If the label is defined we prioritize it over a
 	// possible block variation title match.
-	if ( label && label !== blockType.title ) {
-		return maximumLength && maximumLength > 0
-			? truncate( label, { length: maximumLength } )
-			: label;
+	const blockTitle =
+		label && label !== blockType.title ? label : blockInformation.title;
+
+	if ( maximumLength && maximumLength > 0 ) {
+		return truncate( blockTitle, { length: maximumLength } );
 	}
-	return blockInformation.title;
+
+	return blockTitle;
 }


### PR DESCRIPTION
## What?
This PR truncates all block labels/titles returned from the BlockTitle hook, where  a `maximumLength` prop is passed.

The consequence is that all block titles will be truncated, including core block title metadata. 

We're also adding unit tests that test the priority of block labels.

Finally, I've updated the documentation to recommend against longer block titles as advised in https://github.com/WordPress/gutenberg/pull/39110#issuecomment-1053963593


## Why?
Previously only contextual block labels such as reusable block labels or block variation were truncated.

@gziolo rightly posed the question:

> What if the block title has 100 characters? 😄
> Maybe we should also truncate it for consistency when someone explicitly passes this parameter.

https://github.com/WordPress/gutenberg/pull/39110#discussion_r823466526

## How?

Calling `truncate()` where a `maximumLength` is passed.

## Testing Instructions

Block titles appearing in the Editor Breadcrumb (at the bottom), Block settings Dropdowns, List view labels and Block Toolbar labels should appear as expected.

- In the editor, create a reusable block, preferably with a long name such as `A really really really long name that doesn't really mean much but might be truncated if it all some time if we happen to care`
- Insert a Row block (which is a Group block variation)
- Insert a regular Group block
- Check that the contextual labels (reusable, block variation) take priority over the core title (e.g., Group)
- Check that the truncation still works for very long titles
- Smoke test block titles in another local. I tried Arabic, Russian and German. 

<img width="599" alt="Screen Shot 2022-03-14 at 2 25 44 pm" src="https://user-images.githubusercontent.com/6458278/158100959-4cf58438-a6b3-4409-a09f-f80a7df8c1d4.png">
<img width="683" alt="Screen Shot 2022-03-14 at 2 45 36 pm" src="https://user-images.githubusercontent.com/6458278/158101474-7d3d806e-bb89-41dd-b7e7-9d94a9429d99.png">

<img width="384" alt="Screen Shot 2022-03-14 at 2 44 33 pm" src="https://user-images.githubusercontent.com/6458278/158101285-406bbb7d-7271-45b5-9695-4ebecd6afb11.png">

