### PR TITLE
Quote v2: implement exiting on Enter at end

### DIFF
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -23,6 +23,11 @@ import {
 import { createBlock } from '@wordpress/blocks';
 import { formatLtr } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { useExitOnEnterAtEnd } from './use-enter';
+
 const name = 'core/paragraph';
 
 function ParagraphRTLControl( { direction, setDirection } ) {
@@ -57,6 +62,7 @@ function ParagraphBlock( {
 	const { align, content, direction, dropCap, placeholder } = attributes;
 	const isDropCapFeatureEnabled = useSetting( 'typography.dropCap' );
 	const blockProps = useBlockProps( {
+		ref: useExitOnEnterAtEnd( { clientId, content } ),
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -26,7 +26,7 @@ import { formatLtr } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { useExitOnEnterAtEnd } from './use-enter';
+import { useOnEnter } from './use-enter';
 
 const name = 'core/paragraph';
 
@@ -62,7 +62,7 @@ function ParagraphBlock( {
 	const { align, content, direction, dropCap, placeholder } = attributes;
 	const isDropCapFeatureEnabled = useSetting( 'typography.dropCap' );
 	const blockProps = useBlockProps( {
-		ref: useExitOnEnterAtEnd( { clientId, content } ),
+		ref: useOnEnter( { clientId, content } ),
 		className: classnames( {
 			'has-drop-cap': dropCap,
 			[ `has-text-align-${ align }` ]: align,

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { ENTER } from '@wordpress/keycodes';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { hasBlockSupport } from '@wordpress/blocks';
+
+export function useExitOnEnterAtEnd( props ) {
+	const { moveBlocksToPosition } = useDispatch( blockEditorStore );
+	const {
+		getBlockRootClientId,
+		getBlockIndex,
+		getBlockOrder,
+		getBlockName,
+	} = useSelect( blockEditorStore );
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	return useRefEffect( ( element ) => {
+		function onKeyDown( event ) {
+			if ( event.defaultPrevented ) {
+				return;
+			}
+
+			if ( event.keyCode !== ENTER ) {
+				return;
+			}
+
+			const { content, clientId } = propsRef.current;
+
+			// The paragraph should be empty.
+			if ( content.length ) {
+				return;
+			}
+
+			const wrapperClientId = getBlockRootClientId( clientId );
+
+			if (
+				! hasBlockSupport(
+					getBlockName( wrapperClientId ),
+					'__experimentalExitOnEnterAtEnd',
+					false
+				)
+			) {
+				return;
+			}
+
+			const order = getBlockOrder( wrapperClientId );
+
+			// It should be the last block.
+			if ( order.indexOf( clientId ) !== order.length - 1 ) {
+				return;
+			}
+
+			event.preventDefault();
+
+			moveBlocksToPosition(
+				[ clientId ],
+				wrapperClientId,
+				getBlockRootClientId( wrapperClientId ),
+				getBlockIndex( wrapperClientId ) + 1
+			);
+		}
+
+		element.addEventListener( 'keydown', onKeyDown );
+		return () => {
+			element.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [] );
+}

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -8,7 +8,7 @@ import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { hasBlockSupport, createBlock } from '@wordpress/blocks';
 
-export function useExitOnEnterAtEnd( props ) {
+export function useOnEnter( props ) {
 	const { batch } = useRegistry();
 	const {
 		moveBlocksToPosition,
@@ -48,7 +48,7 @@ export function useExitOnEnterAtEnd( props ) {
 			if (
 				! hasBlockSupport(
 					getBlockName( wrapperClientId ),
-					'__experimentalExitOnEnterAtEnd',
+					'__experimentalOnEnter',
 					false
 				)
 			) {

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -84,7 +84,7 @@ export function useOnEnter( props ) {
 				);
 				replaceInnerBlocks(
 					getNextBlockClientId( wrapperClientId ),
-					wrapperBlock.innerBlocks.slice( position )
+					wrapperBlock.innerBlocks.slice( position + 1 )
 				);
 				insertBlock(
 					createBlock( 'core/paragraph' ),

--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -60,7 +60,8 @@ export function useExitOnEnterAtEnd( props ) {
 			event.preventDefault();
 
 			const position = order.indexOf( clientId );
-			// It should be the last block.
+
+			// If it is the last block, exit.
 			if ( position === order.length - 1 ) {
 				moveBlocksToPosition(
 					[ clientId ],
@@ -71,17 +72,19 @@ export function useExitOnEnterAtEnd( props ) {
 				return;
 			}
 
+			// If it is in the middle, split the block in two.
 			const wrapperBlock = getBlock( wrapperClientId );
 			batch( () => {
 				duplicateBlocks( [ wrapperClientId ] );
 				const blockIndex = getBlockIndex( wrapperClientId );
+
 				replaceInnerBlocks(
 					wrapperClientId,
-					wrapperBlock.innerBlocks.splice( 0, position )
+					wrapperBlock.innerBlocks.slice( 0, position )
 				);
 				replaceInnerBlocks(
 					getNextBlockClientId( wrapperClientId ),
-					wrapperBlock.innerBlocks.splice( position )
+					wrapperBlock.innerBlocks.slice( position )
 				);
 				insertBlock(
 					createBlock( 'core/paragraph' ),

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -30,6 +30,7 @@
 	"supports": {
 		"anchor": true,
 		"__experimentalSlashInserter": true,
+		"__experimentalExitOnEnterAtEnd": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/quote/block.json
+++ b/packages/block-library/src/quote/block.json
@@ -30,7 +30,7 @@
 	"supports": {
 		"anchor": true,
 		"__experimentalSlashInserter": true,
-		"__experimentalExitOnEnterAtEnd": true,
+		"__experimentalOnEnter": true,
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allows the user to exit a wrapper block (like quote) when pressing Enter from an empty paragraph at the end of that wrapper block. This could be useful for other blocks too like group.

![quote-enter-at-end](https://user-images.githubusercontent.com/4710635/160904168-70179246-9253-450c-9494-4e5fa53e37f9.gif)


## Why?

Feature parity. It's nice to be able to exit a quote and continue writing.

## How?



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
