### PR TITLE
Fixed link visible in the mobile now

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -542,6 +542,7 @@ button.wp-block-navigation-item__content {
 			// A default padding is added to submenu items. It's not appropriate inside the modal.
 			.wp-block-navigation-item__content {
 				padding: 0;
+				color: #000;
 			}
 
 			// Default column display for overlay menu contents.


### PR DESCRIPTION
## What?
Closes #39335.

This PR will fix the invisible link issue in the mobile customizer.

## How?
This PR will fix the invisible link issue in the mobile customizer. As this PR will add the styling of color: black to the header links.

## Testing Instructions
Please follow the below steps to check the PR:
1. Add some dummy links to the header nav
2. Now check the responsiveness.
3. The links are visible now

## Screenshots or screencast
https://www.awesomescreenshot.com/image/24461745?key=a933b5bb37b2fdc7962977150332e797