### PR TITLE
ColorPalette: Add SlotFillProvider to story to correct tooltip positioning

### DIFF
--- a/packages/components/src/color-palette/stories/index.js
+++ b/packages/components/src/color-palette/stories/index.js
@@ -7,6 +7,8 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import ColorPalette from '../';
+import Popover from '../../popover';
+import { Provider as SlotFillProvider } from '../../slot-fill';
 
 const meta = {
 	title: 'Components/ColorPalette',
@@ -42,7 +44,12 @@ export default meta;
 
 const Template = ( args ) => {
 	const [ color, setColor ] = useState( '#f00' );
-	return <ColorPalette { ...args } value={ color } onChange={ setColor } />;
+	return (
+		<SlotFillProvider>
+			<ColorPalette { ...args } value={ color } onChange={ setColor } />
+			<Popover.Slot />
+		</SlotFillProvider>
+	);
 };
 
 export const Default = Template.bind( {} );


### PR DESCRIPTION
## What?

The positioning of tooltips for the `ColorPalette` storybook example are misaligned. This PR corrects this and brings their positioning more inline with what is seen when the `ColorPalette` is used in the editor.

## Why?

The current story on `trunk` only renders the `ColorPalette` component directly. This means that the story doesn't have a slot fill provider allowing tooltips to be rendered in their correct positions.

## How?

In the `ColorPalette` storybook example, this PR wraps the component in a SlotFill provider and includes the `Popover.Slot` as a sibling.

## Testing Instructions

1. Checkout `trunk` and fire up the storybook, navigating to the [`ColorPalette` component](http://localhost:50240/?path=/story/components-colorpalette--default)
2. Hover over any of the color swatches and notice that the tooltip is misaligned.
3. Checkout this PR branch and take another look at the `ColorPalette`. The tooltips should now be positioned better.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="483" alt="Screen Shot 2022-03-23 at 5 01 47 pm" src="https://user-images.githubusercontent.com/60436221/159644317-abd79795-f327-4aa4-bcae-956e3d35f700.png"> | <img width="372" alt="Screen Shot 2022-03-23 at 5 02 02 pm" src="https://user-images.githubusercontent.com/60436221/159644338-e22cfa08-4131-4d41-8a51-d2e0a9d22f7c.png"> |


