### PR TITLE
Fix: Navigation block: allow extending the list of allowed inner blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -27,6 +28,11 @@ const ALLOWED_BLOCKS = [
 	'core/site-logo',
 	'core/navigation-submenu',
 ];
+
+const additionalAllowedBlocks = applyFilters(
+	'blocks.navigation.additionalAllowedBlocks',
+	[]
+);
 
 const DEFAULT_BLOCK = {
 	name: 'core/navigation-link',
@@ -114,7 +120,7 @@ export default function NavigationInnerBlocks( {
 			value: blocks,
 			onInput,
 			onChange,
-			allowedBlocks: ALLOWED_BLOCKS,
+			allowedBlocks: [ ...ALLOWED_BLOCKS, ...additionalAllowedBlocks ],
 			__experimentalDefaultBlock: DEFAULT_BLOCK,
 			__experimentalDirectInsert: shouldDirectInsert,
 			orientation,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a new filter allowing plugins to register inner blocks for `<Navigation/>`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #31387.

With the current implementation, plugins can still register Navigation inner blocks by listing `core/navigation` as a parent block. This workaround has a limitation described in https://github.com/WordPress/gutenberg/issues/31387#issuecomment-936329561. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using a filter, blocks can be added to `<Navigation>` but can still be the top-level blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. From a plugin, add a block to the allowed list using the new filter:
```
addFilter(
	'blocks.navigation.additionalAllowedBlocks',
	'woocommerce/mini-cart',
	( allowedBlocks ) => {
		return [ ...allowedBlocks, 'woocommerce/mini-cart' ];
	}
);
```
2. Edit header template part which contains the Navigation block.
3. Try adding an inner block.
4. See the block added above in the block inserter.
5. Can insert that block to the `<Navigation>`.

## Screenshots or screencast <!-- if applicable -->
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/5423135/158570834-5eee0bf7-876d-419c-aae9-941216b5bf4b.png">
