### PR TITLE
Fix migration of list block content

### DIFF
--- a/packages/block-library/src/list/test/migrate.js
+++ b/packages/block-library/src/list/test/migrate.js
@@ -129,4 +129,31 @@ describe( 'Migrate list block', () => {
 <!-- /wp:list --></li>
 <!-- /wp:list-item -->` );
 	} );
+
+	it( 'should not add random space', () => {
+		const [ updatedAttributes, updatedInnerBlocks ] = migrateToListV2( {
+			values: `<li>Europe<ul><li>F<strong>ranc</strong>e<ul><li>Paris</li></ul></li></ul></li>`,
+			ordered: false,
+		} );
+
+		expect( updatedAttributes ).toEqual( {
+			ordered: false,
+			// Ideally the values attributes shouldn't be here
+			// but since we didn't enable v2 by default yet,
+			// we're keeping the old default value in block.json
+			values: '',
+		} );
+		expect( serialize( updatedInnerBlocks ) )
+			.toEqual( `<!-- wp:list-item -->
+<li>Europe<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>F<strong>ranc</strong>e<!-- wp:list -->
+<ul><!-- wp:list-item -->
+<li>Paris</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></li>
+<!-- /wp:list-item -->` );
+	} );
 } );

--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -38,13 +38,13 @@ function createListBlockFromDOMElement( listElement ) {
 			}
 			const htmlNodes = nodes.map( ( node ) => {
 				if ( node.nodeType === node.TEXT_NODE ) {
-					return node.textContent.trim();
+					return node.textContent;
 				}
 				return node.outerHTML;
 			} );
 			htmlNodes.reverse();
 			const childAttributes = {
-				content: htmlNodes.join( ' ' ),
+				content: htmlNodes.join( '' ).trim(),
 			};
 			const childInnerBlocks = [
 				createListBlockFromDOMElement( nestedList ),


### PR DESCRIPTION
Follow-up to #39799 

## What?
Addresses issues raised by this comment https://github.com/WordPress/gutenberg/pull/39799#issuecomment-1082894503

Basically, if you had a list block v1 with the following markup.

```
<!-- wp:list -->
<ul><li>sdsds<ul><li>s<em>ds</em><strong><em>ds</em></strong><ul><li><strong><em>sd</em>s</strong>d</li></ul></li></ul></li></ul>
<!-- /wp:list -->
```

![image](https://user-images.githubusercontent.com/11271197/160807844-42dc6956-3622-4f39-a4ea-a164949cc057.png)

Extra spaces were being added to the update v2 list block.

```
<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>sdsds<!-- wp:list -->
<ul><!-- wp:list-item -->
<li>s <em>ds</em> <strong><em>ds</em></strong><!-- wp:list -->
<ul><!-- wp:list-item -->
<li><strong><em>sd</em>s</strong>d</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item --></ul>
<!-- /wp:list -->
```

![image](https://user-images.githubusercontent.com/11271197/160807947-0ae3ad59-1d67-4b37-9a9a-f8d0cc63a1ea.png)

## Why and How?

Contactenation was adding extra spaces because the real spaces were being removed. It's not fixed. We only trim the whole value and not small pieces. (inline markup)

## Testing Instructions
1- Insert a v1 list block with the initial markup above
2- Enable list v2 block 
3- Open the post to check the upgraded list block
4- No extra spaces were added.
