### PR TITLE
Fix: Comment Query Loop's inner block selection and duplicate inspector control settings

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -103,7 +103,10 @@ function CommentTemplateInnerBlocks( {
 	);
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment === ( activeComment || firstComment ) ? children : null }
+			{ comment.commentId ===
+			( activeComment?.commentId || firstComment?.commentId )
+				? children
+				: null }
 
 			{ /* To avoid flicker when switching active block contexts, a preview
 			is ALWAYS rendered and the preview for the active block is hidden.
@@ -116,7 +119,10 @@ function CommentTemplateInnerBlocks( {
 				blocks={ blocks }
 				comment={ comment }
 				setActiveComment={ setActiveComment }
-				isHidden={ comment === ( activeComment || firstComment ) }
+				isHidden={
+					comment.commentId ===
+					( activeComment?.commentId || firstComment?.commentId )
+				}
 			/>
 
 			{ comment?.children?.length > 0 ? (
@@ -142,7 +148,7 @@ const CommentTemplatePreview = ( {
 	} );
 
 	const handleOnClick = () => {
-		setActiveComment( comment );
+		setActiveComment( comment?.commentId );
 	};
 
 	// We have to hide the preview block if the `comment` props points to

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -131,6 +131,7 @@ function CommentTemplateInnerBlocks( {
 					activeComment={ activeComment }
 					setActiveComment={ setActiveComment }
 					blocks={ blocks }
+					firstComment={ firstComment }
 				/>
 			) : null }
 		</li>
@@ -184,6 +185,8 @@ const MemoizedCommentTemplatePreview = memo( CommentTemplatePreview );
  * @param {Array}  [props.activeComment]    - The block that is currently active.
  * @param {Array}  [props.setActiveComment] - The setter for activeComment.
  * @param {Array}  [props.blocks]           - Array of blocks returned from
+ * @param {Object} [props.firstComment]     - The first comment in the array of
+ *                                          comment objects.
  *                                          getBlocks() in parent .
  * @return {WPElement}                 		List of comments.
  */
@@ -193,6 +196,7 @@ const CommentsList = ( {
 	activeComment,
 	setActiveComment,
 	blocks,
+	firstComment,
 } ) => (
 	<ol { ...blockProps }>
 		{ comments &&
@@ -206,7 +210,7 @@ const CommentsList = ( {
 						activeComment={ activeComment }
 						setActiveComment={ setActiveComment }
 						blocks={ blocks }
-						firstComment={ comments[ 0 ] }
+						firstComment={ firstComment }
 					/>
 				</BlockContextProvider>
 			) ) }
@@ -293,6 +297,7 @@ export default function CommentTemplateEdit( {
 			blocks={ blocks }
 			activeComment={ activeComment }
 			setActiveComment={ setActiveComment }
+			firstComment={ commentTree[ 0 ] }
 		/>
 	);
 }

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -103,8 +103,8 @@ function CommentTemplateInnerBlocks( {
 	);
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment.commentId ===
-			( activeComment?.commentId || firstComment?.commentId )
+			{ comment.commentId === activeComment?.commentId ||
+			comment.commentId === firstComment?.commentId
 				? children
 				: null }
 
@@ -120,8 +120,8 @@ function CommentTemplateInnerBlocks( {
 				comment={ comment }
 				setActiveComment={ setActiveComment }
 				isHidden={
-					comment.commentId ===
-					( activeComment?.commentId || firstComment?.commentId )
+					comment.commentId === activeComment?.commentId ||
+					comment.commentId === firstComment?.commentId
 				}
 			/>
 

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -103,8 +103,8 @@ function CommentTemplateInnerBlocks( {
 	);
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment.commentId === activeComment?.commentId ||
-			comment.commentId === firstComment?.commentId
+			{ comment.commentId ===
+			( activeComment?.commentId || firstComment?.commentId )
 				? children
 				: null }
 
@@ -120,8 +120,8 @@ function CommentTemplateInnerBlocks( {
 				comment={ comment }
 				setActiveComment={ setActiveComment }
 				isHidden={
-					comment.commentId === activeComment?.commentId ||
-					comment.commentId === firstComment?.commentId
+					comment.commentId ===
+					( activeComment?.commentId || firstComment?.commentId )
 				}
 			/>
 

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -148,7 +148,7 @@ const CommentTemplatePreview = ( {
 	} );
 
 	const handleOnClick = () => {
-		setActiveComment( comment?.commentId );
+		setActiveComment( comment );
 	};
 
 	// We have to hide the preview block if the `comment` props points to

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -31,6 +31,10 @@ const TEMPLATE = [
 /**
  * Function that returns a comment structure that will be rendered with default placehoders.
  *
+ * Each comment has a `commentId` property that is always a negative number in
+ * case of the placeholders. This is to ensure that the comment does not
+ * conflict with the actual (real) comments.
+ *
  * @param {Object}  settings                       Discussion Settings.
  * @param {number}  [settings.perPage]             - Comments per page setting or block attribute.
  * @param {boolean} [settings.threadComments]      - Enable threaded (nested) comments setting.
@@ -54,12 +58,13 @@ const getCommentsPlaceholder = ( {
 		perPage <= commentsDepth ? perPage : commentsDepth;
 	if ( ! threadComments || defaultCommentsToShow === 1 ) {
 		// If displaying threaded comments is disabled, we only show one comment
-		return [ { commentId: null, children: [] } ];
+		// A commentId is negative in order to avoid conflicts with the actual comments.
+		return [ { commentId: -1, children: [] } ];
 	} else if ( defaultCommentsToShow === 2 ) {
 		return [
 			{
-				commentId: null,
-				children: [ { commentId: null, children: [] } ],
+				commentId: -1,
+				children: [ { commentId: -2, children: [] } ],
 			},
 		];
 	}
@@ -67,11 +72,11 @@ const getCommentsPlaceholder = ( {
 	// In case that the value is set but larger than 3 we truncate it to 3.
 	return [
 		{
-			commentId: null,
+			commentId: -1,
 			children: [
 				{
-					commentId: null,
-					children: [ { commentId: null, children: [] } ],
+					commentId: -2,
+					children: [ { commentId: -3, children: [] } ],
 				},
 			],
 		},
@@ -101,6 +106,7 @@ function CommentTemplateInnerBlocks( {
 		{},
 		{ template: TEMPLATE }
 	);
+
 	return (
 		<li { ...innerBlocksProps }>
 			{ comment.commentId ===

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -203,13 +203,20 @@ const CommentsList = ( {
 } ) => (
 	<ol { ...blockProps }>
 		{ comments &&
-			comments.map( ( comment, index ) => (
+			comments.map( ( { commentId, ...comment }, index ) => (
 				<BlockContextProvider
 					key={ comment.commentId || index }
-					value={ comment }
+					value={ {
+						// If the commentId is negative it means that this comment is a
+						// "placeholder" and that the block is most likely being used in the
+						// site editor. In this case, we have to set the commentId to `null`
+						// because otherwise the (non-existent) comment with a negative ID
+						// would be reqested from the REST API.
+						commentId: commentId < 0 ? null : commentId,
+					} }
 				>
 					<CommentTemplateInnerBlocks
-						comment={ comment }
+						comment={ { commentId, ...comment } }
 						activeCommentId={ activeCommentId }
 						setActiveCommentId={ setActiveCommentId }
 						blocks={ blocks }

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -109,8 +109,7 @@ function CommentTemplateInnerBlocks( {
 
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment.commentId ===
-			( activeComment?.commentId || firstComment?.commentId )
+			{ comment.commentId === ( activeComment || firstComment )
 				? children
 				: null }
 
@@ -123,11 +122,10 @@ function CommentTemplateInnerBlocks( {
 			block. */ }
 			<MemoizedCommentTemplatePreview
 				blocks={ blocks }
-				comment={ comment }
+				commentId={ comment.commentId }
 				setActiveComment={ setActiveComment }
 				isHidden={
-					comment.commentId ===
-					( activeComment?.commentId || firstComment?.commentId )
+					comment.commentId === ( activeComment || firstComment )
 				}
 			/>
 
@@ -146,7 +144,7 @@ function CommentTemplateInnerBlocks( {
 
 const CommentTemplatePreview = ( {
 	blocks,
-	comment,
+	commentId,
 	setActiveComment,
 	isHidden,
 } ) => {
@@ -155,7 +153,7 @@ const CommentTemplatePreview = ( {
 	} );
 
 	const handleOnClick = () => {
-		setActiveComment( comment );
+		setActiveComment( commentId );
 	};
 
 	// We have to hide the preview block if the `comment` props points to
@@ -303,7 +301,7 @@ export default function CommentTemplateEdit( {
 			blocks={ blocks }
 			activeComment={ activeComment }
 			setActiveComment={ setActiveComment }
-			firstComment={ commentTree[ 0 ] }
+			firstComment={ commentTree[ 0 ]?.commentId }
 		/>
 	);
 }

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -86,20 +86,20 @@ const getCommentsPlaceholder = ( {
 /**
  * Component which renders the inner blocks of the Comment Template.
  *
- * @param {Object} props                    Component props.
- * @param {Array}  [props.comment]          - A comment object.
- * @param {Array}  [props.activeComment]    - The block that is currently active.
- * @param {Array}  [props.setActiveComment] - The setter for activeComment.
- * @param {Array}  [props.firstComment]     - First comment in the array.
- * @param {Array}  [props.blocks]           - Array of blocks returned from
- *                                          getBlocks() in parent .
+ * @param {Object} props                      Component props.
+ * @param {Array}  [props.comment]            - A comment object.
+ * @param {Array}  [props.activeCommentId]    - The ID of the comment that is currently active.
+ * @param {Array}  [props.setActiveCommentId] - The setter for activeCommentId.
+ * @param {Array}  [props.firstCommentId]     - First ID of the first comment in the array.
+ * @param {Array}  [props.blocks]             - Array of blocks returned from
+ *                                            getBlocks() in parent .
  * @return {WPElement}                 		Inner blocks of the Comment Template
  */
 function CommentTemplateInnerBlocks( {
 	comment,
-	activeComment,
-	setActiveComment,
-	firstComment,
+	activeCommentId,
+	setActiveCommentId,
+	firstCommentId,
 	blocks,
 } ) {
 	const { children, ...innerBlocksProps } = useInnerBlocksProps(
@@ -109,7 +109,7 @@ function CommentTemplateInnerBlocks( {
 
 	return (
 		<li { ...innerBlocksProps }>
-			{ comment.commentId === ( activeComment || firstComment )
+			{ comment.commentId === ( activeCommentId || firstCommentId )
 				? children
 				: null }
 
@@ -123,19 +123,19 @@ function CommentTemplateInnerBlocks( {
 			<MemoizedCommentTemplatePreview
 				blocks={ blocks }
 				commentId={ comment.commentId }
-				setActiveComment={ setActiveComment }
+				setActiveCommentId={ setActiveCommentId }
 				isHidden={
-					comment.commentId === ( activeComment || firstComment )
+					comment.commentId === ( activeCommentId || firstCommentId )
 				}
 			/>
 
 			{ comment?.children?.length > 0 ? (
 				<CommentsList
 					comments={ comment.children }
-					activeComment={ activeComment }
-					setActiveComment={ setActiveComment }
+					activeCommentId={ activeCommentId }
+					setActiveCommentId={ setActiveCommentId }
 					blocks={ blocks }
-					firstComment={ firstComment }
+					firstCommentId={ firstCommentId }
 				/>
 			) : null }
 		</li>
@@ -145,7 +145,7 @@ function CommentTemplateInnerBlocks( {
 const CommentTemplatePreview = ( {
 	blocks,
 	commentId,
-	setActiveComment,
+	setActiveCommentId,
 	isHidden,
 } ) => {
 	const blockPreviewProps = useBlockPreview( {
@@ -153,7 +153,7 @@ const CommentTemplatePreview = ( {
 	} );
 
 	const handleOnClick = () => {
-		setActiveComment( commentId );
+		setActiveCommentId( commentId );
 	};
 
 	// We have to hide the preview block if the `comment` props points to
@@ -183,24 +183,23 @@ const MemoizedCommentTemplatePreview = memo( CommentTemplatePreview );
 /**
  * Component that renders a list of (nested) comments. It is called recursively.
  *
- * @param {Object} props                    Component props.
- * @param {Array}  [props.comments]         - Array of comment objects.
- * @param {Array}  [props.blockProps]       - Props from parent's `useBlockProps()`.
- * @param {Array}  [props.activeComment]    - The block that is currently active.
- * @param {Array}  [props.setActiveComment] - The setter for activeComment.
- * @param {Array}  [props.blocks]           - Array of blocks returned from
- * @param {Object} [props.firstComment]     - The first comment in the array of
- *                                          comment objects.
- *                                          getBlocks() in parent .
+ * @param {Object} props                      Component props.
+ * @param {Array}  [props.comments]           - Array of comment objects.
+ * @param {Array}  [props.blockProps]         - Props from parent's `useBlockProps()`.
+ * @param {Array}  [props.activeCommentId]    - The ID of the comment that is currently active.
+ * @param {Array}  [props.setActiveCommentId] - The setter for activeCommentId.
+ * @param {Array}  [props.blocks]             - Array of blocks returned from getBlocks() in parent.
+ * @param {Object} [props.firstCommentId]     - The ID of the first comment in the array of
+ *                                            comment objects.
  * @return {WPElement}                 		List of comments.
  */
 const CommentsList = ( {
 	comments,
 	blockProps,
-	activeComment,
-	setActiveComment,
+	activeCommentId,
+	setActiveCommentId,
 	blocks,
-	firstComment,
+	firstCommentId,
 } ) => (
 	<ol { ...blockProps }>
 		{ comments &&
@@ -211,10 +210,10 @@ const CommentsList = ( {
 				>
 					<CommentTemplateInnerBlocks
 						comment={ comment }
-						activeComment={ activeComment }
-						setActiveComment={ setActiveComment }
+						activeCommentId={ activeCommentId }
+						setActiveCommentId={ setActiveCommentId }
 						blocks={ blocks }
-						firstComment={ firstComment }
+						firstCommentId={ firstCommentId }
 					/>
 				</BlockContextProvider>
 			) ) }
@@ -233,7 +232,7 @@ export default function CommentTemplateEdit( {
 } ) {
 	const blockProps = useBlockProps();
 
-	const [ activeComment, setActiveComment ] = useState();
+	const [ activeCommentId, setActiveCommentId ] = useState();
 	const { commentOrder, threadCommentsDepth, threadComments } = useSelect(
 		( select ) => {
 			const { getSettings } = select( blockEditorStore );
@@ -299,9 +298,9 @@ export default function CommentTemplateEdit( {
 			comments={ commentTree }
 			blockProps={ blockProps }
 			blocks={ blocks }
-			activeComment={ activeComment }
-			setActiveComment={ setActiveComment }
-			firstComment={ commentTree[ 0 ]?.commentId }
+			activeCommentId={ activeCommentId }
+			setActiveCommentId={ setActiveCommentId }
+			firstCommentId={ commentTree[ 0 ]?.commentId }
 		/>
 	);
 }

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -90,7 +90,7 @@ const getCommentsPlaceholder = ( {
  * @param {Array}  [props.comment]            - A comment object.
  * @param {Array}  [props.activeCommentId]    - The ID of the comment that is currently active.
  * @param {Array}  [props.setActiveCommentId] - The setter for activeCommentId.
- * @param {Array}  [props.firstCommentId]     - First ID of the first comment in the array.
+ * @param {Array}  [props.firstCommentId]     - ID of the first comment in the array.
  * @param {Array}  [props.blocks]             - Array of blocks returned from
  *                                            getBlocks() in parent .
  * @return {WPElement}                 		Inner blocks of the Comment Template


### PR DESCRIPTION
## What?
Fixing those two issues:
- #39443
- #38080

## Why?
Those issues were preventing forther work on the Comments Query Loop and Comments Template.

## How?
1. Change how the active comment is being compared to current comment in `CommentTemplateInnerBlocks`
2. Move the `firstComment` one level higher in the component tree.

(More detailed comments below)

## Testing Instructions
1. Create a post and add some comments to it
2. Open the post using any FSE theme
3. Try to insert the Comments Query Loop block

## Screenshots or screencast <!-- if applicable -->

Now, the selection works just fine with no duplicate Inspector Controls:

https://user-images.githubusercontent.com/5417266/158495315-379f5686-5334-4cbb-a422-844b1c72229a.mp4


