### PR TITLE
Preload paths: avoid fatal error on Widgets page.

### DIFF
--- a/lib/compat/wordpress-6.0/edit-form-blocks.php
+++ b/lib/compat/wordpress-6.0/edit-form-blocks.php
@@ -40,7 +40,7 @@ function optimize_preload_paths( $preload_paths ) {
 
 	// modify the preload of `/users/me` to match the real request.
 	foreach ( $preload_paths as $user_index => $user_path ) {
-		if ( 0 === strpos( $user_path, '/wp/v2/users/me' ) ) {
+		if ( is_string( $user_path ) && 0 === strpos( $user_path, '/wp/v2/users/me' ) ) {
 			$preload_paths[ $user_index ] = '/wp/v2/users/me';
 			break;
 		}


### PR DESCRIPTION
Follow-up to #39256

## What and why?

#39256 added some logic using the `block_editor_rest_api_preload_paths` filter. That works well, but on a fresh installation of WordPress, that filter may sometimes return multidimensional arrays. This is the case on the Widgets page for example, where the filter's array of paths to preload will be as follows:

```
Array
(
    [0] => Array
        (
            [0] => /wp/v2/media
            [1] => OPTIONS
        )

    [1] => /wp/v2/sidebars?context=edit&per_page=-1
    [2] => /wp/v2/widgets?context=edit&per_page=-1&_embed=about
)
```

In this situation, when running a version of the Gutenberg plugin including #39256, we end up with this Fatal error when loading the widgets screen:

```
PHP Fatal error:  Uncaught TypeError: strpos(): Argument #1 ($haystack) must be of type string, array given in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.0/edit-form-blocks.php:44
```

## How?

* This PR solves the issue by ensuring that we're dealing with a string when checking for a matching path.

## Testing Instructions

1. Start with a site that runs Gutenberg trunk.
2. Activate a theme that supports sidebars, such as Twenty Twenty.
3. Go to Appearance > Widgets and notice the Fatal error.
4. Apply this patch, and notice that the error disappears.

