### PR TITLE
Avoid automatic saving of uncontrolled Nav blocks

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -568,6 +568,10 @@ function Navigation( {
 							setHasSavedUnsavedInnerBlocks( true );
 							// Switch to using the wp_navigation entity.
 							setRef( post.id );
+
+							showNavigationMenuCreateNotice(
+								__( `New Navigation Menu created.` )
+							);
 						} }
 					/>
 				</ResponsiveWrapper>

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -536,11 +536,12 @@ function Navigation( {
 		} );
 	}, [ clientId, ref ] );
 
-	// If the block has inner blocks, but no menu id, this was an older
-	// navigation block added before the block used a wp_navigation entity.
-	// Either this block was saved in the content or inserted by a pattern.
-	// Consider this 'unsaved'. Offer an uncontrolled version of inner blocks,
-	// that automatically saves the menu.
+	// If the block has inner blocks, but no menu id, then these blocks are either:
+	// - inserted via a pattern.
+	// - inserted directly via Code View (or otherwise).
+	// - from an older version of navigation block added before the block used a wp_navigation entity.
+	// Consider this state as 'unsaved' and offer an uncontrolled version of inner blocks,
+	// that automatically saves the menu as an entity when changes are made to the inner blocks.
 	const hasUnsavedBlocks = hasUncontrolledInnerBlocks && ! isEntityAvailable;
 	if ( hasUnsavedBlocks ) {
 		return (

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -33,6 +33,20 @@ export default function UnsavedInnerBlocks( {
 	onSave,
 	hasSelection,
 } ) {
+	const originalBlocks = useRef();
+
+	// Initially store the uncontrolled inner blocks for
+	// dirty state comparison.
+	if ( ! originalBlocks?.current ) {
+		originalBlocks.current = blocks;
+	}
+
+	// If the current inner blocks object is different in any way
+	// from the original inner blocks from the post content then the
+	// user has made changes to the inner blocks. At this point the inner
+	// blocks can be considered "dirty".
+	const innerBlocksAreDirty = blocks !== originalBlocks.current;
+
 	// The block will be disabled in a block preview, use this as a way of
 	// avoiding the side-effects of this component for block previews.
 	const isDisabled = useContext( Disabled.Context );
@@ -97,7 +111,8 @@ export default function UnsavedInnerBlocks( {
 			savingLock.current ||
 			! hasResolvedDraftNavigationMenus ||
 			! hasResolvedNavigationMenus ||
-			! hasSelection
+			! hasSelection ||
+			! innerBlocksAreDirty
 		) {
 			return;
 		}

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -10,7 +10,7 @@ import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useContext, useEffect, useRef } from '@wordpress/element';
+import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -23,6 +23,22 @@ const DRAFT_MENU_PARAMS = [
 	'postType',
 	'wp_navigation',
 	{ status: 'draft', per_page: -1 },
+];
+
+const DEFAULT_BLOCK = {
+	name: 'core/navigation-link',
+};
+
+const ALLOWED_BLOCKS = [
+	'core/navigation-link',
+	'core/search',
+	'core/social-links',
+	'core/page-list',
+	'core/spacer',
+	'core/home-link',
+	'core/site-title',
+	'core/site-logo',
+	'core/navigation-submenu',
 ];
 
 export default function UnsavedInnerBlocks( {
@@ -47,13 +63,27 @@ export default function UnsavedInnerBlocks( {
 	// blocks can be considered "dirty".
 	const innerBlocksAreDirty = blocks !== originalBlocks.current;
 
+	const shouldDirectInsert = useMemo(
+		() =>
+			blocks.every(
+				( { name } ) =>
+					name === 'core/navigation-link' ||
+					name === 'core/navigation-submenu' ||
+					name === 'core/page-list'
+			),
+		[ blocks ]
+	);
+
 	// The block will be disabled in a block preview, use this as a way of
 	// avoiding the side-effects of this component for block previews.
 	const isDisabled = useContext( Disabled.Context );
 	const savingLock = useRef( false );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		renderAppender: hasSelection ? undefined : false,
+		// renderAppender: hasSelection ? undefined : false,
+		allowedBlocks: ALLOWED_BLOCKS,
+		__experimentalDefaultBlock: DEFAULT_BLOCK,
+		__experimentalDirectInsert: shouldDirectInsert,
 	} );
 
 	const {

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -139,13 +139,13 @@ export default function UnsavedInnerBlocks( {
 				className={ classnames(
 					'wp-block-navigation__unsaved-changes-overlay',
 					{
-						'is-saving': hasSelection,
+						'is-saving': isSaving,
 					}
 				) }
 			>
 				<div { ...innerBlocksProps } />
 			</Disabled>
-			{ hasSelection && <Spinner /> }
+			{ isSaving && <Spinner /> }
 		</div>
 	);
 }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -165,7 +165,7 @@ export default function UnsavedInnerBlocks( {
 
 	return (
 		<div className="wp-block-navigation__unsaved-changes">
-			<Disabled
+			<div
 				className={ classnames(
 					'wp-block-navigation__unsaved-changes-overlay',
 					{
@@ -174,7 +174,7 @@ export default function UnsavedInnerBlocks( {
 				) }
 			>
 				<div { ...innerBlocksProps } />
-			</Disabled>
+			</div>
 			{ isSaving && <Spinner /> }
 		</div>
 	);

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -10,7 +10,13 @@ import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
+import {
+	useContext,
+	useEffect,
+	useRef,
+	useMemo,
+	createElement,
+} from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -165,8 +171,12 @@ export default function UnsavedInnerBlocks( {
 		blocks,
 	] );
 
-	return (
-		<div className="wp-block-navigation__unsaved-changes">
+	return createElement(
+		isSaving ? Disabled : 'div', // when saving make component disabled.
+		{
+			className: 'wp-block-navigation__unsaved-changes',
+		},
+		<>
 			<div
 				className={ classnames(
 					'wp-block-navigation__unsaved-changes-overlay',
@@ -178,6 +188,6 @@ export default function UnsavedInnerBlocks( {
 				<div { ...innerBlocksProps } />
 			</div>
 			{ isSaving && <Spinner /> }
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -10,13 +10,7 @@ import { useInnerBlocksProps } from '@wordpress/block-editor';
 import { Disabled, Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import {
-	useContext,
-	useEffect,
-	useRef,
-	useMemo,
-	createElement,
-} from '@wordpress/element';
+import { useContext, useEffect, useRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -171,12 +165,10 @@ export default function UnsavedInnerBlocks( {
 		blocks,
 	] );
 
-	return createElement(
-		isSaving ? Disabled : 'div', // when saving make component disabled.
-		{
-			className: 'wp-block-navigation__unsaved-changes',
-		},
-		<>
+	const Wrapper = isSaving ? Disabled : 'div';
+
+	return (
+		<Wrapper className="wp-block-navigation__unsaved-changes">
 			<div
 				className={ classnames(
 					'wp-block-navigation__unsaved-changes-overlay',
@@ -188,6 +180,6 @@ export default function UnsavedInnerBlocks( {
 				<div { ...innerBlocksProps } />
 			</div>
 			{ isSaving && <Spinner /> }
-		</>
+		</Wrapper>
 	);
 }

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -51,11 +51,13 @@ export default function UnsavedInnerBlocks( {
 } ) {
 	const originalBlocks = useRef();
 
-	// Initially store the uncontrolled inner blocks for
-	// dirty state comparison.
-	if ( ! originalBlocks?.current ) {
-		originalBlocks.current = blocks;
-	}
+	useEffect( () => {
+		// Initially store the uncontrolled inner blocks for
+		// dirty state comparison.
+		if ( ! originalBlocks?.current ) {
+			originalBlocks.current = blocks;
+		}
+	}, [ blocks ] );
 
 	// If the current inner blocks object is different in any way
 	// from the original inner blocks from the post content then the

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -82,7 +82,7 @@ export default function UnsavedInnerBlocks( {
 	const savingLock = useRef( false );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		// renderAppender: hasSelection ? undefined : false,
+		renderAppender: hasSelection ? undefined : false,
 		allowedBlocks: ALLOWED_BLOCKS,
 		__experimentalDefaultBlock: DEFAULT_BLOCK,
 		__experimentalDirectInsert: shouldDirectInsert,

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -45,5 +45,3 @@ exports[`Navigation encodes URL when create block if needed 1`] = `
 
 <!-- wp:navigation-link {\\"label\\":\\"お問い合わせ\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"https://this/is/a/test/search/%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B\\",\\"kind\\":\\"post-type\\",\\"isTopLevelLink\\":true} /-->"
 `;
-
-exports[`Navigation supports navigation blocks that have inner blocks within their markup and converts them to wp_navigation posts 1`] = `"<!-- wp:page-list /-->"`;

--- a/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
+++ b/packages/e2e-tests/specs/editor/blocks/__snapshots__/navigation.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Navigation Creating and restarting converts uncontrolled inner blocks to an entity when modifications are made to the blocks 1`] = `"<!-- wp:navigation-link {\\"label\\":\\"A Test Page\\",\\"type\\":\\"page\\",\\"id\\":[number],\\"url\\":\\"http://localhost:8889/?page_id=[number]\\",\\"kind\\":\\"post-type\\"} /-->"`;
+
 exports[`Navigation Placeholder placeholder actions allows a navigation block to be created from existing menus 1`] = `
 "<!-- wp:navigation-link {\\"label\\":\\"Home\\",\\"type\\":\\"custom\\",\\"url\\":\\"http://localhost:8889/\\",\\"kind\\":\\"custom\\"} /-->
 

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -977,8 +977,9 @@ describe( 'Navigation', () => {
 			// Modify the uncontrolled inner blocks by converting Page List.
 			await clickBlockToolbarButton( 'Edit' );
 
+			// Must wait for button to be enabled.
 			const convertButton = await page.waitForXPath(
-				`//button[text()="Convert"]`
+				`//button[not(@disabled) and text()="Convert"]`
 			);
 
 			await convertButton.click();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -884,6 +884,46 @@ describe( 'Navigation', () => {
 			newMenuButton.click();
 		}
 
+		it( 'respects the nesting level', async () => {
+			await createNewPost();
+
+			await insertBlock( 'Navigation' );
+
+			const navBlock = await waitForBlock( 'Navigation' );
+
+			// Create empty Navigation block with no items
+			const startEmptyButton = await page.waitForXPath(
+				START_EMPTY_XPATH
+			);
+			await startEmptyButton.click();
+
+			await populateNavWithOneItem();
+
+			await clickOnMoreMenuItem( 'Code editor' );
+			const codeEditorInput = await page.waitForSelector(
+				'.editor-post-text-editor'
+			);
+
+			let code = await codeEditorInput.evaluate( ( el ) => el.value );
+			code = code.replace( '} /-->', ',"maxNestingLevel":0} /-->' );
+			await codeEditorInput.evaluate(
+				( el, newCode ) => ( el.value = newCode ),
+				code
+			);
+			await clickButton( 'Exit code editor' );
+
+			const blockAppender = navBlock.$( '.block-list-appender' );
+
+			expect( blockAppender ).not.toBeNull();
+
+			// Check the Submenu block is no longer present.
+			const navSubmenuSelector =
+				'[aria-label="Editor content"][role="region"] [aria-label="Block: Submenu"]';
+			const submenuBlock = await page.$( navSubmenuSelector );
+
+			expect( submenuBlock ).toBeFalsy();
+		} );
+
 		it( 'retains uncontrolled inner blocks by default', async () => {
 			await createNewPost();
 			await clickOnMoreMenuItem( 'Code editor' );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -994,45 +994,6 @@ describe( 'Navigation', () => {
 			expect( await getNavigationMenuRawContent() ).toMatchSnapshot();
 		} );
 
-		it( 'does not retain uncontrolled inner blocks when creating a new entity', async () => {
-			await createNewPost();
-			await clickOnMoreMenuItem( 'Code editor' );
-			const codeEditorInput = await page.waitForSelector(
-				'.editor-post-text-editor'
-			);
-			await codeEditorInput.click();
-			const markup =
-				'<!-- wp:navigation --><!-- wp:page-list /--><!-- /wp:navigation -->';
-			await page.keyboard.type( markup );
-			await clickButton( 'Exit code editor' );
-
-			const navBlock = await waitForBlock( 'Navigation' );
-
-			// Select the block to convert to a wp_navigation.
-			await navBlock.click();
-
-			// The Page List block is rendered within Navigation InnerBlocks when saving is complete.
-			await waitForBlock( 'Page List' );
-
-			// Reset the nav block to create a new entity.
-			await resetNavBlockToInitialState();
-
-			const startEmptyButton = await page.waitForXPath(
-				START_EMPTY_XPATH
-			);
-			await startEmptyButton.click();
-			await populateNavWithOneItem();
-
-			// Confirm that only the last menu entity was updated.
-			const publishPanelButton2 = await page.waitForSelector(
-				'.editor-post-publish-button__button:not([aria-disabled="true"])'
-			);
-			await publishPanelButton2.click();
-
-			await page.waitForXPath( NAV_ENTITY_SELECTOR );
-			expect( await page.$x( NAV_ENTITY_SELECTOR ) ).toHaveLength( 1 );
-		} );
-
 		it( 'only updates a single entity currently linked with the block', async () => {
 			await createNewPost();
 			await insertBlock( 'Navigation' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the Nav block so that if it has uncontrolled blocks (i.e. those not coming from a `wp_navigation` entity but rather those provided directly as `<-- wp:block`) then it will _not_ automatically convert them into an entity.

Instead the block will now wait for the blocks to become "dirty" (i.e. have been changed) before converting into a `wp_navigation`.

Part of https://github.com/WordPress/gutenberg/issues/38157 and/or https://github.com/WordPress/gutenberg/issues/39489

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are a number of ways where a Nav block might contain raw inner blocks. For example:
- a Theme's template part
- a Pattern

Taking the former example [from TT2 here is the block definition](https://github.com/WordPress/twentytwentytwo/blob/27054dbcb95f5d72cd943a0f3318c3ad97599f85/parts/header.html#L9-L11):

```
<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->
```

Notice how the Page List block is provided in order that there is default content in the block when the Site Editor is loaded.

The current problem with this is that as soon as the user interacts with the Nav block it will automatically convert the uncontrolled blocks into a `wp_navigation` post. There is no warning that this has occured and so the user is none the wiser.

The result of this is that it's super easy to inadvertently create many `wp_navigation` posts simply by selecting Navigation blocks on your site.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes thing by allowing the raw inner blocks to stay uncontrolled until such time as the user makes a _modification_ to those blocks. As soon as that occurs then they will be auto-converted into a `wp_navigation` post and a notice will be displayed announcing that to the user.

In future it might be nice to give the user some means to opt in/out of the conversion perhaps via a dialog. This PR follows te simplest path to fix the core problem of accidental creation of `wp_navigation` posts.

## Testing Instructions

- Create New Post
- Switch to Code View
- Paste
```
<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} -->
<!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
<!-- /wp:navigation -->
```
- Switch back to visual mode.
- See Nav block with Page List block in canvas. 
- Select Nav block (this would previously have triggered conversion to an entity).
- Switch back to Code view and check inner blocks - they should be preserved. There should be no `ref` attribute on the Nav block.
- Switch back to Visual Mode.
- Click on Page List block. Click `Edit` and then `Convert`.
- This will trigger a "change" to the inner blocks.
- See loading state - an `wp_navigation` entity will be created.
- Switch to Code view.
- See inner blocks are gone and there is now a `ref` attribute on the Nav block.

## Screenshots or screencast <!-- if applicable -->
