### PR TITLE
Wp-Scripts: add new command `version-replace`

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -78,6 +78,7 @@
 		"puppeteer-core": "^13.2.0",
 		"react-refresh": "^0.10.0",
 		"read-pkg-up": "^7.0.1",
+		"replace-in-file": "^6.3.2",
 		"resolve-bin": "^0.4.0",
 		"sass": "^1.35.2",
 		"sass-loader": "^12.1.0",

--- a/packages/scripts/scripts/version-replace.js
+++ b/packages/scripts/scripts/version-replace.js
@@ -33,7 +33,9 @@ let pluginFiles = glob(
 
 stdout.write( `Replacing version string for \`${ name }\` plugin... 🔥\n\n` );
 
-let pluginVersionConstant = `${ name.replace( /-/g, '_' ).toUpperCase() }_SINCE`;
+let pluginVersionConstant = `${ name
+	.replace( /-/g, '_' )
+	.toUpperCase() }_SINCE`;
 
 if ( hasPackageProp( 'version-replace' ) ) {
 	const versionReplace = getPackageProp( 'version-replace' );
@@ -43,12 +45,9 @@ if ( hasPackageProp( 'version-replace' ) ) {
 			'Using the `version-replace` field from `package.json` to detect files...\n'
 		);
 
-		pluginFiles = glob(
-			versionReplace.files,
-			{
-				caseSensitiveMatch: false,
-			}
-		);
+		pluginFiles = glob( versionReplace.files, {
+			caseSensitiveMatch: false,
+		} );
 	}
 
 	if ( 'constant' in getPackageProp( 'version-replace' ) ) {
@@ -64,7 +63,9 @@ if ( hasPackageProp( 'version-replace' ) ) {
 	);
 }
 
-stdout.write( `\nFound ${ pluginFiles.length } files to replace the version string\n\n` );
+stdout.write(
+	`\nFound ${ pluginFiles.length } files to replace the version string\n\n`
+);
 
 if ( pluginFiles.length > 0 ) {
 	stdout.write( 'Replacing version in files... ⏳\n\n' );
@@ -74,9 +75,11 @@ if ( pluginFiles.length > 0 ) {
 		from: new RegExp( pluginVersionConstant, 'g' ),
 		to: version,
 		allowEmptyPaths: true,
-	} ).then( () => {
-		stdout.write( 'Version replaced successfully 👍\n\n' );
-	} ).catch( ( error ) => {
-		stdout.write( `Error occurred: ${ error } ❌\n\n` );
-	} );
+	} )
+		.then( () => {
+			stdout.write( 'Version replaced successfully 👍\n\n' );
+		} )
+		.catch( ( error ) => {
+			stdout.write( `Error occurred: ${ error } ❌\n\n` );
+		} );
 }

