### PR TITLE
Gallery: Try replacing "Add" with "Replace".

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -542,7 +542,7 @@ function GalleryEdit( props ) {
 					accept="image/*"
 					handleUpload={ false }
 					onSelect={ updateImages }
-					name={ __( 'Add' ) }
+					name={ __( 'Replace' ) }
 					multiple={ true }
 					mediaIds={ images.map( ( image ) => image.id ) }
 					addToGallery={ hasImageIds }


### PR DESCRIPTION
## What?

The Gallery block has an "Add" item in the block toolbar that lets you add or manage the items in the gallery:

<img width="743" alt="Screenshot 2022-03-28 at 09 19 53" src="https://user-images.githubusercontent.com/1204802/160347011-892deaf9-4d16-4732-a13d-3fb79ecb4409.png">

This PR changes the label to say "Replace" instead:

<img width="738" alt="Screenshot 2022-03-28 at 09 21 28" src="https://user-images.githubusercontent.com/1204802/160347049-4d7d2e27-6da9-4eb7-9f33-84af8a9051f5.png">

## Why?

"Replace" is more reflective of the what the button enables: both replacing items already there, and adding new ones. It's also consistent with other blocks such as Image, Media & Text, etc.

## Testing Instructions

Insert a gallery block (and swoon over the sweet new block spacing control!), then use the "Replace" button in the toolbar.