### PR TITLE
Buttons block: fix focus on insert

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -73,8 +73,14 @@ function isFormElement( element ) {
 export function useFocusFirstElement( clientId ) {
 	const ref = useRef();
 	const initialPosition = useInitialPosition( clientId );
+	const { isBlockSelected } = useSelect( blockEditorStore );
 
 	useEffect( () => {
+		// Check if the block is still selected at the time this effect runs.
+		if ( ! isBlockSelected( clientId ) ) {
+			return;
+		}
+
 		if ( initialPosition === undefined || initialPosition === null ) {
 			return;
 		}
@@ -127,7 +133,7 @@ export function useFocusFirstElement( clientId ) {
 		setContentEditableWrapper( ref.current, false );
 
 		placeCaretAtHorizontalEdge( target, isReverse );
-	}, [ initialPosition ] );
+	}, [ initialPosition, clientId ] );
 
 	return ref;
 }

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/buttons.test.js.snap
@@ -16,6 +16,14 @@ exports[`Buttons dismisses link editor when escape is pressed 1`] = `
 <!-- /wp:buttons -->"
 `;
 
+exports[`Buttons has focus on button content (slash inserter) 1`] = `
+"<!-- wp:buttons -->
+<div class=\\"wp-block-buttons\\"><!-- wp:button -->
+<div class=\\"wp-block-button\\"><a class=\\"wp-block-button__link\\">Content</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->"
+`;
+
 exports[`Buttons has focus on button content 1`] = `
 "<!-- wp:buttons -->
 <div class=\\"wp-block-buttons\\"><!-- wp:button -->

--- a/packages/e2e-tests/specs/editor/blocks/buttons.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/buttons.test.js
@@ -6,6 +6,7 @@ import {
 	getEditedPostContent,
 	createNewPost,
 	pressKeyWithModifier,
+	clickBlockAppender,
 } from '@wordpress/e2e-test-utils';
 
 describe( 'Buttons', () => {
@@ -15,6 +16,15 @@ describe( 'Buttons', () => {
 
 	it( 'has focus on button content', async () => {
 		await insertBlock( 'Buttons' );
+		await page.keyboard.type( 'Content' );
+
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
+	it( 'has focus on button content (slash inserter)', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '/buttons' );
+		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Content' );
 
 		expect( await getEditedPostContent() ).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The button block uses `templateInsertUpdatesSelection`, but it currently doesn't move focus to the first button block. This is because there are two actions dispatched. First, `REPLACE_BLOCKS` inserts the wrapper block (buttons) and selects that block. Then after a small delay, `REPLACE_INNER_BLOCKS` is dispatched to insert the button block and select that block. But right before that, `useFocusFirstElement` is called and places focus on the wrapper (to reflect what was in the store previously). Because what gets focussed (wrapper) and what is selected in the store (button), `SELECT_BLOCK` is now dispatched to update the selection to reflect what is focussed.

The problem here is that `useFocusFirstElement` is also called with a delay (useEffect) while the information it got from the store may no longer be fresh. Double checking if the correct block is still selected fixes the issue. If by the time the `useFocusFirstElement` hook runs and according to the store the child block (button) is now selected, it must no longer focus the wrapper.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
