### PR TITLE
Improve in_footer handling in gutenberg_override_script()

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -66,22 +66,9 @@ function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $v
 		$script->src  = $src;
 		$script->deps = $deps;
 		$script->ver  = $ver;
-		$script->args = $in_footer;
-
-		/*
-		 * The script's `group` designation is an indication of whether it is
-		 * to be printed in the header or footer. The behavior here defers to
-		 * the arguments as passed. Specifically, group data is not assigned
-		 * for a script unless it is designated to be printed in the footer.
-		 */
-
-		// See: `wp_register_script` .
-		unset( $script->extra['group'] );
-		if ( $in_footer ) {
-			$script->add_data( 'group', 1 );
-		}
+		$script->args = $in_footer ? 1 : null;
 	} else {
-		$scripts->add( $handle, $src, $deps, $ver, $in_footer );
+		$scripts->add( $handle, $src, $deps, $ver, ( $in_footer ? 1 : null ) );
 	}
 
 	/*

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -54,6 +54,12 @@ function gutenberg_url( $path ) {
  *                                    Default 'false'.
  */
 function gutenberg_override_script( $scripts, $handle, $src, $deps = array(), $ver = false, $in_footer = false ) {
+	/*
+	 * Force `wp-i18n` script to be registered in the <head> as a
+	 * temporary workaround for https://meta.trac.wordpress.org/ticket/6195.
+	 */
+	$in_footer = 'wp-i18n' === $handle ? false : $in_footer;
+
 	$script = $scripts->query( $handle, 'registered' );
 	if ( $script ) {
 		/*

--- a/phpunit/class-override-script-test.php
+++ b/phpunit/class-override-script-test.php
@@ -62,7 +62,7 @@ class Override_Script_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/updated', $script->src );
 		$this->assertEquals( array( 'updated-dependency', 'wp-i18n' ), $script->deps );
 		$this->assertEquals( 'updated-version', $script->ver );
-		$this->assertTrue( $script->args );
+		$this->assertSame( 1, $script->args );
 	}
 
 	/**
@@ -84,6 +84,6 @@ class Override_Script_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/', $script->src );
 		$this->assertEquals( array( 'dependency', 'wp-i18n' ), $script->deps );
 		$this->assertEquals( 'version', $script->ver );
-		$this->assertTrue( $script->args );
+		$this->assertSame( 1, $script->args );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is related to https://meta.trac.wordpress.org/ticket/6195 ~but still doesn't fix the issue.~ and adds a temporary workaround for a broken script dependency issue related to `common` and `wp-i18n`.

## Why?
`$args` should be set to `1` if a script should be loaded in the footer, see https://github.com/WordPress/wordpress-develop/blob/573581f43f63f12cc37620172432cf93745f568c/src/wp-includes/class.wp-scripts.php#L541-L542.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
