### PR TITLE
Quote v2: bootstrap flag in experiments page

### DIFF
--- a/lib/compat/experimental/blocks.php
+++ b/lib/compat/experimental/blocks.php
@@ -166,12 +166,16 @@ if ( ! function_exists( 'gutenberg_rest_comment_set_children_as_embeddable' ) ) 
 add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );
 
 /**
- * Sets a global JS variable used to trigger the availability of the experimental list block.
+ * Sets a global JS variable used to trigger the availability of the experimental blocks.
  */
-function gutenberg_enable_experimental_list_block() {
+function gutenberg_enable_experimental_blocks() {
 	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-list-v2', get_option( 'gutenberg-experiments' ) ) ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableListBlockV2 = true', 'before' );
 	}
+
+	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-quote-v2', get_option( 'gutenberg-experiments' ) ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableQuoteBlockV2 = true', 'before' );
+	}
 }
 
-add_action( 'admin_init', 'gutenberg_enable_experimental_list_block' );
+add_action( 'admin_init', 'gutenberg_enable_experimental_blocks' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -62,6 +62,17 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-list-v2',
 		)
 	);
+	add_settings_field(
+		'gutenberg-quote-v2',
+		__( 'Quote block v2', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test a new quote block that allows nested blocks (Warning: The new block is not ready. You may experience content loss, avoid using it on production sites)', 'gutenberg' ),
+			'id'    => 'gutenberg-quote-v2',
+		)
+	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -12,12 +12,13 @@ import edit from './edit';
 import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
+import settingsV2 from './v2';
 
 const { name } = metadata;
 
 export { metadata, name };
 
-export const settings = {
+export const settingsV1 = {
 	icon,
 	example: {
 		attributes: {
@@ -51,3 +52,7 @@ export const settings = {
 	},
 	deprecated,
 };
+
+export const settings = window?.__experimentalEnableQuoteBlockV2
+	? settingsV2
+	: settingsV1;

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -1,0 +1,5 @@
+function Edit() {
+	return <div>Quote block v2</div>;
+}
+
+export default Edit;

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { quote as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import save from './save';
+
+const settings = {
+	icon,
+	edit,
+	save,
+};
+
+export default settings;

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -1,0 +1,5 @@
+function Save() {
+	return <div>Quote block v2</div>;
+}
+
+export default Save;


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/15486
Related https://github.com/WordPress/gutenberg/pull/25892

## What?

This PR adds a experimental flag (to be found in Gutenberg > Experiments) for users to enable a v2 of the quote block that supports inner blocks. This PR only provides the code to bootstrap this, doesn't deal with inner blocks yet.

## Why?

In https://github.com/WordPress/gutenberg/pull/25892 we discussed the cross-editor challenges that come with converting a block to inner blocks: a block loses content when edited in the web & mobile editors.

To overcome this challenge, the gallery block did the following: shipped the feature behind a flag for the web editor. When the number of mobile editors out there without support for this feature was lower than a threshold, the feature was activated for the web.

## Testing Instructions

- Go to the "Gutenberg > Experiments" page and enable the quote v2. Then go to the editor and add a quote. Verify that the markup matches what's introduced in this PR.
- Alternatively, disable the experiment and verify that the quote markup (v1) is as before.
