### PR TITLE
Show 'View Preview' link for 'Draft Saved' snackbar notice

### DIFF
--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -135,7 +135,7 @@ describe( 'Post actions', () => {
 			expect( notices ).toMatchObject( [
 				{
 					status: 'success',
-					content: 'Draft saved',
+					content: 'Draft saved.',
 				},
 			] );
 		} );

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -39,12 +39,13 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 
 	let noticeMessage;
 	let shouldShowLink = get( postType, [ 'viewable' ], false );
+	let isDraft;
 
 	// Always should a notice, which will be spoken for accessibility.
 	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
 		noticeMessage = __( 'Draft saved' );
-		shouldShowLink = false;
+		isDraft = true;
 	} else if ( isPublished && ! willPublish ) {
 		// If undoing publish status, show specific notice.
 		noticeMessage = postType.labels.item_reverted_to_draft;
@@ -65,7 +66,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const actions = [];
 	if ( shouldShowLink ) {
 		actions.push( {
-			label: postType.labels.view_item,
+			label: isDraft ? 'View Preview' : postType.labels.view_item,
 			url: post.link,
 		} );
 	}

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -44,7 +44,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	// Always should a notice, which will be spoken for accessibility.
 	if ( ! isPublished && ! willPublish ) {
 		// If saving a non-published post, don't show notice.
-		noticeMessage = __( 'Draft saved' );
+		noticeMessage = __( 'Draft saved.' );
 		isDraft = true;
 	} else if ( isPublished && ! willPublish ) {
 		// If undoing publish status, show specific notice.
@@ -66,7 +66,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	const actions = [];
 	if ( shouldShowLink ) {
 		actions.push( {
-			label: isDraft ? 'View Preview' : postType.labels.view_item,
+			label: isDraft ? __( 'View Preview' ) : postType.labels.view_item,
 			url: post.link,
 		} );
 	}

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -34,7 +34,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 		[
 			'when previous post is not published and post will not be published',
 			[ 'draft', 'draft', false ],
-			[ 'Draft saved', defaultExpectedAction ],
+			[ 'Draft saved.', defaultExpectedAction ],
 		],
 		[
 			'when previous post is published and post will be unpublished',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enables a link to  'View preview' in the 'Draft Saved' snackbar notice that appears when saving a draft.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This was requested here: #39037

When a page or post is updated or published, a link to view the page or post is in the snackbar notice. This PR aims to make the 'Draft Saved' notice consistent and provide a better experience, so a draft can quickly be viewed when a change is saved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`shouldShowLink` was removed, which was set to `false` for drafts. I've added a boolean `isDraft` to check if the post type is a draft when setting the appropriate label. The variable is added as an easier to read version of `! isPublished && ! willPublish`.  If it's a draft, it'll show the string 'View Preview'; otherwise, it'll show the `view_item` label.  

Currently, there isn't a label for previews/drafts in the object `postType` in core which is why the string was added. In Gutenberg, the string 'Draft Saved' has been hardcoded for the notice instead of 'Saved,' which is in core:
<img width="99" alt="Screen Shot 2022-03-15 at 2 37 26 PM" src="https://user-images.githubusercontent.com/35543432/158476950-1cc6bf8f-de70-4ab1-a3b1-d34d2c7f1b0f.png">
Because of this, it seems reasonable to also add the string 'View Preview' directly into the notice here. Otherwise, we'd need to first add a label for previews in core.

## Testing Instructions
1. Create or edit existing page or post draft 
2. Make a change and click 'Save changes'
3. See Snackbar notice in left corner 'Draft Saved.' with 'View Preview' link
4. Click 'View Preview' and see a preview of the page or post
5. Publish the page or post
6. See 'Page/Post Published/Updated.' with the link 'View Page/Post' as it was before

## Screenshots 
Current 'Draft Saved' Snackbar: 
<img width="130" alt="Screen Shot 2022-03-15 at 2 35 37 PM" src="https://user-images.githubusercontent.com/35543432/158476692-a8749573-4d9e-4ce3-8de4-d1e3bf71330c.png">

Proposed 'Draft Saved' Snackbar: 
<img width="247" alt="Screen Shot 2022-03-16 at 10 59 32 AM" src="https://user-images.githubusercontent.com/35543432/158666156-a3a5511c-42d4-4f19-b641-bb445b06cf88.png">

Snackbar notice when not a draft: 
<img width="254" alt="Screen Shot 2022-03-15 at 2 34 01 PM" src="https://user-images.githubusercontent.com/35543432/158476791-88f01a7b-5632-48b4-9bb0-83775be9f38b.png">

