### PR TITLE
Add missing `}` to LinkControl code example

### DIFF
--- a/packages/block-editor/src/components/link-control/README.md
+++ b/packages/block-editor/src/components/link-control/README.md
@@ -85,7 +85,7 @@ Value change handler, called with the updated value if the user selects a new li
 <LinkControl
 	onChange={ ( nextValue ) => {
 		console.log( `The selected item URL: ${ nextValue.url }.` );
-	}
+	} }
 />
 ```
 


### PR DESCRIPTION
} was missing

