### PR TITLE
Stabilize `<PlainText>` v2 and deprecate v1.

### DIFF
--- a/packages/block-editor/src/components/plain-text/README.md
+++ b/packages/block-editor/src/components/plain-text/README.md
@@ -35,6 +35,7 @@ wp.blocks.registerBlockType( /* ... */, {
 
 	edit: function( props ) {
 		return wp.element.createElement( wp.editor.PlainText, {
+			version: 2,
 			className: props.className,
 			value: props.attributes.content,
 			onChange: function( content ) {
@@ -63,6 +64,7 @@ registerBlockType( /* ... */, {
 	edit( { className, attributes, setAttributes } ) {
 		return (
 			<PlainText
+				version={ 2 }
 				className={ className }
 				value={ attributes.content }
 				onChange={ ( content ) => setAttributes( { content } ) }

--- a/packages/block-editor/src/components/plain-text/index.js
+++ b/packages/block-editor/src/components/plain-text/index.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { forwardRef } from '@wordpress/element';
 
 /**
@@ -17,10 +18,15 @@ import EditableText from '../editable-text';
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/plain-text/README.md
  */
-const PlainText = forwardRef( ( { __experimentalVersion, ...props }, ref ) => {
-	if ( __experimentalVersion === 2 ) {
+const PlainText = forwardRef( ( { version, ...props }, ref ) => {
+	if ( version === 2 ) {
 		return <EditableText ref={ ref } { ...props } />;
 	}
+
+	deprecated( 'Version 1 of `<PlainText>`', {
+		since: '6.0',
+		alternative: '`version={2}`',
+	} );
 
 	const { className, onChange, ...remainingProps } = props;
 

--- a/packages/block-library/src/comments-pagination-next/edit.js
+++ b/packages/block-library/src/comments-pagination-next/edit.js
@@ -23,7 +23,7 @@ export default function CommentsPaginationNextEdit( {
 			{ ...useBlockProps() }
 		>
 			<PlainText
-				__experimentalVersion={ 2 }
+				version={ 2 }
 				tagName="span"
 				aria-label={ __( 'Newer comments page link' ) }
 				placeholder={ __( 'Newer Comments' ) }

--- a/packages/block-library/src/comments-pagination-previous/edit.js
+++ b/packages/block-library/src/comments-pagination-previous/edit.js
@@ -30,7 +30,7 @@ export default function CommentsPaginationPreviousEdit( {
 				</span>
 			) }
 			<PlainText
-				__experimentalVersion={ 2 }
+				version={ 2 }
 				tagName="span"
 				aria-label={ __( 'Older comments page link' ) }
 				placeholder={ __( 'Older Comments' ) }

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -54,6 +54,7 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 				/>
 			) : (
 				<PlainText
+					version={ 2 }
 					value={ attributes.content }
 					onChange={ ( content ) => setAttributes( { content } ) }
 					placeholder={ __( 'Write HTML…' ) }

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -52,11 +52,11 @@ export default function PostTitleEdit( {
 		titleElement =
 			userCanEdit && ! isDescendentOfQueryLoop ? (
 				<PlainText
+					version={ 2 }
 					tagName={ TagName }
 					placeholder={ __( 'No Title' ) }
 					value={ rawTitle }
 					onChange={ setTitle }
-					version={ 2 }
 					{ ...blockProps }
 				/>
 			) : (
@@ -72,6 +72,7 @@ export default function PostTitleEdit( {
 			userCanEdit && ! isDescendentOfQueryLoop ? (
 				<TagName { ...blockProps }>
 					<PlainText
+						version={ 2 }
 						tagName="a"
 						href={ link }
 						target={ linkTarget }
@@ -81,7 +82,6 @@ export default function PostTitleEdit( {
 						}
 						value={ rawTitle }
 						onChange={ setTitle }
-						version={ 2 }
 					/>
 				</TagName>
 			) : (

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -56,7 +56,7 @@ export default function PostTitleEdit( {
 					placeholder={ __( 'No Title' ) }
 					value={ rawTitle }
 					onChange={ setTitle }
-					__experimentalVersion={ 2 }
+					version={ 2 }
 					{ ...blockProps }
 				/>
 			) : (
@@ -81,7 +81,7 @@ export default function PostTitleEdit( {
 						}
 						value={ rawTitle }
 						onChange={ setTitle }
-						__experimentalVersion={ 2 }
+						version={ 2 }
 					/>
 				</TagName>
 			) : (

--- a/packages/block-library/src/query-pagination-next/edit.js
+++ b/packages/block-library/src/query-pagination-next/edit.js
@@ -23,7 +23,7 @@ export default function QueryPaginationNextEdit( {
 			{ ...useBlockProps() }
 		>
 			<PlainText
-				__experimentalVersion={ 2 }
+				version={ 2 }
 				tagName="span"
 				aria-label={ __( 'Next page link' ) }
 				placeholder={ __( 'Next Page' ) }

--- a/packages/block-library/src/query-pagination-previous/edit.js
+++ b/packages/block-library/src/query-pagination-previous/edit.js
@@ -31,7 +31,7 @@ export default function QueryPaginationPreviousEdit( {
 				</span>
 			) }
 			<PlainText
-				__experimentalVersion={ 2 }
+				version={ 2 }
 				tagName="span"
 				aria-label={ __( 'Previous page link' ) }
 				placeholder={ __( 'Previous Page' ) }

--- a/packages/block-library/src/shortcode/edit.js
+++ b/packages/block-library/src/shortcode/edit.js
@@ -20,6 +20,7 @@ export default function ShortcodeEdit( { attributes, setAttributes } ) {
 				{ __( 'Shortcode' ) }
 			</label>
 			<PlainText
+				version={ 2 }
 				className="blocks-shortcode__textarea"
 				id={ inputId }
 				value={ attributes.text }

--- a/packages/block-library/src/shortcode/edit.native.js
+++ b/packages/block-library/src/shortcode/edit.native.js
@@ -58,7 +58,7 @@ export function ShortcodeEdit( props ) {
 			<Text style={ titleStyle }>{ __( 'Shortcode' ) }</Text>
 			<View style={ shortcodeContainerStyle }>
 				<PlainText
-					__experimentalVersion={ 2 }
+					version={ 2 }
 					value={ attributes.text }
 					style={ shortcodeStyle }
 					onChange={ onChange }


### PR DESCRIPTION
## What?
Stabilizes `<PlainText>` v2 and deprecates v1. In the future, we can remove v1 entirely.

## Why?
See discussion in #39619.

## How?
Renames `__experimentalVersion` prop to `version`, updates usage of the component across the project, and adds a deprecation warning for using the v1.

## Screenshots or screencast <!-- if applicable -->
