### PR TITLE
Theme Export: Remove default theme.json properties on export

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -97,9 +97,31 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Load theme.json into the zip file.
+	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array( 'with_supports' => false ) );
+	// Merge with user data.
+	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
+
+	$theme_json_raw = $tree->get_data();
+	// If a version is defined, add a schema.
+	if ( $theme_json_raw['version'] ) {
+		global $wp_version;
+		$theme_json_version = substr( $wp_version, 0, strpos( $wp_version, '-' ) );
+		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
+			$theme_json_version = 'trunk';
+		}
+		$schema         = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
+		$theme_json_raw = array_merge( $schema, $theme_json_raw );
+	}
+
+	// Convert to a string.
+	$theme_json_encoded = wp_json_encode( $theme_json_raw, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+	// Replace 4 spaces with a tab.
+	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
+
 	$zip->addFromString(
 		'theme.json',
-		WP_Theme_JSON_Resolver_Gutenberg::export()
+		$theme_json_tabbed
 	);
 
 	// Save changes to the zip file.

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -97,7 +97,7 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Load theme.json into the zip file.
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array( 'with_supports' => false ) );
+	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data( array(), array( 'with_supports' => false ) );
 	// Merge with user data.
 	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
 

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -97,29 +97,9 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Load theme.json into the zip file.
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data_without_supports();
-	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
-
-	$theme_json_raw = $tree->get_data();
-	// If a version is defined, add a schema.
-	if ( $theme_json_raw['version'] ) {
-		global $wp_version;
-		$theme_json_version = substr( $wp_version, 0, strpos( $wp_version, '-' ) );
-		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
-			$theme_json_version = 'trunk';
-		}
-		$schema         = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
-		$theme_json_raw = array_merge( $schema, $theme_json_raw );
-	}
-
-	// Convert to a string.
-	$theme_json_encoded = wp_json_encode( $theme_json_raw, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-	// Replace 4 spaces with a tab.
-	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
-	// Add the theme.json file to the zip.
 	$zip->addFromString(
 		'theme.json',
-		$theme_json_tabbed
+		WP_Theme_JSON_Resolver_Gutenberg::export()
 	);
 
 	// Save changes to the zip file.

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -119,6 +119,7 @@ function gutenberg_generate_block_templates_export_file() {
 	// Replace 4 spaces with a tab.
 	$theme_json_tabbed = preg_replace( '~(?:^|\G)\h{4}~m', "\t", $theme_json_encoded );
 
+	// Add the theme.json file to the zip.
 	$zip->addFromString(
 		'theme.json',
 		$theme_json_tabbed

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -97,7 +97,7 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Load theme.json into the zip file.
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data_without_supports();
 	$tree->merge( WP_Theme_JSON_Resolver_Gutenberg::get_user_data() );
 
 	$theme_json_raw = $tree->get_data();

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -159,9 +159,27 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 		}
 
+		$flattened_theme_json = static::unset_default_properties( $flattened_theme_json );
+
 		wp_recursive_ksort( $flattened_theme_json );
 
 		return $flattened_theme_json;
+	}
+
+	protected static function unset_default_properties( $theme_json ) {
+		if ( isset( $theme_json['settings']['color']['custom'] ) && $theme_json['settings']['color']['custom'] ) {
+			unset( $theme_json['settings']['color']['custom'] );
+		}
+
+		if ( isset( $theme_json['settings']['color']['customGradient'] ) && $theme_json['settings']['color']['customGradient'] ) {
+			unset( $theme_json['settings']['color']['customGradient'] );
+		}
+
+		if ( isset( $theme_json['settings']['typography']['customFontSize'] ) && $theme_json['settings']['typography']['customFontSize'] ) {
+			unset( $theme_json['settings']['typography']['customFontSize'] );
+		}
+
+		return $theme_json;
 	}
 
 }

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -199,6 +199,23 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			unset( $theme_json['settings']['spacing']['padding'] );
 		}
 
+		// Remove empty arrays.
+		if ( empty( $theme_json['settings']['color'] ) ) {
+			unset( $theme_json['settings']['color'] );
+		}
+
+		if ( empty( $theme_json['settings']['typography'] ) ) {
+			unset( $theme_json['settings']['typography'] );
+		}
+
+		if ( empty( $theme_json['settings']['spacing'] ) ) {
+			unset( $theme_json['settings']['spacing'] );
+		}
+
+		if ( empty( $theme_json['settings'] ) ) {
+			unset( $theme_json['settings'] );
+		}
+
 		return $theme_json;
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -166,7 +166,14 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		return $flattened_theme_json;
 	}
 
