### PR TITLE
Global Styles: Add Global styles to inline block styles

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -94,7 +94,17 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 
 			// 2. Generate the rules that use the general selector.
-			$block_rules .= static::to_ruleset( $selector, $declarations );
+			// If the block is not used on this page, return.
+			$general_selector_rules = static::to_ruleset( $selector, $declarations );
+			if ( 'styles' === $metadata['path'][0] && 'blocks' === $metadata['path'][1] ) {
+				$block_name = str_replace( 'core/', '', $metadata['path'][2] );
+				wp_add_inline_style(
+					"wp-block-{$block_name}",
+					$general_selector_rules
+				);
+			} else {
+				$block_rules .= $general_selector_rules;
+			}
 
 			// 3. Generate the rules that use the duotone selector.
 			if ( isset( $metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {

--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -76,13 +76,13 @@ function gutenberg_get_global_styles( $path = array(), $context = array() ) {
 function gutenberg_get_global_stylesheet( $types = array() ) {
 	// Return cached value if it can be used and exists.
 	// It's cached by theme to make sure that theme switching clears the cache.
-	$can_use_cached = (
+	$can_use_cached = false; /* (
 		( empty( $types ) ) &&
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
 		! is_admin()
-	);
+	);*/
 	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 	if ( $can_use_cached ) {
 		$cached = get_transient( $transient_name );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Only load the Global Styles CSS for blocks that are used on the page.

## Why?
So we only load the required CSS.

## How?
This adds the Global Styles CSS for each block to the inline CSS for that block. This mean that the CSS is loaded in a different place to at present. An alternative approach would be to keep the CSS in the `global-styles-inline-css` so that the load order is the same. I tried to do this, but I couldn't find where the CSS is actually enqueued for each block.

## Testing Instructions
- Switch to TT2
- Go to a page without a quote block on
- Check that this CSS isn't in either the `global-styles-inline-css` or `wp-block-quote-css`:
```
.wp-block-quote {
	border-width: 1px;
}
```
- Go to a page with a quote block on
- Check that this CSS is *not* in the `global-styles-inline-css` but *is* in `wp-block-quote-css`:
```
.wp-block-quote {
	border-width: 1px;
}
```

