### PR TITLE
Quote v2: add migration

### DIFF
--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -29,8 +29,7 @@
 		"src/**/*.scss",
 		"src/navigation-link/index.js",
 		"src/template-part/index.js",
-		"src/query/index.js",
-		"src/quote/v2/index.js"
+		"src/query/index.js"
 	],
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",

--- a/packages/block-library/src/quote/v2/deprecated.js
+++ b/packages/block-library/src/quote/v2/deprecated.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { omit } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock, parseWithAttributeSchema } from '@wordpress/blocks';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import deprecationsForV1Block from '../deprecated';
+
+const migrateToQuoteV2 = ( attributes ) => {
+	const { value } = attributes;
+
+	return [
+		{
+			...omit( attributes, [ 'value' ] ),
+		},
+		value
+			? parseWithAttributeSchema( value, {
+					type: 'array',
+					source: 'query',
+					selector: 'p',
+					query: {
+						content: {
+							type: 'string',
+							source: 'text',
+						},
+					},
+			  } ).map( ( { content } ) =>
+					createBlock( 'core/paragraph', { content } )
+			  )
+			: createBlock( 'core/paragraph' ),
+	];
+};
+
+const v3 = {
+	attributes: {
+		value: {
+			type: 'string',
+			source: 'html',
+			selector: 'blockquote',
+			multiline: 'p',
+			default: '',
+			__experimentalRole: 'content',
+		},
+		citation: {
+			type: 'string',
+			source: 'html',
+			selector: 'cite',
+			default: '',
+			__experimentalRole: 'content',
+		},
+		align: {
+			type: 'string',
+		},
+	},
+	supports: {
+		anchor: true,
+		__experimentalSlashInserter: true,
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalLetterSpacing: true,
+			__experimentalTextTransform: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+				fontAppearance: true,
+			},
+		},
+	},
+	save( { attributes } ) {
+		const { align, value, citation } = attributes;
+
+		const className = classnames( {
+			[ `has-text-align-${ align }` ]: align,
+		} );
+
+		return (
+			<blockquote { ...useBlockProps.save( { className } ) }>
+				<RichText.Content multiline value={ value } />
+				{ ! RichText.isEmpty( citation ) && (
+					<RichText.Content tagName="cite" value={ citation } />
+				) }
+			</blockquote>
+		);
+	},
+	migrate: migrateToQuoteV2,
+};
+
+/**
+ * New deprecations need to be placed first
+ * for them to have higher priority.
+ *
+ * Old deprecations may need to be updated as well.
+ *
+ * See block-deprecation.md
+ */
+export default [ v3, ...deprecationsForV1Block ];

--- a/packages/block-library/src/quote/v2/deprecated.js
+++ b/packages/block-library/src/quote/v2/deprecated.js
@@ -15,7 +15,7 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
  */
 import deprecationsForV1Block from '../deprecated';
 
