### PR TITLE
Collapse list view by default in all editors

### DIFF
--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -72,7 +72,7 @@ function ListView(
 		showNestedBlocks,
 		showBlockMovers,
 		id,
-		expandNested,
+		expandNested = false,
 		...props
 	},
 	ref

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,7 +63,6 @@ export default function ListViewSidebar() {
 					showNestedBlocks
 					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
-					expandNested={ false }
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR defaults the List View to have all branches/nodes collapsed by default across **all Editors** by altering the default expanded state on the underlying `<ListView>` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a follow up to https://github.com/WordPress/gutenberg/pull/39573 where we collapse all nodes on the Site Editor only. Many folk suggested this would be good feature to have on all ListView instances across all editors.

 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The PR marks the `expandNested` prop of the underlying `<ListView>` component to be `false` by default.

This means all nodes are collapsed but they can be expanded manually or by clicking on a given block in the canvas.

## Testing Instructions

1. Use default TT2 theme.
2. Open Site, Post _and_ Widget Editors - this must be tested across them all.
3. Toggle List View open.
4. See all nodes collapsed by default - you may need to manually add some nested blocks to test this.
5. Check you can expand/collapse nodes manually as required and that windowing doesn't break.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/159257976-06b1ddc0-ef90-449b-be35-c185e3274541.mov


