### PR TITLE
Comment Form: Experiment with hydration

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -152,6 +152,15 @@ Displays a link to edit the comment in the WordPress Dashboard. This link is onl
 -	**Supports:** color (background, gradients, link, ~~text~~), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** linkTarget, textAlign
 
+## Comment Form
+
+Comment Form ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-form))
+
+-	**Name:** core/comment-form
+-	**Category:** design
+-	**Supports:** align, ~~html~~, ~~reusable~~
+-	**Attributes:** 
+
 ## Comment Reply Link
 
 Displays a link to reply to a comment. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/comment-reply-link))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -62,6 +62,7 @@ function gutenberg_reregister_core_block_types() {
 				'comment-content.php'              => 'core/comment-content',
 				'comment-date.php'                 => 'core/comment-date',
 				'comment-edit-link.php'            => 'core/comment-edit-link',
+				'comment-form.php'                 => 'core/comment-form',
 				'comment-reply-link.php'           => 'core/comment-reply-link',
 				'comment-template.php'             => 'core/comment-template',
 				'comments-pagination.php'          => 'core/comments-pagination',

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -26,11 +26,6 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 			return '';
 		}
 
-		$classes = '';
-		if ( isset( $attributes['textAlign'] ) ) {
-			$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
-		}
-
 		$comment_author     = get_comment_author( $comment );
 		$link               = get_comment_author_url( $comment );
 
@@ -39,6 +34,10 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		}
 	}
 
+	$classes = '';
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
+	}
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 	return sprintf(

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -18,23 +18,28 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$comment = get_comment( $block->context['commentId'] );
-	if ( empty( $comment ) ) {
-		return '';
-	}
+	if ( 0 === $block->context['commentId'] ) {
+		$comment_author = '${ context.author }';
+	} else {
+		$comment = get_comment( $block->context['commentId'] );
+		if ( empty( $comment ) ) {
+			return '';
+		}
 
-	$classes = '';
-	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
+		$classes = '';
+		if ( isset( $attributes['textAlign'] ) ) {
+			$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
+		}
+
+		$comment_author     = get_comment_author( $comment );
+		$link               = get_comment_author_url( $comment );
+
+		if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
+			$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
+		}
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
-	$comment_author     = get_comment_author( $comment );
-	$link               = get_comment_author_url( $comment );
-
-	if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
-		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
-	}
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -18,6 +18,10 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 		return '';
 	}
 
+	if ( 0 === $block->context['commentId'] ) {
+		return '<wp-comment-content></wp-comment-content>';
+	}
+
 	$comment = get_comment( $block->context['commentId'] );
 	if ( empty( $comment ) ) {
 		return '';

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -54,3 +54,26 @@ function register_block_core_comment_content() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_content' );
+
+function define_comment_content_custom_element() {
+    ?>
+		<template id="wp-comment-content">
+			<div><slot></slot></div>
+		</template>
+		<script>
+		customElements.define( 'wp-comment-content',
+			class extends HTMLElement {
+				constructor() {
+					super();
+					const template = document.getElementById( 'wp-comment-content' );
+					const templateContent = template.content;
+
+					const shadowRoot = this.attachShadow( { mode: 'open' } );
+					shadowRoot.appendChild( templateContent.cloneNode( true ) );
+				}
+			}
+		);
+		</script>
+    <?php
+}
+add_action('wp_head', 'define_comment_content_custom_element');

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -19,7 +19,7 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	}
 
 	if ( 0 === $block->context['commentId'] ) {
-		return '<wp-comment-content></wp-comment-content>';
+		return "\${ wpCommentContent( context ) }";
 	}
 
 	$comment = get_comment( $block->context['commentId'] );
@@ -77,6 +77,10 @@ function define_comment_content_custom_element() {
 				}
 			}
 		);
+
+		function wpCommentContent( { content } ) {
+			return `<div>${ content }</div>`;
+		}
 		</script>
     <?php
 }

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -58,26 +58,3 @@ function register_block_core_comment_content() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_content' );
-
-function define_comment_content_custom_element() {
-    ?>
-		<template id="wp-comment-content">
-			<div><slot></slot></div>
-		</template>
-		<script>
-		customElements.define( 'wp-comment-content',
-			class extends HTMLElement {
-				constructor() {
-					super();
-					const template = document.getElementById( 'wp-comment-content' );
-					const templateContent = template.content;
-
-					const shadowRoot = this.attachShadow( { mode: 'open' } );
-					shadowRoot.appendChild( templateContent.cloneNode( true ) );
-				}
-			}
-		);
-		</script>
-    <?php
-}
-add_action('wp_head', 'define_comment_content_custom_element');

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -19,7 +19,8 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	}
 
 	if ( 0 === $block->context['commentId'] ) {
-		return "\${ wpCommentContent( context ) }";
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+		return sprintf( '<div %1$s>${ context.content }</div>', $wrapper_attributes );
 	}
 
 	$comment = get_comment( $block->context['commentId'] );
