### PR TITLE
File block: turn off automatic PDF embedding

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -130,7 +130,7 @@ function FileEdit( {
 				fileName: newMedia.title,
 				textLinkHref: newMedia.url,
 				id: newMedia.id,
-				displayPreview: isPdf ? true : undefined,
+				displayPreview: isPdf ? false : undefined,
 				previewHeight: isPdf ? 600 : undefined,
 			} );
 		}


### PR DESCRIPTION
Simple option to fix #34825

Unchecks the toggle switch for PDF embedding (by default).

## Testing Instructions
1. Open a Post or Page.
2. Insert a File Block.
3. Select a PDF (upload or find one in the Media Library).
4. Confirm that the PDF is not embedded, either in the editor or on the front end. The "Show inline embed" toggle switch should still appear in the sidebar, now unchecked, but the Height selector would not display until the embed option is activated.