### PR TITLE
Fix Nav block flaky e2e test by correctly waiting on menu creation resolution

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -485,6 +485,11 @@ describe( 'Navigation', () => {
 				);
 				await startEmptyButton.click();
 
+				// Wait for Navigation creation to complete.
+				await page.waitForXPath(
+					'//*[contains(@class, "components-snackbar")]/*[text()="Navigation Menu successfully created."]'
+				);
+
 				// Wait for block to resolve
 				let navBlock = await waitForBlock( 'Navigation' );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/39179 by correctly waiting for the Navigation Menu to be created before proceeding with evaluation of the Nav block placeholder state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The e2e test in https://github.com/WordPress/gutenberg/issues/39179 keeps failing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Previously the test would be flaky if you had a slow connection. This was because the test would create an empty menu and then waiting on the Navigation block itself as a means of determining that the request to create the Nav Menu had completed. This was unreliable because we now do not unmount the Nav block in such scenarios.

The problem with this was that the Nav block was still in a "loading" state when the test went on to de-select the block and ascert on the placeholder state.

Here's a video which makes it clearer:


https://user-images.githubusercontent.com/444434/159465318-600f21db-9bb3-423d-b900-187b2c30c8fd.mov



This PR fixes this by instead waiting on the snackbar "success" notice that is triggered when the menu creation has completed. Once we know the Nav block is not in a loading state we can proceed to ascert on the placeholder state.

## Testing Instructions

As it's a flaky test it's difficult to test. However you can manually verify what I explained above does indeed happen.

- Go to the test at https://github.com/WordPress/gutenberg/blob/8a204c8d03e340b7431595a84a441e7cdf14b289/packages/e2e-tests/specs/editor/blocks/navigation.test.js#L478
- Insert a Nav block into a new Post. Don't do _anything_ with it yet!
- Set your network to be super super slow. I did this by adding a custom network profile in browser dev tools.
- Now follow the testing steps:
    - click the `Start empty` button
    - see loading state
    - open global block inserter
    - add paragraph block
    - see that loading state persists and thus it's impossible for the test to check the placeholder state

The other thing we can do here is re-run the e2e tests on this PR several times and verify they passed:

- [x] [Run 1](https://github.com/WordPress/gutenberg/runs/5642665766?check_suite_focus=true)
- [ ] Run 2
- [ ] Run 3
- [ ] Run 4
- [ ] Run 5


## Screenshots or screencast <!-- if applicable -->
