### PR TITLE
Scripts: Add .jsx file extension to Webpack

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -99,7 +99,7 @@ const config = {
 		alias: {
 			'lodash-es': 'lodash',
 		},
-		extensions: [ '.ts', '.tsx', '...' ],
+		extensions: [ '.jsx', '.ts', '.tsx', '...' ],
 	},
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.


### PR DESCRIPTION
## What?
Add .jsx file extension to Webpack Config

## Why?
Import .jsx files without the extension

