### PR TITLE
HTML: Use 'Disabled.Context'

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useContext, useState } from '@wordpress/element';
 import {
 	BlockControls,
 	PlainText,
@@ -20,6 +20,7 @@ import { useSelect } from '@wordpress/data';
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	const [ isPreview, setIsPreview ] = useState();
+	const isDisabled = useContext( Disabled.Context );
 
 	const styles = useSelect( ( select ) => {
 		// Default styles used to unset some of the styles
@@ -69,35 +70,26 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			<Disabled.Consumer>
-				{ ( isDisabled ) =>
-					isPreview || isDisabled ? (
-						<>
-							<SandBox
-								html={ attributes.content }
-								styles={ styles }
-							/>
-							{ /*	
-									An overlay is added when the block is not selected in order to register click events. 
-									Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it 
-									difficult to reselect the block. 
-								*/ }
-							{ ! isSelected && (
-								<div className="block-library-html__preview-overlay"></div>
-							) }
-						</>
-					) : (
-						<PlainText
-							value={ attributes.content }
-							onChange={ ( content ) =>
-								setAttributes( { content } )
-							}
-							placeholder={ __( 'Write HTML…' ) }
-							aria-label={ __( 'HTML' ) }
-						/>
-					)
-				}
-			</Disabled.Consumer>
+			{ isPreview || isDisabled ? (
+				<>
+					<SandBox html={ attributes.content } styles={ styles } />
+					{ /*
+							An overlay is added when the block is not selected in order to register click events.
+							Some browsers do not bubble up the clicks from the sandboxed iframe, which makes it
+							difficult to reselect the block.
+						*/ }
+					{ ! isSelected && (
+						<div className="block-library-html__preview-overlay"></div>
+					) }
+				</>
+			) : (
+				<PlainText
+					value={ attributes.content }
+					onChange={ ( content ) => setAttributes( { content } ) }
+					placeholder={ __( 'Write HTML…' ) }
+					aria-label={ __( 'HTML' ) }
+				/>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## What?
PR updates how HTML block reads `isDisabled` context. The block uses context to display HTML preview when viewing examples.

## Why?
Reading context using `Disabled.Context` should be preferred over using the consumer.

## Testing Instructions
1. Open a Post or Page.
2. Open block inserter.
3. Type HTML.
4. Confirm that the `marquee` preview is visible.
