### PR TITLE
Add @michalczaplinski to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,8 @@
 /packages/block-library/src/navigation-link     @tellthemachines
 /packages/block-library/src/navigation-submenu  @tellthemachines
 /packages/block-library/src/page-list           @tellthemachines
+/packages/block-library/src/comment-template    @michalczaplinski
+/packages/block-library/src/comments-query-loop @michalczaplinski
 
 # Duotone
 /lib/block-supports/duotone.php                       @ajlende


### PR DESCRIPTION
Adding myself as code owner for the `comment-template` and `comments-query-loop` core blocks.