### PR TITLE
Revert addition of Navigation entity

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -115,7 +115,7 @@ export const rootEntitiesConfig = [
 		label: __( 'Comment' ),
 	},
 	{
-		name: 'menu', // Classic Menus
+		name: 'menu',
 		kind: 'root',
 		baseURL: '/wp/v2/menus',
 		baseURLParams: { context: 'edit' },
@@ -123,7 +123,7 @@ export const rootEntitiesConfig = [
 		label: __( 'Menu' ),
 	},
 	{
-		name: 'menuItem', // Classic Menu Items
+		name: 'menuItem',
 		kind: 'root',
 		baseURL: '/wp/v2/menu-items',
 		baseURLParams: { context: 'edit' },
@@ -132,7 +132,7 @@ export const rootEntitiesConfig = [
 		rawAttributes: [ 'title', 'content' ],
 	},
 	{
-		name: 'menuLocation', // Classic Menu Locations
+		name: 'menuLocation',
 		kind: 'root',
 		baseURL: '/wp/v2/menu-locations',
 		baseURLParams: { context: 'edit' },
@@ -141,7 +141,7 @@ export const rootEntitiesConfig = [
 		key: 'name',
 	},
 	{
-		name: 'navigationArea', // Deprecated - can be removed once the concepts of Navigation Areas is removed from the codebase.
+		name: 'navigationArea',
 		kind: 'root',
 		baseURL: '/wp/v2/block-navigation-areas',
 		baseURLParams: { context: 'edit' },
@@ -174,14 +174,6 @@ export const rootEntitiesConfig = [
 		baseURL: '/wp/v2/plugins',
 		baseURLParams: { context: 'edit' },
 		key: 'plugin',
-	},
-	{
-		label: __( 'Navigation' ), // Block based Navigation Menus
-		name: 'navigationMenu',
-		kind: 'root',
-		baseURL: '/wp/v2/navigation',
-		baseURLParams: { context: 'edit' },
-		plural: 'navigationMenus',
 	},
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
It looks like adding the Nav entity may have broken something in Core Data. Reverting until we understand what's going on.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
