### PR TITLE
Document: add the default database password to the getting started document

### DIFF
--- a/docs/contributors/code/getting-started-with-code-contribution.md
+++ b/docs/contributors/code/getting-started-with-code-contribution.md
@@ -116,6 +116,7 @@ To access the MySQL database on the `wp-env` instance you will first need the co
 ```
 Host: 127.0.0.1
 Username: root
+Password: password
 Database: wordpress
 Port: {MYSQL_PORT_NUMBER}
 ```


### PR DESCRIPTION
## What?
Add the default database password to the getting started document.

## Why?
I followed the [getting started document](https://github.com/AlanSyue/gutenberg/blob/trunk/docs/contributors/code/getting-started-with-code-contribution.md) and I have built the local WordPress environment and Gutenberg successfully.

When I wanted to access the MySQL database, I couldn't connect to the database through the connection information from the document.

```
Host: 127.0.0.1
Username: root
Database: wordpress
Port: {MYSQL_PORT_NUMBER}
```

I found that I should use the `password` then I can access the database.

I think we should add the default password to the document to allow the contributors set up the environment easily.

## How?
I add the default database password to the getting started document. When the contributors want to connect to the database, they will note that they should use the password to access the database.

## Testing Instructions
1. build the local WordPress environment.
```console
npm run wp-env start

> gutenberg@12.8.1 wp-env /Users/alansyue/gutenberg
> wp-env "start"

WordPress development site started at http://localhost:8888/
WordPress test site started at http://localhost:8889/
MySQL is listening on port 60967
MySQL for automated testing is listening on port 60965

 ✔ Done! (in 143s 292ms)
```
<img width="643" alt="image" src="https://user-images.githubusercontent.com/33183531/160239537-937b5693-1ebe-4c5a-b9cd-b615a2805761.png">

2. use the Sequel Ace to access the database
### using password: NO
<img width="446" alt="image" src="https://user-images.githubusercontent.com/33183531/160239605-22c47a48-7d4b-4bea-a99b-0fc0c782db56.png">

Access denied
<img width="245" alt="image" src="https://user-images.githubusercontent.com/33183531/160239630-cdc5352b-5e97-4ca1-b194-a09c50548bbc.png">

### using password: YES
<img width="454" alt="image" src="https://user-images.githubusercontent.com/33183531/160239658-4d7aff68-6208-451b-a920-36ba7e8383ff.png">

Access the database successfully
<img width="452" alt="截圖 2022-03-26 下午8 35 40" src="https://user-images.githubusercontent.com/33183531/160239752-ce5f62ac-6750-49f8-ab27-8e259beaa7bb.png">
