### PR TITLE
List block v2: Add start, ordered and reversed list block attributes

### DIFF
--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -1,18 +1,77 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
+import { ToolbarButton } from '@wordpress/components';
+import { isRTL, __ } from '@wordpress/i18n';
+import {
+	formatListBullets,
+	formatListBulletsRTL,
+	formatListNumbered,
+	formatListNumberedRTL,
+} from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import OrderedListSettings from '../ordered-list-settings';
 
 const TEMPLATE = [ [ 'core/list-item' ] ];
 
-function Edit() {
+function Edit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list-item' ],
 		template: TEMPLATE,
 	} );
+	const { ordered, reversed, start } = attributes;
+	const TagName = ordered ? 'ol' : 'ul';
 
-	return <ul { ...innerBlocksProps } />;
+	const controls = (
+		<BlockControls group="block">
+			<ToolbarButton
+				icon={ isRTL() ? formatListBulletsRTL : formatListBullets }
+				title={ __( 'Unordered' ) }
+				describedBy={ __( 'Convert to unordered list' ) }
+				isActive={ ordered === false }
+				onClick={ () => {
+					setAttributes( { ordered: false } );
+				} }
+			/>
+			<ToolbarButton
+				icon={ isRTL() ? formatListNumberedRTL : formatListNumbered }
+				title={ __( 'Ordered' ) }
+				describedBy={ __( 'Convert to ordered list' ) }
+				isActive={ ordered === true }
+				onClick={ () => {
+					setAttributes( { ordered: true } );
+				} }
+			/>
+		</BlockControls>
+	);
+
+	return (
+		<>
+			<TagName
+				reversed={ reversed }
+				start={ start }
+				{ ...innerBlocksProps }
+			/>
+			{ controls }
+			{ ordered && (
+				<OrderedListSettings
+					setAttributes={ setAttributes }
+					ordered={ ordered }
+					reversed={ reversed }
+					start={ start }
+				/>
+			) }
+		</>
+	);
 }
 
 export default Edit;

--- a/packages/block-library/src/list/v2/save.js
+++ b/packages/block-library/src/list/v2/save.js
@@ -3,10 +3,16 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 
-export default function save() {
+export default function save( { attributes } ) {
+	const { ordered, reversed, start } = attributes;
+	const TagName = ordered ? 'ol' : 'ul';
 	return (
-		<ul { ...useBlockProps.save() }>
+		<TagName
+			reversed={ reversed }
+			start={ start }
+			{ ...useBlockProps.save() }
+		>
 			<InnerBlocks.Content />
-		</ul>
+		</TagName>
 	);
 }


### PR DESCRIPTION
closes #39518

## What?

The list block is being refactored and rewritten to use "inner blocks" instead of a single block. As part of that project, this PR brings the list ordered, start and reversed attributes configuration from the v1 into to v2 of the list block.

## How?

The nice thing here is that we don't have to extracted these informations from the "RichText" value like in v1, we can use the dedicated attributes and it will work in a nested way.

Right now though, the controls are only visible when the "list block" is selected as this embraces the inner blocks behavior. That's probably a decent start but I guess we can consider some "aborbToolbar" (or opposite here). What would be the ideal UX here cc @jasmussen @mtias. 

## Testing Instructions

- Enable the list block v2 experiment
- Insert the list block
- Select the parent list block and play with some of the attributes (ordered, reversed, start)

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/272444/159220611-bf11a30d-ac26-4fe3-b4d4-b4138043ee6f.mov

