### PR TITLE
Fix duplicate Additional CSS classes site-logo Block & social-link Block

### DIFF
--- a/packages/block-library/src/site-logo/index.php
+++ b/packages/block-library/src/site-logo/index.php
@@ -44,10 +44,6 @@ function render_block_core_site_logo( $attributes ) {
 	}
 
 	$classnames = array();
-	if ( ! empty( $attributes['className'] ) ) {
-		$classnames[] = $attributes['className'];
-	}
-
 	if ( empty( $attributes['width'] ) ) {
 		$classnames[] = 'is-default-size';
 	}

--- a/packages/block-library/src/social-link/index.php
+++ b/packages/block-library/src/social-link/index.php
@@ -21,7 +21,6 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$url         = ( isset( $attributes['url'] ) ) ? $attributes['url'] : false;
 	$label       = ( isset( $attributes['label'] ) ) ? $attributes['label'] : block_core_social_link_get_name( $service );
 	$show_labels = array_key_exists( 'showLabels', $block->context ) ? $block->context['showLabels'] : false;
-	$class_name  = isset( $attributes['className'] ) ? ' ' . $attributes['className'] : false;
 
 	// Don't render a link if there is no URL set.
 	if ( ! $url ) {
@@ -36,7 +35,7 @@ function render_block_core_social_link( $attributes, $content, $block ) {
 	$icon               = block_core_social_link_get_icon( $service );
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
-			'class' => 'wp-social-link wp-social-link-' . $service . $class_name,
+			'class' => 'wp-social-link wp-social-link-' . $service,
 			'style' => block_core_social_link_get_color_styles( $block->context ),
 		)
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix duplicate Additional CSS classes
related #39759
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Duplicate class names when using custom classes
I don't think it's necessary to add a custom class in each block since it's added with get_block_wrapper_attributes.
https://developer.wordpress.org/reference/functions/get_block_wrapper_attributes/

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a Post or Page.
2.  Insert a site-logo Block & social-link Block.
3.  Set Additional CSS class
4. Look at the class name on the publish screen.


## Screenshots or screencast <!-- if applicable -->
### Before
<img width="1441" alt="before" src="https://user-images.githubusercontent.com/42362903/160220027-f0b30a56-55c5-439a-abd6-b3d670cd768f.png">

### After
<img width="1438" alt="after" src="https://user-images.githubusercontent.com/42362903/160220025-509f44a6-111c-4dee-b671-de8bb5f5b9a2.png">

