### PR TITLE
Core Data: Check for nullity in experimental fetch methods

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -170,7 +170,7 @@ const fetchLinkSuggestions = async (
 			.slice( 0, perPage )
 			.map(
 				/**
-				 * @param {{ id: number, url:string, title?:string, subtype?: string, type?: string }} result
+				 * @param {{ id: number, meta?: object, url:string, title?:string, subtype?: string, type?: string }} result
 				 */
 				( result ) => {
 					return {

--- a/packages/core-data/src/fetch/__experimental-fetch-url-data.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-url-data.js
@@ -60,6 +60,7 @@ const fetchUrlData = async ( url, options = {} ) => {
 	const protocol = getProtocol( url );
 
 	if (
+		! protocol ||
 		! isValidProtocol( protocol ) ||
 		! protocol.startsWith( 'http' ) ||
 		! /^https?:\/\/[^\/\s]/i.test( url )


### PR DESCRIPTION
## Description

Part of #39211

Adds a nullity check and enhances a JSDoc comment to acknowledge
the nullable presence of a property in an object we test.

## Testing Instructions

The only change here is a test for the presence of a `protocol` value
before accessing `.startWith` on it. In production this has been a latent
bug because that value may be undefined at runtime. In such a case the
editor will crash with a runtime type error.

Verify that the added safety guard is an appropriate way to handle this
potential failure, consistent with the approach for handling an invalid
protocol failure.