### PR TITLE
Updating versions in WordPress to add 5.9.x & 6.0

### DIFF
--- a/docs/contributors/versions-in-wordpress.md
+++ b/docs/contributors/versions-in-wordpress.md
@@ -6,6 +6,10 @@ If anything looks incorrect here, please bring it up in #core-editor in [WordPre
 
 | Gutenberg Versions | WordPress Version |
 | ------------------ | ----------------- |
+| 12.0-13.0          | 6.0               |
+| 10.8-11.9          | 5.9.3             |
+| 10.8-11.9          | 5.9.2             |
+| 10.8-11.9          | 5.9.1             |
 | 10.8-11.9          | 5.9               |
 | 10.0-10.7          | 5.8.3             |
 | 10.0-10.7          | 5.8.2             |


### PR DESCRIPTION
## What?
This is just a quick update to include 5.9.x releases and 6.0 since the last Gutenberg version is quite clear at this point for the 6.0 release.

## Why?

To ensure the community knows what version of Gutenberg is coming in upcoming/current releases. 

## How?

Simple text change :D 

## Testing Instructions

N/A