### PR TITLE
Fix center aligned images styles

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -62,8 +62,9 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= "$selector .alignfull { max-width: none; }";
 		}
 
-		$style .= "$selector .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }";
-		$style .= "$selector .alignright { float: right; margin-inline-start: 2em; margin-inline-end: 0; }";
+		$style .= "$selector > .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }";
+		$style .= "$selector > .alignright { float: right; margin-inline-start: 2em; margin-inline-end: 0; }";
+		$style .= "$selector > .aligncenter { margin-left: auto !important; margin-right: auto !important; }";
 		if ( $has_block_gap_support ) {
 			$gap_style = $gap_value ? $gap_value : 'var( --wp--style--block-gap )';
 			$style    .= "$selector > * { margin-block-start: 0; margin-block-end: 0; }";

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -143,6 +143,11 @@ export default {
 				margin-inline-start: 2em;
 				margin-inline-end: 0;
 			}
+
+			${ appendSelectors( selector, '> .aligncenter' ) } {
+				margin-left: auto !important;
+				margin-right: auto !important;
+			}
 		`;
 
 		if ( hasBlockGapStylesSupport ) {

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -39,6 +39,7 @@
 			"__experimentalDefaultControls": {
 				"padding": true
 			}
-		}
+		},
+		"__experimentalLayout": true
 	}
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -58,6 +58,7 @@
 		margin-bottom: 0.5em;
 	}
 
+	// This is needed for classic themes where the align class is not on the container.
 	.aligncenter {
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
closes #39291 

## What?

Centered image blocks inside containers (group blocks) in a block theme were not centered properly. This PR fixes that.

## How?

The "flow" (default) layout didn't have explicit styles for centered blocks that said, the default rule targeting all children implicitly targeted the centered blocks and added margin autos. That default rule is mainly there for wide/full aligned blocks. That said, that default rule is conditionally rendered, it's only added if the layout of the current container defines "widths", meaning it supports wide and full widths and has a centered content area. 

So the PR defines an explicit rule adding the margins for centered aligned blocks.

## Testing Instructions

1- Insert a group block
2- Insert an image block inside that group block
3- Resize the image so it's small
4- Center the image block
5- It should appear centered on both frontend and editor.

Ideally we should test on different themes (classic and block themes)

