### PR TITLE
Core Data: Import types before exporting them

### DIFF
--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-export type { Context, Updatable } from './helpers';
+import type { Context, Updatable } from './helpers';
 import type { Attachment } from './attachment';
 import type { Comment } from './comment';
 import type { MenuLocation } from './menu-location';
@@ -27,6 +27,7 @@ export type { BaseEntityRecords } from './base-entity-records';
 export type {
 	Attachment,
 	Comment,
+	Context,
 	MenuLocation,
 	NavMenu,
 	NavMenuItem,
@@ -38,6 +39,7 @@ export type {
 	Sidebar,
 	Taxonomy,
 	Theme,
+	Updatable,
 	User,
 	Type,
 	Widget,


### PR DESCRIPTION
## Description

Part of #39211

Previously we've been exporting the `Context` and `Updatable` types
from a helper module and also using those types in the same file.
This represents a type violation since we're not importing those
types into the module's namespace.

In this patch we're also importing them before re-exporting them
so that the names are available as we expect.

## Testing Instructions

This is a type-only change and should have no impact on the output code bundles.

Please audit the change and verify that the types are accurate.