### PR TITLE
Partial multi-select: fix error with dead key

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -39,9 +39,8 @@ export default function useInput() {
 				return;
 			}
 
-			node.contentEditable = false;
-
 			if ( event.keyCode === ENTER ) {
+				node.contentEditable = false;
 				event.preventDefault();
 				if ( __unstableIsFullySelected() ) {
 					replaceBlocks(
@@ -55,6 +54,7 @@ export default function useInput() {
 				event.keyCode === BACKSPACE ||
 				event.keyCode === DELETE
 			) {
+				node.contentEditable = false;
 				event.preventDefault();
 				if ( __unstableIsFullySelected() ) {
 					removeBlocks( getSelectedBlockClientIds() );
@@ -69,6 +69,7 @@ export default function useInput() {
 				event.key.length === 1 &&
 				! ( event.metaKey || event.ctrlKey )
 			) {
+				node.contentEditable = false;
 				if ( __unstableIsSelectionMergeable() ) {
 					__unstableDeleteSelection( event.keyCode === DELETE );
 				} else {

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -72,6 +72,8 @@ export default function useInput() {
 				} else {
 					event.preventDefault();
 				}
+			} else {
+				event.preventDefault();
 			}
 		}
 

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -64,7 +64,7 @@ export default function useInput() {
 			} else if (
 				// If key.length is longer than 1, it's a control key that doesn't
 				// input anything.
-				event.key.length === 1 &&
+				( event.key.length === 1 || event.key === 'Dead' ) &&
 				! ( event.metaKey || event.ctrlKey )
 			) {
 				if ( __unstableIsSelectionMergeable() ) {

--- a/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
+++ b/packages/e2e-tests/specs/editor/various/__snapshots__/multi-block-selection.test.js.snap
@@ -317,3 +317,19 @@ exports[`Multi-block selection should use selection direction to determine verti
 <p>3</p>
 <!-- /wp:paragraph -->"
 `;
+
+exports[`Multi-block selection should write over selection 1`] = `
+"<!-- wp:paragraph -->
+<p>1[</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>]2</p>
+<!-- /wp:paragraph -->"
+`;
+
+exports[`Multi-block selection should write over selection 2`] = `
+"<!-- wp:paragraph -->
+<p>1...2</p>
+<!-- /wp:paragraph -->"
+`;

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -858,6 +858,27 @@ describe( 'Multi-block selection', () => {
 		expect( await getEditedPostContent() ).toMatchSnapshot();
 	} );
 
+	it( 'should write over selection', async () => {
+		await clickBlockAppender();
+		await page.keyboard.type( '1[' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( ']2' );
+		await page.keyboard.press( 'ArrowLeft' );
+		// Select everything between [].
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+		await pressKeyWithModifier( 'shift', 'ArrowLeft' );
+
+		// Test setup.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+
+		// Ensure selection is in the correct place.
+		await page.keyboard.type( '...' );
+
+		// Expect a heading with "1&2" as its content.
+		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+
 	it( 'should handle Enter across blocks', async () => {
 		await clickBlockAppender();
 		await page.keyboard.type( '1[' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Unfortunately we can get to work composing characters over a partial multi selection in all browsers. Strangely enough it works in Safari, so we'll just let it work there. In Chrome nothing will happen. In Firefox the selection will be deleted, but no composition state is inserted. This all needs more investigation but this is the best we can do now. The most important thing is that we don't let the browser manipulate the DOM, otherwise there will be errors.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
