### PR TITLE
Fix center aligned image style in Classic theme

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -59,6 +59,7 @@
 	}
 
 	// This is needed for classic themes where the align class is not on the container.
+	&.aligncenter,
 	.aligncenter {
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
Fix #39592
Related #38657 / #39422

## What?
This PR fixes center aligned image style in the Classic theme with layout support.

## Why?
In #38657, the div wrapper of image block has been removed on the front end side for themes that support layout.

I found a problem that the image block is not center aligned on frontend in the classic theme with layout support.

In the Classic theme with layout support, the wrapper div is removed as in the Block theme, and HTML with the structure "`figure.wp-block-image.aligncenter`" is generated. 
However, left/right auto margin style for this selector is not generated.

## How?
I have added a **`.wp-block-image.aligncenter`** selector in addition to the **`.wp-block-image .aligncenter`** selector that is the fallback for the classic theme.
This change does not affect block themes, and classic themes with no layout support.

## Testing Instructions
Use the following content for testing:
```html
<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<!-- /wp:paragraph -->

<!-- wp:image {"align":"center","width":512,"height":342,"sizeSlug":"large"} -->
<figure class="wp-block-image aligncenter size-large is-resized"><img src="https://live.staticflickr.com/4572/38004374914_6b686d708e_b.jpg" alt="" width="512" height="342"/><figcaption>align center</figcaption></figure>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
<!-- /wp:paragraph -->
```

I also tested the following four themes.

### 1. Simple Classic Theme ( **without theme.json** )

`style.css`:
```css
/*
Theme Name: My Theme
*/
```

`index.php`:
```php
<!DOCTYPE html>
<html>
<head>
<?php wp_head(); ?>
</head>

<body <?php body_class(); ?>>

<?
if ( have_posts() ) {
		while ( have_posts() ) {
			the_post();
			the_content();
		}
}
wp_footer();
?>
</body>
```

![classic](https://user-images.githubusercontent.com/54422211/159107657-d9bd3230-a406-4b10-bdde-17303bb3a9ad.png)

### 2. Simple Classic Theme ( **with theme.json** )

Add `theme.json` to "1. Simple Classic Theme":
```json
{
	"version": 2,
	"settings": {
		"layout": {
			"contentSize": "650px",
			"wideSize": "1000px"
		}
	}
}
```
![classic-with-layout](https://user-images.githubusercontent.com/54422211/159107680-7b54408e-a6aa-4738-a26e-2b3ea2313a63.png)

### 3. Astra ( Classic Theme with theme.json )

I looked at the questioner's site in the [support forum](https://wordpress.org/support/topic/images-will-not-align-center-2/page/2/#post-15473517) (mentioned in #39592), and found that astra theme was used.
This theme is a classic theme with layout support.

![astra](https://user-images.githubusercontent.com/54422211/159107785-227087bc-ff0a-4852-bd0a-7da0b92d5409.png)

### 4. Twenty Twenty Two (Block Theme)

![block-theme](https://user-images.githubusercontent.com/54422211/159107602-3b5780c1-aed5-4bc4-819a-8b2004431414.png)

