### PR TITLE
e2e Tests: `waitForNavigation` in Comments Query Loop test

### DIFF
--- a/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
@@ -48,12 +48,13 @@ describe( 'Comment Query Loop', () => {
 				`This is an automated comment - ${ i }`
 			);
 			await pressKeyTimes( 'Tab', 1 );
-			await page.keyboard.press( 'Enter' );
-			await page.waitForNavigation();
+			await Promise.all( [
+				page.keyboard.press( 'Enter' ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			] );
 		}
 
 		// We check that there is a previous comments page link.
-		await page.waitForSelector( '.wp-block-comments-pagination-previous' );
 		expect(
 			await page.$( '.wp-block-comments-pagination-previous' )
 		).not.toBeNull();
@@ -61,21 +62,25 @@ describe( 'Comment Query Loop', () => {
 			await page.$( '.wp-block-comments-pagination-next' )
 		).toBeNull();
 
-		await page.click( '.wp-block-comments-pagination-previous' );
+		await Promise.all( [
+			page.click( '.wp-block-comments-pagination-previous' ),
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+		] );
 
 		// We check that there are a previous and a next link.
-		await page.waitForSelector( '.wp-block-comments-pagination-previous' );
-		await page.waitForSelector( '.wp-block-comments-pagination-next' );
 		expect(
 			await page.$( '.wp-block-comments-pagination-previous' )
 		).not.toBeNull();
 		expect(
 			await page.$( '.wp-block-comments-pagination-next' )
 		).not.toBeNull();
-		await page.click( '.wp-block-comments-pagination-previous' );
+
+		await Promise.all( [
+			page.click( '.wp-block-comments-pagination-previous' ),
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+		] );
 
 		// We check that there is only have a next link
-		await page.waitForSelector( '.wp-block-comments-pagination-next' );
 		expect(
 			await page.$( '.wp-block-comments-pagination-previous' )
 		).toBeNull();


### PR DESCRIPTION
## What?
In the Comments Query Loop e2e test, use [`waitForNavigation`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitfornavigationoptions) rather than `waitForSelector`. (Follow-up to #39502.)

## Why?

After navigating from one page to another (via mouse click), we currently `waitForSelector` in order to make sure that a DOM element exists, before _asserting_ that that DOM element exists. However, if it didn't exist, `waitForSelector` would have timed out and errored -- which means the assertion is redundant.

## How?
In order to keep the assertion and make it non-redundant, while also making sure the page has loaded before we attempt to find the corresponding DOM element, we replace `waitForSelector` by [`waitForNavigation`](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagewaitfornavigationoptions) (which doesn't include any implicit assumptions about the specific DOM element being there).

(First discussed here: https://github.com/WordPress/gutenberg/pull/39502#discussion_r836470645)

## Testing Instructions
Verify that e2e tests pass (see CI). To verify locally:

```
npm run test-e2e -- packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
```

To watch the test while it's ongoing, append ` --puppeteer-interactive` to the above command.