### PR TITLE
[RNMobile] Detect GIF during render

### DIFF
--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -186,7 +186,6 @@ export class ImageEdit extends Component {
 		this.state = {
 			isCaptionSelected: false,
 			uploadStatus: UPLOAD_STATE_IDLE,
-			isAnimatedGif: false,
 		};
 
 		this.replacedFeaturedImage = false;
@@ -364,10 +363,6 @@ export class ImageEdit extends Component {
 
 		setAttributes( { url: payload.mediaUrl, id: payload.mediaServerId } );
 		this.setState( { uploadStatus: UPLOAD_STATE_SUCCEEDED } );
-
-		this.setState( {
-			isAnimatedGif: payload.mediaUrl.toLowerCase().includes( '.gif' ),
-		} );
 	}
 
 	finishMediaUploadWithFailure( payload ) {
@@ -463,10 +458,6 @@ export class ImageEdit extends Component {
 		this.props.setAttributes( {
 			...mediaAttributes,
 			...additionalAttributes,
-		} );
-
-		this.setState( {
-			isAnimatedGif: media.url.toLowerCase().includes( '.gif' ),
 		} );
 	}
 
@@ -615,6 +606,10 @@ export class ImageEdit extends Component {
 		);
 	}
 
+	isGif( url ) {
+		return url.toLowerCase().includes( '.gif' );
+	}
+
 	render() {
 		const { isCaptionSelected } = this.state;
 		const {
@@ -748,11 +743,12 @@ export class ImageEdit extends Component {
 			context?.fixedHeight && styles.fixedHeight,
 		];
 
-		const badgeLabelShown = isFeaturedImage || this.state.isAnimatedGif;
+		const isGif = this.isGif( url );
+		const badgeLabelShown = isFeaturedImage || isGif;
 		let badgeLabelText = '';
 		if ( isFeaturedImage ) {
 			badgeLabelText = __( 'Featured' );
-		} else if ( this.state.isAnimatedGif ) {
+		} else if ( isGif ) {
 			badgeLabelText = __( 'GIF' );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR changes the spot we emply the GIF detection logic to be during render.

### Related PRs
* https://github.com/wordpress-mobile/gutenberg-mobile/pull/4711
* (PR of current implementation) https://github.com/WordPress/gutenberg/pull/38996

## Why?
The current implementation employs the detection logic in certain flows (media upload for instance), but we also need it in other flows, like when opening a post with a GIF image already added.

## How?
By employing the GIF detection logic during render, this PR covers more flows, removing it from the component's state while at it.

### Testing Instructions 1
1. Use the following html (a gallery block with 2 GIFs, a Media&Text block with GIF, an Image block with GIF and a non-gif Image block) as content for the demo app:
```
<!-- wp:gallery {"linkTo":"none"} -->
<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><!-- wp:image {"id":3140} -->
<figure class="wp-block-image"><img src="https://stefanosuser.files.wordpress.com/2022/03/wp-1647877583213.gif" alt="" class="wp-image-3140"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3231} -->
<figure class="wp-block-image"><img src="https://stefanosuser.files.wordpress.com/2022/03/wp-1648633396661.gif" alt="" class="wp-image-3231"/></figure>
<!-- /wp:image --></figure>
<!-- /wp:gallery -->

<!-- wp:media-text {"mediaId":3231,"mediaType":"image"} -->
<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://stefanosuser.files.wordpress.com/2022/03/wp-1648633396661.gif" alt="" class="wp-image-3231 size-full"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
<p>media and text block</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:image {"id":3231,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://stefanosuser.files.wordpress.com/2022/03/wp-1648633396661.gif?w=280" alt="" class="wp-image-3231"/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":3192,"sizeSlug":"large"} -->
<figure class="wp-block-image size-large"><img src="https://stefanosuser.files.wordpress.com/2022/03/wp-1597320162312-2.jpg?w=768" alt="" class="wp-image-3192"/></figure>
<!-- /wp:image -->
```
2. Run the demo app and notice that:
* the Gallery has GIF badges
* the individual Image block of a GIF has the badge
* the Media&Text block doesn't have the badge (it's not implemented for this block)
* the non-gif Image block doesn't have the badge

### Testing Instructions 2
1. Use the WPMobile app against the branch (so we have the media upload options available)
2. In a new post, add an image block and set a GIF image to it (via any of the media upload options)
3. Notice that the badge is visible while uploading, as well as after upload finished
4. Do the same for a gallery block with GIFs