### PR TITLE
Fix PHP notice in gutenberg_get_block_editor_settings

### DIFF
--- a/lib/compat/wordpress-6.0/block-editor-settings.php
+++ b/lib/compat/wordpress-6.0/block-editor-settings.php
@@ -18,6 +18,7 @@ function gutenberg_get_block_editor_settings( $settings ) {
 	if (
 		is_callable( 'get_current_screen' ) &&
 		function_exists( 'gutenberg_is_edit_site_page' ) &&
+		is_object( get_current_screen() ) &&
 		gutenberg_is_edit_site_page( get_current_screen()->id )
 	) {
 		$context = 'site-editor';


### PR DESCRIPTION
## What?
Closes #39530.

PR fixes PHP notices gutenberg_get_block_editor_settings().

## Why?
The `get_current_screen` can be a `null`.

## How?
Adds check for value returned by `get_current_screen`.

## Testing Instructions
You can emulate this condition by overriding `$current_screen`:

```php
add_filter( 'block_editor_settings_all', function( $settings ) {
	global $current_screen;

	$current_screen = null;

	return $settings;
}, 10 );
```