### PR TITLE
Revert unwanted breaking changes in eslint-plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -230,18 +230,19 @@ module.exports = {
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],
 		},
 		{
-			files: [
-				'packages/e2e-tests/**/*.js',
-				'packages/e2e-test-utils/**/*.js',
-			],
+			files: [ 'packages/e2e-test*/**/*.js' ],
+			excludedFiles: [ 'packages/e2e-test-utils-playwright/**/*.js' ],
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-e2e' ],
+			rules: {
+				'jest/expect-expect': 'off',
+			},
 		},
 		{
 			files: [
 				'test/e2e/**/*.[tj]s',
 				'packages/e2e-test-utils-playwright/**/*.[tj]s',
 			],
-			extends: [ 'plugin:@wordpress/eslint-plugin/test-e2e-playwright' ],
+			extends: [ 'plugin:eslint-plugin-playwright/playwright-test' ],
 			rules: {
 				'@wordpress/no-global-active-element': 'off',
 				'@wordpress/no-global-get-selection': 'off',

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1512,6 +1512,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/e2e-tests",
+		"slug": "packages-e2e-tests",
+		"markdown_source": "../packages/e2e-tests/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/edit-post",
 		"slug": "packages-edit-post",
 		"markdown_source": "../packages/edit-post/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17863,7 +17863,6 @@
 				"eslint-plugin-jest": "^25.2.3",
 				"eslint-plugin-jsdoc": "^37.0.3",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
-				"eslint-plugin-playwright": "^0.8.0",
 				"eslint-plugin-prettier": "^3.3.0",
 				"eslint-plugin-react": "^7.27.0",
 				"eslint-plugin-react-hooks": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
 		"eslint-import-resolver-node": "0.3.4",
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.25.2",
+		"eslint-plugin-playwright": "0.8.0",
 		"execa": "4.0.2",
 		"fast-glob": "3.2.7",
 		"filenamify": "^4.2.0",

--- a/packages/e2e-tests/CHANGELOG.md
+++ b/packages/e2e-tests/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-  There's currently an ongoing [project](https://github.com/WordPress/gutenberg/issues/38851) to migrate E2E tests to Playwright instead. This package is deprecated and will only accept bug fixes until fully migrated.
+
 ## 3.0.0 (2022-01-27)
 
 ### Breaking Changes

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@wordpress/e2e-tests",
-	"private": true,
 	"version": "3.1.1",
 	"description": "End-To-End (E2E) tests for WordPress.",
 	"author": "The WordPress Contributors",

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Revert the removal of the automatic environment detection of `test-unit` and `test-e2e` for the `recommended` preset. However, They will still be disabled if `@playwright/test` is installed in the project.
+
 ## 11.0.0 (2022-03-11)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/recommended-with-formatting.js
+++ b/packages/eslint-plugin/configs/recommended-with-formatting.js
@@ -1,3 +1,8 @@
+/**
+ * Internal dependencies
+ */
+const { isPackageInstalled } = require( '../utils' );
+
 // Exclude bundled WordPress packages from the list.
 const wpPackagesRegExp = '^@wordpress/(?!(icons|interface))';
 
@@ -39,5 +44,24 @@ const config = {
 		'import/named': 'warn',
 	},
 };
+
+// Don't apply Jest config if Playwright is installed.
+if (
+	isPackageInstalled( 'jest' ) &&
+	! isPackageInstalled( '@playwright/test' )
+) {
+	config.overrides = [
+		{
+			// Unit test files and their helpers only.
+			files: [ '**/@(test|__tests__)/**/*.js', '**/?(*.)test.js' ],
+			extends: [ require.resolve( './test-unit.js' ) ],
+		},
+		{
+			// End-to-end test files and their helpers only.
+			files: [ '**/specs/**/*.js', '**/?(*.)spec.js' ],
+			extends: [ require.resolve( './test-e2e.js' ) ],
+		},
+	];
+}
 
 module.exports = config;

--- a/packages/eslint-plugin/configs/test-e2e-playwright.js
+++ b/packages/eslint-plugin/configs/test-e2e-playwright.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: [ 'plugin:playwright/playwright-test' ],
-};

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,6 @@
 		"eslint-plugin-jest": "^25.2.3",
 		"eslint-plugin-jsdoc": "^37.0.3",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
-		"eslint-plugin-playwright": "^0.8.0",
 		"eslint-plugin-prettier": "^3.3.0",
 		"eslint-plugin-react": "^7.27.0",
 		"eslint-plugin-react-hooks": "^4.3.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As suggested in https://github.com/WordPress/gutenberg/pull/38570#pullrequestreview-918294036, there are some unwanted breaking changes in the eslint-plugin. This PR reverts them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We want to introduce Playwright testing infrastructure with minimal disruptions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Revert the changes `eslint-plugin` back, add custom overrides in the root `.eslintrc.js`.

Custom overrides for the `test-e2e` preset seem not possible though. I have to do package sniffing (whether `@playwright/test` is installed) to disable the preset.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
```sh
npm run lint-js
```