### PR TITLE
RSS: Add missing classnames

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -83,10 +83,19 @@ function render_block_core_rss( $attributes ) {
 	if ( isset( $attributes['blockLayout'] ) && 'grid' === $attributes['blockLayout'] ) {
 		$classnames[] = 'is-grid';
 	}
-
 	if ( isset( $attributes['columns'] ) && 'grid' === $attributes['blockLayout'] ) {
 		$classnames[] = 'columns-' . $attributes['columns'];
 	}
+	if ( $attributes['displayDate'] ) {
+		$classnames[] = 'has-dates';
+	}
+	if ( $attributes['displayAuthor'] ) {
+		$classnames[] = 'has-authors';
+	}
+	if ( $attributes['displayExcerpt'] ) {
+		$classnames[] = 'has-excerpts';
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classnames ) ) );
 
 	return sprintf( '<ul %s>%s</ul>', $wrapper_attributes, $list_items );


### PR DESCRIPTION
## What?
Resolves #18349.

Adds missing classes to the RSS block.

## Why?
These classes can be used to style RSS blocks based on enabled settings.

## How?
Updates render callback to add classes when settings are enabled.

## Testing Instructions
1. Open a Post or Page.
2. Insert RSS Block.
3. Enter URL.
4. Toggle author, date, and excerpt settings in the sidebar.
5. Confirm that block's container element has corresponding classes.
