### PR TITLE
Media & Text: Allow authors to select image sizes from dropdown

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -161,7 +161,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	const image = useSelect(
 		( select ) =>
 			mediaId && isSelected
-				? select( coreStore ).getMedia( mediaId )
+				? select( coreStore ).getMedia( mediaId, { context: 'view' } )
 				: null,
 		[ isSelected, mediaId ]
 	);


### PR DESCRIPTION
## What?
Displays image size dropdown for non-Admin user roles.

## Why?
Similar to #39580.

The non-Admin user roles cannot request images uploaded by other users in the `edit` context.

## How?
Update `getMedia` selector call and use the `view` context.

## Testing Instructions

1. Upload an image using an Administrator user account.
2. Switch to a user with an Author role.
3. Create a post.
4. Insert a Media & Text block and select the uploaded image.
5. Confirm that the image size dropdown is displayed in the sidebar.
6. DevTools has no 403 requests in the Networks panel.
