### PR TITLE
BlockSettingsMenuControls: Don't render empty MenuGroup

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -44,19 +44,28 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 		[ clientIds ]
 	);
 
-	const isMultiSelected = selectedClientIds.length > 1;
+	const showLockButton = selectedClientIds.length === 1;
 
 	// Check if current selection of blocks is Groupable or Ungroupable
 	// and pass this props down to ConvertToGroupButton.
 	const convertToGroupButtonProps = useConvertToGroupButtonProps();
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
 	const showConvertToGroupButton = isGroupable || isUngroupable;
+
 	return (
 		<Slot fillProps={ { ...fillProps, selectedBlocks, selectedClientIds } }>
 			{ ( fills ) => {
+				if (
+					! fills?.length > 0 &&
+					! showConvertToGroupButton &&
+					! showLockButton
+				) {
+					return null;
+				}
+
 				return (
 					<MenuGroup>
-						{ ! isMultiSelected && (
+						{ showLockButton && (
 							<BlockLockMenuItem
 								clientId={ selectedClientIds[ 0 ] }
 							/>


### PR DESCRIPTION
## What?
Follow-up for https://github.com/WordPress/gutenberg/pull/39183#r826674824

PR adds back checks to `BlockSettingsMenuControls` before rendering the MenuGroup.

## Why?
There could be cases when no block settings menu controls are available, and we don't want to end up with an empty MenuGroup.

Now that I started working on displaying the block lock buttons based on capabilities, this case might occur more often.

## Testing Instructions
1. Open a Post or Page.
2. Disable Group block from Preferences.
3. Insert two "Page List" blocks.
4. Selecting both blocks shouldn't display anything from the Slot.

## Screenshot
![CleanShot 2022-03-17 at 12 30 22](https://user-images.githubusercontent.com/240569/158768897-2bff5633-7d57-4c1c-9f3d-f0d1d921bbab.png)

