### PR TITLE
[RNMobile] - Add waits to fix editor test flakiness

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -2,22 +2,23 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
+import {
+	headingExpectedHTML,
+	imageExpectedHTML,
+	listExpectedHTML,
+	moreExpectedHTML,
+	paragraphExpectedHTML,
+	separatorExpectedHTML,
+} from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'adds new block at the end of post', async () => {
 		await editorPage.addNewBlock( blockNames.heading );
-
 		await editorPage.addNewBlock( blockNames.list );
 
-		const expectedHtml = `<!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:list -->
-<ul><li></li></ul>
-<!-- /wp:list -->`;
-
+		const expectedHtml = `${ headingExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
+
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
@@ -27,22 +28,11 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		);
 
 		await headingBlockElement.click();
-
 		await editorPage.addNewBlock( blockNames.separator );
 
-		const expectedHtml = `<!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:list -->
-<ul><li></li></ul>
-<!-- /wp:list -->`;
-
+		const expectedHtml = `${ headingExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
+
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
@@ -54,83 +44,27 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await separatorBlockElement.click();
 
 		await editorPage.addNewBlock( blockNames.image, 'before' );
-		await editorPage.driver.sleep( 1000 );
 		await editorPage.closePicker();
 
-		const expectedHtml = `<!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:list -->
-<ul><li></li></ul>
-<!-- /wp:list -->`;
-
+		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
+
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
 	it( 'inserts block at the end of post when no block is selected', async () => {
 		await editorPage.addNewBlock( blockNames.more );
 
-		const expectedHtml = `<!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:list -->
-<ul><li></li></ul>
-<!-- /wp:list -->
-
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->`;
-
+		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }\n\n${ moreExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
+
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
 	it( 'creates a new Paragraph block tapping on the empty area below the last block', async () => {
 		await editorPage.addParagraphBlockByTappingEmptyAreaBelowLastBlock();
 
-		const expectedHtml = `<!-- wp:heading -->
-<h2></h2>
-<!-- /wp:heading -->
-
-<!-- wp:image -->
-<figure class="wp-block-image"><img alt=""/></figure>
-<!-- /wp:image -->
-
-<!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:list -->
-<ul><li></li></ul>
-<!-- /wp:list -->
-
-<!-- wp:more -->
-<!--more-->
-<!-- /wp:more -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->`;
-
+		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }\n\n${ moreExpectedHTML }\n\n${ paragraphExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -18,7 +18,6 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		const expectedHtml = `${ headingExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
-
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
@@ -32,7 +31,6 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		const expectedHtml = `${ headingExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
-
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
@@ -48,7 +46,6 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
-
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 
@@ -57,7 +54,6 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 
 		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }\n\n${ moreExpectedHTML }`;
 		const html = await editorPage.getHtmlContent();
-
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
 

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -3,12 +3,12 @@
  */
 import { blockNames } from './pages/editor-page';
 import {
-	headingExpectedHTML,
-	imageExpectedHTML,
-	listExpectedHTML,
-	moreExpectedHTML,
-	paragraphExpectedHTML,
-	separatorExpectedHTML,
+	headerBlockEmpty,
+	imageBlockEmpty,
+	listBlockEmpty,
+	moreBlockEmpty,
+	paragraphBlockEmpty,
+	separatorBlockEmpty,
 } from './helpers/test-data';
 
 describe( 'Gutenberg Editor tests for Block insertion 2', () => {
@@ -16,7 +16,7 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await editorPage.addNewBlock( blockNames.heading );
 		await editorPage.addNewBlock( blockNames.list );
 
-		const expectedHtml = `${ headingExpectedHTML }\n\n${ listExpectedHTML }`;
+		const expectedHtml = `${ headerBlockEmpty }\n\n${ listBlockEmpty }`;
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
@@ -29,7 +29,12 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await headingBlockElement.click();
 		await editorPage.addNewBlock( blockNames.separator );
 
-		const expectedHtml = `${ headingExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
+		const expectedHtml = [
+			headerBlockEmpty,
+			separatorBlockEmpty,
+			listBlockEmpty,
+		].join( '\n\n' );
+
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
@@ -44,7 +49,13 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await editorPage.addNewBlock( blockNames.image, 'before' );
 		await editorPage.closePicker();
 
-		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }`;
+		const expectedHtml = [
+			headerBlockEmpty,
+			imageBlockEmpty,
+			separatorBlockEmpty,
+			listBlockEmpty,
+		].join( '\n\n' );
+
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
@@ -52,7 +63,14 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'inserts block at the end of post when no block is selected', async () => {
 		await editorPage.addNewBlock( blockNames.more );
 
-		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }\n\n${ moreExpectedHTML }`;
+		const expectedHtml = [
+			headerBlockEmpty,
+			imageBlockEmpty,
+			separatorBlockEmpty,
+			listBlockEmpty,
+			moreBlockEmpty,
+		].join( '\n\n' );
+
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );
@@ -60,7 +78,15 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 	it( 'creates a new Paragraph block tapping on the empty area below the last block', async () => {
 		await editorPage.addParagraphBlockByTappingEmptyAreaBelowLastBlock();
 
-		const expectedHtml = `${ headingExpectedHTML }\n\n${ imageExpectedHTML }\n\n${ separatorExpectedHTML }\n\n${ listExpectedHTML }\n\n${ moreExpectedHTML }\n\n${ paragraphExpectedHTML }`;
+		const expectedHtml = [
+			headerBlockEmpty,
+			imageBlockEmpty,
+			separatorBlockEmpty,
+			listBlockEmpty,
+			moreBlockEmpty,
+			paragraphBlockEmpty,
+		].join( '\n\n' );
+
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -16,7 +16,10 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await editorPage.addNewBlock( blockNames.heading );
 		await editorPage.addNewBlock( blockNames.list );
 
-		const expectedHtml = `${ headerBlockEmpty }\n\n${ listBlockEmpty }`;
+		const expectedHtml = [
+			headerBlockEmpty,
+			listBlockEmpty,
+		].join( '\n\n' );
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion-2.test.js
@@ -16,10 +16,9 @@ describe( 'Gutenberg Editor tests for Block insertion 2', () => {
 		await editorPage.addNewBlock( blockNames.heading );
 		await editorPage.addNewBlock( blockNames.list );
 
-		const expectedHtml = [
-			headerBlockEmpty,
-			listBlockEmpty,
-		].join( '\n\n' );
+		const expectedHtml = [ headerBlockEmpty, listBlockEmpty ].join(
+			'\n\n'
+		);
 		const html = await editorPage.getHtmlContent();
 		expect( html.toLowerCase() ).toBe( expectedHtml );
 	} );

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -142,26 +142,26 @@ exports.audioBlockPlaceholder = `<!-- wp:audio {"id":5} -->
 <figure class="wp-block-audio"><audio controls src="https://cldup.com/59IrU0WJtq.mp3"></audio></figure>
 <!-- /wp:audio -->`;
 
-exports.headingExpectedHTML = `<!-- wp:heading -->
+exports.headerBlockEmpty = `<!-- wp:heading -->
 <h2></h2>
 <!-- /wp:heading -->`;
 
-exports.separatorExpectedHTML = `<!-- wp:separator -->
+exports.separatorBlockEmpty = `<!-- wp:separator -->
 <hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->`;
 
-exports.listExpectedHTML = `<!-- wp:list -->
+exports.listBlockEmpty = `<!-- wp:list -->
 <ul><li></li></ul>
 <!-- /wp:list -->`;
 
-exports.imageExpectedHTML = `<!-- wp:image -->
+exports.imageBlockEmpty = `<!-- wp:image -->
 <figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image -->`;
 
-exports.moreExpectedHTML = `<!-- wp:more -->
+exports.moreBlockEmpty = `<!-- wp:more -->
 <!--more-->
 <!-- /wp:more -->`;
 
-exports.paragraphExpectedHTML = `<!-- wp:paragraph -->
+exports.paragraphBlockEmpty = `<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->`;

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -141,3 +141,27 @@ exports.fileBlockPlaceholder = `<!-- wp:file {"id":3,"href":"https://wordpress.o
 exports.audioBlockPlaceholder = `<!-- wp:audio {"id":5} -->
 <figure class="wp-block-audio"><audio controls src="https://cldup.com/59IrU0WJtq.mp3"></audio></figure>
 <!-- /wp:audio -->`;
+
+exports.headingExpectedHTML = `<!-- wp:heading -->
+<h2></h2>
+<!-- /wp:heading -->`;
+
+exports.separatorExpectedHTML = `<!-- wp:separator -->
+<hr class="wp-block-separator"/>
+<!-- /wp:separator -->`;
+
+exports.listExpectedHTML = `<!-- wp:list -->
+<ul><li></li></ul>
+<!-- /wp:list -->`;
+
+exports.imageExpectedHTML = `<!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image -->`;
+
+exports.moreExpectedHTML = `<!-- wp:more -->
+<!--more-->
+<!-- /wp:more -->`;
+
+exports.paragraphExpectedHTML = `<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->`;

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -147,7 +147,7 @@ exports.headingExpectedHTML = `<!-- wp:heading -->
 <!-- /wp:heading -->`;
 
 exports.separatorExpectedHTML = `<!-- wp:separator -->
-<hr class="wp-block-separator"/>
+<hr class="wp-block-separator has-alpha-channel-opacity"/>
 <!-- /wp:separator -->`;
 
 exports.listExpectedHTML = `<!-- wp:list -->

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -622,7 +622,8 @@ class EditorPage {
 	async closePicker() {
 		if ( isAndroid() ) {
 			// Wait for media block picker to load before closing
-			const locator = '//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
+			const locator =
+				'//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
 			await waitForVisible( this.driver, locator );
 
 			await swipeDown( this.driver );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -287,13 +287,6 @@ class EditorPage {
 
 		if ( isAndroid() ) {
 			await blockButton.click();
-
-			// For certain blocks, clicking on it will display additional options that the test should wait for before next steps
-			if ( blockName === 'Image' ) {
-				const locator =
-					'//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
-				await waitForVisible( this.driver, locator );
-			}
 		} else {
 			await this.driver.execute( 'mobile: tap', {
 				element: blockButton,
@@ -322,7 +315,6 @@ class EditorPage {
 		if ( isAndroid() ) {
 			const size = await this.driver.getWindowSize();
 			const x = size.width / 2;
-
 			// Checks if the Block Button is available, and if not will scroll to the second half of the available buttons.
 			while (
 				! ( await this.driver.hasElementByAccessibilityId(
@@ -629,6 +621,10 @@ class EditorPage {
 
 	async closePicker() {
 		if ( isAndroid() ) {
+			// Wait for media block picker to load before closing
+			const locator = '//android.view.ViewGroup[2]/android.view.ViewGroup/android.view.ViewGroup';
+			await waitForVisible( this.driver, locator );
+
 			await swipeDown( this.driver );
 		} else {
 			const cancelButton = await waitForVisible(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds `waitForVisible()` to check that locators are available before continuing the test for all tests on [gutenberg-editor-block-insertion-2.test.js](https://github.com/WordPress/gutenberg/pull/39668/files#diff-248479a7e971959844c83eb10938c6c1495a37e520a18fdf8a6ab60c53948f0e) 

This PR also moved all the test data on that test file to `test-data.js` so that it is consistent with other tests and also if there is a change in the HTML, we would now only need to change it in one place instead of multiple.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The waits are added to ensure that the screen is at the correct stage before the test continues, this will help reduce flakiness.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding `waitForVisible()` to the tests, the test will fail if the locator is not present. 

## Testing Instructions
Ensure that the [gutenberg-editor-block-insertion-2.test.js](https://github.com/WordPress/gutenberg/pull/39668/files#diff-248479a7e971959844c83eb10938c6c1495a37e520a18fdf8a6ab60c53948f0e) test file passes on both local runs and on CI. I've run it 10 times [here](https://app.circleci.com/pipelines/github/wordpress-mobile/gutenberg-mobile?branch=version-toolkit%2Fgutenberg%2Frnmobile%2Feditor-test-fixes&filter=all), while there are failures those are other flaky tests/other reasons. That will be tackled separately in future PRs.

## Screenshots or screencast <!-- if applicable -->
N/A