### PR TITLE
Fix - Block editor settings mobile endpoint - Add missing global styles has support check

### DIFF
--- a/lib/compat/experimental/block-editor-settings-mobile.php
+++ b/lib/compat/experimental/block-editor-settings-mobile.php
@@ -20,7 +20,8 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		defined( 'REST_REQUEST' ) &&
 		REST_REQUEST &&
 		isset( $_GET['context'] ) &&
-		'mobile' === $_GET['context']
+		'mobile' === $_GET['context'] &&
+		WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
 	) {
 		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 	}


### PR DESCRIPTION
## What?
This PR adds a missing check for only passing the `experimentalStyles` data for themes that support global styles.

## Why?
After some recent changes https://github.com/WordPress/gutenberg/pull/39030 while moving some files, this check [was left behind](https://github.com/WordPress/gutenberg/pull/39030/files#diff-0b8e98dead5542e95159bd3c482158111d3f16637e7eef9af13373358fa42dedL35), causing issues on the latest production builds of the mobile WordPress apps.

## How?
Brings back the missing `WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()` check.

## Testing Instructions
- On a local instance of Gutenberg
- Activate a standard theme e.g. `Seedlet`
- Make a request to the following endpoint: `wp-json/wp-block-editor/v1/settings?context=mobile`
- Expect **not** to see the `__experimentalStyles` data in the response. It should only be returned for block-based themes.

## Screenshots or screencast <!-- if applicable -->
N/A