### PR TITLE
Flex Layout: Fix visibility control of allowOrientation

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -42,8 +42,9 @@ export default {
 	inspectorControls: function FlexLayoutInspectorControls( {
 		layout = {},
 		onChange,
+		layoutBlockSupport = {},
 	} ) {
-		const { allowOrientation = true } = layout;
+		const { allowOrientation = true } = layoutBlockSupport;
 		return (
 			<>
 				<Flex>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes the flag that we can set in `block.json` to control the visibility of the orientation control in Flex layouts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like previously the code was trying to grab the flag from the layout object instead of the block supports object, where the flag is set.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Similar to the other controls, grab the setting from the `layoutBlockSupport` object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

In `packages/block-library/src/buttons/block.json` try adding the `allowOrientation` flag to `__experimentalLayout` and set it to `false` like the following:

![image](https://user-images.githubusercontent.com/14988353/158754748-507fdde6-6c67-4c09-ba74-a2f3341552b2.png)

Before this PR, it would have no effect. After this PR, it should hide the control. Also check that switching it to `true` reveals it again.

## Screenshots or screencast <!-- if applicable -->

| Before (even with the flag set to false, it would still show) | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/158754578-4f19899c-9056-44f5-8bcc-f34f4efddd40.png) | ![image](https://user-images.githubusercontent.com/14988353/158754600-8378b108-70aa-4367-931f-7d0a292e7de8.png) |
