### PR TITLE
Read more block: add support for text color

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -689,7 +689,7 @@ Displays the link of a post, page, or any other content-type. ([Source](https://
 
 -	**Name:** core/read-more
 -	**Category:** theme
--	**Supports:** color (background, gradients, ~~text~~), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** content, linkTarget
 
 ## RSS

--- a/packages/block-library/src/read-more/block.json
+++ b/packages/block-library/src/read-more/block.json
@@ -20,7 +20,7 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"text": false
+			"text": true
 		},
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds support for text color on the read more block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When this block was introduced in https://github.com/WordPress/gutenberg/pull/37649 it was mentioned that the way to control the color would be:

> because is just a link, the way to control the color of the link is through the highlight control in RichText toolbar options.

That brings a couple of problems:

- a theme can't define a default color for all instances of the block via theme.json
- using the highlight tool creates an extra `<mark>` tag that is not very semantic if we just want to change colors for stylistic reasons only

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I just added support for text color on block.json

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On a query block with the read more block in it, try to change the text color.
It should also work if we add this to theme.json:

```
"core/read-more": {
    "color": {
        "text": "red"
    }
}
```


## Screenshots or screencast <!-- if applicable -->

<img width="1073" alt="Screenshot 2022-03-28 at 10 50 13" src="https://user-images.githubusercontent.com/3593343/160363280-b90be5b5-7b47-41cd-848f-18d8a8208e2e.png">
