### PR TITLE
Core Data: Pass explicit `undefined` initial value to `createContext`

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -27,7 +27,9 @@ const entityContexts = {
 		if ( ! acc[ loader.kind ] ) {
 			acc[ loader.kind ] = {};
 		}
-		acc[ loader.kind ][ loader.name ] = { context: createContext() };
+		acc[ loader.kind ][ loader.name ] = {
+			context: createContext( undefined ),
+		};
 		return acc;
 	}, {} ),
 	...additionalEntityConfigLoaders.reduce( ( acc, loader ) => {
@@ -41,7 +43,9 @@ const getEntityContext = ( kind, name ) => {
 	}
 
 	if ( ! entityContexts[ kind ][ name ] ) {
-		entityContexts[ kind ][ name ] = { context: createContext() };
+		entityContexts[ kind ][ name ] = {
+			context: createContext( undefined ),
+		};
 	}
 
 	return entityContexts[ kind ][ name ].context;


### PR DESCRIPTION
## What

Part of #39211

Previously we have been calling `createContext()` without any
arguments, but there's a funny note in the official React type
for that function.

> // If you thought this should be optional, see
> // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106

Although not passing an argument is practically the same as passing
`undefined` as the argument we have a type error that TypeScript
doesn't like while we're relying on it to parse JS files with the
JSDoc typings.

In this patch we're just adding the explicit `undefined` which should
have no behavioral change on the output but removes the type issue.

## Why?
We want to do great things with the core-data type system but all of these little nuisances get in the way when we're trying to study those things in isolation. This is a preparatory change to eliminate some of the noise in the existing types.

## Testing Instructions
Please verify the approach of passing `undefined` and that it's safe.
