### PR TITLE
Add color support to the quote block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -680,7 +680,7 @@ Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Ju
 
 -	**Name:** core/quote
 -	**Category:** text
--	**Supports:** anchor, typography (fontSize, lineHeight)
+-	**Supports:** anchor, color (background, gradients, link, text), typography (fontSize, lineHeight)
 -	**Attributes:** align, citation, value
 
 ## Read More

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -41,6 +41,14 @@
 				"fontSize": true,
 				"fontAppearance": true
 			}
+		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -19,8 +19,4 @@
 			text-align: right;
 		}
 	}
-
-	&.has-background {
-		padding: $block-bg-padding--v $block-bg-padding--h;
-	}
 }

--- a/packages/block-library/src/quote/style.scss
+++ b/packages/block-library/src/quote/style.scss
@@ -1,4 +1,5 @@
 .wp-block-quote {
+	box-sizing: border-box;
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	// .is-style-large and .is-large are kept for backwards compatibility. The :not pseudo-class is used to enable switching styles. See PR #37580.
 	&.is-style-large:not(.is-style-plain),
@@ -17,5 +18,9 @@
 			font-size: 1.125em;
 			text-align: right;
 		}
+	}
+
+	&.has-background {
+		padding: $block-bg-padding--v $block-bg-padding--h;
 	}
 }


### PR DESCRIPTION
## What?

This PR adds color support (background, text, link) to the quote block.

## Why?

I think it can be handy to be able to apply the same text color (or link, background) to the whole quote (all paragraphs and cite) in one go. Especially now that we're working on the V2 version of the quote block which leverages inner block.

## How?

There's a number of important considerations. (See inline comments in the PR):

 - border-box added to the quote block.
 - decide which padding to use by default for has-background style.

## Testing Instructions

(This PR works for both v1 and v2 of the block, so you can try both)

 - Insert a quote block
 - Choose colors/gradients from the block inspector
 - Check that the block works as intended in both frontend and backend
 - It would be great to test this PR in different themes.

cc @WordPress/block-themers @WordPress/theme-team 