### PR TITLE
`Spacer` block: stop using `UnitControl`'s deprecated `unit` prop

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -11,7 +11,6 @@ import {
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -43,13 +42,14 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 		onChange( unprocessedValue );
 	};
 
-	const computedValue = useMemo( () => {
-		const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
-			value
-		);
-		// Force the unit to update to `px` when the Spacer is being resized.
-		return [ parsedQuantity, isResizing ? 'px' : parsedUnit ].join( '' );
-	}, [ isResizing, value ] );
+	// Force the unit to update to `px` when the Spacer is being resized.
+	const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
+		value
+	);
+	const computedValue = [
+		parsedQuantity,
+		isResizing ? 'px' : parsedUnit,
+	].join( '' );
 
 	return (
 		<BaseControl label={ label } id={ inputId }>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -55,6 +55,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 		<BaseControl label={ label } id={ inputId }>
 			<UnitControl
 				id={ inputId }
+				isResetValueOnUnitChange
 				min={ 0 }
 				max={ MAX_SPACER_SIZE }
 				onChange={ handleOnChange }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -11,7 +11,7 @@ import {
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useState, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,8 +19,6 @@ import { useState, useMemo } from '@wordpress/element';
 import { MAX_SPACER_SIZE } from './edit';
 
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
-	const [ temporaryInput, setTemporaryInput ] = useState( null );
-
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
 
 	// In most contexts the spacer size cannot meaningfully be set to a
@@ -42,34 +40,23 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	} );
 
 	const handleOnChange = ( unprocessedValue ) => {
-		setTemporaryInput( null );
 		onChange( unprocessedValue );
 	};
 
-	const handleOnBlur = () => {
-		if ( temporaryInput !== null ) {
-			setTemporaryInput( null );
-		}
-	};
-
 	const computedValue = useMemo( () => {
-		const inputValue = temporaryInput !== null ? temporaryInput : value;
 		const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
-			inputValue
+			value
 		);
-
 		// Force the unit to update to `px` when the Spacer is being resized.
 		return [ parsedQuantity, isResizing ? 'px' : parsedUnit ].join( '' );
-	}, [ isResizing, temporaryInput, value ] );
+	}, [ isResizing, value ] );
 
 	return (
 		<BaseControl label={ label } id={ inputId }>
 			<UnitControl
 				id={ inputId }
-				isResetValueOnUnitChange
 				min={ 0 }
 				max={ MAX_SPACER_SIZE }
-				onBlur={ handleOnBlur }
 				onChange={ handleOnChange }
 				style={ { maxWidth: 80 } }
 				value={ computedValue }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -8,9 +8,10 @@ import {
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -51,7 +52,15 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 		}
 	};
 
-	const inputValue = temporaryInput !== null ? temporaryInput : value;
+	const computedValue = useMemo( () => {
+		const inputValue = temporaryInput !== null ? temporaryInput : value;
+		const [ parsedQuantity, parsedUnit ] = parseQuantityAndUnitFromRawValue(
+			inputValue
+		);
+
+		// Force the unit to update to `px` when the Spacer is being resized.
+		return [ parsedQuantity, isResizing ? 'px' : parsedUnit ].join( '' );
+	}, [ isResizing, temporaryInput, value ] );
 
 	return (
 		<BaseControl label={ label } id={ inputId }>
@@ -63,10 +72,8 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 				onBlur={ handleOnBlur }
 				onChange={ handleOnChange }
 				style={ { maxWidth: 80 } }
-				value={ inputValue }
+				value={ computedValue }
 				units={ units }
-				// Force the unit to update to `px` when the Spacer is being resized.
-				unit={ isResizing ? 'px' : undefined }
 			/>
 		</BaseControl>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #39503 , this PR refactors the `Spacer` block `height` controls to avoid using the deprecated `unit` prop from the `UnitControl` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `unit` prop is marked as deprecated, the component's docs recommend passing the unit directly through the `value` prop

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor the code to pass the unit directly through the `value` prop

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Tests pass
- Component behaves as expected in the block editor:
    1. Create a new page/post
    2. Add a spacer block
    3. Play around with the spacer controls in the sidebar, in particular the height (change unit, change value by typing, pressing arrows up/down, mouse dragging...) and make sure it behaves like in production
    4. Using the controls in the sidebar, set a height in a unit different than `px`.
    5. Then, drag the block handle in the editor canvas and resize the spacer that way — as you drag, the unit in the sidebar control should automatically change back to `px`
