### PR TITLE
Block Styles: Revert changing default overflow-wrap to all headers, lists, and paragraphs

### DIFF
--- a/packages/block-library/src/heading/style.scss
+++ b/packages/block-library/src/heading/style.scss
@@ -4,9 +4,6 @@ h3,
 h4,
 h5,
 h6 {
-	// Break long strings of text without spaces so they don't overflow the block.
-	overflow-wrap: break-word;
-
 	&.has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}

--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -1,8 +1,5 @@
 ol,
 ul {
-	// Break long strings of text without spaces so they don't overflow the block.
-	overflow-wrap: break-word;
-
 	&.has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}

--- a/packages/block-library/src/paragraph/style.scss
+++ b/packages/block-library/src/paragraph/style.scss
@@ -28,11 +28,6 @@
 	font-style: normal;
 }
 
-p {
-	// Break long strings of text without spaces so they don't overflow the block.
-	overflow-wrap: break-word;
-}
-
 // Prevent the dropcap from breaking out of the box when a background is applied.
 p.has-drop-cap.has-background {
 	overflow: hidden;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

As https://github.com/WordPress/gutenberg/pull/34222 tries to fix the overflow problem for the long strings of text without spaces, it changes the default `overflow-wrap` behavior to all headers, lists, and paragraphs and leads to some side effects.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As it changes the default behavior to all headers, lists, and paragraphs and leads to some side effects. See https://github.com/WordPress/gutenberg/pull/34222#issuecomment-1013441608, https://github.com/WordPress/gutenberg/pull/34222#issuecomment-1034934343, https://github.com/WordPress/gutenberg/pull/34222#issuecomment-1081141999

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Revert the change of the default `overflow-wrap` behavior to all headers, lists, and paragraphs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create or Edit a post
2. Insert the following blocks
   * h1 through h6
   * ol and ul
   * p
3. Make sure the `overflow-wrap` style doesn't affect these blocks.

## Screenshots or screencast <!-- if applicable -->
