### PR TITLE
Fix align wide not working with root padding

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -59,7 +59,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= '}';
 
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-			$style .= "$selector .alignfull { max-width: none; width: 100vw; margin-left: 50%; transform: translateX(-50%); }";
+			$style .= "$selector .alignfull { max-width: none; width: 100vw; margin-left: 50% ! important; transform: translateX(-50%); }";
 		}
 
 		$style .= "$selector > .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }";

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -59,7 +59,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			$style .= '}';
 
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-			$style .= "$selector .alignfull { max-width: none; }";
+			$style .= "$selector .alignfull { max-width: none; width: 100vw; margin-left: 50%; transform: translateX(-50%); }";
 		}
 
 		$style .= "$selector > .alignleft { float: left; margin-inline-start: 0; margin-inline-end: 2em; }";


### PR DESCRIPTION
## What?
Just exploring solutions for this https://github.com/WordPress/gutenberg/issues/35607

This PR explores using a transform to override the padding for alignwide - early days yet, bound to be some gotchas

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="869" alt="Screen Shot 2022-03-25 at 5 30 05 PM" src="https://user-images.githubusercontent.com/3629020/160054527-f01dda41-9385-4029-9db5-682e5e875ef3.png">

After:
<img width="871" alt="Screen Shot 2022-03-25 at 5 29 30 PM" src="https://user-images.githubusercontent.com/3629020/160054539-f7b184cb-363e-4ac1-a218-5728ecc79703.png">

