### PR TITLE
Theme Export: Sort theme.json properties

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -159,6 +159,8 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 		}
 
+		gutenberg_recursive_ksort( $flattened_theme_json );
+
 		return $flattened_theme_json;
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -159,7 +159,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 		}
 
-		gutenberg_recursive_ksort( $flattened_theme_json );
+		wp_recursive_ksort( $flattened_theme_json );
 
 		return $flattened_theme_json;
 	}

--- a/lib/compat/wordpress-6.0/utils.php
+++ b/lib/compat/wordpress-6.0/utils.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Generic helper functions
+ *
+ * @since 6.0
+ */
+
+/**
+ * Sorts the keys of an array alphabetically.
+ * The array is passed by reference so it doesn't get returned
+ * which mimiks the behaviour of ksort.
+ *
+ * @param array $array The array to sort, passed by reference.
+ */
+function gutenberg_recursive_ksort( &$array ) {
+	foreach ( $array as &$value ) {
+		if ( is_array( $value ) ) {
+			gutenberg_recursive_ksort( $value );
+		}
+	}
+	ksort( $array );
+}

--- a/lib/compat/wordpress-6.0/utils.php
+++ b/lib/compat/wordpress-6.0/utils.php
@@ -2,6 +2,7 @@
 /**
  * Generic helper functions
  *
+ * @package WordPress
  * @since 6.0
  */
 
@@ -12,10 +13,10 @@
  *
  * @param array $array The array to sort, passed by reference.
  */
-function gutenberg_recursive_ksort( &$array ) {
+function wp_recursive_ksort( &$array ) {
 	foreach ( $array as &$value ) {
 		if ( is_array( $value ) ) {
-			gutenberg_recursive_ksort( $value );
+			wp_recursive_ksort( $value );
 		}
 	}
 	ksort( $array );

--- a/lib/load.php
+++ b/lib/load.php
@@ -99,6 +99,7 @@ require __DIR__ . '/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-
 require __DIR__ . '/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php';
 require __DIR__ . '/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php';
 require __DIR__ . '/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php';
+require __DIR__ . '/compat/wordpress-6.0/utils.php';
 require __DIR__ . '/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/compat/wordpress-6.0/rest-api.php';
 require __DIR__ . '/compat/wordpress-6.0/block-patterns.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This sorts the keys of theme.json on export alphabetically. 

## Why?
The order of the properties on the export currently are not predictable, which means that when you export the theme.json back to an existing theme the diff doesn't match as the properties are in a different order.

## How?
Uses a utility function.

## Testing Instructions
- Switch to a block theme
- Export your theme
- Check that the properties are sorted alphabetically
- Copy the theme.json back to the theme source
- Do a diff on the theme
- Is the diff easier to read?

## Notes
I'm not sure if this is really what we want. Often the properties don't read as well in this order, but without a predictable order we will continue to have problems when creating diffs from the site editor.

cc @WordPress/block-themers 
