### PR TITLE
Eslint: Exempt TS files from `jsdoc/require-param`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,10 +249,13 @@ module.exports = {
 			},
 		},
 		{
-			files: [ '**/@(storybook|stories)/*', '**/*.{ts,tsx}' ],
+			files: [
+				'**/@(storybook|stories)/*',
+				'packages/components/src/**/*.{ts,tsx}',
+			],
 			rules: {
 				// Useful to add story descriptions via JSDoc without specifying params,
-				// or in TypeScript files where the param types are already specified outside of the JSDoc.
+				// or in TypeScript files where params are likely already documented outside of the JSDoc.
 				'jsdoc/require-param': 'off',
 			},
 		},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -251,7 +251,7 @@ module.exports = {
 		{
 			files: [
 				'**/@(storybook|stories)/*',
-				'packages/components/src/**/*.{ts,tsx}',
+				'packages/components/src/**/*.tsx',
 			],
 			rules: {
 				// Useful to add story descriptions via JSDoc without specifying params,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,9 +249,10 @@ module.exports = {
 			},
 		},
 		{
-			files: [ '**/@(storybook|stories)/*' ],
+			files: [ '**/@(storybook|stories)/*', '**/*.{ts,tsx}' ],
 			rules: {
-				// Useful to add story descriptions via JSdoc without specifying params.
+				// Useful to add story descriptions via JSDoc without specifying params,
+				// or in TypeScript files where the param types are already specified outside of the JSDoc.
 				'jsdoc/require-param': 'off',
 			},
 		},


### PR DESCRIPTION
## What?

Exempts TypeScript files from the [`jsdoc/require-param`](https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-param.md) rule.

## Why?

TypeScript files generally have their type information in code rather than in JSDoc comments. The `jsdoc/require-param` rule requires all params to be documented in the JSDoc, which would be redundant in these cases.

For example, `jsdoc/require-param` would consider this an error, because `props` is not documented in the comment:

```ts
/**
 * This is Foo
 */
export function Foo( props: Props ) { ... }
```

## Testing Instructions

- Simple doc comments like the above should not trigger eslint errors in TS files.
- The behavior remains the same for `.js` files.