### PR TITLE
List block: Add migration from v1 to v2

### DIFF
--- a/packages/block-library/src/list/test/migrate.js
+++ b/packages/block-library/src/list/test/migrate.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, serialize } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { migrateToListV2 } from '../v2/migrate';
+import * as listItem from '../../list-item';
+import * as list from '../../list';
+import listV2 from '../../list/v2';
+
+describe( 'Migrate list block', () => {
+	beforeAll( () => {
+		const prev = window.__experimentalEnableListBlockV2;
+
+		// force list and list item block registration.
+		registerBlockType(
+			{ name: listItem.name, ...listItem.metadata },
+			listItem.settings
+		);
+		registerBlockType( { name: list.name, ...list.metadata }, listV2 );
+
+		window.__experimentalEnableListBlockV2 = prev;
+	} );
+
+	it( 'should migrate the values attribute to inner blocks', () => {
+		const [ updatedAttributes, updatedInnerBlocks ] = migrateToListV2( {
+			values:
+				'<li>test</li><li>test</li><li>test<ol><li>test test</li><li>test est eesssss</li></ol></li>',
+			ordered: false,
+		} );
+
+		expect( updatedAttributes ).toEqual( {
+			ordered: false,
+			// Ideally the values attributes shouldn't be here
+			// but since we didn't enable v2 by default yet,
+			// we're keeping the old default value in block.json
+			values: '',
+		} );
+		expect( serialize( updatedInnerBlocks ) )
+			.toEqual( `<!-- wp:list-item -->
+<li>test</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>test</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>test<!-- wp:list {\"ordered\":true} -->
+<ol><!-- wp:list-item -->
+<li>test test</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>test est eesssss</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->` );
+	} );
+} );

--- a/packages/block-library/src/list/test/migrate.js
+++ b/packages/block-library/src/list/test/migrate.js
@@ -94,4 +94,39 @@ describe( 'Migrate list block', () => {
 <!-- /wp:list --></li>
 <!-- /wp:list-item -->` );
 	} );
+
+	it( 'should handle formats properly', () => {
+		const [ updatedAttributes, updatedInnerBlocks ] = migrateToListV2( {
+			values: `<li>Europe<ul><li>France<ul><li>Lyon <strong>Rhone</strong>s</li><li>Paris <em>Ile de france</em><ul><li><em>1er</em></li></ul></li></ul></li></ul></li></ul></li>`,
+			ordered: false,
+		} );
+
+		expect( updatedAttributes ).toEqual( {
+			ordered: false,
+			// Ideally the values attributes shouldn't be here
+			// but since we didn't enable v2 by default yet,
+			// we're keeping the old default value in block.json
+			values: '',
+		} );
+		expect( serialize( updatedInnerBlocks ) )
+			.toEqual( `<!-- wp:list-item -->
+<li>Europe<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>France<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Lyon <strong>Rhone</strong>s</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Paris <em>Ile de france</em><!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li><em>1er</em></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->` );
+	} );
 } );

--- a/packages/block-library/src/list/test/migrate.js
+++ b/packages/block-library/src/list/test/migrate.js
@@ -60,4 +60,38 @@ describe( 'Migrate list block', () => {
 <!-- /wp:list --></li>
 <!-- /wp:list-item -->` );
 	} );
+
+	it( 'should handle empty space properly', () => {
+		const [ updatedAttributes, updatedInnerBlocks ] = migrateToListV2( {
+			values: `<li>Europe</li>
+                <li>
+                    \tAfrica
+                    <ol>
+                        <li>Algeria</li>
+                    </ol>
+                    \t
+                </li>`,
+			ordered: false,
+		} );
+
+		expect( updatedAttributes ).toEqual( {
+			ordered: false,
+			// Ideally the values attributes shouldn't be here
+			// but since we didn't enable v2 by default yet,
+			// we're keeping the old default value in block.json
+			values: '',
+		} );
+		expect( serialize( updatedInnerBlocks ) )
+			.toEqual( `<!-- wp:list-item -->
+<li>Europe</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Africa<!-- wp:list {\"ordered\":true} -->
+<ol><!-- wp:list-item -->
+<li>Algeria</li>
+<!-- /wp:list-item --></ol>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->` );
+	} );
 } );

--- a/packages/block-library/src/list/v2/deprecated.js
+++ b/packages/block-library/src/list/v2/deprecated.js
@@ -6,9 +6,10 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import migrateFontFamily from '../utils/migrate-font-family';
+import initialDeprecations from '../deprecated';
+import { migrateToListV2 } from './migrate';
 
