### PR TITLE
Allow full width blocks to override parent or root container padding

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -178,7 +178,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 
 	$block_gap             = gutenberg_get_global_settings( array( 'spacing', 'blockGap' ) );
 	$default_layout        = gutenberg_get_global_settings( array( 'layout' ) );
-	$padding               = _wp_array_get( $block, array( 'attrs', 'style', 'padding' ), null );
+	$padding               = _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'padding' ), null );
 	$has_block_gap_support = isset( $block_gap ) ? null !== $block_gap : false;
 	$default_block_layout  = _wp_array_get( $block_type->supports, array( '__experimentalLayout', 'default' ), array() );
 	$used_layout           = isset( $block['attrs']['layout'] ) ? $block['attrs']['layout'] : $default_block_layout;

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -66,7 +66,7 @@ function gutenberg_get_layout_style( $selector, $layout, $padding, $has_block_ga
 				isset( $padding['left'] ) ? $padding['left'] : 0
 			);
 			$style .= '}';
-			$style  = "$selector > :where(:not(.alignleft):not(.alignright)) {";
+			$style .= "$selector > :where(:not(.alignleft):not(.alignright)) {";
 			$style .= 'max-width: ' . esc_html( $all_max_width_value ) . ';';
 			$style .= 'margin-left: auto !important;';
 			$style .= 'margin-right: auto !important;';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -54,7 +54,7 @@ function gutenberg_get_layout_style( $selector, $layout, $padding, $has_block_ga
 		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
-		if ( $content_size || $wide_size ) {
+		if ( $padding ) {
 			$style = "$selector {";
 			// Using important here to override the inline padding that could be potentially
 			// applied using the custom padding control before the layout inheritance is applied.
@@ -73,7 +73,7 @@ function gutenberg_get_layout_style( $selector, $layout, $padding, $has_block_ga
 			$style .= '}';
 
 			$style .= "$selector > .alignwide { max-width: " . esc_html( $wide_max_width_value ) . ';}';
-			$style .= "$selector .alignfull {";
+			$style .= "$selector > .alignfull {";
 			$style .= 'max-width: none;';
 			$style .= isset( $padding['left'] ) ? sprintf( 'margin-left: calc( -1 * %s ) !important;', $padding['left'] ) : '';
 			$style .= isset( $padding['right'] ) ? sprintf( 'margin-right: calc( -1 * %s ) !important;', $padding['right'] ) : '';

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -54,7 +54,7 @@ function gutenberg_get_layout_style( $selector, $layout, $padding, $has_block_ga
 		$all_max_width_value  = wp_strip_all_tags( explode( ';', $all_max_width_value )[0] );
 		$wide_max_width_value = wp_strip_all_tags( explode( ';', $wide_max_width_value )[0] );
 
-		if ( $padding ) {
+		if ( $content_size || $wide_size ) {
 			$style = "$selector {";
 			// Using important here to override the inline padding that could be potentially
 			// applied using the custom padding control before the layout inheritance is applied.

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
@@ -227,6 +227,7 @@ class WP_Theme_JSON_6_0 extends WP_Theme_JSON_5_9 {
 		'layout'          => array(
 			'contentSize' => null,
 			'wideSize'    => null,
+			'padding'     => null,
 		),
 		'spacing'         => array(
 			'blockGap' => null,

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -285,7 +285,7 @@ export const withLayoutStyles = createHigherOrderComponent(
 		);
 		const padding = layout?.inherit
 			? usedLayout?.padding
-			: get( attributes, [ 'style', 'padding' ] );
+			: get( attributes, [ 'style', 'spacing', 'padding' ] );
 
 		return (
 			<>

--- a/packages/block-editor/src/hooks/padding.js
+++ b/packages/block-editor/src/hooks/padding.js
@@ -28,6 +28,7 @@ import {
 } from './dimensions';
 import { cleanEmptyObject } from './utils';
 import BlockPopover from '../components/block-popover';
+import { useLayout } from './layout';
 
 /**
  * Determines if there is padding support.
@@ -80,11 +81,19 @@ export function resetPadding( { attributes = {}, setAttributes } ) {
  *
  * @return {boolean} Whether padding setting is disabled.
  */
-export function useIsPaddingDisabled( { name: blockName } = {} ) {
+export function useIsPaddingDisabled( { name: blockName, attributes } = {} ) {
+	const { supportsFlowLayout, config } = useLayout( blockName );
+	const hasInheritedLayout =
+		supportsFlowLayout && !! config && attributes?.layout?.inherit;
 	const isDisabled = ! useSetting( 'spacing.padding' );
 	const isInvalid = ! useIsDimensionsSupportValid( blockName, 'padding' );
 
-	return ! hasPaddingSupport( blockName ) || isDisabled || isInvalid;
+	return (
+		! hasPaddingSupport( blockName ) ||
+		hasInheritedLayout ||
+		isDisabled ||
+		isInvalid
+	);
 }
 
 /**

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -112,6 +112,7 @@ export default {
 		layout = {},
 		style,
 		blockName,
+		padding,
 	} ) {
 		const { contentSize, wideSize } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
@@ -126,10 +127,17 @@ export default {
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
 				? blockGapStyleValue?.top
 				: 'var( --wp--style--block-gap )';
+		// Using important here for the padding to override the inline padding that could be potentially
+		// applied using the custom padding control before the layout inheritance is applied.
 
 		let output =
 			!! contentSize || !! wideSize
 				? `
+					${ appendSelectors( selector ) } {
+						padding: ${ padding?.top || 0 } ${ padding?.right || 0 } ${
+						padding?.bottom || 0
+				  } ${ padding?.left || 0 } !important;
+					}
 					${ appendSelectors(
 						selector,
 						'> :where(:not(.alignleft):not(.alignright))'
@@ -143,6 +151,8 @@ export default {
 					}
 					${ appendSelectors( selector, '> .alignfull' ) } {
 						max-width: none;
+						margin-left: calc( -1 * ${ padding?.left || 0 } ) !important;
+						margin-right: calc( -1 * ${ padding?.right || 0 } ) !important;
 					}
 				`
 				: '';

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -158,7 +158,7 @@ export default {
 						}
 						${
 							padding?.right
-								? `margin-left: calc( -1 * ${ padding?.right } ) !important;`
+								? `margin-right: calc( -1 * ${ padding?.right } ) !important;`
 								: ''
 						}
 					}

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -151,8 +151,16 @@ export default {
 					}
 					${ appendSelectors( selector, '> .alignfull' ) } {
 						max-width: none;
-						margin-left: calc( -1 * ${ padding?.left || 0 } ) !important;
-						margin-right: calc( -1 * ${ padding?.right || 0 } ) !important;
+						${
+							padding?.left
+								? `margin-left: calc( -1 * ${ padding?.left } ) !important;`
+								: ''
+						}
+						${
+							padding?.right
+								? `margin-left: calc( -1 * ${ padding?.right } ) !important;`
+								: ''
+						}
 					}
 				`
 				: '';

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,7 +4,6 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
-	width: 100%;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -4,6 +4,7 @@
 	background-size: cover;
 	background-position: center center;
 	min-height: 430px;
+	width: 100%;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/packages/edit-post/src/components/visual-editor/index.js
+++ b/packages/edit-post/src/components/visual-editor/index.js
@@ -198,6 +198,14 @@ export default function VisualEditor( { styles } ) {
 		titleRef?.current?.focus();
 	}, [ isWelcomeGuideVisible, isCleanNewPost ] );
 
+	const padding = useMemo( () => {
+		if ( isTemplateMode || ! themeSupportsLayout ) {
+			return undefined;
+		}
+
+		return defaultLayout?.padding;
+	} );
+
 	return (
 		<BlockTools
 			__unstableContentRef={ ref }
@@ -245,6 +253,7 @@ export default function VisualEditor( { styles } ) {
 							<LayoutStyle
 								selector=".edit-post-visual-editor__post-title-wrapper, .block-editor-block-list__layout.is-root-container"
 								layout={ defaultLayout }
+								padding={ padding }
 							/>
 						) }
 						{ ! isTemplateMode && (


### PR DESCRIPTION
## What?
Part of the solution to https://github.com/WordPress/gutenberg/issues/35607. This part only covers items nested within blocks that have a full width set, and also specify a content width for children. 

Another solution for top-level blocks will be [worked on separately](https://github.com/WordPress/gutenberg/pull/39926).

## Why?
Problem is [outlined here](https://github.com/WordPress/gutenberg/issues/35607#issue-1025625218).

## How?
This PR initially just cherry picks the changes from https://github.com/WordPress/gutenberg/pull/36214 onto a new branch off trunk - the layout module has changed significantly since that PR was opened so a rebase was problematic!

## Testing Instructions

1. Using Empty theme, set 
```
"layout": {
			"contentSize": "840px",
			"wideSize": "1100px",
			"padding": {
				"top": "23px",
				"right": "23px",
				"bottom": "23px",
				"left": "23px"
			}
		}
```
in `theme.json` settings.

2. In a post, add a group block with a content width for children specified and a custom padding specified;
3. Add a child group and set it to full width;
4.  Make sure the full width child ignores the parent container padding and expands to edges of the parent;
5. Set the parent's layout to "inherit;
6. Check that parent's padding now reflects the `theme.json` padding value and child is still full width.


## Screenshots or screencast <!-- if applicable -->
