### PR TITLE
Add font family and text-decoration typography supports to paragraph blocks

### DIFF
--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -43,8 +43,9 @@
 		},
 		"typography": {
 			"fontSize": true,
-			"__experimentalFontFamily": true,
 			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,

--- a/packages/block-library/src/paragraph/block.json
+++ b/packages/block-library/src/paragraph/block.json
@@ -43,6 +43,7 @@
 		},
 		"typography": {
 			"fontSize": true,
+			"__experimentalFontFamily": true,
 			"lineHeight": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,


### PR DESCRIPTION
This PR adds some missing typography like font family and text-decoration supports to paragraph block, which are already available in Gutenberg. 
With the help of this PR block theme developers and website admin will have more customization options to create more beautiful website and design patterns. 
In some places, designers require to have different typography as compare to global typography like font-family, text-decoration etc. to create unique designs. 
In the absence of these typography settings on block level, block theme developers are rely on custom css for these typography options which are not editable by website admin using frontend editor tools. So this PR will provide more flexibility and help admin to get more controls over design and UI elements.

Testing Steps
1. Activate Twenty Twenty-Two theme
2. Add a new page
3. Add a paragraph. 
4. Assign font-family and text-decoration.
5. Publish the page 
6. View and check the page for assigned typography options 

Please check this [screen-cast](https://app.usebubbles.com/tY4CcWhrrUzWa6KafMmP7A/typography-supports-to-button-heading-and-paragraph-blocks)
For more details please check this [comment](https://github.com/WordPress/gutenberg/pull/39642#pullrequestreview-1079909583)