-const v0 = {
+const v1 = {
 	attributes: {
 		ordered: {
 			type: 'boolean',
@@ -43,10 +44,22 @@ const v0 = {
 		typography: {
 			fontSize: true,
 			__experimentalFontFamily: true,
+			lineHeight: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextTransform: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
 		},
 		color: {
 			gradients: true,
 			link: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
 		},
 		__unstablePasteTextInline: true,
 		__experimentalSelector: 'ol,ul',
@@ -62,10 +75,7 @@ const v0 = {
 			</TagName>
 		);
 	},
-	migrate: migrateFontFamily,
-	isEligible( { style } ) {
-		return style?.typography?.fontFamily;
-	},
+	migrate: migrateToListV2,
 };
 
 /**
@@ -76,4 +86,4 @@ const v0 = {
  *
  * See block-deprecation.md
  */
-export default [ v0 ];
+export default [ v1, ...initialDeprecations ];

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -25,6 +25,7 @@ import {
 } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
 import { useCallback, useEffect } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -54,7 +55,14 @@ function useMigrateOnLoad( attributes, clientId ) {
 		if ( ! attributes.values ) {
 			return;
 		}
+
 		const [ newAttributes, newInnerBlocks ] = migrateToListV2( attributes );
+
+		deprecated( 'Value attribute on the list block', {
+			since: '6.0',
+			version: '6.5',
+			alternative: 'inner blocks',
+		} );
 
 		registry.batch( () => {
 			updateBlockAttributes( clientId, newAttributes );

--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -13,7 +13,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { isRTL, __ } from '@wordpress/i18n';
 import {
 	formatListBullets,
@@ -24,14 +24,44 @@ import {
 	formatOutdentRTL,
 } from '@wordpress/icons';
 import { createBlock } from '@wordpress/blocks';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import OrderedListSettings from '../ordered-list-settings';
+import { migrateToListV2 } from './migrate';
 
 const TEMPLATE = [ [ 'core/list-item' ] ];
+
+/**
+ * At the moment, deprecations don't handle create blocks from attributes
+ * (like when using CPT templates). For this reason, this hook is necessary
+ * to avoid breaking templates using the old list block format.
+ *
+ * @param {Object} attributes Block attributes.
+ * @param {string} clientId   Block client ID.
+ */
+function useMigrateOnLoad( attributes, clientId ) {
+	const registry = useRegistry();
+	const { updateBlockAttributes, replaceInnerBlocks } = useDispatch(
+		blockEditorStore
+	);
+
+	useEffect( () => {
+		// As soon as the block is loaded, migrate it to the new version.
+
+		if ( ! attributes.values ) {
+			return;
+		}
+		const [ newAttributes, newInnerBlocks ] = migrateToListV2( attributes );
+
+		registry.batch( () => {
+			updateBlockAttributes( clientId, newAttributes );
+			replaceInnerBlocks( clientId, newInnerBlocks );
+		} );
+	}, [ attributes.values ] );
+}
 
 function useOutdentList( clientId ) {
 	const { canOutdent } = useSelect(
@@ -97,6 +127,7 @@ function Edit( { attributes, setAttributes, clientId } ) {
 		allowedBlocks: [ 'core/list-item' ],
 		template: TEMPLATE,
 	} );
+	useMigrateOnLoad( attributes, clientId );
 	const { ordered, reversed, start } = attributes;
 	const TagName = ordered ? 'ol' : 'ul';
 

--- a/packages/block-library/src/list/v2/index.js
+++ b/packages/block-library/src/list/v2/index.js
@@ -9,12 +9,14 @@ import { list as icon } from '@wordpress/icons';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 const settings = {
 	icon,
 	edit,
 	save,
 	transforms,
+	deprecated,
 };
 
 export default settings;

--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+function createListBlockFromDOMElement( listElement ) {
+	const listAttributes = {
+		ordered: 'OL' === listElement.tagName,
+		start: listElement.getAttribute( 'start' )
+			? parseInt( listElement.getAttribute( 'start' ), 10 )
+			: undefined,
+		reversed:
+			listElement.getAttribute( 'reversed' ) === true ? true : undefined,
+		type: listElement.getAttribute( 'type' ) ?? undefined,
+	};
+
+	const innerBlocks = Array.from( listElement.children ).map(
+		( listItem ) => {
+			const children = Array.from( listItem.childNodes );
+			children.reverse();
+			const [ nestedList, ...nodes ] = children;
+
+			const hasNestedList =
+				nestedList.tagName === 'UL' || nestedList.tagName === 'OL';
+			if ( ! hasNestedList ) {
+				return createBlock( 'core/list-item', {
+					content: listItem.innerHTML,
+				} );
+			}
+			const htmlNodes = nodes.map( ( node ) => {
+				if ( node.nodeType === node.TEXT_NODE ) {
+					return node.textContent;
+				}
+				return node.outerHTML;
+			} );
+			htmlNodes.reverse();
+			const childAttributes = {
+				content: htmlNodes.concat( '' ),
+			};
+			const childInnerBlocks = [
+				createListBlockFromDOMElement( nestedList ),
+			];
+			return createBlock(
+				'core/list-item',
+				childAttributes,
+				childInnerBlocks
+			);
+		}
+	);
+
+	return createBlock( 'core/list', listAttributes, innerBlocks );
+}
+
+export function migrateToListV2( attributes ) {
+	const { values, start, reversed, ordered, type } = attributes;
+
+	const list = document.createElement( ordered ? 'ol' : 'ul' );
+	list.innerHTML = values;
+	if ( start ) {
+		list.setAttribute( 'start', start );
+	}
+	if ( reversed ) {
+		list.setAttribute( 'reversed', true );
+	}
+	if ( type ) {
+		list.setAttribute( 'type', type );
+	}
+
+	const listBlock = createListBlockFromDOMElement( list );
+
+	return [
+		{
+			...omit( attributes, [ 'values' ] ),
+			...listBlock.attributes,
+		},
+		listBlock.innerBlocks,
+	];
+}

--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -21,7 +21,11 @@ function createListBlockFromDOMElement( listElement ) {
 
 	const innerBlocks = Array.from( listElement.children ).map(
 		( listItem ) => {
-			const children = Array.from( listItem.childNodes );
+			const children = Array.from( listItem.childNodes ).filter(
+				( node ) =>
+					node.nodeType !== node.TEXT_NODE ||
+					node.textContent.trim().length !== 0
+			);
 			children.reverse();
 			const [ nestedList, ...nodes ] = children;
 
@@ -34,7 +38,7 @@ function createListBlockFromDOMElement( listElement ) {
 			}
 			const htmlNodes = nodes.map( ( node ) => {
 				if ( node.nodeType === node.TEXT_NODE ) {
-					return node.textContent;
+					return node.textContent.trim();
 				}
 				return node.outerHTML;
 			} );

--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -44,7 +44,7 @@ function createListBlockFromDOMElement( listElement ) {
 			} );
 			htmlNodes.reverse();
 			const childAttributes = {
-				content: htmlNodes.concat( '' ),
+				content: htmlNodes.join( ' ' ),
 			};
 			const childInnerBlocks = [
 				createListBlockFromDOMElement( nestedList ),

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -48,7 +48,7 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 		);
 
 		deprecated( 'Value attribute on the quote block', {
-			since: '6.0', // WP version
+			since: '6.0',
 			version: '6.5',
 			alternative: 'inner blocks',
 		} );


### PR DESCRIPTION
closes #39521

## What?

This PR adds a function to migrate list block v1 to list block v2 and applies this function in two places:
 - A block deprecation
 - On initial load for the block (to ensure backward compatibility for CPT templates)

## Why and How ?

Third-party developers can inject block in multiple ways: saved content (post, reusable blocks ...), CPT templates...

 1- For the first one, we need a way to migrate from old markup to new markup, the block deprecations are here to solve that 
 2- For the second one, we don't have a framework API to deal with block format (attributes) migration. This PR solves that by keeping the old attributes in the block definition and running a block migration on first load (edit function).

## Testing Instructions

1. Create a post with list blocks using the old format (disable the list block v2 experiment)
2. Save the post
3. Enable the list V2 experiment.
4. When loading the post in the editor, the block is migrated automatically, there's no block invalidation and the content is kept.

Test also the Post CPT templates, you can do so by pasting this code in `gutenberg.php` for instance:

```
function myplugin_register_template() {
    $post_type_object = get_post_type_object( 'post' );
    $post_type_object->template = array(
        array( 'core/list', array(
			'values'  => '<li>test</li><li>test</li><li>test<ol><li>test test</li><li>test est eesssss</li></ol></li>',
			'ordered' => true,
		) ),
    );
}
add_action( 'init', 'myplugin_register_template' );
```
 Now, load a new post editor, you should be able to see a "full" list as a starting point.
