### PR TITLE
Add `vendor/` to `.markdownlintignore`

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add `vendor/` to `.markdownlintignore`, to match `lint-md-docs` docs ([#39724](https://github.com/WordPress/gutenberg/pull/39724)).
+
 ## 22.2.0 (2022-03-11)
 
 ### Enhancement

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Bug Fix
+
 -   Add `vendor/` to `.markdownlintignore`, to match `lint-md-docs` docs ([#39724](https://github.com/WordPress/gutenberg/pull/39724)).
 
 ## 22.2.0 (2022-03-11)

--- a/packages/scripts/config/.markdownlintignore
+++ b/packages/scripts/config/.markdownlintignore
@@ -1,2 +1,3 @@
 **/build/**
 **/node_modules/**
+**/vendor/**


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add `vendor/` to `.markdownlintignore`
for wp-scripts, to match the documented behavior
https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-md-docs

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

[Documentation states:](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-scripts/#lint-md-docs)
> By default, files located in `build`, `node_modules`, and `vendor` folders are ignored.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
0. Open a project that has some lint errors in `/vendor` folder, like https://github.com/woocommerce/google-listings-and-ads/
1. Run `wp-scripts lint-md-docs` 

### Before
```
> wp-scripts lint-md-docs

…
vendor/automattic/jetpack-a8c-mc-stats/README.md:35 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```php"]
vendor/automattic/jetpack-assets/README.md:7 MD001/heading-increment/header-increment Heading levels should only increment by one level at a time [Expected: h2; Actual: h3]
```

## Screenshots or screencast <!-- if applicable -->
