### PR TITLE
Accessibility improvements to the query pagination block

### DIFF
--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -76,7 +76,7 @@ export default function QueryPaginationEdit( {
 					</PanelBody>
 				</InspectorControls>
 			) }
-			<div { ...innerBlocksProps } />
+			<nav { ...innerBlocksProps } />
 		</>
 	);
 }

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -18,9 +18,16 @@ function render_block_core_query_pagination( $attributes, $content ) {
 		return '';
 	}
 
+	$wrapper_attributes = get_block_wrapper_attributes( array(
+		'role' => 'navigation',
+		'aria-label' => __( 'Pagination Navigation' ),
+	) );
+
 	return sprintf(
-		'<div %1$s>%2$s</div>',
-		get_block_wrapper_attributes(),
+		'<nav %1$s>
+			%2$s
+		</nav>',
+		$wrapper_attributes,
 		$content
 	);
 }

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -18,10 +18,12 @@ function render_block_core_query_pagination( $attributes, $content ) {
 		return '';
 	}
 
-	$wrapper_attributes = get_block_wrapper_attributes( array(
-		'role' => 'navigation',
-		'aria-label' => __( 'Pagination Navigation' ),
-	) );
+	$wrapper_attributes = get_block_wrapper_attributes(
+		array(
+			'role'       => 'navigation',
+			'aria-label' => __( 'Pagination Navigation' ),
+		)
+	);
 
 	return sprintf(
 		'<nav %1$s>

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -26,9 +26,7 @@ function render_block_core_query_pagination( $attributes, $content ) {
 	);
 
 	return sprintf(
-		'<nav %1$s>
-			%2$s
-		</nav>',
+		'<nav %1$s>%2$s</nav>',
 		$wrapper_attributes,
 		$content
 	);

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -21,7 +21,7 @@ function render_block_core_query_pagination( $attributes, $content ) {
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'role'       => 'navigation',
-			'aria-label' => __( 'Pagination Navigation' ),
+			'aria-label' => __( 'Pagination' ),
 		)
 	);
 


### PR DESCRIPTION
Fixes #39535.

## What?
This PR adds some accessibility improvements to the query pagination block.

## Why?
See https://www.a11ymatters.com/pattern/pagination/

## How?
- Remove the previous `<div>` wrapper and adds the block attributes to a `<nav>` element
- Add the `aria-label` "Pagination" to the `nav`

## Testing Instructions
- Pull the changes in this PR
- On a fresh installation, create a few posts
- Add the Query Loop block to a page, and update the posts number settings so that the navigation block can be displayed
- Check on the frontend the HTML output for the block
  - The block should now be wrapped in a `nav` element with the `aria-label` "Pagination Navigation"
  - The `nav` element should contain the block classes previously in the `div` wrapper

## Screenshots or screencast <!-- if applicable -->

### Before
![CleanShot 2022-03-17 at 10 25 24@2x](https://user-images.githubusercontent.com/33403964/158767990-cdd30fc7-2625-458d-9712-b4a85af9ae3a.png)

### After
![CleanShot 2022-03-17 at 10 24 42@2x](https://user-images.githubusercontent.com/33403964/158768019-de760757-a64e-4cd6-ba16-abf553dc557c.png)

