### PR TITLE
Scripts: Fix typo in the webpack config

### DIFF
--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -36,7 +36,7 @@ if ( ! browserslist.findConfig( '.' ) ) {
 }
 const hasReactFastRefresh = hasArgInCLI( '--hot' ) && ! isProduction;
 
-const copyWebPackPattens = process.env.WP_COPY_PHP_FILES_TO_DIST
+const copyWebPackPatterns = process.env.WP_COPY_PHP_FILES_TO_DIST
 	? '**/{block.json,*.php}'
 	: '**/block.json';
 
@@ -232,7 +232,7 @@ const config = {
 		new CopyWebpackPlugin( {
 			patterns: [
 				{
-					from: copyWebPackPattens,
+					from: copyWebPackPatterns,
 					context: 'src',
 					noErrorOnMissing: true,
 				},


### PR DESCRIPTION
## What?
Fix typo of the constant "copyWebPackPattens" to "copyWebPackPatterns"
