### PR TITLE
Global styles: remove block gap control

### DIFF
--- a/packages/edit-site/src/components/global-styles/dimensions-panel.js
+++ b/packages/edit-site/src/components/global-styles/dimensions-panel.js
@@ -6,7 +6,6 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
-	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { __experimentalUseCustomSides as useCustomSides } from '@wordpress/block-editor';
@@ -21,9 +20,8 @@ const AXIAL_SIDES = [ 'horizontal', 'vertical' ];
 export function useHasDimensionsPanel( name ) {
 	const hasPadding = useHasPadding( name );
 	const hasMargin = useHasMargin( name );
-	const hasGap = useHasGap( name );
 
-	return hasPadding || hasMargin || hasGap;
+	return hasPadding || hasMargin;
 }
 
 function useHasPadding( name ) {
@@ -38,13 +36,6 @@ function useHasMargin( name ) {
 	const [ settings ] = useSetting( 'spacing.margin', name );
 
 	return settings && supports.includes( 'margin' );
-}
-
-function useHasGap( name ) {
-	const supports = getSupportedGlobalStylesPanels( name );
-	const [ settings ] = useSetting( 'spacing.blockGap', name );
-
-	return settings && supports.includes( '--wp--style--block-gap' );
 }
 
 function filterValuesBySides( values, sides ) {
@@ -88,7 +79,6 @@ function splitStyleValue( value ) {
 export default function DimensionsPanel( { name } ) {
 	const showPaddingControl = useHasPadding( name );
 	const showMarginControl = useHasMargin( name );
-	const showGapControl = useHasGap( name );
 	const units = useCustomUnits( {
 		availableUnits: useSetting( 'spacing.units', name )[ 0 ] || [
 			'%',
@@ -128,15 +118,9 @@ export default function DimensionsPanel( { name } ) {
 	const resetMarginValue = () => setMarginValues( {} );
 	const hasMarginValue = () =>
 		!! marginValues && Object.keys( marginValues ).length;
-
-	const [ gapValue, setGapValue ] = useStyle( 'spacing.blockGap', name );
-	const resetGapValue = () => setGapValue( undefined );
-	const hasGapValue = () => !! gapValue;
-
 	const resetAll = () => {
 		resetPaddingValue();
 		resetMarginValue();
-		resetGapValue();
 	};
 
 	return (
@@ -174,23 +158,6 @@ export default function DimensionsPanel( { name } ) {
 						units={ units }
 						allowReset={ false }
 						splitOnAxis={ isAxialMargin }
-					/>
-				</ToolsPanelItem>
-			) }
-			{ showGapControl && (
-				<ToolsPanelItem
-					hasValue={ hasGapValue }
-					label={ __( 'Block spacing' ) }
-					onDeselect={ resetGapValue }
-					isShownByDefault={ true }
-				>
-					<UnitControl
-						label={ __( 'Block spacing' ) }
-						__unstableInputWidth="80px"
-						min={ 0 }
-						onChange={ setGapValue }
-						units={ units }
-						value={ gapValue }
 					/>
 				</ToolsPanelItem>
 			) }


### PR DESCRIPTION
## What?

Remove the block gap controls from Global Styles sidebar. Props to @andrewserong for [noticing](https://github.com/WordPress/gutenberg/pull/37736#pullrequestreview-915188365).

## Why?

1. It's not supported at the root level in [ROOT_BLOCK_SUPPORTS](https://github.com/WordPress/gutenberg/blob/e2f00ff5ed1f4042386a48eedf4eafef36c9eb29/packages/edit-site/src/components/global-styles/hooks.js#L156)
2. It doesn't work at the individual block level in global styles anyway.

## How?
BANISHED!

## Testing Instructions
Before checking out this branch, ensure that blockGap doesn't:

- Appear at the root global styles level
- Work for block Global Style, e.g., edit the Group/Navigation/Social Icons (or any block that has blockGap support) block gap values.

Publish a page after you've set a few Global Style block gap values. Check the source of the published page for any trace of your `gap` value. Any?


1. Check out this branch `git checkout -t origin/remove/global-styles-block-gap-control`
2. Using a block theme, edit your site.
3. Check that Global Style block gap dimensions controls do not show at both the root level and for blocks that has blockGap support

## Screenshots or screencast <!-- if applicable -->

### Before
<img width="290" alt="Screen Shot 2022-03-21 at 3 28 09 pm" src="https://user-images.githubusercontent.com/6458278/159206808-1a6db98d-dd94-4284-abba-97634ec39d5e.png">

### After

<img width="263" alt="Screen Shot 2022-03-21 at 3 40 19 pm" src="https://user-images.githubusercontent.com/6458278/159206799-42ccb613-a179-44e1-b59c-4577250047c2.png">
<img width="267" alt="Screen Shot 2022-03-21 at 3 40 15 pm" src="https://user-images.githubusercontent.com/6458278/159206803-df2b1fdf-d70e-4c01-81ba-a63139e78978.png">
<img width="285" alt="Screen Shot 2022-03-21 at 3 40 05 pm" src="https://user-images.githubusercontent.com/6458278/159206805-f8d47297-d4f4-4bc3-84bc-53ea9ce00ad6.png">


