### PR TITLE
Hide the block inspector button if the block isn't active

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -165,7 +165,7 @@ export function BlockSettingsDropdown( {
 						<>
 							<MenuGroup>
 								<__unstableBlockSettingsMenuFirstItem.Slot
-									fillProps={ { onClose } }
+									fillProps={ { onClose, blocks } }
 								/>
 								{ count === 1 && (
 									<BlockHTMLConvertButton

--- a/packages/edit-site/src/components/block-editor/block-inspector-button.js
+++ b/packages/edit-site/src/components/block-editor/block-inspector-button.js
@@ -7,6 +7,7 @@ import { MenuItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -15,7 +16,8 @@ import { store as editSiteStore } from '../../store';
 import { STORE_NAME } from '../../store/constants';
 import { SIDEBAR_BLOCK } from '../sidebar/constants';
 
-export default function BlockInspectorButton( { onClick = () => {} } ) {
+export default function BlockInspectorButton( { blocks, onClick = () => {} } ) {
+	const { isBlockSelected } = useSelect( blockEditorStore );
 	const { shortcut, isBlockInspectorOpen } = useSelect(
 		( select ) => ( {
 			shortcut: select(
@@ -37,6 +39,17 @@ export default function BlockInspectorButton( { onClick = () => {} } ) {
 	const label = isBlockInspectorOpen
 		? __( 'Hide more settings' )
 		: __( 'Show more settings' );
+
+	// If blocks are passed to this component then check whether any of the blocks are selected.
+	if ( blocks ) {
+		// If none of the blocks are selected then don't show this option.
+		if (
+			blocks.filter( ( block ) => isBlockSelected( block.clientId ) )
+				.length === 0
+		) {
+			return null;
+		}
+	}
 
 	return (
 		<MenuItem

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -170,8 +170,11 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					/>
 				</ResizableEditor>
 				<__unstableBlockSettingsMenuFirstItem>
-					{ ( { onClose } ) => (
-						<BlockInspectorButton onClick={ onClose } />
+					{ ( { onClose, blocks } ) => (
+						<BlockInspectorButton
+							onClick={ onClose }
+							blocks={ blocks }
+						/>
 					) }
 				</__unstableBlockSettingsMenuFirstItem>
 				<__unstableBlockToolbarLastItem>


### PR DESCRIPTION
## What?
Sometimes (like in the navigation sidebar), the block inspector button appears, even when the block isn't selected. All this block does is show/hide the block sidebar, so if the block isn't selected the behaviour of this button is unexpected. This PR hides the button if the block its attached to isn't selected.

Fixes https://github.com/WordPress/gutenberg/issues/39855

## Why?
See above.

## How?
We pass the blocks down to the button and then the button uses `isBlockSelected` to determine if the blocks are selected. If none are then we don't render the button.

## Testing Instructions
- Open the Site Editor
- Click on any block in the main area
- Confirm that the "Show/Hide more settings" button is visible under the three dots
- Open the navigation sidebar
- Click on a navigation item that is not selected
- Confirm that there is no "Show/Hide more settings" button under the three dots
- Select a navigation item in the main area
- Open the navigation sidebar again
- Click on a navigation item that is selected
- Confirm that you can see the "Show/Hide more settings" button under the three dots

## Screenshots or screencast <!-- if applicable -->
WIP