### PR TITLE
Disabled: Add documentation for 'Disabled.Context'

### DIFF
--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -33,7 +33,7 @@ const MyDisabled = () => {
 };
 ```
 
-A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Context` and `useContext`.
+A component can detect if it has been wrapped in a `<Disabled />` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Context`.
 
 ```jsx
 function CustomButton() {

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -36,10 +36,11 @@ const MyDisabled = () => {
 A component can detect if it has been wrapped in a `<Disabled />` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Context`.
 
 ```jsx
-function CustomButton() {
+function CustomButton( props ) {
 	const isDisabled = useContext( Disabled.Context );
 	return (
 		<button
+			{ ...props }
 			style={ { opacity: isDisabled ? 0.5 : 1 } }
 		/>
 	);

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -33,7 +33,22 @@ const MyDisabled = () => {
 };
 ```
 
-A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Consumer`.
+A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html).
+
+A newly written code should read context with `useContext`:
+
+```jsx
+function CustomButton() {
+	const isDisabled = useContext( Disabled.Context );
+	return (
+		<button
+			style={ { opacity: isDisabled ? 0.5 : 1 } }
+		/>
+	);
+}
+```
+
+A legacy way (not recommended) with `Disabled.Consumer`:
 
 ```jsx
 function CustomButton() {

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -55,4 +55,5 @@ The component accepts the following props:
 Whether to disable all the descendant fields. Defaults to `true`.
 
 -   Type: `Boolean`
+-   Required: No
 -   Default: `true`

--- a/packages/components/src/disabled/README.md
+++ b/packages/components/src/disabled/README.md
@@ -33,9 +33,7 @@ const MyDisabled = () => {
 };
 ```
 
-A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html).
-
-A newly written code should read context with `useContext`:
+A component can detect if it has been wrapped in a `<Disabled>` by accessing its [context](https://reactjs.org/docs/context.html) using `Disabled.Context` and `useContext`.
 
 ```jsx
 function CustomButton() {
@@ -44,23 +42,6 @@ function CustomButton() {
 		<button
 			style={ { opacity: isDisabled ? 0.5 : 1 } }
 		/>
-	);
-}
-```
-
-A legacy way (not recommended) with `Disabled.Consumer`:
-
-```jsx
-function CustomButton() {
-	return (
-		<Disabled.Consumer>
-			{ ( isDisabled ) => (
-				<button
-					{ ...this.props }
-					style={ { opacity: isDisabled ? 0.5 : 1 } }
-				/>
-			) }
-		</Disabled.Consumer>
 	);
 }
 ```
@@ -74,5 +55,4 @@ The component accepts the following props:
 Whether to disable all the descendant fields. Defaults to `true`.
 
 -   Type: `Boolean`
--   Required: No
 -   Default: `true`


### PR DESCRIPTION
## What?
PR adds documentation for `Disabled.Context`, introduced in #31134.

## Why?
Reading context with `useContext` should be preferred when possible.

## How?
PR updates documentation and adds notes about the preferred method.
