### PR TITLE
Layout: only show inherit toggle in default layout (hide on Row block variation)

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -56,6 +56,15 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		return null;
 	}
 
+	// Only show the inherit toggle if it's supported,
+	// a default theme layout is set (e.g. one that provides `contentSize` and/or `wideSize` values),
+	// and that the default / flow layout type is in use, as this is the only one that supports inheritance.
+	const showInheritToggle = !! (
+		allowInheriting &&
+		!! defaultThemeLayout &&
+		( ! layout?.type || layout?.type === 'default' || layout?.inherit )
+	);
+
 	const usedLayout = layout || defaultBlockLayout || {};
 	const { inherit = false, type = 'default' } = usedLayout;
 	/**
@@ -77,7 +86,7 @@ function LayoutPanel( { setAttributes, attributes, name: blockName } ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Layout' ) }>
-					{ allowInheriting && !! defaultThemeLayout && (
+					{ showInheritToggle && (
 						<ToggleControl
 							label={ __( 'Inherit default layout' ) }
 							checked={ !! inherit }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hide the "Inherit default layout" toggle if the current layout type is not of the default layout type. This allows us to hide the toggle in the Row variation of the Group block.

This is an opinionated change — the assumption here is that the default layout that we're inheriting from will always be implicitly of the "default" layout type. Is this a safe assumption to make?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in reviews of #39650, the inherit toggle doesn't make much sense for a Row block, and possibly not for any other Flex-based layout. The toggle for the Row block also caused a problem that it'd unexpectedly switch the blog over to the Group variation again. Hiding the toggle altogether potentially resolves both problems.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the conditional that determines whether or not to show the layout "Inherit default layout" control so that it can only appear on default / flow layouts.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Row block — ensure that it does not show an "Inherit default layout" toggle
2. Add a Group block — ensure that id _does_ show the "Inherit default layout" toggle
3. Try toggling these controls, and check that it still works as expected
4. Try changing between the two variations via the "Transform to variation" drop-down

To be really thorough, also check that you can switch _off_ inherit on a block that does have inherit and "flex" so that these erroneous blocks don't wind up in a stuck state. E.g. using the following markup:

```
<!-- wp:group {"layout":{"type":"flex","allowOrientation":false,"inherit":true}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>A row block set to inherit</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

Note, the Orientation control is visible in the Row block in the below screenshots, but will be removed as of #39650.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/159604065-70019613-7f3f-40ad-86e9-9ef6e0c7ff4e.png) | ![image](https://user-images.githubusercontent.com/14988353/159604090-9aa4736f-2c24-441a-b7c8-cc9f10a9c5a9.png) |