### PR TITLE
Link directly to files stored in the Media Library using the Link UI

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -153,6 +153,27 @@ const fetchLinkSuggestions = async (
 		);
 	}
 
+	if ( ! type || type === 'media' ) {
+		queries.push(
+			apiFetch( {
+				path: addQueryArgs( '/wp/v2/media', {
+					search,
+					page,
+					per_page: perPage,
+				} ),
+			} )
+				.then( ( results ) => {
+					return results.map( ( result ) => {
+						return {
+							...result,
+							meta: { kind: 'media' },
+						};
+					} );
+				} )
+				.catch( () => [] )
+		);
+	}
+
 	return Promise.all( queries ).then( ( results ) => {
 		return results
 			.reduce(
@@ -173,12 +194,17 @@ const fetchLinkSuggestions = async (
 				 * @param {{ id: number, meta?: object, url:string, title?:string, subtype?: string, type?: string }} result
 				 */
 				( result ) => {
+					const isMedia = result.type === 'attachment';
+
 					return {
 						id: result.id,
-						url: result.url,
+						url: isMedia ? result.source_url : result.url,
 						title:
-							decodeEntities( result.title || '' ) ||
-							__( '(no title)' ),
+							decodeEntities(
+								isMedia
+									? result.title.rendered
+									: result.title || ''
+							) || __( '(no title)' ),
 						type: result.subtype || result.type,
 						kind: result?.meta?.kind,
 					};

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -126,7 +126,7 @@ const fetchLinkSuggestions = async (
 						};
 					} );
 				} )
-				.catch( () => [] )
+				.catch( () => [] ) // Fail by returning no results.
 		);
 	}
 
@@ -149,7 +149,7 @@ const fetchLinkSuggestions = async (
 						};
 					} );
 				} )
-				.catch( () => [] )
+				.catch( () => [] ) // Fail by returning no results.
 		);
 	}
 
@@ -170,7 +170,7 @@ const fetchLinkSuggestions = async (
 						};
 					} );
 				} )
-				.catch( () => [] )
+				.catch( () => [] ) // Fail by returning no results.
 		);
 	}
 

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js
@@ -153,7 +153,7 @@ const fetchLinkSuggestions = async (
 		);
 	}
 
-	if ( ! type || type === 'media' ) {
+	if ( ! type || type === 'attachment' ) {
 		queries.push(
 			apiFetch( {
 				path: addQueryArgs( '/wp/v2/media', {

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -75,7 +75,7 @@ jest.mock( '@wordpress/api-fetch', () =>
 					{
 						id: 54,
 						title: {
-							rendered: 'Media',
+							rendered: 'Some Test Media Title',
 						},
 						type: 'attachment',
 						source_url:
@@ -174,7 +174,7 @@ describe( 'fetchLinkSuggestions', () => {
 			expect( suggestions ).toEqual( [
 				{
 					id: 54,
-					title: 'Media',
+					title: 'Some Test Media Title',
 					url:
 						'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
 					type: 'attachment',
@@ -224,7 +224,7 @@ describe( 'fetchLinkSuggestions', () => {
 				},
 				{
 					id: 54,
-					title: 'Media',
+					title: 'Some Test Media Title',
 					url:
 						'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
 					type: 'attachment',

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -70,6 +70,18 @@ jest.mock( '@wordpress/api-fetch', () =>
 						subtype: 'page',
 					},
 				] );
+			case '/wp/v2/media?search=&per_page=20':
+				return Promise.resolve( [
+					{
+						id: 54,
+						title: {
+							rendered: 'Media',
+						},
+						type: 'attachment',
+						source_url:
+							'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
+					},
+				] );
 			default:
 				return Promise.resolve( [
 					{
@@ -154,7 +166,25 @@ describe( 'fetchLinkSuggestions', () => {
 			{ disablePostFormats: true }
 		).then( ( suggestions ) => expect( suggestions ).toEqual( [] ) );
 	} );
-	it( 'returns suggestions from post, term, and post-format', () => {
+
+	it( 'filters suggestions by attachment', () => {
+		return fetchLinkSuggestions( '', {
+			type: 'attachment',
+		} ).then( ( suggestions ) =>
+			expect( suggestions ).toEqual( [
+				{
+					id: 54,
+					title: 'Media',
+					url:
+						'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
+					type: 'attachment',
+					kind: 'media',
+				},
+			] )
+		);
+	} );
+
+	it( 'returns suggestions from post, term, post-format and media', () => {
 		return fetchLinkSuggestions( '', {} ).then( ( suggestions ) =>
 			expect( suggestions ).toEqual( [
 				{
@@ -191,6 +221,14 @@ describe( 'fetchLinkSuggestions', () => {
 					url: 'http://wordpress.local/type/quote/',
 					type: 'post-format',
 					kind: 'taxonomy',
+				},
+				{
+					id: 54,
+					title: 'Media',
+					url:
+						'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
+					type: 'attachment',
+					kind: 'media',
 				},
 			] )
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR includes media files (attachments) in the results returned by `__experimentalFetchLinkSuggestions`. This means that you can search for and see results for media files in the Link UI.

This means you can now link _directly_ to files that have been uploaded to the WordPress Media library.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many folks want to be able to link to a Media file directly from the Link UI. Currently [this is not possible](https://github.com/WordPress/gutenberg/issues/8322) without significant workarounds.

A key use case is the ability to link to previously uploaded PDFs which is a very common requirements.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR appends an additional query which makes a request to the [Media REST endpoint](https://developer.wordpress.org/rest-api/reference/media/) using the `search` query parameter to find attachments which match the given query.

Given that the Search and Media endpoints are very similar it's then simple enough to normalize the results into the format expected to be returned by `__experimentalFetchLinkSuggestions`.

The result of this is that you can now search for media files directly from the Link UI.

Please note: this PR [doesn't provide a means to upload media directly from the Link UI itself](https://github.com/WordPress/gutenberg/pull/37260) (that's something for another day).

## Testing Instructions

- Upload some media files to your WP installation.
- Give the uploaded media files titles (via the Media Library fields - _not_ the filenames) that you can remember in order that you can search for them later.
- Add a paragraph block and add some text
- Create a link and search using a query that matches one of the media files you previously uploaded.
- See a result matching your media file
- Check various types of Media that are valid in WordPress.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/159754434-12d4e439-3a26-428a-9efb-23fdf2853a15.mov





