### PR TITLE
Rename name to title in the global style variations

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-global-styles-controller.php
@@ -232,8 +232,8 @@ class Gutenberg_REST_Global_Styles_Controller extends WP_REST_Global_Styles_Cont
 				$decoded_file = wp_json_file_decode( $path, array( 'associative' => true ) );
 				if ( is_array( $decoded_file ) ) {
 					$variation = ( new WP_Theme_JSON_Gutenberg( $decoded_file ) )->get_raw_data();
-					if ( empty( $variation['name'] ) ) {
-						$variation['name'] = basename( $path, '.json' );
+					if ( empty( $variation['title'] ) ) {
+						$variation['title'] = basename( $path, '.json' );
 					}
 					$variations[] = $variation;
 				}

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -28,7 +28,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'styles',
 		'templateParts',
 		'version',
-		'name',
+		'title',
 	);
 
 	/**

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -78,13 +78,13 @@ function Variation( { variation } ) {
 				onClick={ selectVariation }
 				onKeyDown={ selectOnEnter }
 				tabIndex="0"
-				aria-label={ variation?.name }
+				aria-label={ variation?.title }
 				onFocus={ () => setIsFocused( true ) }
 				onBlur={ () => setIsFocused( false ) }
 			>
 				<div className="edit-site-global-styles-variations_item-preview">
 					<StylesPreview
-						label={ variation?.name }
+						label={ variation?.title }
 						isFocused={ isFocused }
 					/>
 				</div>
@@ -105,7 +105,7 @@ function ScreenStyleVariations() {
 	const withEmptyVariation = useMemo( () => {
 		return [
 			{
-				name: __( 'Default' ),
+				title: __( 'Default' ),
 				settings: {},
 				styles: {},
 			},

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -110,7 +110,7 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 						),
 					),
 				),
-				'name'     => 'variation',
+				'title'    => 'variation',
 			),
 		);
 		$this->assertSameSetsWithIndex( $data, $expected );


### PR DESCRIPTION
Follow-up to #39322

## What?

This PR renames the "name" property of the global styles variations/presets to "title".

## Why?

I noticed that "name" was used more as an identifier in a lot of places in our code base: Block Types, Block Categories, Block Pattern Categories while "title" was used to refer to "labels" (sometimes "label" is used) for patterns, block types.
