### PR TITLE
Add __experimentalGetGlobalBlocksByName selector 

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -279,6 +279,29 @@ export const getGlobalBlockCount = createSelector(
 );
 
 /**
+ * Returns all global blocks that match a blockName. Results include nested blocks.
+ *
+ * @param {Object}  state     Global application state.
+ * @param {?string} blockName Optional block name, if not specified, returns an empty array.
+ *
+ * @return {Array} Array of clientIds of blocks with name equal to blockName.
+ */
+export const __experimentalGetGlobalBlocksByName = createSelector(
+	( state, blockName ) => {
+		if ( ! blockName ) {
+			return EMPTY_ARRAY;
+		}
+		const clientIds = getClientIdsWithDescendants( state );
+		const foundBlocks = clientIds.filter( ( clientId ) => {
+			const block = state.blocks.byClientId[ clientId ];
+			return block.name === blockName;
+		} );
+		return foundBlocks.length > 0 ? foundBlocks : EMPTY_ARRAY;
+	},
+	( state ) => [ state.blocks.order, state.blocks.byClientId ]
+);
+
+/**
  * Given an array of block client IDs, returns the corresponding array of block
  * objects.
  *

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -77,6 +77,7 @@ const {
 	__unstableGetClientIdsTree,
 	__experimentalGetPatternTransformItems,
 	wasBlockJustInserted,
+	__experimentalGetGlobalBlocksByName,
 } = selectors;
 
 describe( 'selectors', () => {
@@ -794,6 +795,68 @@ describe( 'selectors', () => {
 			expect( getGlobalBlockCount( emptyState, 'core/heading' ) ).toBe(
 				0
 			);
+		} );
+	} );
+
+	describe( '__experimentalGetGlobalBlocksByName', () => {
+		const state = {
+			blocks: {
+				byClientId: {
+					123: { clientId: 123, name: 'core/heading' },
+					456: { clientId: 456, name: 'core/paragraph' },
+					789: { clientId: 789, name: 'core/paragraph' },
+					1011: { clientId: 1011, name: 'core/group' },
+					1213: { clientId: 1213, name: 'core/paragraph' },
+					1415: { clientId: 1213, name: 'core/paragraph' },
+				},
+				attributes: {
+					123: {},
+					456: {},
+					789: {},
+					1011: {},
+					1213: {},
+					1415: {},
+				},
+				order: {
+					'': [ 123, 456, 1011 ],
+					1011: [ 1415, 1213 ],
+				},
+				parents: {
+					123: '',
+					456: '',
+					1011: '',
+					1213: 1011,
+					1415: 1011,
+				},
+			},
+		};
+
+		it( 'should return the clientIds of blocks of a given type', () => {
+			expect(
+				__experimentalGetGlobalBlocksByName( state, 'core/heading' )
+			).toStrictEqual( [ 123 ] );
+		} );
+
+		it( 'should return the clientIds of blocks of a given type even if blocks are nested', () => {
+			expect(
+				__experimentalGetGlobalBlocksByName( state, 'core/paragraph' )
+			).toStrictEqual( [ 456, 1415, 1213 ] );
+		} );
+
+		it( 'Should return empty array if no blocks match. The empty array should be the same reference', () => {
+			const result = __experimentalGetGlobalBlocksByName(
+				state,
+				'test/missing'
+			);
+			expect(
+				__experimentalGetGlobalBlocksByName( state, 'test/missing' )
+			).toStrictEqual( [] );
+			expect(
+				__experimentalGetGlobalBlocksByName(
+					state,
+					'test/missing2'
+				) === result
+			).toBe( true );
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds a new selector: `__experimentalGetGlobalBlocksByName`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a sub PR spun out of https://github.com/WordPress/gutenberg/pull/39290/.

This selector returns _all_ global blocks that match a given blockName. It also includes nested blocks.

This is required by https://github.com/WordPress/gutenberg/pull/39290/ to quickly get a list (including nested blocks) of any Navigation blocks currently within the current post/template.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This selector is added to the `@wordpresss/block-editor` package.

## Testing Instructions

- Open browser dev tools `Console` drawer on any Editor page.
- Type `wp.data.select('core/block-editor').__experimentalGetGlobalBlocksByName(%%YOUR BLOCK NAME HERE%%)` replacing the placeholder with a block you know is in the current post/template (eg `core/paragraph`).
- See data returned with the array of clientIds of blocks with name equal to blockName.
- Try with a non-existent block - check empty array returned.
- Try passing no block name at all - check empty array returned.

## Screenshots or screencast <!-- if applicable -->
