### PR TITLE
Gallery block: Add a backwards compat fallback to 16px for non-block themes

### DIFF
--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -1,15 +1,24 @@
 /**
  * WordPress dependencies
  */
-import { BlockList } from '@wordpress/block-editor';
+import { BlockList, store as blockEditorStore } from '@wordpress/block-editor';
 import { useContext, createPortal } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 
 export default function GapStyles( { blockGap, clientId } ) {
+	const themeSupportsLayout = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings()?.supportsLayout;
+	}, [] );
 	const styleElement = useContext( BlockList.__unstableElementContext );
 
+	const gapFallback = themeSupportsLayout ? '0.5em' : '16px';
+	const backwardsCompatGap = ! themeSupportsLayout
+		? `; gap: ${ gapFallback }`
+		: '';
 	const gap = blockGap
 		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
+		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, ${ gapFallback } ) ${ backwardsCompatGap }  }`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -57,15 +57,22 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
-	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 0.5em )';
-	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
+	$gap_fallback = WP_Theme_JSON_Resolver::theme_has_support() ? '0.5em' : '16px';
+	$gap_value    = $gap ? $gap : 'var( --wp--style--block-gap, ' . $gap_fallback . ' )';
+	$style        = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
+
+	$backwards_compat_style = '';
+	if ( ! WP_Theme_JSON_Resolver::theme_has_support() ) {
+		$backwards_compat_style = '.' . $class . '.wp-block-gallery' . '{ gap: ' . $gap_value . '}';
+	}
+
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.
 	// See https://core.trac.wordpress.org/ticket/53494.
 	add_action(
 		'wp_footer',
-		function () use ( $style ) {
-			echo '<style> ' . $style . '</style>';
+		function () use ( $style, $backwards_compat_style ) {
+			echo '<style> ' . $style . ' ' . $backwards_compat_style . '</style>';
 		}
 	);
 	return $content;


### PR DESCRIPTION
## What?
Adds a backwards compatibility fallback gap of 16px for non-block themes.

## Why?
The introduction of gap setting to the Gallery block introduced a breaking change for classic themes of reducing the default gap from 16px to 0.5rem.

## How?
Adds a default gap of 16px, but only for classic themes 

## Testing Instructions

- On trunk add a gallery to classic theme like TwentyTwenty and notice gap in editor and frontend is 0.5rem
- Switch to this branch and check that gap is 16px in editor and frontend
- Switch to TwentyTwentyTwo and check that gap is the theme default of 17px and that changing the block gap setting works as expected

