### PR TITLE
Revert: Fix/editor content zindex stack context

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,7 +33,7 @@ $z-layers: (
 	".block-editor-url-input__suggestions": 30,
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
-	".interface-interface-skeleton__content": 91,
+	".interface-interface-skeleton__content": 20,
 	".edit-site-list.interface-interface-skeleton__content": 29, // The content area needs to be lower than the header so tools dropdowns appear over the content.
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -34,7 +34,6 @@ $z-layers: (
 	".edit-post-layout__footer": 30,
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 20,
-	".edit-site-list.interface-interface-skeleton__content": 29, // The content area needs to be lower than the header so tools dropdowns appear over the content.
 	".edit-site-header": 62,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -46,7 +46,6 @@
 			background: $white;
 			align-items: center;
 			padding: $grid-unit-20;
-			z-index: z-index(".edit-site-list.interface-interface-skeleton__content");
 
 			@include break-medium() {
 				padding: $grid-unit * 9;


### PR DESCRIPTION
## What?
Reverts https://github.com/WordPress/gutenberg/pull/38893, "Raise z-index of content div relative to sidebars" (commit b90f46f6911bbeabf3d10a66e388d23ee8bfb47e). This change was introduced to allow the editor's main content area to display link popover modals *above* the sidebars.

Also reverts a subsequent corrective change in https://github.com/WordPress/gutenberg/pull/39331, which was opened due to the original content area `z-index` change (commit 2a18443909fed3757c8b61b3574d62b437ce5b05).

## Why?
While https://github.com/WordPress/gutenberg/pull/38893 addressed the original issue (https://github.com/WordPress/gutenberg/issues/38723), it introduced other downstream issues that rely on the content area appearing at a lower z-axis than the sidebars.

These issues include:
- https://github.com/WordPress/gutenberg/pull/39331
- https://github.com/WordPress/gutenberg/issues/39582
- https://github.com/Automattic/p2/pull/4930

Because of the outsized impact of addressing the original minor issue, there was consensus that the z-axis change should be reverted, and addressed differently. Here are the requests, for reference:
- https://github.com/WordPress/gutenberg/issues/39582#issuecomment-1073824253
- https://github.com/WordPress/gutenberg/pull/38893#issuecomment-1073829898

## How?
Reversion of the change restores `.interface-interface-skeleton__content` to `z-index: 20`. Also rolls back a separate and subsequent adjustment applied for visibility of the Templates "Add New" dropdown menu in https://github.com/WordPress/gutenberg/pull/39331.

## Testing Instructions
Check out PR or apply the patch to `gutenberg:trunk` and re-build the plugin. Make sure the plugin is activated.

### Test 1: Original Issue https://github.com/WordPress/gutenberg/issues/38723 (un-fix)
1. On medium and up screen (tablet, laptop, desktop):
2. Create new or edit a post.
3. Open the **List View** and/or **Settings** sidebars.
4. Enter test paragraph content, if needed, and highlight some text -- *text on the extreme left or right of the paragraph works best to replicate the issue*.
5. Click the "link" option from the inline toolbar, and the Link popover (modal) will activate.
6. Observe that the popover appears "under" either sidebar (⚠️ **this un-fixes the original issue, #38723**).

### Screenshots

#### Before Patch
![Before patch](https://user-images.githubusercontent.com/824344/154562274-312f1542-0fbf-4925-af88-d3f98855031d.png)
*Original fix shows link popover "above" sidebars.*

#### After Patch
![After patch](https://cldup.com/4GljfbaQCd.png)
*Link popover appears "under" sidebars, restoring original behavior.*

#### Regression for #32869
![Regression for PR 32869](https://cldup.com/Cl4QT2wMg7.png)
*Actions panel retains stacking priority, and popover appears "under" sidebars.*


### Test 2: Templates "Add New" Dropdown Visibility https://github.com/WordPress/gutenberg/pull/39331 (revert)
1. With a block theme activated, navigate to *Appearance > Editor* (`/wp-admin/site-editor.php`).
2. Click the WordPress icon in the upper-left corner to toggle navigation.
3. Click *Templates* to open the template selector.
4. Click the "Add New" button to activate the "Add New Template" dropdown menu.
5. Observe that the dropdown is visible and appears "above" the template list.

### Screenshots

#### Regression for #39331
![Regression for PR 39331](https://cldup.com/FnwwfMOwQb.png)
*"Add New" dropdown menu remains visible.*
