### PR TITLE
Block gap: Check for splitOnAxis in the onChange callback

### DIFF
--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -14,7 +14,9 @@ describe( 'gap', () => {
 				top: '88rem',
 				left: '88rem',
 			};
-			expect( getGapBoxControlValueFromStyle( '88rem' ) ).toEqual( expectedValue );
+			expect( getGapBoxControlValueFromStyle( '88rem' ) ).toEqual(
+				expectedValue
+			);
 		} );
 		it( 'should return box control value from object', () => {
 			const blockGapValue = {

--- a/packages/block-editor/src/hooks/test/gap.js
+++ b/packages/block-editor/src/hooks/test/gap.js
@@ -1,9 +1,31 @@
 /**
  * Internal dependencies
  */
-import { getGapCSSValue } from '../gap';
+import { getGapCSSValue, getGapBoxControlValueFromStyle } from '../gap';
 
 describe( 'gap', () => {
+	describe( 'getGapBoxControlValueFromStyle()', () => {
+		it( 'should return `null` if argument is falsey', () => {
+			expect( getGapBoxControlValueFromStyle( undefined ) ).toBeNull();
+			expect( getGapBoxControlValueFromStyle( '' ) ).toBeNull();
+		} );
+		it( 'should return box control value from string', () => {
+			const expectedValue = {
+				top: '88rem',
+				left: '88rem',
+			};
+			expect( getGapBoxControlValueFromStyle( '88rem' ) ).toEqual( expectedValue );
+		} );
+		it( 'should return box control value from object', () => {
+			const blockGapValue = {
+				top: '222em',
+				left: '22px',
+			};
+			expect( getGapBoxControlValueFromStyle( blockGapValue ) ).toEqual( {
+				...blockGapValue,
+			} );
+		} );
+	} );
 	describe( 'getGapCSSValue()', () => {
 		it( 'should return `null` if argument is falsey', () => {
 			expect( getGapCSSValue( undefined ) ).toBeNull();

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -14,7 +14,7 @@ import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
  */
 import useSetting from '../components/use-setting';
 import { appendSelectors } from './utils';
-import { getGapValueFromStyle } from '../hooks/gap';
+import { getGapBoxControlValueFromStyle } from '../hooks/gap';
 
 export default {
 	name: 'default',
@@ -110,7 +110,7 @@ export default {
 		const { contentSize, wideSize } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
-		const blockGapStyleValue = getGapValueFromStyle(
+		const blockGapStyleValue = getGapBoxControlValueFromStyle(
 			style?.spacing?.blockGap
 		);
 		const blockGapValue =


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/39778

## What?

https://github.com/WordPress/gutenberg/pull/37736 introduced a bug whereby we always returning a box control value for block gap, even when `splitOnAxis` and therefore `BoxControl` component were inactive.

## Why?
The consequence of the bug was that blocks that do not opt into split axis gap values, such as the Gallery Block, still expect a string value for gap and will bork when they receive an object. 

They don't know what to do with it, kinda like me with a Rubik's cube.

## How?
This PR checks whether `splitOnAxis` is active and returns a string or box control value appropriately.

I also tested that, if we roll back axial gap support on the [Social Links block](https://github.com/WordPress/gutenberg/blob/ce74a0d4924e34f6ca146834e4a5e52d148bb07b/packages/block-library/src/social-links/block.json), a box control-like value in the block styles will be converted back to a string.

## Testing Instructions

Use a theme that has support for blockGap, e.g., TwentyTwentyTwo

1. Fire up the block editor
2. Add a gallery block with images
3. Ensure that changes to gap spacing appear as expected in the editor and frontend. The value of `--wp--style--unstable-gallery-gap` should be a string, for example `'20px'`.
4. Check that the Social Links block gap controls still work as expected (with axial padding).
5. Run `npm run test-unit packages/block-editor/src/hooks/test/gap.js`





<details><summary>Here's some test HTML</summary>


```html
<!-- wp:gallery {"linkTo":"none","style":{"spacing":{"blockGap":"37px"}}} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":11,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="http://localhost:4759/wp-content/uploads/2022/03/black-neutral-ancient-greek-columns-wallpaper-mural-Plain-820x532-copy.jpg" alt="" class="wp-image-11"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":12,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="http://localhost:4759/wp-content/uploads/2022/03/Madeleines-Recipe.jpg" alt="" class="wp-image-12"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":13,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="http://localhost:4759/wp-content/uploads/2022/03/French-Croissants-SM-2363.jpg" alt="" class="wp-image-13"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":14,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="http://localhost:4759/wp-content/uploads/2022/03/Best-electric-guitars-under-500-1000-300-and-200.jpg" alt="" class="wp-image-14"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":7,"sizeSlug":"large","linkDestination":"none","className":"is-style-default"} -->
<figure class="wp-block-image size-large is-style-default"><img src="http://localhost:4759/wp-content/uploads/2022/03/image.png" alt="" class="wp-image-7"/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->

<!-- wp:social-links {"style":{"spacing":{"blockGap":"272px"}}} -->
<ul class="wp-block-social-links"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->

<!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /--></ul>
<!-- /wp:social-links -->
```

</details>

<img width="883" alt="Screen Shot 2022-03-28 at 10 09 09 am" src="https://user-images.githubusercontent.com/6458278/160305548-4b14b6d5-5a05-45ec-af98-9981be160bcc.png">

https://user-images.githubusercontent.com/6458278/160305550-e8046555-6f76-43d4-bf6c-831a815de392.mp4




