### PR TITLE
Add x2 to url string that defines the image size by default

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -18,6 +18,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { __, isRTL } from '@wordpress/i18n';
+import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -85,6 +86,12 @@ const ResizableAvatar = ( {
 	isSelected,
 } ) => {
 	const borderProps = useBorderProps( attributes );
+	const doubledSizedSrc = addQueryArgs(
+		removeQueryArgs( avatar?.src, [ 's' ] ),
+		{
+			s: attributes?.size * 2,
+		}
+	);
 	return (
 		<div { ...blockProps }>
 			<ResizableBox
@@ -112,7 +119,7 @@ const ResizableAvatar = ( {
 				maxWidth={ avatar.maxSize }
 			>
 				<img
-					src={ avatar.src }
+					src={ doubledSizedSrc }
 					alt={ avatar.alt }
 					{ ...borderProps }
 					className={ classnames(

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -33,7 +33,7 @@ const AvatarInspectorControls = ( {
 	selectUser,
 } ) => (
 	<InspectorControls>
-		<PanelBody title={ __( 'Avatar Settings' ) }>
+		<PanelBody title={ __( 'Settings' ) }>
 			<RangeControl
 				label={ __( 'Image size' ) }
 				onChange={ ( newSize ) =>
@@ -46,16 +46,6 @@ const AvatarInspectorControls = ( {
 				initialPosition={ attributes?.size }
 				value={ attributes?.size }
 			/>
-			{ selectUser && (
-				<UserControl
-					value={ attributes?.userId }
-					onChange={ ( value ) => {
-						setAttributes( {
-							userId: value,
-						} );
-					} }
-				/>
-			) }
 			<ToggleControl
 				label={ __( 'Link to user profile' ) }
 				onChange={ () =>
@@ -72,6 +62,16 @@ const AvatarInspectorControls = ( {
 						} )
 					}
 					checked={ attributes.linkTarget === '_blank' }
+				/>
+			) }
+			{ selectUser && (
+				<UserControl
+					value={ attributes?.userId }
+					onChange={ ( value ) => {
+						setAttributes( {
+							userId: value,
+						} );
+					} }
 				/>
 			) }
 		</PanelBody>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Increase the size of the Avatar image to be 2x of the width chosen, in order not to get pixelated on retina displays.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, WordPress by default has 3 sizes for the User Avatars:
  - 24x24
  - 48x48
  - 96x96

With the new Avatar block, we allow the user up to 240px size. Causing all Avatars above 96px will get pixelated. Also, all Avatars above 48px will get pixelated on retina displays.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Behind the scenes, it calls Gravatar URLs for defaults Avatars as well for custom Avatars based on user emails. Some similar to this:
`http://1.gravatar.com/avatar/d7a973c7dab26985da5f961be7b74480?s=96&d=mm&r=g`
If we check the URL, the query `s` defines the image size -> `?s=96`

It seems that just by doubling that value, Gravatar will return an image of that size. So we can double it both in the editor and in the frontend (the `wp_get_avatar()` function is adding the `srcset` attribute with a 2x by default).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Open a Post or Page.
- Add an Avatar.
- Resize it.
- Check the src attribute of the image, it should be double the Avatar size.
- Check on the frontend that there is a srcset with the size for the Avatar doubled.

## Screenshots or screencast <!-- if applicable -->
Editor with a 165*2 size:
![Screenshot 2022-03-24 at 18 14 24](https://user-images.githubusercontent.com/37012961/159975208-adbee7f9-e74b-48aa-8b3a-bff367daaf40.png)

Frontend with a 165 size for srcset 1x, a 165*2 for srcset2x
![Screenshot 2022-03-24 at 18 15 53](https://user-images.githubusercontent.com/37012961/159975254-228069ce-14c9-4ff5-be91-89329d66e55f.png)

