### PR TITLE
`Cover` block: stop using `UnitControl`'s deprecated `unit` prop

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -9,7 +9,13 @@ import namesPlugin from 'colord/plugins/names';
 /**
  * WordPress dependencies
  */
-import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
+import {
+	Fragment,
+	useEffect,
+	useRef,
+	useState,
+	useMemo,
+} from '@wordpress/element';
 import {
 	BaseControl,
 	Button,
@@ -26,6 +32,7 @@ import {
 	__experimentalBoxControl as BoxControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 } from '@wordpress/components';
 import { compose, useInstanceId } from '@wordpress/compose';
 import {
@@ -133,7 +140,15 @@ function CoverHeightInput( {
 		}
 	};
 
-	const inputValue = temporaryInput !== null ? temporaryInput : value;
+	const computedValue = useMemo( () => {
+		const inputValue = temporaryInput !== null ? temporaryInput : value;
+		const [ parsedQuantity ] = parseQuantityAndUnitFromRawValue(
+			inputValue
+		);
+
+		return [ parsedQuantity, unit ].join( '' );
+	}, [ temporaryInput, value ] );
+
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
@@ -146,9 +161,8 @@ function CoverHeightInput( {
 				onChange={ handleOnChange }
 				onUnitChange={ onUnitChange }
 				style={ { maxWidth: 80 } }
-				unit={ unit }
 				units={ units }
-				value={ inputValue }
+				value={ computedValue }
 			/>
 		</BaseControl>
 	);

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -147,7 +147,7 @@ function CoverHeightInput( {
 		);
 
 		return [ parsedQuantity, unit ].join( '' );
-	}, [ temporaryInput, value ] );
+	}, [ temporaryInput, unit, value ] );
 
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 

--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -103,8 +103,6 @@ function CoverHeightInput( {
 	unit = 'px',
 	value = '',
 } ) {
-	const [ temporaryInput, setTemporaryInput ] = useState( null );
-
 	const instanceId = useInstanceId( UnitControl );
 	const inputId = `block-cover-height-input-${ instanceId }`;
 	const isPx = unit === 'px';
@@ -127,27 +125,15 @@ function CoverHeightInput( {
 				: undefined;
 
 		if ( isNaN( inputValue ) && inputValue !== undefined ) {
-			setTemporaryInput( unprocessedValue );
 			return;
 		}
-		setTemporaryInput( null );
 		onChange( inputValue );
 	};
 
-	const handleOnBlur = () => {
-		if ( temporaryInput !== null ) {
-			setTemporaryInput( null );
-		}
-	};
-
 	const computedValue = useMemo( () => {
-		const inputValue = temporaryInput !== null ? temporaryInput : value;
-		const [ parsedQuantity ] = parseQuantityAndUnitFromRawValue(
-			inputValue
-		);
-
+		const [ parsedQuantity ] = parseQuantityAndUnitFromRawValue( value );
 		return [ parsedQuantity, unit ].join( '' );
-	}, [ temporaryInput, unit, value ] );
+	}, [ unit, value ] );
 
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
@@ -157,7 +143,6 @@ function CoverHeightInput( {
 				id={ inputId }
 				isResetValueOnUnitChange
 				min={ min }
-				onBlur={ handleOnBlur }
 				onChange={ handleOnChange }
 				onUnitChange={ onUnitChange }
 				style={ { maxWidth: 80 } }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #39503 , this PR refactors the `Cover` block `min height` controls to avoid using the deprecated `unit` prop from the `UnitControl` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `unit` prop is marked as deprecated, the component's docs recommend passing the unit directly through the `value` prop

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor the code to pass the unit directly through the `value` prop

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Tests pass
- Component behaves as expected in the block editor:
    1. Create a new page/post
    2. Add a cover block
    3. Play around with the Cover Block controls in the sidebar, in particular the `min height` (change unit, change value by typing, pressing arrows up/down, mouse dragging...) and make sure it behaves like in production
    4. Using the controls in the sidebar, set a `min height` in a unit different than `px`
    5. Then, drag the block handle in the editor canvas and resize the cover block that way — as you drag, the unit in the sidebar control should automatically change back to `px`
