### PR TITLE
Migrate post editor `panels` state to preferences store

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -508,15 +508,11 @@ _Returns_
 
 ### toggleEditorPanelOpened
 
-Returns an action object used to open or close a panel in the editor.
+Opens a closed panel and closes an open panel.
 
 _Parameters_
 
 -   _panelName_ `string`: A string that identifies the panel to open or close.
-
-_Returns_
-
--   `Object`: Action object.
 
 ### toggleFeature
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17573,6 +17573,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/data/src/plugins/persistence/index.js
+++ b/packages/data/src/plugins/persistence/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { merge, isPlainObject } from 'lodash';
+import { merge, isPlainObject, identity } from 'lodash';
 
 /**
  * Internal dependencies
@@ -303,7 +303,8 @@ export function migrateFeaturePreferencesToPreferencesStore(
 export function migrateIndividualPreferenceToPreferencesStore(
 	persistence,
 	sourceStoreName,
-	key
+	key,
+	convert = identity
 ) {
 	const preferencesStoreName = 'core/preferences';
 	const state = persistence.get();
@@ -324,16 +325,20 @@ export function migrateIndividualPreferenceToPreferencesStore(
 		return;
 	}
 
-	const allPreferences = state[ preferencesStoreName ]?.preferences;
-	const targetPreferences =
+	const otherScopes = state[ preferencesStoreName ]?.preferences;
+	const otherPreferences =
 		state[ preferencesStoreName ]?.preferences?.[ sourceStoreName ];
+
+	// Pass an object with the key and value as this allows the convert
+	// function to convert to a data structure that has different keys.
+	const convertedPreferences = convert( { [ key ]: sourcePreference } );
 
 	persistence.set( preferencesStoreName, {
 		preferences: {
-			...allPreferences,
+			...otherScopes,
 			[ sourceStoreName ]: {
-				...targetPreferences,
-				[ key ]: sourcePreference,
+				...otherPreferences,
+				...convertedPreferences,
 			},
 		},
 	} );
@@ -348,6 +353,57 @@ export function migrateIndividualPreferenceToPreferencesStore(
 			[ key ]: undefined,
 		},
 	} );
+}
+
+/**
+ * Convert from:
+ * ```
+ * {
+ *     panels: {
+ *         tags: {
+ *             enabled: true,
+ *             opened: true,
+ *         },
+ *         permalinks: {
+ *             enabled: false,
+ *             opened: false,
+ *         },
+ *     },
+ * }
+ * ```
+ *
+ * to:
+ * {
+ *     inactivePanels: [
+ *         'permalinks',
+ *     ],
+ *     openPanels: [
+ *         'tags',
+ *     ],
+ * }
+ *
+ * @param {Object} preferences A preferences object.
+ *
+ * @return {Object} The converted data.
+ */
+export function convertEditPostPanels( preferences ) {
+	const panels = preferences?.panels ?? {};
+	return Object.keys( panels ).reduce(
+		( convertedData, panelName ) => {
+			const panel = panels[ panelName ];
+
+			if ( panel?.enabled === false ) {
+				convertedData.inactivePanels.push( panelName );
+			}
+
+			if ( panel?.opened === true ) {
+				convertedData.openPanels.push( panelName );
+			}
+
+			return convertedData;
+		},
+		{ inactivePanels: [], openPanels: [] }
+	);
 }
 
 export function migrateThirdPartyFeaturePreferencesToPreferencesStore(
@@ -439,6 +495,12 @@ persistencePlugin.__unstableMigrate = ( pluginOptions ) => {
 		persistence,
 		'core/edit-post',
 		'preferredStyleVariations'
+	);
+	migrateIndividualPreferenceToPreferencesStore(
+		persistence,
+		'core/edit-post',
+		'panels',
+		convertEditPostPanels
 	);
 	migrateIndividualPreferenceToPreferencesStore(
 		persistence,

--- a/packages/data/src/plugins/persistence/test/index.js
+++ b/packages/data/src/plugins/persistence/test/index.js
@@ -12,6 +12,7 @@ import plugin, {
 	migrateFeaturePreferencesToPreferencesStore,
 	migrateThirdPartyFeaturePreferencesToPreferencesStore,
 	migrateIndividualPreferenceToPreferencesStore,
+	convertEditPostPanels,
 } from '../';
 import objectStorage from '../storage/object';
 import { createRegistry } from '../../../';
@@ -920,6 +921,49 @@ describe( 'migrateThirdPartyFeaturePreferencesToPreferencesStore', () => {
 					},
 				},
 			},
+		} );
+	} );
+} );
+
+describe( 'convertEditPostPanels', () => {
+	it( 'converts from one format to another', () => {
+		expect(
+			convertEditPostPanels( {
+				panels: {
+					tags: {
+						enabled: true,
+						opened: true,
+					},
+					permalinks: {
+						enabled: false,
+						opened: false,
+					},
+					categories: {
+						enabled: true,
+						opened: false,
+					},
+					excerpt: {
+						enabled: false,
+						opened: true,
+					},
+					discussion: {
+						enabled: false,
+					},
+					template: {
+						opened: true,
+					},
+				},
+			} )
+		).toEqual( {
+			inactivePanels: [ 'permalinks', 'excerpt', 'discussion' ],
+			openPanels: [ 'tags', 'excerpt', 'template' ],
+		} );
+	} );
+
+	it( 'returns empty arrays when there is no data to convert', () => {
+		expect( convertEditPostPanels( {} ) ).toEqual( {
+			inactivePanels: [],
+			openPanels: [],
 		} );
 	} );
 } );

