### PR TITLE
Query page numbers block: add same supports that next/prev page have

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -653,7 +653,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
--	**Supports:** ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Previous Page

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -13,7 +13,10 @@
 		"html": false,
 		"color": {
 			"gradients": true,
-			"text": false
+			"text": false,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -10,7 +10,22 @@
 	"usesContext": [ "queryId", "query" ],
 	"supports": {
 		"reusable": false,
-		"html": false
+		"html": false,
+		"color": {
+			"gradients": true,
+			"text": false
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
 	},
 	"editorStyle": "query-pagination-numbers-editor"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/38386 as an alternative to https://github.com/WordPress/gutenberg/pull/38508 In this case I'm only adding the color/typography supports as per this [comment](https://github.com/WordPress/gutenberg/pull/38508#issuecomment-1080537977). We can revisit this block at a later date to add spacing options, but this is a safe first step to bring the block in line with the prev/next page blocks in terms of user customization.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before this PR you could customize the prev/next page blocks typography (make the text bold for example), but not the page numbers. This made query pagination look inconsistent if you chose to use page numbers.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR adds the same supports that the other blocks have and updates the docs to reflect the change.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On a query loop block, add query pagination with numbers, the options for the block should be the same for the page numbers and prev/next page blocks

## Screenshots or screencast <!-- if applicable -->

The screenshots show all the available options for the blocks, not just the ones that show by default:

Page numbers block | prev/next page
--- | ---
<img width="286" alt="Screenshot 2022-03-29 at 09 29 09" src="https://user-images.githubusercontent.com/3593343/160558870-fed7e062-0765-4465-b705-ef33a20522ab.png"> | <img width="283" alt="Screenshot 2022-03-29 at 09 29 26" src="https://user-images.githubusercontent.com/3593343/160558865-6c3652f4-006d-42f4-b44a-82b37ba8e856.png">

