### PR TITLE
Add raw attributes config for media entity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -63,6 +63,7 @@ export const rootEntitiesConfig = [
 		baseURLParams: { context: 'edit' },
 		plural: 'mediaItems',
 		label: __( 'Media' ),
+		rawAttributes: [ 'caption', 'title', 'description' ],
 	},
 	{
 		name: 'taxonomy',


### PR DESCRIPTION
## What?

This PR defines the "rawAttributes" for the "media" entity (endpoint). This is a developer change, it shouldn't have any impact feature wise but would allow third-party developers to receive titles... properly when using `useEntityProp( 'root', 'media', 'title', id )`

## Why?

Technically, this is a breaking change but I don't see anyway to avoid breakage here, so our choices are to do this change or just accept the broken state forever. I'm betting on the fact that few devs are using this right now and that potentially a dev note is a solution here. Obviously, we need to do some checks in `wpdirectory.net` maybe to see if we can pinpoint the potential breakage.

## Testing Instructions

1- Open the editor
2- Open the console
3- Call `result = wp.data.select('core').getRawEntityRecord( 'root', 'media', id );` Make sure to pass a valid existing media id and call this multiple time until you get the result.
4- the result should have title, description and captions as strings.
 
