### PR TITLE
[Experiment] Try to store ToolsPanel state for each block

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -774,6 +774,10 @@ _Returns_
 
 -   `?string`: Block Template Lock
 
+### getToolsPanelState
+
+Undocumented declaration.
+
 ### hasBlockMovingClientId
 
 Returns whether block moving mode is enabled.
@@ -1368,6 +1372,10 @@ _Returns_
 
 -   `Object`: Action object.
 
+### resetToolsPanelState
+
+Undocumented declaration.
+
 ### selectBlock
 
 Returns an action object used in signalling that the block with the
@@ -1453,6 +1461,15 @@ _Parameters_
 _Returns_
 
 -   `Object`: Action object.
+
+### setToolsPanelState
+
+Returns an action object used in storing tools panel states for specific blocks.
+
+_Parameters_
+
+-   _blockName_ `string`: Name of the block.
+-   _panelName_ `?string`: Name of the ToolsPanel/block support
 
 ### showInsertionPoint
 

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -51,6 +51,7 @@
 		"@wordpress/keyboard-shortcuts": "file:../keyboard-shortcuts",
 		"@wordpress/keycodes": "file:../keycodes",
 		"@wordpress/notices": "file:../notices",
+		"@wordpress/preferences": "file:../preferences",
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/shortcode": "file:../shortcode",
 		"@wordpress/style-engine": "file:../style-engine",

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -21,6 +21,7 @@ import { speak } from '@wordpress/a11y';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { create, insert, remove, toHTMLString } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Action which will insert a default block insert action if there
@@ -1282,3 +1283,55 @@ export function setHasControlledInnerBlocks(
 		clientId,
 	};
 }
+
+// This should not be here probably, just experimenting.
+
+/**
+ * Returns an action object used in storing tools panel states for specific blocks.
+ *
+ * @param {string}  blockName Name of the block.
+ * @param {?string} panelName Name of the ToolsPanel/block support
+ */
+
+export const setToolsPanelState = (
+	blockName,
+	panelName,
+	panelItemState
+) => ( { registry } ) => {
+	const existingState =
+		registry
+			.select( preferencesStore )
+			.get( 'core/block-inspector', 'toolsPanel' ) ?? {};
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/block-inspector', 'toolsPanel', {
+			...existingState,
+			[ blockName ]: {
+				...existingState?.[ blockName ],
+				[ panelName ]: {
+					...existingState?.[ blockName ]?.[ panelName ],
+					...panelItemState,
+				},
+			},
+		} );
+};
+
+export const resetToolsPanelState = ( blockName, panelName ) => ( {
+	registry,
+} ) => {
+	const existingState =
+		registry
+			.select( preferencesStore )
+			.get( 'core/block-inspector', 'toolsPanel' ) ?? {};
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/block-inspector', 'toolsPanel', {
+			...existingState,
+			[ blockName ]: {
+				...existingState?.[ blockName ],
+				[ panelName ]: {},
+			},
+		} );
+};

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -32,6 +32,8 @@ import {
 import { Platform } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { symbol } from '@wordpress/icons';
+import { createRegistrySelector } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * A block selection object.
@@ -2312,3 +2314,16 @@ export function wasBlockJustInserted( state, clientId, source ) {
 		lastBlockInserted.source === source
 	);
 }
+
+// This should not be here probably, just experimenting.
+export const getToolsPanelState = createRegistrySelector(
+	( select ) => ( state, blockName, panelName ) => {
+		const existingState =
+			select( preferencesStore ).get(
+				'core/block-inspector',
+				'toolsPanel'
+			) ?? {};
+
+		return existingState?.[ blockName ]?.[ panelName ] || {};
+	}
+);


### PR DESCRIPTION
🚧 🚧 🚧 

This is an experiment to test the UX only. 

It needs abstracting, refactoring and a whole bunch of other improvements. 

Maybe even tying it to the ToolsPanel as an optional functionality directly so that it can track custom slots etc.

🚧 🚧 🚧 

![2022-03-18 11 24 28](https://user-images.githubusercontent.com/6458278/158914709-1428910d-8036-4db0-b5a1-ba8799d790f1.gif)

## What?

Just a first and very messy stab at storing the dimensions ToolsPanel state.

## Why?

So that any activated optional ToolsPanel menu items persist when inserting the same block.

For example, users might need to control the (currently) optional margin value of all Group blocks. Since this ToolsPanel item is optional, it won't show when inserting a fresh Group block.

## How?
🍝 

## Testing Instructions

Thing only work for the dimensions ToolsPanel for now and also only for default margin, padding and blockGap (not custom items).

1. Insert a Group block. Select the margin block support control in the dimensions panel.
2. Refresh page.
3. Insert further Group blocks.
4. The the margin block support control should show for all new Group blocks.
5. Resetting all dimension controls, or removing the margin block support control will reset the preference.