### PR TITLE
Theme Export: If the theme declares a version number then add a schema

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -108,7 +108,7 @@ function gutenberg_generate_block_templates_export_file() {
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
 			$theme_json_version = 'trunk';
 		}
-		$schema = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
+		$schema         = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
 		$theme_json_raw = array_merge( $schema, $theme_json_raw );
 	}
 

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -99,8 +99,22 @@ function gutenberg_generate_block_templates_export_file() {
 	// Load theme.json into the zip file.
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
 	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
+
+	$theme_json_raw = $tree->get_data();
+	// If a version is defined, add a schema.
+	if ( $theme_json_raw['version'] ) {
+		global $wp_version;
+		$theme_json_version = substr( $wp_version, 0, strpos( $wp_version, '-' ) );
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+			$theme_json_version = 'trunk';
+		}
+		$theme_json_raw = array_reverse( $theme_json_raw );
+		$theme_json_raw['$schema'] = 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json';
+		$theme_json_raw = array_reverse( $theme_json_raw );
+	}
+
 	// Convert to a string.
-	$theme_json_encoded = wp_json_encode( $tree->get_data(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+	$theme_json_encoded = wp_json_encode( $theme_json_raw, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 	// Replace 4 spaces with a tab.
 	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
 	// Add the theme.json file to the zip.

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -108,9 +108,8 @@ function gutenberg_generate_block_templates_export_file() {
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
 			$theme_json_version = 'trunk';
 		}
-		$theme_json_raw = array_reverse( $theme_json_raw );
-		$theme_json_raw['$schema'] = 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json';
-		$theme_json_raw = array_reverse( $theme_json_raw );
+		$schema = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
+		$theme_json_raw = array_merge( $schema, $theme_json_raw );
 	}
 
 	// Convert to a string.


### PR DESCRIPTION
## What?
Add a $schema key to theme.json if it declares a version.

## Why?
If we know the version of the theme.json then we can add a $schema to improve developer experience.
Fixes https://github.com/WordPress/gutenberg/issues/39575

## How?
We detect the version of the theme.json and then add a $schema attribute if it's present. In the future we'll need to change the schema depending on the version. 

We do `array_reverse` on the data so the $schema gets added to the start of the theme.json file, not the end.

## Testing Instructions
1. Switch to a block theme
2. Go to the site editor
3. Export your theme
4. Verify that the zip file contains a theme.json file which contains a $schema attribute

## Screenshots or screencast <!-- if applicable -->
<img width="823" alt="Screenshot 2022-03-25 at 20 42 20" src="https://user-images.githubusercontent.com/275961/160198101-0c73edc4-09c0-4d3a-ace0-68d8480b57df.png">

cc @WordPress/block-themers 