### PR TITLE
Migrated navigable-toolbar.test.js to Playwright

### DIFF
--- a/packages/e2e-test-utils-playwright/src/page/create-new-post.js
+++ b/packages/e2e-test-utils-playwright/src/page/create-new-post.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Creates new post.
+ *
+ * @this {import('./').PageUtils}
+ * @param {Object}  object                    Object to create new post, along with tips enabling option.
+ * @param {string}  [object.postType]         Post type of the new post.
+ * @param {string}  [object.title]            Title of the new post.
+ * @param {string}  [object.content]          Content of the new post.
+ * @param {string}  [object.excerpt]          Excerpt of the new post.
+ * @param {boolean} [object.showWelcomeGuide] Whether to show the welcome guide.
+ */
+export async function createNewPost( {
+	postType,
+	title,
+	content,
+	excerpt,
+	showWelcomeGuide = false,
+} = {} ) {
+	const query = addQueryArgs( '', {
+		post_type: postType,
+		post_title: title,
+		content,
+		excerpt,
+	} ).slice( 1 );
+
+	await this.visitAdminPage( 'post-new.php', query );
+
+	await this.page.waitForSelector( '.edit-post-layout' );
+
+	const isWelcomeGuideActive = await this.page.evaluate( () =>
+		window.wp.data
+			.select( 'core/edit-post' )
+			.isFeatureActive( 'welcomeGuide' )
+	);
+	const isFullscreenMode = await this.page.evaluate( () =>
+		window.wp.data
+			.select( 'core/edit-post' )
+			.isFeatureActive( 'fullscreenMode' )
+	);
+
+	if ( showWelcomeGuide !== isWelcomeGuideActive ) {
+		await this.page.evaluate( () =>
+			window.wp.data
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'welcomeGuide' )
+		);
+
+		await this.page.reload();
+		await this.page.waitForSelector( '.edit-post-layout' );
+	}
+
+	if ( isFullscreenMode ) {
+		await this.page.evaluate( () =>
+			window.wp.data
+				.dispatch( 'core/edit-post' )
+				.toggleFeature( 'fullscreenMode' )
+		);
+
+		await this.page.waitForSelector( 'body:not(.is-fullscreen-mode)' );
+	}
+}

--- a/packages/e2e-test-utils-playwright/src/page/index.ts
+++ b/packages/e2e-test-utils-playwright/src/page/index.ts
@@ -9,6 +9,7 @@ import type { Browser, Page, BrowserContext } from '@playwright/test';
 import { getPageError } from './get-page-error';
 import { isCurrentURL } from './is-current-url';
 import { visitAdminPage } from './visit-admin-page';
