### PR TITLE
Backspace doesn't (always) delete images

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1248,6 +1248,7 @@ _Parameters_
 
 -   _firstBlockClientId_ `string`: Client ID of the first block to merge.
 -   _secondBlockClientId_ `string`: Client ID of the second block to merge.
+-   _initialPosition_ `0|-1|null`: Value reflecting direction of merge. An initialPosition of -1 indicates a reverse merge (e.g. via backspace).
 
 ### moveBlocksDown
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -121,6 +121,20 @@ _Returns_
 
 -   `WPElement`: Block Breadcrumb.
 
+### BlockCaption
+
+Block caption component which is a thin wrapper around the RichText component
+that can be used to render captions for blocks like image block, video block,
+table block, embed block, gallery block e.t.c
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
+
+_Returns_
+
+-   `WPElement`: Block Caption.
+
 ### BlockColorsStyleSelector
 
 Undocumented declaration.

--- a/packages/block-editor/src/components/block-caption/index.js
+++ b/packages/block-editor/src/components/block-caption/index.js
@@ -8,12 +8,22 @@ import { __ } from '@wordpress/i18n';
  */
 import RichText from '../rich-text/';
 
+// eslint-disable-next-line jsdoc/require-param
+/**
+ * Block caption component which is a thin wrapper around the RichText component
+ * that can be used to render captions for blocks like image block, video block,
+ * table block, embed block, gallery block e.t.c
+ *
+ * @param {Object} props Component props.
+ * @return {WPElement} Block Caption.
+ */
+
 const BlockCaption = ( {
 	isSelected,
 	onChange,
 	placeholder = __( 'Add caption' ),
 	ariaLabel = __( 'Caption text' ),
-	ref,
+	captionRef,
 	caption,
 	tagName = 'figcaption',
 	className,
@@ -34,7 +44,7 @@ const BlockCaption = ( {
 
 	return (
 		<RichText
-			ref={ ref }
+			ref={ captionRef }
 			tagName={ tagName }
 			aria-label={ ariaLabel }
 			placeholder={ placeholder }

--- a/packages/block-editor/src/components/block-caption/index.js
+++ b/packages/block-editor/src/components/block-caption/index.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import RichText from '../rich-text/';
+
+const BlockCaption = ( {
+	isSelected,
+	onChange,
+	placeholder = __( 'Add caption' ),
+	ariaLabel = __( 'Caption text' ),
+	ref,
+	caption,
+	tagName = 'figcaption',
+	className,
+	onFocusCaption,
+	insertBlocksAfter = () => {},
+	unstableOnFocus,
+	inlineToolbar,
+	containerRef,
+	...richTextProps
+} ) => {
+	const onMergeCaption = () => {
+		// If caption is empty, we set focus to the block so that backspacing selects
+		// the parent block and the caret is not stuck inside the caption input.
+		if ( ! caption ) {
+			containerRef.current.focus();
+		}
+	};
+
+	return (
+		<RichText
+			ref={ ref }
+			tagName={ tagName }
+			aria-label={ ariaLabel }
+			placeholder={ placeholder }
+			value={ caption }
+			onChange={ onChange }
+			__unstableOnSplitAtEnd={ insertBlocksAfter }
+			onMerge={ onMergeCaption }
+			className={ className }
+			isSelected={ isSelected }
+			onClick={ onFocusCaption }
+			unstableOnFocus={ unstableOnFocus }
+			inlineToolbar={ inlineToolbar }
+			{ ...richTextProps }
+		/>
+	);
+};
+
+export default BlockCaption;

--- a/packages/block-editor/src/components/block-caption/index.js
+++ b/packages/block-editor/src/components/block-caption/index.js
@@ -30,7 +30,6 @@ const BlockCaption = ( {
 	onFocusCaption,
 	insertBlocksAfter = () => {},
 	unstableOnFocus,
-	inlineToolbar,
 	containerRef,
 	...richTextProps
 } ) => {
@@ -38,7 +37,7 @@ const BlockCaption = ( {
 		// If caption is empty, we set focus to the block so that backspacing selects
 		// the parent block and the caret is not stuck inside the caption input.
 		if ( ! caption ) {
-			containerRef.current.focus();
+			containerRef.current?.focus();
 		}
 	};
 
@@ -56,7 +55,6 @@ const BlockCaption = ( {
 			isSelected={ isSelected }
 			onClick={ onFocusCaption }
 			unstableOnFocus={ unstableOnFocus }
-			inlineToolbar={ inlineToolbar }
 			{ ...richTextProps }
 		/>
 	);

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -306,7 +306,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 					clientId
 				);
 				if ( previousBlockClientId ) {
-					mergeBlocks( previousBlockClientId, clientId );
+					mergeBlocks( previousBlockClientId, clientId, -1 );
 				}
 			}
 		},

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -99,14 +99,12 @@ export function useFocusFirstElement( clientId ) {
 		const isReverse = -1 === initialPosition;
 		const target =
 			( isReverse ? last : first )( textInputs ) || ref.current;
-
-		// Backspacing into a caption field should select the parent block
-		// see https://github.com/WordPress/gutenberg/issues/7422
-		// This prevents situation where the caption 'hijacks' focus
-		// and the caret is stuck inside the caption input.
+		// Backspacing into a caption field should delete the caption text
+		// and then select the parent block when the caption is empty.
+		// This prevents the caret from getting stuck inside the caption input.
 		const targetIsCaption = target?.nodeName === 'FIGCAPTION';
 
-		if ( targetIsCaption || ! isInsideRootBlock( ref.current, target ) ) {
+		if ( ! isInsideRootBlock( ref.current, target ) ) {
 			ref.current.focus();
 			return;
 		}
@@ -125,7 +123,7 @@ export function useFocusFirstElement( clientId ) {
 			}
 		}
 
-		placeCaretAtHorizontalEdge( target, isReverse );
+		placeCaretAtHorizontalEdge( target, targetIsCaption || isReverse );
 	}, [ initialPosition, clientId ] );
 
 	return ref;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -99,10 +99,6 @@ export function useFocusFirstElement( clientId ) {
 		const isReverse = -1 === initialPosition;
 		const target =
 			( isReverse ? last : first )( textInputs ) || ref.current;
-		// Backspacing into a caption field should delete the caption text
-		// and then select the parent block when the caption is empty.
-		// This prevents the caret from getting stuck inside the caption input.
-		const targetIsCaption = target?.nodeName === 'FIGCAPTION';
 
 		if ( ! isInsideRootBlock( ref.current, target ) ) {
 			ref.current.focus();
@@ -123,7 +119,7 @@ export function useFocusFirstElement( clientId ) {
 			}
 		}
 
-		placeCaretAtHorizontalEdge( target, targetIsCaption || isReverse );
+		placeCaretAtHorizontalEdge( target, isReverse );
 	}, [ initialPosition, clientId ] );
 
 	return ref;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -100,7 +100,13 @@ export function useFocusFirstElement( clientId ) {
 		const target =
 			( isReverse ? last : first )( textInputs ) || ref.current;
 
-		if ( ! isInsideRootBlock( ref.current, target ) ) {
+		// Backspacing into a caption field should select the parent block
+		// see https://github.com/WordPress/gutenberg/issues/7422
+		// This prevents situation where the caption 'hijacks' focus
+		// and the caret is stuck inside the caption input.
+		const targetIsCaption = target?.nodeName === 'FIGCAPTION';
+
+		if ( targetIsCaption || ! isInsideRootBlock( ref.current, target ) ) {
 			ref.current.focus();
 			return;
 		}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -11,6 +11,7 @@ export {
 	BlockAlignmentControl,
 	BlockAlignmentToolbar,
 } from './block-alignment-control';
+export { default as BlockCaption } from './block-caption';
 export { default as __experimentalBlockFullHeightAligmentControl } from './block-full-height-alignment-control';
 export { default as __experimentalBlockAlignmentMatrixControl } from './block-alignment-matrix-control';
 export { default as BlockBreadcrumb } from './block-breadcrumb';

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -988,12 +988,12 @@ export const __unstableExpandSelection = () => ( { select, dispatch } ) => {
  * @param {0|-1|null} initialPosition     Value reflecting direction of merge. An initialPosition of -1
  *                                        indicates a reverse merge (e.g. via backspace).
  */
-/* eslint-enable jsdoc/valid-types */
 export const mergeBlocks = (
 	firstBlockClientId,
 	secondBlockClientId,
 	initialPosition = 0
 ) => ( { select, dispatch } ) => {
+	/* eslint-enable jsdoc/valid-types */
 	const blocks = [ firstBlockClientId, secondBlockClientId ];
 	dispatch( { type: 'MERGE_BLOCKS', blocks } );
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -979,16 +979,21 @@ export const __unstableExpandSelection = () => ( { select, dispatch } ) => {
 	} );
 };
 
+/* eslint-disable jsdoc/valid-types */
 /**
  * Action that merges two blocks.
  *
- * @param {string} firstBlockClientId  Client ID of the first block to merge.
- * @param {string} secondBlockClientId Client ID of the second block to merge.
+ * @param {string}    firstBlockClientId  Client ID of the first block to merge.
+ * @param {string}    secondBlockClientId Client ID of the second block to merge.
+ * @param {0|-1|null} initialPosition     Value reflecting direction of merge. An initialPosition of -1
+ *                                        indicates a reverse merge (e.g. via backspace).
  */
-export const mergeBlocks = ( firstBlockClientId, secondBlockClientId ) => ( {
-	select,
-	dispatch,
-} ) => {
+/* eslint-enable jsdoc/valid-types */
+export const mergeBlocks = (
+	firstBlockClientId,
+	secondBlockClientId,
+	initialPosition = 0
+) => ( { select, dispatch } ) => {
 	const blocks = [ firstBlockClientId, secondBlockClientId ];
 	dispatch( { type: 'MERGE_BLOCKS', blocks } );
 
@@ -998,7 +1003,7 @@ export const mergeBlocks = ( firstBlockClientId, secondBlockClientId ) => ( {
 
 	// Only focus the previous block if it's not mergeable.
 	if ( blockAType && ! blockAType.merge ) {
-		dispatch.selectBlock( blockA.clientId );
+		dispatch.selectBlock( blockA.clientId, initialPosition );
 		return;
 	}
 

--- a/packages/block-editor/src/store/test/actions.js
+++ b/packages/block-editor/src/store/test/actions.js
@@ -923,7 +923,7 @@ describe( 'actions', () => {
 				type: 'MERGE_BLOCKS',
 				blocks: [ blockA.clientId, blockB.clientId ],
 			} );
-			expect( dispatch.selectBlock ).toHaveBeenCalledWith( 'chicken' );
+			expect( dispatch.selectBlock ).toHaveBeenCalledWith( 'chicken', 0 );
 		} );
 
 		it( 'should merge the blocks if blocks of the same type', () => {

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -16,6 +16,7 @@ import {
 	withNotices,
 } from '@wordpress/components';
 import {
+	BlockCaption,
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
@@ -25,7 +26,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
@@ -54,6 +55,7 @@ function AudioEdit( {
 		const { getSettings } = select( blockEditorStore );
 		return getSettings().mediaUpload;
 	}, [] );
+	const containerRef = useRef();
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
@@ -125,6 +127,7 @@ function AudioEdit( {
 	} );
 
 	const blockProps = useBlockProps( {
+		ref: containerRef,
 		className: classes,
 	} );
 
@@ -203,11 +206,10 @@ function AudioEdit( {
 				</Disabled>
 				{ isTemporaryAudio && <Spinner /> }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
+					<BlockCaption
+						containerRef={ containerRef }
 						aria-label={ __( 'Audio caption text' ) }
-						placeholder={ __( 'Add caption' ) }
-						value={ caption }
+						caption={ caption }
 						onChange={ ( value ) =>
 							setAttributes( { caption: value } )
 						}

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -23,7 +23,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useBlockProps } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -51,6 +51,8 @@ const EmbedEdit = ( props ) => {
 	};
 	const { icon, title } =
 		getEmbedInfoByProvider( providerNameSlug ) || defaultEmbedInfo;
+
+	const containerRef = useRef();
 
 	const [ url, setURL ] = useState( attributesUrl );
 	const [ isEditingURL, setIsEditingURL ] = useState( false );
@@ -162,7 +164,9 @@ const EmbedEdit = ( props ) => {
 		}
 	}, [ preview, isEditingURL ] );
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		ref: containerRef,
+	} );
 
 	if ( fetching ) {
 		return (
@@ -246,6 +250,7 @@ const EmbedEdit = ( props ) => {
 					icon={ icon }
 					label={ label }
 					insertBlocksAfter={ insertBlocksAfter }
+					containerRef={ containerRef }
 				/>
 			</View>
 		</>

--- a/packages/block-library/src/embed/embed-preview.js
+++ b/packages/block-library/src/embed/embed-preview.js
@@ -13,7 +13,7 @@ import classnames from 'classnames/dedupe';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Placeholder, SandBox } from '@wordpress/components';
-import { RichText, BlockIcon } from '@wordpress/block-editor';
+import { BlockCaption, RichText, BlockIcon } from '@wordpress/block-editor';
 import { Component } from '@wordpress/element';
 import { createBlock } from '@wordpress/blocks';
 
@@ -64,6 +64,7 @@ class EmbedPreview extends Component {
 			icon,
 			label,
 			insertBlocksAfter,
+			containerRef,
 		} = this.props;
 		const { scripts } = preview;
 		const { interactive } = this.state;
@@ -138,10 +139,9 @@ class EmbedPreview extends Component {
 					</Placeholder>
 				) }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
-						placeholder={ __( 'Add caption' ) }
-						value={ caption }
+					<BlockCaption
+						containerRef={ containerRef }
+						caption={ caption }
 						onChange={ onCaptionChange }
 						inlineToolbar
 						__unstableOnSplitAtEnd={ () =>

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -25,7 +25,7 @@ import {
 	BlockControls,
 	MediaReplaceFlow,
 } from '@wordpress/block-editor';
-import { Platform, useEffect, useMemo } from '@wordpress/element';
+import { Platform, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { withViewportMatch } from '@wordpress/viewport';
@@ -465,7 +465,10 @@ function GalleryEdit( props ) {
 		/>
 	);
 
+	const containerRef = useRef( null );
+
 	const blockProps = useBlockProps( {
+		ref: containerRef,
 		className: classnames( className, 'has-nested-images' ),
 	} );
 
@@ -565,6 +568,7 @@ function GalleryEdit( props ) {
 				}
 				blockProps={ blockProps }
 				insertBlocksAfter={ insertBlocksAfter }
+				containerRef={ containerRef }
 			/>
 		</>
 	);

--- a/packages/block-library/src/gallery/gallery.js
+++ b/packages/block-library/src/gallery/gallery.js
@@ -6,7 +6,11 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { RichText, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	BlockCaption,
+	RichText,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { VisuallyHidden } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -23,6 +27,7 @@ export const Gallery = ( props ) => {
 		mediaPlaceholder,
 		insertBlocksAfter,
 		blockProps,
+		containerRef,
 	} = props;
 
 	const { align, columns, caption, imageCrop } = attributes;
@@ -78,8 +83,8 @@ export const Gallery = ( props ) => {
 				</View>
 			) }
 			<RichTextVisibilityHelper
+				containerRef={ containerRef }
 				isHidden={ ! isSelected && RichText.isEmpty( caption ) }
-				captionFocused={ captionFocused }
 				onFocusCaption={ onFocusCaption }
 				tagName="figcaption"
 				className="blocks-gallery-caption"
@@ -98,13 +103,12 @@ export const Gallery = ( props ) => {
 
 function RichTextVisibilityHelper( {
 	isHidden,
-	captionFocused,
 	onFocusCaption,
 	className,
 	value,
 	placeholder,
 	tagName,
-	captionRef,
+	containerRef,
 	...richTextProps
 } ) {
 	if ( isHidden ) {
@@ -112,14 +116,14 @@ function RichTextVisibilityHelper( {
 	}
 
 	return (
-		<RichText
-			ref={ captionRef }
-			value={ value }
-			placeholder={ placeholder }
+		<BlockCaption
 			className={ className }
 			tagName={ tagName }
-			isSelected={ captionFocused }
+			placeholder={ placeholder }
+			containerRef={ containerRef }
+			caption={ value }
 			onClick={ onFocusCaption }
+			unstableOnFocus={ onFocusCaption }
 			{ ...richTextProps }
 		/>
 	);

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -302,9 +302,6 @@ export default function Image( {
 		if ( isSelected && isMediaDestroyed( id ) ) {
 			onImageLoadError();
 		}
-		if ( isSelected ) {
-			containerRef.current?.focus();
-		}
 	}, [ isSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -302,6 +302,9 @@ export default function Image( {
 		if ( isSelected && isMediaDestroyed( id ) ) {
 			onImageLoadError();
 		}
+		if ( isSelected ) {
+			containerRef.current?.focus();
+		}
 	}, [ isSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -22,6 +22,7 @@ import {
 	BlockControls,
 	InspectorControls,
 	RichText,
+	BlockCaption,
 	__experimentalImageSizeControl as ImageSizeControl,
 	__experimentalImageURLInputUI as ImageURLInputUI,
 	MediaReplaceFlow,
@@ -587,19 +588,18 @@ export default function Image( {
 			{ ! temporaryURL && controls }
 			{ img }
 			{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-				<RichText
-					ref={ captionRef }
-					tagName="figcaption"
-					aria-label={ __( 'Image caption text' ) }
-					placeholder={ __( 'Add caption' ) }
-					value={ caption }
+				<BlockCaption
+					captionRef={ captionRef }
+					containerRef={ containerRef }
 					onChange={ ( value ) =>
 						setAttributes( { caption: value } )
 					}
-					inlineToolbar
-					__unstableOnSplitAtEnd={ () =>
+					caption={ caption }
+					ariaLabel={ __( 'Image caption text' ) }
+					insertBlocksAfter={ () =>
 						insertBlocksAfter( createBlock( 'core/paragraph' ) )
 					}
+					inlineToolbar
 				/>
 			) }
 		</ImageEditingProvider>

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -6,11 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import {
 	InspectorControls,
 	BlockControls,
 	RichText,
+	BlockCaption,
 	BlockIcon,
 	AlignmentControl,
 	useBlockProps,
@@ -104,6 +105,8 @@ function TableEdit( {
 
 	const colorProps = useColorProps( attributes );
 	const borderProps = useBorderProps( attributes );
+
+	const containerRef = useRef();
 
 	/**
 	 * Updates the initial column count used for table creation.
@@ -425,8 +428,12 @@ function TableEdit( {
 
 	const isEmpty = ! sections.length;
 
+	const blockProps = useBlockProps( {
+		ref: containerRef,
+	} );
+
 	return (
-		<figure { ...useBlockProps() }>
+		<figure { ...blockProps }>
 			{ ! isEmpty && (
 				<>
 					<BlockControls group="block">
@@ -494,11 +501,12 @@ function TableEdit( {
 				</table>
 			) }
 			{ ! isEmpty && (
-				<RichText
+				<BlockCaption
+					containerRef={ containerRef }
 					tagName="figcaption"
-					aria-label={ __( 'Table caption text' ) }
+					ariaLabel={ __( 'Table caption text' ) }
 					placeholder={ __( 'Add caption' ) }
-					value={ caption }
+					caption={ caption }
 					onChange={ ( value ) =>
 						setAttributes( { caption: value } )
 					}

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -16,6 +16,7 @@ import {
 	withNotices,
 } from '@wordpress/components';
 import {
+	BlockCaption,
 	BlockControls,
 	BlockIcon,
 	InspectorControls,
@@ -63,6 +64,7 @@ function VideoEdit( {
 	const mediaUpload = useSelect(
 		( select ) => select( blockEditorStore ).getSettings().mediaUpload
 	);
+	const containerRef = useRef();
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
@@ -136,6 +138,7 @@ function VideoEdit( {
 	} );
 
 	const blockProps = useBlockProps( {
+		ref: containerRef,
 		className: classes,
 	} );
 
@@ -265,11 +268,10 @@ function VideoEdit( {
 				</Disabled>
 				{ isTemporaryVideo && <Spinner /> }
 				{ ( ! RichText.isEmpty( caption ) || isSelected ) && (
-					<RichText
-						tagName="figcaption"
+					<BlockCaption
+						containerRef={ containerRef }
 						aria-label={ __( 'Video caption text' ) }
-						placeholder={ __( 'Add caption' ) }
-						value={ caption }
+						caption={ caption }
 						onChange={ ( value ) =>
 							setAttributes( { caption: value } )
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR sets focus to the parent block when merging via backspace into a block's caption field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This fixes an issue where the cursor gets stuck in the block's caption when backspacing from a paragraph into an image block. See https://github.com/WordPress/gutenberg/issues/7422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
In the block's onfocus handler, I am setting focus to the block if I detect that the target of a "reverse" merge is a caption by checking if the `nodeName` is a figcaption. I am not very sure if this is the most reliable way to detect captions  so any suggestions here would be much appreciated. This also fixes the bug in other blocks that have captions i.e. embed, video etc

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post with an image and add a bit of text after it
2. Place the cursor at the end of the text and backspace until the paragraph is empty
3. Backspace once to remove the paragraph
4. Backspace again from the image block

<!--## Screenshots or screencast--> <!-- if applicable -->
Fixes #7422
