### PR TITLE
Add a box-sizing border-box to lists

### DIFF
--- a/packages/block-library/src/list/style.scss
+++ b/packages/block-library/src/list/style.scss
@@ -1,5 +1,7 @@
 ol,
 ul {
+	box-sizing: border-box;
+
 	&.has-background {
 		padding: $block-bg-padding--v $block-bg-padding--h;
 	}

--- a/packages/block-library/src/reset.scss
+++ b/packages/block-library/src/reset.scss
@@ -61,7 +61,7 @@ html :where(.editor-styles-wrapper) {
 		margin: revert;
 		padding: revert;
 		list-style-type: revert;
-		box-sizing: revert;
+		box-sizing: border-box;
 
 		// Remove bottom margin from nested lists.
 		ul,


### PR DESCRIPTION
## What?

I noticed that when you apply padding to lists (whether via theme.json or by just picking a background for the list block), the width of the block is impacted and the block becomes unaligned with the rest of the content.

That's because the list block is missing `box-sizing: border-box;` CSS rule. This PR adds this PR to the default style of lists.

This can be seen as a breaking change for themes as it might impact all of them. That said, I expect that most themes already do `box-sizing: border-box` for most of their elements. So I think the impact will be small and mostly bug fixes but I'd like to know what you all think.

Also, right now the list block doesn't support "padding" block support but if we decide to add at some point, the bug will be even more visible, so might as well fix it now.

## Testing Instructions

1- Add a list block
2- Choose a background color
3- Notice that the list block doesn't "grow", it's aligned with the rest of the content.

<img width="1439" alt="Screen Shot 2022-03-30 at 1 56 15 PM" src="https://user-images.githubusercontent.com/272444/160839429-36137120-d8e4-4c76-a313-0fb3b59ada9c.png">

cc @WordPress/theme-team @WordPress/block-themers 