### PR TITLE
Fix small uppercase/lowercase inconsistency in create block template

### DIFF
--- a/packages/create-block-tutorial-template/block-templates/edit.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/edit.js.mustache
@@ -14,7 +14,7 @@ import { TextControl } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
- * The edit function describes the structure of your block in the context of the
+ * The Edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
  *
  * @see https://developer.wordpress.org/block-editor/developers/block-api/block-edit-save/#edit

--- a/packages/create-block-tutorial-template/block-templates/index.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/index.js.mustache
@@ -20,7 +20,7 @@ import './editor.scss';
  * Internal dependencies
  */
 import Edit from './edit';
-import save from './save';
+import Save from './save';
 
 /**
  * Every block starts by registering a new block type definition.
@@ -43,5 +43,5 @@ registerBlockType( '{{namespace}}/{{slug}}', {
 	/**
 	 * @see ./save.js
 	 */
-	save,
+	save: Save,
 } );

--- a/packages/create-block-tutorial-template/block-templates/save.js.mustache
+++ b/packages/create-block-tutorial-template/block-templates/save.js.mustache
@@ -7,7 +7,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
- * The save function defines the way in which the different attributes should
+ * The Save function defines the way in which the different attributes should
  * be combined into the final markup, which is then serialized by the block
  * editor into `post_content`.
  *
@@ -17,7 +17,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  * @param {Object} props.attributes Available block attributes.
  * @return {WPElement} Element to render.
  */
-export default function save( { attributes } ) {
+export default function Save( { attributes } ) {
 	const blockProps = useBlockProps.save();
 	return <div { ...blockProps }>{ attributes.message }</div>;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix a small inconsistency with uppercase/lowercase of Edit and Save components in the create-block template.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It felt a bit weird to use lowercase for `save` and uppercase for `Edit`. Maybe people can think that it is necessary for some reason.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've renamed `save` to `Save` to follow React's standard, but it could be done the other way around (`Edit` to `edit`).
