### PR TITLE
Style Engine: add margin support to frontend

### DIFF
--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -89,6 +89,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 			marginBottom: 'bottom',
 			marginLeft: 'left',
 		},
+		useEngine: true,
 	},
 	padding: {
 		value: [ 'spacing', 'padding' ],

--- a/packages/style-engine/src/styles/index.ts
+++ b/packages/style-engine/src/styles/index.ts
@@ -2,5 +2,6 @@
  * Internal dependencies
  */
 import padding from './padding';
+import margin from './margin';
 
-export const styleDefinitions = [ padding ];
+export const styleDefinitions = [ margin, padding ];

--- a/packages/style-engine/src/styles/margin.ts
+++ b/packages/style-engine/src/styles/margin.ts
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import type { Style, StyleOptions } from '../types';
+import { generateBoxRules } from './utils';
+
+const margin = {
+	name: 'margin',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateBoxRules(
+			style,
+			options,
+			[ 'spacing', 'margin' ],
+			'margin'
+		);
+	},
+};
+
+export default margin;

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -8,29 +8,37 @@ describe( 'generate', () => {
 		expect( generate( {}, '.some-selector' ) ).toEqual( '' );
 	} );
 
-	it( 'should generate padding styles', () => {
+	it( 'should generate spacing styles', () => {
 		expect(
 			generate(
 				{
-					spacing: { padding: '10px' },
+					spacing: { padding: '10px', margin: '12px' },
 				},
 				{
 					selector: '.some-selector',
 				}
 			)
-		).toEqual( '.some-selector { padding: 10px; }' );
+		).toEqual( '.some-selector { margin: 12px; padding: 10px; }' );
 
 		expect(
 			generate(
 				{
-					spacing: { padding: { top: '10px', bottom: '5px' } },
+					spacing: {
+						padding: { top: '10px', bottom: '5px' },
+						margin: {
+							top: '11px',
+							right: '12px',
+							bottom: '13px',
+							left: '14px',
+						},
+					},
 				},
 				{
 					selector: '.some-selector',
 				}
 			)
 		).toEqual(
-			'.some-selector { padding-top: 10px; padding-bottom: 5px; }'
+			'.some-selector { margin-top: 11px; margin-right: 12px; margin-bottom: 13px; margin-left: 14px; padding-top: 10px; padding-bottom: 5px; }'
 		);
 	} );
 } );
@@ -40,17 +48,42 @@ describe( 'getCSSRules', () => {
 		expect( getCSSRules( {}, '.some-selector' ) ).toEqual( [] );
 	} );
 
+	it( 'should ignore unsupported styles', () => {
+		expect(
+			getCSSRules(
+				{
+					typography: {
+						fontVariantLigatures: 'no-common-ligatures',
+					},
+					spacing: { padding: '10px' },
+				},
+				'.some-selector'
+			)
+		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'padding',
+				value: '10px',
+			},
+		] );
+	} );
+
 	it( 'should return a rules array with CSS keys formatted in camelCase', () => {
 		expect(
 			getCSSRules(
 				{
-					spacing: { padding: '10px' },
+					spacing: { padding: '10px', margin: '12px' },
 				},
 				{
 					selector: '.some-selector',
 				}
 			)
 		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'margin',
+				value: '12px',
+			},
 			{
 				selector: '.some-selector',
 				key: 'padding',
@@ -61,13 +94,26 @@ describe( 'getCSSRules', () => {
 		expect(
 			getCSSRules(
 				{
-					spacing: { padding: { top: '10px', bottom: '5px' } },
+					spacing: {
+						padding: { top: '10px', bottom: '5px' },
+						margin: { right: '2em', left: '1vw' },
+					},
 				},
 				{
 					selector: '.some-selector',
 				}
 			)
 		).toEqual( [
+			{
+				selector: '.some-selector',
+				key: 'marginRight',
+				value: '2em',
+			},
+			{
+				selector: '.some-selector',
+				key: 'marginLeft',
+				value: '1vw',
+			},
 			{
 				selector: '.some-selector',
 				key: 'paddingTop',

--- a/packages/style-engine/src/test/index.js
+++ b/packages/style-engine/src/test/index.js
@@ -57,7 +57,9 @@ describe( 'getCSSRules', () => {
 					},
 					spacing: { padding: '10px' },
 				},
-				'.some-selector'
+				{
+					selector: '.some-selector',
+				}
 			)
 		).toEqual( [
 			{


### PR DESCRIPTION
## What? 🙈 
This PR adds margin to the list of supported Style Engine-parsed styles.

## Why? 🙉 
Given that it has similar values to padding, that is string and box model side values, and that the [pending backend PR](https://github.com/WordPress/gutenberg/pull/39446) deals with both padding and margin, it seems like a non-controversial addition.

## How? 🙊 
Following how we added padding in the [initial JS version of the Style Engine](https://github.com/WordPress/gutenberg/pull/37978).

## Testing Instructions

Test in both the site and block editors:

Adjust the margin of an individual block (e.g. Group). Check that the editor and frontends appear correctly and that the right inline styles are added to the block element.

Run `npm run test-unit packages/style-engine/src/test/index.js` for glory!

Run `npm run test-unit packages/edit-site/src/components/global-styles/test/use-global-styles-output.js` for more glory!

## Screenshots or screencast 
![2022-03-28 13 04 08](https://user-images.githubusercontent.com/6458278/160314697-917f12c6-97c0-47b0-a62f-a47ba452ddc1.gif)


