### PR TITLE
Use the post-title as the featured-image's alt text when linked to the post

### DIFF
--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -179,7 +179,13 @@ function PostFeaturedImageDisplay( {
 		) : (
 			<img
 				src={ mediaUrl }
-				alt={ __( 'Featured image' ) }
+				alt={
+					media.alt_text ? sprintf(
+						// translators: %s: The image's alt text.
+						__( 'Featured image: %s' ),
+						media.alt_text
+					) : __( 'Featured image' )
+				}
 				style={ { height, objectFit: height && scale } }
 			/>
 		);

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -179,7 +179,7 @@ function PostFeaturedImageDisplay( {
 		) : (
 			<img
 				src={ mediaUrl }
-				alt={ media.alt_text || __( 'Featured image' ) }
+				alt={ __( 'Featured image' ) }
 				style={ { height, objectFit: height && scale } }
 			/>
 		);

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -180,11 +180,13 @@ function PostFeaturedImageDisplay( {
 			<img
 				src={ mediaUrl }
 				alt={
-					media.alt_text ? sprintf(
-						// translators: %s: The image's alt text.
-						__( 'Featured image: %s' ),
-						media.alt_text
-					) : __( 'Featured image' )
+					media.alt_text
+						? sprintf(
+								// translators: %s: The image's alt text.
+								__( 'Featured image: %s' ),
+								media.alt_text
+						  )
+						: __( 'Featured image' )
 				}
 				style={ { height, objectFit: height && scale } }
 			/>

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -20,7 +20,8 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$post_ID = $block->context['postId'];
 
 	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug );
+	$post_title     = get_the_title( $post_ID );
+	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, array( 'alt' => $post_title ) );
 	if ( ! $featured_image ) {
 		return '';
 	}

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$post_ID = $block->context['postId'];
 
 	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$post_title     = get_the_title( $post_ID );
+	$post_title     = trim( strip_tags( get_the_title( $post_ID ) ) );
 	$featured_image = get_the_post_thumbnail( $post_ID, $size_slug, array( 'alt' => $post_title ) );
 	if ( ! $featured_image ) {
 		return '';


### PR DESCRIPTION
## What?
Use the post-title as the alt-text of a featured image, when that image links to the post.

## Why?
We use `get_the_post_thumbnail()` to get the post-thumbnail, and display it. That function calls `wp_get_attachment_image()` to generate the HTML. The problem here, is that `wp_get_attachment_image` uses the image's metadata to get the alt-text. As a result of that, assistive technologies announce the image's alt text (if one even exists) for the link, and that is not what it should be.
The link points to the post, and therefore should have the post-title as alt description, instead of the image's alt description. The image does not describe the link, the post-title does.

## How?
Added a 3rd argument to the `get_the_post_thumbnail()` call, defining the `alt` attribute as the post-title.

## Testing Instructions
In the twentytwentytwo theme, add a post with a featured image, and then confirm that on the frontpage the post-title is used as the image's alt text when the post-thumbnail is a link to the post itself.