### PR TITLE
Revert renaming of useEntityId hook

### DIFF
--- a/packages/core-data/src/entity-provider.js
+++ b/packages/core-data/src/entity-provider.js
@@ -78,7 +78,7 @@ export default function EntityProvider( { kind, type: name, id, children } ) {
  * @param {string} kind The entity kind.
  * @param {string} name The entity name.
  */
-export function useEntityProviderId( kind, name ) {
+export function useEntityId( kind, name ) {
 	return useContext( getEntityContext( kind, name ) );
 }
 
@@ -100,7 +100,7 @@ export function useEntityProviderId( kind, name ) {
  * 							  `protected` props.
  */
 export function useEntityProp( kind, name, prop, _id ) {
-	const providerId = useEntityProviderId( kind, name );
+	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 
 	const { value, fullValue } = useSelect(
@@ -151,7 +151,7 @@ export function useEntityProp( kind, name, prop, _id ) {
  * @return {[WPBlock[], Function, Function]} The block array and setters.
  */
 export function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
-	const providerId = useEntityProviderId( kind, name );
+	const providerId = useEntityId( kind, name );
 	const id = _id ?? providerId;
 	const { content, blocks } = useSelect(
 		( select ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Alternative to https://github.com/WordPress/gutenberg/pull/39681.

This PR reverts the renaming of `useEntityId` back to the original.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This hook is [part of the public API of `@wordpress/core-data`](https://github.com/WordPress/gutenberg/blob/f6af763e3b1cc1701112b761f3155c53403bfe3d/packages/core-data/src/index.js#L73) but it has been removed in favour of `useEntityProviderId` without the formal deprecation process.

This was [caught as part of a fix to the Navigation block](https://github.com/WordPress/gutenberg/pull/39349/#discussion_r832975278) which broke when the hook was removed.

It has been suggested that renaming to include the "provider" term exposes implementation details to the consumer. 

As the folks who worked on the original PR aren't available right now, it was deemed the simplest option simply to revert the rename of this one hook for now. @adamziel can always resubmit a PR to rename again later.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR takes the approach suggested by @youknowriad in https://github.com/WordPress/gutenberg/pull/39681#discussion_r833051816 which is simply to rename the hook back to the original.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add Nav block
- Click `Start empty`
- Toggle open `Advanced` panel of block's Inspector controls
- The block should not crash (currently on `trunk` it crashes)

## Screenshots or screencast <!-- if applicable -->
