### PR TITLE
Add prop to control default expand/collapse state of ListView nodes

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -72,6 +72,7 @@ function ListViewBranch( props ) {
 		isBranchSelected = false,
 		listPosition = 0,
 		fixedListWindow,
+		expandNested = true,
 	} = props;
 
 	const {
@@ -113,7 +114,7 @@ function ListViewBranch( props ) {
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 
 				const isExpanded = hasNestedBlocks
-					? expandedState[ clientId ] ?? true
+					? expandedState[ clientId ] ?? expandNested
 					: undefined;
 
 				const isDragged = !! draggedClientIds?.includes( clientId );
@@ -165,6 +166,7 @@ function ListViewBranch( props ) {
 								fixedListWindow={ fixedListWindow }
 								isBranchSelected={ isSelectedBranch }
 								selectedClientIds={ selectedClientIds }
+								expandNested={ expandNested }
 							/>
 						) }
 					</AsyncModeProvider>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -23,39 +23,59 @@ import { isClientIdSelected } from './utils';
  * When a block is collapsed, we do not count their children as part of that total. In the current drag
  * implementation dragged blocks and their children are not counted.
  *
- * @param {Object} block            block tree
- * @param {Object} expandedState    state that notes which branches are collapsed
- * @param {Array}  draggedClientIds a list of dragged client ids
+ * @param {Object}  block               block tree
+ * @param {Object}  expandedState       state that notes which branches are collapsed
+ * @param {Array}   draggedClientIds    a list of dragged client ids
+ * @param {boolean} isExpandedByDefault flag to determine the default fallback expanded state.
  * @return {number} block count
  */
-function countBlocks( block, expandedState, draggedClientIds ) {
+function countBlocks(
+	block,
+	expandedState,
+	draggedClientIds,
+	isExpandedByDefault
+) {
 	const isDragged = draggedClientIds?.includes( block.clientId );
 	if ( isDragged ) {
 		return 0;
 	}
-	const isExpanded = expandedState[ block.clientId ] ?? true;
+	const isExpanded = expandedState[ block.clientId ] ?? isExpandedByDefault;
+
 	if ( isExpanded ) {
 		return (
 			1 +
 			block.innerBlocks.reduce(
-				countReducer( expandedState, draggedClientIds ),
+				countReducer(
+					expandedState,
+					draggedClientIds,
+					isExpandedByDefault
+				),
 				0
 			)
 		);
 	}
 	return 1;
 }
-const countReducer = ( expandedState, draggedClientIds ) => (
-	count,
-	block
-) => {
+const countReducer = (
+	expandedState,
+	draggedClientIds,
+	isExpandedByDefault
+) => ( count, block ) => {
 	const isDragged = draggedClientIds?.includes( block.clientId );
 	if ( isDragged ) {
 		return count;
 	}
-	const isExpanded = expandedState[ block.clientId ] ?? true;
+	const isExpanded = expandedState[ block.clientId ] ?? isExpandedByDefault;
 	if ( isExpanded && block.innerBlocks.length > 0 ) {
-		return count + countBlocks( block, expandedState, draggedClientIds );
+		return (
+			count +
+			countBlocks(
+				block,
+				expandedState,
+				draggedClientIds,
+				isExpandedByDefault
+			)
+		);
 	}
 	return count + 1;
 };
@@ -94,14 +114,14 @@ function ListViewBranch( props ) {
 					nextPosition += countBlocks(
 						filteredBlocks[ index - 1 ],
 						expandedState,
-						draggedClientIds
+						draggedClientIds,
+						expandNested
 					);
 				}
 
 				const usesWindowing = __experimentalPersistentListViewFeatures;
 
 				const { itemInView } = fixedListWindow;
-
 				const blockInView =
 					! usesWindowing || itemInView( nextPosition );
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -60,6 +60,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {boolean} props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
  * @param {string}  props.id                                       Unique identifier for the root list element (primarily for a11y purposes).
+ * @param {boolean} props.expandNested                             Flag to determine whether nested levels are expanded by default.
  * @param {Object}  ref                                            Forwarded ref
  */
 function ListView(
@@ -71,6 +72,7 @@ function ListView(
 		showNestedBlocks,
 		showBlockMovers,
 		id,
+		expandNested,
 		...props
 	},
 	ref
@@ -223,6 +225,7 @@ function ListView(
 						showBlockMovers={ showBlockMovers }
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
+						expandNested={ expandNested }
 						{ ...props }
 					/>
 				</ListViewContext.Provider>

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,7 +63,6 @@ export default function ListViewSidebar() {
 					showNestedBlocks
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
-					expandNested={ false }
 				/>
 			</div>
 		</div>

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,6 +63,7 @@ export default function ListViewSidebar() {
 					showNestedBlocks
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
+					expandNested={ false }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## What?
This PR adds a new prop (only) to control the default expanded/collapsed state of nodes with the ListView component.

⚠️ **Please note**: this PR does not attempt to modify the behaviour of the standard ListView component. The change in this PR is just to add a new prop. Nothing about the standard list view should change.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR has been extracted from https://github.com/WordPress/gutenberg/pull/39290/ where it is required to improve the initial UX of the Navigation Menus in the sidebar. Heavily nested menus make for a poor initial experience and this prop affords the ability to initially show only the top level menu items.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new prop has been added to `<ListView>` called `expandNested`.  By default this is set to `true` in order to match the current default behaviour whereby all nodes are expanded. However by setting to `false` all nodes are be collapsed by default.

Note that the windowing algorithm had to be tweaked to account for the default expanded state. It previously defaulted to `true` (assumed expanded) which meant it included sub trees in the windowing calculation even if they weren't actually visible. This meant blocks would disappear from the sidebar if you had a large number of subtrees high up in the block list.

## Testing Instructions

These instructions assume you are tested on a template which has multiple nested blocks. An easy way to do this is to use the Site Editor and the default TT2 block theme.

- Run `npm run dev` on this branch.
- Open Site Editor (or anywhere that the List View is available).
- Toggle list view open.
- Check all nodes are _expanded_ by _default_.
- Now modify the ListView within the Site Editor to add the `expandNested=false` prop:

https://github.com/WordPress/gutenberg/blob/5c39cdb805c4a54ba4d30e5f8948aa2c2569985d/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js#L62-L66

It should look like this:

```diff
<ListView
    showNestedBlocks
    __experimentalFeatures
    __experimentalPersistentListViewFeatures
+    expandNested={false}
/>
```
- Now rebuild and open the Site Editor.
- Toggle list view.
- See all nodes and branches are collapsed by default.
- Check you can expand/collapse nodes manually as required.
- Make sure you carefully check that ALL the nodes are present and can be expanded/collapsed - there is windowing at play in List View which we had to account for in this PR.

## Screenshots or screencast <!-- if applicable -->

⚠️ **Please note**: the screencapture below is for illustration purposes only. This PR does not attempt to modify the behaviour of the standard ListView component. The change in this PR is just to add a new prop in order that the behaviour can be customised elsewhere (namely in https://github.com/WordPress/gutenberg/pull/39290/). Nothing about the standard list view should change.

https://user-images.githubusercontent.com/444434/158559817-876e5888-caf5-4edc-ad59-a05b564d9c18.mov


