### PR TITLE
Comment blocks: Update block descriptions

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -109,7 +109,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 
 ## Comment Author Avatar
 
-Add the avatar of this comment's author. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-avatar))
+Displays the avatar of the comment's author. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-avatar))
 
 -	**Name:** core/comment-author-avatar
 -	**Category:** theme
@@ -118,7 +118,7 @@ Add the avatar of this comment's author. ([Source](https://github.com/WordPress/
 
 ## Comment Author Name
 
-Add the author name of this comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
+Display the name of the author of the comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
 
 -	**Name:** core/comment-author-name
 -	**Category:** theme
@@ -136,7 +136,7 @@ Displays the contents of a comment. ([Source](https://github.com/WordPress/guten
 
 ## Comment Date
 
-Add the date of this comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-date))
+Displays the date on which the comment was posted. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-date))
 
 -	**Name:** core/comment-date
 -	**Category:** theme
@@ -163,7 +163,7 @@ Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gu
 
 ## Comment Template
 
-Contains the block elements used to render a comment, like the title, date, author, avatar and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-template))
+Contains the block elements used to display a comment, like the title, date, author, avatar and more. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-template))
 
 -	**Name:** core/comment-template
 -	**Category:** design
@@ -181,7 +181,7 @@ Displays a paginated navigation to next/previous set of comments, when applicabl
 
 ## Next Page
 
-Displays the next comments page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-next))
+Displays the next comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-next))
 
 -	**Name:** core/comments-pagination-next
 -	**Category:** theme
@@ -208,7 +208,7 @@ Displays the previous comments page link. ([Source](https://github.com/WordPress
 
 ## Comments Query Loop
 
-An advanced block that allows displaying post comments based on different query parameters and visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-query-loop))
+An advanced block that allows displaying post comments using different visual configurations. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-query-loop))
 
 -	**Name:** core/comments-query-loop
 -	**Category:** theme

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -118,7 +118,7 @@ Displays the avatar of the comment's author. ([Source](https://github.com/WordPr
 
 ## Comment Author Name
 
-Display the name of the author of the comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
+Displays the name of the author of the comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-author-name))
 
 -	**Name:** core/comment-author-name
 -	**Category:** theme
@@ -199,7 +199,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 
 ## Previous Page
 
-Displays the previous comments page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-previous))
+Displays the previous comment's page link. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comments-pagination-previous))
 
 -	**Name:** core/comments-pagination-previous
 -	**Category:** theme

--- a/packages/block-library/src/comment-author-avatar/block.json
+++ b/packages/block-library/src/comment-author-avatar/block.json
@@ -5,7 +5,7 @@
 	"title": "Comment Author Avatar",
 	"category": "theme",
 	"parent": [ "core/comment-template" ],
-	"description": "Add the avatar of this comment's author.",
+	"description": "Displays the avatar of the comment's author.",
 	"textdomain": "default",
 	"attributes": {
 		"width": {

--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -5,7 +5,7 @@
 	"title": "Comment Author Name",
 	"category": "theme",
 	"parent": [ "core/comment-template" ],
-	"description": "Add the author name of this comment.",
+	"description": "Display the name of the author of the comment.",
 	"textdomain": "default",
 	"attributes": {
 		"isLink": {

--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -5,7 +5,7 @@
 	"title": "Comment Author Name",
 	"category": "theme",
 	"parent": [ "core/comment-template" ],
-	"description": "Display the name of the author of the comment.",
+	"description": "Displays the name of the author of the comment.",
 	"textdomain": "default",
 	"attributes": {
 		"isLink": {

--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -5,7 +5,7 @@
 	"title": "Comment Date",
 	"category": "theme",
 	"parent": [ "core/comment-template" ],
-	"description": "Add the date of this comment.",
+	"description": "Displays the date on which the comment was posted.",
 	"textdomain": "default",
 	"attributes": {
 		"format": {

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -5,7 +5,7 @@
 	"title": "Comment Template",
 	"category": "design",
 	"parent": [ "core/comments-query-loop" ],
-	"description": "Contains the block elements used to render a comment, like the title, date, author, avatar and more.",
+	"description": "Contains the block elements used to display a comment, like the title, date, author, avatar and more.",
 	"textdomain": "default",
 	"usesContext": [ "postId" ],
 	"supports": {

--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -5,7 +5,7 @@
 	"title": "Next Page",
 	"category": "theme",
 	"parent": [ "core/comments-pagination" ],
-	"description": "Displays the next comments page link.",
+	"description": "Displays the next comment's page link.",
 	"textdomain": "default",
 	"attributes": {
 		"label": {

--- a/packages/block-library/src/comments-pagination-previous/block.json
+++ b/packages/block-library/src/comments-pagination-previous/block.json
@@ -5,7 +5,7 @@
 	"title": "Previous Page",
 	"category": "theme",
 	"parent": [ "core/comments-pagination" ],
-	"description": "Displays the previous comments page link.",
+	"description": "Displays the previous comment's page link.",
 	"textdomain": "default",
 	"attributes": {
 		"label": {

--- a/packages/block-library/src/comments-query-loop/block.json
+++ b/packages/block-library/src/comments-query-loop/block.json
@@ -4,7 +4,7 @@
 	"name": "core/comments-query-loop",
 	"title": "Comments Query Loop",
 	"category": "theme",
-	"description": "An advanced block that allows displaying post comments based on different query parameters and visual configurations.",
+	"description": "An advanced block that allows displaying post comments using different visual configurations.",
 	"textdomain": "default",
 	"attributes": {
 		"tagName": {


### PR DESCRIPTION
A followup to #39664. 

As we removed the all the attributes related to query parameters from the Comments Query Loop block, I've removed the reference to "configuration based on query parameters" from the block's description.

I also took this opportunity to polish a few of the other `Comment-*` blocks' descriptions.
