### PR TITLE
[RNMobile] Add `useOnBlockDrop` hook to update blocks order when dropping a block

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -18,7 +18,7 @@ import Animated, {
  */
 import { Draggable } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
@@ -63,6 +63,8 @@ const COLLAPSE_OPACITY_ANIMATION_CONFIG = { duration: 150 };
  * @return {Function} Render function that passes `onScroll` event handler.
  */
 const BlockDraggableWrapper = ( { children } ) => {
+	const currentClientId = useRef();
+
 	const wrapperStyles = usePreferredColorSchemeStyle(
 		styles[ 'draggable-wrapper__container' ],
 		styles[ 'draggable-wrapper__container--dark' ]
@@ -130,6 +132,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		} );
 
 		const foundClientId = blockLayout?.clientId;
+		currentClientId.current = foundClientId;
 		if ( foundClientId ) {
 			startDraggingBlocks( [ foundClientId ] );
 

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -366,6 +366,7 @@ const BlockDraggable = ( { clientId, children } ) => {
 
 	const blockStyles = useAnimatedStyle( () => {
 		return {
+			display: collapseAnimation.opacity.value !== 0 ? 'none' : 'flex',
 			opacity: 1 - collapseAnimation.opacity.value,
 		};
 	} );

--- a/packages/block-editor/src/components/use-block-drop-zone/index.native.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.native.js
@@ -16,6 +16,7 @@ import { useThrottle } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 import { useBlockListContext } from '../block-list/block-list-context';
 import { getDistanceToNearestEdge } from '../../utils/math';
+import useOnBlockDrop from '../use-on-block-drop';
 
 /** @typedef {import('../../utils/math').WPPoint} WPPoint */
 
@@ -100,7 +101,7 @@ export function getNearestBlockIndex(
  * @param {WPBlockDropZoneConfig} dropZoneConfig configuration data for the drop zone.
  *
  * @return {Object} An object that contains `targetBlockIndex` and the event
- * handlers `onBlockDragOver` and `onBlockDragEnd`.
+ * handlers `onBlockDragOver`, `onBlockDragEnd` and `onBlockDrop`.
  */
 export default function useBlockDropZone( {
 	// An undefined value represents a top-level block. Default to an empty
@@ -122,6 +123,8 @@ export default function useBlockDropZone( {
 	}, [ blocksLayouts.current ] );
 
 	const isRTL = getSettings().isRTL;
+
+	const onBlockDrop = useOnBlockDrop();
 
 	const throttled = useThrottle(
 		useCallback(
@@ -155,6 +158,15 @@ export default function useBlockDropZone( {
 		onBlockDragEnd() {
 			throttled.cancel();
 			targetBlockIndex.value = null;
+		},
+		onBlockDrop: ( event ) => {
+			if ( targetBlockIndex.value !== null ) {
+				onBlockDrop( {
+					...event,
+					targetRootClientId,
+					targetBlockIndex: targetBlockIndex.value,
+				} );
+			}
 		},
 		targetBlockIndex,
 	};

--- a/packages/block-editor/src/components/use-on-block-drop/index.native.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.native.js
@@ -1,0 +1,119 @@
+/**
+ * WordPress dependencies
+ */
+import { cloneBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * A function that returns an event handler function for block drop events.
+ *
+ * @param {Function} getBlockIndex             A function that gets the index of a block.
+ * @param {Function} getClientIdsOfDescendants A function that gets the client ids of descendant blocks.
+ * @param {Function} moveBlocksToPosition      A function that moves blocks.
+ * @param {Function} insertBlocks              A function that inserts blocks.
+ * @param {Function} clearSelectedBlock        A function that clears block selection.
+ * @return {Function} The event handler for a block drop event.
+ */
+export function onBlockDrop(
+	getBlockIndex,
+	getClientIdsOfDescendants,
+	moveBlocksToPosition,
+	insertBlocks,
+	clearSelectedBlock
+) {
+	return ( {
+		blocks,
+		srcClientIds: sourceClientIds,
+		srcRootClientId: sourceRootClientId,
+		targetBlockIndex,
+		targetRootClientId,
+		type: dropType,
+	} ) => {
+		// If the user is inserting a block.
+		if ( dropType === 'inserter' ) {
+			clearSelectedBlock();
+			const blocksToInsert = blocks.map( ( block ) =>
+				cloneBlock( block )
+			);
+			insertBlocks(
+				blocksToInsert,
+				targetBlockIndex,
+				targetRootClientId,
+				true,
+				null
+			);
+		}
+
+		// If the user is moving a block.
+		if ( dropType === 'block' ) {
+			const sourceBlockIndex = getBlockIndex( sourceClientIds[ 0 ] );
+
+			// If the user is dropping to the same position, return early.
+			if (
+				sourceRootClientId === targetRootClientId &&
+				sourceBlockIndex === targetBlockIndex
+			) {
+				return;
+			}
+
+			// If the user is attempting to drop a block within its own
+			// nested blocks, return early as this would create infinite
+			// recursion.
+			if (
+				sourceClientIds.includes( targetRootClientId ) ||
+				getClientIdsOfDescendants( sourceClientIds ).some(
+					( id ) => id === targetRootClientId
+				)
+			) {
+				return;
+			}
+
+			const isAtSameLevel = sourceRootClientId === targetRootClientId;
+			const draggedBlockCount = sourceClientIds.length;
+
+			// If the block is kept at the same level and moved downwards,
+			// subtract to take into account that the blocks being dragged
+			// were removed from the block list above the insertion point.
+			const insertIndex =
+				isAtSameLevel && sourceBlockIndex < targetBlockIndex
+					? targetBlockIndex - draggedBlockCount
+					: targetBlockIndex;
+
+			moveBlocksToPosition(
+				sourceClientIds,
+				sourceRootClientId,
+				targetRootClientId,
+				insertIndex
+			);
+		}
+	};
+}
+
+/**
+ * A React hook for handling block drop events.
+ *
+ * @return {Function} The event handler for a block drop event.
+ */
+export default function useOnBlockDrop() {
+	const { getBlockIndex, getClientIdsOfDescendants } = useSelect(
+		blockEditorStore
+	);
+	const {
+		insertBlocks,
+		moveBlocksToPosition,
+		clearSelectedBlock,
+	} = useDispatch( blockEditorStore );
+
+	return onBlockDrop(
+		getBlockIndex,
+		getClientIdsOfDescendants,
+		moveBlocksToPosition,
+		insertBlocks,
+		clearSelectedBlock
+	);
+}


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4702.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add the native implementation of `useOnBlockDrop` hook to allow the drag & drop functionality to update the blocks order when dropping a block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is part of the Drag & Drops Blocks project.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Based on [the web version](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/use-on-block-drop/index.js), the hook `useOnBlockDrop` has been added applying some tweaks in order to make it work in the native version, like for example removing the support for dropping files and HTML.

This hook has been added to the other dropping-related hook `useBlockDropZone`, which is the one that will provide the `onBlockDrop` event handler that should be triggered upon dropping a block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the app.
1. Add several blocks.
1. Long-press on a block to activate the dragging mode.
1. Drag the block around the block list.
1. Drop the block in a different position within the block list.
1. Observe that the block is now located in the specified position.

## Screenshots or screencast <!-- if applicable -->

Android|iOS
--|--
<video src=https://user-images.githubusercontent.com/14905380/161112043-c4189a54-9f8a-4dbe-928f-4277fe82b481.mp4>|<video src=https://user-images.githubusercontent.com/14905380/161112091-35920bab-240b-422b-b503-c94b46f51468.MP4>


