### PR TITLE
Quote v2: add transforms

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -33,6 +33,7 @@ import {
 import { Platform } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
 import { symbol } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * A block selection object.
@@ -1864,6 +1865,7 @@ export const getInserterItems = createSelector(
  */
 export const getBlockTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
+		const [ sourceBlock ] = blocks;
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
@@ -1877,20 +1879,32 @@ export const getBlockTransformItems = createSelector(
 			blockTypeTransformItems,
 			( { name } ) => name
 		);
+
+		// Consider unwraping the highest priority.
+		itemsByName[ '*' ] = {
+			frecency: +Infinity,
+			id: '*',
+			isDisabled: false,
+			name: '*',
+			title: __( 'Unwrap' ),
+			icon: itemsByName[ sourceBlock.name ]?.icon,
+		};
+
 		const possibleTransforms = getPossibleBlockTransformations(
 			blocks
 		).reduce( ( accumulator, block ) => {
-			if ( itemsByName[ block?.name ] ) {
+			if ( block === '*' ) {
+				accumulator.push( itemsByName[ '*' ] );
+			} else if ( itemsByName[ block?.name ] ) {
 				accumulator.push( itemsByName[ block.name ] );
 			}
 			return accumulator;
 		}, [] );
-		const possibleBlockTransformations = orderBy(
+		return orderBy(
 			possibleTransforms,
 			( block ) => itemsByName[ block.name ].frecency,
 			'desc'
 		);
-		return possibleBlockTransformations;
 	},
 	( state, rootClientId ) => [
 		state.blockListSettings[ rootClientId ],

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -9,7 +9,9 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import edit from './edit';
+import metadata from './block.json';
 import save from './save';
+import transforms from './transforms';
 
 const settings = {
 	icon,
@@ -26,6 +28,7 @@ const settings = {
 			},
 		],
 	},
+	transforms,
 	edit,
 	save,
 };

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -9,7 +9,6 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import edit from './edit';
-import metadata from './block.json';
 import save from './save';
 import transforms from './transforms';
 

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -13,11 +13,12 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation } ) => {
+			transform: ( { value, citation, anchor } ) => {
 				return createBlock(
 					'core/quote',
 					{
 						attribution: citation,
+						anchor,
 					},
 					parseWithAttributeSchema( value, {
 						type: 'array',
@@ -115,10 +116,11 @@ const transforms = {
 					( { name } ) => name === 'core/paragraph'
 				);
 			},
-			transform: ( { attribution }, innerBlocks ) => {
+			transform: ( { attribution, anchor }, innerBlocks ) => {
 				return createBlock( 'core/pullquote', {
 					value: serialize( innerBlocks ),
 					citation: attribution,
+					anchor,
 				} );
 			},
 		},

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -71,15 +71,11 @@ const transforms = {
 				node.nodeName === 'FIGURE' &&
 				!! node.querySelector( 'blockquote' ),
 			transform: ( node ) => {
-				const cite = node.querySelector( 'cite' );
-				const attribution =
-					cite?.innerHTML ??
-					node.querySelector( 'figcaption' )?.innerHTML;
-				cite?.parentNode?.removeChild( cite );
 				return createBlock(
 					'core/quote',
 					{
-						attribution,
+						attribution: node.querySelector( 'figcaption' )
+							?.innerHTML,
 					},
 					rawHandler( {
 						HTML: node.querySelector( 'blockquote' ).innerHTML,

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -1,0 +1,6 @@
+const transforms = {
+	from: [],
+	to: [],
+};
+
+export default transforms;

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -92,7 +92,7 @@ const transforms = {
 			type: 'block',
 			isMultiBlock: true,
 			blocks: [ '*' ],
-			isMatch: ( attributes, blocks ) => {
+			isMatch: ( {}, blocks ) => {
 				return ! blocks.some( ( { name } ) => name === 'core/quote' );
 			},
 			__experimentalConvert: ( blocks ) =>
@@ -113,7 +113,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			isMatch: ( attributes, block ) => {
+			isMatch: ( {}, block ) => {
 				return block.innerBlocks.every(
 					( { name } ) => name === 'core/paragraph'
 				);

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -39,6 +39,12 @@ const transforms = {
 			},
 		},
 		{
+			type: 'block',
+			blocks: [ 'core/group' ],
+			transform: ( { anchor }, innerBlocks ) =>
+				createBlock( 'core/quote', { anchor }, innerBlocks ),
+		},
+		{
 			type: 'prefix',
 			prefix: '>',
 			transform: ( content ) =>
@@ -102,12 +108,6 @@ const transforms = {
 					)
 				),
 		},
-		{
-			type: 'block',
-			blocks: [ 'core/group' ],
-			transform: ( { anchor }, innerBlocks ) =>
-				createBlock( 'core/quote', { anchor }, innerBlocks ),
-		},
 	],
 	to: [
 		{
@@ -133,19 +133,6 @@ const transforms = {
 		},
 		{
 			type: 'block',
-			blocks: [ '*' ],
-			transform: ( { attribution }, innerBlocks ) =>
-				attribution
-					? [
-							...innerBlocks,
-							createBlock( 'core/paragraph', {
-								content: attribution,
-							} ),
-					  ]
-					: innerBlocks,
-		},
-		{
-			type: 'block',
 			blocks: [ 'core/group' ],
 			transform: ( { attribution, anchor }, innerBlocks ) =>
 				createBlock(
@@ -160,6 +147,19 @@ const transforms = {
 						  ]
 						: innerBlocks
 				),
+		},
+		{
+			type: 'block',
+			blocks: [ '*' ],
+			transform: ( { attribution }, innerBlocks ) =>
+				attribution
+					? [
+							...innerBlocks,
+							createBlock( 'core/paragraph', {
+								content: attribution,
+							} ),
+					  ]
+					: innerBlocks,
 		},
 	],
 };

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -81,6 +81,26 @@ const transforms = {
 		},
 		{
 			type: 'block',
+			isMultiBlock: true,
+			blocks: [ '*' ],
+			isMatch: ( attributes, blocks ) => {
+				return ! blocks.some( ( { name } ) => name === 'core/quote' );
+			},
+			__experimentalConvert: ( blocks ) =>
+				createBlock(
+					'core/quote',
+					{},
+					blocks.map( ( block ) =>
+						createBlock(
+							block.name,
+							block.attributes,
+							block.innerBlocks
+						)
+					)
+				),
+		},
+		{
+			type: 'block',
 			blocks: [ 'core/group' ],
 			transform: ( {}, innerBlocks ) =>
 				createBlock( 'core/quote', {}, innerBlocks ),

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -4,6 +4,7 @@
 import {
 	createBlock,
 	parseWithAttributeSchema,
+	rawHandler,
 	serialize,
 } from '@wordpress/blocks';
 
@@ -41,6 +42,38 @@ const transforms = {
 				createBlock( 'core/quote', {}, [
 					createBlock( 'core/paragraph', { content } ),
 				] ),
+		},
+		{
+			type: 'raw',
+			schema: ( { phrasingContentSchema } ) => ( {
+				figure: {
+					require: [ 'blockquote' ],
+					children: {
+						blockquote: {
+							children: '*',
+						},
+						figcaption: {
+							children: phrasingContentSchema,
+						},
+					},
+				},
+			} ),
+			isMatch: ( node ) =>
+				node.nodeName === 'FIGURE' &&
+				!! node.querySelector( 'blockquote' ),
+			transform: ( node ) => {
+				return createBlock(
+					'core/quote',
+					{
+						attribution: node.querySelector( 'figcaption' )
+							?.innerHTML,
+					},
+					rawHandler( {
+						HTML: node.querySelector( 'blockquote' ).innerHTML,
+						mode: 'BLOCKS',
+					} )
+				);
+			},
 		},
 		{
 			type: 'block',

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -124,6 +124,19 @@ const transforms = {
 		},
 		{
 			type: 'block',
+			blocks: [ '*' ],
+			transform: ( { attribution }, innerBlocks ) =>
+				attribution
+					? [
+							...innerBlocks,
+							createBlock( 'core/paragraph', {
+								content: attribution,
+							} ),
+					  ]
+					: innerBlocks,
+		},
+		{
+			type: 'block',
 			blocks: [ 'core/group' ],
 			transform: ( { attribution }, innerBlocks ) =>
 				createBlock(

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -105,8 +105,8 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
-			transform: ( {}, innerBlocks ) =>
-				createBlock( 'core/quote', {}, innerBlocks ),
+			transform: ( { anchor }, innerBlocks ) =>
+				createBlock( 'core/quote', { anchor }, innerBlocks ),
 		},
 	],
 	to: [
@@ -147,10 +147,10 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
-			transform: ( { attribution }, innerBlocks ) =>
+			transform: ( { attribution, anchor }, innerBlocks ) =>
 				createBlock(
 					'core/group',
-					{},
+					{ anchor },
 					attribution
 						? [
 								...innerBlocks,

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -11,12 +11,6 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
-			blocks: [ 'core/group' ],
-			transform: ( {}, innerBlocks ) =>
-				createBlock( 'core/quote', {}, innerBlocks ),
-		},
-		{
-			type: 'block',
 			blocks: [ 'core/pullquote' ],
 			transform: ( { value, citation } ) => {
 				return createBlock(
@@ -48,8 +42,29 @@ const transforms = {
 					createBlock( 'core/paragraph', { content } ),
 				] ),
 		},
+		{
+			type: 'block',
+			blocks: [ 'core/group' ],
+			transform: ( {}, innerBlocks ) =>
+				createBlock( 'core/quote', {}, innerBlocks ),
+		},
 	],
 	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			isMatch: ( attributes, block ) => {
+				return block.innerBlocks.every(
+					( { name } ) => name === 'core/paragraph'
+				);
+			},
+			transform: ( { attribution }, innerBlocks ) => {
+				return createBlock( 'core/pullquote', {
+					value: serialize( innerBlocks ),
+					citation: attribution,
+				} );
+			},
+		},
 		{
 			type: 'block',
 			blocks: [ 'core/group' ],
@@ -66,21 +81,6 @@ const transforms = {
 						  ]
 						: innerBlocks
 				),
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/pullquote' ],
-			isMatch: ( attributes, block ) => {
-				return block.innerBlocks.every(
-					( { name } ) => name === 'core/paragraph'
-				);
-			},
-			transform: ( { attribution }, innerBlocks ) => {
-				return createBlock( 'core/pullquote', {
-					value: serialize( innerBlocks ),
-					citation: attribution,
-				} );
-			},
 		},
 	],
 };

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -4,7 +4,14 @@
 import { createBlock, serialize } from '@wordpress/blocks';
 
 const transforms = {
-	from: [],
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/group' ],
+			transform: ( {}, innerBlocks ) =>
+				createBlock( 'core/quote', {}, innerBlocks ),
+		},
+	],
 	to: [
 		{
 			type: 'block',

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -13,12 +13,14 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/pullquote' ],
-			transform: ( { value, citation, anchor } ) => {
+			transform: ( { value, citation, anchor, fontSize, style } ) => {
 				return createBlock(
 					'core/quote',
 					{
 						attribution: citation,
 						anchor,
+						fontSize,
+						style,
 					},
 					parseWithAttributeSchema( value, {
 						type: 'array',
@@ -116,11 +118,16 @@ const transforms = {
 					( { name } ) => name === 'core/paragraph'
 				);
 			},
-			transform: ( { attribution, anchor }, innerBlocks ) => {
+			transform: (
+				{ attribution, anchor, fontSize, style },
+				innerBlocks
+			) => {
 				return createBlock( 'core/pullquote', {
 					value: serialize( innerBlocks ),
 					citation: attribution,
 					anchor,
+					fontSize,
+					style,
 				} );
 			},
 		},

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -40,6 +40,14 @@ const transforms = {
 				);
 			},
 		},
+		{
+			type: 'prefix',
+			prefix: '>',
+			transform: ( content ) =>
+				createBlock( 'core/quote', {}, [
+					createBlock( 'core/paragraph', { content } ),
+				] ),
+		},
 	],
 	to: [
 		{

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createBlock, serialize } from '@wordpress/blocks';
+import {
+	createBlock,
+	parseWithAttributeSchema,
+	serialize,
+} from '@wordpress/blocks';
 
 const transforms = {
 	from: [
@@ -10,6 +14,31 @@ const transforms = {
 			blocks: [ 'core/group' ],
 			transform: ( {}, innerBlocks ) =>
 				createBlock( 'core/quote', {}, innerBlocks ),
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			transform: ( { value, citation } ) => {
+				return createBlock(
+					'core/quote',
+					{
+						attribution: citation,
+					},
+					parseWithAttributeSchema( value, {
+						type: 'array',
+						source: 'query',
+						selector: 'p',
+						query: {
+							content: {
+								type: 'string',
+								source: 'text',
+							},
+						},
+					} ).map( ( { content } ) =>
+						createBlock( 'core/paragraph', { content } )
+					)
+				);
+			},
 		},
 	],
 	to: [

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -8,6 +8,23 @@ const transforms = {
 	to: [
 		{
 			type: 'block',
+			blocks: [ 'core/group' ],
+			transform: ( { attribution }, innerBlocks ) =>
+				createBlock(
+					'core/group',
+					{},
+					attribution
+						? [
+								...innerBlocks,
+								createBlock( 'core/paragraph', {
+									content: attribution,
+								} ),
+						  ]
+						: innerBlocks
+				),
+		},
+		{
+			type: 'block',
 			blocks: [ 'core/pullquote' ],
 			isMatch: ( attributes, block ) => {
 				return block.innerBlocks.every(

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -1,6 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock, serialize } from '@wordpress/blocks';
+
 const transforms = {
 	from: [],
-	to: [],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/pullquote' ],
+			isMatch: ( attributes, block ) => {
+				return block.innerBlocks.every(
+					( { name } ) => name === 'core/paragraph'
+				);
+			},
+			transform: ( { attribution }, innerBlocks ) => {
+				return createBlock( 'core/pullquote', {
+					value: serialize( innerBlocks ),
+					citation: attribution,
+				} );
+			},
+		},
+	],
 };
 
 export default transforms;

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -62,11 +62,15 @@ const transforms = {
 				node.nodeName === 'FIGURE' &&
 				!! node.querySelector( 'blockquote' ),
 			transform: ( node ) => {
+				const cite = node.querySelector( 'cite' );
+				const attribution =
+					cite?.innerHTML ??
+					node.querySelector( 'figcaption' )?.innerHTML;
+				cite?.parentNode?.removeChild( cite );
 				return createBlock(
 					'core/quote',
 					{
-						attribution: node.querySelector( 'figcaption' )
-							?.innerHTML,
+						attribution,
 					},
 					rawHandler( {
 						HTML: node.querySelector( 'blockquote' ).innerHTML,

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -307,7 +307,9 @@ const getBlockTypesForPossibleToTransforms = ( blocks ) => {
 	);
 
 	// Map block names to block types.
-	return blockNames.map( ( name ) => getBlockType( name ) );
+	return blockNames.map( ( name ) =>
+		name === '*' ? name : getBlockType( name )
+	);
 };
 
 /**
@@ -541,10 +543,9 @@ export function switchToBlockType( blocks, name ) {
 		return null;
 	}
 
-	const hasSwitchedBlock = some(
-		transformationResults,
-		( result ) => result.name === name
-	);
+	const hasSwitchedBlock =
+		name === '*' ||
+		some( transformationResults, ( result ) => result.name === name );
 
 	// Ensure that at least one block object returned by the transformation has
 	// the expected "destination" block type.


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/15486
Related https://github.com/WordPress/gutenberg/pull/25892

## What?

This PR adds transforms to the Quote v2.

## How?

Transform | Before | After |
--- | --- | --- |
From paragraph | :heavy_check_mark:  | :heavy_check_mark: Removed. Superseeded by the `*` transform. |
From heading | :heavy_check_mark:  | :heavy_check_mark: Removed. Superseeded by the `*` transform. |
From Pullquote | :heavy_check_mark:  | :heavy_check_mark: Same behaviour. It's only available if all inner blocks are paragraphs. | 
From `>` prefix | :heavy_check_mark: | :yellow_circle: See TODO section. Focus stays in the wrapper. Before, the paragraph was focused and users could start typing. To be addressed in a [follow-up](https://github.com/WordPress/gutenberg/pull/39718#issuecomment-1079196437). |
From raw (paste) | :heavy_check_mark: Supports `<blockquote><p /><cite /></blockquote>` | :yellow_circle: See TODO section. Supports the old markup and also `<figure><blockquote/><figcaption /></figure>`. It ignores the cite from the old markup. |
From Group | - | :heavy_check_mark: |
From any (`*`) | - | :heavy_check_mark: Allow any block to be transformed into a quote |
To Paragraph | :heavy_check_mark:  | :heavy_check_mark: Removed. Superseeded by the `*` transform. |
To Heading | :heavy_check_mark:  | :heavy_check_mark: Removed. Superseeded by the `*` transform. |
To Pullquote | :heavy_check_mark:  | :heavy_check_mark: |
To Group | - | :heavy_check_mark: |
To any (`*`) | - | :heavy_check_mark: Allow a quote to be "Unwrapped" (see "Transforms > Unwrap") |

## Testing Instructions

- Go to "Gutenberg > Experiments" page and enable the Quote v2 block.
- Test that the transforms listed above work as expected.

<details>
<summary>Content for testing the `raw` transform</summary>

```html
<p>First example:</p>

<figure>
  <blockquote>
    <p>Paragraph.</p>
    <ul>
      <li>list</li>
    </ul>
    <code>rm -rf</code>
  </blockquote>
  <figcaption>Author</figcaption>
</figure>

<p>Second example:</p>

<blockquote>
  <p>Paragraph.</p>
  <ul>
    <li>list</li>
  </ul>
  <code>rm -rf</code>
</blockquote>
<figcaption>Author</figcaption>

<p>Third example:</p>

<blockquote><p>Paragraph.</p><cite>Cite</cite></blockquote>
```
</details>

## TODO

- ~Merge https://github.com/WordPress/gutenberg/pull/39729 (it updates how the block is registered and fixes the issues with `attribution`).~
- ~Update transforms to consider other attributes (anchor, align, etc). Specially when coming from pullquote.~
- For the `>` prefix transformation, investigate if we can make the focus to start in the inner content instead of  in the wrapper. Before, the paragraph was focused and users could start typing. To be addressed in a [follow-up](https://github.com/WordPress/gutenberg/pull/39718#issuecomment-1079196437).
- For the `raw` transform:
  - `attribution` from `figcaption` not working.
  - when the pasted code contains an `<img src=""/>` element, it doesn't transfom it to a quote
