### PR TITLE
RichText: fix splitValue with undefined selection

### DIFF
--- a/packages/block-editor/src/components/rich-text/split-value.js
+++ b/packages/block-editor/src/components/rich-text/split-value.js
@@ -20,8 +20,12 @@ export function splitValue( {
 		return;
 	}
 
+	// Ensure the value has a selection. This might happen when trying to split
+	// an empty value before there was a `selectionchange` event.
+	const { start = 0, end = 0 } = value;
+	const valueWithEnsuredSelection = { ...value, start, end };
 	const blocks = [];
-	const [ before, after ] = split( value );
+	const [ before, after ] = split( valueWithEnsuredSelection );
 	const hasPastedBlocks = pastedBlocks.length > 0;
 	let lastPastedBlockIndex = -1;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

`rich-text/split` requires a selection. We may call it without a selection when holding Enter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Press and hold Enter. In trunk you'll see errors:

```
Uncaught TypeError: undefined is not iterable (cannot read property Symbol(Symbol.iterator))
    at splitValue (split-value.js:24:28)
    at HTMLParagraphElement.onKeyDown (use-enter.js:102:16)
```
 
These should no longer appear with this branch.

## Screenshots or screencast <!-- if applicable -->
