### PR TITLE
E2E: Cross-platform support for Playwright E2E tests

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { devices } from '@playwright/test';
 import type { PlaywrightTestConfig } from '@playwright/test';
 
@@ -19,10 +20,11 @@ const config: PlaywrightTestConfig = {
 	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 100_000, // Defaults to 100 seconds.
 	// Don't report slow test "files", as we will be running our tests in serial.
 	reportSlowTests: null,
-	testDir: new URL( './specs', 'file:' + __filename ).pathname,
+	testDir: fileURLToPath( new URL( './specs', 'file:' + __filename ).href ),
 	outputDir: path.join( process.cwd(), 'artifacts/test-results' ),
-	globalSetup: new URL( './config/global-setup.ts', 'file:' + __filename )
-		.pathname,
+	globalSetup: fileURLToPath(
+		new URL( './config/global-setup.ts', 'file:' + __filename ).href
+	),
 	use: {
 		baseURL: process.env.WP_BASE_URL || 'http://localhost:8889',
 		headless: true,


### PR DESCRIPTION
Fix: #39721, #40352

## What?
This PR ensures that cross-platform valid absolute path strings are generated in configuration file path definitions.

## Why?
In `testDir` and `globalSetup`, `new URL().pathname` is used to set the path, but it generates an invalid path string on some platforms.


## How?
I followed [the node documentation](https://nodejs.org/api/url.html#urlfileurltopathurl) and wrapped `new URL().href` with `url.fileURLToPath` to generate a platform independent path.

The writing may be a little tricky, so please advise if you have a better solution.

## Testing Instructions
- `npm run test-e2e:playwright` 
- One test should run correctly as follows:
```bash
> playwright test --config test/e2e/playwright.config.ts

Running 1 test using 1 worker

  ✓  [chromium] › sanity.spec.js:8:2 › Sanity check › Expect site loaded (6s)


  1 passed (13s)
```