### PR TITLE
Tests: Apply style variations using labels

### DIFF
--- a/packages/e2e-tests/specs/site-editor/style-variations.test.js
+++ b/packages/e2e-tests/specs/site-editor/style-variations.test.js
@@ -22,19 +22,22 @@ async function getAvailableStyleVariations() {
 	return page.$$( VARIATION_ITEMS_STYLES_SELECTOR );
 }
 
-async function applyVariation( number ) {
+async function applyVariation( title ) {
 	await toggleGlobalStyles();
 	await openOtherStyles();
-	const variations = await getAvailableStyleVariations();
-	await variations[ number ].click();
+	const variation = await await page.waitForXPath(
+		`//*[@role="button"][@aria-label="${ title }"]`
+	);
+	await variation.focus();
+	await page.keyboard.press( 'Enter' );
 }
 
 async function applyPinkVariation() {
-	await applyVariation( 1 );
+	await applyVariation( 'pink' );
 }
 
 async function applyYellowVariation() {
-	await applyVariation( 2 );
+	await applyVariation( 'yellow' );
 }
 
 async function openColorsPanel() {

--- a/packages/e2e-tests/specs/site-editor/style-variations.test.js
+++ b/packages/e2e-tests/specs/site-editor/style-variations.test.js
@@ -25,7 +25,7 @@ async function getAvailableStyleVariations() {
 async function applyVariation( label ) {
 	await toggleGlobalStyles();
 	await openOtherStyles();
-	const variation = await await page.waitForXPath(
+	const variation = await page.waitForXPath(
 		`//*[@role="button"][@aria-label="${ label }"]`
 	);
 	await variation.click();

--- a/packages/e2e-tests/specs/site-editor/style-variations.test.js
+++ b/packages/e2e-tests/specs/site-editor/style-variations.test.js
@@ -22,14 +22,13 @@ async function getAvailableStyleVariations() {
 	return page.$$( VARIATION_ITEMS_STYLES_SELECTOR );
 }
 
-async function applyVariation( title ) {
+async function applyVariation( label ) {
 	await toggleGlobalStyles();
 	await openOtherStyles();
 	const variation = await await page.waitForXPath(
-		`//*[@role="button"][@aria-label="${ title }"]`
+		`//*[@role="button"][@aria-label="${ label }"]`
 	);
-	await variation.focus();
-	await page.keyboard.press( 'Enter' );
+	await variation.click();
 }
 
 async function applyPinkVariation() {


### PR DESCRIPTION
## What?
Updates style variation select helper to use variation labels.

## Why?
It matches how a user will interact with the panel.

## How?
* Update `applyVariation` to use variation label, now that they're supported - #39322.

## Testing Instructions

```
npm run test-e2e -- packages/e2e-tests/specs/site-editor/style-variations.test.js
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/159954538-4fb404c1-5a37-409d-9924-adf0faf4b09c.mp4