--- a/packages/scripts/scripts/version-replace.js
+++ b/packages/scripts/scripts/version-replace.js
@@ -24,7 +24,6 @@ let pluginFiles = glob(
 		`${ name }.php`,
 		'uninstall.php',
 		'changelog.*',
-		'license.*',
 		'readme.*',
 	],
 	{
@@ -68,7 +67,7 @@ if ( hasPackageProp( 'version-replace' ) ) {
 stdout.write( `\nFound ${ pluginFiles.length } files to replace the version string\n\n` );
 
 if ( pluginFiles.length > 0 ) {
-	stdout.write( 'Replacing version in files...\n\n' );
+	stdout.write( 'Replacing version in files... ⏳\n\n' );
 
 	replace( {
 		files: pluginFiles,
@@ -76,8 +75,8 @@ if ( pluginFiles.length > 0 ) {
 		to: version,
 		allowEmptyPaths: true,
 	} ).then( () => {
-		stdout.write( 'Version replaced successfully!\n\n' );
+		stdout.write( 'Version replaced successfully 👍\n\n' );
 	} ).catch( ( error ) => {
-		stdout.write( `Error occurred: ${ error }\n\n` );
+		stdout.write( `Error occurred: ${ error } ❌\n\n` );
 	} );
 }

--- a/packages/scripts/scripts/version-replace.js
+++ b/packages/scripts/scripts/version-replace.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+const replace = require( 'replace-in-file' );
+const { sync: glob } = require( 'fast-glob' );
+const { stdout } = require( 'process' );
+
+/**
+ * Internal dependencies
+ */
+const { hasPackageProp, getPackageProp } = require( '../utils' );
+
+const name = getPackageProp( 'name' );
+const version = getPackageProp( 'version' );
+
+// See https://developer.wordpress.org/plugins/plugin-basics/best-practices/#file-organization.
+let pluginFiles = glob(
+	[
+		'admin/**/*',
+		'src/**/*',
+		'includes/**/*',
+		'templates/**/*',
+		'assets/**/*',
+		`${ name }.php`,
+		'uninstall.php',
+		'changelog.*',
+		'license.*',
+		'readme.*',
+	],
+	{
+		caseSensitiveMatch: false,
+	}
+);
+
+stdout.write( `Replacing version string for \`${ name }\` plugin... 🔥\n\n` );
+
+let pluginVersionConstant = `${ name.replace( /-/g, '_' ).toUpperCase() }_SINCE`;
+
+if ( hasPackageProp( 'version-replace' ) ) {
+	const versionReplace = getPackageProp( 'version-replace' );
+
+	if ( 'files' in getPackageProp( 'version-replace' ) ) {
+		stdout.write(
+			'Using the `version-replace` field from `package.json` to detect files...\n'
+		);
+
+		pluginFiles = glob(
+			versionReplace.files,
+			{
+				caseSensitiveMatch: false,
+			}
+		);
+	}
+
+	if ( 'constant' in getPackageProp( 'version-replace' ) ) {
+		stdout.write(
+			'Using the `version-replace` field from `package.json` to detect plugin version constant...\n'
+		);
+
+		pluginVersionConstant = versionReplace.constant;
+	}
+} else {
+	stdout.write(
+		'Using Plugin Handbook best practices to discover files...\n'
+	);
+}
+
+stdout.write( `\nFound ${ pluginFiles.length } files to replace the version string\n\n` );
+
+if ( pluginFiles.length > 0 ) {
+	stdout.write( 'Replacing version in files...\n\n' );
+
+	replace( {
+		files: pluginFiles,
+		from: new RegExp( pluginVersionConstant, 'g' ),
+		to: version,
+		allowEmptyPaths: true,
+	} ).then( () => {
+		stdout.write( 'Version replaced successfully!\n\n' );
+	} ).catch( ( error ) => {
+		stdout.write( `Error occurred: ${ error }\n\n` );
+	} );
+}


### PR DESCRIPTION
## What?
This PR adds a new `version-replace` command in `@wordpress/scripts` to replace version string
on files for a WordPress plugin.

## Why?
fixes #39761

## Usage
Add the following to your `package.json`:

```json
{
    "scripts": {
        "version-replace": "wp-scripts version-replace"
    }
}
```

Execute `npm run version-replace` to replace version constant string in files.

## Default Configuration
By default, the following files are taken into consideration for version replaced:

```javascript
[
    'admin/**/*',
    'src/**/*',
    'includes/**/*',
    'templates/**/*',
    'assets/**/*',
    'main-plugin-file.php',
    'uninstall.php',
    'changelog.*',
    'readme.*',
]
```
Out of the box, the version string constant is your plugin's  `package.json` uppercase `name` field with `_SINCE`.
For `name` field in `package.json` having value of `my-plugin`, the version string constant is `MY_PLUGIN_SINCE`.

More examples:
- for `name` field value `gutenberg`: version string constant `GUTENBERG_SINCE`
- for `name` field value `gutenberg-custom`: version string constant `GUTENBERG_CUSTOM_SINCE`

## Customization
By adding the following to your `package.json`:
- You can use a custom version constant string
- You can override file patterns

```json
{
    "version-replace": {
        "constant": "MY_CUSTOM_CONSTANT",
        "files": [
            "admin/**/*",
            "src/**/*",
            "other-dir/**/*",
            "custom-templates/**/*"
        ]
    }
}
```
## How has this been tested?
I executed the steps manually to test `version-replace` files with WordPress:

https://user-images.githubusercontent.com/28107639/160291783-b2f4f6c7-abcd-4f68-b4da-86d071b64b02.mp4


