### PR TITLE
RSS: Update max items

### DIFF
--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -23,7 +23,7 @@ import { prependHTTP } from '@wordpress/url';
 import ServerSideRender from '@wordpress/server-side-render';
 
 const DEFAULT_MIN_ITEMS = 1;
-const DEFAULT_MAX_ITEMS = 10;
+const DEFAULT_MAX_ITEMS = 20;
 
 export default function RSSEdit( { attributes, setAttributes } ) {
 	const [ isEditing, setIsEditing ] = useState( ! attributes.feedURL );


### PR DESCRIPTION
## What?
Closes #24859.

PR changes RSS block's max items from `10` to `20`.

## Why?
Updated number matches limit set in Classic RSS widget.

## How?
PR updates `DEFAULT_MAX_ITEMS` constant.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Heading Block.
3. Set feed URL - `https://www.smashingmagazine.com/feed/`. Some sites default to 10 items in the feed.
4. Confirm that you can display a max of `20` items in the block.
