### PR TITLE
Blocks: Add supports lock flag

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -519,6 +519,20 @@ supports: {
 }
 ```
 
+## lock
+
+-   Type: `boolean`
+-   Default value: `true`
+
+A block may want to disable the ability to toggle the lock state. A lock state can be changed from the block "Options" dropdown by default. To disable this behavior, set `lock` to `false`.
+
+```js
+supports: {
+	// Remove support for locking UI.
+	lock: false
+}
+```
+
 ## spacing
 
 -   Type: `Object`

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -519,17 +519,17 @@ supports: {
 }
 ```
 
-## lock
+## __experimentalLock
 
 -   Type: `boolean`
 -   Default value: `true`
 
-A block may want to disable the ability to toggle the lock state. It can be locked/unlocked by a user from the block "Options" dropdown by default. To disable this behavior, set `lock` to `false`.
+A block may want to disable the ability to toggle the lock state. It can be locked/unlocked by a user from the block "Options" dropdown by default. To disable this behavior, set `__experimentalLock` to `false`.
 
 ```js
 supports: {
 	// Remove support for locking UI.
-	lock: false
+	__experimentalLock: false
 }
 ```
 

--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -524,7 +524,7 @@ supports: {
 -   Type: `boolean`
 -   Default value: `true`
 
-A block may want to disable the ability to toggle the lock state. A lock state can be changed from the block "Options" dropdown by default. To disable this behavior, set `lock` to `false`.
+A block may want to disable the ability to toggle the lock state. It can be locked/unlocked by a user from the block "Options" dropdown by default. To disable this behavior, set `lock` to `false`.
 
 ```js
 supports: {

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -48,7 +48,7 @@ _Returns_
 
 -   `boolean`: Whether the given block type is allowed to be inserted.
 
-### canLockBlocks
+### canLockBlockType
 
 Determines if the given block type can be locked/unlocked by a user.
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -48,6 +48,19 @@ _Returns_
 
 -   `boolean`: Whether the given block type is allowed to be inserted.
 
+### canLockBlocks
+
+Determines if the given block type can be locked/unlocked by a user.
+
+_Parameters_
+
+-   _state_ `Object`: Editor state.
+-   _nameOrType_ `(string|Object)`: Block name or type object.
+
+_Returns_
+
+-   `boolean`: Whether a given block type can be locked/unlocked.
+
 ### canMoveBlock
 
 Determines if the given block is allowed to be moved.

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -19,14 +19,14 @@ export default function BlockLockMenuItem( { clientId } ) {
 			const {
 				canMoveBlock,
 				canRemoveBlock,
-				canLockBlocks,
+				canLockBlockType,
 				getBlockName,
 				getBlockRootClientId,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 
 			return {
-				canLockBlock: canLockBlocks( getBlockName( clientId ) ),
+				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
 				isLocked:
 					! canMoveBlock( clientId, rootClientId ) ||
 					! canRemoveBlock( clientId, rootClientId ),

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -14,18 +14,19 @@ import BlockLockModal from './modal';
 import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockMenuItem( { clientId } ) {
-	const { canLockBlocks, isLocked } = useSelect(
+	const { canLockBlock, isLocked } = useSelect(
 		( select ) => {
 			const {
 				canMoveBlock,
 				canRemoveBlock,
+				canLockBlocks,
+				getBlockName,
 				getBlockRootClientId,
-				getSettings,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 
 			return {
-				canLockBlocks: getSettings().__experimentalCanLockBlocks,
+				canLockBlock: canLockBlocks( getBlockName( clientId ) ),
 				isLocked:
 					! canMoveBlock( clientId, rootClientId ) ||
 					! canRemoveBlock( clientId, rootClientId ),
@@ -39,7 +40,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		false
 	);
 
-	if ( ! canLockBlocks ) {
+	if ( ! canLockBlock ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -21,14 +21,14 @@ export default function BlockLockToolbar( { clientId } ) {
 			const {
 				canMoveBlock,
 				canRemoveBlock,
-				canLockBlocks,
+				canLockBlockType,
 				getBlockName,
 			} = select( blockEditorStore );
 
 			return {
 				canMove: canMoveBlock( clientId ),
 				canRemove: canRemoveBlock( clientId ),
-				canLockBlock: canLockBlocks( getBlockName( clientId ) ),
+				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
 			};
 		},
 		[ clientId ]

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -63,7 +63,7 @@ export default function BlockLockToolbar( { clientId } ) {
 					icon={ lock }
 					label={ label }
 					onClick={ canLockBlocks ? toggleModal : undefined }
-					disabled={ ! canLockBlocks }
+					aria-disabled={ ! canLockBlocks }
 				/>
 			</ToolbarGroup>
 			{ isModalOpen && canLockBlocks ? (

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -39,7 +39,7 @@ export default function BlockLockToolbar( { clientId } ) {
 		false
 	);
 
-	if ( ! canLockBlocks ) {
+	if ( ! canLockBlock ) {
 		return null;
 	}
 
@@ -47,31 +47,23 @@ export default function BlockLockToolbar( { clientId } ) {
 		return null;
 	}
 
-	const label = canLockBlock
-		? sprintf(
-				/* translators: %s: block name */
-				__( 'Unlock %s' ),
-				blockInformation.title
-		  )
-		: sprintf(
-				/* translators: %s: block name */
-				__( 'Locked %s' ),
-				blockInformation.title
-		  );
-
 	return (
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ label }
-					onClick={ canLockBlock ? toggleModal : undefined }
+					label={ sprintf(
+						/* translators: %s: block name */
+						__( 'Unlock %s' ),
+						blockInformation.title
+					) }
+					onClick={ toggleModal }
 					aria-disabled={ ! canLockBlock }
 				/>
 			</ToolbarGroup>
-			{ isModalOpen && canLockBlock ? (
+			{ isModalOpen && (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
-			) : null }
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -16,16 +16,19 @@ import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockToolbar( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { canMove, canRemove, canLockBlocks } = useSelect(
+	const { canMove, canRemove, canLockBlock } = useSelect(
 		( select ) => {
-			const { canMoveBlock, canRemoveBlock, getSettings } = select(
-				blockEditorStore
-			);
+			const {
+				canMoveBlock,
+				canRemoveBlock,
+				canLockBlocks,
+				getBlockName,
+			} = select( blockEditorStore );
 
 			return {
 				canMove: canMoveBlock( clientId ),
 				canRemove: canRemoveBlock( clientId ),
-				canLockBlocks: getSettings().__experimentalCanLockBlocks,
+				canLockBlock: canLockBlocks( getBlockName( clientId ) ),
 			};
 		},
 		[ clientId ]
@@ -44,7 +47,7 @@ export default function BlockLockToolbar( { clientId } ) {
 		return null;
 	}
 
-	const label = canLockBlocks
+	const label = canLockBlock
 		? sprintf(
 				/* translators: %s: block name */
 				__( 'Unlock %s' ),
@@ -62,11 +65,11 @@ export default function BlockLockToolbar( { clientId } ) {
 				<ToolbarButton
 					icon={ lock }
 					label={ label }
-					onClick={ canLockBlocks ? toggleModal : undefined }
-					aria-disabled={ ! canLockBlocks }
+					onClick={ canLockBlock ? toggleModal : undefined }
+					aria-disabled={ ! canLockBlock }
 				/>
 			</ToolbarGroup>
-			{ isModalOpen && canLockBlocks ? (
+			{ isModalOpen && canLockBlock ? (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
 			) : null }
 		</>

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -44,22 +44,31 @@ export default function BlockLockToolbar( { clientId } ) {
 		return null;
 	}
 
+	const label = canLockBlocks
+		? sprintf(
+				/* translators: %s: block name */
+				__( 'Unlock %s' ),
+				blockInformation.title
+		  )
+		: sprintf(
+				/* translators: %s: block name */
+				__( 'Locked %s' ),
+				blockInformation.title
+		  );
+
 	return (
 		<>
 			<ToolbarGroup className="block-editor-block-lock-toolbar">
 				<ToolbarButton
 					icon={ lock }
-					label={ sprintf(
-						/* translators: %s: block name */
-						__( 'Unlock %s' ),
-						blockInformation.title
-					) }
-					onClick={ toggleModal }
+					label={ label }
+					onClick={ canLockBlocks ? toggleModal : undefined }
+					disabled={ ! canLockBlocks }
 				/>
 			</ToolbarGroup>
-			{ isModalOpen && (
+			{ isModalOpen && canLockBlocks ? (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
-			) }
+			) : null }
 		</>
 	);
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1450,7 +1450,7 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
  *
  * @return {boolean} Whether a given block type can be locked/unlocked.
  */
-export function canLockBlocks( state, nameOrType ) {
+export function canLockBlockType( state, nameOrType ) {
 	if ( ! hasBlockSupport( nameOrType, 'lock', true ) ) {
 		return false;
 	}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1451,7 +1451,7 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
  * @return {boolean} Whether a given block type can be locked/unlocked.
  */
 export function canLockBlockType( state, nameOrType ) {
-	if ( ! hasBlockSupport( nameOrType, 'lock', true ) ) {
+	if ( ! hasBlockSupport( nameOrType, '__experimentalLock', true ) ) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1443,6 +1443,23 @@ export function canMoveBlocks( state, clientIds, rootClientId = null ) {
 }
 
 /**
+ * Determines if the given block type can be locked/unlocked by a user.
+ *
+ * @param {Object}          state      Editor state.
+ * @param {(string|Object)} nameOrType Block name or type object.
+ *
+ * @return {boolean} Whether a given block type can be locked/unlocked.
+ */
+export function canLockBlocks( state, nameOrType ) {
+	if ( ! hasBlockSupport( nameOrType, 'lock', true ) ) {
+		return false;
+	}
+
+	// Use block editor settings as the default value.
+	return !! state.settings?.__experimentalCanLockBlocks;
+}
+
+/**
  * Returns information about how recently and frequently a block has been inserted.
  *
  * @param {Object} state Global application state.


### PR DESCRIPTION
## What?
Part of #29864.

Introduces new blocks `supports.__experimentalLock` flag.

## Why?
A new support flag will allow disabling locking UI on the block type level.

## How?
PR adds a new `canLockBlockType` selector that checks block type supports flag and fallbacks to block editor settings.

## Todos

- [x] Document new supports flag.

## Testing Instructions
1. Modify any core blocks support settings and add `"__experimentalLock": false.`
2. Open a post/page.
3. Insert this block.
4. Confirm that Block Lock settings aren't visible.
