### PR TITLE
[List v2]: Simple list item splitting/merging

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -7,8 +7,15 @@ import {
 	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 
-export default function ListItemEdit( { attributes, setAttributes } ) {
+export default function ListItemEdit( {
+	name,
+	attributes,
+	setAttributes,
+	mergeBlocks,
+	onReplace,
+} ) {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
@@ -25,6 +32,14 @@ export default function ListItemEdit( { attributes, setAttributes } ) {
 				value={ attributes.content }
 				aria-label={ __( 'List text' ) }
 				placeholder={ attributes.placeholder || __( 'List' ) }
+				onSplit={ ( value ) =>
+					createBlock( name, {
+						...attributes,
+						content: value,
+					} )
+				}
+				onMerge={ mergeBlocks }
+				onReplace={ onReplace }
 			/>
 			{ innerBlocksProps.children }
 		</li>

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -18,4 +18,14 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	merge( attributes, attributesToMerge ) {
+		const { content } = attributesToMerge;
+		if ( ! content || content === '<li></li>' ) {
+			return attributes;
+		}
+		return {
+			...attributes,
+			content: attributes.content + content,
+		};
+	},
 };

--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -19,13 +19,9 @@ export const settings = {
 	edit,
 	save,
 	merge( attributes, attributesToMerge ) {
-		const { content } = attributesToMerge;
-		if ( ! content || content === '<li></li>' ) {
-			return attributes;
-		}
 		return {
 			...attributes,
-			content: attributes.content + content,
+			content: attributes.content + attributesToMerge.content,
 		};
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/39519
Adds simple `list item` splitting/merging. I'll add in a follow up the proper splitting/merging with the innerBlocks involved as is more convoluted and can be done in a follow up.



## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/158785585-044ea7f8-a028-449b-8063-1205f7d5a761.mov


