### PR TITLE
Fix Border Radius Control showing Mixed when switching between units in an empty control

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/test/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/test/utils.js
@@ -150,6 +150,10 @@ describe( 'hasMixedValues', () => {
 		expect( hasMixedValues( '2px' ) ).toBe( false );
 	} );
 
+	it( 'should return false when passed a string value containing a unit with no quantity', () => {
+		expect( hasMixedValues( 'em' ) ).toBe( false );
+	} );
+
 	it( 'should return true when passed mixed values', () => {
 		const values = {
 			bottomLeft: '1em',

--- a/packages/block-editor/src/components/border-radius-control/utils.js
+++ b/packages/block-editor/src/components/border-radius-control/utils.js
@@ -91,7 +91,8 @@ export function getAllValue( values = {} ) {
  */
 export function hasMixedValues( values = {} ) {
 	const allValue = getAllValue( values );
-	const isMixed = isNaN( parseFloat( allValue ) );
+	const isMixed =
+		typeof values === 'string' ? false : isNaN( parseFloat( allValue ) );
 
 	return isMixed;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix the Border Radius Control displaying `Mixed` when switching between units in a control that has not yet been edited.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `hasMixedValues` function uses `parseFloat` to detect whether or not a common `allValue` exists, however when the value is a single string (and not a set of separate values) then an empty control will cause this function to erroneously return `true`. Adding in a `typeof` check for `string` allows us to preserve the backwards compatibility behaviour of allowing strings for this value (unlike in the regular `BoxControl`) while fixing the logic of when to display `Mixed`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In `hasMixedValues` always return `false` if the current value is a string — since it's only a single value, it cannot be mixed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Add a Group block and in the border radius control, switch from `px` to `em` without entering a value. It should no longer say `Mixed`.

Test that updating the individual expanded values for the border radius control continues to correctly display `Mixed`.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![2022-03-18 12 44 44](https://user-images.githubusercontent.com/14988353/158921593-fa619839-2ca5-4750-8ea0-10621a42477a.gif) | ![2022-03-18 12 43 47](https://user-images.githubusercontent.com/14988353/158921512-0a20fb41-7458-49a0-99ae-5446cfd45e61.gif) |