### PR TITLE
Plugin: Guard code from redeclaration errors after WP core merge

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
@@ -2,19 +2,28 @@
 /**
  * REST API: WP_REST_Block_Pattern_Catergories_Controller class
  *
- * @subpackage REST_API
  * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
  */
+
+if ( class_exists( 'WP_REST_Block_Pattern_Categories_Controller' ) ) {
+	return;
+}
 
 /**
  * Core class used to access block pattern categories via the REST API.
  *
  * @see   WP_REST_Controller
+ *
+ * @since 6.0.0
  */
 class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 
 	/**
 	 * Constructor.
+	 *
+	 * @since 6.0.0
 	 */
 	public function __construct() {
 		$this->namespace = '__experimental';
@@ -25,6 +34,8 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	 * Registers the routes for the objects of the controller.
 	 *
 	 * @see   register_rest_route()
+	 *
+	 * @since 6.0.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -43,6 +54,8 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 
 	/**
 	 * Checks whether a given request has permission to read block patterns.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
@@ -69,6 +82,8 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves all block pattern categories.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
@@ -85,6 +100,8 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 
 	/**
 	 * Prepare a raw block pattern category before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param object          $item    Raw category as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -108,6 +125,8 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 
 	/**
 	 * Retrieves the block pattern category schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @return array Item schema data.
 	 */

--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -2,14 +2,21 @@
 /**
  * REST API: WP_REST_Block_Patterns_Controller class
  *
- * @subpackage REST_API
  * @package    WordPress
+ * @subpackage REST_API
+ * @since      6.0.0
  */
+
+if ( class_exists( 'WP_REST_Block_Patterns_Controller' ) ) {
+	return;
+}
 
 /**
  * Core class used to access block patterns via the REST API.
  *
  * @see   WP_REST_Controller
+ *
+ * @since 6.0.0
  */
 class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 
@@ -25,6 +32,8 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Registers the routes for the objects of the controller.
 	 *
 	 * @see   register_rest_route()
+	 *
+	 * @since 6.0.0
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -43,6 +52,8 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 
 	/**
 	 * Checks whether a given request has permission to read block patterns.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
@@ -69,6 +80,8 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves all block patterns.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
@@ -90,6 +103,8 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 
 	/**
 	 * Prepare a raw block pattern before it gets output in a REST API response.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param object          $item    Raw pattern as registered, before any changes.
 	 * @param WP_REST_Request $request Request object.
@@ -122,6 +137,8 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 
 	/**
 	 * Retrieves the block pattern schema, conforming to JSON Schema.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @return array Item schema data.
 	 */

--- a/lib/compat/wordpress-6.0/class-wp-webfonts-provider-local.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts-provider-local.php
@@ -7,6 +7,10 @@
  * @since      6.0.0
  */
 
+if ( class_exists( 'WP_Webfonts_Provider_Local' ) ) {
+	return;
+}
+
 /**
  * A core bundled provider for generating `@font-face` styles
  * from locally-hosted font files.

--- a/lib/compat/wordpress-6.0/class-wp-webfonts-provider.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts-provider.php
@@ -9,6 +9,10 @@
  * @since      6.0.0
  */
 
+if ( class_exists( 'WP_Webfonts_Provider' ) ) {
+	return;
+}
+
 /**
  * Abstract class for Webfonts API providers.
  *

--- a/lib/compat/wordpress-6.0/class-wp-webfonts.php
+++ b/lib/compat/wordpress-6.0/class-wp-webfonts.php
@@ -2,16 +2,26 @@
 /**
  * Webfonts API class.
  *
- * @package Gutenberg
+ * @package    WordPress
+ * @subpackage WebFonts
+ * @since      6.0.0
  */
+
+if ( class_exists( 'WP_Webfonts' ) ) {
+	return;
+}
 
 /**
  * Class WP_Webfonts
+ *
+ * @since 6.0.0
  */
 class WP_Webfonts {
 
 	/**
 	 * An array of registered webfonts.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @access private
 	 * @var array
@@ -21,6 +31,8 @@ class WP_Webfonts {
 	/**
 	 * An array of registered providers.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @access private
 	 * @var array
 	 */
@@ -29,12 +41,16 @@ class WP_Webfonts {
 	/**
 	 * Stylesheet handle.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @var string
 	 */
 	private $stylesheet_handle = '';
 
 	/**
 	 * Init.
+	 *
+	 * @since 6.0.0
 	 */
 	public function init() {
 
@@ -58,6 +74,8 @@ class WP_Webfonts {
 	/**
 	 * Get the list of fonts.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @return array
 	 */
 	public function get_fonts() {
@@ -67,6 +85,8 @@ class WP_Webfonts {
 	/**
 	 * Get the list of providers.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @return array
 	 */
 	public function get_providers() {
@@ -75,6 +95,8 @@ class WP_Webfonts {
 
 	/**
 	 * Register a webfont.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param array $font The font arguments.
 	 */
@@ -89,6 +111,8 @@ class WP_Webfonts {
 	/**
 	 * Get the font ID.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @param array $font The font arguments.
 	 * @return string
 	 */
@@ -98,6 +122,8 @@ class WP_Webfonts {
 
 	/**
 	 * Validate a font.
+	 *
+	 * @since 6.0.0
 	 *
 	 * @param array $font The font arguments.
 	 *
@@ -183,6 +209,8 @@ class WP_Webfonts {
 	/**
 	 * Register a provider.
 	 *
+	 * @since 6.0.0
+	 *
 	 * @param string $provider The provider name.
 	 * @param string $class    The provider class name.
 	 *
@@ -198,6 +226,8 @@ class WP_Webfonts {
 
 	/**
 	 * Generate and enqueue webfonts styles.
+	 *
+	 * @since 6.0.0
 	 */
 	public function generate_and_enqueue_styles() {
 		// Generate the styles.
@@ -218,6 +248,8 @@ class WP_Webfonts {
 
 	/**
 	 * Generate and enqueue editor styles.
+	 *
+	 * @since 6.0.0
 	 */
 	public function generate_and_enqueue_editor_styles() {
 		// Generate the styles.

--- a/lib/compat/wordpress-6.0/webfonts.php
+++ b/lib/compat/wordpress-6.0/webfonts.php
@@ -1,150 +1,159 @@
 <?php
 /**
- * Webfonts API: Webfonts functions
+ * Webfonts API functions.
  *
- * @since 6.0.0
- *
- * @package WordPress
- * @subpackage Webfonts
+ * @package    WordPress
+ * @subpackage WebFonts
+ * @since      6.0.0
  */
 
-/**
- * Instantiates the webfonts controller, if not already set, and returns it.
- *
- * @since 6.0.0
- *
- * @return WP_Webfonts Instance of the controller.
- */
-function wp_webfonts() {
-	global $wp_webfonts;
+if ( ! function_exists( 'wp_webfonts' ) ) {
+	/**
+	 * Instantiates the webfonts controller, if not already set, and returns it.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return WP_Webfonts Instance of the controller.
+	 */
+	function wp_webfonts() {
+		global $wp_webfonts;
 
-	if ( ! $wp_webfonts instanceof WP_Webfonts ) {
-		$wp_webfonts = new WP_Webfonts();
-		$wp_webfonts->init();
-	}
+		if ( ! $wp_webfonts instanceof WP_Webfonts ) {
+			$wp_webfonts = new WP_Webfonts();
+			$wp_webfonts->init();
+		}
 
-	return $wp_webfonts;
-}
-
-/**
- * Registers a collection of webfonts.
- *
- * Example of how to register Source Serif Pro font with font-weight range of 200-900
- * and font-style of normal and italic:
- *
- * If the font files are contained within the theme:
- * <code>
- * wp_register_webfonts(
- *      array(
- *          array(
- *              'provider'    => 'local',
- *              'font_family' => 'Source Serif Pro',
- *              'font_weight' => '200 900',
- *              'font_style'  => 'normal',
- *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
- *          ),
- *          array(
- *              'provider'    => 'local',
- *              'font_family' => 'Source Serif Pro',
- *              'font_weight' => '200 900',
- *              'font_style'  => 'italic',
- *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
- *          ),
- *      )
- * );
- * </code>
- *
- * Webfonts should be registered in the `after_setup_theme` hook.
- *
- * @since 6.0.0
- *
- * @param array $webfonts Webfonts to be registered.
- *                        This contains an array of webfonts to be registered.
- *                        Each webfont is an array.
- *                        See {@see WP_Webfonts_Registry::register()} for a list of
- *                        supported arguments for each webfont.
- */
-function wp_register_webfonts( array $webfonts = array() ) {
-	foreach ( $webfonts as $webfont ) {
-		wp_register_webfont( $webfont );
+		return $wp_webfonts;
 	}
 }
 
-/**
- * Registers a single webfont.
- *
- * Example of how to register Source Serif Pro font with font-weight range of 200-900:
- *
- * If the font file is contained within the theme:
- * ```
- * wp_register_webfont(
- *      array(
- *          'provider'    => 'local',
- *          'font_family' => 'Source Serif Pro',
- *          'font_weight' => '200 900',
- *          'font_style'  => 'normal',
- *          'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
- *      )
- * );
- * ```
- *
- * @since 6.0.0
- *
- * @param array $webfont Webfont to be registered.
- *                       See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
- */
-function wp_register_webfont( array $webfont ) {
-	wp_webfonts()->register_font( $webfont );
+if ( ! function_exists( 'wp_register_webfonts' ) ) {
+	/**
+	 * Registers a collection of webfonts.
+	 *
+	 * Example of how to register Source Serif Pro font with font-weight range of 200-900
+	 * and font-style of normal and italic:
+	 *
+	 * If the font files are contained within the theme:
+	 * <code>
+	 * wp_register_webfonts(
+	 *      array(
+	 *          array(
+	 *              'provider'    => 'local',
+	 *              'font_family' => 'Source Serif Pro',
+	 *              'font_weight' => '200 900',
+	 *              'font_style'  => 'normal',
+	 *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+	 *          ),
+	 *          array(
+	 *              'provider'    => 'local',
+	 *              'font_family' => 'Source Serif Pro',
+	 *              'font_weight' => '200 900',
+	 *              'font_style'  => 'italic',
+	 *              'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Italic.ttf.woff2' ),
+	 *          ),
+	 *      )
+	 * );
+	 * </code>
+	 *
+	 * Webfonts should be registered in the `after_setup_theme` hook.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array $webfonts Webfonts to be registered.
+	 *                        This contains an array of webfonts to be registered.
+	 *                        Each webfont is an array.
+	 *                        See {@see WP_Webfonts_Registry::register()} for a list of
+	 *                        supported arguments for each webfont.
+	 */
+	function wp_register_webfonts( array $webfonts = array() ) {
+		foreach ( $webfonts as $webfont ) {
+			wp_register_webfont( $webfont );
+		}
+	}
 }
 
-/**
- * Registers a custom font service provider.
- *
- * A webfont provider contains the business logic for how to
- * interact with a remote font service and how to generate
- * the `@font-face` styles for that remote service.
- *
- * How to register a custom font service provider:
- *    1. Load its class file into memory before registration.
- *    2. Pass the class' name to this function.
- *
- * For example, for a class named `My_Custom_Font_Service_Provider`:
- * ```
- *    wp_register_webfont_provider( My_Custom_Font_Service_Provider::class );
- * ```
- *
- * @since 6.0.0
- *
- * @param string $name      The provider's name.
- * @param string $classname The provider's class name.
- *                          The class should be a child of `WP_Webfonts_Provider`.
- *                          See {@see WP_Webfonts_Provider}.
- *
- * @return bool True when registered. False when provider does not exist.
- */
-function wp_register_webfont_provider( $name, $classname ) {
-	return wp_webfonts()->register_provider( $name, $classname );
+if ( ! function_exists( 'wp_register_webfont' ) ) {
+	/**
+	 * Registers a single webfont.
+	 *
+	 * Example of how to register Source Serif Pro font with font-weight range of 200-900:
+	 *
+	 * If the font file is contained within the theme:
+	 * ```
+	 * wp_register_webfont(
+	 *      array(
+	 *          'provider'    => 'local',
+	 *          'font_family' => 'Source Serif Pro',
+	 *          'font_weight' => '200 900',
+	 *          'font_style'  => 'normal',
+	 *          'src'         => get_theme_file_uri( 'assets/fonts/source-serif-pro/SourceSerif4Variable-Roman.ttf.woff2' ),
+	 *      )
+	 * );
+	 * ```
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array $webfont Webfont to be registered.
+	 *                       See {@see WP_Webfonts_Registry::register()} for a list of supported arguments.
+	 */
+	function wp_register_webfont( array $webfont ) {
+		wp_webfonts()->register_font( $webfont );
+	}
 }
 
-/**
- * Gets all registered providers.
- *
- * Return an array of providers, each keyed by their unique
- * ID (i.e. the `$id` property in the provider's object) with
- * an instance of the provider (object):
- *     ID => provider instance
- *
- * Each provider contains the business logic for how to
- * process its specific font service (i.e. local or remote)
- * and how to generate the `@font-face` styles for its service.
- *
- * @since 6.0.0
- *
- * @return WP_Webfonts_Provider[] All registered providers,
- *                               each keyed by their unique ID.
- */
-function wp_get_webfont_providers() {
-	return wp_webfonts()->get_providers();
+if ( ! function_exists( 'wp_register_webfont_provider' ) ) {
+	/**
+	 * Registers a custom font service provider.
+	 *
+	 * A webfont provider contains the business logic for how to
+	 * interact with a remote font service and how to generate
+	 * the `@font-face` styles for that remote service.
+	 *
+	 * How to register a custom font service provider:
+	 *    1. Load its class file into memory before registration.
+	 *    2. Pass the class' name to this function.
+	 *
+	 * For example, for a class named `My_Custom_Font_Service_Provider`:
+	 * ```
+	 *    wp_register_webfont_provider( My_Custom_Font_Service_Provider::class );
+	 * ```
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param string $name      The provider's name.
+	 * @param string $classname The provider's class name.
+	 *                          The class should be a child of `WP_Webfonts_Provider`.
+	 *                          See {@see WP_Webfonts_Provider}.
+	 *
+	 * @return bool True when registered. False when provider does not exist.
+	 */
+	function wp_register_webfont_provider( $name, $classname ) {
+		return wp_webfonts()->register_provider( $name, $classname );
+	}
+}
+
+if ( ! function_exists( 'wp_get_webfont_providers' ) ) {
+	/**
+	 * Gets all registered providers.
+	 *
+	 * Return an array of providers, each keyed by their unique
+	 * ID (i.e. the `$id` property in the provider's object) with
+	 * an instance of the provider (object):
+	 *     ID => provider instance
+	 *
+	 * Each provider contains the business logic for how to
+	 * process its specific font service (i.e. local or remote)
+	 * and how to generate the `@font-face` styles for its service.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @return WP_Webfonts_Provider[] All registered providers,
+	 *                                each keyed by their unique ID.
+	 */
+	function wp_get_webfont_providers() {
+		return wp_webfonts()->get_providers();
+	}
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #39889.

It is expected to declare functions and classes only when they are missing in WordPress core. As soon as we backport the files updated in this PR to WordPress core, they will work only as a fallback for older versions of WordPress.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To avoid fatal errors because of redeclared functions and classes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I followed the guidelines at https://github.com/WordPress/gutenberg/tree/trunk/lib#wrap-functions-and-classes-with--function_exists-and--class_exists.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

There are unit tests that cover those files and they should continue to pass.

We should also test that webfonts API and block patterns continue to work in the editor.
