### PR TITLE
Quote v2: add innerblocks support

### DIFF
--- a/packages/block-library/src/quote/v2/block.json
+++ b/packages/block-library/src/quote/v2/block.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/quote",
+	"title": "Quote",
+	"category": "text",
+	"description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
+	"keywords": [ "blockquote", "cite" ],
+	"textdomain": "default"
+}

--- a/packages/block-library/src/quote/v2/block.json
+++ b/packages/block-library/src/quote/v2/block.json
@@ -6,5 +6,14 @@
 	"category": "text",
 	"description": "Give quoted text visual emphasis. \"In quoting others, we cite ourselves.\" — Julio Cortázar",
 	"keywords": [ "blockquote", "cite" ],
-	"textdomain": "default"
+	"textdomain": "default",
+	"attributes": {
+		"attribution": {
+			"type": "string",
+			"source": "html",
+			"selector": "figcaption",
+			"default": "",
+			"__experimentalRole": "content"
+		}
+	}
 }

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -17,6 +17,8 @@ import {
 import { useSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
+const TEMPLATE = [ [ 'core/paragraph', {} ] ];
+
 export default function QuoteEdit( {
 	attributes: { attribution },
 	setAttributes,
@@ -37,7 +39,7 @@ export default function QuoteEdit( {
 	const innerBlocksProps = useInnerBlocksProps(
 		showAttribution ? blockProps : {},
 		{
-			template: [ [ 'core/paragraph', {} ] ],
+			template: TEMPLATE,
 			templateInsertUpdatesSelection: true,
 		}
 	);

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -24,19 +24,6 @@ export default function QuoteEdit( {
 	insertBlocksAfter,
 	clientId,
 } ) {
-	const wrapperProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps(
-		{},
-		{
-			template: [ [ 'core/paragraph', {} ] ],
-			templateInsertUpdatesSelection: true,
-		}
-	);
-	const allBlockProps = useInnerBlocksProps( wrapperProps, {
-		template: [ [ 'core/paragraph', {} ] ],
-		templateInsertUpdatesSelection: true,
-	} );
-
 	const isAncestorOfSelectedBlock = useSelect( ( select ) =>
 		select( blockEditorStore ).hasSelectedInnerBlock( clientId )
 	);
@@ -45,6 +32,15 @@ export default function QuoteEdit( {
 	const showAttribution =
 		( isEditingQuote && hasAttribution ) ||
 		! RichText.isEmpty( attribution );
+
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		showAttribution ? blockProps : {},
+		{
+			template: [ [ 'core/paragraph', {} ] ],
+			templateInsertUpdatesSelection: true,
+		}
+	);
 
 	return (
 		<>
@@ -64,7 +60,7 @@ export default function QuoteEdit( {
 				</ToolbarGroup>
 			</BlockControls>
 			{ showAttribution ? (
-				<figure { ...wrapperProps }>
+				<figure { ...blockProps }>
 					<BlockQuotation { ...innerBlocksProps } />
 					<RichText
 						identifier="attribution"
@@ -87,7 +83,7 @@ export default function QuoteEdit( {
 					/>
 				</figure>
 			) : (
-				<BlockQuotation { ...allBlockProps } />
+				<BlockQuotation { ...innerBlocksProps } />
 			) }
 		</>
 	);

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -1,5 +1,15 @@
-function Edit() {
-	return <div>Quote block v2</div>;
-}
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { BlockQuotation } from '@wordpress/components';
 
-export default Edit;
+export default function QuoteEdit() {
+	const blockProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		template: [ [ 'core/paragraph', {} ] ],
+		templateInsertUpdatesSelection: true,
+	} );
+
+	return <BlockQuotation { ...innerBlocksProps } />;
+}

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -1,15 +1,94 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { BlockQuotation } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import {
+	BlockControls,
+	RichText,
+	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import {
+	BlockQuotation,
+	ToolbarGroup,
+	ToolbarButton,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
 
-export default function QuoteEdit() {
-	const blockProps = useBlockProps();
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+export default function QuoteEdit( {
+	attributes: { attribution },
+	setAttributes,
+	isSelected,
+	insertBlocksAfter,
+	clientId,
+} ) {
+	const wrapperProps = useBlockProps();
+	const innerBlocksProps = useInnerBlocksProps(
+		{},
+		{
+			template: [ [ 'core/paragraph', {} ] ],
+			templateInsertUpdatesSelection: true,
+		}
+	);
+	const allBlockProps = useInnerBlocksProps( wrapperProps, {
 		template: [ [ 'core/paragraph', {} ] ],
 		templateInsertUpdatesSelection: true,
 	} );
 
-	return <BlockQuotation { ...innerBlocksProps } />;
+	const isAncestorOfSelectedBlock = useSelect( ( select ) =>
+		select( blockEditorStore ).hasSelectedInnerBlock( clientId )
+	);
+	const hasAttribution = attribution !== null;
+	const isEditingQuote = isSelected || isAncestorOfSelectedBlock;
+	const showAttribution =
+		( isEditingQuote && hasAttribution ) ||
+		! RichText.isEmpty( attribution );
+
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton
+						isActive={ hasAttribution }
+						label={ __( 'Toggle attribution visibility' ) }
+						onClick={ () =>
+							setAttributes( {
+								attribution: hasAttribution ? null : '',
+							} )
+						}
+					>
+						{ __( 'Add attribution' ) }
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
+			{ showAttribution ? (
+				<figure { ...wrapperProps }>
+					<BlockQuotation { ...innerBlocksProps } />
+					<RichText
+						identifier="attribution"
+						tagName={ 'figcaption' }
+						style={ { display: 'block' } }
+						value={ attribution ?? '' }
+						onChange={ ( nextAttribution ) => {
+							setAttributes( { attribution: nextAttribution } );
+						} }
+						__unstableMobileNoFocusOnMount
+						aria-label={ __( 'Quote attribution' ) }
+						placeholder={
+							// translators: placeholder text used for the attribution
+							__( 'Add attribution' )
+						}
+						className="wp-block-quote__attribution"
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
+						}
+					/>
+				</figure>
+			) : (
+				<BlockQuotation { ...allBlockProps } />
+			) }
+		</>
+	);
 }

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -1,16 +1,32 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { quote as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
 import save from './save';
 
+const { name } = metadata;
+
+export { metadata, name };
+
 const settings = {
 	icon,
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: __( 'In quoting others, we cite ourselves.' ),
+				},
+			},
+		],
+	},
 	edit,
 	save,
 };

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -18,6 +18,9 @@ export { metadata, name };
 const settings = {
 	icon,
 	example: {
+		attributes: {
+			attribution: 'Julio Cortázar',
+		},
 		innerBlocks: [
 			{
 				name: 'core/paragraph',

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -1,27 +1,25 @@
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	useBlockProps,
-	useInnerBlocksProps,
-} from '@wordpress/block-editor';
+import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const { attribution } = attributes;
-	const wrapperProps = useBlockProps.save();
-	const innerBlocksProps = useInnerBlocksProps.save();
-	const allBlockProps = useInnerBlocksProps.save( wrapperProps );
+	const blockProps = useBlockProps.save();
 
 	const hasAttribution = ! RichText.isEmpty( attribution );
 	return hasAttribution ? (
-		<figure { ...wrapperProps }>
-			<blockquote { ...innerBlocksProps } />
+		<figure { ...blockProps }>
+			<blockquote>
+				<InnerBlocks.Content />
+			</blockquote>
 			<figcaption>
 				<RichText.Content value={ attribution } />
 			</figcaption>
 		</figure>
 	) : (
-		<blockquote { ...allBlockProps } />
+		<blockquote { ...blockProps }>
+			<InnerBlocks.Content />
+		</blockquote>
 	);
 }

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -1,5 +1,9 @@
-function Save() {
-	return <div>Quote block v2</div>;
-}
+/**
+ * WordPress dependencies
+ */
+import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
-export default Save;
+export default function save() {
+	const innerBlocksProps = useInnerBlocksProps.save( useBlockProps.save() );
+	return <blockquote { ...innerBlocksProps } />;
+}

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -1,9 +1,27 @@
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
-export default function save() {
-	const innerBlocksProps = useInnerBlocksProps.save( useBlockProps.save() );
-	return <blockquote { ...innerBlocksProps } />;
+export default function save( { attributes } ) {
+	const { attribution } = attributes;
+	const wrapperProps = useBlockProps.save();
+	const innerBlocksProps = useInnerBlocksProps.save();
+	const allBlockProps = useInnerBlocksProps.save( wrapperProps );
+
+	const hasAttribution = ! RichText.isEmpty( attribution );
+	return hasAttribution ? (
+		<figure { ...wrapperProps }>
+			<blockquote { ...innerBlocksProps } />
+			<figcaption>
+				<RichText.Content value={ attribution } />
+			</figcaption>
+		</figure>
+	) : (
+		<blockquote { ...allBlockProps } />
+	);
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/15486
Related https://github.com/WordPress/gutenberg/pull/25892
Depends on https://github.com/WordPress/gutenberg/pull/39703

## What?

This PR makes the Quote v2 support inner blocks.

## How?

The markup for this block behaves this way: without an attribution a quote is a simple `<blockquote />` but with an attribution we follow the HTML spec with `<figure><blockquote /><ficaption /></figure>`.

I've added as co-authors all the people that had contributed to the original PR.

## Testing Instructions

- Enable the quote v2 block in "Gutenberg > Experiments" page.
- Verify that it allows you to start typing right away and that you can add any block.

https://user-images.githubusercontent.com/583546/159770191-290bcdaf-0c7c-4480-89d1-e1be3dde8671.mp4

## Follow-ups

As per the conversations at https://github.com/WordPress/gutenberg/pull/25892 we want the attribution to behave like this:

- Quote blocks starts without an attribution. It gains one by clicking the "Add Attribution" button in the toolbar.
- By clicking the "Add attribution" button the focus goes to that field and button dissapears from the toolbar ([see](https://github.com/WordPress/gutenberg/pull/25892#issuecomment-768242092)).
- Removing the content of the attribution should remove the field and focus return to the inner blocks ([see](https://github.com/WordPress/gutenberg/pull/25892#issuecomment-768208131)).

By defering this to a follow-up we can unblock changes to bring transformations in parallel.
