### PR TITLE
Add aria-selected and multiselect to TreeGrid, plus Home and End key support to List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -186,6 +186,7 @@ function ListViewBlock( {
 			id={ `list-view-block-${ clientId }` }
 			data-block={ clientId }
 			isExpanded={ isExpanded }
+			isSelected={ isSelected }
 		>
 			<TreeGridCell
 				className="block-editor-list-view-block__contents-cell"

--- a/packages/block-editor/src/components/list-view/leaf.js
+++ b/packages/block-editor/src/components/list-view/leaf.js
@@ -40,6 +40,7 @@ export default function ListViewLeaf( {
 			level={ level }
 			positionInSet={ position }
 			setSize={ rowCount }
+			isSelected={ isSelected }
 			{ ...props }
 		>
 			{ children }

--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -10,7 +10,7 @@ import { speak } from '@wordpress/a11y';
 import { __, sprintf } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { UP, DOWN } from '@wordpress/keycodes';
+import { UP, DOWN, HOME, END } from '@wordpress/keycodes';
 import { store as blocksStore } from '@wordpress/blocks';
 
 /**
@@ -49,7 +49,10 @@ export default function useBlockSelection() {
 
 			const isKeyPress =
 				event.type === 'keydown' &&
-				( event.keyCode === UP || event.keyCode === DOWN );
+				( event.keyCode === UP ||
+					event.keyCode === DOWN ||
+					event.keyCode === HOME ||
+					event.keyCode === END );
 
 			// Handle clicking on a block when no blocks are selected, and return early.
 			if (

--- a/packages/components/src/tree-grid/index.js
+++ b/packages/components/src/tree-grid/index.js
@@ -294,6 +294,7 @@ function TreeGrid(
 			<table
 				{ ...props }
 				role="treegrid"
+				aria-multiselectable="true"
 				onKeyDown={ onKeyDown }
 				ref={ ref }
 			>

--- a/packages/components/src/tree-grid/row.js
+++ b/packages/components/src/tree-grid/row.js
@@ -4,7 +4,15 @@
 import { forwardRef } from '@wordpress/element';
 
 function TreeGridRow(
-	{ children, level, positionInSet, setSize, isExpanded, ...props },
+	{
+		children,
+		level,
+		positionInSet,
+		setSize,
+		isExpanded,
+		isSelected,
+		...props
+	},
 	ref
 ) {
 	return (
@@ -22,6 +30,7 @@ function TreeGridRow(
 			aria-posinset={ positionInSet }
 			aria-setsize={ setSize }
 			aria-expanded={ isExpanded }
+			aria-selected={ !! isSelected }
 		>
 			{ children }
 		</tr>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds `aria-select` to TreeGrid rows, and a `multiselectable` role to the TreeGrid itself.
Adds multiselect support with Home and End key to List View.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Home and End key part is an alternative to #39272; I'm hoping that setting the aria roles on the TreeGrid will make screen readers announce a multi-selection without also reading out the currently focused item. This may not work, but I thought it was worth a try 🤷 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See above!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Test the following steps using a screen reader, or even better, test on multiple screen readers.

1. In a post, add four blocks.
2. Open List View
3. Arrow Down to the third block; Press Shift + Home (Windows) or Shift + Fn + Left Arrow (macOS) to select blocks 1 to 3.
4. Screen reader should read only "3 blocks selected"

## Screenshots or screencast <!-- if applicable -->
