### PR TITLE
Quote v2: add align feature to have feature parity with v1

### DIFF
--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import {
+	AlignmentControl,
+	BlockControls,
 	RichText,
 	useBlockProps,
 	useInnerBlocksProps,
@@ -66,8 +73,9 @@ export default function QuoteEdit( {
 	isSelected,
 	insertBlocksAfter,
 	clientId,
+	className,
 } ) {
-	const { citation } = attributes;
+	const { citation, align } = attributes;
 
 	useMigrateOnLoad( attributes, clientId );
 
@@ -76,7 +84,11 @@ export default function QuoteEdit( {
 	);
 	const hasSelection = isSelected || isAncestorOfSelectedBlock;
 
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		className: classNames( className, {
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		templateInsertUpdatesSelection: true,
@@ -84,6 +96,14 @@ export default function QuoteEdit( {
 
 	return (
 		<>
+			<BlockControls group="block">
+				<AlignmentControl
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
 			<BlockQuotation { ...innerBlocksProps }>
 				{ innerBlocksProps.children }
 				{ ( ! RichText.isEmpty( citation ) || hasSelection ) && (

--- a/packages/block-library/src/quote/v2/save.js
+++ b/packages/block-library/src/quote/v2/save.js
@@ -1,11 +1,20 @@
 /**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { InnerBlocks, RichText, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { citation } = attributes;
-	const blockProps = useBlockProps.save();
+	const { align, citation } = attributes;
+	const blockProps = useBlockProps.save( {
+		className: classNames( {
+			[ `has-text-align-${ align }` ]: align,
+		} ),
+	} );
 	return (
 		<blockquote { ...blockProps }>
 			<InnerBlocks.Content />


### PR DESCRIPTION
## What?

This PR adds the ability to align the contents of the quote v2, similarly to what's possible with v1.

## Why?

We want to have feature parity.

## How?

Uses the existing `align` attribute to attach the classes on `edit` and `save` functions.

## Testing Instructions

- Go to "Gutenberg > Experiments" and activate quote v2.
- Verify that the align feature on the block toolbar (align right, center, left) is visible and that it works both on editor and frontend.
