### PR TITLE
ResizableBox: Ensure tooltip text remains on a single line

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 -   `NumberControl`: commit (and constrain) value on `blur` event ([#39186](https://github.com/WordPress/gutenberg/pull/39186)).
 -   Fix `UnitControl`'s reset of unit when the quantity value is cleared. ([#39531](https://github.com/WordPress/gutenberg/pull/39531/)).
+-   `ResizableBox`: Ensure tooltip text remains on a single line. ([#39623](https://github.com/WordPress/gutenberg/pull/39623)).
 
 ### Deprecation
 

--- a/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
+++ b/packages/components/src/resizable-box/resize-tooltip/styles/resize-tooltip.styles.js
@@ -48,5 +48,6 @@ export const LabelText = styled( Text )`
 		display: block;
 		font-size: 13px;
 		line-height: 1.4;
+		white-space: nowrap;
 	}
 `;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In this small PR, we update the `ResizableBox` tooltip to ensure that the text does not wrap, to keep the text on a single line.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While testing https://github.com/WordPress/gutenberg/pull/39577, I noticed that in the horizontal configuration of the Spacer block, that when we resize the block to be quite small, the tooltip text wraps to multiple lines. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Given that the tooltip text will always be very small for this control, I thought that it's probably pretty safe to ensure that it never wraps, rather than add a more complex min width value. But, happy to go with a different approach if folks prefer!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Test in storybook by running `npm run storybook:dev` and then go to http://localhost:50240/?path=/story/components-resizablebox--default — you'll likely need to open up the Knobs tab, set `__experimentalShowTooltip` to `true` and set the minimum width to `0` to be able to test how this looks.

For real world usage, open up the post editor and add a Navigation block containing a variety of blocks (e.g. a link + a site logo) to enable adding arbitrary blocks to it. Then, add a spacer block. Adjust the spacer block using the resizer control and observe that the tooltip text should now be on a single line.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![resizable-tooltip-before](https://user-images.githubusercontent.com/14988353/159387033-cbf59cf8-0e1f-4fcd-a34e-950439e33fe3.gif) | ![resizable-tooltip-after](https://user-images.githubusercontent.com/14988353/159387048-aa2203c9-536a-48c7-9e33-dd14190c8c49.gif) | 
| ![2022-03-22 11 48 41](https://user-images.githubusercontent.com/14988353/159386006-131a1747-d8ce-4eda-9cbc-df888b148ad8.gif) | ![2022-03-22 11 46 36](https://user-images.githubusercontent.com/14988353/159385807-76f39323-c5ef-4e7b-bf99-c5623caa64bc.gif) |

