### PR TITLE
RSS: Try prepending HTTP to a URL

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -19,6 +19,7 @@ import {
 import { useState } from '@wordpress/element';
 import { grid, list, edit, rss } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { prependHTTP } from '@wordpress/url';
 import ServerSideRender from '@wordpress/server-side-render';
 
 const DEFAULT_MIN_ITEMS = 1;
@@ -50,6 +51,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 		event.preventDefault();
 
 		if ( feedURL ) {
+			setAttributes( { feedURL: prependHTTP( feedURL ) } );
 			setIsEditing( false );
 		}
 	}


### PR DESCRIPTION
## What?
Resolves #27902.

PR fixes the issue when feed URLs are entered without a protocol.

## Why?
Feed URLs without protocol aren't valid, and the RSS block will display an error.

## How?
Update URL submission logic to prepend HTTP. The `prependHTTP` doesn't update URLs if they already have a protocol.

## Testing Instructions
1. Open a Post or Page.
2. Insert RSS Block.
3. Set URL without a protocol - `make.wordpress.org/core`
4. Confirm that feed loads without an error.
