### PR TITLE
Core data: Fall back to default API batch size of 25.

### DIFF
--- a/packages/core-data/src/batch/default-processor.js
+++ b/packages/core-data/src/batch/default-processor.js
@@ -12,7 +12,8 @@ import apiFetch from '@wordpress/api-fetch';
  * Maximum number of requests to place in a single batch request. Obtained by
  * sending a preflight OPTIONS request to /batch/v1/.
  *
- * @type {number?}
+ * @type {number|null}
+ * @default 25 (set by Core)
  */
 let maxItems = null;
 
@@ -36,7 +37,7 @@ export default async function defaultProcessor( requests ) {
 
 	const results = [];
 
-	for ( const batchRequests of chunk( requests, maxItems ) ) {
+	for ( const batchRequests of chunk( requests, maxItems ?? 25 ) ) {
 		const batchResponse = await apiFetch( {
 			path: '/batch/v1',
 			method: 'POST',

--- a/packages/core-data/src/batch/default-processor.js
+++ b/packages/core-data/src/batch/default-processor.js
@@ -8,6 +8,12 @@ import { chunk } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 
+/** How long to wait to hear back from the server for batch size before defaulting. */
+const BATCH_SIZE_FETCH_TIMEOUT_MS = 1000;
+
+/** Default value shipped with Core */
+const DEFAULT_BATCH_SIZE = 25;
+
 /**
  * Maximum number of requests to place in a single batch request. Obtained by
  * sending a preflight OPTIONS request to /batch/v1/.
@@ -18,26 +24,55 @@ import apiFetch from '@wordpress/api-fetch';
 let maxItems = null;
 
 /**
+ * Waits a given number of milliseconds then resolves.
+ *
+ * @param {number} msDelay How many milliseconds to wait before resolving.
+ */
+const wait = ( msDelay ) =>
+	new Promise( ( resolve ) => setTimeout( resolve, msDelay ) );
+
+/**
+ * Returns the batching API batch size, updated from the server.
+ *
+ * @return {Promise<number>} How many API requests to send in one batch.
+ */
+const batchSize = async () => {
+	if ( null !== maxItems ) {
+		return maxItems;
+	}
+
+	const fetcher = apiFetch( { path: '/batch/v1', method: 'OPTIONS' } ).then(
+		( { endpoints } ) => {
+			try {
+				maxItems = endpoints[ 0 ].args.requests.maxItems;
+			} catch ( e ) {
+				// Catching and re-throwing in a new task lets us fall back
+				// to the default value while still surfacing the error.
+				// We do this so that we don't block the batched API calls.
+				setTimeout( () => {
+					throw e;
+				}, 0 );
+			}
+		}
+	);
+
+	await Promise.race( [ wait( BATCH_SIZE_FETCH_TIMEOUT_MS ), fetcher ] );
+
+	return maxItems ?? DEFAULT_BATCH_SIZE;
+};
+
+/**
  * Default batch processor. Sends its input requests to /batch/v1.
  *
  * @param {Array} requests List of API requests to perform at once.
  *
- * @return {Promise} Promise that resolves to a list of objects containing
- *                   either `output` (if that request was succesful) or `error`
- *                   (if not ).
+ * @return {Promise} Resolves to a list of objects containing either
+ *                   `output` if that request was successful else `error`.
  */
 export default async function defaultProcessor( requests ) {
-	if ( maxItems === null ) {
-		const preflightResponse = await apiFetch( {
-			path: '/batch/v1',
-			method: 'OPTIONS',
-		} );
-		maxItems = preflightResponse.endpoints[ 0 ].args.requests.maxItems;
-	}
-
 	const results = [];
 
-	for ( const batchRequests of chunk( requests, maxItems ?? 25 ) ) {
+	for ( const batchRequests of chunk( requests, await batchSize() ) ) {
 		const batchResponse = await apiFetch( {
 			path: '/batch/v1',
 			method: 'POST',


### PR DESCRIPTION
## What

Part of #39211

Previously it was possible that we fail to register a batch size from
the server and we leave the batch size null.

In this patch we fallback to the Core-defined default of 25.

## Testing Instructions

It may not be possible to test this as it probably can never occur that we get to the point in line 39 without having set `maxItems`.

Maybe we should type-cast instead to assert that `maxItems` is set? But it's just a tiny addition as a compromise to prevent playing mind tricks in the type system.