### PR TITLE
Remove script group override

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -67,19 +67,6 @@ function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $v
 		$script->deps = $deps;
 		$script->ver  = $ver;
 		$script->args = $in_footer;
-
-		/*
-		 * The script's `group` designation is an indication of whether it is
-		 * to be printed in the header or footer. The behavior here defers to
-		 * the arguments as passed. Specifically, group data is not assigned
-		 * for a script unless it is designated to be printed in the footer.
-		 */
-
-		// See: `wp_register_script` .
-		unset( $script->extra['group'] );
-		if ( $in_footer ) {
-			$script->add_data( 'group', 1 );
-		}
 	} else {
 		$scripts->add( $handle, $src, $deps, $ver, $in_footer );
 	}


### PR DESCRIPTION
After the core commit https://core.trac.wordpress.org/changeset/52937 e2e tests started failing in Gutenberg. There's some debugging and related discussion happening here https://meta.trac.wordpress.org/ticket/6195#comment:7

I found that scripts are not loaded in the same way between Gutenberg and core, not in the same positions. I also found that it's related to that "group" assignment. So removing that code seems to fix it but I honestly don't know what I'm doing here :P 