### PR TITLE
[RNMobile] Remove error banners from native media&text and audio blocks

### DIFF
--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -66,10 +66,6 @@ function AudioEdit( {
 
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const onError = () => {
-		createErrorNotice( __( 'Failed to insert audio file.' ) );
-	};
-
 	function toggleAttribute( attribute ) {
 		return ( newValue ) => {
 			setAttributes( { [ attribute ]: newValue } );
@@ -144,7 +140,6 @@ function AudioEdit( {
 			<MediaUploadProgress
 				mediaId={ id }
 				onFinishMediaUploadWithSuccess={ onFileChange }
-				onFinishMediaUploadWithFailure={ onError }
 				onMediaUploadStateReset={ onFileChange }
 				containerStyle={ styles.progressContainer }
 				progressBarStyle={ styles.progressBar }

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -26,8 +26,6 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { isURL, getProtocol } from '@wordpress/url';
 import { compose, withPreferredColorScheme } from '@wordpress/compose';
-import { withDispatch } from '@wordpress/data';
-import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -152,10 +150,6 @@ class MediaContainer extends Component {
 	}
 
 	finishMediaUploadWithFailure() {
-		const { createErrorNotice } = this.props;
-
-		createErrorNotice( __( 'Failed to insert media.' ) );
-
 		this.setState( { isUploadInProgress: false } );
 	}
 
@@ -381,11 +375,4 @@ class MediaContainer extends Component {
 	}
 }
 
-export default compose( [
-	withDispatch( ( dispatch ) => {
-		const { createErrorNotice } = dispatch( noticesStore );
-
-		return { createErrorNotice };
-	} ),
-	withPreferredColorScheme,
-] )( MediaContainer );
+export default compose( [ withPreferredColorScheme ] )( MediaContainer );

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,8 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+-   [*] Remove banner error notification on upload failure [#39694]
+
 ## 1.73.0
 
 -   [*] Update react-native-reanimated version to 2.4.1 [#39430]


### PR DESCRIPTION
## What?
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4247 by removing the error banner that appeared at the top of the screen when an upload failed on native in the Media&Text or Audio blocks.

## Why?
The error information is already contained within the block itself and WPAndroid also sends a second error banner already.

## How?
Removing the calls to `createErrorNotice`.

## Testing Instructions

Perform the following with both the (1) Audio and (2) Media&Text blocks:
1. Open a new post
2. Add the relevant block being tested
3. Turn on Airplane mode
4. Add a media item from the device to the block
5. Observe that there is **not** a banner across the _top_ of the screen with the error. WPAndroid will display an error message across the bottom of the screen, and the block itself should reflect the error on both Android and iOS.

Before | After
--- | ---
![extra_error-before](https://user-images.githubusercontent.com/4656348/159719910-95d3364c-d926-4c4f-969c-4e576f3df9a8.png) | ![extra_error-after](https://user-images.githubusercontent.com/4656348/159719917-e9cf97ff-edf1-437f-be79-824f959b38a8.png) |

_Note that WPiOS does not display the bottom banner shown in the screenshots._

