### PR TITLE
Fix `UnitControl` resets unit when value is cleared

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Bug Fix
-
--   Fix `UnitControl`’s reset of unit when the quantity value is cleared. ([#39531](https://github.com/WordPress/gutenberg/pull/39531/)).
-
 ### Enhancements
 
 -   `BaseControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#39325](https://github.com/WordPress/gutenberg/pull/39325)).
@@ -23,6 +19,7 @@
 ### Bug Fix
 
 -   `NumberControl`: commit (and constrain) value on `blur` event ([#39186](https://github.com/WordPress/gutenberg/pull/39186)).
+-   Fix `UnitControl`'s reset of unit when the quantity value is cleared. ([#39531](https://github.com/WordPress/gutenberg/pull/39531/)).
 
 ## 19.6.0 (2022-03-11)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix `UnitControl`’s reset of unit when the quantity value is cleared. ([#39531](https://github.com/WordPress/gutenberg/pull/39531/)).
+
 ### Enhancements
 
 -   `BaseControl`: Add `__nextHasNoMarginBottom` prop for opting into the new margin-free styles ([#39325](https://github.com/WordPress/gutenberg/pull/39325)).

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -80,7 +80,9 @@ function UnforwardedUnitControl(
 	);
 
 	useEffect( () => {
-		setUnit( parsedUnit );
+		if ( parsedUnit !== undefined ) {
+			setUnit( parsedUnit );
+		}
 	}, [ parsedUnit ] );
 
 	// Stores parsed value for hand-off in state reducer.

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -359,6 +359,25 @@ describe( 'UnitControl', () => {
 			await waitFor( () => expect( selectA ).toHaveValue( 'vw' ) );
 			expect( selectB ).toHaveValue( 'vw' );
 		} );
+
+		it( 'should maintain the chosen non-default unit when value is cleared', async () => {
+			const units = [
+				{ value: 'pt', label: 'pt' },
+				{ value: 'vmax', label: 'vmax' },
+			];
+
+			const { user } = render(
+				<UnitControl units={ units } value="5" />
+			);
+
+			const select = getSelect();
+			await user.selectOptions( select, [ 'vmax' ] );
+
+			const input = getInput();
+			await user.clear( input );
+
+			expect( select ).toHaveValue( 'vmax' );
+		} );
 	} );
 
 	describe( 'Unit Parser', () => {


### PR DESCRIPTION
## What?
Prevents reset of the unit when the quantity input is cleared in `UnitControl`.

## Why?
I believe this will mostly resolve #38872. Some instances of the issue may be due to components still passing the deprecated `unit` prop to `UnitControl` but those are being fixed in separate PRs. For instance, I noticed that the border radius control was not fixed by this PR but if the change from #39549 is applied on top of this then it is fixed.

## How?
Does not set the unit from parsed value prop if the unit returned by the parse is `undefined`.

## Testing Instructions
Try the `UnitControl` component in storybook or border width controls in the block editor.
1. Set the quantity value to something
2. Set the unit to something other than "px"
3. Clear the quantity value
4. Verify the unit did not reset to "px"