### PR TITLE
Scan block.json to generate a list of files to be copied via CopyWebpackPlugin

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
-
+-   Parse block.json files to look for a `files` property and generate a list of files to be copied from `src` to the output directory (`build` by default)([39653](https://github.com/WordPress/gutenberg/pull/39653)
 ## 22.2.0 (2022-03-11)
 
 ### Enhancement

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -26,6 +26,7 @@ const {
 	hasCssnanoConfig,
 	hasPostCSSConfig,
 	getWebpackEntryPoints,
+	getFilesToCopy,
 } = require( '../utils' );
 
 const isProduction = process.env.NODE_ENV === 'production';
@@ -36,9 +37,7 @@ if ( ! browserslist.findConfig( '.' ) ) {
 }
 const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 
-const copyWebPackPattens = process.env.WP_COPY_PHP_FILES_TO_DIST
-	? '**/{block.json,*.php}'
-	: '**/block.json';
+const copyWebPackPattens = getFilesToCopy();
 
 const cssLoaders = [
 	{

--- a/packages/scripts/utils/index.js
+++ b/packages/scripts/utils/index.js
@@ -11,6 +11,7 @@ const {
 	spawnScript,
 } = require( './cli' );
 const {
+	getFilesToCopy,
 	getJestOverrideConfigFile,
 	getWebpackArgs,
 	getWebpackEntryPoints,
@@ -29,6 +30,7 @@ module.exports = {
 	getArgFromCLI,
 	getArgsFromCLI,
 	getFileArgsFromCLI,
+	getFilesToCopy,
 	getJestOverrideConfigFile,
 	getNodeArgsFromCLI,
 	getPackageProp,


### PR DESCRIPTION
## What?
The PR is a first attempt at a solution to allow block.json files to determine what files should be copied from `src` to the defined `build`

## Why?
Many blocks have files that they need to reference and having them files moved from `src` to `build` simplifies working with them This is why the `--webpack-copy-php` flag was added with https://github.com/WordPress/gutenberg/pull/39171.

## How?
This PR allows a block to define what files need to be copied by adding a `files` property to block.json. This should be a comma-separated list of files or glob style patterns ie. `"test.xml, *.csv"` etc. Each block.json is scanned and a list of files to copy is generated and passed to the CopyWebpackPlugin in the webpack configuration. This PR takes into account whether or not the `--webpack-copy-php` is set currently but if this approach is adopted, it may not be needed.

## Testing Instructions
1. Create a block using npx @wordpress/create-block@ scripts-test
2. Add multiple folders into `src` to represent blocks, giving each a block.json file and adding some extra files ie `test.xml` and `test.php`
3. Add a files entry to the block.json with the values of `"files": "text.xml,test.php"`
4. Run node {FULLPATH}/gutenberg/packages/scripts/bin/wp-scripts.js -- build 
5. Confirm that all the files listed are copied to the build directory.

There is a known side-effect in that the files are cumulative and are not copied on a per-block basis. If block one indicates a file to be copied and that same file is present in other block directories, it will be copied even if the file isn't added to the second block.json