### PR TITLE
Block Editor: Add block lock setting

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -570,6 +570,7 @@ _Properties_
 -   _\_\_experimentalBlockPatterns_ `Array`: Array of objects representing the block patterns
 -   _\_\_experimentalBlockPatternCategories_ `Array`: Array of objects representing the block pattern categories
 -   _\_\_experimentalGenerateAnchors_ `boolean`: Enable/Disable auto anchor generation for Heading blocks
+-   _\_\_experimentalCanLockBlocks_ `boolean`: Whether the user can manage Block Lock state
 -   _\_\_unstableGalleryWithImageBlocks_ `boolean`: Whether the user has enabled the refactored gallery block which uses InnerBlocks
 
 ### SkipToSelectedBlock

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -14,16 +14,18 @@ import BlockLockModal from './modal';
 import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockMenuItem( { clientId } ) {
-	const { isLocked } = useSelect(
+	const { canLockBlocks, isLocked } = useSelect(
 		( select ) => {
 			const {
 				canMoveBlock,
 				canRemoveBlock,
 				getBlockRootClientId,
+				getSettings,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 
 			return {
+				canLockBlocks: getSettings().__experimentalCanLockBlocks,
 				isLocked:
 					! canMoveBlock( clientId, rootClientId ) ||
 					! canRemoveBlock( clientId, rootClientId ),
@@ -36,6 +38,10 @@ export default function BlockLockMenuItem( { clientId } ) {
 		( isActive ) => ! isActive,
 		false
 	);
+
+	if ( ! canLockBlocks ) {
+		return null;
+	}
 
 	const label = isLocked ? __( 'Unlock' ) : __( 'Lock' );
 

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -64,8 +64,4 @@
 			right: $grid-unit-15 !important;
 		}
 	}
-
-	.components-button[aria-disabled="true"] {
-		opacity: 1;
-	}
 }

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -64,4 +64,8 @@
 			right: $grid-unit-15 !important;
 		}
 	}
+
+	.components-button[aria-disabled="true"] {
+		opacity: 1;
+	}
 }

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -59,7 +59,7 @@ export default function BlockLockToolbar( { clientId } ) {
 					icon={ lock }
 					label={ label }
 					onClick={ canLockBlocks ? toggleModal : undefined }
-					disabled={ ! canLockBlocks }
+					aria-disabled={ ! canLockBlocks }
 				/>
 			</ToolbarGroup>
 			{ isModalOpen && canLockBlocks ? (

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -16,13 +16,16 @@ import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockToolbar( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { canMove, canRemove } = useSelect(
+	const { canMove, canRemove, canLockBlocks } = useSelect(
 		( select ) => {
-			const { canMoveBlock, canRemoveBlock } = select( blockEditorStore );
+			const { canMoveBlock, canRemoveBlock, getSettings } = select(
+				blockEditorStore
+			);
 
 			return {
 				canMove: canMoveBlock( clientId ),
 				canRemove: canRemoveBlock( clientId ),
+				canLockBlocks: getSettings().__experimentalCanLockBlocks,
 			};
 		},
 		[ clientId ]
@@ -37,22 +40,31 @@ export default function BlockLockToolbar( { clientId } ) {
 		return null;
 	}
 
+	const label = canLockBlocks
+		? sprintf(
+				/* translators: %s: block name */
+				__( 'Unlock %s' ),
+				blockInformation.title
+		  )
+		: sprintf(
+				/* translators: %s: block name */
+				__( 'Locked %s' ),
+				blockInformation.title
+		  );
+
 	return (
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ sprintf(
-						/* translators: %s: block name */
-						__( 'Unlock %s' ),
-						blockInformation.title
-					) }
-					onClick={ toggleModal }
+					label={ label }
+					onClick={ canLockBlocks ? toggleModal : undefined }
+					disabled={ ! canLockBlocks }
 				/>
 			</ToolbarGroup>
-			{ isModalOpen && (
+			{ isModalOpen && canLockBlocks ? (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
-			) }
+			) : null }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -36,35 +36,30 @@ export default function BlockLockToolbar( { clientId } ) {
 		false
 	);
 
-	if ( canMove && canRemove ) {
+	if ( ! canLockBlocks ) {
 		return null;
 	}
 
-	const label = canLockBlocks
-		? sprintf(
-				/* translators: %s: block name */
-				__( 'Unlock %s' ),
-				blockInformation.title
-		  )
-		: sprintf(
-				/* translators: %s: block name */
-				__( 'Locked %s' ),
-				blockInformation.title
-		  );
+	if ( canMove && canRemove ) {
+		return null;
+	}
 
 	return (
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ label }
-					onClick={ canLockBlocks ? toggleModal : undefined }
-					aria-disabled={ ! canLockBlocks }
+					label={ sprintf(
+						/* translators: %s: block name */
+						__( 'Unlock %s' ),
+						blockInformation.title
+					) }
+					onClick={ toggleModal }
 				/>
 			</ToolbarGroup>
-			{ isModalOpen && canLockBlocks ? (
+			{ isModalOpen && (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
-			) : null }
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -29,6 +29,7 @@ export const PREFERENCES_DEFAULTS = {
  * @property {Array}         __experimentalBlockPatterns            Array of objects representing the block patterns
  * @property {Array}         __experimentalBlockPatternCategories   Array of objects representing the block pattern categories
  * @property {boolean}       __experimentalGenerateAnchors          Enable/Disable auto anchor generation for Heading blocks
+ * @property {boolean}       __experimentalCanLockBlocks            Whether the user can manage Block Lock state
  * @property {boolean}       __unstableGalleryWithImageBlocks       Whether the user has enabled the refactored gallery block which uses InnerBlocks
  */
 export const SETTINGS_DEFAULTS = {
@@ -158,6 +159,7 @@ export const SETTINGS_DEFAULTS = {
 	__experimentalBlockPatternCategories: [],
 	__experimentalSpotlightEntityBlocks: [],
 	__experimentalGenerateAnchors: false,
+	__experimentalCanLockBlocks: true,
 	__unstableGalleryWithImageBlocks: false,
 	// gradients setting is not used anymore now defaults are passed from theme.json on the server and core has its own defaults.
 	// The setting is only kept for backward compatibility purposes.

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -92,6 +92,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
 				'__experimentalGenerateAnchors',
+				'__experimentalCanLockBlocks',
 				'__unstableGalleryWithImageBlocks',
 				'alignWide',
 				'allowedBlockTypes',


### PR DESCRIPTION
## What?
Part of #29864.

PR introduces new `__experimentalCanLockBlocks` block editor setting.

## Why?
Currently, a new Block Locking UI is available for every user. The new settings will allow developers/site admins to enable/disable UI based on specific conditions (seen in the example below).

## How?
The setting value can be set on the server-side using the `block_editor_settings_all` filter; it's then used to hide the Options menu item and disable the "Lock" button in the block toolbar.

```php
add_filter(
	'block_editor_settings_all',
	static function( $settings, $context ) {
		// Allow for the Editor role and above.
		$settings['__experimentalCanLockBlocks'] = current_user_can( 'delete_others_posts' );

		// Only enable for specific user(s).
		$user = wp_get_current_user();
		if ( in_array( $user->user_email, array( 'george@example.com' ), true ) ) {
			$settings['__experimentalCanLockBlocks'] = false;
		}

		// Disable for posts/pages.
		if ( $context->post && $context->post->post_type === 'page' ) {
			$settings['__experimentalCanLockBlocks'] = false;
		}

		return $settings;
	},
	10,
	2
);
```

## Questions
* Do we want to disable "Code editor" if a user cannot edit the block lock state?
* The lock icon is greyed out when disabled; should I leave it this way?

## Testing Instructions
1. Open a Post or Page
2. Insert a block
3. Lock it.
4. Use any of the conditional settings from example.
5. Confirm that Block Locking UI is disabled.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-03-18 at 12 21 36](https://user-images.githubusercontent.com/240569/158963304-4370ffd2-2e0d-40dd-a4b1-3bc15623a174.png)

