### PR TITLE
Fix flaky test by finalising request resolution in Nav block e2e test

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -360,14 +360,16 @@ describe( 'Navigation', () => {
 						request.url().includes( `rest_route` ) &&
 						request.url().includes( `navigation` ) &&
 						request.url().includes( testNavId ),
-					onRequestMatch: () => {
+					onRequestMatch: ( request ) => {
 						// The Promise simulates a REST API request whose resolultion
 						// the test has full control over.
 						return new Promise( ( resolve ) => {
 							// Assign the resolution function to the var in the
 							// upper scope to afford control over resolution.
 							resolveNavigationRequest = resolve;
-						} );
+
+							// Call request.continue() is required to fully resolve the mock.
+						} ).then( () => request.continue() );
 					},
 				},
 			] );
@@ -411,14 +413,16 @@ describe( 'Navigation', () => {
 						request.url().includes( `rest_route` ) &&
 						request.url().includes( `navigation` ) &&
 						request.url().includes( testNavId ),
-					onRequestMatch: () => {
+					onRequestMatch: ( request ) => {
 						// The Promise simulates a REST API request whose resolultion
 						// the test has full control over.
 						return new Promise( ( resolve ) => {
 							// Assign the resolution function to the var in the
 							// upper scope to afford control over resolution.
 							resolveNavigationRequest = resolve;
-						} );
+
+							// Call request.continue() is required to fully resolve the mock.
+						} ).then( () => request.continue() );
 					},
 				},
 			] );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -356,6 +356,7 @@ describe( 'Navigation', () => {
 			await setUpResponseMocking( [
 				{
 					match: ( request ) =>
+						request.method() === 'GET' &&
 						request.url().includes( `rest_route` ) &&
 						request.url().includes( `navigation` ) &&
 						request.url().includes( testNavId ),
@@ -390,7 +391,9 @@ describe( 'Navigation', () => {
 			await navBlock.waitForSelector( '.components-spinner' );
 
 			// Resolve the controlled mocked API request.
-			resolveNavigationRequest();
+			if ( typeof resolveNavigationRequest === 'function' ) {
+				resolveNavigationRequest();
+			}
 		} );
 
 		it( 'shows a loading indicator whilst empty Navigation menu is being created', async () => {
@@ -437,7 +440,9 @@ describe( 'Navigation', () => {
 			await navBlock.waitForSelector( '.components-spinner' );
 
 			// Resolve the controlled mocked API request.
-			resolveNavigationRequest();
+			if ( typeof resolveNavigationRequest === 'function' ) {
+				resolveNavigationRequest();
+			}
 		} );
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes to the e2e tests to resolve https://github.com/WordPress/gutenberg/issues/39231.

Closes https://github.com/WordPress/gutenberg/issues/39231.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This e2e test keeps failing https://github.com/WordPress/gutenberg/issues/39231 because the resolution function maybe be null and not callable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionalises the calling of the resolution function to check whether it is a function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
