### PR TITLE
Comments Query Loop: Always inherit from core Discussion settings

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -213,7 +213,7 @@ An advanced block that allows displaying post comments based on different query 
 -	**Name:** core/comments-query-loop
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), ~~html~~
--	**Attributes:** defaultPage, inherit, order, perPage, tagName
+-	**Attributes:** tagName
 
 ## Cover
 

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 			$comment_args['hierarchical'] = false;
 		}
 
-		$per_page = get_option( 'comments_per_page' );
+		$per_page     = get_option( 'comments_per_page' );
 		$default_page = get_option( 'default_comments_page' );
 
 		if ( $per_page > 0 ) {

--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -35,21 +35,8 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 			$comment_args['hierarchical'] = false;
 		}
 
-		$inherit = ! empty( $block->context['comments/inherit'] );
-
-		$per_page = 0;
-		if ( $inherit && get_option( 'page_comments' ) ) {
-			$per_page = get_option( 'comments_per_page' );
-		}
-
-		if ( ! $inherit && ! empty( $block->context['comments/perPage'] ) ) {
-			$per_page = (int) $block->context['comments/perPage'];
-		}
-
+		$per_page = get_option( 'comments_per_page' );
 		$default_page = get_option( 'default_comments_page' );
-		if ( ! $inherit && ! empty( $block->context['comments/defaultPage'] ) ) {
-			$default_page = $block->context['comments/defaultPage'];
-		}
 
 		if ( $per_page > 0 ) {
 			$comment_args['number'] = $per_page;

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -7,13 +7,7 @@
 	"parent": [ "core/comments-query-loop" ],
 	"description": "Contains the block elements used to render a comment, like the title, date, author, avatar and more.",
 	"textdomain": "default",
-	"usesContext": [
-		"comments/defaultPage",
-		"comments/inherit",
-		"comments/order",
-		"comments/perPage",
-		"postId"
-	],
+	"usesContext": [ "postId" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -229,29 +229,23 @@ const CommentsList = ( {
 
 export default function CommentTemplateEdit( {
 	clientId,
-	context: {
-		postId,
-		'comments/perPage': perPage,
-		'comments/order': order,
-		'comments/defaultPage': defaultPage,
-		'comments/inherit': inherit,
-	},
+	context: { postId },
 } ) {
 	const blockProps = useBlockProps();
 
 	const [ activeCommentId, setActiveCommentId ] = useState();
-	const { commentOrder, threadCommentsDepth, threadComments } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-			return getSettings().__experimentalDiscussionSettings;
-		}
-	);
+	const {
+		commentOrder,
+		threadCommentsDepth,
+		threadComments,
+		commentsPerPage,
+	} = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().__experimentalDiscussionSettings;
+	} );
 
 	const commentQuery = useCommentQueryArgs( {
 		postId,
-		perPage,
-		defaultPage,
-		inherit,
 	} );
 
 	const { topLevelComments, blocks } = useSelect(
@@ -270,12 +264,10 @@ export default function CommentTemplateEdit( {
 		[ clientId, commentQuery ]
 	);
 
-	order = inherit || ! order ? commentOrder : order;
-
 	// Generate a tree structure of comment IDs.
 	let commentTree = useCommentTree(
 		// Reverse the order of top comments if needed.
-		order === 'desc' && topLevelComments
+		commentOrder === 'desc' && topLevelComments
 			? [ ...topLevelComments ].reverse()
 			: topLevelComments
 	);
@@ -290,7 +282,7 @@ export default function CommentTemplateEdit( {
 
 	if ( ! postId ) {
 		commentTree = getCommentsPlaceholder( {
-			perPage,
+			perPage: commentsPerPage,
 			threadComments,
 			threadCommentsDepth,
 		} );

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -11,21 +11,13 @@ import apiFetch from '@wordpress/api-fetch';
  * Return an object with the query args needed to fetch the default page of
  * comments.
  *
- * @param {Object}  props             Hook props.
- * @param {number}  props.postId      ID of the post that contains the comments.
- * @param {number}  props.perPage     The number of comments included per page.
- * @param {string}  props.defaultPage Page shown by default (newest/oldest).
- * @param {boolean} props.inherit     Overwrite props with values from WP
- *                                    discussion settings.
+ * @param {Object} props        Hook props.
+ * @param {number} props.postId ID of the post that contains the comments.
+ *                              discussion settings.
  *
  * @return {Object} Query args to retrieve the comments.
  */
-export const useCommentQueryArgs = ( {
-	postId,
-	perPage,
-	defaultPage,
-	inherit,
-} ) => {
+export const useCommentQueryArgs = ( { postId } ) => {
 	// Initialize the query args that are not going to change.
 	const queryArgs = {
 		status: 'approve',
@@ -36,22 +28,14 @@ export const useCommentQueryArgs = ( {
 	};
 
 	// Get the Discussion settings that may be needed to query the comments.
-	const { commentsPerPage, defaultCommentsPage } = useSelect( ( select ) => {
+	const {
+		commentsPerPage: perPage,
+		defaultCommentsPage: defaultPage,
+	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
 		return __experimentalDiscussionSettings;
 	} );
-
-	// Overwrite the received attributes if `inherit` is true.
-	if ( inherit ) {
-		perPage = commentsPerPage;
-		defaultPage = defaultCommentsPage;
-	}
-
-	// If a block props is not set, use the settings value to generate the
-	// appropriate query arg.
-	perPage = perPage || commentsPerPage;
-	defaultPage = defaultPage || defaultCommentsPage;
 
 	// Get the number of the default page.
 	const page = useDefaultPageIndex( {

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -68,9 +68,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment_order = empty( $block->context['comments/inherit'] ) && ! empty( $block->context['comments/order'] )
-		? $block->context['comments/order']
-		: get_option( 'comment_order' );
+	$comment_order = get_option( 'comment_order' );
 
 	if ( 'desc' === $comment_order ) {
 		$comments = array_reverse( $comments );

--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -12,14 +12,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [
-		"postId",
-		"comments/perPage",
-		"comments/order",
-		"comments/inherit",
-		"comments/defaultPage",
-		"comments/paginationArrow"
-	],
+	"usesContext": [ "postId", "comments/paginationArrow" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -3,17 +3,11 @@
 	"apiVersion": 2,
 	"name": "core/comments-pagination-numbers",
 	"title": "Page Numbers",
-  	"category": "theme",
+	"category": "theme",
 	"parent": [ "core/comments-pagination" ],
 	"description": "Displays a list of page numbers for comments pagination.",
 	"textdomain": "default",
-	"usesContext": [
-		"postId",
-		"comments/perPage",
-		"comments/order",
-		"comments/inherit",
-		"comments/defaultPage"
-	],
+	"usesContext": [ "postId" ],
 	"supports": {
 		"reusable": false,
 		"html": false

--- a/packages/block-library/src/comments-query-loop/block.json
+++ b/packages/block-library/src/comments-query-loop/block.json
@@ -7,32 +7,10 @@
 	"description": "An advanced block that allows displaying post comments based on different query parameters and visual configurations.",
 	"textdomain": "default",
 	"attributes": {
-		"inherit": {
-			"type": "boolean",
-			"default": true
-		},
-		"order": {
-			"type": "string",
-			"default": null
-		},
-		"perPage": {
-			"type": "number",
-			"default": null
-		},
 		"tagName": {
 			"type": "string",
 			"default": "div"
-		},
-		"defaultPage": {
-			"type": "string",
-			"default": "oldest"
 		}
-	},
-	"providesContext": {
-		"comments/perPage": "perPage",
-		"comments/order": "order",
-		"comments/defaultPage": "defaultPage",
-		"comments/inherit": "inherit"
 	},
 	"supports": {
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/comments-query-loop/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments-query-loop/edit/comments-inspector-controls.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 
@@ -11,7 +11,6 @@ export default function CommentsInspectorControls( {
 } ) {
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings' ) }></PanelBody>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

--- a/packages/block-library/src/comments-query-loop/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments-query-loop/edit/comments-inspector-controls.js
@@ -1,97 +1,17 @@
 /**
  * WordPress dependencies
  */
-import {
-	PanelBody,
-	SelectControl,
-	ToggleControl,
-	__experimentalNumberControl as NumberControl,
-} from '@wordpress/components';
+import { PanelBody, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 
-const orderOptions = [
-	{
-		label: __( 'Newest to oldest' ),
-		value: 'desc',
-	},
-	{
-		label: __( 'Oldest to newest' ),
-		value: 'asc',
-	},
-];
-
-const defaultPageOptions = [
-	{
-		label: __( 'Newest' ),
-		value: 'newest',
-	},
-	{
-		label: __( 'Oldest' ),
-		value: 'oldest',
-	},
-];
-
 export default function CommentsInspectorControls( {
-	attributes: { TagName, perPage, order, inherit, defaultPage },
+	attributes: { TagName },
 	setAttributes,
 } ) {
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Settings' ) }>
-				<ToggleControl
-					label={ __( 'Inherit from Discussion Settings' ) }
-					checked={ inherit }
-					onChange={ () => {
-						setAttributes( {
-							inherit: ! inherit,
-						} );
-					} }
-				/>
-				{ ! inherit && (
-					<>
-						<SelectControl
-							label={ __( 'Order by' ) }
-							value={ order }
-							options={ orderOptions }
-							onChange={ ( value ) => {
-								setAttributes( {
-									order: value,
-								} );
-							} }
-						/>
-						<SelectControl
-							label={ __( 'Default page' ) }
-							value={ defaultPage }
-							options={ defaultPageOptions }
-							onChange={ ( value ) => {
-								setAttributes( {
-									defaultPage: value,
-								} );
-							} }
-						/>
-						<NumberControl
-							__unstableInputWidth="60px"
-							label={ __( 'Items per Page' ) }
-							labelPosition="edge"
-							min={ 1 }
-							max={ 100 }
-							onChange={ ( value ) => {
-								const num = parseInt( value, 10 );
-								if ( isNaN( num ) || num < 1 || num > 100 ) {
-									return;
-								}
-								setAttributes( {
-									perPage: num,
-								} );
-							} }
-							step="1"
-							value={ perPage }
-							isDragEnabled={ false }
-						/>
-					</>
-				) }
-			</PanelBody>
+			<PanelBody title={ __( 'Settings' ) }></PanelBody>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -53,7 +53,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			$parsed_blocks[0],
 			array(
 				'postId'           => self::$custom_post->ID,
-				'comments/perPage' => 77,
 			)
 		);
 
@@ -67,39 +66,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'update_comment_meta_cache' => false,
 				'post_id'                   => self::$custom_post->ID,
 				'hierarchical'              => 'threaded',
-				'number'                    => 77,
-				'paged'                     => 1,
-			)
-		);
-	}
-
-	function test_build_comment_query_vars_from_block_with_context_and_inherit() {
-		$parsed_blocks = parse_blocks(
-			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
-		);
-
-		$block = new WP_Block(
-			$parsed_blocks[0],
-			array(
-				'postId'           => self::$custom_post->ID,
-				'comments/perPage' => 77,
-				'comments/order'   => 'desc',
-				'comments/inherit' => true,
-			)
-		);
-
-		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
-			array(
-				'orderby'                   => 'comment_date_gmt',
-				'order'                     => 'ASC',
-				'status'                    => 'approve',
-				'no_found_rows'             => false,
-				'update_comment_meta_cache' => false,
-				'post_id'                   => self::$custom_post->ID,
-				'hierarchical'              => 'threaded',
-				'number'                    => self::$per_page,
-				'paged'                     => 1,
 			)
 		);
 	}
@@ -124,33 +90,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		);
 	}
 
-	function test_build_comment_query_vars_from_block_with_context_and_pagination() {
-		$parsed_blocks = parse_blocks(
-			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
-		);
-
-		$block = new WP_Block(
-			$parsed_blocks[0],
-			array(
-				'comments/perPage' => 77,
-			)
-		);
-
-		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
-			array(
-				'orderby'                   => 'comment_date_gmt',
-				'order'                     => 'ASC',
-				'status'                    => 'approve',
-				'no_found_rows'             => false,
-				'update_comment_meta_cache' => false,
-				'hierarchical'              => 'threaded',
-				'number'                    => 77,
-				'paged'                     => 1,
-			)
-		);
-	}
-
 	/**
 	 * Test rendering a single comment
 	 */
@@ -163,7 +102,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			$parsed_blocks[0],
 			array(
 				'postId'           => self::$custom_post->ID,
-				'comments/perPage' => 10,
 			)
 		);
 
@@ -213,7 +151,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			$parsed_blocks[0],
 			array(
 				'postId'           => self::$custom_post->ID,
-				'comments/perPage' => 10,
 			)
 		);
 

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -52,7 +52,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		$block = new WP_Block(
 			$parsed_blocks[0],
 			array(
-				'postId'           => self::$custom_post->ID,
+				'postId' => self::$custom_post->ID,
 			)
 		);
 
@@ -101,7 +101,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		$block = new WP_Block(
 			$parsed_blocks[0],
 			array(
-				'postId'           => self::$custom_post->ID,
+				'postId' => self::$custom_post->ID,
 			)
 		);
 
@@ -150,7 +150,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		$block = new WP_Block(
 			$parsed_blocks[0],
 			array(
-				'postId'           => self::$custom_post->ID,
+				'postId' => self::$custom_post->ID,
 			)
 		);
 

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -66,6 +66,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'update_comment_meta_cache' => false,
 				'post_id'                   => self::$custom_post->ID,
 				'hierarchical'              => 'threaded',
+				'number'                    => 5,
+				'paged'                     => 1,
 			)
 		);
 	}
@@ -86,6 +88,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'no_found_rows'             => false,
 				'update_comment_meta_cache' => false,
 				'hierarchical'              => 'threaded',
+				'number'                    => 5,
+				'paged'                     => 1,
 			)
 		);
 	}

--- a/test/integration/fixtures/blocks/core__comments-query-loop.html
+++ b/test/integration/fixtures/blocks/core__comments-query-loop.html
@@ -1,15 +1,17 @@
-<!-- wp:comments-query-loop {"inherit":false,"perPage":2,"order":"desc","defaultPage":"oldest"} -->
-<div class="wp-block-comments-query-loop"><!-- wp:comment-template -->
-    <!-- wp:comment-author-avatar /-->
-    
-    <!-- wp:comment-author-name /-->
-    
-    <!-- wp:comment-date /-->
-    
-    <!-- wp:comment-content /-->
-    
-    <!-- wp:comment-reply-link /-->
-    
-    <!-- wp:comment-edit-link /-->
-    <!-- /wp:comment-template --></div>
-    <!-- /wp:comments-query-loop -->
+<!-- wp:comments-query-loop -->
+<div class="wp-block-comments-query-loop">
+	<!-- wp:comment-template -->
+	<!-- wp:comment-author-avatar /-->
+
+	<!-- wp:comment-author-name /-->
+
+	<!-- wp:comment-date /-->
+
+	<!-- wp:comment-content /-->
+
+	<!-- wp:comment-reply-link /-->
+
+	<!-- wp:comment-edit-link /-->
+	<!-- /wp:comment-template -->
+</div>
+<!-- /wp:comments-query-loop -->

--- a/test/integration/fixtures/blocks/core__comments-query-loop.json
+++ b/test/integration/fixtures/blocks/core__comments-query-loop.json
@@ -3,11 +3,7 @@
 		"name": "core/comments-query-loop",
 		"isValid": true,
 		"attributes": {
-			"inherit": false,
-			"order": "desc",
-			"perPage": 2,
-			"tagName": "div",
-			"defaultPage": "oldest"
+			"tagName": "div"
 		},
 		"innerBlocks": [
 			{

--- a/test/integration/fixtures/blocks/core__comments-query-loop.parsed.json
+++ b/test/integration/fixtures/blocks/core__comments-query-loop.parsed.json
@@ -1,12 +1,7 @@
 [
 	{
 		"blockName": "core/comments-query-loop",
-		"attrs": {
-			"inherit": false,
-			"perPage": 2,
-			"order": "desc",
-			"defaultPage": "oldest"
-		},
+		"attrs": {},
 		"innerBlocks": [
 			{
 				"blockName": "core/comment-template",
@@ -55,29 +50,29 @@
 						"innerContent": []
 					}
 				],
-				"innerHTML": "\n    \n    \n    \n    \n    \n    \n    \n    \n    \n    \n    \n    ",
+				"innerHTML": "\n\t\n\n\t\n\n\t\n\n\t\n\n\t\n\n\t\n\t",
 				"innerContent": [
-					"\n    ",
+					"\n\t",
 					null,
-					"\n    \n    ",
+					"\n\n\t",
 					null,
-					"\n    \n    ",
+					"\n\n\t",
 					null,
-					"\n    \n    ",
+					"\n\n\t",
 					null,
-					"\n    \n    ",
+					"\n\n\t",
 					null,
-					"\n    \n    ",
+					"\n\n\t",
 					null,
-					"\n    "
+					"\n\t"
 				]
 			}
 		],
-		"innerHTML": "\n<div class=\"wp-block-comments-query-loop\"></div>\n    ",
+		"innerHTML": "\n<div class=\"wp-block-comments-query-loop\">\n\t\n</div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-comments-query-loop\">",
+			"\n<div class=\"wp-block-comments-query-loop\">\n\t",
 			null,
-			"</div>\n    "
+			"\n</div>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__comments-query-loop.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments-query-loop.serialized.html
@@ -1,4 +1,4 @@
-<!-- wp:comments-query-loop {"inherit":false,"order":"desc","perPage":2} -->
+<!-- wp:comments-query-loop -->
 <div class="wp-block-comments-query-loop"><!-- wp:comment-template -->
 <!-- wp:comment-author-avatar /-->
 


### PR DESCRIPTION
## What?
Remove the `inherit` option of the and ALWAYS inherit the settings of the Comments Query Loop from the core Discussion settings. This implies also removing the following attributes from the Comments Query Loop block as well any code that depends on them:

- `perPage`
- `order`
- `defaultPage`
- `inherit`

Additionally, we remove any options related to those attributes in the Inspector Controls of the Comments Query Loop. 

Fixing #39648

## Why?
It was identified that whenever the discussion settings are NOT inherited from Discussion settings and the user is allowed to control them *per block*, there are multiple subtle issues caused by the two mechanisms (the core settings and the block settings) being out of sync.

## How?
Removing the aforementioned attributes and any code that depends on them.


## Screenshots or screencast <!-- if applicable -->

### Before:

First screenshot is when "inherit" is `true`, the second one is when it's `false`.

<div>
<img width="283" alt="Screenshot 2022-03-22 at 20 35 02" src="https://user-images.githubusercontent.com/5417266/159604487-01dfeff7-2584-432d-b2bc-1e59bf9adb80.png">
<img width="285" alt="Screenshot 2022-03-22 at 20 34 25" src="https://user-images.githubusercontent.com/5417266/159604493-1ed187f8-199c-4036-948b-cc2f51c78cf8.png">
</div>

### After:

<img width="284" alt="Screenshot 2022-03-22 at 20 07 51" src="https://user-images.githubusercontent.com/5417266/159604344-c298d16b-8860-45f3-b437-e6a0c51b6cf6.png">

