### PR TITLE
Global Styles: Update "Other styles" to "Browse styles"

### DIFF
--- a/packages/e2e-tests/specs/site-editor/style-variations.test.js
+++ b/packages/e2e-tests/specs/site-editor/style-variations.test.js
@@ -11,7 +11,7 @@ import {
 } from '@wordpress/e2e-test-utils';
 
 async function openOtherStyles() {
-	const OTHER_STYLES_SELECTOR = '//div[contains(text(),"Other styles")]';
+	const OTHER_STYLES_SELECTOR = '//div[contains(text(),"Browse styles")]';
 	await ( await page.waitForXPath( OTHER_STYLES_SELECTOR ) ).click();
 }
 

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -42,7 +42,7 @@ function ScreenRoot() {
 					{ !! variations?.length && (
 						<NavigationButton path="/variations">
 							<HStack justify="space-between">
-								<FlexItem>{ __( 'Other styles' ) }</FlexItem>
+								<FlexItem>{ __( 'Browse styles' ) }</FlexItem>
 								<FlexItem>
 									<Icon
 										icon={

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -117,7 +117,7 @@ function ScreenStyleVariations() {
 		<>
 			<ScreenHeader
 				back="/"
-				title={ __( 'Other styles' ) }
+				title={ __( 'Browse styles' ) }
 				description={ __(
 					'Choose a different style combination for the theme styles'
 				) }


### PR DESCRIPTION
## What?

In Global Styles when you have copies of theme.json in a "styles" theme subfolder, you can switch to one of those variants in the interface. This PR changes the title from "Other styles" to "Browse styles".

Before:

<img width="269" alt="before" src="https://user-images.githubusercontent.com/1204802/160082374-70efeb08-9366-4be3-90ef-08a4ee034f74.png">

After:

<img width="268" alt="after" src="https://user-images.githubusercontent.com/1204802/160082400-f31be028-4845-4c8a-8edf-e047a1b7a89d.png">

## Why?

It's a better label for a cool feature.

## Testing Instructions

Easiest to test with the "Empty Theme" variant that comes with the docker install of this repo, it has a few style variants. Activate the theme, go to global styles, and observe the label change.
