### PR TITLE
Add an empty list block v2

### DIFF
--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -159,3 +159,14 @@ if ( ! function_exists( 'gutenberg_rest_comment_set_children_as_embeddable' ) ) 
 	}
 }
 add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );
+
+/**
+ * Sets a global JS variable used to trigger the availability of the experimental list block.
+ */
+function gutenberg_enable_experimental_list_block() {
+	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-list-v2', get_option( 'gutenberg-experiments' ) ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableListBlockV2 = true', 'before' );
+	}
+}
+
+add_action( 'admin_init', 'gutenberg_enable_experimental_list_block' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -58,7 +58,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enable List block v2 (with inner blocks)', 'gutenberg' ),
+			'label' => __( 'Test a new list block that uses nested list item blocks (Warning: The new block is not ready. You may experience content loss, avoid using it on production sites)', 'gutenberg' ),
 			'id'    => 'gutenberg-list-v2',
 		)
 	);

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -51,6 +51,17 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-navigation',
 		)
 	);
+	add_settings_field(
+		'gutenberg-list-v2',
+		__( 'List block v2', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable List block v2 (with inner blocks)', 'gutenberg' ),
+			'id'    => 'gutenberg-list-v2',
+		)
+	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -11,12 +11,13 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import settingsV2 from './v2';
 
 const { name } = metadata;
 
 export { metadata, name };
 
-export const settings = {
+const settingsV1 = {
 	icon,
 	example: {
 		attributes: {
@@ -41,3 +42,7 @@ export const settings = {
 	save,
 	deprecated,
 };
+
+export const settings = window.__experimentalEnableListBlockV2
+	? settingsV2
+	: settingsV1;

--- a/packages/block-library/src/list/index.js
+++ b/packages/block-library/src/list/index.js
@@ -43,6 +43,6 @@ const settingsV1 = {
 	deprecated,
 };
 
-export const settings = window.__experimentalEnableListBlockV2
+export const settings = window?.__experimentalEnableListBlockV2
 	? settingsV2
 	: settingsV1;

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -1,0 +1,5 @@
+function Edit() {
+	return <div>List block v2</div>;
+}
+
+export default Edit;

--- a/packages/block-library/src/list/v2/index.js
+++ b/packages/block-library/src/list/v2/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { list as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
+const settings = {
+	icon,
+	edit,
+	save,
+};
+
+export default settings;

--- a/packages/block-library/src/list/v2/save.js
+++ b/packages/block-library/src/list/v2/save.js
@@ -1,0 +1,5 @@
+function Save() {
+	return <div>List block v2</div>;
+}
+
+export default Save;


### PR DESCRIPTION
Related #6394

## What?

This is a PR that adds a v2 version to the list block that you can trigger using an experimental flag on the "experiments" page of the Gutenberg Plugin. For now, that list block does nothing, it's just a static block rendering a div. The idea is to use this as a placeholder to iterate on the list block described in #6394, the main point being that it should use inner blocks for list items.

## Why?

Building a list block with inner blocks is going to be a complex task that will take several PRs and iterations until success (or not). So we need a safe place to iterate on the block, get some feedback, make breaking changes... without breaking production websites. 

## How?

I think a similar approach with a unique block that changes behavior depending on an experimental flag has been used before for the Gallery block refactor. Would love some eyes and thoughts from folks who worked on that to assess the pros/cons here. cc @andrewserong @aaronrobertshaw @glendaviesnz 

**Notes**

I hesitated about whether to push the PR further and start adding some real logic (inner blocks) but decided that there's a merit to discuss and land the "placeholder empty block" on its own first.

## Testing Instructions

1- Open the experiments page under "Gutenberg" menu item
2- Enable the list block v2 flag
3- Go back to the editor
4- Check that inserting a list block gives just a static div for now.
