### PR TITLE
Spacer: Use layout context to work out whether or not Spacer should be horizontal in the Row block

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -6,7 +6,8 @@
  */
 
 /**
- * Registers the layout block attribute for block types that support it.
+ * Registers the layout block attribute for block types that support it,
+ * and sets `provides_context` to allow children to access the layout settings.
  *
  * @param WP_Block_Type $block_type Block Type.
  */
@@ -21,6 +22,14 @@ function gutenberg_register_layout_support( $block_type ) {
 			$block_type->attributes['layout'] = array(
 				'type' => 'object',
 			);
+		}
+
+		if ( ! isset( $block_type->provides_context ) ) {
+			$block_type->provides_context = array();
+		}
+
+		if ( ! array_key_exists( 'layout', $block_type->provides_context ) ) {
+			$block_type->provides_context['layout'] = 'layout';
 		}
 	}
 }

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -167,6 +167,29 @@ export function addAttribute( settings ) {
 }
 
 /**
+ * Adds layout to `providesContext` so that the layout context can be accessed
+ * via child blocks.
+ *
+ * @param {Object} settings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addProvidesContext( settings ) {
+	if ( settings.providesContext?.layout ) {
+		return settings;
+	}
+	if ( hasBlockSupport( settings, layoutBlockSupportKey ) ) {
+		const providesContext = settings.providesContext || {};
+		settings.providesContext = {
+			...providesContext,
+			layout: 'layout',
+		};
+	}
+
+	return settings;
+}
+
+/**
  * Override the default edit UI to include layout controls
  *
  * @param {Function} BlockEdit Original component.
@@ -239,6 +262,11 @@ addFilter(
 	'blocks.registerBlockType',
 	'core/layout/addAttribute',
 	addAttribute
+);
+addFilter(
+	'blocks.registerBlockType',
+	'core/layout/addProvidesContext',
+	addProvidesContext
 );
 addFilter(
 	'editor.BlockListBlock',

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -17,6 +17,10 @@
 			"enum": [ "all", "insert", false ]
 		}
 	},
+	"providesContext": {
+		"layout": "layout",
+		"orientation": "orientation"
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"anchor": true,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -17,10 +17,6 @@
 			"enum": [ "all", "insert", false ]
 		}
 	},
-	"providesContext": {
-		"layout": "layout",
-		"orientation": "orientation"
-	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"anchor": true,

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -15,7 +15,10 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "orientation" ],
+	"usesContext": [
+		"layout",
+		"orientation"
+	],
 	"supports": {
 		"anchor": true
 	},

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -80,7 +80,14 @@ const SpacerEdit = ( {
 	toggleSelection,
 	context,
 } ) => {
-	const { orientation } = context;
+	const { layout, orientation: orientationContext } = context;
+
+	let orientation = orientationContext || layout?.orientation;
+
+	if ( ! orientation && layout?.type === 'flex' ) {
+		orientation = 'horizontal';
+	}
+
 	const { height, width } = attributes;
 
 	const [ isResizing, setIsResizing ] = useState( false );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #36197

Update the Spacer block to look at `layout` data to infer orientation if no default orientation is available. This primarily addresses an issue when the Spacer block is a child of the Row block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Row block does not set a `horizontal` orientation explicitly — its orientation is implicit.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the Layout block support to automatically add the `layout` attribute to the context that's provided for blocks that opt-in to the layout support
* In the Spacer block, grab that context to infer the correct orientation

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Row block
2. Add a Spacer block in between two blocks within that Row block
3. With this PR applied, the orientation of the Row block should be horizontal, not vertical
4. Check that the orientation of the Spacer block is correct in all other contexts (defaults vertical, is vertical when a child of the Group block)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/160063906-b4e0b7e2-ca6a-4173-bf1a-d79257ea6f58.png) | ![image](https://user-images.githubusercontent.com/14988353/160063940-458e1558-6cdd-46db-b785-84a9c11fa10f.png) |