### PR TITLE
Wrap title of block in `<ListView>` in a span

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -69,7 +69,7 @@ function ListViewBlockSelectButton(
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
-				<span className="block-editor-list-view-block__title">
+				<span className="block-editor-list-view-block-select-button__title">
 					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
 				</span>
 				{ blockInformation?.anchor && (

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -69,7 +69,9 @@ function ListViewBlockSelectButton(
 			>
 				<ListViewExpander onClick={ onToggleExpanded } />
 				<BlockIcon icon={ blockInformation?.icon } showColors />
-				<BlockTitle clientId={ clientId } maximumLength={ 35 } />
+				<span className="block-editor-list-view-block__title">
+					<BlockTitle clientId={ clientId } maximumLength={ 35 } />
+				</span>
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">
 						{ blockInformation.anchor }

--- a/packages/e2e-test-utils/README.md
+++ b/packages/e2e-test-utils/README.md
@@ -406,6 +406,18 @@ _Returns_
 
 -   `Promise`: Promise resolving with post content markup.
 
+### getListViewBlocks
+
+Gets all block anchor nodes in the list view that match a given block name label.
+
+_Parameters_
+
+-   _blockLabel_ `string`: the label of the block as displayed in the ListView.
+
+_Returns_
+
+-   `Promise`: all the blocks anchor nodes matching the lable in the ListView.
+
 ### getOption
 
 Returns a site option, from the options admin page.

--- a/packages/e2e-test-utils/src/get-list-view-blocks.js
+++ b/packages/e2e-test-utils/src/get-list-view-blocks.js
@@ -1,0 +1,11 @@
+/**
+ * Gets all block anchor nodes in the list view that match a given block name label.
+ *
+ * @param {string} blockLabel the label of the block as displayed in the ListView.
+ * @return {Promise} all the blocks anchor nodes matching the lable in the ListView.
+ */
+export async function getListViewBlocks( blockLabel ) {
+	return page.$x(
+		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
+	);
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -37,6 +37,7 @@ export { getAvailableBlockTransforms } from './get-available-block-transforms';
 export { getBlockSetting } from './get-block-setting';
 export { getEditedPostContent } from './get-edited-post-content';
 export { getCurrentPostContent } from './get-current-post-content';
+export { getListViewBlocks } from './get-list-view-blocks';
 export { hasBlockSwitcher } from './has-block-switcher';
 export { getPageError } from './get-page-error';
 export { getOption } from './get-option';

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -9,6 +9,12 @@ import {
 	closeGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 
+async function getListViewBlocks( blockLabel ) {
+	return page.$x(
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
+	);
+}
+
 describe( 'Columns', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -19,10 +25,9 @@ describe( 'Columns', () => {
 		await closeGlobalBlockInserter();
 		await page.click( '[aria-label="Two columns; equal split"]' );
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
+
 		const columnBlockMenuItem = (
-			await page.$x(
-				'//a[contains(concat(" ", @class, " "), " block-editor-list-view-block-select-button ")][text()="Column"]'
-			)
+			await getListViewBlocks( 'Column' )
 		 )[ 0 ];
 		await columnBlockMenuItem.click();
 		await openGlobalBlockInserter();

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -11,7 +11,7 @@ import {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -7,13 +7,8 @@ import {
 	insertBlock,
 	openGlobalBlockInserter,
 	closeGlobalBlockInserter,
+	getListViewBlocks,
 } from '@wordpress/e2e-test-utils';
-
-async function getListViewBlocks( blockLabel ) {
-	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
-	);
-}
 
 describe( 'Columns', () => {
 	beforeEach( async () => {

--- a/packages/e2e-tests/specs/editor/blocks/columns.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/columns.test.js
@@ -11,7 +11,7 @@ import {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -40,7 +40,7 @@ async function upload( selector ) {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -38,6 +38,12 @@ async function upload( selector ) {
 	return filename;
 }
 
+async function getListViewBlocks( blockLabel ) {
+	return page.$x(
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
+	);
+}
+
 describe( 'Gallery', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -63,9 +69,8 @@ describe( 'Gallery', () => {
 		// The Gallery needs to be selected from the List view panel due to the
 		// way that Image uploads take and lose focus.
 		await openListView();
-		const galleryListLink = await page.waitForXPath(
-			`//a[contains(text(), 'Gallery')]`
-		);
+
+		const galleryListLink = ( await getListViewBlocks( 'Gallery' ) )[ 0 ];
 		await galleryListLink.click();
 
 		await page.click( '.wp-block-gallery .blocks-gallery-caption' );

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -104,14 +104,14 @@ describe( 'Gallery', () => {
 		// way that Image uploads take and lose focus.
 		await openListView();
 
-		// const galleryListViewItem = await page.waitForXPath(
-		// 	`//a[contains(text(), 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
-		// );
 		// Due to collapsed state of ListView nodes Gallery must be expanded to reveal the child blocks.
-		const galleryListViewItem = (
-			await getListViewBlocks( 'Gallery' )
-		 )[ 0 ];
-		await galleryListViewItem.click();
+		// This xpath selects the anchor node for the block which has a child span which contains the text
+		// label of the block and then selects the expander span for that node.
+		const galleryExpander = await page.waitForXPath(
+			`//a[span[text()='Gallery']]/span[contains(@class, 'block-editor-list-view__expander')]`
+		);
+
+		await galleryExpander.click();
 
 		const imageListLink = ( await getListViewBlocks( 'Image' ) )[ 0 ];
 		await imageListLink.click();

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -40,7 +40,7 @@ async function upload( selector ) {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -104,14 +104,16 @@ describe( 'Gallery', () => {
 		// way that Image uploads take and lose focus.
 		await openListView();
 
-		const galleryListViewItem = await page.waitForXPath(
-			`//a[contains(text(), 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
-		);
+		// const galleryListViewItem = await page.waitForXPath(
+		// 	`//a[contains(text(), 'Gallery')]/span[contains(@class, 'block-editor-list-view__expander')]`
+		// );
+		// Due to collapsed state of ListView nodes Gallery must be expanded to reveal the child blocks.
+		const galleryListViewItem = (
+			await getListViewBlocks( 'Gallery' )
+		 )[ 0 ];
 		await galleryListViewItem.click();
 
-		const imageListLink = await page.waitForXPath(
-			`//a[contains(text(), 'Image')]`
-		);
+		const imageListLink = ( await getListViewBlocks( 'Image' ) )[ 0 ];
 		await imageListLink.click();
 
 		const captionElement = await figureElement.$(

--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -15,6 +15,7 @@ import {
 	createNewPost,
 	clickButton,
 	openListView,
+	getListViewBlocks,
 } from '@wordpress/e2e-test-utils';
 
 async function upload( selector ) {
@@ -36,12 +37,6 @@ async function upload( selector ) {
 		`.wp-block-gallery img[src$="${ filename }.png"]`
 	);
 	return filename;
-}
-
-async function getListViewBlocks( blockLabel ) {
-	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
-	);
 }
 
 describe( 'Gallery', () => {

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -78,10 +78,10 @@ describe( 'Navigating the block hierarchy', () => {
 		);
 
 		// Navigate to the last column block.
-		const lastColumnsBlockMenuItem = (
-			await await getListViewBlocks( 'Column' )
-		 )[ 3 ];
-		await lastColumnsBlockMenuItem.click();
+		const lastColumnBlockMenuItem = (
+			await getListViewBlocks( 'Column' )
+		 )[ 2 ];
+		await lastColumnBlockMenuItem.click();
 
 		// Insert text in the last column block.
 		await page.keyboard.press( 'ArrowDown' ); // Navigate to inserter.

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -30,6 +30,12 @@ async function tabToColumnsControl() {
 	} while ( ! isColumnsControl );
 }
 
+async function selectBlocksInListView( blockLabel ) {
+	return await page.$x(
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and contains(text(), ${ blockLabel })]`
+	);
+}
+
 describe( 'Navigating the block hierarchy', () => {
 	beforeEach( async () => {
 		await createNewPost();
@@ -49,12 +55,11 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Navigate to the columns blocks.
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
-		const columnsBlockMenuItem = (
-			await page.$x(
-				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Columns')]"
-			)
+
+		const firstColumnsBlockMenuItem = (
+			await selectBlocksInListView( 'Columns' )
 		 )[ 0 ];
-		await columnsBlockMenuItem.click();
+		await firstColumnsBlockMenuItem.click();
 
 		// Tweak the columns count.
 		await openDocumentSettingsSidebar();
@@ -74,9 +79,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Navigate to the last column block.
 		const lastColumnsBlockMenuItem = (
-			await page.$x(
-				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Column')]"
-			)
+			await await selectBlocksInListView( 'Column' )
 		 )[ 3 ];
 		await lastColumnsBlockMenuItem.click();
 
@@ -186,11 +189,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Try selecting the group block using the Outline.
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
-		const groupMenuItem = (
-			await page.$x(
-				"//a[contains(@class,'block-editor-list-view-block-select-button') and contains(text(), 'Group')]"
-			)
-		 )[ 0 ];
+		const groupMenuItem = ( await selectBlocksInListView( 'Group' ) )[ 0 ];
 		await groupMenuItem.click();
 
 		// The group block's wrapper should be selected.

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -30,9 +30,9 @@ async function tabToColumnsControl() {
 	} while ( ! isColumnsControl );
 }
 
-async function selectBlocksInListView( blockLabel ) {
-	return await page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and contains(text(), ${ blockLabel })]`
+async function getListViewBlocks( blockLabel ) {
+	return page.$x(
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
 	);
 }
 
@@ -57,7 +57,7 @@ describe( 'Navigating the block hierarchy', () => {
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
 
 		const firstColumnsBlockMenuItem = (
-			await selectBlocksInListView( 'Columns' )
+			await getListViewBlocks( 'Columns' )
 		 )[ 0 ];
 		await firstColumnsBlockMenuItem.click();
 
@@ -79,7 +79,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Navigate to the last column block.
 		const lastColumnsBlockMenuItem = (
-			await await selectBlocksInListView( 'Column' )
+			await await getListViewBlocks( 'Column' )
 		 )[ 3 ];
 		await lastColumnsBlockMenuItem.click();
 
@@ -189,7 +189,7 @@ describe( 'Navigating the block hierarchy', () => {
 
 		// Try selecting the group block using the Outline.
 		await page.click( '.edit-post-header-toolbar__list-view-toggle' );
-		const groupMenuItem = ( await selectBlocksInListView( 'Group' ) )[ 0 ];
+		const groupMenuItem = ( await getListViewBlocks( 'Group' ) )[ 0 ];
 		await groupMenuItem.click();
 
 		// The group block's wrapper should be selected.

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -32,7 +32,7 @@ async function tabToColumnsControl() {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
 	);
 }
 

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -8,6 +8,7 @@ import {
 	pressKeyTimes,
 	pressKeyWithModifier,
 	openDocumentSettingsSidebar,
+	getListViewBlocks,
 } from '@wordpress/e2e-test-utils';
 
 async function openListViewSidebar() {
@@ -28,12 +29,6 @@ async function tabToColumnsControl() {
 			);
 		} );
 	} while ( ! isColumnsControl );
-}
-
-async function getListViewBlocks( blockLabel ) {
-	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
-	);
 }
 
 describe( 'Navigating the block hierarchy', () => {

--- a/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
+++ b/packages/e2e-tests/specs/editor/various/block-hierarchy-navigation.test.js
@@ -32,7 +32,7 @@ async function tabToColumnsControl() {
 
 async function getListViewBlocks( blockLabel ) {
 	return page.$x(
-		`//table[contains(@aria-label,'Block navigation structure')]//span[contains(@class,'block-editor-list-view-block-select-button__title') and text()='${ blockLabel }']`
+		`//table[contains(@aria-label,'Block navigation structure')]//a[span[text()='${ blockLabel }']]`
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracts changes from https://github.com/WordPress/gutenberg/pull/39290/ into this dedicated PR.

Wraps the title of the block shown within the list view in a `<span>` in order to afford the ability to target via CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently you cannot directly target the name of the block with CSS. This is sometimes necessary - for example in https://github.com/WordPress/gutenberg/pull/39290/ we needed to alter the alignment of the block name to accommodate the wrapping of long block titles. We were unable to do this until the span was added.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wraps the block title in a span with a classname.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open List View
- See the name of the block is wrapped in `<span>`.
- Check for obvious visual regressions.

## Screenshots or screencast <!-- if applicable -->
<img width="881" alt="Screen Shot 2022-03-23 at 11 49 39" src="https://user-images.githubusercontent.com/444434/159692772-3935e271-32f8-4df9-867a-d5518e68a7e5.png">

