### PR TITLE
Core Data: Replace spread arguments with non-spread variants

### DIFF
--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -15,16 +15,16 @@ import { rootEntitiesConfig, getMethodName } from './entities';
 import { STORE_NAME } from './name';
 
 // The entity selectors/resolvers and actions are shortcuts to their generic equivalents
-// (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecordss)
-// Instead of getEntityRecord, the consumer could use more user-frieldly named selector: getPostType, getTaxonomy...
+// (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecords)
+// Instead of getEntityRecord, the consumer could use more user-friendly named selector: getPostType, getTaxonomy...
 // The "kind" and the "name" of the entity are combined to generate these shortcuts.
 
 const entitySelectors = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const { kind, name } = entity;
 	result[ getMethodName( kind, name ) ] = ( state, key, query ) =>
 		selectors.getEntityRecord( state, kind, name, key, query );
-	result[ getMethodName( kind, name, 'get', true ) ] = ( state, ...args ) =>
-		selectors.getEntityRecords( state, kind, name, ...args );
+	result[ getMethodName( kind, name, 'get', true ) ] = ( state, query ) =>
+		selectors.getEntityRecords( state, kind, name, query );
 	return result;
 }, {} );
 
@@ -35,13 +35,8 @@ const entityResolvers = rootEntitiesConfig.reduce( ( result, entity ) => {
 	const pluralMethodName = getMethodName( kind, name, 'get', true );
 	result[ pluralMethodName ] = ( ...args ) =>
 		resolvers.getEntityRecords( kind, name, ...args );
-	result[ pluralMethodName ].shouldInvalidate = ( action, ...args ) =>
-		resolvers.getEntityRecords.shouldInvalidate(
-			action,
-			kind,
-			name,
-			...args
-		);
+	result[ pluralMethodName ].shouldInvalidate = ( action ) =>
+		resolvers.getEntityRecords.shouldInvalidate( action, kind, name );
 	return result;
 }, {} );
 


### PR DESCRIPTION
## Description

Part of #39211

When dynamically creating accessor and updator methods for core data entities
we catch variable arguments in the methods and pass them through as spread arguments.

While this offers a certain expandability should we update the underlying methods
it also confuses the types of the interfaces since those underlying methods don't
allow variable argument lists (or at least, they ignore anything past the known
arguments).

In this patch we're replacing those spread variants with direct named arguments
to match the underlying inferface. This will present cleaner types and remove
one bit of confusion.

## Testing Instructions

Gutenberg has allowed passing more arguments to the entity accessor functions
than the underlying methods acknowledge or use. Test this patch by running a normal
array of operations that require fetching entity records. For example, test loading
block templates or FSE layouts.

Audit the code and verify that by removing the spread argument we aren't limiting
ourselves or ignoring ways these methods might be overwritten at runtime to accept
more arguments.