### PR TITLE
[List v2]: Split lists on Enter in empty list items

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -333,6 +333,7 @@ function RichTextWrapper(
 					forwardedRef,
 					autocompleteProps.ref,
 					props.ref,
+					forwardedRef,
 					richTextRef,
 					useInputRules( {
 						value,

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -1,25 +1,124 @@
 /**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
 	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { createBlock } from '@wordpress/blocks';
+import {
+	createBlock,
+	getDefaultBlockName,
+	cloneBlock,
+} from '@wordpress/blocks';
+import { useSelect, useDispatch } from '@wordpress/data';
 
-export default function ListItemEdit( {
-	name,
-	attributes,
-	setAttributes,
-	mergeBlocks,
-	onReplace,
-} ) {
+function splitList( topParentListBlock, blockParents, clientId ) {
+	const remainingBlocks = [];
+	// We cloneDeep with lodash here because we mutate the top list block
+	// and we can't use `cloneBlock` because we need to traverse with
+	// specific block clientIds.
+	const parentClone = cloneDeep( topParentListBlock );
+	let parent = parentClone;
+	const parentIds = [ ...blockParents.slice( 1 ), clientId ];
+	parentIds.forEach( ( parentClientId, index ) => {
+		const matchIndex = parent.innerBlocks.findIndex(
+			( innerBlock ) => innerBlock.clientId === parentClientId
+		);
+		const matchParent = parent.innerBlocks[ matchIndex ];
+		const blocksAfter = parent.innerBlocks.slice( matchIndex + 1 );
+		if ( blocksAfter.length ) {
+			remainingBlocks.unshift( ...blocksAfter );
+		}
+		// Last parent item by might be a non empty `list`, so append
+		// remaining innerBlocks blocks if any.
+		const isLastMatch = parentIds.length === index + 1;
+		if (
+			isLastMatch &&
+			matchParent.innerBlocks?.[ 0 ]?.innerBlocks?.length
+		) {
+			remainingBlocks.unshift(
+				...matchParent.innerBlocks[ 0 ].innerBlocks
+			);
+		}
+		// In last parent block don't include the last(empty) list-item.
+		parent.innerBlocks = parent.innerBlocks.slice(
+			0,
+			isLastMatch ? matchIndex : matchIndex + 1
+		);
+		parent = matchParent;
+	} );
+	return { beforeBlock: parentClone, remainingBlocks };
+}
+
+export default function ListItemEdit( props ) {
+	const {
+		attributes,
+		setAttributes,
+		name,
+		onReplace,
+		mergeBlocks,
+		clientId,
+	} = props;
+	const { placeholder, content } = attributes;
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { topParentListBlock, blockParents } = useSelect(
+		( select ) => {
+			const {
+				getBlockParents,
+				getBlock,
+				getBlockParentsByBlockName,
+			} = select( blockEditorStore );
+			return {
+				topParentListBlock: getBlock(
+					getBlockParentsByBlockName( clientId, 'core/list' )[ 0 ]
+				),
+				blockParents: getBlockParents( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
 	} );
+
+	const onSplit = ( value ) => {
+		if ( ! content.length && ! value.length ) {
+			const { beforeBlock, remainingBlocks } = splitList(
+				topParentListBlock,
+				blockParents,
+				clientId
+			);
+			const extraBlocks = [ createBlock( getDefaultBlockName() ) ];
+			if ( remainingBlocks.length ) {
+				extraBlocks.push(
+					createBlock(
+						'core/list',
+						{},
+						remainingBlocks.map( ( block ) => cloneBlock( block ) )
+					)
+				);
+			}
+			replaceBlocks(
+				topParentListBlock.clientId,
+				[ cloneBlock( beforeBlock ), ...extraBlocks ],
+				1
+			);
+			return;
+		}
+		return createBlock( name, {
+			...attributes,
+			content: value,
+		} );
+	};
 
 	return (
 		<li { ...innerBlocksProps }>
@@ -29,15 +128,10 @@ export default function ListItemEdit( {
 				onChange={ ( nextContent ) =>
 					setAttributes( { content: nextContent } )
 				}
-				value={ attributes.content }
+				value={ content }
 				aria-label={ __( 'List text' ) }
-				placeholder={ attributes.placeholder || __( 'List' ) }
-				onSplit={ ( value ) =>
-					createBlock( name, {
-						...attributes,
-						content: value,
-					} )
-				}
+				placeholder={ placeholder || __( 'List' ) }
+				onSplit={ onSplit }
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 			/>

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -1,62 +1,19 @@
 /**
- * External dependencies
- */
-import { cloneDeep } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
 	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import {
-	createBlock,
-	getDefaultBlockName,
-	cloneBlock,
-} from '@wordpress/blocks';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import { useMergeRefs } from '@wordpress/compose';
 
-function splitList( topParentListBlock, blockParents, clientId ) {
-	const remainingBlocks = [];
-	// We cloneDeep with lodash here because we mutate the top list block
-	// and we can't use `cloneBlock` because we need to traverse with
-	// specific block clientIds.
-	const parentClone = cloneDeep( topParentListBlock );
-	let parent = parentClone;
-	const parentIds = [ ...blockParents.slice( 1 ), clientId ];
-	parentIds.forEach( ( parentClientId, index ) => {
-		const matchIndex = parent.innerBlocks.findIndex(
-			( innerBlock ) => innerBlock.clientId === parentClientId
-		);
-		const matchParent = parent.innerBlocks[ matchIndex ];
-		const blocksAfter = parent.innerBlocks.slice( matchIndex + 1 );
-		if ( blocksAfter.length ) {
-			remainingBlocks.unshift( ...blocksAfter );
-		}
-		// Last parent item by might be a non empty `list`, so append
-		// remaining innerBlocks blocks if any.
-		const isLastMatch = parentIds.length === index + 1;
-		if (
-			isLastMatch &&
-			matchParent.innerBlocks?.[ 0 ]?.innerBlocks?.length
-		) {
-			remainingBlocks.unshift(
-				...matchParent.innerBlocks[ 0 ].innerBlocks
-			);
-		}
-		// In last parent block don't include the last(empty) list-item.
-		parent.innerBlocks = parent.innerBlocks.slice(
-			0,
-			isLastMatch ? matchIndex : matchIndex + 1
-		);
-		parent = matchParent;
-	} );
-	return { beforeBlock: parentClone, remainingBlocks };
-}
+/**
+ * Internal dependencies
+ */
+import { useEnter } from './utils';
 
 export default function ListItemEdit( props ) {
 	const {
@@ -68,61 +25,15 @@ export default function ListItemEdit( props ) {
 		clientId,
 	} = props;
 	const { placeholder, content } = attributes;
-	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const { topParentListBlock, blockParents } = useSelect(
-		( select ) => {
-			const {
-				getBlockParents,
-				getBlock,
-				getBlockParentsByBlockName,
-			} = select( blockEditorStore );
-			return {
-				topParentListBlock: getBlock(
-					getBlockParentsByBlockName( clientId, 'core/list' )[ 0 ]
-				),
-				blockParents: getBlockParents( clientId ),
-			};
-		},
-		[ clientId ]
-	);
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list' ],
 	} );
-
-	const onSplit = ( value ) => {
-		if ( ! content.length && ! value.length ) {
-			const { beforeBlock, remainingBlocks } = splitList(
-				topParentListBlock,
-				blockParents,
-				clientId
-			);
-			const extraBlocks = [ createBlock( getDefaultBlockName() ) ];
-			if ( remainingBlocks.length ) {
-				extraBlocks.push(
-					createBlock(
-						'core/list',
-						{},
-						remainingBlocks.map( ( block ) => cloneBlock( block ) )
-					)
-				);
-			}
-			replaceBlocks(
-				topParentListBlock.clientId,
-				[ cloneBlock( beforeBlock ), ...extraBlocks ],
-				1
-			);
-			return;
-		}
-		return createBlock( name, {
-			...attributes,
-			content: value,
-		} );
-	};
-
+	const useEnterRef = useEnter( { content, clientId } );
 	return (
 		<li { ...innerBlocksProps }>
 			<RichText
+				ref={ useMergeRefs( [ useEnterRef ] ) }
 				identifier="content"
 				tagName="div"
 				onChange={ ( nextContent ) =>
@@ -131,7 +42,12 @@ export default function ListItemEdit( props ) {
 				value={ content }
 				aria-label={ __( 'List text' ) }
 				placeholder={ placeholder || __( 'List' ) }
-				onSplit={ onSplit }
+				onSplit={ ( value ) =>
+					createBlock( name, {
+						...attributes,
+						content: value,
+					} )
+				}
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 			/>

--- a/packages/block-library/src/list-item/utils.js
+++ b/packages/block-library/src/list-item/utils.js
@@ -1,0 +1,109 @@
+/**
+ * External dependencies
+ */
+import { cloneDeep } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	getDefaultBlockName,
+	cloneBlock,
+} from '@wordpress/blocks';
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { ENTER } from '@wordpress/keycodes';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+export function splitList( topParentListBlock, blockParents, clientId ) {
+	const remainingBlocks = [];
+	// We cloneDeep with lodash here because we mutate the top list block
+	// and we can't use `cloneBlock` because we need to traverse with
+	// specific block clientIds.
+	const parentClone = cloneDeep( topParentListBlock );
+	let parent = parentClone;
+	// We append the clientId because the handling is really similar
+	// to the parent blocks.
+	const parentIds = [ ...blockParents.slice( 1 ), clientId ];
+	parentIds.forEach( ( parentClientId, index ) => {
+		const matchIndex = parent.innerBlocks.findIndex(
+			( innerBlock ) => innerBlock.clientId === parentClientId
+		);
+		const matchParent = parent.innerBlocks[ matchIndex ];
+		const blocksAfter = parent.innerBlocks.slice( matchIndex + 1 );
+		if ( blocksAfter.length ) {
+			remainingBlocks.unshift( ...blocksAfter );
+		}
+		// Last parent item by might be a non empty `list`, so append
+		// remaining innerBlocks blocks if any.
+		const isLastMatch = parentIds.length === index + 1;
+		if (
+			isLastMatch &&
+			matchParent.innerBlocks?.[ 0 ]?.innerBlocks?.length
+		) {
+			remainingBlocks.unshift(
+				...matchParent.innerBlocks[ 0 ].innerBlocks
+			);
+		}
+		// The last block is the actual empty list item, so don't include it.
+		parent.innerBlocks = parent.innerBlocks.slice(
+			0,
+			isLastMatch ? matchIndex : matchIndex + 1
+		);
+		parent = matchParent;
+	} );
+	return { beforeBlock: parentClone, remainingBlocks };
+}
+
+export function useEnter( props ) {
+	// const { __unstableMarkAutomaticChange } = useDispatch( blockEditorStore );
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { getBlock, getBlockParents, getBlockParentsByBlockName } = useSelect(
+		blockEditorStore
+	);
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.defaultPrevented || event.keyCode !== ENTER ) {
+				return;
+			}
+			const { content, clientId } = propsRef.current;
+			if ( content.length ) {
+				return;
+			}
+			event.preventDefault();
+			const topParentListBlockClientId = getBlockParentsByBlockName(
+				clientId,
+				'core/list'
+			)[ 0 ];
+			const { beforeBlock, remainingBlocks } = splitList(
+				getBlock( topParentListBlockClientId ),
+				getBlockParents( clientId ),
+				clientId
+			);
+			const extraBlocks = [ createBlock( getDefaultBlockName() ) ];
+			if ( remainingBlocks.length ) {
+				extraBlocks.push(
+					createBlock(
+						'core/list',
+						{},
+						remainingBlocks.map( ( block ) => cloneBlock( block ) )
+					)
+				);
+			}
+			replaceBlocks(
+				topParentListBlockClientId,
+				[ cloneBlock( beforeBlock ), ...extraBlocks ],
+				1
+			);
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/39519

In the experimental new `list` blocks we should split lists on empty list items if we press enter.
<!-- In a few words, what is the PR actually doing? -->



## How?
Needs more work to handle the split more gracefully outside of current RichTexts `onSplit` function.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Insert a new list block with any nested lists
2. On an empty list item press `Enter`
3. Should split the list and insert a paragraph in the middle
4. Every remaining nested list item should become top level list item

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/159426251-84a75ed1-0135-4d59-a9e0-ca7c0e11de2d.mov


