### PR TITLE
BorderControl: Fix vertical alignment of inner slider control

### DIFF
--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -185,5 +185,6 @@ export const borderSlider = () => css`
 	${ StyledField } {
 		margin-bottom: 0;
 		font-size: 0;
+		display: flex;
 	}
 `;


### PR DESCRIPTION
## What?

Improve the styling of the `BorderControl` to ensure the inner slider control is more reliably vertically aligned to the center out of the box.

## Why?

This change is being made to the component itself so there is less that any consumer may need to tweak for everything to be neatly aligned in their UI.

## How?

Adds back the `display: flex` rule that the component originally used to solve this alignment (https://github.com/WordPress/gutenberg/pull/37769#discussion_r809133186)

## Testing Instructions

1. Checkout this branch and start up the Storybook
    - `npm run storybook:dev`
2. Confirm the slider within the [`BorderControl`](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default) is still vertically aligned to the center.
3. Check the alignment for the [`BorderBoxControl`](http://localhost:50240/?path=/story/components-experimental-borderboxcontrol--default)'s linked view.
4. If you're still not convinced. You can apply the changes from this branch onto [#37770](https://github.com/WordPress/gutenberg/pull/37770) and confirm the alignment now works in the block editor
    - Create a post, add a group block, and select it
    - Take a look at the border control in the inspector controls sidebar 


## Screenshots or screencast <!-- if applicable -->

Screenshots below are from #37770 and the block editor.

| Before | After |
|---|---|
| <img width="282" alt="Screen Shot 2022-03-25 at 5 39 30 pm" src="https://user-images.githubusercontent.com/60436221/160079373-93609243-0e18-4869-acf2-30e330bf3444.png"> | <img width="280" alt="Screen Shot 2022-03-25 at 5 40 54 pm" src="https://user-images.githubusercontent.com/60436221/160079384-70a0a566-2b6b-4e0b-a001-2484648f53a1.png"> |

