### PR TITLE
[RNMobile] Remove upload options for users who lack upload permission

### DIFF
--- a/packages/block-library/src/gallery/test/helpers.native.js
+++ b/packages/block-library/src/gallery/test/helpers.native.js
@@ -105,7 +105,12 @@ export const initializeWithGalleryBlock = async ( {
 		generateGalleryBlock( numberOfItems, media, {
 			useLocalUrl,
 		} );
-	const screen = await initializeEditor( { initialHtml } );
+	const screen = await initializeEditor( {
+		initialHtml,
+		capabilities: {
+			canUploadMedia: true,
+		},
+	} );
 	const { getByA11yLabel } = screen;
 
 	const galleryBlock = getByA11yLabel( /Gallery Block\. Row 1/ );

--- a/packages/react-native-bridge/CHANGELOG.md
+++ b/packages/react-native-bridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.73.0
+
+- [**] Remove upload options for users without permission to upload media [#39769]
+
 ## 1.70.1
 
 -   [***] Fix launching video preview on Android 11+ [#38377]

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -17,6 +17,7 @@ data class GutenbergProps @JvmOverloads constructor(
     val enableXPosts: Boolean,
     val enableUnsupportedBlockEditor: Boolean,
     val canEnableUnsupportedBlockEditor: Boolean,
+    val canUploadMedia: Boolean,
     val isAudioBlockMediaUploadEnabled: Boolean,
     val enableReusableBlock: Boolean,
     val localeSlug: String,
@@ -62,7 +63,10 @@ data class GutenbergProps @JvmOverloads constructor(
         putBoolean(PROP_CAPABILITIES_MEDIAFILES_COLLECTION_BLOCK, enableMediaFilesCollectionBlocks)
         putBoolean(PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, enableUnsupportedBlockEditor)
         putBoolean(PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR, canEnableUnsupportedBlockEditor)
-        putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, isAudioBlockMediaUploadEnabled)
+        putBoolean(PROP_CAPABILITIES_CAN_UPLOAD_MEDIA, canUploadMedia)
+        putBoolean(PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED,
+                isAudioBlockMediaUploadEnabled
+        )
         putBoolean(PROP_CAPABILITIES_REUSABLE_BLOCK, enableReusableBlock)
         putBoolean(PROP_CAPABILITIES_FACEBOOK_EMBED_BLOCK, enableFacebookEmbed)
         putBoolean(PROP_CAPABILITIES_INSTAGRAM_EMBED_BLOCK, enableInstagramEmbed)
@@ -105,6 +109,7 @@ data class GutenbergProps @JvmOverloads constructor(
         const val PROP_CAPABILITIES_XPOSTS = "xposts"
         const val PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR = "unsupportedBlockEditor"
         const val PROP_CAPABILITIES_CAN_ENABLE_UNSUPPORTED_BLOCK_EDITOR = "canEnableUnsupportedBlockEditor"
+        const val PROP_CAPABILITIES_CAN_UPLOAD_MEDIA = "canUploadMedia"
         const val PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED = "isAudioBlockMediaUploadEnabled"
         const val PROP_CAPABILITIES_REUSABLE_BLOCK = "reusableBlock"
 

--- a/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDelegate.swift
@@ -24,6 +24,7 @@ public enum Capabilities: String {
     case xposts
     case unsupportedBlockEditor
     case canEnableUnsupportedBlockEditor
+    case canUploadMedia
     case isAudioBlockMediaUploadEnabled
     case reusableBlock
     case facebookEmbed

--- a/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
+++ b/packages/react-native-editor/android/app/src/main/java/com/gutenberg/MainActivity.java
@@ -48,6 +48,7 @@ public class MainActivity extends ReactActivity {
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_XPOSTS, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_UNSUPPORTED_BLOCK_EDITOR, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_REUSABLE_BLOCK, false);
+                capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_CAN_UPLOAD_MEDIA, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_IS_AUDIO_BLOCK_MEDIA_UPLOAD_ENABLED, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_TILED_GALLERY_BLOCK, true);
                 capabilities.putBoolean(GutenbergProps.PROP_CAPABILITIES_FACEBOOK_EMBED_BLOCK, true);

--- a/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
+++ b/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift
@@ -318,6 +318,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .canEnableUnsupportedBlockEditor: unsupportedBlockCanBeActivated,
             .mediaFilesCollectionBlock: true,
             .tiledGalleryBlock: true,
+            .canUploadMedia: true,
             .isAudioBlockMediaUploadEnabled: true,
             .reusableBlock: false,
             .facebookEmbed: true,


### PR DESCRIPTION
Related PRs:
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4696
- https://github.com/wordpress-mobile/WordPress-Android/pull/16188
- https://github.com/wordpress-mobile/WordPress-iOS/pull/18229

## What?
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/3259 by removing upload options from the media blocks for users who do not have permission to upload to a site (i.e., Contributors).

## Why?
Prevents users from being given the option to upload a file when that upload will always fail due to their lack of permission to upload to the site.

## How?
The upload permission for the user is passed up from the native apps and if the user does not have an upload permission, they are only allowed to select media already in the site's media library.

## Testing Instructions

Please perform the following tests on both WPAndroid and WPiOS since there are native changes on both platforms.

### 1. On dotcom Site Where the User is only a Contributor

1. Add the following blocks to a post and verify that the only option for adding media to the block is to use the WordPress Media Library
    1. Image block
    2. Video block
    3. Audio block
    4. File block

### On dotcom Site Where the User is an Editor/Admin (i.e., can upload)

1. Add an image block and verify the following options for adding media
    1. Choose from device
    2. Take a Photo
    3. WordPress Media Library
    4. Choose from Free Photo Library
    6. Choose from Tenor

2. Add a video block and verify the following options for adding media
    1. Choose from device
    2. Take a Video
    3. WordPress Media Library

3. Add a file block and verify the following options for adding media
    1. WordPress Media Library
    2. Choose from device
 
4. Add an audio block and verify the following options for adding media
    1. WordPress Media Library
    2. Insert from URL
    4. Choose from device

### 2. On a self-hosted Site Where the User is an Editor/Admin

Perform the same checks listed under "On dotcom Site Where the User is an Editor/Admin".

Note that even if the user is only a contributor, they will still have all the upload options on a self-hosted site because we do not have user role information for self-hosted sites in the app currently, so we just treat everyone as having permission as the default.

### 3. On a dotcom FREE Site where the User is an Editor/Admin

1. Add an audio block 
2. Verify that the only option is "Insert from URL"

## Screenshots

Note that the two sites I'm using have different themes, so the colors are different.

<details><summary>Image Block</summary>
<table>
<tr>
<th>WITHOUT upload permission</th>
<th>WIith upload permission</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160423577-10021cd9-b30e-4cea-afec-1b124e900760.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160423970-c53012d9-d8dd-477a-9bd9-fa11778f3509.png">
</td>
</tr>
</table>
</details>

<details><summary>Video Block</summary>
<table>
<tr>
<th>WITHOUT upload permission</th>
<th>With upload permission</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160423376-c686fda8-1414-4375-8df3-2c210fecb8fa.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160424061-b0d9ad02-d2ed-415d-b1db-2ffe32d6045e.png">
</td>
</tr>
</table>
</details>


<details><summary>File Block</summary>
<table>
<tr>
<th>WITHOUT upload permission</th>
<th>With upload permission</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160423246-a7a00257-dc21-48c0-936f-39e8fd69dcaf.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160424154-a153b22e-4f35-45d8-a3f8-ee104dd021f9.png">
</td>
</tr>
</table>
</details>

<details><summary>Audio Block</summary>
<table>
<tr>
<th>WITHOUT upload permission</th>
<th>With upload permission</th>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160423136-3f400a58-244d-463e-8485-2b5e554fd86a.png">
</td>
<td>
<img src="https://user-images.githubusercontent.com/4656348/160424299-3e72d869-6606-4e0c-b14d-76f5ff6b5546.png">
</td>
</tr>
</table>
</details>