### PR TITLE
Add local env variable for chromium path

### DIFF
--- a/packages/scripts/config/jest-environment-puppeteer/global.js
+++ b/packages/scripts/config/jest-environment-puppeteer/global.js
@@ -39,7 +39,10 @@ async function setup( jestConfig = {} ) {
 	if ( config.connect ) {
 		browser = await puppeteer.connect( config.connect );
 	} else {
-		browser = await puppeteer.launch( config.launch );
+		browser = await puppeteer.launch( {
+			...config.launch,
+			executablePath: process.env.PUPPETEER_EXECUTABLE_PATH,
+		} );
 	}
 	process.env.PUPPETEER_WS_ENDPOINT = browser.wsEndpoint();
 


### PR DESCRIPTION
This change enables the setting of a local chromium for Puppeteer via the `PUPPETEER_EXECUTABLE_PATH` env variable.