### PR TITLE
[Patterns]: Load theme patterns only in block and site editor

### DIFF
--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -35,9 +35,13 @@ function gutenberg_register_remote_theme_patterns() {
 add_action(
 	'current_screen',
 	function( $current_screen ) {
-		$should_load_remote = apply_filters( 'should_load_remote_block_patterns', true );
-		$theme_has_support  = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-		if ( ! get_theme_support( 'core-block-patterns' ) || ! $should_load_remote || ! $theme_has_support ) {
+		if ( ! get_theme_support( 'core-block-patterns' ) ) {
+			return;
+		}
+		if ( ! apply_filters( 'should_load_remote_block_patterns', true ) ) {
+			return;
+		}
+		if ( ! WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
 			return;
 		}
 

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -10,12 +10,6 @@
  * `theme.json` file.
  */
 function gutenberg_register_remote_theme_patterns() {
-	$should_load_remote = apply_filters( 'should_load_remote_block_patterns', true );
-	$theme_has_support  = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
-	if ( ! get_theme_support( 'core-block-patterns' ) || ! $should_load_remote || ! $theme_has_support ) {
-		return;
-	}
-
 	$pattern_settings = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()->get_patterns();
 	if ( empty( $pattern_settings ) ) {
 		return;
@@ -38,4 +32,18 @@ function gutenberg_register_remote_theme_patterns() {
 	}
 }
 
-add_action( 'init', 'gutenberg_register_remote_theme_patterns' );
+add_action(
+	'current_screen',
+	function( $current_screen ) {
+		$should_load_remote = apply_filters( 'should_load_remote_block_patterns', true );
+		$theme_has_support  = WP_Theme_JSON_Resolver_Gutenberg::theme_has_support();
+		if ( ! get_theme_support( 'core-block-patterns' ) || ! $should_load_remote || ! $theme_has_support ) {
+			return;
+		}
+
+		$is_site_editor = ( function_exists( 'gutenberg_is_edit_site_page' ) && gutenberg_is_edit_site_page( $current_screen->id ) );
+		if ( $current_screen->is_block_editor || $is_site_editor ) {
+			gutenberg_register_remote_theme_patterns();
+		}
+	}
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Load theme patterns only in block and site editor

## Why?
From @jsnajdr 's [comment](https://github.com/WordPress/gutenberg/issues/39055#issuecomment-1068897162):
>Downloading and registering current theme patterns is not even limited to the editor pages, but is hooked to the init hook and happens for every page, even site frontend. See https://github.com/WordPress/gutenberg/pull/38323


## How?
This PR adds checks to fetch/register them only in block and site editor.
