### PR TITLE
[Site Logo] Fix center alignment

### DIFF
--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -46,6 +46,7 @@
 
 	// Style the placeholder.
 	.components-placeholder {
+		display: flex;
 		justify-content: center;
 		align-items: center;
 		box-shadow: none;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -1,3 +1,4 @@
+.wp-block[data-align="center"] > .wp-block-site-logo,
 .wp-block-site-logo.aligncenter > div {
 	display: table;
 	margin-left: auto;

--- a/packages/block-library/src/site-logo/editor.scss
+++ b/packages/block-library/src/site-logo/editor.scss
@@ -1,4 +1,4 @@
-.wp-block[data-align="center"] > .wp-block-site-logo {
+.wp-block-site-logo.aligncenter > div {
 	display: table;
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
The site logo's center alignment rules rely on a `[data-align]` div that no longer exists for themes that support layout (https://github.com/WordPress/gutenberg/pull/38613). This PR adds in an additional rule to get the alignment working for that use case. 

---

Testing: 

1. Using a block theme
2. Add a group with a site logo block inside of it.
3. Try to center-align the site logo block. 
4. See if it works or not. 

---

Sample markup: 

```
<!-- wp:group {"layout":{"inherit":true}} -->
<div class="wp-block-group"><!-- wp:site-logo {"align":"center"} /--></div>
<!-- /wp:group -->
```

---

Screenshots: 

Before|After
---|---
<img width="445" alt="Screen Shot 2022-03-18 at 8 29 46 AM" src="https://user-images.githubusercontent.com/1202812/159003273-083ea912-6bc8-4aa6-b5f3-a9cf222ab7fa.png">|<img width="438" alt="Screen Shot 2022-03-18 at 8 30 08 AM" src="https://user-images.githubusercontent.com/1202812/159003290-facd4dd3-ab90-4bcb-8eb8-fbc62ed7879c.png">

