### PR TITLE
Media Utils: Don't convert error messages into an array

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -130,9 +130,7 @@ function CoverEdit( {
 	const isUploadingMedia = isTemporaryMedia( id, url );
 
 	const onUploadError = ( message ) => {
-		createErrorNotice( Array.isArray( message ) ? message[ 2 ] : message, {
-			type: 'snackbar',
-		} );
+		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
 	const mediaElement = useRef();

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -118,7 +118,7 @@ function PostFeaturedImageDisplay( {
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const onUploadError = ( message ) => {
-		createErrorNotice( message[ 2 ], { type: 'snackbar' } );
+		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
 	const controls = (

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -469,7 +469,7 @@ export default function LogoEdit( {
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const onUploadError = ( message ) => {
-		createErrorNotice( message[ 2 ], { type: 'snackbar' } );
+		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
 	const controls = canUserEdit && logoUrl && (

--- a/packages/media-utils/CHANGELOG.md
+++ b/packages/media-utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+-   The `onError` now always receives the `message` as a string ([#39448](https://github.com/WordPress/gutenberg/pull/39448)).
+
 ## 3.6.0 (2022-05-04)
 
 ## 3.5.0 (2022-04-21)

--- a/packages/media-utils/src/utils/upload-media.js
+++ b/packages/media-utils/src/utils/upload-media.js
@@ -104,17 +104,6 @@ export async function uploadMedia( {
 		return includes( allowedMimeTypesForUser, fileType );
 	};
 
-	// Build the error message including the filename.
-	const triggerError = ( error ) => {
-		error.message = [
-			<strong key="filename">{ error.file.name }</strong>,
-			': ',
-			error.message,
-		];
-
-		onError( error );
-	};
-
 	const validFiles = [];
 
 	for ( const mediaFile of files ) {
@@ -125,7 +114,7 @@ export async function uploadMedia( {
 			mediaFile.type &&
 			! isAllowedMimeTypeForUser( mediaFile.type )
 		) {
-			triggerError( {
+			onError( {
 				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
 				message: __(
 					'Sorry, you are not allowed to upload this file type.'
@@ -138,7 +127,7 @@ export async function uploadMedia( {
 		// Check if the block supports this mime type.
 		// Defer to the server when type not detected.
 		if ( mediaFile.type && ! isAllowedType( mediaFile.type ) ) {
-			triggerError( {
+			onError( {
 				code: 'MIME_TYPE_NOT_SUPPORTED',
 				message: __( 'Sorry, this file type is not supported here.' ),
 				file: mediaFile,
@@ -148,7 +137,7 @@ export async function uploadMedia( {
 
 		// Verify if file is greater than the maximum file upload size allowed for the site.
 		if ( maxUploadFileSize && mediaFile.size > maxUploadFileSize ) {
-			triggerError( {
+			onError( {
 				code: 'SIZE_ABOVE_LIMIT',
 				message: __(
 					'This file exceeds the maximum upload size for this site.'
@@ -160,7 +149,7 @@ export async function uploadMedia( {
 
 		// Don't allow empty files to be uploaded.
 		if ( mediaFile.size <= 0 ) {
-			triggerError( {
+			onError( {
 				code: 'EMPTY_FILE',
 				message: __( 'This file is empty.' ),
 				file: mediaFile,

--- a/packages/media-utils/src/utils/upload-media.js
+++ b/packages/media-utils/src/utils/upload-media.js
@@ -116,8 +116,12 @@ export async function uploadMedia( {
 		) {
 			onError( {
 				code: 'MIME_TYPE_NOT_ALLOWED_FOR_USER',
-				message: __(
-					'Sorry, you are not allowed to upload this file type.'
+				message: sprintf(
+					// translators: %s: file name.
+					__(
+						'%s: Sorry, you are not allowed to upload this file type.'
+					),
+					mediaFile.name
 				),
 				file: mediaFile,
 			} );
@@ -129,7 +133,11 @@ export async function uploadMedia( {
 		if ( mediaFile.type && ! isAllowedType( mediaFile.type ) ) {
 			onError( {
 				code: 'MIME_TYPE_NOT_SUPPORTED',
-				message: __( 'Sorry, this file type is not supported here.' ),
+				message: sprintf(
+					// translators: %s: file name.
+					__( '%s: Sorry, this file type is not supported here.' ),
+					mediaFile.name
+				),
 				file: mediaFile,
 			} );
 			continue;
@@ -139,8 +147,12 @@ export async function uploadMedia( {
 		if ( maxUploadFileSize && mediaFile.size > maxUploadFileSize ) {
 			onError( {
 				code: 'SIZE_ABOVE_LIMIT',
-				message: __(
-					'This file exceeds the maximum upload size for this site.'
+				message: sprintf(
+					// translators: %s: file name.
+					__(
+						'%s: This file exceeds the maximum upload size for this site.'
+					),
+					mediaFile.name
 				),
 				file: mediaFile,
 			} );
@@ -151,7 +163,11 @@ export async function uploadMedia( {
 		if ( mediaFile.size <= 0 ) {
 			onError( {
 				code: 'EMPTY_FILE',
-				message: __( 'This file is empty.' ),
+				message: sprintf(
+					// translators: %s: file name.
+					__( '%s: This file is empty.' ),
+					mediaFile.name
+				),
 				file: mediaFile,
 			} );
 			continue;


### PR DESCRIPTION
## What?
It makes the message type passed to the `onError` callback consistent.

## Why?
Based on usage in the core, messages are cast back to the strings, or the actual message part is extracted from the array. Returning single type should improve the developer experience.

## How?
I've removed the `triggerError` helper, and now messages errors are directly passed into the `onError` callback.

I searched WP Directory/GitHub. Based on the results, this change shouldn't cause any breakage.

## Testing Instructions
Tests should pass.
