### PR TITLE
Add Navigation menu to known entities

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -115,7 +115,7 @@ export const rootEntitiesConfig = [
 		label: __( 'Comment' ),
 	},
 	{
-		name: 'menu',
+		name: 'menu', // Classic Menus
 		kind: 'root',
 		baseURL: '/wp/v2/menus',
 		baseURLParams: { context: 'edit' },
@@ -123,7 +123,7 @@ export const rootEntitiesConfig = [
 		label: __( 'Menu' ),
 	},
 	{
-		name: 'menuItem',
+		name: 'menuItem', // Classic Menu Items
 		kind: 'root',
 		baseURL: '/wp/v2/menu-items',
 		baseURLParams: { context: 'edit' },
@@ -132,7 +132,7 @@ export const rootEntitiesConfig = [
 		rawAttributes: [ 'title', 'content' ],
 	},
 	{
-		name: 'menuLocation',
+		name: 'menuLocation', // Classic Menu Locations
 		kind: 'root',
 		baseURL: '/wp/v2/menu-locations',
 		baseURLParams: { context: 'edit' },
@@ -141,7 +141,7 @@ export const rootEntitiesConfig = [
 		key: 'name',
 	},
 	{
-		name: 'navigationArea',
+		name: 'navigationArea', // Deprecated - can be removed once the concepts of Navigation Areas is removed from the codebase.
 		kind: 'root',
 		baseURL: '/wp/v2/block-navigation-areas',
 		baseURLParams: { context: 'edit' },
@@ -176,7 +176,7 @@ export const rootEntitiesConfig = [
 		key: 'plugin',
 	},
 	{
-		label: __( 'Navigation' ),
+		label: __( 'Navigation' ), // Block based Navigation Menus
 		name: 'navigationMenu',
 		kind: 'root',
 		baseURL: '/wp/v2/navigation',

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -175,6 +175,14 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		key: 'plugin',
 	},
+	{
+		label: __( 'Navigation' ),
+		name: 'navigationMenu',
+		kind: 'root',
+		baseURL: '/wp/v2/navigation',
+		baseURLParams: { context: 'edit' },
+		plural: 'navigationMenus',
+	},
 ];
 
 export const additionalEntityConfigLoaders = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a new `navigationMenus` entity (`wp_navigation`) to the list of ["known" entities](https://github.com/WordPress/gutenberg/blob/70f6f1924509b5a2389ac48d13e3eb00fae9a744/packages/core-data/src/entities.js#L21). This enables use of selector "shortcuts" to fetch Navigation Menus.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


Spun out of https://github.com/WordPress/gutenberg/pull/39290/ in order to simplify that PR.

We often want to fetch data about Navigation Menus. To do this we have to write out the full `getEntityRecords()` providing all the correct parameters. This is rather verbose and requires remember all the correct params:

```js
wp.data.select('core').getEntityRecords('postType','wp_navigation')
```

Given that `wp_navigation` is now part of WP Core it makes sense to add a shortcut to enable shorthand selectors.

With this PR we can now achieve the same result with the following selector:

```js
wp.data.select('core').getNavigationMenus()
```

## How?

By adding the new entity to the root entity records `core-data` will generate a selector which will fetch Navigation Menus.

## Testing Instructions

First verify that Navigatoin Menus are available in the root entity records.

- Open dev tools console
- Type:
```
wp.data.select('core').getEntitiesByKind('root').map( ({kind,name}) => (name));
```
- Check for the `navigationMenu` entry.

Now check you can call the shortcut selector to return available Navigation posts.

- Create some Navigation Menus using the Nav block.
- Open devtools console
- Type:
```js
wp.data.select('core').getNavigationMenus()
```
- You should see all the available Navigation Menus (note you may have to run the selector twice in order to allow for the resolver to run).

Also verify you can utilise the singular form of the selector:

```
wp.data.select('core').getNavigationMenu(%%VALID_NAV_MENU_ID_HERE%%)
```



## Screenshots or screencast <!-- if applicable -->
