### PR TITLE
Add note to Handbook themes page about FSE eligible themes

### DIFF
--- a/docs/how-to-guides/themes/README.md
+++ b/docs/how-to-guides/themes/README.md
@@ -12,6 +12,10 @@ In terms of block editor terminology this is any theme that defines its template
 
 This is any theme that has, at a minimum, an `index.html` format template in the `/block-templates` or `/templates` folders, and with templates  provided in form of block content markup. While many `Block` themes will make use of a `theme.json` file to provide configuration and styling settings, a `theme.json` is not a requirement of `Block` themes. The advantage of `Block` themes is that the block editor can be used to edit all areas of the site: headers, footers, sidebars, etc.
 
+### Full site editing (FSE)
+
+There isn't an FSE specific theme type. In WordPress > 5.9 FSE is enabled for any `Block` theme, ie. any theme that has an `index.html` format template in the `/block-templates` or `/templates` folders.
+
 **Contents**
 
 - [Block Theme Overview](/docs/how-to-guides/themes/block-theme-overview.md)


### PR DESCRIPTION
## What?
Adds a section to Handbook themes page to indicate what makes a theme FSE eligible

## Why?
In discussions around some theming issues in 5.9 there were some misunderstandings about exactly what made a theme eligible for FSE

## How?
Added new FSE specific heading

## Testing Instructions
Read and grammar check

