### PR TITLE
Use the Button block inside of the Search block

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1276,6 +1276,15 @@ function selectionHelper( state = {}, action ) {
  * @return {boolean} Updated state.
  */
 export function selection( state = {}, action ) {
+	if (
+		action.clientId ===
+		document.querySelector( '.wp-block-button' )?.dataset?.block
+	) {
+		action.clientId = document.querySelector(
+			'.wp-block-search'
+		)?.dataset?.block;
+	}
+
 	switch ( action.type ) {
 		case 'SELECTION_CHANGE':
 			return {


### PR DESCRIPTION
## Description

This PR replaces the `<button />` element inside of the Search block for a `Button` block. It is a step towards consolidating the CSS required to render the Search block inside of the search block ([overview issue](https://github.com/WordPress/gutenberg/issues/39188)). There are two major downsides of using an HTML element instead of a block:

* [Part of that CSS related to the button element must be provided by each theme](https://github.com/WordPress/gutenberg/issues/36444)
* The Search block do not inherit the global styles of a button

The solution proposed here comes with its own set of challenges.

Most notably, it is unclear how to reconcile granular control over the button block with the search block attributes such as `isButtonPositionInside` or `buttonUseIcon`. It was simple with a controlled HTML `<button />`, but with a Button block the user may set `buttonUseIcon` to `true` on the **Search** block and then click on said icon inside the **Button** block and remove it. Should it be disallowed? Should that icon be restored after setting `buttonUseIcon` to `false` and then back to `true`?

cc @mtias @scruffian @getdave @draganescu @gziolo  @dmsnell 
