### PR TITLE
Blocks: Preserves source of unrecognized blocks inside of Code Editor

### DIFF
--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -341,7 +341,7 @@ export function getCommentDelimitedContent(
  * serialized attributes and content form from the current state of the block.
  *
  * @param {WPBlock}                      block   Block instance.
- * @param {WPBlockSerializationOptions} options Serialization options.
+ * @param {WPBlockSerializationOptions}  options Serialization options.
  *
  * @return {string} Serialized block.
  */

--- a/packages/blocks/src/api/serializer.js
+++ b/packages/blocks/src/api/serializer.js
@@ -24,7 +24,10 @@ import {
 	getFreeformContentHandlerName,
 	getUnregisteredTypeHandlerName,
 } from './registration';
+import { serializeRawBlock } from './parser/serialize-raw-block';
 import { isUnmodifiedDefaultBlock, normalizeBlockType } from './utils';
+
+/** @typedef {import('./parser').WPBlock} WPBlock */
 
 /**
  * @typedef {Object} WPBlockSerializationOptions Serialization Options.
@@ -337,12 +340,16 @@ export function getCommentDelimitedContent(
  * Returns the content of a block, including comment delimiters, determining
  * serialized attributes and content form from the current state of the block.
  *
- * @param {Object}                      block   Block instance.
+ * @param {WPBlock}                      block   Block instance.
  * @param {WPBlockSerializationOptions} options Serialization options.
  *
  * @return {string} Serialized block.
  */
 export function serializeBlock( block, { isInnerBlocks = false } = {} ) {
+	if ( ! block.isValid && block.__unstableBlockSource ) {
+		return serializeRawBlock( block.__unstableBlockSource );
+	}
+
 	const blockName = block.name;
 	const saveContent = getBlockInnerHTML( block );
 

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -307,6 +307,48 @@ describe( 'block serializer', () => {
 
 			expect( content ).toBe( 'Bananas' );
 		} );
+		it( 'preserves content from invalid blocks when source information is present', () => {
+			registerBlockType( 'core/quote', {
+				category: 'text',
+				title: 'Quote',
+				attributes: { content: 'string' },
+				save: ( { attributes } ) =>
+					createElement( 'blockquote', {}, attributes.content ),
+			} );
+
+			const block = {
+				...createBlock( 'core/quote' ),
+				isValid: false,
+				__unstableBlockSource: {
+					blockName: 'quote',
+					attrs: {},
+					innerHTML: '<p>Not a quote</p>',
+					innerBlocks: [],
+					innerContent: ['<p>Not a quote</p>'],
+				},
+			};
+
+			expect( serializeBlock( block ) ).toBe(
+				'<!-- wp:quote -->\n<p>Not a quote</p>\n<!-- /wp:quote -->'
+			);
+		} );
+		it( 're-generates content from invalid blocks when source information is missing (losing content)', () => {
+			registerBlockType( 'core/quote', {
+				category: 'text',
+				title: 'Quote',
+				attributes: { content: 'string' },
+				save: ( { attributes } ) =>
+					createElement( 'blockquote', {}, attributes.content ),
+			} );
+
+			// missing attributes as a result of a failed parse
+			const block = {
+				...createBlock( 'core/quote' ),
+				isValid: false,
+			};
+
+			expect( serializeBlock( block ) ).toBe( '<!-- wp:quote /-->' );
+		} );
 	} );
 
 	describe( 'serialize()', () => {

--- a/packages/blocks/src/api/test/serializer.js
+++ b/packages/blocks/src/api/test/serializer.js
@@ -324,7 +324,7 @@ describe( 'block serializer', () => {
 					attrs: {},
 					innerHTML: '<p>Not a quote</p>',
 					innerBlocks: [],
-					innerContent: ['<p>Not a quote</p>'],
+					innerContent: [ '<p>Not a quote</p>' ],
 				},
 			};
 


### PR DESCRIPTION
Following the work of #38923 where we started preserving the source
content for blocks that the editor fails to recognize, this patch
uses that information in the Code Editor to ensure that we don't
accidentally corrupt or lose content when making edits there.

Previously the `serializeBlock` function, which generates the HTML
for the Code Editor, would try to re-generated the saved content
for blocks that we know are invalid. Because we know the input is
invalid we can guarantee that the output will have even more problems.

Now that `serializeBlock` function is aware of the source content for
a block, and if the block is marked invalid _and_ that source exists
it will pass that along to the output and skip the processing and
re-generation of the saved content. This ensures that errors don't
cascade and that unrelated edits to other blocks from the Code Editor
won't destroy content in the marked-invalid blocks.

## Testing Instructions

As we can see in the small diff, the serialize function only changes when a block is marked invalid _and_ an original source is available. Because of this we should be able to assert by inspection that this patch is safe; it only comes into play when things are already broken.

Still, please consider the uses of `serialize` and whether there could be situations in which preserving the source markup could trigger unexpected consequences.

To test you only need to load the branch and create some invalid block content in a post. It may be difficult to do this from `trunk` so start in this branch, save the content, and then load `trunk` to confirm the different behaviors.

Not every invalid or unrecognized block will lead to data loss or corruption. Explore different kinds of block invalidations and see which ones are impacted by this change:
 - Invalid block comment delimiter syntax leads to a failure to recognize a block / large chunks of a post might collapse into a freeform block.
 - Unrecognized block with valid content needs a supporting block implementation. This can be faked by changing the name of a stored block to a name that doesn't exist. e.g. `group` to `grourp`.
 - Invalid core attributes on a block lead.
 - Presence or disappearance of inner blocks.

## Screenshots or screencast

Behavior in `trunk` - when opening the Code Editor we can see that unrecognized content can be immediately erased or corrupted.

https://user-images.githubusercontent.com/5431237/158716701-68f467c4-9343-428a-8331-56a793e47ef4.mov

Behavior in this branch - we can see that not only is the source of unrecognized blocks preserved but additionally we can make edits to it without requiring that the editor can understand those edits.


https://user-images.githubusercontent.com/5431237/158716993-06a9aa3c-5c53-4066-85ac-4263364a759f.mov

Note that until now it was not always possible to resolve issues with invalid blocks manually from the Code Editor. For some kinds of errors the editor would not load the appropriate markup that one would need in order to fix the block.

Conversely, until now it's been difficult to force blocks into an invalid state because of the same issue. `onBlur` the Code Editor would wipe out content it couldn't recognize, making it impossible through the editor to setup a broken post to work with.
