### PR TITLE
CheckboxControl: Support indeterminate state

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,11 +8,8 @@
 -   `Divider`: Make the divider visible by default (`display: inline`) in flow layout containers when the divider orientation is vertical ([#39316](https://github.com/WordPress/gutenberg/pull/39316)).
 -   Stop using deprecated `event.keyCode` in favor of `event.key` for keyboard events in `UnitControl` and `InputControl`.  ([#39360](https://github.com/WordPress/gutenberg/pull/39360))
 -   `ColorPalette`: refine custom color button's label. ([#39386](https://github.com/WordPress/gutenberg/pull/39386))
-<<<<<<< HEAD
 -   `FocalPointPicker`: stop using `UnitControl`'s deprecated `unit` prop ([#39504](https://github.com/WordPress/gutenberg/pull/39504)).
-=======
 -   `CheckboxControl`: Add support for the `indeterminate` state ([#39462](https://github.com/WordPress/gutenberg/pull/39462)).
->>>>>>> d7ef883f0d (Update changelog)
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,7 +8,11 @@
 -   `Divider`: Make the divider visible by default (`display: inline`) in flow layout containers when the divider orientation is vertical ([#39316](https://github.com/WordPress/gutenberg/pull/39316)).
 -   Stop using deprecated `event.keyCode` in favor of `event.key` for keyboard events in `UnitControl` and `InputControl`.  ([#39360](https://github.com/WordPress/gutenberg/pull/39360))
 -   `ColorPalette`: refine custom color button's label. ([#39386](https://github.com/WordPress/gutenberg/pull/39386))
+<<<<<<< HEAD
 -   `FocalPointPicker`: stop using `UnitControl`'s deprecated `unit` prop ([#39504](https://github.com/WordPress/gutenberg/pull/39504)).
+=======
+-   `CheckboxControl`: Add support for the `indeterminate` state ([#39462](https://github.com/WordPress/gutenberg/pull/39462)).
+>>>>>>> d7ef883f0d (Update changelog)
 
 ### Internal
 

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -39,7 +39,9 @@ export default function CheckboxControl( {
 	const onChangeValue = ( event ) => onChange( event.target.checked );
 
 	useEffect( () => {
-		ref.current.indeterminate = !! indeterminate;
+		if ( ref.current ) {
+			ref.current.indeterminate = !! indeterminate;
+		}
 	}, [ indeterminate ] );
 
 	return (
@@ -57,7 +59,7 @@ export default function CheckboxControl( {
 					type="checkbox"
 					value="1"
 					onChange={ onChangeValue }
-					checked={ ! indeterminate && checked }
+					checked={ checked }
 					aria-describedby={ !! help ? id + '__help' : undefined }
 					{ ...props }
 				/>

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import { useInstanceId, useRefEffect } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
 import { Icon, check, reset } from '@wordpress/icons';
 
@@ -33,16 +33,29 @@ export default function CheckboxControl( {
 		} );
 	}
 
-	const ref = useRef();
+	const [ showCheckedIcon, setShowCheckedIcon ] = useState( false );
+	const [ showIndeterminateIcon, setShowIndeterminateIcon ] = useState(
+		false
+	);
+
+	// Run the following callback everytime the `ref` (and the additional
+	// dependencies) change.
+	const ref = useRefEffect(
+		( node ) => {
+			if ( ! node ) {
+				return;
+			}
+
+			node.indeterminate = !! indeterminate;
+
+			setShowCheckedIcon( node.matches( ':checked' ) );
+			setShowIndeterminateIcon( node.matches( ':indeterminate' ) );
+		},
+		[ checked, indeterminate ]
+	);
 	const instanceId = useInstanceId( CheckboxControl );
 	const id = `inspector-checkbox-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.checked );
-
-	useEffect( () => {
-		if ( ref.current ) {
-			ref.current.indeterminate = !! indeterminate;
-		}
-	}, [ indeterminate ] );
 
 	return (
 		<BaseControl
@@ -63,14 +76,14 @@ export default function CheckboxControl( {
 					aria-describedby={ !! help ? id + '__help' : undefined }
 					{ ...props }
 				/>
-				{ indeterminate && ! checked ? (
+				{ showIndeterminateIcon ? (
 					<Icon
 						icon={ reset }
 						className="components-checkbox-control__indeterminate"
 						role="presentation"
 					/>
 				) : null }
-				{ checked ? (
+				{ showCheckedIcon ? (
 					<Icon
 						icon={ check }
 						className="components-checkbox-control__checked"

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -58,15 +58,6 @@ export default function CheckboxControl( {
 	const id = `inspector-checkbox-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.checked );
 
-	let ariaChecked;
-	if ( showCheckedIcon ) {
-		ariaChecked = 'true';
-	} else if ( showIndeterminateIcon ) {
-		ariaChecked = 'mixed';
-	} else {
-		ariaChecked = 'false';
-	}
-
 	return (
 		<BaseControl
 			label={ heading }
@@ -84,7 +75,6 @@ export default function CheckboxControl( {
 					onChange={ onChangeValue }
 					checked={ checked }
 					aria-describedby={ !! help ? id + '__help' : undefined }
-					aria-checked={ ariaChecked }
 					{ ...props }
 				/>
 				{ showIndeterminateIcon ? (

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -46,6 +46,7 @@ export default function CheckboxControl( {
 				return;
 			}
 
+			// It cannot be set using an HTML attribute.
 			node.indeterminate = !! indeterminate;
 
 			setShowCheckedIcon( node.matches( ':checked' ) );
@@ -56,6 +57,15 @@ export default function CheckboxControl( {
 	const instanceId = useInstanceId( CheckboxControl );
 	const id = `inspector-checkbox-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.checked );
+
+	let ariaChecked;
+	if ( showCheckedIcon ) {
+		ariaChecked = 'true';
+	} else if ( showIndeterminateIcon ) {
+		ariaChecked = 'mixed';
+	} else {
+		ariaChecked = 'false';
+	}
 
 	return (
 		<BaseControl
@@ -74,6 +84,7 @@ export default function CheckboxControl( {
 					onChange={ onChangeValue }
 					checked={ checked }
 					aria-describedby={ !! help ? id + '__help' : undefined }
+					aria-checked={ ariaChecked }
 					{ ...props }
 				/>
 				{ showIndeterminateIcon ? (

--- a/packages/components/src/checkbox-control/index.js
+++ b/packages/components/src/checkbox-control/index.js
@@ -6,9 +6,10 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { useEffect, useRef } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import deprecated from '@wordpress/deprecated';
-import { Icon, check } from '@wordpress/icons';
+import { Icon, check, reset } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ export default function CheckboxControl( {
 	className,
 	heading,
 	checked,
+	indeterminate,
 	help,
 	onChange,
 	...props
@@ -31,9 +33,14 @@ export default function CheckboxControl( {
 		} );
 	}
 
+	const ref = useRef();
 	const instanceId = useInstanceId( CheckboxControl );
 	const id = `inspector-checkbox-control-${ instanceId }`;
 	const onChangeValue = ( event ) => onChange( event.target.checked );
+
+	useEffect( () => {
+		ref.current.indeterminate = !! indeterminate;
+	}, [ indeterminate ] );
 
 	return (
 		<BaseControl
@@ -44,15 +51,23 @@ export default function CheckboxControl( {
 		>
 			<span className="components-checkbox-control__input-container">
 				<input
+					ref={ ref }
 					id={ id }
 					className="components-checkbox-control__input"
 					type="checkbox"
 					value="1"
 					onChange={ onChangeValue }
-					checked={ checked }
+					checked={ ! indeterminate && checked }
 					aria-describedby={ !! help ? id + '__help' : undefined }
 					{ ...props }
 				/>
+				{ indeterminate && ! checked ? (
+					<Icon
+						icon={ reset }
+						className="components-checkbox-control__indeterminate"
+						role="presentation"
+					/>
+				) : null }
 				{ checked ? (
 					<Icon
 						icon={ check }

--- a/packages/components/src/checkbox-control/stories/index.js
+++ b/packages/components/src/checkbox-control/stories/index.js
@@ -45,3 +45,47 @@ export const all = () => {
 
 	return <CheckboxControlWithState label={ label } help={ help } checked />;
 };
+
+export const Indeterminate = () => {
+	const [ fruits, setFruits ] = useState( { apple: false, orange: false } );
+
+	const isAllChecked = Object.values( fruits ).every( Boolean );
+	const isIndeterminate =
+		Object.values( fruits ).some( Boolean ) && ! isAllChecked;
+
+	return (
+		<>
+			<CheckboxControl
+				label="Select All"
+				checked={ isAllChecked }
+				indeterminate={ isIndeterminate }
+				onChange={ ( newValue ) =>
+					setFruits( {
+						apple: newValue,
+						orange: newValue,
+					} )
+				}
+			/>
+			<CheckboxControl
+				label="Apple"
+				checked={ fruits.apple }
+				onChange={ ( apple ) =>
+					setFruits( ( prevState ) => ( {
+						...prevState,
+						apple,
+					} ) )
+				}
+			/>
+			<CheckboxControl
+				label="Orange"
+				checked={ fruits.orange }
+				onChange={ ( orange ) =>
+					setFruits( ( prevState ) => ( {
+						...prevState,
+						orange,
+					} ) )
+				}
+			/>
+		</>
+	);
+};

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -33,7 +33,8 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 		outline: 2px solid transparent;
 	}
 
-	&:checked {
+	&:checked,
+	&:indeterminate {
 		background: var(--wp-admin-theme-color);
 		border-color: var(--wp-admin-theme-color);
 
@@ -62,7 +63,8 @@ $checkbox-input-size-sm: 24px; // Width & height for small viewports.
 	}
 }
 
-svg.components-checkbox-control__checked {
+svg.components-checkbox-control__checked,
+svg.components-checkbox-control__indeterminate {
 	fill: $white;
 	cursor: pointer;
 	position: absolute;


### PR DESCRIPTION
## What?
Closes #39434.

PR adds [indeterminate](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-indeterminate) state support to the CheckboxControl.

## Why?
Previously, we could achieve this by manually setting `aria-checked="mixed"` on the component. However, Spec provides a "native" way to handle this state, so I think this should be the preferred method.

## How?
The implementation is pretty simple. While I included a few safeguards for the impossibles states, the parent component is responsible for correctly setting both `indeterminate` and `checked` props.

## Testing Instructions
Tested locally using Storybook

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/158393197-e82bd99f-75a3-4e9b-b851-48ff1c448c08.mp4


