### PR TITLE
Embeds: Update the Wolfram embed name

### DIFF
--- a/packages/block-library/src/embed/variations.js
+++ b/packages/block-library/src/embed/variations.js
@@ -344,9 +344,9 @@ const variations = [
 	},
 	{
 		name: 'wolfram-cloud',
-		title: 'Wolfram Cloud',
+		title: 'Wolfram',
 		icon: embedWolframIcon,
-		description: __( 'Embed Wolfram Cloud notebook content.' ),
+		description: __( 'Embed Wolfram notebook content.' ),
 		patterns: [ /^https?:\/\/(www\.)?wolframcloud\.com\/obj\/.+/i ],
 		attributes: { providerNameSlug: 'wolfram-cloud', responsive: true },
 	},


### PR DESCRIPTION
## What?

Wolfram folks have reached out to mention that they'd prefer the Wolfram embed name to just be called "Wolfram", rather than "Wolfram Cloud". This PR reflects that request.

## Testing Instructions

Open the block inserter, confirm that the Wolfram block is named "Wolfram", not "Wolfram Cloud".
