### PR TITLE
Add id prop to ListView

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -59,6 +59,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {boolean} props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {boolean} props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
+ * @param {string}  props.id                                       Unique identifier for the root list element (primarily for a11y purposes).
  * @param {Object}  ref                                            Forwarded ref
  */
 function ListView(
@@ -69,6 +70,7 @@ function ListView(
 		__experimentalHideContainerBlockActions,
 		showNestedBlocks,
 		showBlockMovers,
+		id,
 		...props
 	},
 	ref
@@ -205,6 +207,7 @@ function ListView(
 				blockDropTarget={ blockDropTarget }
 			/>
 			<TreeGrid
+				id={ id }
 				className="block-editor-list-view-tree"
 				aria-label={ __( 'Block navigation structure' ) }
 				ref={ treeGridRef }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds an `id` prop to `<ListView>`. This is ultimately passed down as `...props` to `<TreeGrid>` and thus ends up being the `id` attribute of the root `<table>` element of the list view.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a11y purposes it is often important to have an `id` attribute on an element. For example if you have some kind of control that is associated with the list view then you would need to add an `aria-controls` attribute to it which references the `id` attribute of the list view.

An example of this requirement is shown in https://github.com/WordPress/gutenberg/pull/39290 where we need to associate the Navigation Menu dropdown `<select>` with the list view as when you select a menu it changes the list view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It adds an `id` prop.

## Testing Instructions

- Modify the ListView within the Site Editor to add an `id` prop:

https://github.com/WordPress/gutenberg/blob/5c39cdb805c4a54ba4d30e5f8948aa2c2569985d/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js#L62-L66

It should look like this:

```diff
<ListView
    showNestedBlocks
    __experimentalFeatures
    __experimentalPersistentListViewFeatures
+    id="some-id"
/>
```

- Now reload Site Editor, expand list view and check the DOM that the `id` attribute is present on the List View `<table>` element.

## Screenshots or screencast <!-- if applicable -->
