### PR TITLE
Fix month number ordinal suffix not working when formatting dates

### DIFF
--- a/packages/date/src/index.js
+++ b/packages/date/src/index.js
@@ -196,6 +196,32 @@ function setupWPTimezone() {
 	);
 }
 
+/**
+ * Gets the ordinal suffix for a month number (e.g. 'nd' for 2).
+ *
+ * Marked as unstable because it's only exported for testing.
+ *
+ * @param {string|number} dayOfMonth The day of month
+ * @return {string} The suffix (e.g. 'st' for the number 1)
+ */
+export function __unstableGetMonthNumberOrdinalSuffix( dayOfMonth ) {
+	if ( typeof dayOfMonth === 'number' ) {
+		dayOfMonth = dayOfMonth.toString();
+	}
+
+	if ( dayOfMonth !== '11' && dayOfMonth.endsWith( '1' ) ) {
+		return 'st';
+	}
+	if ( dayOfMonth !== '12' && dayOfMonth.endsWith( '2' ) ) {
+		return 'nd';
+	}
+	if ( dayOfMonth !== '13' && dayOfMonth.endsWith( '3' ) ) {
+		return 'rd';
+	}
+
+	return 'th';
+}
+
 // Date constants.
 /**
  * Number of seconds in one minute.
@@ -242,10 +268,9 @@ const formatMap = {
 	 * @return {string} Formatted date.
 	 */
 	S( momentDate ) {
-		// Do - D.
-		const num = momentDate.format( 'D' );
-		const withOrdinal = momentDate.format( 'Do' );
-		return withOrdinal.replace( num, '' );
+		return __unstableGetMonthNumberOrdinalSuffix(
+			momentDate.format( 'D' )
+		);
 	},
 
 	w: 'd',

--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -10,6 +10,7 @@ import {
 	gmdateI18n,
 	isInTheFuture,
 	setSettings,
+	__unstableGetMonthNumberOrdinalSuffix,
 } from '../';
 
 describe( 'isInTheFuture', () => {
@@ -505,4 +506,88 @@ describe( 'Moment.js Localization', () => {
 		// Restore default settings.
 		setSettings( settings );
 	} );
+} );
+
+describe( '__unstableGetMonthNumberOrdinalSuffix', () => {
+	it.each( [
+		{ monthNumber: 1, expected: 'st' },
+		{ monthNumber: 2, expected: 'nd' },
+		{ monthNumber: 3, expected: 'rd' },
+		{ monthNumber: 4, expected: 'th' },
+		{ monthNumber: 5, expected: 'th' },
+		{ monthNumber: 6, expected: 'th' },
+		{ monthNumber: 7, expected: 'th' },
+		{ monthNumber: 8, expected: 'th' },
+		{ monthNumber: 9, expected: 'th' },
+		{ monthNumber: 10, expected: 'th' },
+		{ monthNumber: 11, expected: 'th' },
+		{ monthNumber: 12, expected: 'th' },
+		{ monthNumber: 13, expected: 'th' },
+		{ monthNumber: 14, expected: 'th' },
+		{ monthNumber: 15, expected: 'th' },
+		{ monthNumber: 16, expected: 'th' },
+		{ monthNumber: 17, expected: 'th' },
+		{ monthNumber: 18, expected: 'th' },
+		{ monthNumber: 19, expected: 'th' },
+		{ monthNumber: 20, expected: 'th' },
+		{ monthNumber: 21, expected: 'st' },
+		{ monthNumber: 22, expected: 'nd' },
+		{ monthNumber: 23, expected: 'rd' },
+		{ monthNumber: 24, expected: 'th' },
+		{ monthNumber: 25, expected: 'th' },
+		{ monthNumber: 26, expected: 'th' },
+		{ monthNumber: 27, expected: 'th' },
+		{ monthNumber: 28, expected: 'th' },
+		{ monthNumber: 29, expected: 'th' },
+		{ monthNumber: 30, expected: 'th' },
+		{ monthNumber: 31, expected: 'st' },
+	] )(
+		'outputs $expected for the integer month number $monthNumber',
+		( { monthNumber, expected } ) => {
+			expect( __unstableGetMonthNumberOrdinalSuffix( monthNumber ) ).toBe(
+				expected
+			);
+		}
+	);
+
+	it.each( [
+		{ monthNumber: '1', expected: 'st' },
+		{ monthNumber: '2', expected: 'nd' },
+		{ monthNumber: '3', expected: 'rd' },
+		{ monthNumber: '4', expected: 'th' },
+		{ monthNumber: '5', expected: 'th' },
+		{ monthNumber: '6', expected: 'th' },
+		{ monthNumber: '7', expected: 'th' },
+		{ monthNumber: '8', expected: 'th' },
+		{ monthNumber: '9', expected: 'th' },
+		{ monthNumber: '10', expected: 'th' },
+		{ monthNumber: '11', expected: 'th' },
+		{ monthNumber: '12', expected: 'th' },
+		{ monthNumber: '13', expected: 'th' },
+		{ monthNumber: '14', expected: 'th' },
+		{ monthNumber: '15', expected: 'th' },
+		{ monthNumber: '16', expected: 'th' },
+		{ monthNumber: '17', expected: 'th' },
+		{ monthNumber: '18', expected: 'th' },
+		{ monthNumber: '19', expected: 'th' },
+		{ monthNumber: '20', expected: 'th' },
+		{ monthNumber: '21', expected: 'st' },
+		{ monthNumber: '22', expected: 'nd' },
+		{ monthNumber: '23', expected: 'rd' },
+		{ monthNumber: '24', expected: 'th' },
+		{ monthNumber: '25', expected: 'th' },
+		{ monthNumber: '26', expected: 'th' },
+		{ monthNumber: '27', expected: 'th' },
+		{ monthNumber: '28', expected: 'th' },
+		{ monthNumber: '29', expected: 'th' },
+		{ monthNumber: '30', expected: 'th' },
+		{ monthNumber: '31', expected: 'st' },
+	] )(
+		'outputs $expected for the string month number $monthNumber',
+		( { monthNumber, expected } ) => {
+			expect( __unstableGetMonthNumberOrdinalSuffix( monthNumber ) ).toBe(
+				expected
+			);
+		}
+	);
 } );


### PR DESCRIPTION
## What?
Fixes #39567

As explained on the issue, the Post Date block wasn't displaying the month number ordinal (the 'st' after 1, or 'nd' after 2 etc.) when a date format includes `jS` (https://wordpress.org/support/article/formatting-date-and-time/).

I'm not sure why it was broken, the function seems to use moment-js (which ironically doesn't format `jS`), a deprecated library that's rather complicated.

## How?
This might be a naive fix, but I've written a very basic function that outputs the correct ordinal. This should in theory be a microscopic shuffle towards reducing the dependency on moment-js.

I don't know if the suffixes need to be localized or if this planet only has one kind of suffix.

## Testing Instructions
1. In a post date block, specify a custom format that has `jS` for the month number
2. The editor should show the correct suffix

## Screenshots or screencast <!-- if applicable -->
![Screen Shot 2022-03-18 at 4 09 13 pm](https://user-images.githubusercontent.com/677833/158961525-34ead3ca-984c-44ab-8919-2efce7aa9ce7.png)
