### PR TITLE
Auto set first Navigation Menu as current if only 1 exists

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -287,7 +287,6 @@ function Navigation( {
 	} = useNavigationMenu( ref );
 
 	// Setup initial block insertion state.
-
 	// If:
 	// - not explicitly creating an **empty** menu.
 	// - there is not currently a ref to a Navigation Menu `wp_navigation`
@@ -337,6 +336,7 @@ function Navigation( {
 		! ref &&
 		! isCreatingNavigationMenu &&
 		! isConvertingClassicMenu &&
+		! isResolvingNavigationMenus &&
 		( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
 
 	const isEntityAvailable =

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -305,7 +305,9 @@ function Navigation( {
 			return;
 		}
 
-		setRef( navigationMenus[ 0 ]?.id );
+		const firstAndOnlyNavigationMenu = navigationMenus[ 0 ];
+
+		setRef( firstAndOnlyNavigationMenu.id );
 	}, [ navigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -143,6 +143,8 @@ function Navigation( {
 		);
 	}
 
+	const isCreatingEmpty = useRef( false );
+
 	const navigationAreaMenu = areaMenu === 0 ? undefined : areaMenu;
 
 	const ref = navigationArea ? navigationAreaMenu : attributes.ref;
@@ -284,8 +286,22 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
+	// Setup initial block insertion state.
+
+	// If:
+	// - not explicitly creating an **empty** menu.
+	// - there is not currently a ref to a Navigation Menu `wp_navigation`
+	// - there are some Navigation Menus
+	// - there is only a single Navigation Menu
+	//
+	// ...then automatically use that Navigation Menu by default.
 	useEffect( () => {
-		if ( ! navigationMenus?.length || navigationMenus?.length > 1 ) {
+		if (
+			isCreatingEmpty.current ||
+			ref ||
+			! navigationMenus?.length ||
+			navigationMenus?.length > 1
+		) {
 			return;
 		}
 
@@ -547,6 +563,13 @@ function Navigation( {
 		} );
 	}, [ clientId, ref ] );
 
+	function handleCreateEmptyMenu() {
+		isCreatingEmpty.current = true;
+		createNavigationMenu( '', [] ).finally(
+			() => ( isCreatingEmpty.current = false )
+		);
+	}
+
 	// If the block has inner blocks, but no menu id, this was an older
 	// navigation block added before the block used a wp_navigation entity.
 	// Either this block was saved in the content or inserted by a pattern.
@@ -636,7 +659,7 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onFinish={ handleSelectNavigation }
-					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
+					onCreateEmpty={ handleCreateEmptyMenu }
 				/>
 			</TagName>
 		);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -286,14 +286,7 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
-	// Setup initial block insertion state.
-	// If:
-	// - not explicitly creating an **empty** menu.
-	// - there is not currently a ref to a Navigation Menu `wp_navigation`
-	// - there are some Navigation Menus
-	// - there is only a single Navigation Menu
-	//
-	// ...then automatically use that Navigation Menu by default.
+	// Attempt to retrieve and prioritize any existing navigation menu
 	useEffect( () => {
 		if (
 			isCreatingEmpty.current ||

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,9 +297,7 @@ function Navigation( {
 			return;
 		}
 
-		const firstAndOnlyNavigationMenu = navigationMenus[ 0 ];
-
-		setRef( firstAndOnlyNavigationMenu.id );
+		setRef( navigationMenus[ 0 ].id );
 	}, [ navigationMenus ] );
 
 	const navRef = useRef();

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -270,6 +270,7 @@ function Navigation( {
 	const [ overlayMenuPreview, setOverlayMenuPreview ] = useState( false );
 
 	const {
+		isResolvingNavigationMenus,
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
 		navigationMenus,
@@ -283,7 +284,16 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
+	useEffect( () => {
+		if ( ! navigationMenus?.length || navigationMenus?.length > 1 ) {
+			return;
+		}
+
+		setRef( navigationMenus[ 0 ]?.id );
+	}, [ navigationMenus ] );
+
 	const navRef = useRef();
+
 	const isDraftNavigationMenu = navigationMenu?.status === 'draft';
 
 	const {
@@ -321,6 +331,7 @@ function Navigation( {
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =
+		isResolvingNavigationMenus ||
 		isCreatingNavigationMenu ||
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -190,6 +190,17 @@ function Navigation( {
 		createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING;
 
 	useEffect( () => {
+		// Unset flag to indicate that user initiated manual
+		// creation of an empty/blank menu.
+		if (
+			createNavigationMenuStatus === CREATE_NAVIGATION_MENU_SUCCESS ||
+			createNavigationMenuStatus === CREATE_NAVIGATION_MENU_ERROR
+		) {
+			isCreatingEmpty.current = false;
+		}
+	}, [ createNavigationMenuStatus ] );
+
+	useEffect( () => {
 		hideNavigationMenuCreateNotice();
 
 		if ( createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING ) {
@@ -557,10 +568,10 @@ function Navigation( {
 	}, [ clientId, ref ] );
 
 	function handleCreateEmptyMenu() {
+		// Set flag to indicate that user initiated manual
+		// creation of an empty/blank menu.
 		isCreatingEmpty.current = true;
-		createNavigationMenu( '', [] ).finally(
-			() => ( isCreatingEmpty.current = false )
-		);
+		createNavigationMenu( '', [] );
 	}
 
 	// If the block has inner blocks, but no menu id, this was an older

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -556,10 +556,6 @@ function Navigation( {
 		} );
 	}, [ clientId, ref ] );
 
-	function handleCreateEmptyMenu() {
-		createNavigationMenu( '', [] );
-	}
-
 	// If the block has inner blocks, but no menu id, this was an older
 	// navigation block added before the block used a wp_navigation entity.
 	// Either this block was saved in the content or inserted by a pattern.
@@ -649,7 +645,7 @@ function Navigation( {
 						isResolvingCanUserCreateNavigationMenu
 					}
 					onFinish={ handleSelectNavigation }
-					onCreateEmpty={ handleCreateEmptyMenu }
+					onCreateEmpty={ () => createNavigationMenu( '', [] ) }
 				/>
 			</TagName>
 		);

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -297,7 +297,9 @@ function Navigation( {
 		hasResolvedCanUserCreateNavigationMenu,
 	} = useNavigationMenu( ref );
 
-	// Attempt to retrieve and prioritize any existing navigation menu
+	// Attempt to retrieve and prioritize any existing navigation menu unless
+	// a specific ref is allocated or the user is explicitly creating a new menu. The aim is
+	// for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (
 			isCreatingEmpty.current ||

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -283,7 +283,7 @@ function Navigation( {
 	const [ overlayMenuPreview, setOverlayMenuPreview ] = useState( false );
 
 	const {
-		isResolvingNavigationMenus,
+		hasResolvedNavigationMenus,
 		isNavigationMenuResolved,
 		isNavigationMenuMissing,
 		navigationMenus,
@@ -338,7 +338,7 @@ function Navigation( {
 		! ref &&
 		! isCreatingNavigationMenu &&
 		! isConvertingClassicMenu &&
-		! isResolvingNavigationMenus &&
+		hasResolvedNavigationMenus &&
 		( ! hasUncontrolledInnerBlocks || isWithinUnassignedArea );
 
 	const isEntityAvailable =
@@ -351,7 +351,7 @@ function Navigation( {
 	// - there is a ref attribute pointing to a Navigation Post
 	// - the Navigation Post isn't available (hasn't resolved) yet.
 	const isLoading =
-		isResolvingNavigationMenus ||
+		! hasResolvedNavigationMenus ||
 		isCreatingNavigationMenu ||
 		isConvertingClassicMenu ||
 		!! ( ref && ! isEntityAvailable && ! isConvertingClassicMenu );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -143,8 +143,6 @@ function Navigation( {
 		);
 	}
 
-	const isCreatingEmpty = useRef( false );
-
 	const navigationAreaMenu = areaMenu === 0 ? undefined : areaMenu;
 
 	const ref = navigationArea ? navigationAreaMenu : attributes.ref;
@@ -188,17 +186,6 @@ function Navigation( {
 
 	const isCreatingNavigationMenu =
 		createNavigationMenuStatus === CREATE_NAVIGATION_MENU_PENDING;
-
-	useEffect( () => {
-		// Unset flag to indicate that user initiated manual
-		// creation of an empty/blank menu.
-		if (
-			createNavigationMenuStatus === CREATE_NAVIGATION_MENU_SUCCESS ||
-			createNavigationMenuStatus === CREATE_NAVIGATION_MENU_ERROR
-		) {
-			isCreatingEmpty.current = false;
-		}
-	}, [ createNavigationMenuStatus ] );
 
 	useEffect( () => {
 		hideNavigationMenuCreateNotice();
@@ -302,7 +289,7 @@ function Navigation( {
 	// for the block to "just work" from a user perspective using existing data.
 	useEffect( () => {
 		if (
-			isCreatingEmpty.current ||
+			isCreatingNavigationMenu ||
 			ref ||
 			! navigationMenus?.length ||
 			navigationMenus?.length > 1
@@ -570,9 +557,6 @@ function Navigation( {
 	}, [ clientId, ref ] );
 
 	function handleCreateEmptyMenu() {
-		// Set flag to indicate that user initiated manual
-		// creation of an empty/blank menu.
-		isCreatingEmpty.current = true;
 		createNavigationMenu( '', [] );
 	}
 

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -60,6 +60,10 @@ export default function useNavigationMenu( ref ) {
 					! ref ||
 					( hasResolvedNavigationMenu && ! rawNavigationMenu ),
 				canSwitchNavigationMenu,
+				isResolvingNavigationMenus: isResolving(
+					'getEntityRecords',
+					navigationMenuMultipleArgs
+				),
 				hasResolvedNavigationMenus: hasFinishedResolution(
 					'getEntityRecords',
 					navigationMenuMultipleArgs

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -351,9 +351,17 @@ describe( 'Navigation', () => {
 	} );
 
 	describe( 'loading states', () => {
-		it( 'does not show a loading indicator if there is no ref to a Navigation post', async () => {
+		it( 'does not show a loading indicator if there is no ref to a Navigation post and Nav Menus have loaded', async () => {
 			await createNewPost();
+
+			// Insert an empty block to trigger resolution of Nav Menu items.
+			await insertBlock( 'Navigation' );
+			await waitForBlock( 'Navigation' );
+			await page.waitForXPath( START_EMPTY_XPATH );
+
+			// Now we have Nav Menu items resolved. Continue to assert.
 			await clickOnMoreMenuItem( 'Code editor' );
+
 			const codeEditorInput = await page.waitForSelector(
 				'.editor-post-text-editor'
 			);

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -915,17 +915,6 @@ describe( 'Navigation', () => {
 		const NAV_ENTITY_SELECTOR =
 			'//div[@class="entities-saved-states__panel"]//label//strong[contains(text(), "Navigation")]';
 
-		async function resetNavBlockToInitialState() {
-			const selectMenuDropdown = await page.waitForSelector(
-				'[aria-label="Select Menu"]'
-			);
-			await selectMenuDropdown.click();
-			const newMenuButton = await page.waitForXPath(
-				'//span[text()="Create new menu"]'
-			);
-			newMenuButton.click();
-		}
-
 		it( 'respects the nesting level', async () => {
 			await createNewPost();
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -1322,7 +1322,7 @@ describe( 'Navigation', () => {
 			);
 		} );
 
-		it( 'automatically uses the first Navigation Menu if only one available', async () => {
+		it( 'automatically uses the first Navigation Menu if only one is available', async () => {
 			await createNavigationMenu( {
 				title: 'Example Navigation',
 				content:
@@ -1347,7 +1347,7 @@ describe( 'Navigation', () => {
 			expect( linkText ).toBe( 'WordPress' );
 		} );
 
-		it( 'does not automatically use first Navigation Menu if be than one exists', async () => {
+		it( 'does not automatically use first Navigation Menu if more than one exists', async () => {
 			await createNavigationMenu( {
 				title: 'Example Navigation',
 				content:

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -220,7 +220,6 @@ async function populateNavWithOneItem() {
 const PLACEHOLDER_ACTIONS_CLASS = 'wp-block-navigation-placeholder__actions';
 const PLACEHOLDER_ACTIONS_XPATH = `//*[contains(@class, '${ PLACEHOLDER_ACTIONS_CLASS }')]`;
 const START_EMPTY_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Start empty']`;
-const SELECT_MENU_XPATH = `${ PLACEHOLDER_ACTIONS_XPATH }//button[text()='Select Menu']`;
 
 /**
  * Delete all items for the given REST resources using the REST API.
@@ -1257,18 +1256,9 @@ describe( 'Navigation', () => {
 
 			await createNewPost();
 
+			// At this point the block will automatically pick the first Navigation Menu
+			// which will be the one created by the Admin User.
 			await insertBlock( 'Navigation' );
-
-			// Select the Navigation post created by the Admin earlier
-			// in the test.
-			const navigationPostCreatedByAdminName = 'Navigation';
-
-			const dropdown = await page.waitForXPath( SELECT_MENU_XPATH );
-			await dropdown.click();
-			const theOption = await page.waitForXPath(
-				`//*[contains(@class, 'components-menu-item__item')][ text()="${ navigationPostCreatedByAdminName }" ]`
-			);
-			await theOption.click();
 
 			// Make sure the snackbar error shows up.
 			await page.waitForXPath(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->



## What?

This PR causes the Navigation block to auto select the first Navigation Menu as its current active menu _if_ there is only a single `wp_navigation`.

## What is NOT

This PR does _not_:

- attempt to automatically provide Page List as a fallback if the block is empty (we need to keep the scope reasonable).
- [handle uncontrolled inner blocks saving](https://github.com/WordPress/gutenberg/pull/39883).



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently an empty Nav block requires the user to select the Navigation Menu they want to use. However, most users will probably only have a single Navigation Menu - `Primary`.

On Theme switch currently the user is required to reselect their Menu each time which is unwanted overhead. The change in this PR means that if there is only a single Menu then the block will automatically use that Menu. This avoids the need to reselect the Menu.

Note that if there is more than 1 Menu then we don't pursue this behaviour as we cannot determine which Menu would be the most appropriate.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check for how many Navigation Menus are available and if there is only one then auto-select that as the current Nav block's active Menu.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Delete all Navigation Menus.
- Insert Nav block.
- Check that default placeholder is shown with option to `Start empty`.
- Click Start Empty to create a new Nav Menu. Populate with some items you can easily remember. Publish to save the Menu.
- Start a new Post.
- Insert Nav block. 
- See that it will automatically select the Navigation Menu - because you have only 1 which you created above.
- Use the `Select menu` dropdown and click `Create empty menu`.
- See block resets to placeholder state.
- Click `Start empty`.
- Verify that a brand new empty menu is created.
- Publish to Save.
- Double check you have x2 Navigation Menus saved (see `/wp-admin/edit.php?post_type=wp_navigation`).
- Start a _new_ Post. 
- Insert the Nav block.
- Check that it does NOT automatically select a Navigation Menu. See default placeholder.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/161039198-1f0e0c5f-be81-4910-8020-4dd4ba69a78b.mov


