### PR TITLE
Core data: Fix minor type issue in onSubKey

### DIFF
--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -1,3 +1,3 @@
 export interface AnyFunction {
-	(...args: any[]): any;
+	( ...args: any[] ): any;
 }

--- a/packages/core-data/src/types.ts
+++ b/packages/core-data/src/types.ts
@@ -1,0 +1,3 @@
+export interface AnyFunction {
+	(...args: any[]): any;
+}

--- a/packages/core-data/src/utils/on-sub-key.js
+++ b/packages/core-data/src/utils/on-sub-key.js
@@ -1,10 +1,12 @@
+/** @typedef {import('../types').AnyFunction} AnyFunction */
+
 /**
  * Higher-order reducer creator which creates a combined reducer object, keyed
  * by a property on the action object.
  *
  * @param {string} actionProperty Action property by which to key object.
  *
- * @return {Function} Higher-order reducer.
+ * @return {AnyFunction} Higher-order reducer.
  */
 export const onSubKey = ( actionProperty ) => ( reducer ) => (
 	state = {},


### PR DESCRIPTION
## What?

Part of #39211

The `Function` type in `onSubKey` caused an issue when enabling TypeScript
for the `core-data` module (when analyzing JS files) because it's not a
callable interface.

In this patch we're creating a transition type `AnyFunction` and using that
as the type in `onSubKey` to remove the type error.

After enabling TypeScript for the module we'll be able to provide better
types on the function directly, but for now this prevents raising an error.

We want to do great things with the `core-data` type system but all of these
little nuisances get in the way when we're trying to study those things in
isolation. This is a preparatory change to eliminate some of the noise in the
existing types.

## Testing

As a type-only change this will have no impact on the built code.
Please audit the types and the introduction of the `types.ts` where
we import an actual TypeScript type into JSDoc through `@typedef`.

Note that this change doesn't "fully-type" `onSubKey` in the sense
that it provides full inference for the passed-through reducer.
The goal is merely to avoid creating type errors when activating
TypeScript across the module.
