### PR TITLE
Migrate entities.js to Typescript

### DIFF
--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { addEntities } from './actions';
+import type { Post, Taxonomy, Type, Updatable } from './entity-types';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 
@@ -191,7 +192,7 @@ export const additionalEntityConfigLoaders = [
  * @return {Object} Updated edits.
  */
 export const prePersistPostType = ( persistedRecord, edits ) => {
-	const newEdits = {};
+	const newEdits = {} as Partial< Updatable< Post< 'edit' > > >;
 
 	if ( persistedRecord?.status === 'auto-draft' ) {
 		// Saving an auto-draft should create a draft by default.
@@ -219,7 +220,9 @@ export const prePersistPostType = ( persistedRecord, edits ) => {
  * @return {Promise} Entities promise
  */
 async function loadPostTypeEntities() {
-	const postTypes = await apiFetch( { path: '/wp/v2/types?context=view' } );
+	const postTypes = ( await apiFetch( {
+		path: '/wp/v2/types?context=view',
+	} ) ) as Record< string, Type< 'view' > >;
 	return map( postTypes, ( postType, name ) => {
 		const isTemplate = [ 'wp_template', 'wp_template_part' ].includes(
 			name
@@ -253,9 +256,9 @@ async function loadPostTypeEntities() {
  * @return {Promise} Entities promise
  */
 async function loadTaxonomyEntities() {
-	const taxonomies = await apiFetch( {
+	const taxonomies = ( await apiFetch( {
 		path: '/wp/v2/taxonomies?context=view',
-	} );
+	} ) ) as Record< string, Taxonomy< 'view' > >;
 	return map( taxonomies, ( taxonomy, name ) => {
 		const namespace = taxonomy?.rest_namespace ?? 'wp/v2';
 		return {


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/pull/39025

This is a minimal changeset to give `entities.js` a `.ts` extension without raising any type errors. It will make the upcoming migration much easier as any merge conflicts will occur inside `entities.ts` and not between the two files.

## Why?

We want to do great things with the `core-data` type system but reconciling conflicts between two files make any long-lived PR really hard to maintain.

## Testing Instructions

Confirm the types make sense and there are no type errors resulting out of this PR. No dynamic code is changed in this PR, so there is nothing to test in the browser.