### PR TITLE
Theme Export: Add missing properties to theme.json

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -14,7 +14,7 @@
  *
  * @access private
  */
-class WP_Theme_JSON_5_9 {
+class WP_Theme_JSON_5_9 extends WP_Theme_JSON {
 
 	/**
 	 * Container of data in theme.json format.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -14,7 +14,7 @@
  *
  * @access private
  */
-class WP_Theme_JSON_5_9 extends WP_Theme_JSON {
+class WP_Theme_JSON_5_9 {
 
 	/**
 	 * Container of data in theme.json format.

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -99,20 +99,9 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Load theme.json into the zip file.
-	$user_data = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
-	// Update settings that aren't present in the $tree.
-	if ( file_exists( $theme_path . '/theme.json' ) ) {
-		$theme_json_data = wp_json_file_decode( $theme_path . '/theme.json', array( 'associative' => true ) );
-		if ( ! empty( $theme_json_data ) ) {
-			$merged_data = WP_Theme_JSON_Gutenberg::functional_merge( $theme_json_data, $user_data->get_raw_data() );
-		}
-	} else {
-		$merged_data = $user_data;
-	}
-
 	$zip->addFromString(
 		$theme_name . '/theme.json',
-		wp_json_encode( $merged_data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		wp_json_encode( WP_Theme_JSON_Gutenberg::get_merged_theme_json(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
 	);
 
 	// Save changes to the zip file.

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -30,7 +30,7 @@ function gutenberg_is_theme_directory_ignored( $path ) {
  * Recursively applies ksort to an array.
  * From tests/phpunit/tests/theme/wpThemeJsonResolver.php
  */
-function gutenburg_recursive_ksort( &$array ) {
+function gutenberg_recursive_ksort( &$array ) {
 	foreach ( $array as &$value ) {
 		if ( is_array( $value ) ) {
 			gutenburg_recursive_ksort( $value );

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -120,8 +120,13 @@ function gutenberg_generate_block_templates_export_file() {
 	if ( file_exists( $theme_path . '/theme.json' ) ) {
 		$theme_json_data = wp_json_file_decode( $theme_path . '/theme.json', array( 'associative' => true ) );
 		if ( ! empty( $theme_json_data ) ) {
-			$merged_data['$schema'] = $theme_json_data['$schema'];
-			$merged_data['settings']['appearanceTools'] = $theme_json_data['settings']['appearanceTools'];
+			if ( ! empty( $theme_json_data['$schema'] ) ) {
+				$merged_data['$schema'] = $theme_json_data['$schema'];
+			}
+
+			if ( ! empty( $theme_json_data['settings']['appearanceTools'] ) ) {
+				$merged_data['settings']['appearanceTools'] = $theme_json_data['settings']['appearanceTools'];
+			}
 		}
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -176,6 +176,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 	/**
 	 * Get a `default`'s preset name by a provided slug.
+	 * Renamed from get_name_from_default
 	 *
 	 * @param array $default_array The slug we want to find a match from default presets.
 	 * @param string $slug The slug we want to find a match from default presets.
@@ -183,7 +184,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	 *
 	 * @return string|null
 	 */
-	protected function get_name_from_defaults( $default_array, $slug, $base_path ) {
+	protected static function get_name_from_array( $default_array, $slug, $base_path ) {
 		$path            = array_merge( $base_path, array( 'default' ) );
 		$default_content = _wp_array_get( $default_array, $path, null );
 		if ( ! $default_content ) {
@@ -246,7 +247,9 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 			// Replace the presets.
 			foreach ( static::PRESETS_METADATA as $preset ) {
-				$override_preset = ! static::get_metadata_boolean( $base['settings'], $preset['prevent_override'], true );
+				if ( array_key_exists( 'settings', $base ) ) {
+					$override_preset = ! static::get_metadata_boolean( $base['settings'], $preset['prevent_override'], true );
+				}
 
 				foreach ( static::VALID_ORIGINS as $origin ) {
 					$base_path = array_merge( $node['path'], $preset['path'] );
@@ -259,7 +262,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 					if ( 'theme' === $origin && $preset['use_default_names'] ) {
 						foreach ( $content as &$item ) {
 							if ( ! array_key_exists( 'name', $item ) ) {
-								$name = static::get_name_from_defaults( $base, $item['slug'], $base_path );
+								$name = static::get_name_from_array( $base, $item['slug'], $base_path );
 								if ( null !== $name ) {
 									$item['name'] = $name;
 								}

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -175,6 +175,29 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	}
 
 	/**
+	 * Get a `default`'s preset name by a provided slug.
+	 *
+	 * @param array $default_array The slug we want to find a match from default presets.
+	 * @param string $slug The slug we want to find a match from default presets.
+	 * @param array  $base_path The path to inspect. It's 'settings' by default.
+	 *
+	 * @return string|null
+	 */
+	protected function get_name_from_defaults( $default_array, $slug, $base_path ) {
+		$path            = array_merge( $base_path, array( 'default' ) );
+		$default_content = _wp_array_get( $default_array, $path, null );
+		if ( ! $default_content ) {
+			return null;
+		}
+		foreach ( $default_content as $item ) {
+			if ( $slug === $item['slug'] ) {
+				return $item['name'];
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * Merge two theme.json data structures
 	 *
 	 * @since 6.0.0
@@ -236,7 +259,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 					if ( 'theme' === $origin && $preset['use_default_names'] ) {
 						foreach ( $content as &$item ) {
 							if ( ! array_key_exists( 'name', $item ) ) {
-								$name = static::get_name_from_defaults( $item['slug'], $base_path );
+								$name = static::get_name_from_defaults( $base, $item['slug'], $base_path );
 								if ( null !== $name ) {
 									$item['name'] = $name;
 								}

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -287,4 +287,28 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		return $merged_data;
 	}
 
+	/**
+	 * Gets the result of merging the theme's theme.json and the user settings
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return array The result of the merge
+	 */
+	public static function get_merged_theme_json() {
+		// Get the user data
+		$user_data = WP_Theme_JSON_Resolver_Gutenberg::get_user_data();
+
+		// Get the raw theme.json file from the theme.
+		$theme_path = wp_normalize_path( get_stylesheet_directory() );
+		if ( file_exists( $theme_path . '/theme.json' ) ) {
+			$theme_json_data = wp_json_file_decode( $theme_path . '/theme.json', array( 'associative' => true ) );
+			if ( ! empty( $theme_json_data ) ) {
+				// Merge the theme's theme.json with the user settings.
+				return WP_Theme_JSON_Gutenberg::functional_merge( $theme_json_data, $user_data->get_raw_data() );
+			}
+		}
+
+		// If there's no theme.json file in the theme, just use the user settings.
+		return $user_data;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This changes our approach to getting and merging theme.json data when a user exports a theme.

## Why?
The export should be a copy of the theme, including the user changes. We also should include everything that was in the original theme.json from the theme.

## How?
This abstracts the merge function to a static function, so that it can be used by any two arrays. This gives us the freedom to call it from other contexts and reuse the same logic.

## Testing Instructions
- Switch to TT2
- Export a theme from the Site Editor
- Confirm that the `$schema` and `settings > appearanceTools` attributes are in the theme.json file.
- Make some user edits (e.g. change the site background color, and try changing the settings for a particular block)
- Do another export
- Confirm that the original settings from TT2 are still present, but combined with the user settings made above.

## Notes
This exports theme.json with spaces not tabs. We should convert this to tabs.