### PR TITLE
[RNMobile] Update separator block's expected HTML in UI tests

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -66,7 +66,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator" has-alpha-channel-opacity/>
+<hr class="wp-block-separator has-alpha-channel-opacity" />
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -89,7 +89,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator" has-alpha-channel-opacity/>
+<hr class="wp-block-separator has-alpha-channel-opacity" />
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -116,7 +116,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator" has-alpha-channel-opacity/>
+<hr class="wp-block-separator has-alpha-channel-opacity" />
 <!-- /wp:separator -->
 
 <!-- wp:list -->

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -66,7 +66,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity" />
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -89,7 +89,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity" />
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -116,7 +116,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity" />
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -35,7 +35,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:heading -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator"/>
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -66,7 +66,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator"/>
+<hr class="wp-block-separator" has-alpha-channel-opacity/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -89,7 +89,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator"/>
+<hr class="wp-block-separator" has-alpha-channel-opacity/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->
@@ -116,7 +116,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 <!-- /wp:image -->
 
 <!-- wp:separator -->
-<hr class="wp-block-separator"/>
+<hr class="wp-block-separator" has-alpha-channel-opacity/>
 <!-- /wp:separator -->
 
 <!-- wp:list -->


### PR DESCRIPTION
## Related PRs

* `Gutenberg Mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4679

## What?

This PR updates the separator block's expected HTML in [the block insertion UI test (part 2)](https://github.com/WordPress/gutenberg/blob/8a204c8d03e340b7431595a84a441e7cdf14b289/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js). 

## Why?

The separator block's HTML was updated following changes in https://github.com/WordPress/gutenberg/pull/38428. Following this update, the block insertion UI tests began to fail [here](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile/16669/workflows/aa786e54-c402-430b-8365-48bdbb33d72b/jobs/90452 ), due to the change to the expected HTML.

## How?

The block's new `has-alpha-channel-opacity` class has been added to the expected HTML in the tests. This is in line with updates to the tests on the web-side, as shown in the code changes in https://github.com/WordPress/gutenberg/pull/38428, for example [here](https://github.com/WordPress/gutenberg/blob/22ff3a29094d7563063487880e95fda469a7470b/test/integration/fixtures/blocks/core__separator.html#L2).

## Testing Instructions

* Locally: Run `npm run native test:e2e:ios:local` and `npm run native test:e2e:android:local` to verify the UI tests pass (specifically `Gutenberg Editor tests for Block insertion 2`).
* CI: Check if all tests pass on `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4679