### PR TITLE
Quote v2: retain selection after transform

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -361,6 +361,7 @@ function RichTextWrapper(
 						__unstableAllowPrefixTransformations,
 						formatTypes,
 						onReplace,
+						selectionChange,
 					} ),
 					useRemoveBrowserShortcuts(),
 					useShortcuts( keyboardShortcuts ),

--- a/packages/block-editor/src/components/rich-text/use-input-rules.js
+++ b/packages/block-editor/src/components/rich-text/use-input-rules.js
@@ -35,7 +35,10 @@ function findSelection( blocks ) {
 		);
 
 		if ( attributeKey ) {
-			return [ blocks[ i ].clientId, attributeKey, 0 ];
+			blocks[ i ].attributes[ attributeKey ] = blocks[ i ].attributes[
+				attributeKey
+			].replace( START_OF_SELECTED_AREA, '' );
+			return blocks[ i ].clientId;
 		}
 
 		const nestedSelection = findSelection( blocks[ i ].innerBlocks );
@@ -89,8 +92,8 @@ export function useInputRules( props ) {
 			} );
 			const block = transformation.transform( content );
 
+			selectionChange( findSelection( [ block ] ) );
 			onReplace( [ block ] );
-			selectionChange( ...findSelection( [ block ] ) );
 			__unstableMarkAutomaticChange();
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Similar to howe we retains focus through other block transforms and merges, we can use the selection character trick to find out where focus should move to. Previously the input rule returned just one blocks so it was easy for `replaceBlocks` to just place focus on the first block. With nested blocks this is not so simple. The selection character is a robust way to recover selection from any kind of structure the block implementor may insert with an input rule.

## Why?

When creating a quote with `> `, it is important to be able to keep typing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
