### PR TITLE
Core data: create type for undo state and initialize atomically

### DIFF
--- a/packages/core-data/src/reducer.js
+++ b/packages/core-data/src/reducer.js
@@ -398,16 +398,28 @@ export const entities = ( state = {}, action ) => {
 };
 
 /**
+ * @typedef {Object} UndoStateMeta
+ *
+ * @property {number} offset          Where in the undo stack we are.
+ * @property {Object} [flattenedUndo] Flattened form of undo stack.
+ */
+
+/** @typedef {Array<Object> & UndoStateMeta} UndoState */
+
+/** @type {UndoState} */
+const UNDO_INITIAL_STATE = Object.assign( [], { offset: 0 } );
+
+/** @type {Object} */
+let lastEditAction;
+
+/**
  * Reducer keeping track of entity edit undo history.
  *
- * @param {Object} state  Current state.
+ * @param {UndoState} state  Current state.
  * @param {Object} action Dispatched action.
  *
- * @return {Object} Updated state.
+ * @return {UndoState} Updated state.
  */
-const UNDO_INITIAL_STATE = [];
-UNDO_INITIAL_STATE.offset = 0;
-let lastEditAction;
 export function undo( state = UNDO_INITIAL_STATE, action ) {
 	switch ( action.type ) {
 		case 'EDIT_ENTITY_RECORD':
@@ -439,7 +451,9 @@ export function undo( state = UNDO_INITIAL_STATE, action ) {
 				}
 			}
 
+			/** @type {UndoState} */
 			let nextState;
+
 			if ( isUndoOrRedo ) {
 				nextState = [ ...state ];
 				nextState.offset =


### PR DESCRIPTION
## What?

Part of #39211

In this patch we're adding some types to the undo state tracked
in the core data store. Additionally we're intializing it in one
atomic operation whereas previously that took two partial assignments.

Futher, a JSDoc comment has been moved from its previously erroneous
location and back to the function it describes. This error had been
overlooked in a previous change to the module.

The purpose is to remove type issues when toggling on TypeScript
across the `core-data` package.

This is almost entirely a type-level change but the initialization
of `UNDO_INITIAL_STATE` has been collapsed into a single assignment.

## Testing

Verify that the editor undo/redo functionality works as expected.
Given that the one code change impacts the initialization it should
be quickly obvious if there's a problem or regression with undo/redo.