### PR TITLE
Core Data: Remove unused import of `Widget` type

### DIFF
--- a/packages/core-data/src/entity-types/sidebar.ts
+++ b/packages/core-data/src/entity-types/sidebar.ts
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import type { Widget } from './widget';
 import type { Context, OmitNevers } from './helpers';
 
 import type { BaseEntityRecords as _BaseEntityRecords } from './base-entity-records';


### PR DESCRIPTION
## What

Removes an unused type import.

## Testing Instructions

There should be no code changes with this patch.
Please audit the types and ensure the change doesn't break the types.