-const migrateToQuoteV2 = ( attributes ) => {
+export const migrateToQuoteV2 = ( attributes ) => {
 	const { value } = attributes;
 
 	return [

--- a/packages/block-library/src/quote/v2/deprecated.js
+++ b/packages/block-library/src/quote/v2/deprecated.js
@@ -30,7 +30,7 @@ export const migrateToQuoteV2 = ( attributes ) => {
 					query: {
 						content: {
 							type: 'string',
-							source: 'text',
+							source: 'html',
 						},
 					},
 			  } ).map( ( { content } ) =>

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -48,7 +48,7 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 
 		deprecated( 'Value attribute on the quote block', {
 			since: '6.0', // WP version
-			version: '6.5' // when the attribute gets removed. We can drop this property to never remove the deprecation
+			version: '6.5'
 			alternative: 'inner blocks'
 		});
 

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -12,6 +12,7 @@ import { BlockQuotation } from '@wordpress/components';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { Platform, useEffect } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -48,9 +49,9 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 
 		deprecated( 'Value attribute on the quote block', {
 			since: '6.0', // WP version
-			version: '6.5'
-			alternative: 'inner blocks'
-		});
+			version: '6.5',
+			alternative: 'inner blocks',
+		} );
 
 		registry.batch( () => {
 			updateBlockAttributes( clientId, newAttributes );

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -46,6 +46,12 @@ const useMigrateOnLoad = ( attributes, clientId ) => {
 			attributes
 		);
 
+		deprecated( 'Value attribute on the quote block', {
+			since: '6.0', // WP version
+			version: '6.5' // when the attribute gets removed. We can drop this property to never remove the deprecation
+			alternative: 'inner blocks'
+		});
+
 		registry.batch( () => {
 			updateBlockAttributes( clientId, newAttributes );
 			replaceInnerBlocks( clientId, newInnerBlocks );

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { quote as icon } from '@wordpress/icons';
-import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -35,34 +34,3 @@ const settings = {
 };
 
 export default settings;
-
-/**
- * This function updates the attributes for the quote v2.
- * This should be moved to block.json when v2 becomes the default.
- *
- * @param {Array}  blockSettings The settings of the block to be registered.
- * @param {string} blockName     The name of the block to be registered.
- * @return {Array} New settings.
- */
-function registerQuoteV2Attributes( blockSettings, blockName ) {
-	if ( ! window?.__experimentalEnableQuoteBlockV2 ) {
-		return blockSettings;
-	}
-
-	if ( blockName !== 'core/quote' ) {
-		return blockSettings;
-	}
-
-	// Deregister the old ones.
-	delete blockSettings.attributes.value;
-
-	return blockSettings;
-}
-
-// Importing this file includes side effects.
-// This has been declared in block-library/package.json under sideEffects.
-addFilter(
-	'blocks.registerBlockType',
-	'core/quote/v2-attributes',
-	registerQuoteV2Attributes
-);

--- a/packages/block-library/src/quote/v2/index.js
+++ b/packages/block-library/src/quote/v2/index.js
@@ -11,6 +11,7 @@ import { addFilter } from '@wordpress/hooks';
 import edit from './edit';
 import save from './save';
 import transforms from './transforms';
+import deprecated from './deprecated';
 
 const settings = {
 	icon,
@@ -30,6 +31,7 @@ const settings = {
 	transforms,
 	edit,
 	save,
+	deprecated,
 };
 
 export default settings;

--- a/packages/block-library/src/quote/v2/test/migrate.js
+++ b/packages/block-library/src/quote/v2/test/migrate.js
@@ -65,4 +65,28 @@ describe( 'Migrate quote block', () => {
 <!-- /wp:paragraph -->`
 		);
 	} );
+
+	it( 'should keep the formats of the value', () => {
+		const [ attributes, innerBlocks ] = migrateToQuoteV2( {
+			value:
+				'<p><strong>Bold</strong></p><p> and </p><p><em>italic</em></p>',
+			citation: 'Author',
+		} );
+		expect( attributes ).toEqual( {
+			citation: 'Author',
+		} );
+		expect( serialize( innerBlocks ) ).toEqual(
+			`<!-- wp:paragraph -->
+<p><strong>Bold</strong></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p> and </p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p><em>italic</em></p>
+<!-- /wp:paragraph -->`
+		);
+	} );
 } );

--- a/packages/block-library/src/quote/v2/test/migrate.js
+++ b/packages/block-library/src/quote/v2/test/migrate.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	registerBlockType,
+	serialize,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { migrateToQuoteV2 } from '../deprecated';
+import * as paragraph from '../../../paragraph';
+import * as quote from '../../../quote';
+import * as quoteV2 from '../../../quote/v2';
+
+describe( 'Migrate quote block', () => {
+	beforeAll( () => {
+		registerBlockType(
+			{ name: paragraph.name, ...paragraph.metadata },
+			paragraph.settings
+		);
+		registerBlockType(
+			{ name: quote.name, ...quote.metadata },
+			quoteV2.settings
+		);
+	} );
+
+	afterAll( () => {
+		unregisterBlockType( paragraph.name );
+		unregisterBlockType( quote.name );
+	} );
+
+	it( 'should migrate the value attribute to inner blocks', () => {
+		const [ attributes, innerBlocks ] = migrateToQuoteV2( {
+			value: '<p>First paragraph</p><p>Second paragraph</p>',
+			citation: 'Author',
+		} );
+		expect( attributes ).toEqual( {
+			citation: 'Author',
+		} );
+		expect( serialize( innerBlocks ) ).toEqual(
+			`<!-- wp:paragraph -->
+<p>First paragraph</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second paragraph</p>
+<!-- /wp:paragraph -->`
+		);
+	} );
+
+	it( 'should create a paragraph if value is empty', () => {
+		const [ attributes, innerBlocks ] = migrateToQuoteV2( {
+			value: undefined,
+			citation: 'Author',
+		} );
+		expect( attributes ).toEqual( {
+			citation: 'Author',
+		} );
+		expect( serialize( innerBlocks ) ).toEqual(
+			`<!-- wp:paragraph -->
+<p></p>
+<!-- /wp:paragraph -->`
+		);
+	} );
+} );

--- a/packages/block-library/src/quote/v2/transforms.js
+++ b/packages/block-library/src/quote/v2/transforms.js
@@ -29,7 +29,7 @@ const transforms = {
 						query: {
 							content: {
 								type: 'string',
-								source: 'text',
+								source: 'html',
 							},
 						},
 					} ).map( ( { content } ) =>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/15486
Related https://github.com/WordPress/gutenberg/pull/25892

## What?

This PR adds the migration from quote v1 to quote v2.

## Why?

We need to support existing content.

## How?

- Migrates v1 versions of the block by declaring deprecations.
- Migrates blocks created from templates provided to CPT by means of a hook in the edit function.

## Testing Instructions

Verify that the deprecation works:

- Disable the v2 quote in "Gutenberg > Experiments".
- Create some post with quote content. Here's an example that covers all cases:

```html
<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>Single p and cite</p>
<!-- /wp:paragraph --><cite>Cite</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>multiple</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>and</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>cite</p>
<!-- /wp:paragraph --><cite>cite</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p>multiple</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>paragraph</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph --><cite>cite</cite></blockquote>
<!-- /wp:quote -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->
```

- Enable back the v2 quote and load the post.
- The expected result is that all quotes are properly migrated to the v2 forrmat.

https://user-images.githubusercontent.com/583546/160582647-f876f1e0-c75f-40fc-af4c-0f0b322eb967.mp4

Verify that templates provided to CPT are migrated:

- Register a template for a CPT. For example, by adding the following code to `gutenberg.php`:

```php
function myplugin_register_template() {
    $post_type_object = get_post_type_object( 'post' );
    $post_type_object->template = array(
        array( 'core/quote', array(
			'value'    => '<p>First</p><p>Second</p>',
			'citation' => 'Howdy',
		) ),
    );
}
add_action( 'init', 'myplugin_register_template' );
```

- Make sure the v2 quote is enabled.
- Create a new post and verify that the quote template is properly converted to the v2.


https://user-images.githubusercontent.com/583546/160582608-fea0b611-de78-43b5-bfa0-9cd4fc6669be.mp4