@@ -77,10 +78,6 @@ function define_comment_content_custom_element() {
 				}
 			}
 		);
-
-		function wpCommentContent( { content } ) {
-			return `<div>${ content }</div>`;
-		}
 		</script>
     <?php
 }

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -19,18 +19,17 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	}
 
 	if ( 0 === $block->context['commentId'] ) {
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
-		return sprintf( '<div %1$s>${ context.content }</div>', $wrapper_attributes );
-	}
+		$comment_text = '${ context.content }';
+	} else {
+		$comment = get_comment( $block->context['commentId'] );
+		if ( empty( $comment ) ) {
+			return '';
+		}
 
-	$comment = get_comment( $block->context['commentId'] );
-	if ( empty( $comment ) ) {
-		return '';
-	}
-
-	$comment_text = get_comment_text( $comment );
-	if ( ! $comment_text ) {
-		return '';
+		$comment_text = get_comment_text( $comment );
+		if ( ! $comment_text ) {
+			return '';
+		}
 	}
 
 	$classes = '';

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -54,3 +54,26 @@ function register_block_core_comment_date() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_date' );
+
+function define_comment_date_custom_element() {
+    ?>
+		<template id="wp-comment-date">
+			<div><time><slot name="date"></slot></time></div>
+		</template>
+		<script>
+		customElements.define( 'wp-comment-date',
+			class extends HTMLElement {
+				constructor() {
+					super();
+					const template = document.getElementById( 'wp-comment-date' );
+					const templateContent = template.content;
+
+					const shadowRoot = this.attachShadow( { mode: 'open' } );
+					shadowRoot.appendChild( templateContent.cloneNode( true ) );
+				}
+			}
+		);
+		</script>
+    <?php
+}
+add_action('wp_head', 'define_comment_date_custom_element');

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -18,6 +18,10 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 		return '';
 	}
 
+	if ( 0 === $block->context['commentId'] ) {
+		return '<wp-comment-date></wp-comment-date>';
+	}
+
 	$comment = get_comment( $block->context['commentId'] );
 	if ( empty( $comment ) ) {
 		return '';

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -58,7 +58,7 @@ add_action( 'init', 'register_block_core_comment_date' );
 function define_comment_date_custom_element() {
     ?>
 		<template id="wp-comment-date">
-			<div><time><slot name="date"></slot></time></div>
+			<div><time><slot></slot></time></div>
 		</template>
 		<script>
 		customElements.define( 'wp-comment-date',
@@ -70,6 +70,13 @@ function define_comment_date_custom_element() {
 
 					const shadowRoot = this.attachShadow( { mode: 'open' } );
 					shadowRoot.appendChild( templateContent.cloneNode( true ) );
+					const slotDate = shadowRoot.querySelector( 'slot' ).assignedNodes()[ 0 ];
+					const datetime = new Date( slotDate.textContent );
+					const timeElement = shadowRoot.querySelector( 'time' );
+
+					if ( datetime ) {
+						timeElement.setAttribute ( 'datetime', datetime.toISOString() );
+					}
 				}
 			}
 		);

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -18,8 +18,16 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 		return '';
 	}
 
+	// Comment Date Template.
 	if ( 0 === $block->context['commentId'] ) {
-		return '<wp-comment-date></wp-comment-date>';
+		// Block attributes are known at server-render time, so we can hard-wire them into the template.
+		$attrs = '{ ';
+		if ( isset( $attributes['format'] ) ) {
+			// TODO: Translate format to JS-style.
+			$attrs .= 'format: "' . $attributes['format'] . '" ';
+		}
+		$attrs .= '}';
+		return "\${ wpCommentDate( context, $attrs ) }";
 	}
 
 	$comment = get_comment( $block->context['commentId'] );
@@ -84,6 +92,16 @@ function define_comment_date_custom_element() {
 				}
 			}
 		);
