### PR TITLE
RSS: Add missing self-URL check

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -14,7 +14,7 @@
  */
 function render_block_core_rss( $attributes ) {
 	if ( in_array( untrailingslashit( $attributes['feedURL'] ), array( site_url(), home_url() ), true ) ) {
-		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'To avoid a loop slowing down your site, adding an RSS feed to this site’s home page is not supported. Try using another block, like the <strong>Latest Posts</strong> block, to list posts from the site.' ) . '</div></div>';
+		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'Adding an RSS feed to this site’s homepage is not supported, as it could lead to a loop that slows down your site. Try using another block, like the <strong>Latest Posts</strong> block, to list posts from the site.' ) . '</div></div>';
 	}
 
 	$rss = fetch_feed( $attributes['feedURL'] );

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -13,6 +13,10 @@
  * @return string Returns the block content with received rss items.
  */
 function render_block_core_rss( $attributes ) {
+	if ( in_array( untrailingslashit( $attributes['feedURL'] ), array( site_url(), home_url() ), true ) ) {
+		return '<div class="components-placeholder"><div class="notice notice-error">' . __( 'To avoid a loop slowing down your site, adding an RSS feed to this site’s home page is not supported. Try using another block, like the <strong>Latest Posts</strong> block, to list posts from the site.' ) . '</div></div>';
+	}
+
 	$rss = fetch_feed( $attributes['feedURL'] );
 
 	if ( is_wp_error( $rss ) ) {


### PR DESCRIPTION
## What?
Resolves: #36969

PR adds a missing self-URL check to the RSS block.

Props, @getsource, for helping with the error message.

## Why?
Using the site's URL for feed might cause infinite loops when the block tries to resolve the correct feed address. You can find more details in the original Trac ticket: https://core.trac.wordpress.org/ticket/8910.

## How?
The render callback now will check for self-URL and suggest the **Latest Post** block as an alternative.

## Testing Instructions
1. Open a Post or Page.
2. Insert RSS Block.
3. Use the site's URL as a feed URL.
4. Confirm that the error message is displayed.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-03-25 at 13 39 14](https://user-images.githubusercontent.com/240569/160097344-03e681a6-7297-405a-890a-5bd1fcc596e7.png)

