### PR TITLE
Add: Outdent and Indent actions for the list block v2.

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -13,7 +13,7 @@ import {
 	BlockControls,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { isRTL, __, _x } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect, select } from '@wordpress/data';
 import { ToolbarButton } from '@wordpress/components';
@@ -23,6 +23,7 @@ import {
 	formatIndentRTL,
 	formatIndent,
 } from '@wordpress/icons';
+import { useCallback } from '@wordpress/element';
 
 function createListItem( listItemAttributes, listAttributes, children ) {
 	return createBlock(
@@ -34,8 +35,131 @@ function createListItem( listItemAttributes, listAttributes, children ) {
 	);
 }
 
-function IndentUI( { attributes, clientId } ) {
-	const { canOutdent, blockIndex } = useSelect(
+function useIndentListItem( clientId ) {
+	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+	return useCallback( () => {
+		const {
+			getBlockRootClientId,
+			getBlock,
+			getBlockOrder,
+			getSelectionStart,
+			getSelectionEnd,
+			getBlockIndex,
+		} = select( blockEditorStore );
+
+		const selectionStart = getSelectionStart();
+		const selectionEnd = getSelectionEnd();
+
+		const parentId = getBlockRootClientId( clientId );
+		const previousSiblingId = getBlockOrder( parentId )[
+			getBlockIndex( clientId ) - 1
+		];
+		const previousSibling = getBlock( previousSiblingId );
+		const previousSiblingChildren =
+			first( previousSibling.innerBlocks )?.innerBlocks || [];
+		const previousSiblingListAttributes =
+			first( previousSibling.innerBlocks )?.attributes || {};
+		const block = getBlock( clientId );
+
+		const childListAttributes = first( block.innerBlocks )?.attributes;
+		const childItemBlocks = first( block.innerBlocks )?.innerBlocks || [];
+
+		const newBlock = createListItem(
+			block.attributes,
+			childListAttributes,
+			childItemBlocks
+		);
+		// Replace the previous sibling of the block being indented and the indented block,
+		// with a new block whose attributes are equal to the ones of the previous sibling and
+		// whose descendants are the children of the previous sibling, followed by the indented block.
+		replaceBlocks(
+			[ previousSiblingId, clientId ],
+			[
+				createListItem(
+					previousSibling.attributes,
+					previousSiblingListAttributes,
+					[ ...previousSiblingChildren, newBlock ]
+				),
+			]
+		);
+
+		// Restore the selection state.
+		selectionChange(
+			newBlock.clientId,
+			selectionEnd.attributeKey,
+			selectionEnd.clientId === selectionStart.clientId
+				? selectionStart.offset
+				: selectionEnd.offset,
+			selectionEnd.offset
+		);
+	}, [ clientId ] );
+}
+
+function useOutdentListItem( clientId ) {
+	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+	return useCallback( () => {
+		const {
+			getBlockRootClientId,
+			getBlockAttributes,
+			getBlock,
+			getBlockIndex,
+			getSelectionStart,
+			getSelectionEnd,
+		} = select( blockEditorStore );
+		const selectionStart = getSelectionStart();
+		const selectionEnd = getSelectionEnd();
+
+		const listParentId = getBlockRootClientId( clientId );
+		const listAttributes = getBlockAttributes( listParentId );
+		const listItemParentId = getBlockRootClientId( listParentId );
+		const listItemParentAttributes = getBlockAttributes( listItemParentId );
+
+		const index = getBlockIndex( clientId );
+		const siblingBlocks = getBlock( listParentId ).innerBlocks;
+		const previousSiblings = siblingBlocks.slice( 0, index );
+		const afterSiblings = siblingBlocks.slice( index + 1 );
+
+		// Create a new parent list item block with just the siblings
+		// that existed before the child item being outdent.
+		const newListItemParent = createListItem(
+			listItemParentAttributes,
+			listAttributes,
+			previousSiblings
+		);
+
+		const block = getBlock( clientId );
+		const childList = first( block.innerBlocks );
+		const childItems = childList?.innerBlocks || [];
+		const hasChildItems = !! childItems.length;
+
+		// Create a new list item block whose attributes are equal to the
+		// block being outdent and whose children are the children that it had (if any)
+		// followed by the siblings that existed after it.
+		const newItem = createListItem(
+			block.attributes,
+			hasChildItems ? childList.attributes : listAttributes,
+			[ ...childItems, ...afterSiblings ]
+		);
+
+		// Replace the parent list item block, with a new block containing
+		// the previous siblings, followed by another block containing after siblings
+		// in relation to the block being outdent.
+		replaceBlocks( [ listItemParentId ], [ newListItemParent, newItem ] );
+
+		// Restore the selection state.
+		selectionChange(
+			newItem.clientId,
+			selectionEnd.attributeKey,
+			selectionEnd.clientId === selectionStart.clientId
+				? selectionStart.offset
+				: selectionEnd.offset,
+			selectionEnd.offset
+		);
+	}, [ clientId ] );
+}
+
+function IndentUI( { clientId } ) {
+	const { canOutdent, canIndent } = useSelect(
 		( innerSelect ) => {
 			const { getBlockRootClientId, getBlockIndex } = innerSelect(
 				blockEditorStore
@@ -44,150 +168,31 @@ function IndentUI( { attributes, clientId } ) {
 				getBlockRootClientId( clientId )
 			);
 			return {
-				blockIndex: getBlockIndex( clientId ),
+				canIndent: getBlockIndex( clientId ) > 0,
 				canOutdent: !! grandParentId,
 			};
 		},
 		[ clientId ]
 	);
-	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+
+	const indentListItem = useIndentListItem( clientId );
+	const outdentListItem = useOutdentListItem( clientId );
+
 	return (
 		<>
 			<ToolbarButton
 				icon={ isRTL() ? formatOutdentRTL : formatOutdent }
 				title={ __( 'Outdent' ) }
 				describedBy={ __( 'Outdent list item' ) }
-				shortcut={ _x( 'Backspace', 'keyboard key' ) }
 				disabled={ ! canOutdent }
-				onClick={ () => {
-					const {
-						getBlockRootClientId,
-						getBlockAttributes,
-						getBlock,
-						getBlockIndex,
-						getSelectionStart,
-						getSelectionEnd,
-					} = select( blockEditorStore );
-					const selectionStart = getSelectionStart();
-					const selectionEnd = getSelectionEnd();
-
-					const listParentId = getBlockRootClientId( clientId );
-					const listAttributes = getBlockAttributes( listParentId );
-					const listItemParentId = getBlockRootClientId(
-						listParentId
-					);
-					const listItemParentAttributes = getBlockAttributes(
-						listItemParentId
-					);
-
-					const index = getBlockIndex( clientId );
-					const siblingBlocks = getBlock( listParentId ).innerBlocks;
-					const previousSiblings = siblingBlocks.slice( 0, index );
-					const afterSiblings = siblingBlocks.slice( index + 1 );
-
-					// Create a new parent list item block with just the siblings
-					// that existed before the child item being outdent.
-					const newListItemParent = createListItem(
-						listItemParentAttributes,
-						listAttributes,
-						previousSiblings
-					);
-
-					const childList = first( getBlock( clientId ).innerBlocks );
-					const childItems = childList?.innerBlocks || [];
-					const hasChildItems = !! childItems.length;
-
-					// Create a new list item block whose attributes are equal to the
-					// block being outdent and whose children are the children that it had (if any)
-					// followed by the siblings that existed after it.
-					const newItem = createListItem(
-						attributes,
-						hasChildItems ? childList.attributes : listAttributes,
-						[ ...childItems, ...afterSiblings ]
-					);
-
-					// Replace the parent list item block, with a new block containing
-					// the previous siblings, followed by another block containing after siblings
-					// in relation to the block being outdent.
-					replaceBlocks(
-						[ listItemParentId ],
-						[ newListItemParent, newItem ]
-					);
-
-					// Restore the selection state.
-					selectionChange(
-						newItem.clientId,
-						selectionEnd.attributeKey,
-						selectionEnd.clientId === selectionStart.clientId
-							? selectionStart.offset
-							: selectionEnd.offset,
-						selectionEnd.offset
-					);
-				} }
+				onClick={ outdentListItem }
 			/>
 			<ToolbarButton
 				icon={ isRTL() ? formatIndentRTL : formatIndent }
 				title={ __( 'Indent' ) }
 				describedBy={ __( 'Indent list item' ) }
-				shortcut={ _x( 'Space', 'keyboard key' ) }
-				isDisabled={ ! blockIndex }
-				onClick={ () => {
-					const {
-						getBlockRootClientId,
-						getBlock,
-						getBlockOrder,
-						getSelectionStart,
-						getSelectionEnd,
-					} = select( blockEditorStore );
-
-					const selectionStart = getSelectionStart();
-					const selectionEnd = getSelectionEnd();
-
-					const parentId = getBlockRootClientId( clientId );
-					const previousSiblingId = getBlockOrder( parentId )[
-						blockIndex - 1
-					];
-					const previousSibling = getBlock( previousSiblingId );
-					const previousSiblingChildren =
-						first( previousSibling.innerBlocks )?.innerBlocks || [];
-					const previousSiblingListAttributes =
-						first( previousSibling.innerBlocks )?.attributes || {};
-					const block = getBlock( clientId );
-
-					const childListAttributes = first( block.innerBlocks )?.attributes;
-					const childItemBlocks =
-						first( block.innerBlocks )?.innerBlocks || [];
-
-
-					const newBlock = createListItem(
-						block.attributes,
-						childListAttributes,
-						childItemBlocks
-					);
-					// Replace the previous sibling of the block being indented and the indented block,
-					// with a new block whose attributes are equal to the ones of the previous sibling and
-					// whose descendants are the children of the previous sibling, followed by the indented block.
-					replaceBlocks(
-						[ previousSiblingId, clientId ],
-						[
-							createListItem(
-								previousSibling.attributes,
-								previousSiblingListAttributes,
-								[ ...previousSiblingChildren, newBlock ]
-							),
-						]
-					);
-
-					// Restore the selection state.
-					selectionChange(
-						newBlock.clientId,
-						selectionEnd.attributeKey,
-						selectionEnd.clientId === selectionStart.clientId
-							? selectionStart.offset
-							: selectionEnd.offset,
-						selectionEnd.offset
-					);
-				} }
+				isDisabled={ ! canIndent }
+				onClick={ indentListItem }
 			/>
 		</>
 	);
@@ -230,7 +235,7 @@ export default function ListItemEdit( {
 				{ innerBlocksProps.children }
 			</li>
 			<BlockControls group="block">
-				<IndentUI clientId={ clientId } attributes={ attributes } />
+				<IndentUI clientId={ clientId } />
 			</BlockControls>
 		</>
 	);

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -1,13 +1,170 @@
 /**
+ * External dependencies
+ */
+import { get, first } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
 	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
+	BlockControls,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { isRTL, __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect, select } from '@wordpress/data';
+import { ToolbarButton } from '@wordpress/components';
+import {
+	formatOutdent,
+	formatOutdentRTL,
+	formatIndentRTL,
+	formatIndent,
+} from '@wordpress/icons';
+
+function IdentUI( { attributes, clientId } ) {
+	const { canOutdent, blockIndex } = useSelect(
+		( innerSelect ) => {
+			const { getBlockRootClientId, getBlockIndex } = innerSelect(
+				blockEditorStore
+			);
+			const grandParentId = getBlockRootClientId(
+				getBlockRootClientId( clientId )
+			);
+			return {
+				blockIndex: getBlockIndex( clientId ),
+				canOutdent: !! grandParentId,
+			};
+		},
+		[ clientId ]
+	);
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+	return (
+		<>
+			<ToolbarButton
+				icon={ isRTL() ? formatOutdentRTL : formatOutdent }
+				title={ __( 'Outdent' ) }
+				describedBy={ __( 'Outdent list item' ) }
+				shortcut={ _x( 'Backspace', 'keyboard key' ) }
+				disabled={ ! canOutdent }
+				onClick={ () => {
+					const {
+						getBlockRootClientId,
+						getBlockAttributes,
+						getBlock,
+						getBlockIndex,
+					} = select( blockEditorStore );
+					const listParentId = getBlockRootClientId( clientId );
+					const listAttributes = getBlockAttributes( listParentId );
+					const listItemParentId = getBlockRootClientId(
+						listParentId
+					);
+					const listItemParentAttributes = getBlockAttributes(
+						listItemParentId
+					);
+
+					const index = getBlockIndex( clientId );
+					const siblingBlocks = getBlock( listParentId ).innerBlocks;
+
+					const newListItemParent = createBlock(
+						'core/list-item',
+						listItemParentAttributes,
+						index === 0
+							? []
+							: [
+									createBlock(
+										'core/list',
+										listAttributes,
+										siblingBlocks.slice( 0, index )
+									),
+							  ]
+					);
+
+					const childList = first( getBlock( clientId ).innerBlocks );
+					const childItems = childList?.innerBlocks || [];
+					const hasChildItems = !! childItems.length;
+
+					const newItem = createBlock(
+						'core/list-item',
+						attributes,
+						hasChildItems || index < siblingBlocks.length - 1
+							? [
+									createBlock(
+										'core/list',
+										hasChildItems
+											? childList.attributes
+											: listAttributes,
+										[
+											...childItems,
+											...siblingBlocks.slice( index + 1 ),
+										]
+									),
+							  ]
+							: []
+					);
+
+					replaceBlocks(
+						[ listItemParentId ],
+						[ newListItemParent, newItem ]
+					);
+				} }
+			/>
+			<ToolbarButton
+				icon={ isRTL() ? formatIndentRTL : formatIndent }
+				title={ __( 'Indent' ) }
+				describedBy={ __( 'Indent list item' ) }
+				shortcut={ _x( 'Space', 'keyboard key' ) }
+				isDisabled={ ! blockIndex }
+				onClick={ () => {
+					const {
+						getBlockRootClientId,
+						getBlock,
+						getBlockOrder,
+					} = select( blockEditorStore );
+					const parentId = getBlockRootClientId( clientId );
+					const previousSiblingId = getBlockOrder( parentId )[
+						blockIndex - 1
+					];
+					const previousSibling = getBlock( previousSiblingId );
+					const previousSiblingChildren =
+						first( previousSibling.innerBlocks )?.innerBlocks || [];
+					const previousSiblingAttributes = first( previousSibling.innerBlocks )?.attributes || {};
+					const block = getBlock( clientId );
+					const childItemBlocks =
+						first( block.innerBlocks )?.innerBlocks || [];
+					// Replace the block previous sibling of the block being indented and the indented block
+					// with a new block equal whose attributes are equal to the ones of the previous sibling and
+					// whose descendants are the children of the previous sibling, followed by the indented block followed by the children of the indented block.
+					replaceBlocks(
+						[ previousSiblingId, clientId ],
+						[
+							createBlock(
+								'core/list-item',
+								previousSibling.attributes,
+								[
+									createBlock(
+										'core/list',
+										previousSiblingAttributes,
+										[
+											...previousSiblingChildren,
+											createBlock(
+												'core/list-item',
+												block.attributes
+											),
+											...childItemBlocks,
+										]
+									),
+								]
+							),
+						]
+					);
+				} }
+			/>
+		</>
+	);
+}
 
 export default function ListItemEdit( {
 	name,
@@ -15,6 +172,7 @@ export default function ListItemEdit( {
 	setAttributes,
 	mergeBlocks,
 	onReplace,
+	clientId,
 } ) {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -22,26 +180,31 @@ export default function ListItemEdit( {
 	} );
 
 	return (
-		<li { ...innerBlocksProps }>
-			<RichText
-				identifier="content"
-				tagName="div"
-				onChange={ ( nextContent ) =>
-					setAttributes( { content: nextContent } )
-				}
-				value={ attributes.content }
-				aria-label={ __( 'List text' ) }
-				placeholder={ attributes.placeholder || __( 'List' ) }
-				onSplit={ ( value ) =>
-					createBlock( name, {
-						...attributes,
-						content: value,
-					} )
-				}
-				onMerge={ mergeBlocks }
-				onReplace={ onReplace }
-			/>
-			{ innerBlocksProps.children }
-		</li>
+		<>
+			<li { ...innerBlocksProps }>
+				<RichText
+					identifier="content"
+					tagName="div"
+					onChange={ ( nextContent ) =>
+						setAttributes( { content: nextContent } )
+					}
+					value={ attributes.content }
+					aria-label={ __( 'List text' ) }
+					placeholder={ attributes.placeholder || __( 'List' ) }
+					onSplit={ ( value ) =>
+						createBlock( name, {
+							...attributes,
+							content: value,
+						} )
+					}
+					onMerge={ mergeBlocks }
+					onReplace={ onReplace }
+				/>
+				{ innerBlocksProps.children }
+			</li>
+			<BlockControls group="block">
+				<IdentUI clientId={ clientId } attributes={ attributes } />
+			</BlockControls>
+		</>
 	);
 }

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -114,7 +114,6 @@ function IndentUI( { attributes, clientId } ) {
 						[ newListItemParent, newItem ]
 					);
 
-
 					// Restore the selection state.
 					selectionChange(
 						newItem.clientId,
@@ -151,27 +150,30 @@ function IndentUI( { attributes, clientId } ) {
 					const previousSibling = getBlock( previousSiblingId );
 					const previousSiblingChildren =
 						first( previousSibling.innerBlocks )?.innerBlocks || [];
-					const previousSiblingAttributes =
+					const previousSiblingListAttributes =
 						first( previousSibling.innerBlocks )?.attributes || {};
 					const block = getBlock( clientId );
+
+					const childListAttributes = first( block.innerBlocks )?.attributes;
 					const childItemBlocks =
 						first( block.innerBlocks )?.innerBlocks || [];
 
-					const newBlock = createListItem( block.attributes );
+
+					const newBlock = createListItem(
+						block.attributes,
+						childListAttributes,
+						childItemBlocks
+					);
 					// Replace the previous sibling of the block being indented and the indented block,
 					// with a new block whose attributes are equal to the ones of the previous sibling and
-					// whose descendants are the children of the previous sibling, followed by the indented block followed by the children of the indented block.
+					// whose descendants are the children of the previous sibling, followed by the indented block.
 					replaceBlocks(
 						[ previousSiblingId, clientId ],
 						[
 							createListItem(
 								previousSibling.attributes,
-								previousSiblingAttributes,
-								[
-									...previousSiblingChildren,
-									newBlock,
-									...childItemBlocks,
-								]
+								previousSiblingListAttributes,
+								[ ...previousSiblingChildren, newBlock ]
 							),
 						]
 					);

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -27,7 +32,7 @@ import OrderedListSettings from '../ordered-list-settings';
 
 const TEMPLATE = [ [ 'core/list-item' ] ];
 
-function IdentUI( { clientId } ) {
+function IndentUI( { clientId } ) {
 	const { canOutdent } = useSelect(
 		( innerSelect ) => {
 			const { getBlockRootClientId, getBlock } = innerSelect(
@@ -42,7 +47,7 @@ function IdentUI( { clientId } ) {
 		},
 		[ clientId ]
 	);
-	const { replaceBlocks } = useDispatch( blockEditorStore );
+	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
 
 	return (
 		<>
@@ -62,17 +67,20 @@ function IdentUI( { clientId } ) {
 					const parentBlockAttributes = getBlockAttributes(
 						parentBlockId
 					);
+					// Create a new parent block without the inner blocks.
+					const newParentBlock = createBlock(
+						'core/list-item',
+						parentBlockAttributes
+					);
 					const { innerBlocks } = getBlock( clientId );
+					// Replace the parent block with a new parent block without inner blocks,
+					// and make the inner blocks siblings of the parent.
 					replaceBlocks(
 						[ parentBlockId ],
-						[
-							createBlock(
-								'core/list-item',
-								parentBlockAttributes
-							),
-							...innerBlocks,
-						]
+						[ newParentBlock, ...innerBlocks ]
 					);
+					// Select the last child of the list being outdent.
+					selectionChange( last( innerBlocks ).clientId );
 				} }
 			/>
 		</>
@@ -108,7 +116,7 @@ function Edit( { attributes, setAttributes, clientId } ) {
 					setAttributes( { ordered: true } );
 				} }
 			/>
-			<IdentUI clientId={ clientId } />
+			<IndentUI clientId={ clientId } />
 		</BlockControls>
 	);
 

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -24,6 +24,7 @@ import {
 	formatOutdentRTL,
 } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,6 +32,28 @@ import { createBlock } from '@wordpress/blocks';
 import OrderedListSettings from '../ordered-list-settings';
 
 const TEMPLATE = [ [ 'core/list-item' ] ];
+
+function useOutdentList( clientId ) {
+	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+	return useCallback( () => {
+		const { getBlockRootClientId, getBlockAttributes, getBlock } = select(
+			blockEditorStore
+		);
+		const parentBlockId = getBlockRootClientId( clientId );
+		const parentBlockAttributes = getBlockAttributes( parentBlockId );
+		// Create a new parent block without the inner blocks.
+		const newParentBlock = createBlock(
+			'core/list-item',
+			parentBlockAttributes
+		);
+		const { innerBlocks } = getBlock( clientId );
+		// Replace the parent block with a new parent block without inner blocks,
+		// and make the inner blocks siblings of the parent.
+		replaceBlocks( [ parentBlockId ], [ newParentBlock, ...innerBlocks ] );
+		// Select the last child of the list being outdent.
+		selectionChange( last( innerBlocks ).clientId );
+	}, [ clientId ] );
+}
 
 function IndentUI( { clientId } ) {
 	const { canOutdent } = useSelect(
@@ -47,7 +70,8 @@ function IndentUI( { clientId } ) {
 		},
 		[ clientId ]
 	);
-	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+
+	const outdentList = useOutdentList( clientId );
 
 	return (
 		<>
@@ -55,33 +79,8 @@ function IndentUI( { clientId } ) {
 				icon={ isRTL() ? formatOutdentRTL : formatOutdent }
 				title={ __( 'Outdent' ) }
 				describedBy={ __( 'Outdent list item' ) }
-				shortcut={ _x( 'Backspace', 'keyboard key' ) }
 				disabled={ ! canOutdent }
-				onClick={ () => {
-					const {
-						getBlockRootClientId,
-						getBlockAttributes,
-						getBlock,
-					} = select( blockEditorStore );
-					const parentBlockId = getBlockRootClientId( clientId );
-					const parentBlockAttributes = getBlockAttributes(
-						parentBlockId
-					);
-					// Create a new parent block without the inner blocks.
-					const newParentBlock = createBlock(
-						'core/list-item',
-						parentBlockAttributes
-					);
-					const { innerBlocks } = getBlock( clientId );
-					// Replace the parent block with a new parent block without inner blocks,
-					// and make the inner blocks siblings of the parent.
-					replaceBlocks(
-						[ parentBlockId ],
-						[ newParentBlock, ...innerBlocks ]
-					);
-					// Select the last child of the list being outdent.
-					selectionChange( last( innerBlocks ).clientId );
-				} }
+				onClick={ outdentList }
 			/>
 		</>
 	);

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -5,15 +5,20 @@ import {
 	BlockControls,
 	useBlockProps,
 	useInnerBlocksProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
-import { isRTL, __ } from '@wordpress/i18n';
+import { useDispatch, useSelect, select } from '@wordpress/data';
+import { isRTL, __, _x } from '@wordpress/i18n';
 import {
 	formatListBullets,
 	formatListBulletsRTL,
 	formatListNumbered,
 	formatListNumberedRTL,
+	formatOutdent,
+	formatOutdentRTL,
 } from '@wordpress/icons';
+import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -22,7 +27,59 @@ import OrderedListSettings from '../ordered-list-settings';
 
 const TEMPLATE = [ [ 'core/list-item' ] ];
 
-function Edit( { attributes, setAttributes } ) {
+function IdentUI( { clientId } ) {
+	const { canOutdent } = useSelect(
+		( innerSelect ) => {
+			const { getBlockRootClientId, getBlock } = innerSelect(
+				blockEditorStore
+			);
+			const parentId = getBlockRootClientId( clientId );
+			return {
+				canOutdent:
+					!! parentId &&
+					getBlock( parentId ).name === 'core/list-item',
+			};
+		},
+		[ clientId ]
+	);
+	const { replaceBlocks } = useDispatch( blockEditorStore );
+
+	return (
+		<>
+			<ToolbarButton
+				icon={ isRTL() ? formatOutdentRTL : formatOutdent }
+				title={ __( 'Outdent' ) }
+				describedBy={ __( 'Outdent list item' ) }
+				shortcut={ _x( 'Backspace', 'keyboard key' ) }
+				disabled={ ! canOutdent }
+				onClick={ () => {
+					const {
+						getBlockRootClientId,
+						getBlockAttributes,
+						getBlock,
+					} = select( blockEditorStore );
+					const parentBlockId = getBlockRootClientId( clientId );
+					const parentBlockAttributes = getBlockAttributes(
+						parentBlockId
+					);
+					const { innerBlocks } = getBlock( clientId );
+					replaceBlocks(
+						[ parentBlockId ],
+						[
+							createBlock(
+								'core/list-item',
+								parentBlockAttributes
+							),
+							...innerBlocks,
+						]
+					);
+				} }
+			/>
+		</>
+	);
+}
+
+function Edit( { attributes, setAttributes, clientId } ) {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list-item' ],
@@ -51,6 +108,7 @@ function Edit( { attributes, setAttributes } ) {
 					setAttributes( { ordered: true } );
 				} }
 			/>
+			<IdentUI clientId={ clientId } />
 		</BlockControls>
 	);
 


### PR DESCRIPTION
Fix: https://github.com/WordPress/gutenberg/issues/39516

This PR implements Outdent and Indent actions for the list block v2.
For now, the actions are only implemented using the toolbar buttons we should follow up with a keyboard mechanism.

## Testing Instructions
I created complex list blocks, with nested lists and verified the Outdent and Indent results are the expected ones.
