### PR TITLE
Implement the nested block behavior in list block v2

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -323,6 +323,15 @@ Create a bulleted or numbered list. ([Source](https://github.com/WordPress/guten
 -	**Supports:** __unstablePasteTextInline, anchor, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** ordered, placeholder, reversed, start, type, values
 
+## List item
+
+Create a list item. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/list-item))
+
+-	**Name:** core/list-item
+-	**Category:** text
+-	**Supports:** ~~className~~
+-	**Attributes:** content, placeholder
+
 ## Login/out
 
 Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/loginout))

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -46,6 +46,7 @@ import * as image from './image';
 import * as latestComments from './latest-comments';
 import * as latestPosts from './latest-posts';
 import * as list from './list';
+import * as listItem from './list-item';
 import * as logInOut from './loginout';
 import * as mediaText from './media-text';
 import * as missing from './missing';
@@ -135,6 +136,7 @@ export const __experimentalGetCoreBlocks = () => [
 	heading,
 	gallery,
 	list,
+	listItem,
 	quote,
 
 	// Register all remaining core blocks.

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/list-item",
+	"title": "List item",
+	"category": "text",
+	"parent": [ "core/list" ],
+	"description": "Create a list item.",
+	"textdomain": "default",
+	"attributes": {
+		"placeholder": {
+			"type": "string"
+		},
+		"content": {
+			"type": "string",
+			"source": "html",
+            "selector": "li",
+			"default": "",
+			"__experimentalRole": "content"
+		}
+	},
+	"supports": {
+		"className": false,
+		"__experimentalSelector": "li"
+	},
+	"editorStyle": "wp-block-list-item-editor",
+	"style": "wp-block-list-item"
+}

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -14,7 +14,7 @@
 		"content": {
 			"type": "string",
 			"source": "html",
-            "selector": "li",
+    		"selector": "li",
 			"default": "",
 			"__experimentalRole": "content"
 		}
@@ -22,7 +22,5 @@
 	"supports": {
 		"className": false,
 		"__experimentalSelector": "li"
-	},
-	"editorStyle": "wp-block-list-item-editor",
-	"style": "wp-block-list-item"
+	}
 }

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	RichText,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+export default function ListItemEdit( { attributes, setAttributes } ) {
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			allowedBlocks: [ 'core/list' ],
+		}
+	);
+
+	return (
+		<li { ...blockProps }>
+			<RichText
+				identifier="content"
+				tagName="div"
+				onChange={ ( nextContent ) =>
+					setAttributes( { content: nextContent } )
+				}
+				value={ attributes.content }
+				aria-label={ __( 'List text' ) }
+				placeholder={ attributes.placeholder || __( 'List' ) }
+			/>
+			<div { ...innerBlocksProps } />
+		</li>
+	);
+}

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -10,15 +10,12 @@ import { __ } from '@wordpress/i18n';
 
 export default function ListItemEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps(
-		{},
-		{
-			allowedBlocks: [ 'core/list' ],
-		}
-	);
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/list' ],
+	} );
 
 	return (
-		<li { ...blockProps }>
+		<li { ...innerBlocksProps }>
 			<RichText
 				identifier="content"
 				tagName="div"
@@ -29,7 +26,7 @@ export default function ListItemEdit( { attributes, setAttributes } ) {
 				aria-label={ __( 'List text' ) }
 				placeholder={ attributes.placeholder || __( 'List' ) }
 			/>
-			<div { ...innerBlocksProps } />
+			{ innerBlocksProps.children }
 		</li>
 	);
 }

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { list as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import save from './save';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+	save,
+};

--- a/packages/block-library/src/list-item/save.js
+++ b/packages/block-library/src/list-item/save.js
@@ -1,0 +1,13 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
+
+export default function save( { attributes } ) {
+	return (
+		<li { ...useBlockProps.save() }>
+			<RichText.Content value={ attributes.content } />
+			<InnerBlocks.Content />
+		</li>
+	);
+}

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -1,5 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+
+const TEMPLATE = [ [ 'core/list-item' ] ];
+
 function Edit() {
-	return <div>List block v2</div>;
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		allowedBlocks: [ 'core/list-item' ],
+		template: TEMPLATE,
+	} );
+
+	return <ul { ...innerBlocksProps } />;
 }
 
 export default Edit;

--- a/packages/block-library/src/list/v2/save.js
+++ b/packages/block-library/src/list/v2/save.js
@@ -1,5 +1,12 @@
-function Save() {
-	return <div>List block v2</div>;
-}
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default Save;
+export default function save() {
+	return (
+		<ul { ...useBlockProps.save() }>
+			<InnerBlocks.Content />
+		</ul>
+	);
+}

--- a/test/integration/fixtures/blocks/core__list-item.html
+++ b/test/integration/fixtures/blocks/core__list-item.html
@@ -1,0 +1,1 @@
+<!-- wp:list-item --><li></li><!-- /wp:list-item -->

--- a/test/integration/fixtures/blocks/core__list-item.json
+++ b/test/integration/fixtures/blocks/core__list-item.json
@@ -1,0 +1,10 @@
+[
+	{
+		"name": "core/list-item",
+		"isValid": true,
+		"attributes": {
+			"content": ""
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__list-item.parsed.json
+++ b/test/integration/fixtures/blocks/core__list-item.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/list-item",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "<li></li>",
+		"innerContent": [ "<li></li>" ]
+	}
+]

--- a/test/integration/fixtures/blocks/core__list-item.serialized.html
+++ b/test/integration/fixtures/blocks/core__list-item.serialized.html
@@ -1,0 +1,3 @@
+<!-- wp:list-item -->
+<li></li>
+<!-- /wp:list-item -->


### PR DESCRIPTION
Related #6394

## What?
This PR implements the logic for the list block v2 (with inner blocks). It adds the base save/edit for list and list item blocks.

## How?
At the moment, the block is very rough, I decided explicitly to only focus on:
 
 - Making sure the saved markup is the exact markup that we want to achieve (similar to the current list block)
 - Making sure we can add list and list items in the editor (though very rough)

There's a lot of things to be implemented here to make this block more usable, the idea is that now that we have the list block and basic behavior in place, we can potentially work in parallel if needed on some of these points:

 - Making sure the editor markup and the frontend markup match. Right now the editor has two extra wrappers: a "span" around the RichText and a "div" around the inner blocks of a list item. Both of these wrappers make the initial implementation simple but we should see if it's possible to remove them to totally match the frontend.
 - Improve the appenders: Potentially remove some of them or show them in the right position (avoid layout shifts)
 - Keyboard interactions:
     - Enter should create new list items
     - Implement indent/outdent shortcuts
     - Implement double enter to leave the list block
     - Implement merging and splitting list blocks
  - Explore if absorb toolbar make sense
  - Bring back the features of the old list block (choosing the "start", "reverse" and type of list)
  - Decide what customization options (block supports) we want to enable in the "list item" block.

## Testing Instructions

1- Enable the "list block v2" experiment
2- Insert a list block
3- You can use appenders and such (regular inner blocks UI) to insert list items and nested lists (interaction is very rough without keyboard support)
4- Make sure the produced markup is correct. 


https://user-images.githubusercontent.com/272444/158547851-acd14f72-737f-413c-a6c1-07853326e13c.mov


