### PR TITLE
Improve feedback on Nav Menu deletion

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -167,6 +167,11 @@ function Navigation( {
 	// the Select Menu dropdown.
 	useNavigationEntities();
 
+	const [ showNavigationMenuDeleteNotice ] = useNavigationNotice( {
+		name: 'block-library/core/navigation/delete',
+		message: __( 'Navigation Menu successfully deleted.' ),
+	} );
+
 	const [
 		showNavigationMenuCreateNotice,
 		hideNavigationMenuCreateNotice,
@@ -794,7 +799,10 @@ function Navigation( {
 						{ hasResolvedCanUserDeleteNavigationMenu &&
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
-									onDelete={ resetToEmptyBlock }
+									onDelete={ () => {
+										resetToEmptyBlock();
+										showNavigationMenuDeleteNotice();
+									} }
 								/>
 							) }
 					</InspectorControls>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -38,7 +38,7 @@ import {
 	Button,
 	Spinner,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 
 /**
@@ -169,7 +169,6 @@ function Navigation( {
 
 	const [ showNavigationMenuDeleteNotice ] = useNavigationNotice( {
 		name: 'block-library/core/navigation/delete',
-		message: __( 'Navigation Menu successfully deleted.' ),
 	} );
 
 	const [
@@ -799,9 +798,17 @@ function Navigation( {
 						{ hasResolvedCanUserDeleteNavigationMenu &&
 							canUserDeleteNavigationMenu && (
 								<NavigationMenuDeleteControl
-									onDelete={ () => {
+									onDelete={ ( deletedMenuTitle = '' ) => {
 										resetToEmptyBlock();
-										showNavigationMenuDeleteNotice();
+										showNavigationMenuDeleteNotice(
+											sprintf(
+												// translators: %s: the name of a menu (e.g. Header navigation).
+												__(
+													'Navigation menu %s successfully deleted.'
+												),
+												deletedMenuTitle
+											)
+										);
 									} }
 								/>
 							) }

--- a/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-delete-control.js
@@ -67,7 +67,7 @@ export default function NavigationMenuDeleteControl( { onDelete } ) {
 										id,
 										{ force: true }
 									);
-									onDelete();
+									onDelete( title );
 								} }
 							>
 								{ __( 'Confirm' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

~⚠️ This PR currently relies on https://github.com/WordPress/gutenberg/pull/39683. Once that is merged this PR will be testable.~ ✅ 

## What?
This PR adds feedback when the user _deletes_ a Navigation menu via the block.

Now when the menu is deleted a notice is displayed providing both auditory and visual confirmation that the operation succeeded.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously when deleting the menu using the Nav block inspector controls under the `Advanced` tab, there was no feedback that the operation had succeeded other than the block returning to a given "resting" state. That's not really good enough. Moreover, it provides zero feedback for users of assistive tech who may not be able to perceive that change.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

When the menu is successfully deleted a message is shown.


## Testing Instructions

- Add Nav block
- Click `Start empty`
- Wait for Nav Menu to be created
- Toggle open `Advanced` panel in block inspector controls.
- Click the `Delete` button 
- See snackbar notice appear when the operation completes.

## Screenshots or screencast <!-- if applicable -->
