### PR TITLE
Templates: Update the available templates

### DIFF
--- a/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
+++ b/lib/compat/wordpress-5.9/class-gutenberg-rest-templates-controller.php
@@ -2,17 +2,24 @@
 /**
  * REST API: Gutenberg_REST_Templates_Controller class
  *
- * @package    Gutenberg
+ * @package    WordPress
  * @subpackage REST_API
+ * @since 5.8.0
  */
 
 /**
  * Base Templates REST API Controller.
+ *
+ * @since 5.8.0
+ *
+ * @see WP_REST_Controller
  */
 class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
+
 	/**
 	 * Post type.
 	 *
+	 * @since 5.8.0
 	 * @var string
 	 */
 	protected $post_type;
@@ -20,19 +27,21 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Constructor.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param string $post_type Post type.
 	 */
 	public function __construct( $post_type ) {
 		$this->post_type = $post_type;
-		$this->namespace = 'wp/v2';
 		$obj             = get_post_type_object( $post_type );
 		$this->rest_base = ! empty( $obj->rest_base ) ? $obj->rest_base : $obj->name;
+		$this->namespace = ! empty( $obj->rest_namespace ) ? $obj->rest_namespace : 'wp/v2';
 	}
 
 	/**
 	 * Registers the controllers routes.
 	 *
-	 * @return void
+	 * @since 5.8.0
 	 */
 	public function register_routes() {
 		// Lists all templates.
@@ -59,18 +68,30 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		// Lists/updates a single template based on the given id.
 		register_rest_route(
 			$this->namespace,
-			'/' . $this->rest_base . '/(?P<id>[\/\s%\w\.\(\)\[\]\@_\-]+)',
+			// The route.
+			sprintf(
+				'/%s/(?P<id>%s%s)',
+				$this->rest_base,
+				// Matches theme's directory: `/themes/<subdirectory>/<theme>/` or `/themes/<theme>/`.
+				// Excludes invalid directory name characters: `/:<>*?"|`.
+				'([^\/:<>\*\?"\|]+(?:\/[^\/:<>\*\?"\|]+)?)',
+				// Matches the template name.
+				'[\/\w-]+'
+			),
 			array(
+				'args'   => array(
+					'id' => array(
+						'description'       => __( 'The id of a template' ),
+						'type'              => 'string',
+						'sanitize_callback' => array( $this, '_sanitize_template_id' ),
+					),
+				),
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_item' ),
 					'permission_callback' => array( $this, 'get_item_permissions_check' ),
 					'args'                => array(
-						'id' => array(
-							'description'       => __( 'The id of a template', 'gutenberg' ),
-							'type'              => 'string',
-							'sanitize_callback' => array( $this, '_sanitize_template_id' ),
-						),
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
 					),
 				),
 				array(
@@ -87,7 +108,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 						'force' => array(
 							'type'        => 'boolean',
 							'default'     => false,
-							'description' => __( 'Whether to bypass Trash and force deletion.', 'gutenberg' ),
+							'description' => __( 'Whether to bypass Trash and force deletion.' ),
 						),
 					),
 				),
@@ -99,15 +120,18 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if the user has permissions to make the request.
 	 *
+	 * @since 5.8.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
-	protected function permissions_check() {
+	protected function permissions_check( $request ) {
 		// Verify if the current user has edit_theme_options capability.
 		// This capability is required to edit/view/delete templates.
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
 			return new WP_Error(
 				'rest_cannot_manage_templates',
-				__( 'Sorry, you are not allowed to access the templates on this site.', 'gutenberg' ),
+				__( 'Sorry, you are not allowed to access the templates on this site.' ),
 				array(
 					'status' => rest_authorization_required_code(),
 				)
@@ -118,23 +142,25 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Requesting this endpoint for a template like "twentytwentytwo//home" requires using
-	 * a path like /wp/v2/templates/twentytwentytwo//home. There are special cases when
-	 * WordPress routing corrects the name to contain only a single slash like "twentytwentytwo/home".
+	 * Requesting this endpoint for a template like 'twentytwentytwo//home'
+	 * requires using a path like /wp/v2/templates/twentytwentytwo//home. There
+	 * are special cases when WordPress routing corrects the name to contain
+	 * only a single slash like 'twentytwentytwo/home'.
 	 *
-	 * This method doubles the last slash if it's not already doubled. It relies on the template
-	 * ID format {theme_name}//{template_slug} and the fact that slugs cannot contain slashes.
+	 * This method doubles the last slash if it's not already doubled. It relies
+	 * on the template ID format {theme_name}//{template_slug} and the fact that
+	 * slugs cannot contain slashes.
 	 *
-	 * See https://core.trac.wordpress.org/ticket/54507 for more context
+	 * @since 5.9.0
+	 * @see https://core.trac.wordpress.org/ticket/54507
 	 *
 	 * @param string $id Template ID.
 	 * @return string Sanitized template ID.
 	 */
 	public function _sanitize_template_id( $id ) {
-		// Decode empty space.
-		$last_slash_pos = strrpos( $id, '/' );
-		$id             = urldecode( $id );
+		$id = urldecode( $id );
 
+		$last_slash_pos = strrpos( $id, '/' );
 		if ( false === $last_slash_pos ) {
 			return $id;
 		}
@@ -153,6 +179,8 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to read templates.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
@@ -163,11 +191,13 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Returns a list of templates.
 	 *
-	 * @param WP_REST_Request $request The request instance.
+	 * @since 5.8.0
 	 *
+	 * @param WP_REST_Request $request The request instance.
 	 * @return WP_REST_Response
 	 */
 	public function get_items( $request ) {
+		error_log('get items');
 		$query = array();
 		if ( isset( $request['wp_id'] ) ) {
 			$query['wp_id'] = $request['wp_id'];
@@ -191,6 +221,8 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Checks if a given request has access to read a single template.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
@@ -201,19 +233,20 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Returns the given template
 	 *
-	 * @param WP_REST_Request $request The request instance.
+	 * @since 5.8.0
 	 *
+	 * @param WP_REST_Request $request The request instance.
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_item( $request ) {
 		if ( isset( $request['source'] ) && 'theme' === $request['source'] ) {
 			$template = get_block_file_template( $request['id'], $this->post_type );
 		} else {
-			$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+			$template = get_block_template( $request['id'], $this->post_type );
 		}
 
 		if ( ! $template ) {
-			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
 		}
 
 		return $this->prepare_item_for_response( $template, $request );
@@ -221,6 +254,8 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 	/**
 	 * Checks if a given request has access to write a single template.
+	 *
+	 * @since 5.8.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has write access for the item, WP_Error object otherwise.
@@ -232,18 +267,27 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Updates a single template.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function update_item( $request ) {
-		$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+		$template = get_block_template( $request['id'], $this->post_type );
 		if ( ! $template ) {
-			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
 		}
+
+		$post_before = get_post( $template->wp_id );
 
 		if ( isset( $request['source'] ) && 'theme' === $request['source'] ) {
 			wp_delete_post( $template->wp_id, true );
-			return $this->prepare_item_for_response( get_block_file_template( $request['id'], $this->post_type ), $request );
+			$request->set_param( 'context', 'edit' );
+
+			$template = get_block_template( $request['id'], $this->post_type );
+			$response = $this->prepare_item_for_response( $template, $request );
+
+			return rest_ensure_response( $response );
 		}
 
 		$changes = $this->prepare_item_for_database( $request );
@@ -253,28 +297,46 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 		}
 
 		if ( 'custom' === $template->source ) {
-			$result = wp_update_post( wp_slash( (array) $changes ), true );
+			$update = true;
+			$result = wp_update_post( wp_slash( (array) $changes ), false );
 		} else {
-			$result = wp_insert_post( wp_slash( (array) $changes ), true );
+			$update      = false;
+			$post_before = null;
+			$result      = wp_insert_post( wp_slash( (array) $changes ), false );
 		}
+
 		if ( is_wp_error( $result ) ) {
+			if ( 'db_update_error' === $result->get_error_code() ) {
+				$result->add_data( array( 'status' => 500 ) );
+			} else {
+				$result->add_data( array( 'status' => 400 ) );
+			}
 			return $result;
 		}
 
-		$template      = gutenberg_get_block_template( $request['id'], $this->post_type );
+		$template      = get_block_template( $request['id'], $this->post_type );
 		$fields_update = $this->update_additional_fields_for_object( $template, $request );
 		if ( is_wp_error( $fields_update ) ) {
 			return $fields_update;
 		}
 
-		return $this->prepare_item_for_response(
-			gutenberg_get_block_template( $request['id'], $this->post_type ),
-			$request
-		);
+		$request->set_param( 'context', 'edit' );
+
+		$post = get_post( $template->wp_id );
+		/** This action is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
+		do_action( "rest_after_insert_{$this->post_type}", $post, $request, false );
+
+		wp_after_insert_post( $post, $update, $post_before );
+
+		$response = $this->prepare_item_for_response( $template, $request );
+
+		return rest_ensure_response( $response );
 	}
 
 	/**
 	 * Checks if a given request has access to create a template.
+	 *
+	 * @since 5.8.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
@@ -286,40 +348,59 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Creates a single template.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function create_item( $request ) {
-		$changes = $this->prepare_item_for_database( $request );
+		$prepared_post = $this->prepare_item_for_database( $request );
 
-		if ( is_wp_error( $changes ) ) {
-			return $changes;
+		if ( is_wp_error( $prepared_post ) ) {
+			return $prepared_post;
 		}
 
-		$changes->post_name = $request['slug'];
-		$result             = wp_insert_post( wp_slash( (array) $changes ), true );
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		$prepared_post->post_name = $request['slug'];
+		$post_id                  = wp_insert_post( wp_slash( (array) $prepared_post ), true );
+		if ( is_wp_error( $post_id ) ) {
+			if ( 'db_insert_error' === $post_id->get_error_code() ) {
+				$post_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$post_id->add_data( array( 'status' => 400 ) );
+			}
+
+			return $post_id;
 		}
-		$posts = gutenberg_get_block_templates( array( 'wp_id' => $result ), $this->post_type );
+		$posts = get_block_templates( array( 'wp_id' => $post_id ), $this->post_type );
 		if ( ! count( $posts ) ) {
-			return new WP_Error( 'rest_template_insert_error', __( 'No templates exist with that id.', 'gutenberg' ) );
+			return new WP_Error( 'rest_template_insert_error', __( 'No templates exist with that id.' ), array( 'status' => 400 ) );
 		}
 		$id            = $posts[0]->id;
-		$template      = gutenberg_get_block_template( $id, $this->post_type );
+		$post          = get_post( $post_id );
+		$template      = get_block_template( $id, $this->post_type );
 		$fields_update = $this->update_additional_fields_for_object( $template, $request );
 		if ( is_wp_error( $fields_update ) ) {
 			return $fields_update;
 		}
 
-		return $this->prepare_item_for_response(
-			gutenberg_get_block_template( $id, $this->post_type ),
-			$request
-		);
+		/** This action is documented in wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php */
+		do_action( "rest_after_insert_{$this->post_type}", $post, $request, true );
+
+		wp_after_insert_post( $post, false, null );
+
+		$response = $this->prepare_item_for_response( $template, $request );
+		$response = rest_ensure_response( $response );
+
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '%s/%s/%s', $this->namespace, $this->rest_base, $template->id ) ) );
+
+		return $response;
 	}
 
 	/**
 	 * Checks if a given request has access to delete a single template.
+	 *
+	 * @since 5.8.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has delete access for the item, WP_Error object otherwise.
@@ -331,25 +412,29 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Deletes a single template.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 	 */
 	public function delete_item( $request ) {
-		$template = gutenberg_get_block_template( $request['id'], $this->post_type );
+		$template = get_block_template( $request['id'], $this->post_type );
 		if ( ! $template ) {
-			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.', 'gutenberg' ), array( 'status' => 404 ) );
+			return new WP_Error( 'rest_template_not_found', __( 'No templates exist with that id.' ), array( 'status' => 404 ) );
 		}
 		if ( 'custom' !== $template->source ) {
-			return new WP_Error( 'rest_invalid_template', __( 'Templates based on theme files can\'t be removed.', 'gutenberg' ), array( 'status' => 400 ) );
+			return new WP_Error( 'rest_invalid_template', __( 'Templates based on theme files can\'t be removed.' ), array( 'status' => 400 ) );
 		}
 
 		$id    = $template->wp_id;
 		$force = (bool) $request['force'];
 
+		$request->set_param( 'context', 'edit' );
+
 		// If we're forcing, then delete permanently.
 		if ( $force ) {
 			$previous = $this->prepare_item_for_response( $template, $request );
-			wp_delete_post( $id, true );
+			$result   = wp_delete_post( $id, true );
 			$response = new WP_REST_Response();
 			$response->set_data(
 				array(
@@ -357,32 +442,44 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'previous' => $previous->get_data(),
 				)
 			);
+		} else {
+			// Otherwise, only trash if we haven't already.
+			if ( 'trash' === $template->status ) {
+				return new WP_Error(
+					'rest_template_already_trashed',
+					__( 'The template has already been deleted.' ),
+					array( 'status' => 410 )
+				);
+			}
 
-			return $response;
+			// (Note that internally this falls through to `wp_delete_post()`
+			// if the Trash is disabled.)
+			$result           = wp_trash_post( $id );
+			$template->status = 'trash';
+			$response         = $this->prepare_item_for_response( $template, $request );
 		}
 
-		// Otherwise, only trash if we haven't already.
-		if ( 'trash' === $template->status ) {
+		if ( ! $result ) {
 			return new WP_Error(
-				'rest_template_already_trashed',
-				__( 'The template has already been deleted.', 'gutenberg' ),
-				array( 'status' => 410 )
+				'rest_cannot_delete',
+				__( 'The template cannot be deleted.' ),
+				array( 'status' => 500 )
 			);
 		}
 
-		wp_trash_post( $id );
-		$template->status = 'trash';
-		return $this->prepare_item_for_response( $template, $request );
+		return $response;
 	}
 
 	/**
 	 * Prepares a single template for create or update.
 	 *
+	 * @since 5.8.0
+	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return stdClass Changes to pass to wp_update_post.
 	 */
 	protected function prepare_item_for_database( $request ) {
-		$template = $request['id'] ? gutenberg_get_block_template( $request['id'], $this->post_type ) : null;
+		$template = $request['id'] ? get_block_template( $request['id'], $this->post_type ) : null;
 		$changes  = new stdClass();
 		if ( null === $template ) {
 			$changes->post_type   = $this->post_type;
@@ -406,12 +503,20 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			$changes->post_status = 'publish';
 		}
 		if ( isset( $request['content'] ) ) {
-			$changes->post_content = $request['content'];
+			if ( is_string( $request['content'] ) ) {
+				$changes->post_content = $request['content'];
+			} elseif ( isset( $request['content']['raw'] ) ) {
+				$changes->post_content = $request['content']['raw'];
+			}
 		} elseif ( null !== $template && 'custom' !== $template->source ) {
 			$changes->post_content = $template->content;
 		}
 		if ( isset( $request['title'] ) ) {
-			$changes->post_title = $request['title'];
+			if ( is_string( $request['title'] ) ) {
+				$changes->post_title = $request['title'];
+			} elseif ( ! empty( $request['title']['raw'] ) ) {
+				$changes->post_title = $request['title']['raw'];
+			}
 		} elseif ( null !== $template && 'custom' !== $template->source ) {
 			$changes->post_title = $template->title;
 		}
@@ -440,7 +545,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 				if ( ! $user_obj ) {
 					return new WP_Error(
 						'rest_invalid_author',
-						__( 'Invalid author ID.', 'gutenberg' ),
+						__( 'Invalid author ID.' ),
 						array( 'status' => 400 )
 					);
 				}
@@ -455,43 +560,110 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Prepare a single template output for response
 	 *
-	 * @param Gutenberg_Block_Template $template Template instance.
-	 * @param WP_REST_Request          $request Request object.
+	 * @since 5.8.0
+	 * @since 5.9.0 Renamed `$template` to `$item` to match parent class for PHP 8 named parameter support.
 	 *
-	 * @return WP_REST_Response $data
+	 * @param WP_Block_Template $item    Template instance.
+	 * @param WP_REST_Request   $request Request object.
+	 * @return WP_REST_Response Response object.
 	 */
-	public function prepare_item_for_response( $template, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$result = array(
-			'id'             => $template->id,
-			'theme'          => $template->theme,
-			'content'        => array( 'raw' => $template->content ),
-			'slug'           => $template->slug,
-			'source'         => $template->source,
-			'origin'         => $template->origin,
-			'type'           => $template->type,
-			'description'    => $template->description,
-			'title'          => array(
-				'raw'      => $template->title,
-				'rendered' => $template->title,
-			),
-			'status'         => $template->status,
-			'wp_id'          => $template->wp_id,
-			'has_theme_file' => $template->has_theme_file,
-			'author'         => (int) $template->author,
-		);
+	public function prepare_item_for_response( $item, $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		// Restores the more descriptive, specific name for use within this method.
+		$template = $item;
 
-		if ( 'wp_template' === $template->type ) {
-			$result['is_custom'] = $template->is_custom;
+		$fields = $this->get_fields_for_response( $request );
+
+		// Base fields for every template.
+		$data = array();
+
+		if ( rest_is_field_included( 'id', $fields ) ) {
+			$data['id'] = $template->id;
 		}
 
-		if ( 'wp_template_part' === $template->type ) {
-			$result['area'] = $template->area;
+		if ( rest_is_field_included( 'theme', $fields ) ) {
+			$data['theme'] = $template->theme;
 		}
 
-		$result = $this->add_additional_fields_to_object( $result, $request );
+		if ( rest_is_field_included( 'content', $fields ) ) {
+			$data['content'] = array();
+		}
+		if ( rest_is_field_included( 'content.raw', $fields ) ) {
+			$data['content']['raw'] = $template->content;
+		}
 
-		$response = rest_ensure_response( $result );
-		$links    = $this->prepare_links( $template->id );
+		if ( rest_is_field_included( 'content.block_version', $fields ) ) {
+			$data['content']['block_version'] = block_version( $template->content );
+		}
+
+		if ( rest_is_field_included( 'slug', $fields ) ) {
+			$data['slug'] = $template->slug;
+		}
+
+		if ( rest_is_field_included( 'source', $fields ) ) {
+			$data['source'] = $template->source;
+		}
+
+		if ( rest_is_field_included( 'origin', $fields ) ) {
+			$data['origin'] = $template->origin;
+		}
+
+		if ( rest_is_field_included( 'type', $fields ) ) {
+			$data['type'] = $template->type;
+		}
+
+		if ( rest_is_field_included( 'description', $fields ) ) {
+			$data['description'] = $template->description;
+		}
+
+		if ( rest_is_field_included( 'title', $fields ) ) {
+			$data['title'] = array();
+		}
+
+		if ( rest_is_field_included( 'title.raw', $fields ) ) {
+			$data['title']['raw'] = $template->title;
+		}
+
+		if ( rest_is_field_included( 'title.rendered', $fields ) ) {
+			if ( $template->wp_id ) {
+				/** This filter is documented in wp-includes/post-template.php */
+				$data['title']['rendered'] = apply_filters( 'the_title', $template->title, $template->wp_id );
+			} else {
+				$data['title']['rendered'] = $template->title;
+			}
+		}
+
+		if ( rest_is_field_included( 'status', $fields ) ) {
+			$data['status'] = $template->status;
+		}
+
+		if ( rest_is_field_included( 'wp_id', $fields ) ) {
+			$data['wp_id'] = (int) $template->wp_id;
+		}
+
+		if ( rest_is_field_included( 'has_theme_file', $fields ) ) {
+			$data['has_theme_file'] = (bool) $template->has_theme_file;
+		}
+
+		if ( rest_is_field_included( 'is_custom', $fields ) && 'wp_template' === $template->type ) {
+			$data['is_custom'] = $template->is_custom;
+		}
+
+		if ( rest_is_field_included( 'author', $fields ) ) {
+			$data['author'] = (int) $template->author;
+		}
+
+		if ( rest_is_field_included( 'area', $fields ) && 'wp_template_part' === $template->type ) {
+			$data['area'] = $template->area;
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$links = $this->prepare_links( $template->id );
 		$response->add_links( $links );
 		if ( ! empty( $links['self']['href'] ) ) {
 			$actions = $this->get_available_actions();
@@ -507,6 +679,8 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 	/**
 	 * Prepares links for the request.
+	 *
+	 * @since 5.8.0
 	 *
 	 * @param integer $id ID.
 	 * @return array Links for the given post.
@@ -532,7 +706,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Get the link relations available for the post and current user.
 	 *
-	 * @return array List of link relations.
+	 * @since 5.8.0
+	 *
+	 * @return string[] List of link relations.
 	 */
 	protected function get_available_actions() {
 		$rels = array();
@@ -553,21 +729,24 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves the query params for the posts collection.
 	 *
+	 * @since 5.8.0
+	 * @since 5.9.0 Added `'area'` and `'post_type'`.
+	 *
 	 * @return array Collection parameters.
 	 */
 	public function get_collection_params() {
 		return array(
-			'context'   => $this->get_context_param(),
+			'context'   => $this->get_context_param( array( 'default' => 'view' ) ),
 			'wp_id'     => array(
-				'description' => __( 'Limit to the specified post id.', 'gutenberg' ),
+				'description' => __( 'Limit to the specified post id.' ),
 				'type'        => 'integer',
 			),
 			'area'      => array(
-				'description' => __( 'Limit to the specified template part area.', 'gutenberg' ),
+				'description' => __( 'Limit to the specified template part area.' ),
 				'type'        => 'string',
 			),
 			'post_type' => array(
-				'description' => __( 'Post type to get the templates for.', 'gutenberg' ),
+				'description' => __( 'Post type to get the templates for.' ),
 				'type'        => 'string',
 			),
 		);
@@ -575,6 +754,9 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 	/**
 	 * Retrieves the block type' schema, conforming to JSON Schema.
+	 *
+	 * @since 5.8.0
+	 * @since 5.9.0 Added `'area'`.
 	 *
 	 * @return array Item schema data.
 	 */
@@ -589,13 +771,13 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 			'type'       => 'object',
 			'properties' => array(
 				'id'             => array(
-					'description' => __( 'ID of template.', 'gutenberg' ),
+					'description' => __( 'ID of template.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'slug'           => array(
-					'description' => __( 'Unique slug identifying the template.', 'gutenberg' ),
+					'description' => __( 'Unique slug identifying the template.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'required'    => true,
@@ -603,60 +785,92 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 					'pattern'     => '[a-zA-Z0-9_\-]+',
 				),
 				'theme'          => array(
-					'description' => __( 'Theme identifier for the template.', 'gutenberg' ),
+					'description' => __( 'Theme identifier for the template.' ),
+					'type'        => 'string',
+					'context'     => array( 'embed', 'view', 'edit' ),
+				),
+				'type'           => array(
+					'description' => __( 'Type of template.' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 				),
 				'source'         => array(
-					'description' => __( 'Source of template', 'gutenberg' ),
+					'description' => __( 'Source of template' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'origin'         => array(
-					'description' => __( 'Source of customized template', 'gutenberg' ),
+					'description' => __( 'Source of a customized template' ),
 					'type'        => 'string',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'content'        => array(
-					'description' => __( 'Content of template.', 'gutenberg' ),
+					'description' => __( 'Content of template.' ),
 					'type'        => array( 'object', 'string' ),
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'properties'  => array(
+						'raw'           => array(
+							'description' => __( 'Content for the template, as it exists in the database.' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'block_version' => array(
+							'description' => __( 'Version of the content block format used by the template.' ),
+							'type'        => 'integer',
+							'context'     => array( 'edit' ),
+							'readonly'    => true,
+						),
+					),
 				),
 				'title'          => array(
-					'description' => __( 'Title of template.', 'gutenberg' ),
+					'description' => __( 'Title of template.' ),
 					'type'        => array( 'object', 'string' ),
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
+					'properties'  => array(
+						'raw'      => array(
+							'description' => __( 'Title for the template, as it exists in the database.' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+						),
+						'rendered' => array(
+							'description' => __( 'HTML title for the template, transformed for display.' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit', 'embed' ),
+							'readonly'    => true,
+						),
+					),
 				),
 				'description'    => array(
-					'description' => __( 'Description of template.', 'gutenberg' ),
+					'description' => __( 'Description of template.' ),
 					'type'        => 'string',
 					'default'     => '',
 					'context'     => array( 'embed', 'view', 'edit' ),
 				),
 				'status'         => array(
-					'description' => __( 'Status of template.', 'gutenberg' ),
+					'description' => __( 'Status of template.' ),
 					'type'        => 'string',
+					'enum'        => array_keys( get_post_stati( array( 'internal' => false ) ) ),
 					'default'     => 'publish',
 					'context'     => array( 'embed', 'view', 'edit' ),
 				),
 				'wp_id'          => array(
-					'description' => __( 'Post ID.', 'gutenberg' ),
+					'description' => __( 'Post ID.' ),
 					'type'        => 'integer',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'has_theme_file' => array(
-					'description' => __( 'Theme file exists.', 'gutenberg' ),
+					'description' => __( 'Theme file exists.' ),
 					'type'        => 'bool',
 					'context'     => array( 'embed', 'view', 'edit' ),
 					'readonly'    => true,
 				),
 				'author'         => array(
-					'description' => __( 'The ID for the author of the template.', 'gutenberg' ),
+					'description' => __( 'The ID for the author of the template.' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
@@ -665,7 +879,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( 'wp_template' === $this->post_type ) {
 			$schema['properties']['is_custom'] = array(
-				'description' => __( 'Whether a template is a custom template.', 'gutenberg' ),
+				'description' => __( 'Whether a template is a custom template.' ),
 				'type'        => 'bool',
 				'context'     => array( 'embed', 'view', 'edit' ),
 				'readonly'    => true,
@@ -674,7 +888,7 @@ class Gutenberg_REST_Templates_Controller extends WP_REST_Controller {
 
 		if ( 'wp_template_part' === $this->post_type ) {
 			$schema['properties']['area'] = array(
-				'description' => __( 'Where the template part is intended for use (header, footer, etc.)', 'gutenberg' ),
+				'description' => __( 'Where the template part is intended for use (header, footer, etc.)' ),
 				'type'        => 'string',
 				'context'     => array( 'embed', 'view', 'edit' ),
 			);

--- a/lib/compat/wordpress-5.9/template-parts.php
+++ b/lib/compat/wordpress-5.9/template-parts.php
@@ -11,9 +11,7 @@
  * @package gutenberg
  */
 
-// Only run any of the code in this file if the version is less than 5.9.
-// wp_list_users was introduced in 5.9.
-if ( ! function_exists( 'wp_list_users' ) ) {
+
 	/**
 	 * Registers block editor 'wp_template_part' post type.
 	 */
@@ -65,8 +63,11 @@ if ( ! function_exists( 'wp_list_users' ) ) {
 
 		register_post_type( 'wp_template_part', $args );
 	}
-	add_action( 'init', 'gutenberg_register_template_part_post_type' );
 
+	add_action( 'init', 'gutenberg_register_template_part_post_type' );
+// Only run any of the code in this file if the version is less than 5.9.
+// wp_list_users was introduced in 5.9.
+if ( ! function_exists( 'wp_list_users' ) ) {
 	/**
 	 * Registers the 'wp_template_part_area' taxonomy.
 	 */


### PR DESCRIPTION
## What?
This makes all created templates and template parts available to users when they are editing their site. Fixes #25071

## Why?
This will make it easier for users to switch between different template parts and build themes more easily.

## How?
This implementation is messy.  I've copied the changes from core back into the 5.9 compat file, but I guess ideally this would happen in the 6.0 compat folder? It's not easy to override since `gutenberg_get_block_templates` isn't a class method. If anyone has an idea for a better approach that would be great.

We also need to think a bit about the design. Should we make it clear what theme these template parts came from? What other details should we surface? @jameskoster 

<img width="1000" alt="Screenshot 2022-03-25 at 14 56 39" src="https://user-images.githubusercontent.com/275961/160145491-33a1c118-e2c0-4c7f-a88e-658276cd01c2.png">

<img width="780" alt="Screenshot 2022-03-25 at 14 57 12" src="https://user-images.githubusercontent.com/275961/160145581-dd75006e-592a-4b51-a7c7-75de088fa5a2.png">


## Testing Instructions
- Switch to a block theme
- Open the site editor
- Edit a template part
- Switch to a different block theme
- Open the site editor
- You should see the edited template in your list of templates
- Add a template part block to the site editor
- Choose an existing template part
- You should have your edited template as an option

## Screenshots or screencast <!-- if applicable -->
See above
