### PR TITLE
Theme Export: Restore appearanceTools when exporting a theme

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -438,8 +438,11 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	}
 
 	/**
-	 * Returns a valid theme.json for a theme.
-	 * Essentially, it flattens the preset data.
+	 * Returns a valid theme.json as provided by a theme.
+	 *
+	 * Unlike get_raw_data() this returns the presets flattened,
+	 * as provided by a theme. This also uses appearanceTools
+	 * instead of their opt-ins if all of them are true.
 	 *
 	 * @return array
 	 */

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -492,6 +492,8 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 				_wp_array_set( $context, $path, true );
 			}
 		}
+
+		unset( $context['appearanceTools'] );
 	}
 
 	protected static function do_opt_out_of_settings( $theme_json ) {

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -511,7 +511,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		// this code unsets them and sets 'appearanceTools' instead.
 		foreach ( $nodes as $node ) {
 			$all_opt_ins_are_set = true;
-			foreach( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+			foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
 				$full_path = array_merge( $node['path'], $opt_in_path );
 				// Use "unset prop" as a marker instead of "null" because
 				// "null" can be a valid value for some props (e.g. blockGap).
@@ -524,7 +524,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 			if ( $all_opt_ins_are_set ) {
 				_wp_array_set( $output, array_merge( $node['path'], array( 'appearanceTools' ) ), true );
-				foreach( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+				foreach ( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
 					$full_path = array_merge( $node['path'], $opt_in_path );
 					// Use "unset prop" as a marker instead of "null" because
 					// "null" can be a valid value for some props (e.g. blockGap).
@@ -536,8 +536,8 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 					// The following could be improved to be path independent.
 					// At the moment it relies on a couple of assumptions:
 					//
-					// - all opt-ins having a path of size 2
-					// - there's two sources of settings: the top-level and the block-level
+					// - all opt-ins having a path of size 2.
+					// - there's two sources of settings: the top-level and the block-level.
 					if (
 						( 1 === count( $node['path'] ) ) &&
 						( 'settings' === $node['path'][0] )
@@ -547,7 +547,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 						if ( empty( $output['settings'][ $opt_in_path[0] ] ) ) {
 							unset( $output['settings'][ $opt_in_path[0] ] );
 						}
-					} else if (
+					} elseif (
 						( 3 === count( $node['path'] ) ) &&
 						( 'settings' === $node['path'][0] ) &&
 						( 'blocks' === $node['path'][1] )
@@ -565,10 +565,16 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 		wp_recursive_ksort( $output );
 
-
 		return $output;
 	}
 
+	/**
+	 * Enables some settings.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param array $context The context to which the settings belong.
+	 */
 	protected static function do_opt_in_into_settings( &$context ) {
 		foreach ( static::APPEARANCE_TOOLS_OPT_INS as $path ) {
 			// Use "unset prop" as a marker instead of "null" because

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -477,7 +477,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 		}
 
-		$flattened_theme_json = static::do_opt_out_of_settings( $flattened_theme_json );
+		$flattened_theme_json = static::use_appearance_tools_setting( $flattened_theme_json );
 
 		wp_recursive_ksort( $flattened_theme_json );
 
@@ -496,7 +496,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		unset( $context['appearanceTools'] );
 	}
 
-	protected static function do_opt_out_of_settings( $theme_json ) {
+	protected static function use_appearance_tools_setting( $theme_json ) {
 		if ( array_key_exists( 'appearanceTools', $theme_json['settings'] ) ) { // Is it safe to assume that 'settings' always exsits?
 			foreach ( static::APPEARANCE_TOOLS_OPT_INS as $path ) {
 				// Remove the path.

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -450,30 +450,32 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		$output = $this->theme_json;
 		$nodes  = static::get_setting_nodes( $output );
 
-		// Flatten the theme & custom origins into a single one.
-		//
-		// For example, the following:
-		//
-		// {
-		//   "settings": {
-		//     "color": {
-		//       "palette": {
-		//         "theme": [ {} ],
-		//         "custom": [ {} ]
-		//       }
-		//     }
-		//   }
-		// }
-		//
-		// will be converted to:
-		//
-		// {
-		//   "settings": {
-		//     "color": {
-		//       "palette": [ {} ]
-		//     }
-		//   }
-		// }
+		/**
+		 * Flatten the theme & custom origins into a single one.
+		 *
+		 * For example, the following:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": {
+		 *         "theme": [ {} ],
+		 *         "custom": [ {} ]
+		 *       }
+		 *     }
+		 *   }
+		 * }
+		 *
+		 * will be converted to:
+		 *
+		 * {
+		 *   "settings": {
+		 *     "color": {
+		 *       "palette": [ {} ]
+		 *     }
+		 *   }
+		 * }
+		 */
 		foreach ( $nodes as $node ) {
 			foreach ( static::PRESETS_METADATA as $preset_metadata ) {
 				$path   = array_merge( $node['path'], $preset_metadata['path'] );

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -133,7 +133,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'title',
 	);
 
-	const TO_OPT_IN = array(
+	const APPEARANCE_TOOLS_OPT_INS = array(
 		array( 'border', 'color' ),
 		array( 'border', 'radius' ),
 		array( 'border', 'style' ),
@@ -485,7 +485,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	}
 
 	protected static function do_opt_in_into_settings( &$context ) {
-		foreach ( static::TO_OPT_IN as $path ) {
+		foreach ( static::APPEARANCE_TOOLS_OPT_INS as $path ) {
 			// Use "unset prop" as a marker instead of "null" because
 			// "null" can be a valid value for some props (e.g. blockGap).
 			if ( 'unset prop' === _wp_array_get( $context, $path, 'unset prop' ) ) {
@@ -496,7 +496,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 	protected static function do_opt_out_of_settings( $theme_json ) {
 		if ( array_key_exists( 'appearanceTools', $theme_json['settings'] ) ) { // Is it safe to assume that 'settings' always exsits?
-			foreach ( static::TO_OPT_IN as $path ) {
+			foreach ( static::APPEARANCE_TOOLS_OPT_INS as $path ) {
 				// Remove the path.
 				if ( ! empty( $theme_json['settings'][ $path[ 0 ] ][ $path[ 1 ] ] ) ) {
 					unset( $theme_json['settings'][ $path[ 0 ] ][ $path[ 1 ] ] );

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -519,9 +519,44 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 				// "null" can be a valid value for some props (e.g. blockGap).
 				$opt_in_value = _wp_array_get( $theme_json, $full_path, 'unset prop' );
 				if ( true === $opt_in_value ) {
+					// This could be improved to be independent from the size of the opt in path.
+					// At the moment it relies on all opt-ins having a path of size 2.
 					unset( $theme_json['settings'][ $opt_in_path[0] ][ $opt_in_path[1] ]);
 					if ( empty( $theme_json['settings'][ $opt_in_path[0]] ) ) {
 						unset( $theme_json['settings'][ $opt_in_path[0] ]);
+					}
+				}
+			}
+		}
+
+		// Block-level settings.
+		if ( isset( $theme_json['settings']['blocks'] ) && is_array( $theme_json['settings']['blocks'] ) ) {
+			foreach ( $theme_json['settings']['blocks'] as &$block ) {
+				$all_opt_ins_are_set = true;
+				foreach( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+					// Use "unset prop" as a marker instead of "null" because
+					// "null" can be a valid value for some props (e.g. blockGap).
+					$opt_in_value = _wp_array_get( $block, $opt_in_path, 'unset prop' );
+					if ( 'unset prop' === $opt_in_value ) {
+						$all_opt_ins_are_set = false;
+						break;
+					}
+				}
+		
+				if ( $all_opt_ins_are_set ) {
+					_wp_array_set( $block, array( 'appearanceTools'), true );
+					foreach( static::APPEARANCE_TOOLS_OPT_INS as $opt_in_path ) {
+						// Use "unset prop" as a marker instead of "null" because
+						// "null" can be a valid value for some props (e.g. blockGap).
+						$opt_in_value = _wp_array_get( $block, $opt_in_path, 'unset prop' );
+						if ( true === $opt_in_value ) {
+							// This could be improved to be independent from the size of the opt in path.
+							// At the moment it relies on all opt-ins having a path of size 2.
+							unset( $block[ $opt_in_path[0] ][ $opt_in_path[1] ]);
+							if ( empty( $block[ $opt_in_path[0]] ) ) {
+								unset( $block[ $opt_in_path[0] ]);
+							}
+						}
 					}
 				}
 			}

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -236,6 +236,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
+			'appearanceTools' => true,
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -236,7 +236,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'typography' => array(
 				'lineHeight' => true,
 			),
-			'appearanceTools' => true,
 			'blocks'     => array(
 				'core/paragraph' => array(
 					'typography' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2479,6 +2479,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'version'  => 2,
 				'settings' => array(
 					'appearanceTools' => true,
+					'blocks'          => array(
+						'core/paragraph' => array(
+							'appearanceTools' => true,
+						),
+					),
 				),
 			)
 		);
@@ -2488,6 +2493,11 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'version'  => 2,
 			'settings' => array(
 				'appearanceTools' => true,
+				'blocks'          => array(
+					'core/paragraph' => array(
+						'appearanceTools' => true,
+					),
+				),
 			),
 		);
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2472,4 +2472,25 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected_v1 = array( 'version' => 2 );
 		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
 	}
+
+	function test_export_data_sets_appearance_tools() {
+		$theme = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+				'settings' => array(
+					'appearanceTools' => true,
+				),
+			)
+		);
+
+		$actual   = $theme->get_data();
+		$expected = array(
+			'version'  => 2,
+			'settings' => array(
+				'appearanceTools' => true,
+			),
+		);
+
+		$this->assertEqualSetsWithIndex( $expected, $actual );
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When you export a theme that declares support for `appearanceTools` in theme.json we should keep this declaration rather than converting it to the properties that this maps to. Fixes #39464.

## Why?
This will make it easier for theme developers to use the theme export tool, and also enable them to easy opt in to more settings in the future.

## How?
By overloading the `do_opt_in_into_settings` method in `WP_Theme_JSON_Gutenberg` and creating a new one called `do_opt_out_of_settings` which does the reverse.

## Testing Instructions
- Switch to a theme that uses the `appearanceTools` property in theme.json (e.g. TT2)
- Go to the Site Editor and export the theme
- Confirm that the appearanceTools remain in the theme.json file under settings
- Confirm that the other properties aren't declared:
```
settings.border.color
settings.border.radius
settings.border.style
settings.border.width
settings.color.link
settings.spacing.padding
settings.spacing.blockGap
settings.spacing.margin
```

## Notes
There are also some other settings that are opted in to (e.g. settings.color.custom, settings.color.customGradient) but this has a different cause so we should look at it in a different PR...

cc @WordPress/block-themers 