### PR TITLE
Hide the orientation switcher from the group block

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -61,7 +61,9 @@
 				"fontSize": true
 			}
 		},
-		"__experimentalLayout": true
+		"__experimentalLayout": {
+			"allowOrientation": false
+		}
 	},
 	"editorStyle": "wp-block-group-editor",
 	"style": "wp-block-group"

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -18,7 +18,7 @@ const variations = [
 		name: 'group-row',
 		title: __( 'Row' ),
 		description: __( 'Blocks shown in a row.' ),
-		attributes: { layout: { type: 'flex', allowOrientation: false } },
+		attributes: { layout: { type: 'flex' } },
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'flex',


### PR DESCRIPTION
closes #39647 

## What?

This PR hides the orientation switcher from the "row" block variation.

## Why?

It is arguable whether we should have a "column" block variation as well at some point for the group block, but until we do, it was never the intent to have an "orientation" switcher for the row variation. See original reasoning here https://github.com/WordPress/gutenberg/pull/35819#discussion_r740857483

## How?

Initially when we implemented the "allowOrientation" opt-out flag in the "layout" block support, it was mistakenly added as a block attribute property, while it should have been added as a block support flag.

The #39532 PR fixed that by making it a block support config (like it should be) but making sure the flag is false for the group "row" variation was missed.

## Testing Instructions

- Insert the "Row" block
- In the sidebar, it shouldn't be possible to switch the orientation (veritical/horizontal) of the block.

**Note** 

I just noticed that the "inherit default layout" is also visible for the "flex" layouts right now (row block). That doesn't make a lot of sense and it should probably be removed from there if the layout is not "flow"
