### PR TITLE
`UnitControl`: mark `unit` prop as deprecated

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,10 @@
 
 -   `NumberControl`: commit (and constrain) value on `blur` event ([#39186](https://github.com/WordPress/gutenberg/pull/39186)).
 
+### Deprecation
+
+-   `unit` prop in `UnitControl` marked as deprecated ([#39503](https://github.com/WordPress/gutenberg/pull/39503)).
+
 ## 19.6.0 (2022-03-11)
 
 ### Enhancements

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -61,8 +61,7 @@ function UnforwardedUnitControl(
 	if ( typeof unitProp !== 'undefined' ) {
 		deprecated( 'UnitControl unit prop', {
 			since: '5.6',
-			hint:
-				'Please provide a unit with a value through the `value` prop.',
+			hint: 'The unit should be provided within the `value` prop.',
 			version: '6.2',
 		} );
 	}

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -37,7 +37,14 @@ import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
 import type { StateReducer } from '../input-control/reducer/state';
 
 function UnforwardedUnitControl(
-	{
+	unitControlProps: WordPressComponentProps<
+		UnitControlProps,
+		'input',
+		false
+	>,
+	forwardedRef: ForwardedRef< any >
+) {
+	const {
 		__unstableStateReducer: stateReducerProp,
 		autoComplete = 'off',
 		className,
@@ -55,10 +62,9 @@ function UnforwardedUnitControl(
 		units: unitsProp = CSS_UNITS,
 		value: valueProp,
 		...props
-	}: WordPressComponentProps< UnitControlProps, 'input', false >,
-	forwardedRef: ForwardedRef< any >
-) {
-	if ( typeof unitProp !== 'undefined' ) {
+	} = unitControlProps;
+
+	if ( 'unit' in unitControlProps ) {
 		deprecated( 'UnitControl unit prop', {
 			since: '5.6',
 			hint: 'The unit should be provided within the `value` prop.',

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -15,6 +15,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { forwardRef, useMemo, useRef, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -57,6 +58,15 @@ function UnforwardedUnitControl(
 	}: WordPressComponentProps< UnitControlProps, 'input', false >,
 	forwardedRef: ForwardedRef< any >
 ) {
+	if ( typeof unitProp !== 'undefined' ) {
+		deprecated( 'UnitControl unit prop', {
+			since: '5.6',
+			hint:
+				'Please provide a unit with a value through the `value` prop.',
+			version: '6.2',
+		} );
+	}
+
 	// The `value` prop, in theory, should not be `null`, but the following line
 	// ensures it fallback to `undefined` in case a consumer of `UnitControl`
 	// still passes `null` as a `value`.

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -100,7 +100,7 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should not render select, if units are disabled', () => {
-			render( <UnitControl unit="em" units={ [] } /> );
+			render( <UnitControl value="3em" units={ [] } /> );
 			const input = getInput();
 			const select = getSelect();
 
@@ -224,17 +224,24 @@ describe( 'UnitControl', () => {
 
 	describe( 'Unit', () => {
 		it( 'should update unit value on change', async () => {
-			let state = 'px';
+			let state = '14rem';
 			const setState = ( nextState ) => ( state = nextState );
 
+			const spy = jest.fn();
+
 			const { user } = render(
-				<UnitControl unit={ state } onUnitChange={ setState } />
+				<UnitControl
+					value={ state }
+					onChange={ setState }
+					onUnitChange={ spy }
+				/>
 			);
 
 			const select = getSelect();
-			await user.selectOptions( select, [ 'em' ] );
+			await user.selectOptions( select, [ 'px' ] );
 
-			expect( state ).toBe( 'em' );
+			expect( spy ).toHaveBeenCalledWith( 'px', expect.anything() );
+			expect( state ).toBe( '14px' );
 		} );
 
 		it( 'should render customized units, if defined', () => {
@@ -319,7 +326,6 @@ describe( 'UnitControl', () => {
 			const { user } = render(
 				<UnitControl
 					value={ state }
-					unit="%"
 					units={ [ { value: '%', label: '%' } ] }
 					onChange={ setState }
 				/>
@@ -450,16 +456,16 @@ describe( 'UnitControl', () => {
 			expect( state ).toBe( '123rem' );
 		} );
 
-		it( 'should update unit after initial render and with new unit prop', () => {
+		it( 'should update unit after initial render and with new unit prop', async () => {
 			const { rerender } = render( <UnitControl value={ '10%' } /> );
 
 			const select = getSelect();
 
 			expect( select.value ).toBe( '%' );
 
-			rerender( <UnitControl value={ '20' } unit="em" /> );
+			rerender( <UnitControl value={ '20vh' } /> );
 
-			expect( select.value ).toBe( 'em' );
+			await waitFor( () => expect( select.value ).toBe( 'vh' ) );
 		} );
 
 		it( 'should fallback to default unit if parsed unit is invalid', () => {

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -73,7 +73,7 @@ export type UnitSelectControlProps = {
 };
 
 // TODO: when available, should (partially) extend `NumberControl` props.
-export type UnitControlProps = UnitSelectControlProps &
+export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
 	Pick< InputControlProps, 'hideLabelFromVision' > & {
 		__unstableStateReducer?: StateReducer;
 		__unstableInputWidth?: CSSProperties[ 'width' ];
@@ -105,6 +105,12 @@ export type UnitControlProps = UnitSelectControlProps &
 		 * Callback when the `unit` changes.
 		 */
 		onUnitChange?: UnitControlOnChangeCallback;
+		/**
+		 * Current unit. _Note: this prop is deprecated. Instead, provide a unit with a value through the `value` prop._
+		 *
+		 * @deprecated
+		 */
+		unit?: string;
 		/**
 		 * Current value. If passed as a string, the current unit will be inferred from this value.
 		 * For example, a `value` of "50%" will set the current unit to `%`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #35744, this PR marks the `unit` prop in `UnitControl` as deprecated.

Note: these changes only apply to the web version of `UnitControl` (the native version is still relying on the `unit` prop at the time of working on this PR).

*Note: this PR requires that all usages of the `UnitControl` component (web version) are refactored to avoid using the `unit` prop*:

- #39504
- #39511
- #39513
- #39514
- #39522
- #39549

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The unit prop was marked as deprecated in the README, but this was not reflected in the docs

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Mark the `unit` prop as `@deprecated` in the TypeScript types
- Add an official deprecation warning
- Update related unit tests

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

No runtime/behavioral changes:

- Tests pass
- UnitControl behaves as expected in Storybook / Gutenberg
