### PR TITLE
@wordpress/date: Fix ordinal token (S), RFC2822 token (r), and timezone offset handling

### DIFF
--- a/packages/date/src/test/index.js
+++ b/packages/date/src/test/index.js
@@ -49,37 +49,65 @@ describe( 'isInTheFuture', () => {
 } );
 
 describe( 'Function date', () => {
-	it( 'should format date in English, ignoring locale settings', () => {
-		const settings = __experimentalGetSettings();
+	test.each( [
+		[ 'j/n/y', '18/6/19' ],
+		[ 'd/m/y', '18/06/19' ],
+		[ 'D j M Y', 'Tue 18 Jun 2019' ],
+		[ 'l jS F Y', 'Tuesday 18th June 2019' ],
+		[ 'N w', '2 2' ],
+		[ 'z', '168' ],
+		[ 'W', '25' ],
+		[ 't', '30' ],
+		[ 'L', '0' ],
+		[ 'o', '2019' ],
+		[ 'g:i a', '11:00 am' ],
+		[ 'h:i A', '11:00 AM' ],
+		[ 'G:i:s', '11:00:00' ],
+		[ 'H:i:s', '11:00:00' ],
+		[ 'B', '499' ],
+		[ 'u', '000000' ],
+		[ 'v', '000' ],
+		[ 'e I T', 'Coordinated Universal Time 0 UTC' ],
+		[ 'O P Z', '+0000 +00:00 0' ],
+		[ 'c', '2019-06-18T11:00:00+00:00' ],
+		[ 'r', 'Tue, 18 Jun 2019 11:00:00 +0000' ],
+		[ 'U', '1560855600' ],
+	] )(
+		'should format date as "%s", ignoring locale settings',
+		( formatString, expected ) => {
+			const settings = __experimentalGetSettings();
 
-		// Simulate different locale.
-		const l10n = settings.l10n;
-		setSettings( {
-			...settings,
-			l10n: {
-				...l10n,
-				locale: 'es',
-				months: l10n.months.map( ( month ) => `es_${ month }` ),
-				monthsShort: l10n.monthsShort.map(
-					( month ) => `es_${ month }`
-				),
-				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
-				weekdaysShort: l10n.weekdaysShort.map(
-					( weekday ) => `es_${ weekday }`
-				),
-			},
-		} );
+			// Simulate different locale.
+			const l10n = settings.l10n;
+			setSettings( {
+				...settings,
+				l10n: {
+					...l10n,
+					locale: 'es',
+					months: l10n.months.map( ( month ) => `es_${ month }` ),
+					monthsShort: l10n.monthsShort.map(
+						( month ) => `es_${ month }`
+					),
+					weekdays: l10n.weekdays.map(
+						( weekday ) => `es_${ weekday }`
+					),
+					weekdaysShort: l10n.weekdaysShort.map(
+						( weekday ) => `es_${ weekday }`
+					),
+				},
+			} );
 
-		// Check.
-		const formattedDate = dateNoI18n(
-			'F M l D',
-			'2019-06-18T11:00:00.000Z'
-		);
-		expect( formattedDate ).toBe( 'June Jun Tuesday Tue' );
+			// Check.
+			const formattedDate = dateNoI18n(
+				formatString,
+				'2019-06-18T11:00:00.000Z'
+			);
+			expect( formattedDate ).toBe( expected );
 
-		// Restore default settings.
-		setSettings( settings );
-	} );
+			// Restore default settings.
+			setSettings( settings );
+		}
+	);
 
 	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
 		const settings = __experimentalGetSettings();
@@ -192,34 +220,65 @@ describe( 'Function date', () => {
 } );
 
 describe( 'Function gmdate', () => {
-	it( 'should format date in English, ignoring locale settings', () => {
-		const settings = __experimentalGetSettings();
+	test.each( [
+		[ 'j/n/y', '18/6/19' ],
+		[ 'd/m/y', '18/06/19' ],
+		[ 'D j M Y', 'Tue 18 Jun 2019' ],
+		[ 'l jS F Y', 'Tuesday 18th June 2019' ],
+		[ 'N w', '2 2' ],
+		[ 'z', '168' ],
+		[ 'W', '25' ],
+		[ 't', '30' ],
+		[ 'L', '0' ],
+		[ 'o', '2019' ],
+		[ 'g:i a', '11:00 am' ],
+		[ 'h:i A', '11:00 AM' ],
+		[ 'G:i:s', '11:00:00' ],
+		[ 'H:i:s', '11:00:00' ],
+		[ 'B', '499' ],
+		[ 'u', '000000' ],
+		[ 'v', '000' ],
+		[ 'e I T', 'Coordinated Universal Time 0 UTC' ],
+		[ 'O P Z', '+0000 +00:00 0' ],
+		[ 'c', '2019-06-18T11:00:00+00:00' ],
+		[ 'r', 'Tue, 18 Jun 2019 11:00:00 +0000' ],
+		[ 'U', '1560855600' ],
+	] )(
+		'should format date as "%s", ignoring locale settings',
+		( formatString, expected ) => {
+			const settings = __experimentalGetSettings();
 
-		// Simulate different locale.
-		const l10n = settings.l10n;
-		setSettings( {
-			...settings,
-			l10n: {
-				...l10n,
-				locale: 'es',
-				months: l10n.months.map( ( month ) => `es_${ month }` ),
-				monthsShort: l10n.monthsShort.map(
-					( month ) => `es_${ month }`
-				),
-				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
-				weekdaysShort: l10n.weekdaysShort.map(
-					( weekday ) => `es_${ weekday }`
-				),
-			},
-		} );
+			// Simulate different locale.
+			const l10n = settings.l10n;
+			setSettings( {
+				...settings,
+				l10n: {
+					...l10n,
+					locale: 'es',
+					months: l10n.months.map( ( month ) => `es_${ month }` ),
+					monthsShort: l10n.monthsShort.map(
+						( month ) => `es_${ month }`
+					),
+					weekdays: l10n.weekdays.map(
+						( weekday ) => `es_${ weekday }`
+					),
+					weekdaysShort: l10n.weekdaysShort.map(
+						( weekday ) => `es_${ weekday }`
+					),
+				},
+			} );
 
-		// Check.
-		const formattedDate = gmdate( 'F M l D', '2019-06-18T11:00:00.000Z' );
-		expect( formattedDate ).toBe( 'June Jun Tuesday Tue' );
+			// Check.
+			const formattedDate = gmdate(
+				formatString,
+				'2019-06-18T11:00:00.000Z'
+			);
+			expect( formattedDate ).toBe( expected );
 
-		// Restore default settings.
-		setSettings( settings );
-	} );
+			// Restore default settings.
+			setSettings( settings );
+		}
+	);
 
 	it( 'should format date into a UTC date', () => {
 		const settings = __experimentalGetSettings();
@@ -240,38 +299,66 @@ describe( 'Function gmdate', () => {
 } );
 
 describe( 'Function dateI18n', () => {
-	it( 'should format date using locale settings', () => {
-		const settings = __experimentalGetSettings();
+	test.each( [
+		[ 'j/n/y', '18/6/19' ],
+		[ 'd/m/y', '18/06/19' ],
+		[ 'D j M Y', 'es_Tue 18 es_Jun 2019' ],
+		[ 'l jS F Y', 'es_Tuesday 18th es_June 2019' ], // Day ordinal should be in English, matching wp_date().
+		[ 'N w', '2 2' ],
+		[ 'z', '168' ],
+		[ 'W', '25' ],
+		[ 't', '30' ],
+		[ 'L', '0' ],
+		[ 'o', '2019' ],
+		[ 'g:i a', '11:00 am' ],
+		[ 'h:i A', '11:00 AM' ],
+		[ 'G:i:s', '11:00:00' ],
+		[ 'H:i:s', '11:00:00' ],
+		[ 'B', '499' ],
+		[ 'u', '000000' ],
+		[ 'v', '000' ],
+		[ 'e I T', 'Coordinated Universal Time 0 UTC' ],
+		[ 'O P Z', '+0000 +00:00 0' ],
+		[ 'c', '2019-06-18T11:00:00+00:00' ],
+		[ 'r', 'Tue, 18 Jun 2019 11:00:00 +0000' ], // Day and month should be in English, as per RFC 2822.
+		[ 'U', '1560855600' ],
+	] )(
+		'should format date as "%s", using locale settings',
+		( formatString, expected ) => {
+			const settings = __experimentalGetSettings();
 
-		// Simulate different locale.
-		const l10n = settings.l10n;
-		setSettings( {
-			...settings,
-			l10n: {
-				...l10n,
-				locale: 'es',
-				months: l10n.months.map( ( month ) => `es_${ month }` ),
-				monthsShort: l10n.monthsShort.map(
-					( month ) => `es_${ month }`
-				),
-				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
-				weekdaysShort: l10n.weekdaysShort.map(
-					( weekday ) => `es_${ weekday }`
-				),
-			},
-		} );
+			// Simulate different locale.
+			const l10n = settings.l10n;
+			setSettings( {
+				...settings,
+				l10n: {
+					...l10n,
+					locale: 'es',
+					months: l10n.months.map( ( month ) => `es_${ month }` ),
+					monthsShort: l10n.monthsShort.map(
+						( month ) => `es_${ month }`
+					),
+					weekdays: l10n.weekdays.map(
+						( weekday ) => `es_${ weekday }`
+					),
+					weekdaysShort: l10n.weekdaysShort.map(
+						( weekday ) => `es_${ weekday }`
+					),
+				},
+			} );
 
-		// Check.
-		const formattedDate = dateI18n(
-			'F M l D',
-			'2019-06-18T11:00:00.000Z',
-			true
-		);
-		expect( formattedDate ).toBe( 'es_June es_Jun es_Tuesday es_Tue' );
+			// Check.
+			const formattedDate = dateI18n(
+				formatString,
+				'2019-06-18T11:00:00.000Z',
+				true
+			);
+			expect( formattedDate ).toBe( expected );
 
-		// Restore default settings.
-		setSettings( settings );
-	} );
+			// Restore default settings.
+			setSettings( settings );
+		}
+	);
 
 	it( 'should format date into a date that uses site’s timezone, if no timezone was provided and there’s a site timezone set', () => {
 		const settings = __experimentalGetSettings();
@@ -422,37 +509,65 @@ describe( 'Function dateI18n', () => {
 } );
 
 describe( 'Function gmdateI18n', () => {
-	it( 'should format date using locale settings', () => {
-		const settings = __experimentalGetSettings();
+	test.each( [
+		[ 'j/n/y', '18/6/19' ],
+		[ 'd/m/y', '18/06/19' ],
+		[ 'D j M Y', 'es_Tue 18 es_Jun 2019' ],
+		[ 'l jS F Y', 'es_Tuesday 18th es_June 2019' ], // Day ordinal should be in English, matching wp_date().
+		[ 'N w', '2 2' ],
+		[ 'z', '168' ],
+		[ 'W', '25' ],
+		[ 't', '30' ],
+		[ 'L', '0' ],
+		[ 'o', '2019' ],
+		[ 'g:i a', '11:00 am' ],
+		[ 'h:i A', '11:00 AM' ],
+		[ 'G:i:s', '11:00:00' ],
+		[ 'H:i:s', '11:00:00' ],
+		[ 'B', '499' ],
+		[ 'u', '000000' ],
+		[ 'v', '000' ],
+		[ 'e I T', 'Coordinated Universal Time 0 UTC' ],
+		[ 'O P Z', '+0000 +00:00 0' ],
+		[ 'c', '2019-06-18T11:00:00+00:00' ],
+		[ 'r', 'Tue, 18 Jun 2019 11:00:00 +0000' ], // Day and month should be in English, as per RFC 2822.
+		[ 'U', '1560855600' ],
+	] )(
+		'should format date as "%s", using locale settings',
+		( formatString, expected ) => {
+			const settings = __experimentalGetSettings();
 
-		// Simulate different locale.
-		const l10n = settings.l10n;
-		setSettings( {
-			...settings,
-			l10n: {
-				...l10n,
-				locale: 'es',
-				months: l10n.months.map( ( month ) => `es_${ month }` ),
-				monthsShort: l10n.monthsShort.map(
-					( month ) => `es_${ month }`
-				),
-				weekdays: l10n.weekdays.map( ( weekday ) => `es_${ weekday }` ),
-				weekdaysShort: l10n.weekdaysShort.map(
-					( weekday ) => `es_${ weekday }`
-				),
-			},
-		} );
+			// Simulate different locale.
+			const l10n = settings.l10n;
+			setSettings( {
+				...settings,
+				l10n: {
+					...l10n,
+					locale: 'es',
+					months: l10n.months.map( ( month ) => `es_${ month }` ),
+					monthsShort: l10n.monthsShort.map(
+						( month ) => `es_${ month }`
+					),
+					weekdays: l10n.weekdays.map(
+						( weekday ) => `es_${ weekday }`
+					),
+					weekdaysShort: l10n.weekdaysShort.map(
+						( weekday ) => `es_${ weekday }`
+					),
+				},
+			} );
 
-		// Check.
-		const formattedDate = gmdateI18n(
-			'F M l D',
-			'2019-06-18T11:00:00.000Z'
-		);
-		expect( formattedDate ).toBe( 'es_June es_Jun es_Tuesday es_Tue' );
+			// Check.
+			const formattedDate = gmdateI18n(
+				formatString,
+				'2019-06-18T11:00:00.000Z'
+			);
+			expect( formattedDate ).toBe( expected );
 
-		// Restore default settings.
-		setSettings( settings );
-	} );
+			// Restore default settings.
+			setSettings( settings );
+		}
+	);
 
 	it( 'should format date into a UTC date', () => {
 		const settings = __experimentalGetSettings();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes three bugs in `@wordpress/date` including https://github.com/WordPress/gutenberg/issues/15221.

1. `wp.date.dateI18n( 'jS' )` should output e.g. `23rd`, but it was outputting `23`.
2. `wp.date.dateI18n( 'r' )` should be in English (per RFC822 spec) when site language is set to a non-English language.
3. `wp.date.format( 'P' )` should be `'+00:00'` when site's timezone offset is `'0'`.

I've also added unit tests for all of the format string characters that `date` and its friends accept.

The fix for https://github.com/WordPress/gutenberg/issues/15221 was my intention. The other two bugs I noticed while writing unit tests.

## Why?

1. WordPress doesn't have enough information about the current locale to translate a date's ordinal, which is why `wp_date( 'jS' )` in PHP always outputs e.g. `23rd` in English even if the site's language is a non-English language. `wp.date.date()` should match the behaviour of `wp_date()` so I did not attempt to fix this. (I have ideas on how we could...)

   Because there isn't any information about the ordinal, we don't set `ordinal` when defining our locale in Moment.js. This means that when Moment.js renders the `jS` token, it will look at the _parent locale_ for information on how to output the ordinal.

   Gutenberg **is** passing `parentLocale` to `moment.updateLocale()`, but this does not work. Only `moment.defineLocale()` accepts `parentLocale`.

2. We were naively translating the `r` token to `ddd, DD MMM YYYY HH:mm:ss ZZ` but that's not right as the day and month shouldn't be localised.

3. `moment.utcOffset()` accepts a string like `'+00:00'` or an integer like `0`. A string like `'0'` is invalid and will cause the created moment instance to be in whatever timezone the user is in.

## How?

1. The fix is to use `defineLocale()` instead of `updateLocale()`.

   Because Core [might have already defined the locale](https://github.com/WordPress/wordpress-develop/blob/d7f9f4405b30be28c026e6a3162b5e0b24f9c8e4/src/wp-includes/script-loader.php#L138), we must delete any existing locale before creating it. We can detect whether it's a locale created by Core or not based on whether it's incorrectly configured. Core (and Gutenberg, until this PR) is setting `LTS`, `L` and `LLLL` to `null` in the locale config, which is not permitted, [according to the type definitions](https://github.com/moment/moment/blob/e96809208c9d1b1bbe22d605e76985770024de42/moment.d.ts#L115).

2. Calling `locale( 'en' )` on the moment instance before rendering it will ensure it's in English.

3. Coercing the site's timezone offset to a number before passing it to `utcOffset` will ensure Moment.js is happy.

## Testing Instructions

Unit tests are included. You could also follow the steps in https://github.com/WordPress/gutenberg/issues/15221 and https://github.com/WordPress/gutenberg/pull/39569.

You could also set your site to a few different languages and make sure dates e.g. in the _Publish_ dropdown look correct.

I ordered the commits in a TDD way so you can `git checkout HEAD^` if you want to see that the new tests I added fail on `trunk`.