### PR TITLE
Components: Add more prominent documentation around popover use

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -33,7 +33,9 @@ In non-WordPress projects, link to the `build-style/style.css` file directly, it
 
 ### Popovers and Tooltips
 
-By default, the [`Popover`](/packages/components/src/popover/README.md) component will render inline i.e. within its
+_If you're using [`Popover`](/packages/components/src/popover/README.md) or [`Tooltip`](/packages/components/src/tooltip/README.md) components outside of the editor, make sure they are rendered within a `SlotFillProvider` and with a `Popover.Slot` somewhere up the element tree._
+
+By default, the `Popover` component will render inline i.e. within its
 parent to which it should anchor. Depending upon the context in which the
 `Popover` is being consumed, this might lead to incorrect positioning. For
 example, when being nested within another popover.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -42,7 +42,7 @@ This issue can be solved by rendering popovers to a specific location in the DOM
 `Popover.Slot`. For this to work, you will need your use of the `Popover`
 component and its `Slot` to be wrapped in a [`SlotFill`](/packages/components/src/slot-fill/README.md) provider.
 
-A `Popover` is also used as the underlying mechanism to display `ToolTip` components.
+A `Popover` is also used as the underlying mechanism to display `Tooltip` components.
 So the same considerations should be applied to them.
 
 The following example illustrates how you can wrap a component using a

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -31,6 +31,42 @@ Many components include CSS to add style, you will need to add in order to appea
 
 In non-WordPress projects, link to the `build-style/style.css` file directly, it is located at `node_modules/@wordpress/components/build-style/style.css`.
 
+### Popovers and Tooltips
+
+By default, the [`Popover`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/README.md) component will render inline i.e. within its
+parent to which it should anchor. Depending upon the context in which the
+`Popover` is being consumed, this might lead to incorrect positioning. For
+example, when being nested within another popover.
+
+This issue can be solved by rendering popovers to a specific location in the DOM via the
+`Popover.Slot`. For this to work, you will need your use of the `Popover`
+component and its `Slot` to be wrapped in a [`SlotFill`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/slot-fill/README.md) provider.
+
+A `Popover` is also used as the underlying mechanism to display `ToolTip` components.
+So the same considerations should be applied to them.
+
+The following example illustrates how you can wrap a component using a
+`Popover` and have those popovers render to a single location in the DOM.
+
+```jsx
+/**
+ * External dependencies
+ */
+import { Popover, SlotFillProvider } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { MyComponentWithPopover } from './my-component';
+
+const Example = () => {
+	<SlotFillProvider>
+		<MyComponentWithPopover />
+		<Popover.Slot>
+	</SlotFillProvider>
+};
+```
+
 ## Docs & examples
 
 You can browse the components docs and examples at https://wordpress.github.io/gutenberg/

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -33,14 +33,14 @@ In non-WordPress projects, link to the `build-style/style.css` file directly, it
 
 ### Popovers and Tooltips
 
-By default, the [`Popover`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/popover/README.md) component will render inline i.e. within its
+By default, the [`Popover`](/packages/components/src/popover/README.md) component will render inline i.e. within its
 parent to which it should anchor. Depending upon the context in which the
 `Popover` is being consumed, this might lead to incorrect positioning. For
 example, when being nested within another popover.
 
 This issue can be solved by rendering popovers to a specific location in the DOM via the
 `Popover.Slot`. For this to work, you will need your use of the `Popover`
-component and its `Slot` to be wrapped in a [`SlotFill`](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/slot-fill/README.md) provider.
+component and its `Slot` to be wrapped in a [`SlotFill`](/packages/components/src/slot-fill/README.md) provider.
 
 A `Popover` is also used as the underlying mechanism to display `ToolTip` components.
 So the same considerations should be applied to them.

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -60,7 +60,7 @@ const MyBorderBoxControl = () => {
 };
 ```
 
-To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
+To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
 for the `BorderBoxControl`'s color swatches, render your `BorderBoxControl` with
 a `Popover.Slot` further up the element tree and within a
 `SlotFillProvider` overall.

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -60,10 +60,11 @@ const MyBorderBoxControl = () => {
 };
 ```
 
