### PR TITLE
Code Block: add keyboard shortcut to indent lines inside code block

### DIFF
--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -2,22 +2,49 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	RichTextShortcut,
+} from '@wordpress/block-editor';
+import { __unstableIndentCode } from '@wordpress/rich-text';
 
-export default function CodeEdit( { attributes, setAttributes, onRemove } ) {
+export default function CodeEdit( {
+	attributes,
+	setAttributes,
+	onRemove,
+	onReplace,
+} ) {
 	const blockProps = useBlockProps();
+
+	const controls = ( { value, onChange } ) => {
+		return (
+			<>
+				<RichTextShortcut
+					type="primary"
+					character="]"
+					onUse={ () => {
+						onChange( __unstableIndentCode( value ) );
+					} }
+				/>
+			</>
+		);
+	};
 	return (
 		<pre { ...blockProps }>
 			<RichText
 				tagName="code"
 				value={ attributes.content }
 				onChange={ ( content ) => setAttributes( { content } ) }
+				onReplace={ onReplace }
 				onRemove={ onRemove }
 				placeholder={ __( 'Write code…' ) }
 				aria-label={ __( 'Code' ) }
 				preserveWhiteSpace
 				__unstablePastePlainText
-			/>
+			>
+				{ controls }
+			</RichText>
 		</pre>
 	);
 }

--- a/packages/rich-text/src/can-indent-code.js
+++ b/packages/rich-text/src/can-indent-code.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+import { getLineIndex } from './get-line-index';
+
+/** @typedef {import('./create').RichTextValue} RichTextValue */
+
+/**
+ * Checks if the selected list item can be indented.
+ *
+ * @param {RichTextValue} value Value to check.
+ *
+ * @return {boolean} Whether or not the selected list item can be indented.
+ */
+export function canIndentCode( value ) {
+	const lineIndex = getLineIndex( value );
+
+	// There is only one line, so the line cannot be indented.
+	if ( lineIndex === undefined ) {
+		return false;
+	}
+
+	const { replacements } = value;
+	const previousLineIndex = getLineIndex( value, lineIndex );
+	const formatsAtLineIndex = replacements[ lineIndex ] || [];
+	const formatsAtPreviousLineIndex = replacements[ previousLineIndex ] || [];
+
+	// If the indentation of the current line is greater than previous line,
+	// then the line cannot be furter indented.
+	return formatsAtLineIndex.length <= formatsAtPreviousLineIndex.length;
+}

--- a/packages/rich-text/src/get-line-index.js
+++ b/packages/rich-text/src/get-line-index.js
@@ -18,10 +18,14 @@ import { LINE_SEPARATOR } from './special-characters';
  * @return {number|void} The line index. Undefined if not found.
  */
 export function getLineIndex( { start, text }, startIndex = start ) {
+	const NEW_LINE_CHARACTER = '\n';
 	let index = startIndex;
 
 	while ( index-- ) {
-		if ( text[ index ] === LINE_SEPARATOR ) {
+		if (
+			text[ index ] === LINE_SEPARATOR ||
+			text[ index ] === NEW_LINE_CHARACTER
+		) {
 			return index;
 		}
 	}

--- a/packages/rich-text/src/indent-code.js
+++ b/packages/rich-text/src/indent-code.js
@@ -1,0 +1,31 @@
+/**
+ * Internal dependencies
+ */
+
+import { canIndentCode } from './can-indent-code';
+
+/** @typedef {import('./create').RichTextValue} RichTextValue */
+
+/**
+ * Indents any selected list items if possible.
+ *
+ * @param {RichTextValue}  value      Value to change.
+ *
+ * @return {RichTextValue} The changed value.
+ */
+export function indentCode( value ) {
+	if ( ! canIndentCode( value ) ) {
+		return value;
+	}
+
+	const { replacements } = value;
+	const newFormats = replacements.slice();
+
+	newFormats[ 0 ] = 'Z';
+	newFormats[ 59 ] = '\t\t';
+
+	return {
+		...value,
+		replacements: newFormats,
+	};
+}

--- a/packages/rich-text/src/index.js
+++ b/packages/rich-text/src/index.js
@@ -31,6 +31,7 @@ export { indentListItems as __unstableIndentListItems } from './indent-list-item
 export { outdentListItems as __unstableOutdentListItems } from './outdent-list-items';
 export { changeListType as __unstableChangeListType } from './change-list-type';
 export { createElement as __unstableCreateElement } from './create-element';
+export { indentCode as __unstableIndentCode } from './indent-code';
 
 export { useAnchorRef } from './component/use-anchor-ref';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: #15791
## What?
<!-- In a few words, what is the PR actually doing? -->
In this PR, we are trying to do is adding a keyboard shortcut to indent lines in the `code` block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
User accessibility - enhancement

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
