### PR TITLE
Fix global style variations previews not showing correct height

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -91,7 +91,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 			{ containerResizeListener }
 			<motion.div
 				style={ {
-					height: '100%',
+					height: 150 * ratio,
 					width: '100%',
 					background: gradientValue ?? backgroundColor,
 					cursor: 'pointer',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related and potential alternative to #39725

## What?
Should help fix the failing tests in `trunk`. This seems to have started happening after #38855 was merged.

## Why?
From what I can tell, now that the previews are rendering using standards mode instead of quirks mode, there's a change to how the document in the iframe determines its size. Previously it assumed the size of the iframe (like having `height: 100%`), but now it assumes the size of the content (like having `height: auto`).

The problem with this is not only did the previews end up looking wrong, but there was also a problem where the bottom part of the preview couldn't be clicked (the cause of the e2e test failures—props to @Mamaduka for diagnosing that).

## How?
I've fixed it by giving the content an explicit height that matches the iframe's height.

I'm not all that familiar with the code, so unsure if there are issues with this fix. It looks like content in the iframe is all known ahead of time rather than dynamic, so I wouldn't expect any problems.

## Testing Instructions
Use a theme that has style variations. The gutenberg test environment has one called 'Style Variations'.
1. Open the global styles panel
2. Click 'Other styles'
3. The variations should display correctly and the bottom part of them can be clicked.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2022-03-25 at 12 07 39 pm](https://user-images.githubusercontent.com/677833/160052444-96758d63-e1d8-481f-a596-45d339830e5d.png)

#### After
![Screen Shot 2022-03-25 at 12 07 22 pm](https://user-images.githubusercontent.com/677833/160052471-45ef55a4-ce68-465d-aab4-89303eb0cba4.png)

