### PR TITLE
Block Lock toolbar remove leftovers

### DIFF
--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -58,7 +58,6 @@ export default function BlockLockToolbar( { clientId } ) {
 						blockInformation.title
 					) }
 					onClick={ toggleModal }
-					aria-disabled={ ! canLockBlock }
 				/>
 			</ToolbarGroup>
 			{ isModalOpen && (


### PR DESCRIPTION
## What?
Removes leftover code from the original PR. The button is never disabled when displayed.
