### PR TITLE
Remove Cameron from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,9 +119,9 @@
 /packages/plugins                               @gziolo @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @ellatrix @cameronvoell
-/packages/rich-text                             @ellatrix @cameronvoell
-/packages/block-editor/src/components/rich-text @ellatrix @cameronvoell
+/packages/format-library                        @ellatrix
+/packages/rich-text                             @ellatrix
+/packages/block-editor/src/components/rich-text @ellatrix
 
 # Project Management
 /.github


### PR DESCRIPTION
## What?
Removing @cameronvoell as a codeowner.

## Why?
Cameron is not actively working on this project anymore.