-To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
-for the `BorderBoxControl`'s color swatches, render your `BorderBoxControl` with
-a `Popover.Slot` further up the element tree and within a
-`SlotFillProvider` overall.
+If you're using this component outside the editor, you can
+[ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
+for the `BorderBoxControl`'s color and style options, by rendering your
+`BorderBoxControl` with a `Popover.Slot` further up the element tree and within
+a `SlotFillProvider` overall.
 
 ## Props
 

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -60,7 +60,7 @@ const MyBorderBoxControl = () => {
 };
 ```
 
-To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
 for the `BorderBoxControl`'s color swatches, render your `BorderBoxControl` with
 a `Popover.Slot` further up the element tree and within a
 `SlotFillProvider` overall.

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -60,6 +60,11 @@ const MyBorderBoxControl = () => {
 };
 ```
 
+To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+for the `BorderBoxControl`'s color swatches, render your `BorderBoxControl` with
+a `Popover.Slot` further up the element tree and within a
+`SlotFillProvider` overall.
+
 ## Props
 
 ### `colors`: `Array`

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -43,9 +43,10 @@ const MyBorderControl = () => {
 };
 ```
 
-To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
-for the `BorderControl`'s color swatches, render your `BorderControl` with a
-`Popover.Slot` further up the element tree and within a
+If you're using this component outside the editor, you can
+[ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
+for the `BorderControl`'s color and style options, by rendering your
+`BorderControl` with a `Popover.Slot` further up the element tree and within a
 `SlotFillProvider` overall.
 
 ## Props

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -43,7 +43,7 @@ const MyBorderControl = () => {
 };
 ```
 
-To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
+To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
 for the `BorderControl`'s color swatches, render your `BorderControl` with a
 `Popover.Slot` further up the element tree and within a
 `SlotFillProvider` overall.

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -43,6 +43,11 @@ const MyBorderControl = () => {
 };
 ```
 
+To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+for the `BorderControl`'s color swatches, render your `BorderControl` with a
+`Popover.Slot` further up the element tree and within a
+`SlotFillProvider` overall.
+
 ## Props
 
 ### `colors`: `Array`

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -43,7 +43,7 @@ const MyBorderControl = () => {
 };
 ```
 
-To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
 for the `BorderControl`'s color swatches, render your `BorderControl` with a
 `Popover.Slot` further up the element tree and within a
 `SlotFillProvider` overall.

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -75,6 +75,6 @@ const MyColorPalette = () => {
 } );
 ```
 
-To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
+To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
 when hovering the `ColorPalette`'s swatches, render your `ColorPalette` with a
 `Popover.Slot` further up the element tree and within a `SlotFillProvider` overall.

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -75,6 +75,8 @@ const MyColorPalette = () => {
 } );
 ```
 
-To [ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
-when hovering the `ColorPalette`'s swatches, render your `ColorPalette` with a
-`Popover.Slot` further up the element tree and within a `SlotFillProvider` overall.
+If you're using this component outside the editor, you can
+[ensure `Tooltip` positioning](/packages/components/README.md#popovers-and-tooltips)
+for the `ColorPalette`'s color swatches, by rendering your `ColorPalette` with a
+`Popover.Slot` further up the element tree and within a
+`SlotFillProvider` overall.

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -75,6 +75,6 @@ const MyColorPalette = () => {
 } );
 ```
 
-To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+To [ensure `ToolTip` positioning](/packages/components/README.md#popovers-and-tooltips)
 when hovering the `ColorPalette`'s swatches, render your `ColorPalette` with a
 `Popover.Slot` further up the element tree and within a `SlotFillProvider` overall.

--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -74,3 +74,7 @@ const MyColorPalette = () => {
 	);
 } );
 ```
+
+To [ensure `ToolTip` positioning](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/README.md#popovers-and-tooltips)
+when hovering the `ColorPalette`'s swatches, render your `ColorPalette` with a
+`Popover.Slot` further up the element tree and within a `SlotFillProvider` overall.


### PR DESCRIPTION
## What?

Highlights usage of the `Popover` and `Tooltip` components to ensure correct positioning.

## Why?

When using the `Tooltip` component, and therefore `Popover` by proxy, outside the block or site editors, it isn't immediately obvious why each `Popover` is being rendered inline and out of position.

This was encountered during the development of new border controls where improving the docs was [suggested](https://github.com/WordPress/gutenberg/pull/37769#discussion_r833310769).


## How?

A prominent section relating to using `Popover` and `ToolTip` components is added to the main readme for the components package which can then be linked to from individual component docs that are likely to need `Popover`s rendered via a `SlotFill`.


## Testing Instructions

Proofread edited docs.

- [Component Reference](https://github.com/WordPress/gutenberg/blob/90d163691e4c12758978b5e5208e1f3508b80530/packages/components/README.md)
- [`ColorPalette` README](https://github.com/WordPress/gutenberg/blob/90d163691e4c12758978b5e5208e1f3508b80530/packages/components/src/color-palette/README.md)
- [`BorderControl` README](https://github.com/WordPress/gutenberg/blob/90d163691e4c12758978b5e5208e1f3508b80530/packages/components/src/border-control/border-control/README.md)
- [`BorderBoxControl` README](https://github.com/WordPress/gutenberg/blob/7b2c7fe4fb7fdec6585bc2bc764e91fae2cd1281/packages/components/src/border-box-control/border-box-control/README.md)