+
+		function wpCommentDate( { timestamp }, { format } ) {
+			const dateOptions = { // TODO: Format datetime according to `format` arg.
+					year: 'numeric', month: 'long', day: 'numeric',
+					hour: 'numeric', minute: 'numeric'
+			};
+			const datetime = timestamp.toLocaleString( 'en', dateOptions );
+
+			return `<div><time datetime="${ timestamp.toISOString() }">${ datetime }</time></div>`;
+		}
 		</script>
     <?php
 }

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -68,33 +68,3 @@ function register_block_core_comment_date() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_date' );
-
-function define_comment_date_custom_element() {
-    ?>
-		<template id="wp-comment-date">
-			<div><time><slot></slot></time></div>
-		</template>
-		<script>
-		customElements.define( 'wp-comment-date',
-			class extends HTMLElement {
-				constructor() {
-					super();
-					const template = document.getElementById( 'wp-comment-date' );
-					const templateContent = template.content;
-
-					const shadowRoot = this.attachShadow( { mode: 'open' } );
-					shadowRoot.appendChild( templateContent.cloneNode( true ) );
-					const slotDate = shadowRoot.querySelector( 'slot' ).assignedNodes()[ 0 ];
-					const datetime = new Date( slotDate.textContent );
-					const timeElement = shadowRoot.querySelector( 'time' );
-
-					if ( datetime ) {
-						timeElement.setAttribute ( 'datetime', datetime.toISOString() );
-					}
-				}
-			}
-		);
-		</script>
-    <?php
-}
-add_action('wp_head', 'define_comment_date_custom_element');

--- a/packages/block-library/src/comment-form/block.json
+++ b/packages/block-library/src/comment-form/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/comment-form",
+	"title": "Comment Form",
+	"category": "design",
+	"description": "Comment Form",
+	"textdomain": "default",
+	"usesContext": [ "postId" ],
+	"supports": {
+		"reusable": false,
+		"html": false,
+		"align": true
+	},
+	"style": "wp-block-comment-form"
+}

--- a/packages/block-library/src/comment-form/edit.js
+++ b/packages/block-library/src/comment-form/edit.js
@@ -1,0 +1,3 @@
+export default function CommentFormEdit( {} ) {
+	return <p>Comment Form</p>;
+}

--- a/packages/block-library/src/comment-form/index.js
+++ b/packages/block-library/src/comment-form/index.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress dependencies
+ */
+import { layout as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -55,3 +55,21 @@ function register_block_core_comment_form() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_form' );
+
+function add_comment_form_onsubmit_handler() {
+    ?>
+		<script>
+			window.onload = function() {
+				const form = document.querySelector( '.comment-form' );
+				form.addEventListener( 'submit', submitted, false );
+			}
+
+			function submitted( event ) {
+				event.preventDefault();
+				const el = document.createElement( 'wp-comment-date' );
+				document.body.append( el );
+			}
+		</script>
+    <?php
+}
+add_action('wp_head', 'add_comment_form_onsubmit_handler');

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -72,7 +72,11 @@ function add_comment_form_onsubmit_handler() {
 					hour: 'numeric', minute: 'numeric'
 				};
 				const form = document.querySelector( '.comment-form' );
-				form.innerHTML = `<wp-comment-date>${ date.toLocaleDateString( 'en', dateOptions ) }</wp-comment-date>`;
+
+				const content = document.querySelector( '#comment' ).value;
+				form.innerHTML = `<wp-comment-content>${ content }</wp-comment-content>`;
+				form.innerHTML += `<wp-comment-date>${ date.toLocaleDateString( 'en', dateOptions ) }</wp-comment-date>`;
+
 			}
 		</script>
     <?php

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -24,7 +24,6 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes();
 
 	$form_contents = <<<END
-	<turbo-frame id="new_comment">
 	<h3 id="reply-title" class="comment-reply-title">Leave a Reply</h3>
 	<form action="/wp-comments-post.php" method="post" id="commentform" class="comment-form" novalidate>
 	<p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> <span class="required-field-message" aria-hidden="true">Required fields are marked <span class="required" aria-hidden="true">*</span></span></p>
@@ -33,7 +32,6 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 	<input type="hidden" name="comment_post_ID" value="{$block->context['postId']}">
 	<input type="submit" value="Submit">
 	<form>
-	</turbo-frame>
 	END;
 
 
