### PR TITLE
Remove batch support declaration from block patterns REST, fix navigation areas

### DIFF
--- a/lib/class-wp-rest-block-navigation-areas-controller.php
+++ b/lib/class-wp-rest-block-navigation-areas-controller.php
@@ -37,8 +37,7 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 					'args'                => $this->get_collection_params(),
 				),
-				'schema'      => array( $this, 'get_public_item_schema' ),
-				'allow_batch' => array( 'v1' => true ),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 
@@ -46,7 +45,7 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<area>[\w-]+)',
 			array(
-				'args'   => array(
+				'args'        => array(
 					'area' => array(
 						'description' => __( 'An alphanumeric identifier for the navigation area.', 'gutenberg' ),
 						'type'        => 'string',
@@ -66,7 +65,8 @@ class WP_REST_Block_Navigation_Areas_Controller extends WP_REST_Controller {
 					'permission_callback' => array( $this, 'update_item_permissions_check' ),
 					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
 				),
-				'schema' => array( $this, 'get_public_item_schema' ),
+				'schema'      => array( $this, 'get_public_item_schema' ),
+				'allow_batch' => array( 'v1' => true ),
 			)
 		);
 	}

--- a/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
@@ -36,8 +36,7 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
-				'schema'      => array( $this, 'get_public_item_schema' ),
-				'allow_batch' => array( 'v1' => true ),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 	}

--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -36,8 +36,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'callback'            => array( $this, 'get_items' ),
 					'permission_callback' => array( $this, 'get_items_permissions_check' ),
 				),
-				'schema'      => array( $this, 'get_public_item_schema' ),
-				'allow_batch' => array( 'v1' => true ),
+				'schema' => array( $this, 'get_public_item_schema' ),
 			)
 		);
 	}


### PR DESCRIPTION
Followup to #39185 that removes batch support declaration from the block patterns and categories REST endpoints. They both support only `GET`, and batching is relevant only for write methods like `POST`.

I'm also fixing batch support declaration for the `/wp/v2/block-navigation-areas` endpoints (originally added by @anton-vlasenko in #36374). The `/block-navigation-areas` endpoint is only readable and doesn't need the declaration. But the `/block-navigation-areas/{id}` endpoint is writable and _doesn't_ declare batch support. So I moved the declaration to the right place.

**How to test:**
Before this patch, a batch request like:
```js
await wp.apiFetch( {
  path: '/batch/v1',
  method: 'POST',
  data: {
    requests: [ {
      path: '/wp/v2/block-navigation-areas/1'
    } ]
  }
} )
```
would fail with a `rest_batch_not_allowed` error. After this patch, it fails with `rest_navigation_area_invalid` which is better: the batch is performed, and it's the `1` id that's deemed invalid.
