### PR TITLE
Add default `as` prop to `PluginMoreMenuItem` component

### DIFF
--- a/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-post/src/components/header/plugin-more-menu-item/index.js
@@ -3,6 +3,7 @@
  */
 import { ActionItem } from '@wordpress/interface';
 import { compose } from '@wordpress/compose';
+import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
@@ -64,6 +65,7 @@ import { withPluginContext } from '@wordpress/plugins';
 export default compose(
 	withPluginContext( ( context, ownProps ) => {
 		return {
+			as: ownProps.as ?? MenuItem,
 			icon: ownProps.icon || context.icon,
 			name: 'core/edit-post/plugin-more-menu',
 		};

--- a/packages/edit-site/src/components/header/plugin-more-menu-item/index.js
+++ b/packages/edit-site/src/components/header/plugin-more-menu-item/index.js
@@ -3,6 +3,7 @@
  */
 import { ActionItem } from '@wordpress/interface';
 import { compose } from '@wordpress/compose';
+import { MenuItem } from '@wordpress/components';
 import { withPluginContext } from '@wordpress/plugins';
 
 /**
@@ -64,6 +65,7 @@ import { withPluginContext } from '@wordpress/plugins';
 export default compose(
 	withPluginContext( ( context, ownProps ) => {
 		return {
+			as: ownProps.as ?? MenuItem,
 			icon: ownProps.icon || context.icon,
 			name: 'core/edit-site/plugin-more-menu',
 		};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
closes #39474

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR resolves the issue reported in #37474 by providing a default `as` prop of the `MenuItem` component. This solution allows users to continue to override the `as` prop just as behavior was previously.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
By being able to use the MenuItem we gain the benefits of existing work done to handle aria attributes for example among other benefits such as styling consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Minimal JavaScript changes to this package. Should only affect custom menu elements in the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
With this PR the following snippet will render a `MenuItem` as [explained in the `PluginMoreMenuItem` docs](https://github.com/WordPress/gutenberg/blob/8001881edc6236959bd83e3e8b1b47fd0bb967c7/packages/edit-post/README.md#pluginmoremenuitem)

```javascript
import { PluginMoreMenuItem } from '@wordpress/edit-post';

...
	return (
		<>
			<PluginMoreMenuItem  onClick={ openModal }>
				{ __( 'Editor settings', 'coblocks' ) }
			</PluginMoreMenuItem>
			...
		</>
        )
```

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/30462574/158683161-547d6921-ec9f-4007-adae-8306ff185401.png)
