### PR TITLE
E2E Test Utils: activateTheme wait for the user to switch

### DIFF
--- a/packages/e2e-test-utils/src/activate-theme.js
+++ b/packages/e2e-test-utils/src/activate-theme.js
@@ -18,7 +18,7 @@ export async function activateTheme( slug ) {
 		`div[data-slug="${ slug }"] .button.activate`
 	);
 	if ( ! activateButton ) {
-		switchUserToTest();
+		await switchUserToTest();
 		return;
 	}
 


### PR DESCRIPTION
## What?
Closes #39862.

PR adds missing `await` to `switchUserToTest` when activating theme util has to bail early. It happens if a theme is already active or missing.

P.S. I couldn't reproduce the error provided in the issue, but adding `await` here makes sense to me.

## Testing Instructions
All tests are passing.
