### PR TITLE
ListView: fix e2e flakiness

### DIFF
--- a/packages/e2e-tests/specs/editor/various/list-view.test.js
+++ b/packages/e2e-tests/specs/editor/various/list-view.test.js
@@ -81,7 +81,7 @@ describe( 'List view', () => {
 		const listViewImageBlock = await page.waitForXPath(
 			'//a[contains(., "Image")]'
 		);
-		expect( listViewImageBlock ).toHaveFocus();
+		await expect( listViewImageBlock ).toHaveFocus();
 
 		// Select the image block in the canvas.
 		await page.keyboard.press( 'Enter' );
@@ -89,7 +89,7 @@ describe( 'List view', () => {
 		const uploadButton = await page.waitForXPath(
 			'//button[contains( text(), "Upload" ) ]'
 		);
-		expect( uploadButton ).toHaveFocus();
+		await expect( uploadButton ).toHaveFocus();
 
 		// Delete the image block in the canvas.
 		await page.keyboard.press( 'ArrowUp' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
ListView e2e test is being flagged as flaky

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes: #39506
Fixes: #39641

## How?

Wait for the `expect` promise to be resolved.

## Testing Instructions

Run `packages/e2e-tests/specs/editor/various/list-view.test.js` a few times, you will see it fails sometimes.

## Screenshots or screencast <!-- if applicable -->
