### PR TITLE
Theme Export: Convert spaces to tabs in theme.json

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -99,10 +99,14 @@ function gutenberg_generate_block_templates_export_file() {
 	// Load theme.json into the zip file.
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
 	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
-
+	// Convert to a string.
+	$theme_json_encoded = wp_json_encode( $tree->get_data(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	// Replace 4 spaces with a tab.
+	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
+	// Add the theme.json file to the zip.
 	$zip->addFromString(
 		'theme.json',
-		wp_json_encode( $tree->get_data(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )
+		$theme_json_tabbed
 	);
 
 	// Save changes to the zip file.


### PR DESCRIPTION
## What?
Convert spaces to tabs when we export theme.json during a theme export.

## Why?
WordPress coding standards require tabs for json files.

## How?
This uses a regex to do the conversion.

## Testing Instructions
1. Switch to a theme that has a theme.json file
2. Export the theme
3. Check that the zip file contains a theme.json file with tabs not spaces

@WordPress/block-themers 