### PR TITLE
Spacer block: use same `min` value resizable box and controls, remove `max` limit

### DIFF
--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -15,12 +15,7 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import {
-	MIN_SPACER_WIDTH,
-	MAX_SPACER_WIDTH,
-	MIN_SPACER_HEIGHT,
-	MAX_SPACER_HEIGHT,
-} from './edit';
+import { MIN_SPACER_WIDTH, MIN_SPACER_HEIGHT } from './edit';
 
 function DimensionInput( {
 	label,
@@ -98,7 +93,6 @@ export default function SpacerControls( {
 						}
 						isResizing={ isResizing }
 						min={ MIN_SPACER_WIDTH }
-						max={ MAX_SPACER_WIDTH }
 					/>
 				) }
 				{ orientation !== 'horizontal' && (
@@ -110,7 +104,6 @@ export default function SpacerControls( {
 						}
 						isResizing={ isResizing }
 						min={ MIN_SPACER_HEIGHT }
-						max={ MAX_SPACER_HEIGHT }
 					/>
 				) }
 			</PanelBody>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -15,7 +15,7 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { MAX_SPACER_SIZE } from './edit';
+import { MIN_SPACER_SIZE, MAX_SPACER_SIZE } from './edit';
 
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
@@ -56,7 +56,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange
-				min={ 0 }
+				min={ MIN_SPACER_SIZE }
 				max={ MAX_SPACER_SIZE }
 				onChange={ handleOnChange }
 				style={ { maxWidth: 80 } }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -15,9 +15,21 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_SIZE, MAX_SPACER_SIZE } from './edit';
+import {
+	MIN_SPACER_WIDTH,
+	MAX_SPACER_WIDTH,
+	MIN_SPACER_HEIGHT,
+	MAX_SPACER_HEIGHT,
+} from './edit';
 
-function DimensionInput( { label, onChange, isResizing, value = '' } ) {
+function DimensionInput( {
+	label,
+	onChange,
+	isResizing,
+	value = '',
+	min,
+	max,
+} ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
 
 	// In most contexts the spacer size cannot meaningfully be set to a
@@ -56,8 +68,8 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange
-				min={ MIN_SPACER_SIZE }
-				max={ MAX_SPACER_SIZE }
+				min={ min }
+				max={ max }
 				onChange={ handleOnChange }
 				style={ { maxWidth: 80 } }
 				value={ computedValue }
@@ -85,6 +97,8 @@ export default function SpacerControls( {
 							setAttributes( { width: nextWidth } )
 						}
 						isResizing={ isResizing }
+						min={ MIN_SPACER_WIDTH }
+						max={ MAX_SPACER_WIDTH }
 					/>
 				) }
 				{ orientation !== 'horizontal' && (
@@ -95,6 +109,8 @@ export default function SpacerControls( {
 							setAttributes( { height: nextHeight } )
 						}
 						isResizing={ isResizing }
+						min={ MIN_SPACER_HEIGHT }
+						max={ MAX_SPACER_HEIGHT }
 					/>
 				) }
 			</PanelBody>

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -15,16 +15,9 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_WIDTH, MIN_SPACER_HEIGHT } from './edit';
+import { MIN_SPACER_SIZE } from './edit';
 
-function DimensionInput( {
-	label,
-	onChange,
-	isResizing,
-	value = '',
-	min,
-	max,
-} ) {
+function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );
 
 	// In most contexts the spacer size cannot meaningfully be set to a
@@ -63,8 +56,7 @@ function DimensionInput( {
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange
-				min={ min }
-				max={ max }
+				min={ MIN_SPACER_SIZE }
 				onChange={ handleOnChange }
 				style={ { maxWidth: 80 } }
 				value={ computedValue }
@@ -92,7 +84,6 @@ export default function SpacerControls( {
 							setAttributes( { width: nextWidth } )
 						}
 						isResizing={ isResizing }
-						min={ MIN_SPACER_WIDTH }
 					/>
 				) }
 				{ orientation !== 'horizontal' && (
@@ -103,7 +94,6 @@ export default function SpacerControls( {
 							setAttributes( { height: nextHeight } )
 						}
 						isResizing={ isResizing }
-						min={ MIN_SPACER_HEIGHT }
 					/>
 				) }
 			</PanelBody>

--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,12 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	MIN_SPACER_WIDTH,
-	MAX_SPACER_WIDTH,
-	MIN_SPACER_HEIGHT,
-	MAX_SPACER_HEIGHT,
-} from './edit';
+import { MIN_SPACER_WIDTH, MIN_SPACER_HEIGHT } from './edit';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };
@@ -76,11 +71,6 @@ function Controls( { attributes, context, setAttributes } ) {
 						orientation === 'horizontal'
 							? MIN_SPACER_WIDTH
 							: MIN_SPACER_HEIGHT
-					}
-					max={
-						orientation === 'horizontal'
-							? MAX_SPACER_WIDTH
-							: MAX_SPACER_HEIGHT
 					}
 					value={ value }
 					onChange={ handleChange }

--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { MIN_SPACER_SIZE, MAX_SPACER_SIZE } from './edit';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };
@@ -66,7 +67,8 @@ function Controls( { attributes, context, setAttributes } ) {
 			<PanelBody title={ __( 'Dimensions' ) }>
 				<UnitControl
 					label={ label }
-					min={ 1 }
+					min={ MIN_SPACER_SIZE }
+					max={ MAX_SPACER_SIZE }
 					value={ value }
 					onChange={ handleChange }
 					onUnitChange={ handleUnitChange }

--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_WIDTH, MIN_SPACER_HEIGHT } from './edit';
+import { MIN_SPACER_SIZE } from './edit';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };
@@ -67,11 +67,7 @@ function Controls( { attributes, context, setAttributes } ) {
 			<PanelBody title={ __( 'Dimensions' ) }>
 				<UnitControl
 					label={ label }
-					min={
-						orientation === 'horizontal'
-							? MIN_SPACER_WIDTH
-							: MIN_SPACER_HEIGHT
-					}
+					min={ MIN_SPACER_SIZE }
 					value={ value }
 					onChange={ handleChange }
 					onUnitChange={ handleUnitChange }

--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,7 +14,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_SIZE, MAX_SPACER_SIZE } from './edit';
+import {
+	MIN_SPACER_WIDTH,
+	MAX_SPACER_WIDTH,
+	MIN_SPACER_HEIGHT,
+	MAX_SPACER_HEIGHT,
+} from './edit';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };
@@ -67,8 +72,16 @@ function Controls( { attributes, context, setAttributes } ) {
 			<PanelBody title={ __( 'Dimensions' ) }>
 				<UnitControl
 					label={ label }
-					min={ MIN_SPACER_SIZE }
-					max={ MAX_SPACER_SIZE }
+					min={
+						orientation === 'horizontal'
+							? MIN_SPACER_WIDTH
+							: MIN_SPACER_HEIGHT
+					}
+					max={
+						orientation === 'horizontal'
+							? MAX_SPACER_WIDTH
+							: MAX_SPACER_HEIGHT
+					}
 					value={ value }
 					onChange={ handleChange }
 					onUnitChange={ handleUnitChange }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,8 +16,10 @@ import { View } from '@wordpress/primitives';
  */
 import SpacerControls from './controls';
 
-export const MIN_SPACER_SIZE = 10;
-export const MAX_SPACER_SIZE = 500;
+export const MIN_SPACER_WIDTH = 1;
+export const MAX_SPACER_WIDTH = 500;
+export const MIN_SPACER_HEIGHT = 10;
+export const MAX_SPACER_HEIGHT = 500;
 
 const ResizableSpacer = ( {
 	orientation,
@@ -59,7 +61,9 @@ const ResizableSpacer = ( {
 			} }
 			onResizeStop={ ( _event, _direction, elt ) => {
 				const nextVal = Math.min(
-					MAX_SPACER_SIZE,
+					orientation === 'horizontal'
+						? MAX_SPACER_WIDTH
+						: MAX_SPACER_HEIGHT,
 					getCurrentSize( elt )
 				);
 				onResizeStop( `${ nextVal }px` );
@@ -122,8 +126,7 @@ const SpacerEdit = ( {
 		if ( blockOrientation === 'horizontal' ) {
 			return (
 				<ResizableSpacer
-					minWidth={ MIN_SPACER_SIZE }
-					maxWidth={ MAX_SPACER_SIZE }
+					minWidth={ MIN_SPACER_WIDTH }
 					enable={ {
 						top: false,
 						right: true,
@@ -148,8 +151,7 @@ const SpacerEdit = ( {
 		return (
 			<>
 				<ResizableSpacer
-					minHeight={ MIN_SPACER_SIZE }
-					maxHeight={ MAX_SPACER_SIZE }
+					minHeight={ MIN_SPACER_HEIGHT }
 					enable={ {
 						top: false,
 						right: false,

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,9 +16,9 @@ import { View } from '@wordpress/primitives';
  */
 import SpacerControls from './controls';
 
-export const MIN_SPACER_WIDTH = 1;
+export const MIN_SPACER_WIDTH = 0;
 export const MAX_SPACER_WIDTH = 500;
-export const MIN_SPACER_HEIGHT = 10;
+export const MIN_SPACER_HEIGHT = 0;
 export const MAX_SPACER_HEIGHT = 500;
 
 const ResizableSpacer = ( {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -123,6 +123,7 @@ const SpacerEdit = ( {
 			return (
 				<ResizableSpacer
 					minWidth={ MIN_SPACER_SIZE }
+					maxWidth={ MAX_SPACER_SIZE }
 					enable={ {
 						top: false,
 						right: true,
@@ -147,6 +148,8 @@ const SpacerEdit = ( {
 		return (
 			<>
 				<ResizableSpacer
+					minHeight={ MIN_SPACER_SIZE }
+					maxHeight={ MAX_SPACER_SIZE }
 					enable={ {
 						top: false,
 						right: false,

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -17,9 +17,7 @@ import { View } from '@wordpress/primitives';
 import SpacerControls from './controls';
 
 export const MIN_SPACER_WIDTH = 0;
-export const MAX_SPACER_WIDTH = 500;
 export const MIN_SPACER_HEIGHT = 0;
-export const MAX_SPACER_HEIGHT = 500;
 
 const ResizableSpacer = ( {
 	orientation,
@@ -60,12 +58,7 @@ const ResizableSpacer = ( {
 				}
 			} }
 			onResizeStop={ ( _event, _direction, elt ) => {
-				const nextVal = Math.min(
-					orientation === 'horizontal'
-						? MAX_SPACER_WIDTH
-						: MAX_SPACER_HEIGHT,
-					getCurrentSize( elt )
-				);
+				const nextVal = getCurrentSize( elt );
 				onResizeStop( `${ nextVal }px` );
 				setIsResizing( false );
 			} }

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,7 +16,7 @@ import { View } from '@wordpress/primitives';
  */
 import SpacerControls from './controls';
 
-export const MIN_SPACER_SIZE = 1;
+export const MIN_SPACER_SIZE = 10;
 export const MAX_SPACER_SIZE = 500;
 
 const ResizableSpacer = ( {

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -16,8 +16,7 @@ import { View } from '@wordpress/primitives';
  */
 import SpacerControls from './controls';
 
-export const MIN_SPACER_WIDTH = 0;
-export const MIN_SPACER_HEIGHT = 0;
+export const MIN_SPACER_SIZE = 0;
 
 const ResizableSpacer = ( {
 	orientation,
@@ -119,7 +118,7 @@ const SpacerEdit = ( {
 		if ( blockOrientation === 'horizontal' ) {
 			return (
 				<ResizableSpacer
-					minWidth={ MIN_SPACER_WIDTH }
+					minWidth={ MIN_SPACER_SIZE }
 					enable={ {
 						top: false,
 						right: true,
@@ -144,7 +143,7 @@ const SpacerEdit = ( {
 		return (
 			<>
 				<ResizableSpacer
-					minHeight={ MIN_SPACER_HEIGHT }
+					minHeight={ MIN_SPACER_SIZE }
 					enable={ {
 						top: false,
 						right: false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR tweaks the interactive resizable box and the sidebar controls used to tweaks the Spacer block. With the changes in this PR, both the resizable box (used to resize the spacer by dragging its handle) and the sidebar controls have:
  - a shared `min` value of `0`
  - no `max` value

This is true for both the horizontal and the vertical orientations.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As flagged by @aaronrobertshaw in https://github.com/WordPress/gutenberg/pull/39513#pullrequestreview-913919292, currently the controls in the sidebar and the interactive resizable box operate with different minimum and maximum allowed values.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The main reason for adopting a minimum value of `0` and not having a maximum value is that it would be almost impossible to have a numeric min/max value that would translate fairly to all possible units available through `UnitControl`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- insert a spacer block, play around by resizing it both by dragging the handle and by changing the value in the controls in the sidebar
- both methods of interacting with the spacer should avoid its width to go negative, but there shouldn't be any limit to how big the spacer can grow.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/1083581/159273977-183387d0-74dd-42bf-aaa4-64f9babd590c.mp4


