### PR TITLE
solved image left and right align issue

### DIFF
--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,5 @@
 .wp-block-group {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	display: flow-root;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
There was an issue in the left and right alignment of the image when the image is placed in the group block. So I made a fix for it.

## Why?
the image is placed in the group block and then when we set the image to left or right alignment the issue is happening so I found a display issue in the wp-group-block class. So I made a fix for it by adding display: flow-root.

## Testing Instructions
1. Theme should be Twenty Twenty-Two, Add group block and set some background color to group block.
2. Add an image in the group block.
3. Set the image size to see the left and right alignment effects properly.
4. Now set the image in the left or right-align. Now see in front end the issue is solved.

## Screenshots or screencast <!-- if applicable -->
Before display styles changes the issue which was happening, the image is below.
Link: https://prnt.sc/Rzznv4pf4Ea4

After making display changes in styles, the issue is now solved and image is below.
Link: https://prnt.sc/irtImkkXJ-OA
