### PR TITLE
Latest Posts: Don't remove transparent background color style

### DIFF
--- a/packages/block-library/src/latest-posts/index.php
+++ b/packages/block-library/src/latest-posts/index.php
@@ -15,6 +15,22 @@ global $block_core_latest_posts_excerpt_length;
 $block_core_latest_posts_excerpt_length = 0;
 
 /**
+ * Callback for the safecss_filter_attr_allow_css filter used by
+ * the Latest Posts block at render time.
+ *
+ * @param bool   $allow_css       Whether the CSS in the test string is considered safe.
+ * @param string $css_test_string The CSS string to test.
+ * @return bool Whether the CSS in the test string is considered safe.
+ */
+function gutenberg_block_core_latest_posts_filter_allow_css( $allow_css, $css_test_string ) {
+	// Allow transparent background color that is assigned automatically to highlighted text as safe CSS.
+	if ( 'background-color:rgba(0, 0, 0, 0)' === $css_test_string ) {
+		return true;
+	}
+	return $allow_css;
+}
+
+/**
  * Callback for the excerpt_length filter used by
  * the Latest Posts block at render time.
  *
@@ -156,10 +172,14 @@ function render_block_core_latest_posts( $attributes ) {
 				$post_content = __( 'This content is password protected.' );
 			}
 
+			add_filter( 'safecss_filter_attr_allow_css', 'gutenberg_block_core_latest_posts_filter_allow_css', 10, 2 );
+
 			$list_items_markup .= sprintf(
 				'<div class="wp-block-latest-posts__post-full-content">%1$s</div>',
 				wp_kses_post( $post_content )
 			);
+
+			remove_filter( 'safecss_filter_attr_allow_css', 'gutenberg_block_core_latest_posts_filter_allow_css' );
 		}
 
 		$list_items_markup .= "</li>\n";


### PR DESCRIPTION
Fix: #39402

## What?
This PR prevents the transparent background color style from being removed in the rendering of the content.

## Why?
In RichText, when an inline text color is specified, a transparent background color style (`background-color:rgba(0, 0, 0, 0)`) is generated at the same time.
This is to disable the browser's default style (`yellow` for Chrome), since highlighted text is wrapped with a `mark` tag.

However, this background color is sanitized by wp_kes_post, and the browser's default style is restored.
This is because parentheses are not allowed as CSS values inside wp_kses_post, except for `calc` and `var`.

This part:
https://github.com/WordPress/wordpress-develop/blob/34d46cd5013c6433bb0e4d2b447abe162e6521d1/src/wp-includes/kses.php#L2514-L2521

## How?
This PR temporarily hooks `safecss_filter_attr_allow_css` filter and adds a transparent background color as valid CSS.
If you know of any other appropriate methods, please advise me.

## Testing Instructions

- Create post, and highlight a portion of text in any text color.
- Insert the "Latest Post" block into any page.
- Activate "Post content" from "Post content settings".
- Select "Full post"
- Verify that the highlighted text keeps transparent background color style on the front-end.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/54422211/158552096-5c66910b-6311-42b7-99c0-9867e762ce1c.mp4


