### PR TITLE
[RNMobile] Add `useScrollWhenDragging` hook

### DIFF
--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
@@ -22,6 +22,15 @@ const SCROLL_INACTIVE_DISTANCE_PX = 50;
 const SCROLL_INTERVAL_MS = 1000;
 const VELOCITY_MULTIPLIER = 5000;
 
+/**
+ * React hook that scrolls the scroll container when a block is being dragged.
+ *
+ * @return {Function[]} `startScrolling`, `scrollOnDragOver`, `stopScrolling`
+ *                      functions to be called in `onDragStart`, `onDragOver`
+ *                      and `onDragEnd` events respectively. Additionally,
+ * 						`scrollHandler` function is returned which should be
+ * 						called in the `onScroll` event of the block list.
+ */
 export default function useScrollWhenDragging() {
 	const { scrollRef } = useBlockListContext();
 	const animatedScrollRef = useAnimatedRef();

--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
@@ -49,6 +49,8 @@ export default function useScrollWhenDragging() {
 
 	const stopScrolling = () => {
 		'worklet';
+		cancelAnimation( animationTimer );
+
 		isAnimationTimerActive.value = false;
 		isScrollActive.value = false;
 		velocityY.value = 0;
@@ -96,6 +98,10 @@ export default function useScrollWhenDragging() {
 	useAnimatedReaction(
 		() => animationTimer.value,
 		( value, previous ) => {
+			if ( velocityY.value === 0 ) {
+				return;
+			}
+
 			const delta = Math.abs( value - previous );
 			let newOffset = offsetY.value + delta * velocityY.value;
 
@@ -110,13 +116,9 @@ export default function useScrollWhenDragging() {
 				// new offset value.
 				newOffset = Math.max( 0, newOffset );
 			}
-			offsetY.value = newOffset;
 
-			if ( velocityY.value !== 0 ) {
-				scrollTo( animatedScrollRef, 0, offsetY.value, false );
-			} else if ( ! isAnimationTimerActive.value ) {
-				cancelAnimation( animationTimer );
-			}
+			offsetY.value = newOffset;
+			scrollTo( animatedScrollRef, 0, offsetY.value, false );
 		}
 	);
 

--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { Dimensions } from 'react-native';
+import {
+	useSharedValue,
+	useAnimatedRef,
+	scrollTo,
+	useAnimatedReaction,
+	withTiming,
+	withRepeat,
+	cancelAnimation,
+	Easing,
+} from 'react-native-reanimated';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockListContext } from '../block-list/block-list-context';
+
+const SCROLL_INACTIVE_DISTANCE_PX = 50;
+const SCROLL_INTERVAL_MS = 1000;
+const VELOCITY_MULTIPLIER = 5000;
+
+export default function useScrollWhenDragging() {
+	const { scrollRef } = useBlockListContext();
+	const animatedScrollRef = useAnimatedRef();
+	animatedScrollRef( scrollRef );
+
+	const windowHeight = Dimensions.get( 'window' ).height;
+
+	const velocityY = useSharedValue( 0 );
+	const offsetY = useSharedValue( 0 );
+	const dragStartY = useSharedValue( 0 );
+	const animationTimer = useSharedValue( 0 );
+	const isAnimationTimerActive = useSharedValue( false );
+	const isScrollActive = useSharedValue( false );
+
+	const scroll = {
+		offsetY: useSharedValue( 0 ),
+		maxOffsetY: useSharedValue( 0 ),
+	};
+	const scrollHandler = ( event ) => {
+		'worklet';
+		const { contentSize, contentOffset, layoutMeasurement } = event;
+		scroll.offsetY.value = contentOffset.y;
+		scroll.maxOffsetY.value = contentSize.height - layoutMeasurement.height;
+	};
+
+	const stopScrolling = () => {
+		'worklet';
+		isAnimationTimerActive.value = false;
+		isScrollActive.value = false;
+		velocityY.value = 0;
+	};
+
+	const startScrolling = ( y ) => {
+		'worklet';
+		stopScrolling();
+		offsetY.value = scroll.offsetY.value;
+		dragStartY.value = y;
+
+		animationTimer.value = 0;
+		animationTimer.value = withRepeat(
+			withTiming( 1, {
+				duration: SCROLL_INTERVAL_MS,
+				easing: Easing.linear,
+			} ),
+			-1,
+			true
+		);
+		isAnimationTimerActive.value = true;
+	};
+
+	const scrollOnDragOver = ( y ) => {
+		'worklet';
+		const dragDistance = Math.max(
+			Math.abs( y - dragStartY.value ) - SCROLL_INACTIVE_DISTANCE_PX,
+			0
+		);
+		const distancePercentage = dragDistance / windowHeight;
+
+		if ( ! isScrollActive.value ) {
+			isScrollActive.value = dragDistance > 0;
+		} else if ( y > dragStartY.value ) {
+			// User is dragging downwards.
+			velocityY.value = VELOCITY_MULTIPLIER * distancePercentage;
+		} else if ( y < dragStartY.value ) {
+			// User is dragging upwards.
+			velocityY.value = -VELOCITY_MULTIPLIER * distancePercentage;
+		} else {
+			velocityY.value = 0;
+		}
+	};
+
+	useAnimatedReaction(
+		() => animationTimer.value,
+		( value, previous ) => {
+			const delta = Math.abs( value - previous );
+			let newOffset = offsetY.value + delta * velocityY.value;
+
+			if ( scroll.maxOffsetY.value !== 0 ) {
+				newOffset = Math.max(
+					0,
+					Math.min( scroll.maxOffsetY.value, newOffset )
+				);
+			} else {
+				// Scroll values are empty until receiving the first scroll event.
+				// In that case, the max offset is unknown and we can't clamp the
+				// new offset value.
+				newOffset = Math.max( 0, newOffset );
+			}
+			offsetY.value = newOffset;
+
+			if ( velocityY.value !== 0 ) {
+				scrollTo( animatedScrollRef, 0, offsetY.value, false );
+			} else if ( ! isAnimationTimerActive.value ) {
+				cancelAnimation( animationTimer );
+			}
+		}
+	);
+
+	return [ startScrolling, scrollOnDragOver, stopScrolling, scrollHandler ];
+}

--- a/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
+++ b/packages/block-editor/src/components/block-draggable/use-scroll-when-dragging.native.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Dimensions } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 import {
 	useSharedValue,
 	useAnimatedRef,
@@ -36,7 +36,7 @@ export default function useScrollWhenDragging() {
 	const animatedScrollRef = useAnimatedRef();
 	animatedScrollRef( scrollRef );
 
-	const windowHeight = Dimensions.get( 'window' ).height;
+	const { height: windowHeight } = useWindowDimensions();
 
 	const velocityY = useSharedValue( 0 );
 	const offsetY = useSharedValue( 0 );


### PR DESCRIPTION
**NOTE:** This PR points to [rnmobile/feature/drag-and-drop-block-draggable-component](https://github.com/WordPress/gutenberg/tree/rnmobile/feature/drag-and-drop-block-draggable-component), once https://github.com/WordPress/gutenberg/pull/39617 PR is merged, it should point to [rnmobile/feature/drag-and-drop](https://github.com/WordPress/gutenberg/tree/rnmobile/feature/drag-and-drop).

Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4673.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add`useScrollWhenDragging` hook for allowing scroll when dragging a block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This hook is required for providing the drag & drop functionality for blocks, similarly as we have in the web version.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This hook is used by the `BlockDraggable` component which notifies when the drag gesture starts and finishes. With this information and scroll events from the block list, it runs a timer that updates the scroll position via the [Reanimated's `scrollTo` function](https://docs.swmansion.com/react-native-reanimated/docs/api/nativeMethods/scrollTo). Similar to the web implementation, the scroll is controlled with a velocity value that increases by the distance between the touch position and the position where the drag started.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post/page.
2. Add some blocks.
3. Tap over a block for around one second.
4. Observe that the block collapses and a visual clue is shown on top of the touch position.
5. Drag the block to the top and observe that the scroll moves upwards.
6. Drag the block to the bottom and observe that the scroll moves downwards.
7. Additionally, observe that the further the block is dragged from the original position, the scroll moves faster.

## Screenshots or screencast <!-- if applicable -->
iOS|Android
--|--
<video src=https://user-images.githubusercontent.com/14905380/159924867-a410d801-29e7-4050-ba93-194e3560662e.MP4>|<video src=https://user-images.githubusercontent.com/14905380/159925231-b4a7c270-e06c-4a72-8f59-67b5cfca0b9c.mp4>