### PR TITLE
useEntityRecord(s) fix ESLint warning

### DIFF
--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -30,10 +30,10 @@ interface Options {
 /**
  * Resolves the specified entity record.
  *
- * @param  kind                                 Kind of the requested entity.
- * @param  name                                 Name of the requested  entity.
- * @param  recordId                             Record ID of the requested entity.
- * @param  options                              Hook options.
+ * @param  kind                   Kind of the requested entity.
+ * @param  name                   Name of the requested  entity.
+ * @param  recordId               Record ID of the requested entity.
+ * @param  options                Hook options.
  * @param  [options.enabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
  * @example
  * ```js

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -40,10 +40,10 @@ interface Options {
 /**
  * Resolves the specified entity records.
  *
- * @param  kind                                 Kind of the requested entities.
- * @param  name                                 Name of the requested entities.
- * @param  queryArgs                            HTTP query for the requested entities.
- * @param  options                              Hook options.
+ * @param  kind      Kind of the requested entities.
+ * @param  name      Name of the requested entities.
+ * @param  queryArgs HTTP query for the requested entities.
+ * @param  options   Hook options.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';


### PR DESCRIPTION
## What?
Fixes ESLint warning for `useEntityRecord` and `useEntityRecord` hooks DocBlock.

```
Expected JSDoc block lines to be aligned.
```