### PR TITLE
`BorderRadiusControl`: Stop using `UnitControl`’s deprecated `unit` prop

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/index.js
+++ b/packages/block-editor/src/components/border-radius-control/index.js
@@ -79,7 +79,6 @@ export default function BorderRadiusControl( { onChange, values } ) {
 							values={ values }
 							min={ MIN_BORDER_RADIUS_VALUE }
 							onChange={ onChange }
-							unit={ unit }
 							units={ units }
 						/>
 						<RangeControl


### PR DESCRIPTION
## What?
Related to #39503 , this PR removes the use of `UnitControl`’s deprecated `unit` prop in `BorderRadiusControl`.

## Why?
The `unit` prop is marked as deprecated, the component's docs recommend passing the unit directly through the `value` prop

## How?
Remove the `unit` prop on sub-component `AllInputControl`. It is redundant since the values already contain the unit.

## Testing Instructions
- Tests pass
- Component behaves as expected in the block editor:
    1. Create a new page/post
    2. Add a Group block
    3. Play around with the border radius controls in the sidebar.
    4. Unlink the sides and change at least one of the sides to have a different unit and value*.
    5. Link the sides, type a number and verify the unit defaults to "px".

*I think there is a bug in this control. When the sides are unlinked and units vary but the radius values are all the same number, switching back to linked sides does not show the "Mixed" placeholder in the input.