### PR TITLE
Image: Allow authors to select image sizes from dropdown

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -95,7 +95,10 @@ export default function Image( {
 			);
 			const multiSelectedClientIds = getMultiSelectedBlockClientIds();
 			return {
-				image: id && isSelected ? getMedia( id ) : null,
+				image:
+					id && isSelected
+						? getMedia( id, { context: 'view' } )
+						: null,
 				multiImageSelection:
 					multiSelectedClientIds.length &&
 					multiSelectedClientIds.every(


### PR DESCRIPTION
## What?
Resolves #39570.

Displays image size dropdown for non-Admin user roles.

## Why?
Similar to #33567.

The non-Admin user roles cannot request images uploaded by other users in the `edit` context.

## How?
Update `getMedia` selector call and use the `view` context.

## Testing Instructions
1. Upload an image using an Administrator user account.
2. Switch to a user with an Author role.
3. Create a post.
4. Insert an Image block and select the uploaded image.
5. Confirm that the image size dropdown is displayed in the sidebar.
6. DevTools has no 403 requests in the Networks panel.
