### PR TITLE
Adjust the layout of thumbnails in the template part replacement modal

### DIFF
--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -12,13 +12,3 @@
 		height: 70%;
 	}
 }
-
-.block-library-template-part__selection-content .block-editor-block-patterns-list {
-	display: grid;
-	grid-template-columns: 1fr 1fr;
-	grid-gap: $grid-unit-10;
-
-	.block-editor-block-patterns-list__list-item {
-		margin-bottom: 0;
-	}
-}


### PR DESCRIPTION
The current two column layout isn't ideal:

<img width="825" alt="Screenshot 2022-03-25 at 16 26 47" src="https://user-images.githubusercontent.com/846565/160161467-db5586d4-c954-4c12-b3c1-48e6dfc9af7d.png">

The thumbnails are too small to give an effective preview, and the columns make the text difficult to scan.

Until we figure out a more holistic solution (#39308) I've adjusted the modal to display the template parts in a single column:

<img width="850" alt="Screenshot 2022-03-25 at 16 24 23" src="https://user-images.githubusercontent.com/846565/160161638-b959fc95-1cc9-4e63-b509-4406b11096ab.png">

I think this makes the previews much more effective.

Another option would be to use a popover containing a list of template parts with previews on hover, but this is a much simpler change and seemed worth trying first.

There's also a question of whether we need to distinguish between template parts and patterns with headings, but we can probably address that separately.