### PR TITLE
Remove unwanted default `false` in ListView branch component

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -92,7 +92,7 @@ function ListViewBranch( props ) {
 		isBranchSelected = false,
 		listPosition = 0,
 		fixedListWindow,
-		expandNested = true,
+		expandNested,
 	} = props;
 
 	const {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes the `true` default in List View branch component. This is unwanted as the parent defaults to `false` and thus it will already have a default.



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Looks like I missed this default when I merged https://github.com/WordPress/gutenberg/pull/39611/

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the default value allowing it to use the parent's default from:

https://github.com/WordPress/gutenberg/blob/a92b73ceb9e58dc600fb16f2865b2716ee67cef0/packages/block-editor/src/components/list-view/index.js#L75

...which is in turn passed down to into the branch component in:

https://github.com/WordPress/gutenberg/blob/a92b73ceb9e58dc600fb16f2865b2716ee67cef0/packages/block-editor/src/components/list-view/index.js#L228


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Go into both Post and Site Editors
- Expand list view
- See all nodes are _collapsed_ by default.

## Screenshots or screencast <!-- if applicable -->