@@ -57,12 +55,3 @@ function register_block_core_comment_form() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_form' );
-
-function hook_javascript() {
-    ?>
-		<script type="module">
-			import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
-		</script>
-    <?php
-}
-add_action('wp_head', 'hook_javascript');

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -66,8 +66,13 @@ function add_comment_form_onsubmit_handler() {
 
 			function submitted( event ) {
 				event.preventDefault();
-				const el = document.createElement( 'wp-comment-date' );
-				document.body.append( el );
+				const date = new Date();
+				const dateOptions = {
+					year: 'numeric', month: 'long', day: 'numeric',
+					hour: 'numeric', minute: 'numeric'
+				};
+				const form = document.querySelector( '.comment-form' );
+				form.innerHTML = `<wp-comment-date>${ date.toLocaleDateString( 'en', dateOptions ) }</wp-comment-date>`;
 			}
 		</script>
     <?php

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -57,3 +57,12 @@ function register_block_core_comment_form() {
 	);
 }
 add_action( 'init', 'register_block_core_comment_form' );
+
+function hook_javascript() {
+    ?>
+		<script type="module">
+			import hotwiredTurbo from 'https://cdn.skypack.dev/@hotwired/turbo';
+		</script>
+    <?php
+}
+add_action('wp_head', 'hook_javascript');

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Server-side rendering of the `core/comment-form` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/comment-form` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string Returns the HTML representing the comments using the layout
+ * defined by the block's inner blocks.
+ */
+function render_block_core_comment_form( $attributes, $content, $block ) {
+	// Bail out early if the post ID is not set for some reason.
+	if ( empty( $block->context['postId'] ) ) {
+		return '';
+	}
+
+	$wrapper_attributes = get_block_wrapper_attributes();
+
+	$form_contents = <<<END
+	<label for="name">Name:</label>
+
+	<input type="text" id="name" name="name" required size="10">
+	END;
+
+	return sprintf(
+		'<form %1$s>%2$s</form>',
+		$wrapper_attributes,
+		$form_contents
+	);
+}
+
+/**
+ * Registers the `core/comment-form` block on the server.
+ */
+function register_block_core_comment_form() {
+	register_block_type_from_metadata(
+		__DIR__ . '/comment-form',
+		array(
+			'render_callback'   => 'render_block_core_comment_form',
+			'skip_inner_blocks' => true,
+		)
+	);
+}
+add_action( 'init', 'register_block_core_comment_form' );

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -24,13 +24,21 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes();
 
 	$form_contents = <<<END
+	<turbo-frame id="new_comment">
+	<form>
 	<label for="name">Name:</label>
-
 	<input type="text" id="name" name="name" required size="10">
+
+	<label for="comment">Tell us your story:</label>
+	<textarea id="comment" name="comment" rows="5" cols="33">
+		It was a dark and stormy night...
+	</textarea>
+	<form>
+	</turbo-frame>
 	END;
 
 	return sprintf(
-		'<form %1$s>%2$s</form>',
+		'<div %1$s>%2$s</div>',
 		$wrapper_attributes,
 		$form_contents
 	);

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -25,7 +25,7 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 
 	$form_contents = <<<END
 	<turbo-frame id="new_comment">
-	<form>
+	<form action="/wp-comments-post.php" method="post">
 	<label for="name">Name:</label>
 	<input type="text" id="name" name="name" required size="10">
 
@@ -33,9 +33,12 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 	<textarea id="comment" name="comment" rows="5" cols="33">
 		It was a dark and stormy night...
 	</textarea>
+	<input type="hidden" name="comment_post_ID" value="{$block->context['postId']}">
+	<input type="submit" value="Submit">
 	<form>
 	</turbo-frame>
 	END;
+
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -70,9 +70,11 @@ function add_comment_form_onsubmit_handler() {
 
 				const form = document.querySelector( '.comment-form' );
 
+				const author = document.querySelector( '#author' ).value;
 				const content = document.querySelector( '#comment' ).value;
 
 				const context = {
+					author,
 					content,
 					timestamp: date
 				};

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -67,15 +67,16 @@ function add_comment_form_onsubmit_handler() {
 			function submitted( event ) {
 				event.preventDefault();
 				const date = new Date();
-				const dateOptions = {
-					year: 'numeric', month: 'long', day: 'numeric',
-					hour: 'numeric', minute: 'numeric'
-				};
+
 				const form = document.querySelector( '.comment-form' );
 
 				const content = document.querySelector( '#comment' ).value;
-				form.innerHTML = `<wp-comment-content>${ content }</wp-comment-content>`;
-				form.innerHTML += `<wp-comment-date>${ date.toLocaleDateString( 'en', dateOptions ) }</wp-comment-date>`;
+
+				const context = {
+					content,
+					timestamp: date
+				};
+				form.innerHTML = wpCommentTemplate( context );
 
 			}
 		</script>

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -31,7 +31,7 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 	<p class="comment-form-author"><label for="author">Name <span class="required" aria-hidden="true">*</span></label> <input id="author" name="author" type="text" value="" size="30" maxlength="245" required /></p>
 	<input type="hidden" name="comment_post_ID" value="{$block->context['postId']}">
 	<input type="submit" value="Submit">
-	<form>
+	</form>
 	END;
 
 

--- a/packages/block-library/src/comment-form/index.php
+++ b/packages/block-library/src/comment-form/index.php
@@ -25,14 +25,11 @@ function render_block_core_comment_form( $attributes, $content, $block ) {
 
 	$form_contents = <<<END
 	<turbo-frame id="new_comment">
-	<form action="/wp-comments-post.php" method="post">
-	<label for="name">Name:</label>
-	<input type="text" id="name" name="name" required size="10">
-
-	<label for="comment">Tell us your story:</label>
-	<textarea id="comment" name="comment" rows="5" cols="33">
-		It was a dark and stormy night...
-	</textarea>
+	<h3 id="reply-title" class="comment-reply-title">Leave a Reply</h3>
+	<form action="/wp-comments-post.php" method="post" id="commentform" class="comment-form" novalidate>
+	<p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> <span class="required-field-message" aria-hidden="true">Required fields are marked <span class="required" aria-hidden="true">*</span></span></p>
+	<p class="comment-form-comment"><label for="comment">Comment <span class="required" aria-hidden="true">*</span></label><textarea id="comment" name="comment" cols="45" rows="8" maxlength="65525" required></textarea></p>
+	<p class="comment-form-author"><label for="author">Name <span class="required" aria-hidden="true">*</span></label> <input id="author" name="author" type="text" value="" size="30" maxlength="245" required /></p>
 	<input type="hidden" name="comment_post_ID" value="{$block->context['postId']}">
 	<input type="submit" value="Submit">
 	<form>

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -58,14 +58,19 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$block_content = '<wp-comment-template>';
+	$block_content = '<script>';
+	$block_content .= 'function wpCommentTemplate( context ) {';
+	$block_content .= 'output = `';
 	$block_content .= ( new WP_Block(
 		$block->parsed_block,
 		array(
 			'commentId' => 0,
 		)
 	) )->render( array( 'dynamic' => false ) );
