### PR TITLE
Documentation: Dependency "wp-editor" should be "wp-block-editor" in the code example

### DIFF
--- a/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -30,7 +30,7 @@ There are a number of [components available](/docs/reference-guides/packages/pac
 
 The `RichText` component can be considered as a super-powered `textarea` element, enabling rich content editing including bold, italics, hyperlinks, etc.
 
-To use the `RichText` component, and using ES5 code, remember to add `wp-editor` to the dependency array of registered script handles when calling `wp_register_script`.
+To use the `RichText` component, and using ES5 code, remember to add `wp-block-editor` to the dependency array of registered script handles when calling `wp_register_script`.
 
 ```php
 // automatically load dependencies and version


### PR DESCRIPTION
Al least looking at the generated code in index.asset.php, probably the dependency "wp-editor" was used some versions ago and later deprecated.

## What?
Changing wp-editor to wp-block-editor
