### PR TITLE
Optimize block parser by avoiding repeated HTML parsing and matcher creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16299,6 +16299,7 @@
 				"colord": "^2.7.0",
 				"hpq": "^1.3.0",
 				"lodash": "^4.17.21",
+				"memize": "^1.1.0",
 				"rememo": "^3.0.0",
 				"showdown": "^1.9.1",
 				"simple-html-tokenizer": "^0.5.7",

--- a/packages/block-editor/src/hooks/anchor.js
+++ b/packages/block-editor/src/hooks/anchor.js
@@ -25,6 +25,13 @@ import { InspectorControls } from '../components';
  */
 const ANCHOR_REGEX = /[\s#]/g;
 
+const ANCHOR_SCHEMA = {
+	type: 'string',
+	source: 'attribute',
+	attribute: 'id',
+	selector: '*',
+};
+
 /**
  * Filters registered block settings, extending attributes with anchor using ID
  * of the first node.
@@ -42,12 +49,7 @@ export function addAttribute( settings ) {
 		// Gracefully handle if settings.attributes is undefined.
 		settings.attributes = {
 			...settings.attributes,
-			anchor: {
-				type: 'string',
-				source: 'attribute',
-				attribute: 'id',
-				selector: '*',
-			},
+			anchor: ANCHOR_SCHEMA,
 		};
 	}
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -264,7 +264,7 @@ Returns the block attributes of a registered block node given its type.
 _Parameters_
 
 -   _blockTypeOrName_ `string|Object`: Block type or name.
--   _innerHTML_ `string`: Raw block content.
+-   _innerHTML_ `string|Node`: Raw block content.
 -   _attributes_ `?Object`: Known block attributes (from delimiters).
 
 _Returns_
@@ -643,7 +643,7 @@ value depending on its source.
 
 _Parameters_
 
--   _innerHTML_ `string`: Block's raw content.
+-   _innerHTML_ `string|Node`: Block's raw content.
 -   _attributeSchema_ `Object`: Attribute's schema.
 
 _Returns_

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -45,6 +45,7 @@
 		"colord": "^2.7.0",
 		"hpq": "^1.3.0",
 		"lodash": "^4.17.21",
+		"memize": "^1.1.0",
 		"rememo": "^3.0.0",
 		"showdown": "^1.9.1",
 		"simple-html-tokenizer": "^0.5.7",

--- a/packages/blocks/src/api/parser/fix-custom-classname.js
+++ b/packages/blocks/src/api/parser/fix-custom-classname.js
@@ -10,6 +10,13 @@ import { hasBlockSupport } from '../registration';
 import { getSaveContent } from '../serializer';
 import { parseWithAttributeSchema } from './get-block-attributes';
 
+const CLASS_ATTR_SCHEMA = {
+	type: 'string',
+	source: 'attribute',
+	selector: '[data-custom-class-name] > *',
+	attribute: 'class',
+};
+
 /**
  * Given an HTML string, returns an array of class names assigned to the root
  * element in the markup.
@@ -19,14 +26,10 @@ import { parseWithAttributeSchema } from './get-block-attributes';
  * @return {string[]} Array of class names assigned to the root element.
  */
 export function getHTMLRootElementClasses( innerHTML ) {
-	innerHTML = `<div data-custom-class-name>${ innerHTML }</div>`;
-
-	const parsed = parseWithAttributeSchema( innerHTML, {
-		type: 'string',
-		source: 'attribute',
-		selector: '[data-custom-class-name] > *',
-		attribute: 'class',
-	} );
+	const parsed = parseWithAttributeSchema(
+		`<div data-custom-class-name>${ innerHTML }</div>`,
+		CLASS_ATTR_SCHEMA
+	);
 
 	return parsed ? parsed.trim().split( /\s+/ ) : [];
 }

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -3,6 +3,7 @@
  */
 import { parse as hpqParse } from 'hpq';
 import { flow, mapValues, castArray } from 'lodash';
+import memoize from 'memize';
 
 /**
  * WordPress dependencies
@@ -179,26 +180,6 @@ export function isValidByType( value, type ) {
  */
 export function isValidByEnum( value, enumSet ) {
 	return ! Array.isArray( enumSet ) || enumSet.includes( value );
-}
-
-/**
- * Memoize one-parameter function using a WeakMap.
- *
- * @param {Function} fn Function to memoize.
- *
- * @return {Function} The same function memoized.
- */
-function memoize( fn ) {
-	const cache = new WeakMap();
-
-	return function ( param ) {
-		let result = cache.get( param );
-		if ( result === undefined ) {
-			result = fn( param );
-			cache.set( param, result );
-		}
-		return result;
-	};
 }
 
 /**

--- a/packages/blocks/src/api/parser/get-block-attributes.js
+++ b/packages/blocks/src/api/parser/get-block-attributes.js
@@ -182,13 +182,33 @@ export function isValidByEnum( value, enumSet ) {
 }
 
 /**
+ * Memoize one-parameter function using a WeakMap.
+ *
+ * @param {Function} fn Function to memoize.
+ *
+ * @return {Function} The same function memoized.
+ */
+function memoize( fn ) {
+	const cache = new WeakMap();
+
+	return function ( param ) {
+		let result = cache.get( param );
+		if ( result === undefined ) {
+			result = fn( param );
+			cache.set( param, result );
+		}
+		return result;
+	};
+}
+
+/**
  * Returns an hpq matcher given a source object.
  *
  * @param {Object} sourceConfig Attribute Source object.
  *
  * @return {Function} A hpq Matcher.
  */
-export function matcherFromSource( sourceConfig ) {
+export const matcherFromSource = memoize( ( sourceConfig ) => {
 	switch ( sourceConfig.source ) {
 		case 'attribute':
 			let matcher = attr( sourceConfig.selector, sourceConfig.attribute );
@@ -221,7 +241,7 @@ export function matcherFromSource( sourceConfig ) {
 			// eslint-disable-next-line no-console
 			console.error( `Unknown source type "${ sourceConfig.source }"` );
 	}
-}
+} );
 
 /**
  * Parse a HTML string into DOM tree.


### PR DESCRIPTION
Two simple optimizations of the block parser that lead to significant speed improvement. The [large-post.html](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/assets/large-post.html) sample post (1000+ blocks) took 600ms to parse before this patch, now it takes only 340ms.

- `getBlockAttributes` parses HTML only once: before this patch, each inner `getBlockAttribute` call parsed the block HTML again before selecting a target value from the parsed DOM. This patch optimizes that to parse only once. Makes use of the fact that `hpq()` is an identity when called with an already parsed DOM node
- `matcherFromSource` that converts a `schema` object to a matcher function used to be called 3900 times on the `large-post.html`, although there are only 41 unique attribute schemas. I speeded up the parser by memoizing by the `schema` object argument. There are two places where I extracted a schema to a separate variable to make it referentially unique. After this memoization, there are only 75 unique schemas. The difference between 41 and 75 is caused by some identical schemas to be defined multiple times, for example, in `block.json` files.