### PR TITLE
Add new hook to allow additional featured block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -43,6 +43,7 @@ import {
 import { placeCaretAtHorizontalEdge } from '@wordpress/dom';
 import { link as linkIcon, addSubmenu } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -507,12 +508,21 @@ export default function NavigationLinkEdit( {
 		replaceBlock( clientId, newSubmenu );
 	}
 
-	const featuredBlocks = [
+	const defaultFeaturedBlocks = [
 		'core/site-logo',
 		'core/social-links',
 		'core/search',
 	];
 	const featuredTransforms = blockTransforms.filter( ( item ) => {
+		/**
+		 * Filters the featured blocks in the transform control panel.
+		 *
+		 * @param {Array} defaultFeaturedBlocks The default blocks to display.
+		 */
+		const featuredBlocks = applyFilters(
+			'allow_additional_featured_block_in_navigation',
+			defaultFeaturedBlocks
+		);
 		return featuredBlocks.includes( item.name );
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/39814

## What?
Introduce a new filter to allow adding blocks in the navigation transform control panel.

## Why?
This could be useful for third party plugins to feature their custom blocks and for the user to use it easily.

## Testing Instructions
This PR can be manually tested after creating and registering a custom block and adding something like:
```js
const featureNavigationCustomBlock = ( blockNames ) => {
    return blockNames.concat( [ 'my-plugin/my-custom-block' ] );
}

addFilter( 'allow_additional_featured_block_in_navigation', 'my-plugin/add_my_custom_block_to_featured_blocks', featureNavigationCustomBlock );
```
Your custom block feature should be displayed here:
![Capture d’écran 2022-03-28 à 15 52 44](https://user-images.githubusercontent.com/69580439/160436615-c49bb58e-8d68-4685-95d7-a37f0653fa45.png)


