### PR TITLE
List v2: Avoid using global 'select' part 2

### DIFF
--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -13,7 +13,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { ToolbarButton } from '@wordpress/components';
-import { useDispatch, useSelect, select } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { isRTL, __ } from '@wordpress/i18n';
 import {
 	formatListBullets,
@@ -49,14 +49,13 @@ function useOutdentList( clientId ) {
 		[ clientId ]
 	);
 	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+	const { getBlockRootClientId, getBlockAttributes, getBlock } = useSelect(
+		blockEditorStore
+	);
+
 	return [
 		canOutdent,
 		useCallback( () => {
-			const {
-				getBlockRootClientId,
-				getBlockAttributes,
-				getBlock,
-			} = select( blockEditorStore );
 			const parentBlockId = getBlockRootClientId( clientId );
 			const parentBlockAttributes = getBlockAttributes( parentBlockId );
 			// Create a new parent block without the inner blocks.


### PR DESCRIPTION
## What?
Missed a spot in #39821.

Replaces global `select` usage with `useSelect` selector getter.

## Testing Instructions
Confirm that outdent works on List block.
