### PR TITLE
E2E: Check for missing figcaption before clicking gallery image again from list view

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -85,6 +85,16 @@ describe( 'Gallery', () => {
 			'.wp-block-gallery .wp-block-image'
 		);
 
+		// Check that the Image is unselected, in which case the figcaption won't be
+		// in the DOM - due the way that the Gallery block handles the upload the latest
+		// image gets selected in order to scroll to the position of it, as in large
+		// galleries the new upload may be off-canvas. After upload the image is unselected
+		// so if we don't check for that it may get unselected again by this flow after we
+		// have re-selected it to edit it.
+		await page.waitForFunction(
+			() => ! document.querySelector( '.wp-block-image figcaption' )
+		);
+
 		// The Image needs to be selected from the List view panel due to the
 		// way that Image uploads take and lose focus.
 		await openListView();
@@ -103,9 +113,9 @@ describe( 'Gallery', () => {
 			'.block-editor-rich-text__editable'
 		);
 
+		await captionElement.click();
 		const caption = 'Tested caption';
 
-		await captionElement.click();
 		await page.keyboard.type( caption );
 
 		expect( await getEditedPostContent() ).toMatch(

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -100,7 +100,7 @@ describe( 'Gallery', () => {
 		await openListView();
 
 		const galleryListViewItem = await page.waitForXPath(
-			`//a[contains(text(), 'Gallery')]`
+			`//a[contains(text(), 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
 		);
 		await galleryListViewItem.click();
 


### PR DESCRIPTION
## What?
Makes selection of the Image caption more reliable in Gallery e2e test

## Why?
Cause ain't nobody got time for [flakey tests](https://github.com/WordPress/gutenberg/issues/39533)!

## How?
- Narrows down the click on the Gallery link in list view to the expand span 
- Waits for Image to be unselected after upload before selecting again in List view

## Testing Instructions
Make sure `specs/editor/blocks/gallery.test.js` passes locally and in CI