### PR TITLE
Quote v2: fix markup (and double styling)

### DIFF
--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -37,7 +37,7 @@ export default function QuoteEdit( {
 
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps(
-		showAttribution ? blockProps : {},
+		{},
 		{
 			template: TEMPLATE,
 			templateInsertUpdatesSelection: true,
@@ -61,32 +61,36 @@ export default function QuoteEdit( {
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			{ showAttribution ? (
+			{
 				<figure { ...blockProps }>
 					<BlockQuotation { ...innerBlocksProps } />
-					<RichText
-						identifier="attribution"
-						tagName={ 'figcaption' }
-						style={ { display: 'block' } }
-						value={ attribution ?? '' }
-						onChange={ ( nextAttribution ) => {
-							setAttributes( { attribution: nextAttribution } );
-						} }
-						__unstableMobileNoFocusOnMount
-						aria-label={ __( 'Quote attribution' ) }
-						placeholder={
-							// translators: placeholder text used for the attribution
-							__( 'Add attribution' )
-						}
-						className="wp-block-quote__attribution"
-						__unstableOnSplitAtEnd={ () =>
-							insertBlocksAfter( createBlock( 'core/paragraph' ) )
-						}
-					/>
+					{ showAttribution && (
+						<RichText
+							identifier="attribution"
+							tagName={ 'figcaption' }
+							style={ { display: 'block' } }
+							value={ attribution ?? '' }
+							onChange={ ( nextAttribution ) => {
+								setAttributes( {
+									attribution: nextAttribution,
+								} );
+							} }
+							__unstableMobileNoFocusOnMount
+							aria-label={ __( 'Quote attribution' ) }
+							placeholder={
+								// translators: placeholder text used for the attribution
+								__( 'Add attribution' )
+							}
+							className="wp-block-quote__attribution"
+							__unstableOnSplitAtEnd={ () =>
+								insertBlocksAfter(
+									createBlock( 'core/paragraph' )
+								)
+							}
+						/>
+					) }
 				</figure>
-			) : (
-				<BlockQuotation { ...innerBlocksProps } />
-			) }
+			}
 		</>
 	);
 }

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -6,20 +6,17 @@ import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 export default function save( { attributes } ) {
 	const { attribution } = attributes;
 	const blockProps = useBlockProps.save();
-
 	const hasAttribution = ! RichText.isEmpty( attribution );
-	return hasAttribution ? (
+	return (
 		<figure { ...blockProps }>
 			<blockquote>
 				<InnerBlocks.Content />
 			</blockquote>
-			<figcaption>
-				<RichText.Content value={ attribution } />
-			</figcaption>
+			{ hasAttribution && (
+				<figcaption>
+					<RichText.Content value={ attribution } />
+				</figcaption>
+			) }
 		</figure>
-	) : (
-		<blockquote { ...blockProps }>
-			<InnerBlocks.Content />
-		</blockquote>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Consistently leave the figure/blockquote structure regardless of whether there is an attribution. We do the same thing for images and other blocks. This will also make it easier to style for themes if the markup doesn't change when there is an attribution or not.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
