### PR TITLE
Fix duplicate Additional CSS classes post author, etc.

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -30,7 +30,6 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 
 	$byline  = ! empty( $attributes['byline'] ) ? $attributes['byline'] : false;
 	$classes = array_merge(
-		isset( $attributes['className'] ) ? array( $attributes['className'] ) : array(),
 		isset( $attributes['itemsJustification'] ) ? array( 'items-justified-' . $attributes['itemsJustification'] ) : array(),
 		isset( $attributes['textAlign'] ) ? array( 'has-text-align-' . $attributes['textAlign'] ) : array()
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix duplicate Additional CSS classes

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Duplicate class names when using custom classes
I don't think it's necessary to add a custom class in each block since it's added with `get_block_wrapper_attributes`.
https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/

## How?
<!-- `How is your PR addressing the issue at hand? What are the implementation details?` -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a Post or Page.
2.  Insert a Heading post author Block.
3.  Set Additional CSS class
4. Look at the class name on the publish screen.

## Screenshots or screencast <!-- if applicable -->

### Movie
https://user-images.githubusercontent.com/42362903/160118306-b109f038-7da3-4e86-963d-0c59898a8eb6.mov

### Before
![before](https://user-images.githubusercontent.com/42362903/160118360-a0720346-878c-4ab3-b497-ff638017c0af.png)

### After
![after](https://user-images.githubusercontent.com/42362903/160118384-984da31a-6315-4394-96db-bcd1a761bb7e.png)

Site logo, social icon also had duplicated class names, but they were included in this branch, is it OK to include them in this branch?
