### PR TITLE
Gallery block: reduce e2e flakiness

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -85,7 +85,10 @@ describe( 'Gallery', () => {
 			'.wp-block-gallery .wp-block-image'
 		);
 
-		await figureElement.click();
+		// The Image needs to be selected from the List view panel due to the
+		// way that Image uploads take and lose focus.
+		await openListView();
+		await clickButton( 'Image' );
 
 		const captionElement = await figureElement.$(
 			'.block-editor-rich-text__editable'

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -88,7 +88,10 @@ describe( 'Gallery', () => {
 		// The Image needs to be selected from the List view panel due to the
 		// way that Image uploads take and lose focus.
 		await openListView();
-		await clickButton( 'Image' );
+		const imageListLink = await page.waitForXPath(
+			`//a[contains(text(), 'Image')]`
+		);
+		await imageListLink.click();
 
 		const captionElement = await figureElement.$(
 			'.block-editor-rich-text__editable'


### PR DESCRIPTION
## What?
The Gallery e2e test is currently being flagged as flakey

## Why?
Fixes: #39533

## How?
Changes to seleting Image from list view panel to try and avoid issues with upload image getting and losing focus

## Testing Instructions
Make sure `specs/editor/blocks/gallery.test.js` passes locally and in CI