### PR TITLE
Core Data: Check for presence of entity config before testing plural form

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -297,7 +297,7 @@ export const getMethodName = (
 	const nameSuffix =
 		upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
 	const suffix =
-		usePlural && entityConfig.plural
+		usePlural && entityConfig?.plural
 			? upperFirst( camelCase( entityConfig.plural ) )
 			: nameSuffix;
 	return `${ prefix }${ kindPrefix }${ suffix }`;


### PR DESCRIPTION
## Description

Part of #39211

When auto-generating method names for various entities in the data system we
want to use manually-listed plural forms if they exist.

Previously, however, we've been assuming that when we search for an entity's
config that it exists. While this probably hasn't been a real source of bugs
it does present an opportunity for an invalid-type runtime exception.

In this patch we're verifying that the config exists before we access the
`plural` property, eliminating the opportunity for the rutnime crash.

## Testing Instructions

This patch adds a safety guard for a place where we access a property from
an object which could be null or undefined. Audit the code to ensure that the
elimination of the possible type error doesn't cause unintended side-effects.