+	/**
+	 * Removes default properties from theme.json
+	 *
+	 * @param array The theme.json to update
+	 * @return array An updated version of theme.json
+	 */
 	protected static function unset_default_properties( $theme_json ) {
+		// Unset properties that default to true.
 		if ( isset( $theme_json['settings']['color']['custom'] ) && $theme_json['settings']['color']['custom'] ) {
 			unset( $theme_json['settings']['color']['custom'] );
 		}
@@ -177,6 +184,19 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 		if ( isset( $theme_json['settings']['typography']['customFontSize'] ) && $theme_json['settings']['typography']['customFontSize'] ) {
 			unset( $theme_json['settings']['typography']['customFontSize'] );
+		}
+
+		// Unset properties that default to false.
+		if ( isset( $theme_json['settings']['typography']['lineHeight'] ) && ! $theme_json['settings']['typography']['lineHeight'] ) {
+			unset( $theme_json['settings']['typography']['lineHeight'] );
+		}
+
+		if ( isset( $theme_json['settings']['spacing']['units'] ) && ! $theme_json['settings']['spacing']['units'] ) {
+			unset( $theme_json['settings']['spacing']['units'] );
+		}
+
+		if ( isset( $theme_json['settings']['spacing']['padding'] ) && ! $theme_json['settings']['spacing']['padding'] ) {
+			unset( $theme_json['settings']['spacing']['padding'] );
 		}
 
 		return $theme_json;

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -169,7 +169,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	/**
 	 * Removes default properties from theme.json
 	 *
-	 * @param array The theme.json to update
+	 * @param array $theme_json The theme.json to update
 	 * @return array An updated version of theme.json
 	 */
 	protected static function unset_default_properties( $theme_json ) {

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -159,64 +159,8 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 			}
 		}
 
-		$flattened_theme_json = static::unset_default_properties( $flattened_theme_json );
-
 		wp_recursive_ksort( $flattened_theme_json );
 
 		return $flattened_theme_json;
 	}
-
-	/**
-	 * Removes default properties from theme.json
-	 *
-	 * @param array $theme_json The theme.json to update
-	 * @return array An updated version of theme.json
-	 */
-	protected static function unset_default_properties( $theme_json ) {
-		// Unset properties that default to true.
-		if ( isset( $theme_json['settings']['color']['custom'] ) && $theme_json['settings']['color']['custom'] ) {
-			unset( $theme_json['settings']['color']['custom'] );
-		}
-
-		if ( isset( $theme_json['settings']['color']['customGradient'] ) && $theme_json['settings']['color']['customGradient'] ) {
-			unset( $theme_json['settings']['color']['customGradient'] );
-		}
-
-		if ( isset( $theme_json['settings']['typography']['customFontSize'] ) && $theme_json['settings']['typography']['customFontSize'] ) {
-			unset( $theme_json['settings']['typography']['customFontSize'] );
-		}
-
-		// Unset properties that default to false.
-		if ( isset( $theme_json['settings']['typography']['lineHeight'] ) && ! $theme_json['settings']['typography']['lineHeight'] ) {
-			unset( $theme_json['settings']['typography']['lineHeight'] );
-		}
-
-		if ( isset( $theme_json['settings']['spacing']['units'] ) && ! $theme_json['settings']['spacing']['units'] ) {
-			unset( $theme_json['settings']['spacing']['units'] );
-		}
-
-		if ( isset( $theme_json['settings']['spacing']['padding'] ) && ! $theme_json['settings']['spacing']['padding'] ) {
-			unset( $theme_json['settings']['spacing']['padding'] );
-		}
-
-		// Remove empty arrays.
-		if ( empty( $theme_json['settings']['color'] ) ) {
-			unset( $theme_json['settings']['color'] );
-		}
-
-		if ( empty( $theme_json['settings']['typography'] ) ) {
-			unset( $theme_json['settings']['typography'] );
-		}
-
-		if ( empty( $theme_json['settings']['spacing'] ) ) {
-			unset( $theme_json['settings']['spacing'] );
-		}
-
-		if ( empty( $theme_json['settings'] ) ) {
-			unset( $theme_json['settings'] );
-		}
-
-		return $theme_json;
-	}
-
 }

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -72,6 +72,10 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		return $with_theme_supports;
 	}
 