-	$block_content .= '</wp-comment-template>';
+	$block_content .= '`;';
+	$block_content .= 'return output;';
+	$block_content .= '}';
+	$block_content .= '</script>';
 
 	$comment_query = new WP_Comment_Query(
 		build_comment_query_vars_from_block( $block )

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -58,6 +58,15 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		return '';
 	}
 
+	$block_content = '<wp-comment-template>';
+	$block_content .= ( new WP_Block(
+		$block->parsed_block,
+		array(
+			'commentId' => 0,
+		)
+	) )->render( array( 'dynamic' => false ) );
+	$block_content .= '</wp-comment-template>';
+
 	$comment_query = new WP_Comment_Query(
 		build_comment_query_vars_from_block( $block )
 	);
@@ -80,7 +89,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		'<ol %1$s>%2$s</ol>',
 		$wrapper_attributes,
 		block_core_comment_template_render_comments( $comments, $block )
-	);
+	) . $block_content;
 }
 
 /**

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -28,6 +28,7 @@ import * as commentAuthorName from './comment-author-name';
 import * as commentContent from './comment-content';
 import * as commentDate from './comment-date';
 import * as commentEditLink from './comment-edit-link';
+import * as commentForm from './comment-form';
 import * as commentReplyLink from './comment-reply-link';
 import * as commentTemplate from './comment-template';
 import * as commentsPaginationPrevious from './comments-pagination-previous';
@@ -264,6 +265,7 @@ export const __experimentalRegisterExperimentalCoreBlocks = process.env
 							commentContent,
 							commentDate,
 							commentEditLink,
+							commentForm,
 							commentReplyLink,
 							commentTemplate,
 							commentsQueryLoop,


### PR DESCRIPTION
## What?
Some explorations around a Comment Form block that, upon submission, renders the resulting comment instantly.

## Why?
This is one of various experiments with different hydration techniques.

## How?
"Minimally invasive", i.e. trying to introduce as few concepts as possible on top of what's already provided by WordPress and Gutenberg. Here's a walkthrough video: 

<a href="https://www.loom.com/share/80a227c099684ee89ca26d0b77b3a618">
    <p>Comments Form hydration experiment - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/80a227c099684ee89ca26d0b77b3a618-with-play.gif">
  </a>

## Testing Instructions
Insert the newly added Comment Form block into an FSE template, and view a post on the frontend. Click the form's Submit button and see what happens.

## Screenshots or screencast

TBD
