### PR TITLE
Formalise deprecation of `useEntityId` hook in favour of `useEntityProviderId`

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { parse, __unstableSerializeAndClean } from '@wordpress/blocks';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -69,6 +70,21 @@ const getEntityContext = ( kind, name ) => {
 export default function EntityProvider( { kind, type: name, id, children } ) {
 	const Provider = getEntityContext( kind, name ).Provider;
 	return <Provider value={ id }>{ children }</Provider>;
+}
+
+/**
+ * Hook that returns the ID for the nearest
+ * provided entity of the specified type.
+ *
+ * @param {string} kind The entity kind.
+ * @param {string} type The entity type.
+ */
+export function useEntityId( kind, type ) {
+	deprecated( 'the @wordpress/core-data useEntityId() hook', {
+		since: '6.0',
+		alternative: 'the @wordpress/core-data useEntityProviderId() hook',
+	} );
+	return useEntityProviderId( kind, type );
 }
 
 /**

--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -76,6 +76,8 @@ export default function EntityProvider( { kind, type: name, id, children } ) {
  * Hook that returns the ID for the nearest
  * provided entity of the specified type.
  *
+ * @deprecated since 12.9. Callers should use the useEntityProviderId hook instead.
+ *
  * @param {string} kind The entity kind.
  * @param {string} type The entity type.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/39683

This PR fully handles the formal deprecation of `useEntityId` in favour of `useEntityProviderId`. This was undertaken in https://github.com/WordPress/gutenberg/pull/39349/ but that PR didn't handle the deprecation process.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This hook is [part of the public API of `@wordpress/core-data`](https://github.com/WordPress/gutenberg/blob/f6af763e3b1cc1701112b761f3155c53403bfe3d/packages/core-data/src/index.js#L73) but it has been removed in favour of `useEntityProviderId` without the formal deprecation process.

This was [caught as part of a fix to the Navigation block](https://github.com/WordPress/gutenberg/pull/39349/#discussion_r832975278) which broke when the hook was removed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR

- restores the hook to the public API of `@wordpress/core-data`
- proxies any calls to the new hook (which accepts the same args)
- adds a formal `deprecation()` call.

I believe the change of arg signature from `type` to `name` is purely nomenclature, but it would be worth validating I have understood this correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add Nav block
- Click `Start empty`
- Toggle open `Advanced` panel of block's Inspector controls
- The block should not crash (currently on `trunk` it crashes)
- Add "deprecation" warning should be shown in the devtools console - check this reads well and is accurate

## Screenshots or screencast <!-- if applicable -->

<img width="1211" alt="Screen Shot 2022-03-23 at 09 32 54" src="https://user-images.githubusercontent.com/444434/159667990-d6bb3b5c-fff0-47bb-9839-36c0031e23a8.png">