+	/**
+	 * Gets the data from the theme.json file and converts it to an object.
+	 * Also merges with the parent theme.
+	 */
 	private static function get_theme_data_without_supports() {
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -31,25 +31,8 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
-		if ( null === static::$theme ) {
-			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );
-			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
 
-			if ( wp_get_theme()->parent() ) {
-				// Get parent theme.json.
-				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
-				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $parent_theme_json_data );
-				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
-
-				// Merge the child theme.json into the parent theme.json.
-				// The child theme takes precedence over the parent.
-				$parent_theme->merge( static::$theme );
-				static::$theme = $parent_theme;
-			}
-		}
+		static::get_theme_data_without_supports();
 
 		/*
 		 * We want the presets and settings declared in theme.json
@@ -87,5 +70,29 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$with_theme_supports->merge( static::$theme );
 
 		return $with_theme_supports;
+	}
+
+	public static function get_theme_data_without_supports() {
+		if ( null === static::$theme ) {
+			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );
+			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+
+			if ( wp_get_theme()->parent() ) {
+				// Get parent theme.json.
+				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+				$parent_theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $parent_theme_json_data );
+				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+
+				// Merge the child theme.json into the parent theme.json.
+				// The child theme takes precedence over the parent.
+				$parent_theme->merge( static::$theme );
+				static::$theme = $parent_theme;
+			}
+		}
+
+		return static::$theme;
 	}
 }

--- a/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-resolver-gutenberg.php
@@ -24,12 +24,35 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 	 * is present in theme.json and in theme supports,
 	 * the theme.json takes precedence.
 	 *
+	 * @param array $deprecated Deprecated argument.
 	 * @param array $settings Contains a key called with_supports to determine whether to include theme supports in the data.
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
-	public static function get_theme_data( $settings = array( 'with_supports' => true ) ) {
+	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
+		if ( ! empty( $deprecated ) ) {
+			_deprecated_argument( __METHOD__, '5.9' );
+		}
 
-		static::get_theme_data_without_supports();
+		if ( null === static::$theme ) {
+			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
+			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
+			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );
+			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
+
+			if ( wp_get_theme()->parent() ) {
+				// Get parent theme.json.
+				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
+				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
+				$parent_theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $parent_theme_json_data );
+				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
+
+				// Merge the child theme.json into the parent theme.json.
+				// The child theme takes precedence over the parent.
+				$parent_theme->merge( static::$theme );
+				static::$theme = $parent_theme;
+			}
+		}
+
 		if ( ! $settings['with_supports'] ) {
 			return static::$theme;
 		}
@@ -70,33 +93,5 @@ class WP_Theme_JSON_Resolver_Gutenberg extends WP_Theme_JSON_Resolver_6_0 {
 		$with_theme_supports->merge( static::$theme );
 
 		return $with_theme_supports;
-	}
-
-	/**
-	 * Gets the data from the theme.json file and converts it to an object.
-	 * Also merges with the parent theme.
-	 */
-	protected static function get_theme_data_without_supports() {
-		if ( null === static::$theme ) {
-			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
-			$theme_json_data = static::translate( $theme_json_data, wp_get_theme()->get( 'TextDomain' ) );
-			$theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $theme_json_data );
-			static::$theme   = new WP_Theme_JSON_Gutenberg( $theme_json_data );
-
-			if ( wp_get_theme()->parent() ) {
-				// Get parent theme.json.
-				$parent_theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json', true ) );
-				$parent_theme_json_data = static::translate( $parent_theme_json_data, wp_get_theme()->parent()->get( 'TextDomain' ) );
-				$parent_theme_json_data = gutenberg_add_registered_webfonts_to_theme_json( $parent_theme_json_data );
-				$parent_theme           = new WP_Theme_JSON_Gutenberg( $parent_theme_json_data );
-
-				// Merge the child theme.json into the parent theme.json.
-				// The child theme takes precedence over the parent.
-				$parent_theme->merge( static::$theme );
-				static::$theme = $parent_theme;
-			}
-		}
-
-		return static::$theme;
 	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2451,4 +2451,26 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertEqualSetsWithIndex( $expected, $actual );
 	}
 
+	function test_export_data_deals_with_empty_data() {
+		$theme_v2 = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 2,
+			),
+			'theme'
+		);
+		$actual_v2   = $theme_v2->get_data();
+		$expected_v2 = array( 'version' => 2 );
+		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
+
+		$theme_v1 = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version'  => 1,
+			),
+			'theme'
+		);
+		$actual_v1   = $theme_v1->get_data();
+		$expected_v1 = array( 'version' => 2 );
+		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
+		
+	}
 }

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2452,9 +2452,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 	}
 
 	function test_export_data_deals_with_empty_data() {
-		$theme_v2 = new WP_Theme_JSON_Gutenberg(
+		$theme_v2    = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version'  => 2,
+				'version' => 2,
 			),
 			'theme'
 		);
@@ -2462,15 +2462,14 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$expected_v2 = array( 'version' => 2 );
 		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
 
-		$theme_v1 = new WP_Theme_JSON_Gutenberg(
+		$theme_v1    = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version'  => 1,
+				'version' => 1,
 			),
 			'theme'
 		);
 		$actual_v1   = $theme_v1->get_data();
 		$expected_v1 = array( 'version' => 2 );
 		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
-		
 	}
 }


### PR DESCRIPTION
## What?
Three settings in theme.json are enabled by default:
```
settings.color.custom
settings.color.customGradient
settings.typography.customFontSize
```
This PR removes these properties on export if they are set to true.

## Why?
We don't want to make these settings explicit if they are the default.

## How?
We use `unset` on the theme.json for each property.

## Testing Instructions
- Switch to a block theme
- Export the theme from the site editor
- Confirm that the properties above are missing.

- Now try setting these properties to false in the theme.json file for the current theme
- Confirm that the properties are maintained on export.

cc @WordPress/block-themers 