### PR TITLE
Try to render flex layout styles as presets

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -235,7 +235,7 @@ function gutenberg_apply_layout_support( $block_type, $block_attributes ) {
 		$classes[] = 'has-layout-vertical';
 		// Space-between doesn't work on vertical layouts so use default.
 		if ( $justify_content === 'space-between') {
-			$classes[] = 'has-layout-vertical-left'
+			$classes[] = 'has-layout-vertical-left';
 		} else {
 			$classes[] = sprintf( 'has-layout-vertical-%s', _wp_to_kebab_case( $justify_content ) );
 		}

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -157,6 +157,66 @@ class WP_Theme_JSON_5_9 {
 			'classes'             => array( '.has-$slug-font-family' => 'font-family' ),
 			'properties'          => array( 'font-family' ),
 		),
+		array(
+			'path'                => array( 'layout', 'flex' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'value',
+			'css_vars'            => '--wp--preset--layout--$slug',
+			'classes'             => array( 
+				'.has-layout-$slug' => 'display',
+			),
+			'properties'          => array( 'display' ),
+		),
+		array(
+			'path'                => array( 'layout', 'flexWrap' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'value',
+			'css_vars'            => '--wp--preset--layout--$slug',
+			'classes'             => array( 
+				'.has-layout-$slug' => 'flex-wrap',
+			),
+			'properties'          => array( 'flex-wrap' ),
+		),
+		array(
+			'path'                => array( 'layout', 'flexDirection' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'value',
+			'css_vars'            => '--wp--preset--layout--$slug',
+			'classes'             => array( 
+				'.has-layout-$slug' => 'flex-direction',
+			),
+			'properties'          => array( 'flex-direction' ),
+		),
+		array(
+			'path'                => array( 'layout', 'flexJustify' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'value',
+			'css_vars'            => '--wp--preset--layout--$slug',
+			'classes'             => array( 
+				'.has-layout-$slug' => 'justify-content',
+			),
+			'properties'          => array( 'justify-content' ),
+		),
+		array(
+			'path'                => array( 'layout', 'flexAlign' ),
+			'prevent_override'    => false,
+			'use_default_presets' => true,
+			'use_default_names'   => false,
+			'value_key'           => 'value',
+			'css_vars'            => '--wp--preset--layout--$slug',
+			'classes'             => array( 
+				'.has-layout-$slug' => 'align-items',
+			),
+			'properties'          => array( 'align-items' ),
+		),
 	);
 
 	/**
@@ -256,6 +316,11 @@ class WP_Theme_JSON_5_9 {
 		'layout'          => array(
 			'contentSize' => null,
 			'wideSize'    => null,
+			'flex'        => null,
+			'flexWrap'    => null,
+			'flexDirection' => null,
+			'flexJustify'   => null,
+			'flexAlign'     => null,
 		),
 		'spacing'         => array(
 			'blockGap' => null,
@@ -311,6 +376,13 @@ class WP_Theme_JSON_5_9 {
 			'lineHeight'     => null,
 			'textDecoration' => null,
 			'textTransform'  => null,
+		),
+		'layout'   => array(
+			'display'         => null,
+			'flex-wrap'       => null,
+			'flex-direction'  => null,
+			'justify-content' => null,
+			'align-items'     => null,
 		),
 	);
 

--- a/lib/compat/wordpress-5.9/theme.json
+++ b/lib/compat/wordpress-5.9/theme.json
@@ -185,6 +185,79 @@
 			],
 			"text": true
 		},
+		"layout": {
+			"flow": [],
+			"flex":[
+				{
+					"name": "Flexbox",
+					"slug": "flex",
+					"value": "flex"
+				}
+			],
+			"flexWrap": [
+				{
+					"name": "Wrap",
+					"slug": "wrap",
+					"value": "wrap"
+				},
+				{
+					"name": "Nowrap",
+					"slug": "nowrap",
+					"value": "nowrap"
+				}
+			],
+			"flexDirection": [
+				{
+					"name": "Horizontal",
+					"slug": "horizontal",
+					"value": "row"
+				},
+				{
+					"name": "Vertical",
+					"slug": "vertical",
+					"value": "column"
+				}
+			],
+			"flexJustify": [
+				{
+					"name": "Justify left",
+					"slug": "horizontal-left",
+					"value": "flex-start"
+				},
+				{
+					"name": "Justify center",
+					"slug": "horizontal-center",
+					"value": "center"
+				},
+				{
+					"name": "Justify right",
+					"slug": "horizontal-right",
+					"value": "flex-end"
+				},
+				{
+					"name": "Justify space between",
+					"slug": "horizontal-space-between",
+					"value": "space-between"
+				}
+			],
+			"flexAlign": [
+				{
+					"name": "Align left",
+					"slug": "vertical-left",
+					"value": "flex-start"
+				},
+				{
+					"name": "Align center",
+					"slug": "vertical-center",
+					"value": "center"
+				},
+				{
+					"name": "Align right",
+					"slug": "vertical-right",
+					"value": "flex-end"
+				}
+			]
+		},
 		"spacing": {
 			"blockGap": null,
 			"margin": false,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries to convert the flex layout styles into presets. 

This is very much a WIP. It only addresses server rendered blocks for now, and it ignores properties for which arbitrary values can be set (e.g. gap). 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Inspired by #36944 and #39374, mainly because I was wondering what a _default_ approach would look like for layout.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Flattens out the styles needed for flex layout so they fit neatly into classname -> property pairs. 
* Uses readable, verbose classnames for each property, because Classnames are Poetry (or something). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Pick a server rendered block with flex layout that is NOT the Navigation block (because that one has custom logic for its styles). Query Pagination seems to be the only core one available.
2. Check that changing its layout works as expected on the front end.

## Screenshots or screencast <!-- if applicable -->

<img width="650" alt="Screen Shot 2022-03-24 at 3 32 49 pm" src="https://user-images.githubusercontent.com/8096000/159842872-169c43f5-e0ee-410a-a3e2-32aa416e46e9.png">