+import { createNewPost } from './create-new-post';
 
 class PageUtils {
 	browser: Browser;
@@ -24,6 +25,7 @@ class PageUtils {
 	getPageError = getPageError;
 	isCurrentURL = isCurrentURL;
 	visitAdminPage = visitAdminPage;
+	createNewPost = createNewPost;
 }
 
 export { PageUtils };

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -38,7 +38,7 @@ const config: PlaywrightTestConfig = {
 			strictSelectors: true,
 		},
 		storageState: STORAGE_STATE_PATH,
-		actionTimeout: 10_000, // 10 seconds.
+		actionTimeout: 20_000, // 20 seconds.
 		trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'on-first-retry',

--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -19,10 +19,11 @@ const config: PlaywrightTestConfig = {
 	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 100_000, // Defaults to 100 seconds.
 	// Don't report slow test "files", as we will be running our tests in serial.
 	reportSlowTests: null,
-	testDir: new URL( './specs', 'file:' + __filename ).pathname,
+	// testDir: new URL( './specs', 'file:' + __filename ).pathname,
+	testDir: './specs',
 	outputDir: path.join( process.cwd(), 'artifacts/test-results' ),
-	globalSetup: new URL( './config/global-setup.ts', 'file:' + __filename )
-		.pathname,
+	// globalSetup: new URL( './config/global-setup.ts', 'file:' + __filename ).pathname,
+	globalSetup: './config/global-setup.ts',
 	use: {
 		baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',
 		headless: true,

--- a/test/e2e/specs/editor/various/new-post.spec.js
+++ b/test/e2e/specs/editor/various/new-post.spec.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'new editor state', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin(
+			'gutenberg-test-plugin-post-formats-support'
+		);
+	} );
+
+	test.beforeEach( async ( { pageUtils } ) => {
+		await pageUtils.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin(
+			'gutenberg-test-plugin-post-formats-support'
+		);
+	} );
+
+	test( 'should show the New Post page in Gutenberg', async ( { page } ) => {
+		expect( page.url() ).toEqual(
+			expect.stringContaining( 'post-new.php' )
+		);
+		// Should display the blank title.
+		const title = await page.locator( '[aria-label="Add title"]' );
+		await expect( title ).toHaveCount( 1 );
+
+		// Trim padding non-breaking space.
+		expect(
+			await title.evaluate( ( el ) => el.textContent.trim() )
+		).toBeFalsy();
+		// Should display the Preview button.
+		const postPreviewButton = await page.locator(
+			'.editor-post-preview.components-button'
+		);
+		await expect( postPreviewButton ).toHaveCount( 1 );
+
+		// Should display the Post Formats UI.
+		const postFormatsUi = await page.locator( '.editor-post-format' );
+		await expect( postFormatsUi ).toHaveCount( 1 );
+	} );
+
+	test( 'should have no history', async ( { page } ) => {
+		const undoButton = await page.locator(
+			'.editor-history__undo[aria-disabled="false"]'
+		);
+		const redoButton = await page.locator(
+			'.editor-history__redo[aria-disabled="false"]'
+		);
+
+		await expect( undoButton ).toHaveCount( 0 );
+		await expect( redoButton ).toHaveCount( 0 );
+	} );
+
+	test( 'should focus the title if the title is empty', async ( {
+		page,
+	} ) => {
+		const activeElementClasses = await page.evaluate( () => {
+			return Object.values( document.activeElement.classList );
+		} );
+		const activeElementTagName = await page.evaluate( () => {
+			return document.activeElement.tagName.toLowerCase();
+		} );
+
+		expect( activeElementClasses ).toContain( 'editor-post-title__input' );
+		expect( activeElementTagName ).toEqual( 'h1' );
+	} );
+
+	test( 'should not focus the title if the title exists', async ( {
+		page,
+	} ) => {
+		// Enter a title for this post.
+		await page.type( '.editor-post-title__input', 'Here is the title' );
+		// Save the post as a draft.
+		await page.click( '.editor-post-save-draft' );
+		await page.waitForSelector( '.editor-post-saved-state.is-saved' );
+		// Reload the browser so a post is loaded with a title.
+		await page.reload();
+		await page.waitForSelector( '.edit-post-layout' );
+
+		const activeElementClasses = await page.evaluate( () => {
+			return Object.values( document.activeElement.classList );
+		} );
+		const activeElementTagName = await page.evaluate( () => {
+			return document.activeElement.tagName.toLowerCase();
+		} );
+
+		expect( activeElementClasses ).not.toContain(
+			'editor-post-title__input'
+		);
+		// The document `body` should be the `activeElement`, because nothing is
+		// focused by default when a post already has a title.
+		expect( activeElementTagName ).toEqual( 'body' );
+	} );
+
+	test( 'should be saveable with sufficient initial edits', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.createNewPost( { title: 'Here is the title' } );
+
+		// Verify saveable by presence of the Save Draft button.
+		await page.locator( 'button.editor-post-save-draft' );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Based on https://github.com/WordPress/gutenberg/pull/38570, part of https://github.com/WordPress/gutenberg/issues/38851. Navigable Toolbar [navigable-toolbar.test.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/various/navigable-toolbar.test.js) to its Playwright counterpart.

## Why?
[Migration to Playwright](https://make.wordpress.org/core/2022/03/23/migrating-wordpress-e2e-tests-to-playwright/)

## How?
[Migration to Playwright](https://make.wordpress.org/core/2022/03/23/migrating-wordpress-e2e-tests-to-playwright/)

## Testing Instructions
npm run test-e2e:playwright -- test/e2e/specs/editor/various/navigable-toolbar.spec.js

## Screenshots or screencast <!-- if applicable -->


