### PR TITLE
Auto batch dispatch calls

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -226,7 +226,9 @@ function LinkControl( {
 			...updatedValue,
 			title: internalTextValue || updatedValue?.title,
 		} );
-		stopEditing();
+		queueMicrotask( () => {
+			stopEditing();
+		} );
 	};
 
 	const handleSubmit = () => {
@@ -239,7 +241,9 @@ function LinkControl( {
 				title: internalTextValue,
 			} );
 		}
-		stopEditing();
+		queueMicrotask( () => {
+			stopEditing();
+		} );
 	};
 
 	const handleSubmitWithEnter = ( event ) => {

--- a/packages/data/src/types.ts
+++ b/packages/data/src/types.ts
@@ -44,9 +44,6 @@ export interface DataRegistry {
 export interface DataEmitter {
 	emit: () => void;
 	subscribe: ( listener: () => void ) => () => void;
-	pause: () => void;
-	resume: () => void;
-	isPaused: boolean;
 }
 
 // Type Helpers.

--- a/packages/data/src/utils/emitter.js
+++ b/packages/data/src/utils/emitter.js
@@ -7,11 +7,11 @@ export function createEmitter() {
 	let isPending = false;
 	const listeners = new Set();
 	const notifyListeners = () => {
+		isPending = false;
 		// We use Array.from to clone the listeners Set
 		// This ensures that we don't run a listener
 		// that was added as a response to another listener.
 		Array.from( listeners ).forEach( ( listener ) => listener() );
-		isPending = false;
 	};
 
 	return {

--- a/packages/data/src/utils/emitter.js
+++ b/packages/data/src/utils/emitter.js
@@ -4,43 +4,27 @@
  * @return {import("../types").DataEmitter} Emitter.
  */
 export function createEmitter() {
-	let isPaused = false;
 	let isPending = false;
 	const listeners = new Set();
-	const notifyListeners = () =>
+	const notifyListeners = () => {
 		// We use Array.from to clone the listeners Set
 		// This ensures that we don't run a listener
 		// that was added as a response to another listener.
 		Array.from( listeners ).forEach( ( listener ) => listener() );
+		isPending = false;
+	};
 
 	return {
-		get isPaused() {
-			return isPaused;
-		},
-
 		subscribe( listener ) {
 			listeners.add( listener );
 			return () => listeners.delete( listener );
 		},
 
-		pause() {
-			isPaused = true;
-		},
-
-		resume() {
-			isPaused = false;
-			if ( isPending ) {
-				isPending = false;
-				notifyListeners();
-			}
-		},
-
 		emit() {
-			if ( isPaused ) {
+			if ( ! isPending ) {
 				isPending = true;
-				return;
+				queueMicrotask( () => notifyListeners() );
 			}
-			notifyListeners();
 		},
 	};
 }


### PR DESCRIPTION
## What?

Call me noob, but I recently just learned about "microtasks" in JavaScript 🤷‍♂️ and I thought it was the ideal way to batch dispatch (store) calls instead of asking the user to explicitly call the `registry.batch` function.

## Why?

Performance, my hope is that we'll have a very small number of breakage and improvements to re-rendering performance.

## How?

Store listeners are only called on a microstask: After all sync code is expected but before any other event in the JS loop.
This is still very experimental, I wanted to see how the e2e test react to this change.