### PR TITLE
Add mutations data and helper functions to useEntityRecord

### DIFF
--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -764,6 +764,57 @@ In the above example, when `PageTitleDisplay` is rendered into an
 application, the page and the resolution details will be retrieved from
 the store state using `getEntityRecord()`, or resolved if missing.
 
+```js
+import { useEntityRecord } from '@wordpress/core-data';
+
+function PageRenameForm( { id } ) {
+	const page = useEntityRecord( 'postType', 'page', id );
+	const [ title, setTitle ] = useState( () => page.record.title.rendered );
+
+	if ( page.isResolving ) {
+		return 'Loading...';
+	}
+
+	async function onRename( event ) {
+		event.preventDefault();
+		page.edit( { title } );
+		try {
+			await page.save( { throwOnError: true } );
+			createSuccessNotice( __( 'Page renamed.' ), {
+				type: 'snackbar',
+			} );
+		} catch ( e ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while renaming the entity.' );
+
+			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		}
+	}
+
+	return (
+		<form onSubmit={ onRename }>
+			<TextControl
+				label={ __( 'Name' ) }
+				value={ title }
+				onChange={ setTitle }
+			/>
+			<Button variant="primary" type="submit">
+				{ __( 'Save' ) }
+			</Button>
+		</form>
+	);
+}
+
+// Rendered in the application:
+// <PageRenameForm id={ 1 } />
+```
+
+In the above example, updating and saving the page title is handled
+via the `edit()` and `save()` mutation helpers provided by
+`useEntityRecord()`;
+
 _Parameters_
 
 -   _kind_ `string`: Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -765,11 +765,18 @@ application, the page and the resolution details will be retrieved from
 the store state using `getEntityRecord()`, or resolved if missing.
 
 ```js
+import { useState } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { store as noticeStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
 
 function PageRenameForm( { id } ) {
 	const page = useEntityRecord( 'postType', 'page', id );
 	const [ title, setTitle ] = useState( () => page.record.title.rendered );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticeStore );
 
 	if ( page.isResolving ) {
 		return 'Loading...';
@@ -783,13 +790,8 @@ function PageRenameForm( { id } ) {
 			createSuccessNotice( __( 'Page renamed.' ), {
 				type: 'snackbar',
 			} );
-		} catch ( e ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while renaming the entity.' );
-
-			createErrorNotice( errorMessage, { type: 'snackbar' } );
+		} catch ( error ) {
+			createErrorNotice( error.message, { type: 'snackbar' } );
 		}
 	}
 
@@ -800,9 +802,7 @@ function PageRenameForm( { id } ) {
 				value={ title }
 				onChange={ setTitle }
 			/>
-			<Button variant="primary" type="submit">
-				{ __( 'Save' ) }
-			</Button>
+			<button type="submit">{ __( 'Save' ) }</button>
 		</form>
 	);
 }

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -779,7 +779,7 @@ function PageRenameForm( { id } ) {
 		event.preventDefault();
 		page.edit( { title } );
 		try {
-			await page.save( { throwOnError: true } );
+			await page.save();
 			createSuccessNotice( __( 'Page renamed.' ), {
 				type: 'snackbar',
 			} );

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -50,7 +50,11 @@ describe( 'useEntityRecord', () => {
 		);
 
 		expect( data ).toEqual( {
-			records: undefined,
+			edit: expect.any( Function ),
+			editedRecord: {},
+			hasEdits: false,
+			record: undefined,
+			save: expect.any( Function ),
 			hasResolved: false,
 			isResolving: false,
 			status: 'IDLE',
@@ -66,7 +70,11 @@ describe( 'useEntityRecord', () => {
 		} );
 
 		expect( data ).toEqual( {
+			edit: expect.any( Function ),
+			editedRecord: {},
+			hasEdits: false,
 			record: { hello: 'world', id: 1 },
+			save: expect.any( Function ),
 			hasResolved: true,
 			isResolving: false,
 			status: 'SUCCESS',

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -102,7 +102,7 @@ export interface Options {
  *           createSuccessNotice( __( 'Page renamed.' ), {
  *               type: 'snackbar',
  *           } );
- *       } catch(e) {
+ *       } catch( error ) {
  *            const errorMessage =
  *                error.message && error.code !== 'unknown_error'
  *                    ? error.message

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -19,7 +19,7 @@ export interface EntityRecordResolution< RecordType > {
 	/** The edited entity record */
 	editedRecord: Partial< RecordType >;
 
-	/** Apply edits to the edited entity record */
+	/** Apply local (in-browser) edits to the edited entity record */
 	edit: ( diff: Partial< RecordType > ) => void;
 
 	/** Persist the edits to the server */

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -13,44 +13,44 @@ import { store as coreStore } from '../';
 import type { Status } from './constants';
 
 export interface EntityRecordResolution< RecordType > {
-  /** The requested entity record */
-  record: RecordType | null;
+	/** The requested entity record */
+	record: RecordType | null;
 
-  /** The edited entity record */
-  editedRecord: Partial< RecordType >;
+	/** The edited entity record */
+	editedRecord: Partial< RecordType >;
 
-  /** Apply edits to the edited entity record */
-  edit: ( diff: Partial< RecordType > ) => void;
+	/** Apply edits to the edited entity record */
+	edit: ( diff: Partial< RecordType > ) => void;
 
-  /** Persist the edits to the server */
-  save: () => Promise< void >;
+	/** Persist the edits to the server */
+	save: () => Promise< void >;
 
-  /**
-   * Is the record still being resolved?
-   */
-  isResolving: boolean;
+	/**
+	 * Is the record still being resolved?
+	 */
+	isResolving: boolean;
 
-  /**
-   * Does the record have any edits?
-   */
-  hasEdits: boolean;
+	/**
+	 * Does the record have any edits?
+	 */
+	hasEdits: boolean;
 
-  /**
-   * Is the record resolved by now?
-   */
-  hasResolved: boolean;
+	/**
+	 * Is the record resolved by now?
+	 */
+	hasResolved: boolean;
 
-  /** Resolution status */
-  status: Status;
+	/** Resolution status */
+	status: Status;
 }
 
 export interface Options {
-  /**
-   * Whether to run the query or short-circuit and return null.
-   *
-   * @default true
-   */
-  enabled: boolean;
+	/**
+	 * Whether to run the query or short-circuit and return null.
+	 *
+	 * @default true
+	 */
+	enabled: boolean;
 }
 
 /**
@@ -138,61 +138,60 @@ export interface Options {
  * @template RecordType
  */
 export default function useEntityRecord< RecordType >(
-  kind: string,
-  name: string,
-  recordId: string | number,
-  options: Options = { enabled: true }
+	kind: string,
+	name: string,
+	recordId: string | number,
+	options: Options = { enabled: true }
 ): EntityRecordResolution< RecordType > {
-  const { editEntityRecord, saveEditedEntityRecord } = useDispatch(
-    coreStore
-  );
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
 
-  const mutations = useMemo(
-    () => ( {
-      edit: ( record ) =>
-        editEntityRecord( kind, name, recordId, record ),
-      save: ( saveOptions: any ) =>
-        saveEditedEntityRecord( kind, name, recordId, saveOptions ),
-    } ),
-    [ recordId ]
-  );
+	const mutations = useMemo(
+		() => ( {
+			edit: ( record ) =>
+				editEntityRecord( kind, name, recordId, record ),
+			save: ( saveOptions: any ) =>
+				saveEditedEntityRecord( kind, name, recordId, saveOptions ),
+		} ),
+		[ recordId ]
+	);
 
-  const { editedRecord, hasEdits } = useSelect(
-    ( select ) => ( {
-      editedRecord: select( coreStore ).getEditedEntityRecord(),
-      hasEdits: select( coreStore ).hasEditsForEntityRecord(),
-    } ),
-    [ kind, name, recordId ]
-  );
+	const { editedRecord, hasEdits } = useSelect(
+		( select ) => ( {
+			editedRecord: select( coreStore ).getEditedEntityRecord(),
+			hasEdits: select( coreStore ).hasEditsForEntityRecord(),
+		} ),
+		[ kind, name, recordId ]
+	);
 
-  const { data: record, ...querySelectRest } = useQuerySelect(
-    ( query ) => {
-      if ( ! options.enabled ) {
-        return null;
-      }
-      return query( coreStore ).getEntityRecord( kind, name, recordId );
-    },
-    [ kind, name, recordId, options.enabled ]
-  );
+	const { data: record, ...querySelectRest } = useQuerySelect(
+		( query ) => {
+			if ( ! options.enabled ) {
+				return null;
+			}
+			return query( coreStore ).getEntityRecord( kind, name, recordId );
+		},
+		[ kind, name, recordId, options.enabled ]
+	);
 
-  return {
-    record,
-    editedRecord,
-    hasEdits,
-    ...querySelectRest,
-    ...mutations,
-  };
+	return {
+		record,
+		editedRecord,
+		hasEdits,
+		...querySelectRest,
+		...mutations,
+	};
 }
 
 export function __experimentalUseEntityRecord(
-  kind: string,
-  name: string,
-  recordId: any,
-  options: any
+	kind: string,
+	name: string,
+	recordId: any,
+	options: any
 ) {
-  deprecated( `wp.data.__experimentalUseEntityRecord`, {
-    alternative: 'wp.data.useEntityRecord',
-    since: '6.1',
-  } );
-  return useEntityRecord( kind, name, recordId, options );
+	deprecated( `wp.data.__experimentalUseEntityRecord`, {
+		alternative: 'wp.data.useEntityRecord',
+		since: '6.1',
+	} );
+	return useEntityRecord( kind, name, recordId, options );
 }

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -31,7 +31,7 @@ export interface EntityRecordResolution< RecordType > {
 	isResolving: boolean;
 
 	/**
-	 * Does the record have any edits?
+	 * Does the record have any local edits?
 	 */
 	hasEdits: boolean;
 

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -84,46 +84,46 @@ export interface Options {
  *
  * @example
  * ```js
