### PR TITLE
Fix Gallery block flaky test image captions

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/gallery.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/gallery.test.js
@@ -88,6 +88,12 @@ describe( 'Gallery', () => {
 		// The Image needs to be selected from the List view panel due to the
 		// way that Image uploads take and lose focus.
 		await openListView();
+
+		const galleryListViewItem = await page.waitForXPath(
+			`//a[contains(text(), 'Gallery')]`
+		);
+		await galleryListViewItem.click();
+
 		const imageListLink = await page.waitForXPath(
 			`//a[contains(text(), 'Image')]`
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/39533

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

With the ListView now collapsed by default the Image block is not revealed by default in the ListView.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The test now clicks on the Gallery block to expand it within the ListView before attempting to select the Image block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
