### PR TITLE
Remove pointless `<span>`s in Custom HTML block controls.

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -59,14 +59,14 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 						isPressed={ ! isPreview }
 						onClick={ switchToHTML }
 					>
-						<span>HTML</span>
+						HTML
 					</ToolbarButton>
 					<ToolbarButton
 						className="components-tab-button"
 						isPressed={ isPreview }
 						onClick={ switchToPreview }
 					>
-						<span>{ __( 'Preview' ) }</span>
+						{ __( 'Preview' ) }
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>


### PR DESCRIPTION
## What?
This PR simplifies the markup of the HTML block controls by removing some pointless wrapping elements.

## Why?
Because the useless markup annoyed me.

## How?
It removes some pointless `<span>` wrappers in the HTML block's `<ToolbarButton>`s.

## Testing Instructions
1. Insert a Custom HTML block.
2. Ensure that the "HTML"/"Preview" buttons still look the same as before.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/19592990/160650147-3fd49dd9-2b3c-474d-a759-a3acfe644493.png)

### After
![image](https://user-images.githubusercontent.com/19592990/160648475-0fba7514-4c2b-4ee7-90ca-8e4852aac20a.png)
