### PR TITLE
Add: Transforms for the list v2 block

### DIFF
--- a/packages/block-library/src/list/v2/index.js
+++ b/packages/block-library/src/list/v2/index.js
@@ -8,11 +8,13 @@ import { list as icon } from '@wordpress/icons';
  */
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const settings = {
 	icon,
 	edit,
 	save,
+	transforms,
 };
 
 export default settings;

--- a/packages/block-library/src/list/v2/transforms.js
+++ b/packages/block-library/src/list/v2/transforms.js
@@ -1,0 +1,116 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, switchToBlockType } from '@wordpress/blocks';
+import {
+	__UNSTABLE_LINE_SEPARATOR,
+	create,
+	split,
+	toHTMLString,
+} from '@wordpress/rich-text';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ 'core/paragraph', 'core/heading' ],
+			transform: ( blockAttributes ) => {
+				let childBlocks = [];
+				if ( blockAttributes.length > 1 ) {
+					childBlocks = blockAttributes.map( ( { content } ) => {
+						return createBlock( 'core/list-item', { content } );
+					} );
+				} else if ( blockAttributes.length === 1 ) {
+					const value = create( {
+						html: blockAttributes[ 0 ].content,
+					} );
+					childBlocks = split( value, '\n' ).map( ( result ) => {
+						return createBlock( 'core/list-item', {
+							content: toHTMLString( { value: result } ),
+						} );
+					} );
+				}
+				return createBlock(
+					'core/list',
+					{
+						anchor: blockAttributes.anchor,
+					},
+					childBlocks
+				);
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/quote', 'core/pullquote' ],
+			transform: ( { value, anchor } ) => {
+				return createBlock(
+					'core/list',
+					{
+						anchor,
+					},
+					split(
+						create( { html: value, multilineTag: 'p' } ),
+						__UNSTABLE_LINE_SEPARATOR
+					).map( ( result ) => {
+						return createBlock( 'core/list-item', {
+							content: toHTMLString( { value: result } ),
+						} );
+					} )
+				);
+			},
+		},
+		...[ '*', '-' ].map( ( prefix ) => ( {
+			type: 'prefix',
+			prefix,
+			transform( content ) {
+				return createBlock( 'core/list', {}, [
+					createBlock( 'core/list-item', { content } ),
+				] );
+			},
+		} ) ),
+		...[ '1.', '1)' ].map( ( prefix ) => ( {
+			type: 'prefix',
+			prefix,
+			transform( content ) {
+				return createBlock(
+					'core/list',
+					{
+						ordered: true,
+					},
+					[ createBlock( 'core/list-item', { content } ) ]
+				);
+			},
+		} ) ),
+	],
+	to: [
+		...[ 'core/paragraph', 'core/heading' ].map( ( block ) => ( {
+			type: 'block',
+			blocks: [ block ],
+			transform: ( _attributes, childBlocks ) => {
+				return childBlocks
+					.filter( ( { name } ) => name === 'core/list-item' )
+					.map( ( { attributes } ) =>
+						createBlock( block, {
+							content: attributes.content,
+						} )
+					);
+			},
+		} ) ),
+		...[ 'core/quote', 'core/pullquote' ].map( ( block ) => ( {
+			type: 'block',
+			blocks: [ block ],
+			transform: ( attributes, innerBlocks ) => {
+				return switchToBlockType(
+					switchToBlockType(
+						createBlock( 'core/list', attributes, innerBlocks ),
+						'core/paragraph'
+					),
+					block
+				);
+			},
+		} ) ),
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/39520

This PR adds transforms for the list v2 block.

Issues:
- Raw handling is not implemented e.g: pasting raw HTML lists does not automatically create list blocks. With nested blocks raw handling is harder I will look into this issue separately.
- When we use the prefix transforms e.g: "- " the list item is not selected the selected block is the parent making the typing impossible to continue unless we explicitly change the selection.


## Testing Instructions
Create a multiline paragraph, and verify it is correctly transformed to a list.
Create multiple paragraphs and headings, and verify they are correctly transformed to a list.
Create quote and pull-quote, and verify it is correctly transformed to a list.
Repeat all the tests in the opposite transform direction.