### PR TITLE
Remove Antonis as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -133,7 +133,7 @@
 # PHP
 /lib                                                                 @timothybjacobs @spacedmonkey
 /lib/global-styles.php                                               @timothybjacobs @spacedmonkey @oandregal
-/lib/class-wp-rest-block-editor-settings-controller.php              @timothybjacobs @spacedmonkey @geriux @antonis
+/lib/class-wp-rest-block-editor-settings-controller.php              @timothybjacobs @spacedmonkey @geriux
 /lib/compat/wordpress-5.9/theme.json                                 @timothybjacobs @spacedmonkey @oandregal
 /lib/compat/wordpress-5.9/theme-i18n.json                            @timothybjacobs @spacedmonkey @oandregal
 /lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php          @timothybjacobs @spacedmonkey @oandregal
@@ -146,7 +146,7 @@
 /lib/service-worker.js                          @ellatrix
 
 # Native
-/packages/components/src/mobile/global-styles-context                @geriux @antonis
+/packages/components/src/mobile/global-styles-context                @geriux
 
 # Native (Unowned)
 *.native.js


### PR DESCRIPTION
## What?
Removing @antonis  as a codeowner.

## Why?
Antonis is not actively working on this project anymore.