### PR TITLE
Fix Nav block error on toggle of `Advanced` inspector control panel

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { Button, Flex, FlexItem, Modal } from '@wordpress/components';
-import {
-	store as coreStore,
-	useEntityId,
-	useEntityProp,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -15,7 +11,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 	const [ isConfirmModalVisible, setIsConfirmModalVisible ] = useState(
 		false
 	);
-	const id = useEntityId( 'postType', 'wp_navigation' );
+	const [ id ] = useEntityProp( 'postType', 'wp_navigation', 'id' );
 	const [ title ] = useEntityProp( 'postType', 'wp_navigation', 'title' );
 	const { deleteEntityRecord } = useDispatch( coreStore );
 


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a bug whereby the Nav block would crash if the user toggled the `Advanced` panel in the block inspector controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The block crashes if we don't fix this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The block relied on a selector from `@wordpress/core-data` called `useEntityId` which no longer exists 🤷‍♂️ 

This PR updates to use an alternative selector `useEntityProp` to fetch the `id` instead.

## Testing Instructions

- Add Nav block
- Start empty
- Toggle open block inspector controls
- Toggle open the `Advanced` panel 
- See block does not crash 
- Compare with `trunk` where it does crash

## Screenshots or screencast <!-- if applicable -->