+ * import { useState } from '@wordpress/data';
+ * import { useDispatch } from '@wordpress/data';
+ * import { __ } from '@wordpress/i18n';
+ * import { TextControl } from '@wordpress/components';
+ * import { store as noticeStore } from '@wordpress/notices';
  * import { useEntityRecord } from '@wordpress/core-data';
  *
  * function PageRenameForm( { id } ) {
- *   const page = useEntityRecord( 'postType', 'page', id );
- *   const [ title, setTitle ] = useState( () => page.record.title.rendered );
+ * 	const page = useEntityRecord( 'postType', 'page', id );
+ * 	const [ title, setTitle ] = useState( () => page.record.title.rendered );
+ * 	const { createSuccessNotice, createErrorNotice } =
+ * 		useDispatch( noticeStore );
  *
- *   if ( page.isResolving ) {
- *     return 'Loading...';
- *   }
+ * 	if ( page.isResolving ) {
+ * 		return 'Loading...';
+ * 	}
  *
- *   async function onRename( event ) {
- *       event.preventDefault();
- *       page.edit({ title });
- *       try {
- *           await page.save()
- *           createSuccessNotice( __( 'Page renamed.' ), {
- *               type: 'snackbar',
- *           } );
- *       } catch(e) {
- *            const errorMessage =
- *                error.message && error.code !== 'unknown_error'
- *                    ? error.message
- *                    : __( 'An error occurred while renaming the entity.' );
+ * 	async function onRename( event ) {
+ * 		event.preventDefault();
+ * 		page.edit( { title } );
+ * 		try {
+ * 			await page.save();
+ * 			createSuccessNotice( __( 'Page renamed.' ), {
+ * 				type: 'snackbar',
+ * 			} );
+ * 		} catch ( error ) {
+ * 			createErrorNotice( error.message, { type: 'snackbar' } );
+ * 		}
+ * 	}
  *
- *            createErrorNotice( errorMessage, { type: 'snackbar' } );
- *       }
- *   }
- *
- *   return (
- *       <form onSubmit={ onRename }>
- *           <TextControl
- *               label={ __( 'Name' ) }
- *               value={ title }
- *               onChange={ setTitle }
- *           />
- *           <Button variant="primary" type="submit">
- *               { __( 'Save' ) }
- *           </Button>
- *       </form>
- *   );
+ * 	return (
+ * 		<form onSubmit={ onRename }>
+ * 			<TextControl
+ * 				label={ __( 'Name' ) }
+ * 				value={ title }
+ * 				onChange={ setTitle }
+ * 			/>
+ * 			<button type="submit">{ __( 'Save' ) }</button>
+ * 		</form>
+ * 	);
  * }
  *
  * // Rendered in the application:

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -98,7 +98,7 @@ export interface Options {
  *       event.preventDefault();
  *       page.edit({ title });
  *       try {
- *           await page.save({ throwOnError: true })
+ *           await page.save()
  *           createSuccessNotice( __( 'Page renamed.' ), {
  *               type: 'snackbar',
  *           } );
@@ -150,8 +150,11 @@ export default function useEntityRecord< RecordType >(
 		() => ( {
 			edit: ( record ) =>
 				editEntityRecord( kind, name, recordId, record ),
-			save: ( saveOptions: any ) =>
-				saveEditedEntityRecord( kind, name, recordId, saveOptions ),
+			save: ( saveOptions: any = {} ) =>
+				saveEditedEntityRecord( kind, name, recordId, {
+					throwOnError: true,
+					...saveOptions,
+				} ),
 		} ),
 		[ recordId ]
 	);

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -99,7 +99,8 @@ export default function useEntityRecord< RecordType >(
 		() => ( {
 			edit: ( record ) =>
 				editEntityRecord( kind, name, recordId, record ),
-			save: () => saveEditedEntityRecord( kind, name, recordId ),
+			save: ( saveOptions: any ) =>
+				saveEditedEntityRecord( kind, name, recordId, saveOptions ),
 		} ),
 		[ recordId ]
 	);

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -12,15 +12,19 @@ import {
 	Modal,
 	TextControl,
 } from '@wordpress/components';
-import { store as coreStore } from '@wordpress/core-data';
+import { useEntityRecord } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function RenameMenuItem( { template, onClose } ) {
 	const [ title, setTitle ] = useState( () => template.title.rendered );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const { editEntityRecord, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const { edit, save } = useEntityRecord(
+		'postType',
+		template.type,
+		template.id
+	);
+
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
@@ -32,9 +36,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 		event.preventDefault();
 
 		try {
-			await editEntityRecord( 'postType', template.type, template.id, {
-				title,
-			} );
+			await edit( { title } );
 
 			// Update state before saving rerenders the list.
 			setTitle( '' );
@@ -42,12 +44,7 @@ export default function RenameMenuItem( { template, onClose } ) {
 			onClose();
 
 			// Persist edited entity.
-			await saveEditedEntityRecord(
-				'postType',
-				template.type,
-				template.id,
-				{ throwOnError: true }
-			);
+			await save( { throwOnError: true } );
 
 			createSuccessNotice( __( 'Entity renamed.' ), {
 				type: 'snackbar',

--- a/packages/edit-site/src/components/list/actions/rename-menu-item.js
+++ b/packages/edit-site/src/components/list/actions/rename-menu-item.js
@@ -12,19 +12,15 @@ import {
 	Modal,
 	TextControl,
 } from '@wordpress/components';
-import { useEntityRecord } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { store as noticesStore } from '@wordpress/notices';
 
 export default function RenameMenuItem( { template, onClose } ) {
 	const [ title, setTitle ] = useState( () => template.title.rendered );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const { edit, save } = useEntityRecord(
-		'postType',
-		template.type,
-		template.id
-	);
-
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
@@ -36,7 +32,9 @@ export default function RenameMenuItem( { template, onClose } ) {
 		event.preventDefault();
 
 		try {
-			await edit( { title } );
+			await editEntityRecord( 'postType', template.type, template.id, {
+				title,
+			} );
 
 			// Update state before saving rerenders the list.
 			setTitle( '' );
@@ -44,7 +42,12 @@ export default function RenameMenuItem( { template, onClose } ) {
 			onClose();
 
 			// Persist edited entity.
-			await save( { throwOnError: true } );
+			await saveEditedEntityRecord(
+				'postType',
+				template.type,
+				template.id,
+				{ throwOnError: true }
+			);
 
 			createSuccessNotice( __( 'Entity renamed.' ), {
 				type: 'snackbar',


### PR DESCRIPTION
## What?

This PR proposes merging entity mutations utilities into the `useEntityRecord` hook. This is an alternative to https://github.com/WordPress/gutenberg/pull/38135 and was earlier discussed in  https://github.com/WordPress/gutenberg/pull/39258.

The rationale is that manipulating entity records in core-data is quite difficult these days. Building a simple form currently requires a snippet like this:

```js
const {
	editEntityRecord,
	saveEditedEntityRecord
} = useDispatch( coreStore );

const { editedRecord, hasEdits, isSaving, saveError } = useSelect(
	( select ) => {
		const args = [kind, type, id];
		return {
			editedRecord: select( coreStore ).getEditedEntityRecord( ...args ),
			hasEdits: select( coreStore ).hasEditsForEntityRecord( ...args ),
			isSaving: select( coreStore ).isSavingEntityRecord( ...args ),
			saveError: select( coreStore ).getLastEntitySaveError( ...args ),
		};
	},
	[kind, type, id],
);
```

I'd like it to look more like this:

```js
const { record, edit, editedRecord, hasEdits, save } = useEntityRecord( 'postType', 'page', pageId );
// Or just:
const page = useEntityRecord( 'postType', 'page', pageId );
page.edit({ title: newTitle });
page.save();
```

## Different angles

Re-throwing errors is different than having a convenience wrapper for actions like `editEntityRecord`, `saveEditedEntityRecord`, `saveEntityRecord` and the `getEditedEntityRecord` selector. Perhaps that's where a hook would actually shine:

```js
const { create, isCreating, error } = useEntityRecordCreate();
const { editedRecord, applyEdits, saveEdits, isSaving, error } = useEntityRecordEdit();
const { remove, isRemoving, error } = useEntityRecordRemove(); // it's "remove", because "delete" is a reserved keyword
```

However, given the "throwing" actions, accessing `error` and `isCreating/isSaving/isRemoving` would not be needed as often, which leaves us with just:

```js
const { create } = useEntityRecordCreate();
const { editedRecord, applyEdits, saveEdits } = useEntityRecordEdit();
const { remove } = useEntityRecordRemove();
```

Which doesn't do much for creating and removing records so we could also ditch these hooks and settle only for the `useEntityRecord` hook:

```js
const { edit, editedRecord, hasEdits, save } = useEntityRecord( 'postType', 'page', pageId );
```

## Dev note

The [Make Core post](https://make.wordpress.org/core/?p=97299&preview=true) can be easily repurposed as a dev note.

cc @gziolo 