### PR TITLE
Add support for navigation-link descriptions

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -776,10 +776,10 @@ export default function NavigationLinkEdit( {
 										} }
 									/>
 									{ description && (
-									<span className="wp-block-navigation-item__description">
-										{ description || '' }
-									</span>
-									)}
+										<span className="wp-block-navigation-item__description">
+											{ description }
+										</span>
+									) }
 								</>
 							) }
 							{ ( isInvalid || isDraft ) && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -775,9 +775,11 @@ export default function NavigationLinkEdit( {
 											}
 										} }
 									/>
+									{ description && (
 									<span className="wp-block-navigation-item__description">
 										{ description || '' }
 									</span>
+									)}
 								</>
 							) }
 							{ ( isInvalid || isDraft ) && (

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -738,40 +738,47 @@ export default function NavigationLinkEdit( {
 					) : (
 						<>
 							{ ! isInvalid && ! isDraft && (
-								<RichText
-									ref={ ref }
-									identifier="label"
-									className="wp-block-navigation-item__label"
-									value={ label }
-									onChange={ ( labelValue ) =>
-										setAttributes( {
-											label: labelValue,
-										} )
-									}
-									onMerge={ mergeBlocks }
-									onReplace={ onReplace }
-									__unstableOnSplitAtEnd={ () =>
-										insertBlocksAfter(
-											createBlock(
-												'core/navigation-link'
-											)
-										)
-									}
-									aria-label={ __( 'Navigation link text' ) }
-									placeholder={ itemLabelPlaceholder }
-									withoutInteractiveFormatting
-									allowedFormats={ [
-										'core/bold',
-										'core/italic',
-										'core/image',
-										'core/strikethrough',
-									] }
-									onClick={ () => {
-										if ( ! url ) {
-											setIsLinkOpen( true );
+								<>
+									<RichText
+										ref={ ref }
+										identifier="label"
+										className="wp-block-navigation-item__label"
+										value={ label }
+										onChange={ ( labelValue ) =>
+											setAttributes( {
+												label: labelValue,
+											} )
 										}
-									} }
-								/>
+										onMerge={ mergeBlocks }
+										onReplace={ onReplace }
+										__unstableOnSplitAtEnd={ () =>
+											insertBlocksAfter(
+												createBlock(
+													'core/navigation-link'
+												)
+											)
+										}
+										aria-label={ __(
+											'Navigation link text'
+										) }
+										placeholder={ itemLabelPlaceholder }
+										withoutInteractiveFormatting
+										allowedFormats={ [
+											'core/bold',
+											'core/italic',
+											'core/image',
+											'core/strikethrough',
+										] }
+										onClick={ () => {
+											if ( ! url ) {
+												setIsLinkOpen( true );
+											}
+										} }
+									/>
+									<span className="wp-block-navigation-item__description">
+										{ description || '' }
+									</span>
+								</>
 							) }
 							{ ( isInvalid || isDraft ) && (
 								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -197,6 +197,13 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 	}
 
 	$html .= '</span>';
+
+	if ( ! empty( $attributes['description'] ) ) {
+		$html .= '<span class="wp-block-navigation-item__description">';
+		$html .= wp_kses_post( $attributes['description'] );
+		$html .= '</span>';
+	}
+
 	$html .= '</a>';
 	// End anchor tag content.
 

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -198,6 +198,7 @@ function render_block_core_navigation_link( $attributes, $content, $block ) {
 
 	$html .= '</span>';
 
+	// Add description if available.
 	if ( ! empty( $attributes['description'] ) ) {
 		$html .= '<span class="wp-block-navigation-item__description">';
 		$html .= wp_kses_post( $attributes['description'] );

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -8,4 +8,10 @@
 		word-break: normal;
 		overflow-wrap: break-word;
 	}
+
+	// Hide the description by default.
+	// If a theme opts-in to show descriptions, they will need to provide styles for them.
+	.wp-block-navigation-item__description {
+		display: none;
+	}
 }


### PR DESCRIPTION
## What?
This PR adds support for navigation-link descriptions.
Navigation-link blocks have a `description` field where users can enter a description for their links, and the description of that field is `The description will be displayed in the menu if the current theme supports it.`
However, there is no way for a theme to "support" these.

See #28446

## Why?
Descriptions in menus is a widely supported feature in lots of "classic" themes, but there's currently no way for a block theme to do something similar (unless they rewrite the `render_callback` of the block and override core).
We need a way to allow block themes to use that feature.

## How?
* Add a `<span class="wp-block-navigation-item__description">` after the link's label in the PHP render callback
* Do the same in JS
* Hide the `.wp-block-navigation-item__description` element with CSS. If a theme wants to opt-in to menu descriptions, it is expected they'll do some heavy styling on them, so they can add `display:block` to show them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
