### PR TITLE
Template Mode: Try fix flaky tests

### DIFF
--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -30,16 +30,17 @@ const openSidebarPanelWithTitle = async ( title ) => {
 
 const disableTemplateWelcomeGuide = async () => {
 	// Turn off the welcome guide if it's visible.
-	const isWelcomeGuideActive = await page.evaluate( () =>
-		wp.data
-			.select( 'core/edit-post' )
-			.isFeatureActive( 'welcomeGuideTemplate' )
+	const isWelcomeGuideActive = await page.evaluate(
+		() =>
+			!! wp.data
+				.select( 'core/preferences' )
+				.get( 'core/edit-post', 'welcomeGuide' )
 	);
 	if ( isWelcomeGuideActive ) {
 		await page.evaluate( () =>
 			wp.data
-				.dispatch( 'core/edit-post' )
-				.toggleFeature( 'welcomeGuideTemplate' )
+				.dispatch( 'core/preferences' )
+				.toggle( 'core/edit-post', 'welcomeGuide' )
 		);
 	}
 };
@@ -239,7 +240,7 @@ describe( 'Delete Post Template Confirmation Dialog', () => {
 			if ( isWelcomeGuideActive === true ) {
 				await page.evaluate( () =>
 					wp.data
-						.dispatch( 'core/edit-post' )
+						.dispatch( 'core/preferences' )
 						.toggle( 'core/edit-post', 'welcomeGuide' )
 				);
 				await page.reload();

--- a/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
+++ b/packages/e2e-tests/specs/editor/various/post-editor-template-mode.test.js
@@ -30,17 +30,16 @@ const openSidebarPanelWithTitle = async ( title ) => {
 
 const disableTemplateWelcomeGuide = async () => {
 	// Turn off the welcome guide if it's visible.
-	const isWelcomeGuideActive = await page.evaluate(
-		() =>
-			!! wp.data
-				.select( 'core/preferences' )
-				.get( 'core/edit-post', 'welcomeGuide' )
+	const isWelcomeGuideActive = await page.evaluate( () =>
+		wp.data
+			.select( 'core/edit-post' )
+			.isFeatureActive( 'welcomeGuideTemplate' )
 	);
 	if ( isWelcomeGuideActive ) {
 		await page.evaluate( () =>
 			wp.data
-				.dispatch( 'core/preferences' )
-				.toggle( 'core/edit-post', 'welcomeGuide' )
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'welcomeGuideTemplate' )
 		);
 	}
 };


### PR DESCRIPTION
## What?
Template mode tests were failing because the Welcome Guide wasn't correctly disabled.

Fixes following error:

```
Evaluation failed: TypeError: wp.data.dispatch(...).toggle is not a function
```

## Why?
Tests need a welcome guide to being disabled.

## How?
Use the correct store to disable Welcome Guide.

## Testing Instructions
E2E Tests should be passing
