### PR TITLE
Theme Export: Use the theme name for the zip file

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -42,18 +42,16 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	$obscura  = wp_generate_password( 12, false, false );
-	$filename = get_temp_dir() . 'edit-site-export-' . $obscura . '.zip';
+	$theme_name = wp_get_theme()->get( 'TextDomain' );
+	$filename = get_temp_dir() . $theme_name . $obscura . '.zip';
 
 	$zip = new ZipArchive();
 	if ( true !== $zip->open( $filename, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {
 		return new WP_Error( 'unable_to_create_zip', __( 'Unable to open export file (archive) for writing.', 'gutenberg' ) );
 	}
 
-	$theme_name = wp_get_theme()->get( 'TextDomain' );
-
-	$zip->addEmptyDir( $theme_name );
-	$zip->addEmptyDir( $theme_name . '/templates' );
-	$zip->addEmptyDir( $theme_name . '/parts' );
+	$zip->addEmptyDir( 'templates' );
+	$zip->addEmptyDir( 'parts' );
 
 	// Get path of the theme.
 	$theme_path = wp_normalize_path( get_stylesheet_directory() );
@@ -73,7 +71,7 @@ function gutenberg_generate_block_templates_export_file() {
 			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
 
 			if ( ! gutenberg_is_theme_directory_ignored( $relative_path ) ) {
-				$zip->addFile( $file_path, $theme_name . '/' . $relative_path );
+				$zip->addFile( $file_path, $relative_path );
 			}
 		}
 	}
@@ -84,7 +82,7 @@ function gutenberg_generate_block_templates_export_file() {
 		$template->content = _remove_theme_attribute_in_block_template_content( $template->content );
 
 		$zip->addFromString(
-			$theme_name . '/templates/' . $template->slug . '.html',
+			'templates/' . $template->slug . '.html',
 			$template->content
 		);
 	}
@@ -93,7 +91,7 @@ function gutenberg_generate_block_templates_export_file() {
 	$template_parts = gutenberg_get_block_templates( array(), 'wp_template_part' );
 	foreach ( $template_parts as $template_part ) {
 		$zip->addFromString(
-			$theme_name . '/parts/' . $template_part->slug . '.html',
+			'parts/' . $template_part->slug . '.html',
 			$template_part->content
 		);
 	}
@@ -103,7 +101,7 @@ function gutenberg_generate_block_templates_export_file() {
 	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
 
 	$zip->addFromString(
-		$theme_name . '/theme.json',
+		'theme.json',
 		wp_json_encode( $tree->get_data(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 	);
 

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -41,9 +41,9 @@ function gutenberg_generate_block_templates_export_file() {
 		return new WP_Error( 'missing_zip_package', __( 'Zip Export not supported.', 'gutenberg' ) );
 	}
 
-	$obscura  = wp_generate_password( 12, false, false );
+	$obscura    = wp_generate_password( 12, false, false );
 	$theme_name = wp_get_theme()->get( 'TextDomain' );
-	$filename = get_temp_dir() . $theme_name . $obscura . '.zip';
+	$filename   = get_temp_dir() . $theme_name . $obscura . '.zip';
 
 	$zip = new ZipArchive();
 	if ( true !== $zip->open( $filename, ZipArchive::CREATE | ZipArchive::OVERWRITE ) ) {

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -67,7 +67,7 @@ function gutenberg_generate_block_templates_export_file() {
 		// Skip directories as they are added automatically.
 		if ( ! $file->isDir() ) {
 			// Get real and relative path for current file.
-			$file_path     = wp_normalize_path( $file->getRealPath() );
+			$file_path     = wp_normalize_path( $file );
 			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
 
 			if ( ! gutenberg_is_theme_directory_ignored( $relative_path ) ) {

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
@@ -76,8 +76,9 @@ class Gutenberg_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 			return $filename;
 		}
 
+		$theme_name = wp_get_theme()->get( 'TextDomain' );
 		header( 'Content-Type: application/zip' );
-		header( 'Content-Disposition: attachment; filename=edit-site-export.zip' );
+		header( 'Content-Disposition: attachment; filename=' . $theme_name . '.zip' );
 		header( 'Content-Length: ' . filesize( $filename ) );
 		flush();
 		readfile( $filename );

--- a/packages/e2e-tests/specs/site-editor/site-editor-export.test.js
+++ b/packages/e2e-tests/specs/site-editor/site-editor-export.test.js
@@ -43,7 +43,7 @@ describe( 'Site Editor Templates Export', () => {
 		await visitSiteEditor();
 	} );
 
-	it( 'clicking export should download edit-site-export.zip file', async () => {
+	it( 'clicking export should download emptytheme.zip file', async () => {
 		const directory = fs.mkdtempSync(
 			path.join( os.tmpdir(), 'test-edit-site-export-' )
 		);
@@ -53,7 +53,7 @@ describe( 'Site Editor Templates Export', () => {
 		} );
 
 		await clickOnMoreMenuItem( 'Export', 'site-editor' );
-		const filePath = path.join( directory, 'edit-site-export.zip' );
+		const filePath = path.join( directory, 'emptytheme.zip' );
 		await waitForFileExists( filePath );
 		expect( fs.existsSync( filePath ) ).toBe( true );
 		fs.unlinkSync( filePath );

--- a/packages/edit-site/src/components/header/more-menu/site-export.js
+++ b/packages/edit-site/src/components/header/more-menu/site-export.js
@@ -23,8 +23,11 @@ export default function SiteExport() {
 				parse: false,
 			} );
 			const blob = await response.blob();
+			const contentDisposition = response.headers.get( 'content-disposition' );
+			const contentDispositionMatches = contentDisposition.match( /=(.+)\.zip/ );
+			const fileName = contentDispositionMatches[ 1 ] ? contentDispositionMatches[ 1 ] : 'edit-site-export';
 
-			downloadjs( blob, 'edit-site-export.zip', 'application/zip' );
+			downloadjs( blob, fileName + '.zip', 'application/zip' );
 		} catch ( errorResponse ) {
 			let error = {};
 			try {

--- a/packages/edit-site/src/components/header/more-menu/site-export.js
+++ b/packages/edit-site/src/components/header/more-menu/site-export.js
@@ -23,9 +23,15 @@ export default function SiteExport() {
 				parse: false,
 			} );
 			const blob = await response.blob();
-			const contentDisposition = response.headers.get( 'content-disposition' );
-			const contentDispositionMatches = contentDisposition.match( /=(.+)\.zip/ );
-			const fileName = contentDispositionMatches[ 1 ] ? contentDispositionMatches[ 1 ] : 'edit-site-export';
+			const contentDisposition = response.headers.get(
+				'content-disposition'
+			);
+			const contentDispositionMatches = contentDisposition.match(
+				/=(.+)\.zip/
+			);
+			const fileName = contentDispositionMatches[ 1 ]
+				? contentDispositionMatches[ 1 ]
+				: 'edit-site-export';
 
 			downloadjs( blob, fileName + '.zip', 'application/zip' );
 		} catch ( errorResponse ) {


### PR DESCRIPTION
## What?
Use the name of the theme in the zip file for the export.

## Why?
This makes it easier to add the theme to your WordPress install

## How?
We pass the theme name from the REST endpoint to the JS in the headers.

## Testing Instructions
- Switch to a block theme
- Go to the site editor
- Click on Export
- Confirm that the name of the file that is downloaded is the same as the theme slug

