### PR TITLE
Collapse list view by default in Site Editor

### DIFF
--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,6 +63,7 @@ export default function ListViewSidebar() {
 					showNestedBlocks
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
+					expandNested={ false }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR sets nodes within the List View to be collapsed by default.

## Why?
In https://github.com/WordPress/gutenberg/issues/34759 a few folks said the list view could be overwhelming. This also has accessibility concerns.

Given that the Site Editor is the most likely to have heavily nested block structures it makes sense to experiment with making all nodes collapsed by default here first.

This should make the initial list view experience a lot less overwhelming.

## How?

It toggles to `false` [the new `expandNested` prop of `<ListView>`](https://github.com/WordPress/gutenberg/pull/39486.) which forces all nodes to default to `collapsed` state.

## Testing Instructions

1. Use default TT2 theme.
2. Open Site Editor.
3. Toggle List View open.
4. See all nodes collapsed by default.
5. Check you can expand/collapse nodes manually as required and that windowing doesn't break.

## Screenshots or screencast <!-- if applicable -->
<img width="358" alt="Screen Shot 2022-03-18 at 09 59 59" src="https://user-images.githubusercontent.com/444434/158982202-64163737-cb21-46f1-b3e6-a22645b04de7.png">

