### PR TITLE
`Search` block: stop using `UnitControl`'s deprecated `unit` prop

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -352,7 +352,6 @@ export default function SearchEdit( {
 							} }
 							style={ { maxWidth: 80 } }
 							value={ `${ width }${ widthUnit }` }
-							unit={ widthUnit }
 							units={ units }
 						/>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #39503 , this PR refactors the `Search` block `width` controls to avoid using the deprecated `unit` prop from the `UnitControl` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `unit` prop is marked as deprecated, the component's docs recommend passing the unit directly through the `value` prop

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor the code to pass the unit directly through the `value` prop

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Tests pass
- Component behaves as expected in the block editor:
    1. Create a new page/post
    2. Add a search block
    3. Play around with the search controls in the sidebar, in particular the width (change unit, change value by typing, pressing arrows up/down, mouse dragging...) and make sure it behaves like in production
    4. Using the controls in the sidebar, set a width in a unit in `%`
    5. Then, drag the block handle in the editor canvas and resize the search block that way — as you drag, the unit in the sidebar control should automatically change back to `px`
