### PR TITLE
Sidebar: update post editor help links to use newer documentation

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-link/index.js
+++ b/packages/edit-post/src/components/sidebar/post-link/index.js
@@ -97,7 +97,7 @@ function PostLink( {
 						{ __( 'The last part of the URL.' ) }{ ' ' }
 						<ExternalLink
 							href={ __(
-								'https://wordpress.org/support/article/writing-posts/#post-field-descriptions'
+								'https://wordpress.org/support/article/settings-sidebar/#permalink'
 							) }
 						>
 							{ __( 'Read about permalinks' ) }

--- a/packages/editor/src/components/post-excerpt/index.js
+++ b/packages/editor/src/components/post-excerpt/index.js
@@ -21,7 +21,9 @@ function PostExcerpt( { excerpt, onUpdateExcerpt } ) {
 				value={ excerpt }
 			/>
 			<ExternalLink
-				href={ __( 'https://wordpress.org/support/article/excerpt/' ) }
+				href={ __(
+					'https://wordpress.org/support/article/settings-sidebar/#excerpt'
+				) }
 			>
 				{ __( 'Learn more about manual excerpts' ) }
 			</ExternalLink>


### PR DESCRIPTION
## What?
There are two links to WordPress.org documentation that I believe could be better linked. I am proposing to change:

| From | To |
| - | - |
| https://wordpress.org/support/article/excerpt/ | https://wordpress.org/support/article/settings-sidebar/#excerpt |
| https://wordpress.org/support/article/writing-posts/#post-field-descriptions | https://wordpress.org/support/article/settings-sidebar/#permalink |

## Why?
### Permalink
This link is currently a bit out of date as it pertains to the Classic editor. The article gives very few information to the user about the component they just clicked on. The link gives context to the exact element they clicked on and has links to more details if they want.

### Excerpt
While the link is relevant in general and up-to-date, the new link provides a better summary and is within the context of the element they just clicked. This new article also has links to the previous one in case the user wants more details.

## How?
Manually change the URL for each component.

## Testing Instructions
1. Go to the editor
2. In the sidebar click the help links
3. You should go to the new articles

## Screenshots or screencast <!-- if applicable -->
<img width="546" alt="Markup 2022-03-23 at 13 01 08" src="https://user-images.githubusercontent.com/33258733/159694638-1949e359-7ed9-4eae-8dc3-a110fc0e6e5b.png">

