### PR TITLE
BlockToolbar: Show Group button in toolbar when multiple blocks are selected

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -21,6 +21,7 @@ import BlockSwitcher from '../block-switcher';
 import BlockControls from '../block-controls';
 import BlockSettingsMenu from '../block-settings-menu';
 import { BlockLockToolbar } from '../block-lock';
+import { BlockGroupToolbar } from '../convert-to-group-buttons';
 import { useShowMoversGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
 
@@ -127,6 +128,9 @@ export default function BlockToolbar( { hideDragHandle } ) {
 					</ToolbarGroup>
 				) }
 			</div>
+			{ shouldShowVisualToolbar && isMultiToolbar && (
+				<BlockGroupToolbar />
+			) }
 			{ shouldShowVisualToolbar && (
 				<>
 					<BlockControls.Slot

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -11,6 +11,7 @@ import { useDispatch } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 import useConvertToGroupButtonProps from './use-convert-to-group-button-props';
+import BlockGroupToolbar from './toolbar';
 
 function ConvertToGroupButton( {
 	clientIds,
@@ -73,4 +74,8 @@ function ConvertToGroupButton( {
 	);
 }
 
-export { useConvertToGroupButtonProps, ConvertToGroupButton };
+export {
+	BlockGroupToolbar,
+	ConvertToGroupButton,
+	useConvertToGroupButtonProps,
+};

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { group } from '@wordpress/icons';
@@ -22,6 +22,16 @@ function BlockGroupToolbar( { label = __( 'Group' ) } ) {
 	} = useConvertToGroupButtonProps();
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
+	const { canRemove } = useSelect(
+		( select ) => {
+			const { canRemoveBlocks } = select( blockEditorStore );
+			return {
+				canRemove: canRemoveBlocks( clientIds ),
+			};
+		},
+		[ clientIds ]
+	);
+
 	const onConvertToGroup = () => {
 		const newBlocks = switchToBlockType(
 			blocksSelection,
@@ -35,7 +45,8 @@ function BlockGroupToolbar( { label = __( 'Group' ) } ) {
 	// Don't render the button if the current selection cannot be grouped.
 	// A good example is selecting multiple button blocks within a Buttons block:
 	// The group block is not a valid child of Buttons, so we should not show the button.
-	if ( ! isGroupable ) {
+	// Any blocks that are locked against removal also cannot be grouped.
+	if ( ! isGroupable || ! canRemove ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { group } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
 
-function BlockGroupToolbar( { label = __( 'Group' ) } ) {
+function BlockGroupToolbar( { label = _x( 'Group', 'verb' ) } ) {
 	const {
 		blocksSelection,
 		clientIds,

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { switchToBlockType } from '@wordpress/blocks';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { group } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
+import { store as blockEditorStore } from '../../store';
+
+function BlockGroupToolbar( { label = __( 'Group' ) } ) {
+	const {
+		blocksSelection,
+		clientIds,
+		groupingBlockName,
+		isGroupable,
+	} = useConvertToGroupButtonProps();
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	const onConvertToGroup = () => {
+		const newBlocks = switchToBlockType(
+			blocksSelection,
+			groupingBlockName
+		);
+		if ( newBlocks ) {
+			replaceBlocks( clientIds, newBlocks );
+		}
+	};
+
+	// Don't render the button if the current selection cannot be grouped.
+	// A good example is selecting multiple button blocks within a Buttons block:
+	// The group block is not a valid child of Buttons, so we should not show the button.
+	if ( ! isGroupable ) {
+		return null;
+	}
+
+	return (
+		<ToolbarGroup>
+			<ToolbarButton
+				icon={ group }
+				label={ label }
+				onClick={ onConvertToGroup }
+			/>
+		</ToolbarGroup>
+	);
+}
+
+export default BlockGroupToolbar;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #34461

In this PR we expose a "Group" control in the block toolbar when multiple blocks are selected.

This PR borrows the implementation from #37619 (kudos @jiteshdhamaniya for opening that PR and kicking off this work! This PR is just a few tweaks on top of that one.)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As raised in #34461, it will be helpful for users working with grouping together multiple blocks to have the control more visible and available in the block toolbar. After this PR lands, we could extend the approach to also include grouping multiple blocks into other containers e.g. Row and Cover blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add a `BlockGroupToolbar` component and conditionally render it in the block toolbar if multiple blocks are selected. If blocks cannot be grouped, we don't render that toolbar group.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Insert a few blocks into a post. Shift + select the blocks and you should see the Group icon in the block toolbar.
2. Click it, and the blocks should now be grouped, and the group block should be selected.
3. In block editor preferences, switch to the "Display button label" toggle on, and check that the Group button in the block toolbar is displayed via the "Group" label text.
4. To ensure that the control _doesn't_ render when it shouldn't create a Social Icons block and add a couple of icons to the block. Select these child blocks together, and you should not see the Group option in the toolbar — this is because Group is not a valid child block of the Social Icons block.

## Screenshots or screencast <!-- if applicable -->

| Group button in the block toolbar | Group button in display labels mode |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/159848015-7f5c2eab-8c69-440a-80bf-2f09ea555864.png) | ![image](https://user-images.githubusercontent.com/14988353/159848048-50d4fb49-c5e7-4ecc-a892-7a11aa16cca5.png) |

For reference, here is a screenshot of the Group button not being rendered when multiple social link blocks are selected:

<img src="https://user-images.githubusercontent.com/14988353/159848157-4b660d72-2cf0-4787-b4b8-1b453b8dbc5d.png" width="300" />