--- a/packages/edit-post/package.json
+++ b/packages/edit-post/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/edit-post/src/editor.js
+++ b/packages/edit-post/src/editor.js
@@ -18,6 +18,7 @@ import { StrictMode, useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { ShortcutProvider } from '@wordpress/keyboard-shortcuts';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -50,7 +51,6 @@ function Editor( {
 		( select ) => {
 			const {
 				isFeatureActive,
-				getPreference,
 				__experimentalGetPreviewDeviceType,
 				isEditingTemplate,
 				getEditedPostTemplate,
@@ -86,7 +86,8 @@ function Editor( {
 				focusMode: isFeatureActive( 'focusMode' ),
 				hasReducedUI: isFeatureActive( 'reducedUI' ),
 				hasThemeStyles: isFeatureActive( 'themeStyles' ),
-				preferredStyleVariations: getPreference(
+				preferredStyleVariations: select( preferencesStore ).get(
+					'core/edit-post',
 					'preferredStyleVariations'
 				),
 				hiddenBlockTypes: getHiddenBlockTypes(),

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -111,6 +111,8 @@ export function initializeEditor(
 		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
+		inactivePanels: [],
+		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -26,6 +26,8 @@ export function initializeEditor( id, postType, postId ) {
 		fixedToolbar: false,
 		fullscreenMode: true,
 		hiddenBlockTypes: [],
+		inactivePanels: [],
+		openPanels: [ 'post-status' ],
 		preferredStyleVariations: {},
 		welcomeGuide: true,
 	} );

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -107,26 +107,58 @@ export function togglePublishSidebar() {
  *
  * @return {Object} Action object.
  */
-export function toggleEditorPanelEnabled( panelName ) {
-	return {
-		type: 'TOGGLE_PANEL_ENABLED',
-		panelName,
-	};
-}
+export const toggleEditorPanelEnabled = ( panelName ) => ( { registry } ) => {
+	const inactivePanels =
+		registry
+			.select( preferencesStore )
+			.get( 'core/edit-post', 'inactivePanels' ) ?? [];
+
+	const isPanelInactive = !! inactivePanels?.includes( panelName );
+
+	// If the panel is inactive, remove it to enable it, else add it to
+	// make it inactive.
+	let updatedInactivePanels;
+	if ( isPanelInactive ) {
+		updatedInactivePanels = inactivePanels.filter(
+			( invactivePanelName ) => invactivePanelName !== panelName
+		);
+	} else {
+		updatedInactivePanels = [ ...inactivePanels, panelName ];
+	}
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/edit-post', 'inactivePanels', updatedInactivePanels );
+};
 
 /**
- * Returns an action object used to open or close a panel in the editor.
+ * Opens a closed panel and closes an open panel.
  *
  * @param {string} panelName A string that identifies the panel to open or close.
- *
- * @return {Object} Action object.
  */
-export function toggleEditorPanelOpened( panelName ) {
-	return {
-		type: 'TOGGLE_PANEL_OPENED',
-		panelName,
-	};
-}
+export const toggleEditorPanelOpened = ( panelName ) => ( { registry } ) => {
+	const openPanels =
+		registry
+			.select( preferencesStore )
+			.get( 'core/edit-post', 'openPanels' ) ?? [];
+
+	const isPanelOpen = !! openPanels?.includes( panelName );
+
+	// If the panel is open, remove it to close it, else add it to
+	// make it open.
+	let updatedOpenPanels;
+	if ( isPanelOpen ) {
+		updatedOpenPanels = openPanels.filter(
+			( openPanelName ) => openPanelName !== panelName
+		);
+	} else {
+		updatedOpenPanels = [ ...openPanels, panelName ];
+	}
+
+	registry
+		.dispatch( preferencesStore )
+		.set( 'core/edit-post', 'openPanels', updatedOpenPanels );
+};
 
 /**
  * Returns an action object used to remove a panel from the editor.

--- a/packages/edit-post/src/store/defaults.js
+++ b/packages/edit-post/src/store/defaults.js
@@ -1,7 +1,0 @@
-export const PREFERENCES_DEFAULTS = {
-	panels: {
-		'post-status': {
-			opened: true,
-		},
-	},
-};

--- a/packages/edit-post/src/store/index.js
+++ b/packages/edit-post/src/store/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,13 +11,6 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 import { STORE_NAME } from './constants';
 
-const storeConfig = {
-	reducer,
-	actions,
-	selectors,
-	persist: [ 'preferences' ],
-};
-
 /**
  * Store definition for the edit post namespace.
  *
@@ -25,7 +18,10 @@ const storeConfig = {
  *
  * @type {Object}
  */
-export const store = createReduxStore( STORE_NAME, storeConfig );
+export const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+} );
 
-// Ideally we use register instead of register store.
-registerStore( STORE_NAME, storeConfig );
+register( store );

--- a/packages/edit-post/src/store/reducer.js
+++ b/packages/edit-post/src/store/reducer.js
@@ -1,84 +1,12 @@
 /**
  * External dependencies
  */
-import { flow, get, includes } from 'lodash';
+import { includes } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { PREFERENCES_DEFAULTS } from './defaults';
-
-/**
- * Higher-order reducer creator which provides the given initial state for the
- * original reducer.
- *
- * @param {*} initialState Initial state to provide to reducer.
- *
- * @return {Function} Higher-order reducer.
- */
-const createWithInitialState = ( initialState ) => ( reducer ) => {
-	return ( state = initialState, action ) => reducer( state, action );
-};
-
-/**
- * Reducer returning the user preferences.
- *
- * @param {Object}  state                           Current state.
- * @param {string}  state.mode                      Current editor mode, either
- *                                                  "visual" or "text".
- * @param {boolean} state.isGeneralSidebarDismissed Whether general sidebar is
- *                                                  dismissed. False by default
- *                                                  or when closing general
- *                                                  sidebar, true when opening
- *                                                  sidebar.
- * @param {boolean} state.isSidebarOpened           Whether the sidebar is
- *                                                  opened or closed.
- * @param {Object}  state.panels                    The state of the different
- *                                                  sidebar panels.
- * @param {Object}  action                          Dispatched action.
- *
- * @return {Object} Updated state.
- */
-export const preferences = flow( [
-	combineReducers,
-	createWithInitialState( PREFERENCES_DEFAULTS ),
-] )( {
-	panels( state, action ) {
-		switch ( action.type ) {
-			case 'TOGGLE_PANEL_ENABLED': {
-				const { panelName } = action;
-				return {
-					...state,
-					[ panelName ]: {
-						...state[ panelName ],
-						enabled: ! get( state, [ panelName, 'enabled' ], true ),
-					},
-				};
-			}
-
-			case 'TOGGLE_PANEL_OPENED': {
-				const { panelName } = action;
-				const isOpen =
-					state[ panelName ] === true ||
-					get( state, [ panelName, 'opened' ], false );
-				return {
-					...state,
-					[ panelName ]: {
-						...state[ panelName ],
-						opened: ! isOpen,
-					},
-				};
-			}
-		}
-
-		return state;
-	},
-} );
 
 /**
  * Reducer storing the list of all programmatically removed panels.
@@ -263,7 +191,6 @@ const metaBoxes = combineReducers( {
 export default combineReducers( {
 	activeModal,
 	metaBoxes,
-	preferences,
 	publishSidebarActive,
 	removedPanels,
 	deviceType,

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -177,7 +177,8 @@ export const getPreferences = createRegistrySelector( ( select ) => () => {
 
 	// Panels were a preference, but the data structure changed when the state
 	// was migrated to the preferences store. They need to be converted from
-	// the old to new format.
+	// the new preferences store format to old format to ensure no breaking
+	// changes for plugins.
 	const inactivePanels = select( preferencesStore ).get(
 		'core/edit-post',
 		'inactivePanels'

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import createSelector from 'rememo';
-import { get, includes, some, flatten, values } from 'lodash';
+import { includes, some, flatten, values } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,8 +12,10 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
+import deprecated from '@wordpress/deprecated';
 
 const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
 
 /**
  * Returns the current editing mode.
@@ -89,13 +91,57 @@ export const getActiveGeneralSidebarName = createRegistrySelector(
 	}
 );
 
-// The current list of preference keys that have been migrated to the
-// preferences package.
-const MIGRATED_KEYS = [
-	'hiddenBlockTypes',
-	'editorMode',
-	'preferredStyleVariations',
-];
+/**
+ * Converts panels from the new preferences store format to the old format
+ * that the post editor previously used.
+ *
+ * The resultant converted data should look like this:
+ * {
+ *     panelName: {
+ *         enabled: false,
+ *         opened: true,
+ *     },
+ *     anotherPanelName: {
+ *         opened: true
+ *     },
+ * }
+ *
+ * @param {string[] | undefined} inactivePanels An array of inactive panel names.
+ * @param {string[] | undefined} openPanels     An array of open panel names.
+ *
+ * @return {Object} The converted panel data.
+ */
+function convertPanelsToOldFormat( inactivePanels, openPanels ) {
+	// First reduce the inactive panels.
+	const panelsWithEnabledState = inactivePanels?.reduce(
+		( accumulatedPanels, panelName ) => ( {
+			...accumulatedPanels,
+			[ panelName ]: {
+				enabled: false,
+			},
+		} ),
+		{}
+	);
+
+	// Then reduce the open panels, passing in the result of the previous
+	// reduction as the initial value so that both open and inactive
+	// panel state is combined.
+	const panels = openPanels?.reduce( ( accumulatedPanels, panelName ) => {
+		const currentPanelState = accumulatedPanels?.[ panelName ];
+		return {
+			...accumulatedPanels,
+			[ panelName ]: {
+				...currentPanelState,
+				opened: true,
+			},
+		};
+	}, panelsWithEnabledState ?? {} );
+
+	// The panels variable will only be set if openPanels wasn't `undefined`.
+	// If it isn't set just return `panelsWithEnabledState`, and if that isn't
+	// set return an empty object.
+	return panels ?? panelsWithEnabledState ?? EMPTY_OBJECT;
+}
 
 /**
  * Returns the preferences (these preferences are persisted locally).
@@ -104,34 +150,49 @@ const MIGRATED_KEYS = [
  *
  * @return {Object} Preferences Object.
  */
-export const getPreferences = createRegistrySelector(
-	( select ) => ( state ) => {
-		const editPostPreferences = state.preferences;
+export const getPreferences = createRegistrySelector( ( select ) => () => {
+	deprecated( `wp.data.select( 'core/edit-post' ).getPreferences`, {
+		version: '6.0',
+		alternative: `wp.data.select( 'core/preferences' ).get`,
+	} );
 
-		// Some preferences now exist in the preferences store.
-		// Fetch them so that they can be merged into the post
-		// editor preferences.
-		const preferenceStorePreferences = MIGRATED_KEYS.reduce(
-			( accumulatedPrefs, preferenceKey ) => {
-				const value = select( preferencesStore ).get(
-					'core/edit-post',
-					preferenceKey
-				);
-
-				return {
-					...accumulatedPrefs,
-					[ preferenceKey ]: value,
-				};
-			},
-			{}
+	// These preferences now exist in the preferences store.
+	// Fetch them so that they can be merged into the post
+	// editor preferences.
+	const preferences = [
+		'hiddenBlockTypes',
+		'editorMode',
+		'preferredStyleVariations',
+	].reduce( ( accumulatedPrefs, preferenceKey ) => {
+		const value = select( preferencesStore ).get(
+			'core/edit-post',
+			preferenceKey
 		);
 
 		return {
-			...editPostPreferences,
-			...preferenceStorePreferences,
+			...accumulatedPrefs,
+			[ preferenceKey ]: value,
 		};
-	}
-);
+	}, {} );
+
+	// Panels were a preference, but the data structure changed when the state
+	// was migrated to the preferences store. They need to be converted from
+	// the old to new format.
+	const inactivePanels = select( preferencesStore ).get(
+		'core/edit-post',
+		'inactivePanels'
+	);
+	const openPanels = select( preferencesStore ).get(
+		'core/edit-post',
+		'openPanels'
+	);
+	const panels = convertPanelsToOldFormat( inactivePanels, openPanels );
+
+	return {
+		...preferences,
+		panels,
+	};
+} );
 
 /**
  *
@@ -142,11 +203,13 @@ export const getPreferences = createRegistrySelector(
  * @return {*} Preference Value.
  */
 export function getPreference( state, preferenceKey, defaultValue ) {
+	deprecated( `wp.data.select( 'core/edit-post' ).getPreference`, {
+		version: '6.0',
+		alternative: `wp.data.select( 'core/preferences' ).get`,
+	} );
+
 	// Avoid using the `getPreferences` registry selector where possible.
-	const isMigratedKey = MIGRATED_KEYS.includes( preferenceKey );
-	const preferences = isMigratedKey
-		? getPreferences( state )
-		: state.preferences;
+	const preferences = getPreferences( state );
 	const value = preferences[ preferenceKey ];
 	return value === undefined ? defaultValue : value;
 }
@@ -198,14 +261,15 @@ export function isEditorPanelRemoved( state, panelName ) {
  *
  * @return {boolean} Whether or not the panel is enabled.
  */
-export function isEditorPanelEnabled( state, panelName ) {
-	const panels = getPreference( state, 'panels' );
-
-	return (
-		! isEditorPanelRemoved( state, panelName ) &&
-		get( panels, [ panelName, 'enabled' ], true )
-	);
-}
+export const isEditorPanelEnabled = createRegistrySelector(
+	( select ) => ( state, panelName ) => {
+		const inactivePanels = select( preferencesStore ).get(
+			'core/edit-post',
+			'inactivePanels'
+		);
+		return ! inactivePanels?.includes( panelName );
+	}
+);
 
 /**
  * Returns true if the given panel is open, or false otherwise. Panels are
@@ -216,13 +280,15 @@ export function isEditorPanelEnabled( state, panelName ) {
  *
  * @return {boolean} Whether or not the panel is open.
  */
-export function isEditorPanelOpened( state, panelName ) {
-	const panels = getPreference( state, 'panels' );
-	return (
-		get( panels, [ panelName ] ) === true ||
-		get( panels, [ panelName, 'opened' ] ) === true
-	);
-}
+export const isEditorPanelOpened = createRegistrySelector(
+	( select ) => ( state, panelName ) => {
+		const openPanels = select( preferencesStore ).get(
+			'core/edit-post',
+			'openPanels'
+		);
+		return !! openPanels?.includes( panelName );
+	}
+);
 
 /**
  * Returns true if a modal is active, or false otherwise.

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -267,7 +267,10 @@ export const isEditorPanelEnabled = createRegistrySelector(
 			'core/edit-post',
 			'inactivePanels'
 		);
-		return ! inactivePanels?.includes( panelName );
+		return (
+			! isEditorPanelRemoved( state, panelName ) &&
+			! inactivePanels?.includes( panelName )
+		);
 	}
 );
 

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -152,7 +152,7 @@ function convertPanelsToOldFormat( inactivePanels, openPanels ) {
  */
 export const getPreferences = createRegistrySelector( ( select ) => () => {
 	deprecated( `wp.data.select( 'core/edit-post' ).getPreferences`, {
-		version: '6.0',
+		since: '6.0',
 		alternative: `wp.data.select( 'core/preferences' ).get`,
 	} );
 
@@ -204,7 +204,7 @@ export const getPreferences = createRegistrySelector( ( select ) => () => {
  */
 export function getPreference( state, preferenceKey, defaultValue ) {
 	deprecated( `wp.data.select( 'core/edit-post' ).getPreference`, {
-		version: '6.0',
+		since: '6.0',
 		alternative: `wp.data.select( 'core/preferences' ).get`,
 	} );
 

--- a/packages/edit-post/src/store/test/actions.js
+++ b/packages/edit-post/src/store/test/actions.js
@@ -157,7 +157,6 @@ describe( 'actions', () => {
 
 			const expected = [ 'core/quote', 'core/table' ];
 
-			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
@@ -167,6 +166,9 @@ describe( 'actions', () => {
 			expect(
 				registry.select( editPostStore ).getHiddenBlockTypes()
 			).toEqual( expected );
+
+			// Expect a deprecation message for `getPreference`.
+			expect( console ).toHaveWarned();
 		} );
 	} );
 
@@ -178,7 +180,6 @@ describe( 'actions', () => {
 
 			const expectedA = [ 'core/quote', 'core/table' ];
 
-			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
@@ -195,7 +196,6 @@ describe( 'actions', () => {
 
 			const expectedB = [ 'core/quote' ];
 
-			// TODO - remove once `getPreference` is deprecated.
 			expect(
 				registry
 					.select( editPostStore )
@@ -210,22 +210,21 @@ describe( 'actions', () => {
 
 	describe( 'toggleEditorPanelEnabled', () => {
 		it( 'toggles panels to be enabled and not enabled', () => {
-			const defaultState = {
-				'post-status': {
-					opened: true,
-				},
-			};
-
 			// This will switch it off, since the default is on.
 			registry
 				.dispatch( editPostStore )
 				.toggleEditorPanelEnabled( 'control-panel' );
 
-			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry
+					.select( editPostStore )
+					.isEditorPanelEnabled( 'control-panel' )
+			).toBe( false );
+
+			// Also check that the `getPreference` selector includes panels.
 			expect(
 				registry.select( editPostStore ).getPreference( 'panels' )
 			).toEqual( {
-				...defaultState,
 				'control-panel': {
 					enabled: false,
 				},
@@ -236,36 +235,34 @@ describe( 'actions', () => {
 				.dispatch( editPostStore )
 				.toggleEditorPanelEnabled( 'control-panel' );
 
-			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry
+					.select( editPostStore )
+					.isEditorPanelEnabled( 'control-panel' )
+			).toBe( true );
+
 			expect(
 				registry.select( editPostStore ).getPreference( 'panels' )
-			).toEqual( {
-				...defaultState,
-				'control-panel': {
-					enabled: true,
-				},
-			} );
+			).toEqual( {} );
 		} );
 	} );
 
 	describe( 'toggleEditorPanelOpened', () => {
 		it( 'toggles panels open and closed', () => {
-			const defaultState = {
-				'post-status': {
-					opened: true,
-				},
-			};
-
 			// This will open it, since the default is closed.
 			registry
 				.dispatch( editPostStore )
 				.toggleEditorPanelOpened( 'control-panel' );
 
-			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry
+					.select( editPostStore )
+					.isEditorPanelOpened( 'control-panel' )
+			).toBe( true );
+
 			expect(
 				registry.select( editPostStore ).getPreference( 'panels' )
 			).toEqual( {
-				...defaultState,
 				'control-panel': {
 					opened: true,
 				},
@@ -276,15 +273,15 @@ describe( 'actions', () => {
 				.dispatch( editPostStore )
 				.toggleEditorPanelOpened( 'control-panel' );
 
-			// TODO - remove once `getPreference` is deprecated.
+			expect(
+				registry
+					.select( editPostStore )
+					.isEditorPanelOpened( 'control-panel' )
+			).toBe( false );
+
 			expect(
 				registry.select( editPostStore ).getPreference( 'panels' )
-			).toEqual( {
-				...defaultState,
-				'control-panel': {
-					opened: false,
-				},
-			} );
+			).toEqual( {} );
 		} );
 	} );
 

--- a/packages/edit-post/src/store/test/reducer.js
+++ b/packages/edit-post/src/store/test/reducer.js
@@ -7,7 +7,6 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	preferences,
 	activeModal,
 	isSavingMetaBoxes,
 	metaBoxLocations,
@@ -15,135 +14,10 @@ import {
 	blockInserterPanel,
 	listViewPanel,
 } from '../reducer';
-import { PREFERENCES_DEFAULTS } from '../defaults';
 
 import { setIsInserterOpened, setIsListViewOpened } from '../actions';
 
 describe( 'state', () => {
-	describe( 'preferences()', () => {
-		it( 'should apply all defaults', () => {
-			const state = preferences( undefined, {} );
-
-			expect( state ).toEqual( PREFERENCES_DEFAULTS );
-		} );
-
-		it( 'should disable panels by default', () => {
-			const original = deepFreeze( {
-				panels: {},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_ENABLED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { enabled: false },
-			} );
-		} );
-
-		it( 'should disable panels that are enabled', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': { enabled: true },
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_ENABLED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { enabled: false },
-			} );
-		} );
-
-		it( 'should enable panels that are disabled', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': { enabled: false },
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_ENABLED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { enabled: true },
-			} );
-		} );
-
-		it( 'should open panels by default', () => {
-			const original = deepFreeze( {
-				panels: {},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_OPENED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { opened: true },
-			} );
-		} );
-
-		it( 'should open panels that are closed', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': { opened: false },
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_OPENED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { opened: true },
-			} );
-		} );
-
-		it( 'should close panels that are opened', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': { opened: true },
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_OPENED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { opened: false },
-			} );
-		} );
-
-		it( 'should open panels that are legacy closed', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': false,
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_OPENED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { opened: true },
-			} );
-		} );
-
-		it( 'should close panels that are legacy opened', () => {
-			const original = deepFreeze( {
-				panels: {
-					'post-status': true,
-				},
-			} );
-			const state = preferences( original, {
-				type: 'TOGGLE_PANEL_OPENED',
-				panelName: 'post-status',
-			} );
-			expect( state.panels ).toEqual( {
-				'post-status': { opened: false },
-			} );
-		} );
-	} );
-
 	describe( 'activeModal', () => {
 		it( 'should default to null', () => {
 			const state = activeModal( undefined, {} );

--- a/packages/edit-post/src/store/test/selectors.js
+++ b/packages/edit-post/src/store/test/selectors.js
@@ -7,48 +7,17 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import {
-	getPreference,
-	isEditorPanelOpened,
 	isModalActive,
 	hasMetaBoxes,
 	isSavingMetaBoxes,
 	getActiveMetaBoxLocations,
 	isMetaBoxLocationActive,
-	isEditorPanelEnabled,
 	isEditorPanelRemoved,
 	isInserterOpened,
 	isListViewOpened,
 } from '../selectors';
 
 describe( 'selectors', () => {
-	describe( 'getPreference', () => {
-		it( 'should return the preference value if set', () => {
-			const state = {
-				preferences: { chicken: true },
-			};
-
-			expect( getPreference( state, 'chicken' ) ).toBe( true );
-		} );
-
-		it( 'should return undefined if the preference is unset', () => {
-			const state = {
-				preferences: { chicken: true },
-			};
-
-			expect( getPreference( state, 'ribs' ) ).toBeUndefined();
-		} );
-
-		it( 'should return the default value if provided', () => {
-			const state = {
-				preferences: {},
-			};
-
-			expect( getPreference( state, 'ribs', 'chicken' ) ).toEqual(
-				'chicken'
-			);
-		} );
-	} );
-
 	describe( 'isModalActive', () => {
 		it( 'returns true if the provided name matches the value in the preferences activeModal property', () => {
 			const state = {
@@ -92,130 +61,6 @@ describe( 'selectors', () => {
 			} );
 
 			expect( isEditorPanelRemoved( state, 'post-status' ) ).toBe( true );
-		} );
-	} );
-
-	describe( 'isEditorPanelEnabled', () => {
-		it( 'should return true by default', () => {
-			const state = {
-				preferences: {
-					panels: {},
-				},
-			};
-
-			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe( true );
-		} );
-
-		it( 'should return true when a panel has been enabled', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': { enabled: true },
-					},
-				},
-			};
-
-			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe( true );
-		} );
-
-		it( 'should return false when a panel has been disabled', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': { enabled: false },
-					},
-				},
-			};
-
-			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe(
-				false
-			);
-		} );
-
-		it( 'should return false when a panel is enabled but removed', () => {
-			const state = deepFreeze( {
-				preferences: {
-					panels: {
-						'post-status': {
-							enabled: true,
-						},
-					},
-				},
-				removedPanels: [ 'post-status' ],
-			} );
-
-			expect( isEditorPanelEnabled( state, 'post-status' ) ).toBe(
-				false
-			);
-		} );
-	} );
-
-	describe( 'isEditorPanelOpened', () => {
-		it( 'is tolerant to an undefined panels preference', () => {
-			// See: https://github.com/WordPress/gutenberg/issues/14580
-			const state = {
-				preferences: {},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( false );
-		} );
-
-		it( 'should return false by default', () => {
-			const state = {
-				preferences: {
-					panels: {},
-				},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( false );
-		} );
-
-		it( 'should return true when a panel has been opened', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': { opened: true },
-					},
-				},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( true );
-		} );
-
-		it( 'should return false when a panel has been closed', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': { opened: false },
-					},
-				},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( false );
-		} );
-
-		it( 'should return true when a panel has been legacy opened', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': true,
-					},
-				},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( true );
-		} );
-
-		it( 'should return false when a panel has been legacy closed', () => {
-			const state = {
-				preferences: {
-					panels: {
-						'post-status': false,
-					},
-				},
-			};
-
-			expect( isEditorPanelOpened( state, 'post-status' ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/31965

## What?
Migrates the post editor `panels` data to the preferences store.

This also deprecates and removes a few things.

The `getPreference` and `getPreferences` selectors in the post editor are both deprecated, as they no longer need to be used, but as stable APIs backwards compatibility is needed. 

The entire `preferences` reducer is also no longer needed, so that can be removed and the store switched over to using `register` instead of `registerStore` now that there's no persistence.

## Why?
As outlined in https://github.com/WordPress/gutenberg/issues/31965, the goal is to move persisted data out of our various stores to a centralized preferences store.

When doing this, I decided to change the data structure. The original data structure involved some heavily nested data, it wasn't normalized in the way redux style state often is, and that makes it complicated to work with.

There were some problems as well in that the existing data structure requires serializing and persisting far more data than is necessary. Each panel defaults to `true`, and yet the reducer still stores and persists `enabled: true`. Each panel is also not `opened` by default, and yet it stores `opened: false`. In both these cases, the absence of a value is perfectly adequate.

In the new data structure, `enabled` has been flipped to be stored in an `inactivePanels` preference.

## How?
This follows a familiar process to other migration PRs. The selectors and actions have been rewired to use the preferences store. 

The only difference is the conversion of the data into a different structure. This is a bit ugly in the `getPreference` selector, but that selector is now deprecated and unused, so I don't think it's a big issue.

## Testing Instructions
1. Checkout `trunk` and build
2. Delete any WP local storage data using the browser dev tools
3. Open the post editor and go the the 'Panels' section of the preferences modal
4. Toggle off the of some 'Document Settings' panels (make a mental note of which ones)
5. Open the 'Post' document settings sidebar.
6. Expand some of the collapsed panels (make a mental note of which ones)
7. Checkout this branch and rebuild
8. Check that the enabled panels and expanded panels are still the same as when you modified them (at steps 4 and 6)
9. Toggle the enabled/expanded state of a few more panels
10. Reload, they should be the same as you set them at step 9.
