### PR TITLE
Group: Add group block variations to Group toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -312,16 +312,14 @@
 // Size multiple sequential buttons to be optically balanced.
 // Icons are 36px, as set by a 24px icon and 12px padding.
 .block-editor-block-toolbar > .components-toolbar > .block-editor-block-toolbar__slot, // When a plugin adds to a slot, the segment has a `components-toolbar` class.
-.block-editor-block-toolbar > .components-toolbar-group > .block-editor-block-toolbar__slot, // When no plugin adds to slots, the segment has a `components-toolbar-group` class.
 .block-editor-block-toolbar > .block-editor-block-toolbar__slot > .components-toolbar, // The nesting order is sometimes reversed.
 .block-editor-block-toolbar > .block-editor-block-toolbar__slot > .components-dropdown, // Targets unique markup for the "Replace" button.
-.block-editor-block-toolbar .block-editor-block-toolbar__slot .components-toolbar-group { // Inline formatting tools use this class.
+.block-editor-block-toolbar .components-toolbar-group {
 	padding-left: $grid-unit-15 * 0.5; // 6px.
 	padding-right: $grid-unit-15 * 0.5;
 
-	> .components-button,
-	> div > .components-button,
-	> .components-dropdown .components-button {
+	.components-button,
+	.components-button.has-icon.has-icon {
 		min-width: $block-toolbar-height - $grid-unit-15;
 		padding-left: $grid-unit-15 * 0.5; // 6px.
 		padding-right: $grid-unit-15 * 0.5;

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -13,7 +13,8 @@ import { _x } from '@wordpress/i18n';
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
 
-const variationAttributes = {
+const layouts = {
+	group: undefined,
 	row: { type: 'flex' },
 	stack: { type: 'flex', orientation: 'vertical' },
 };
@@ -37,19 +38,16 @@ function BlockGroupToolbar() {
 		[ clientIds ]
 	);
 
-	const onConvertToGroup = ( variation = 'group' ) => {
+	const onConvertToGroup = ( layout = 'group' ) => {
 		const newBlocks = switchToBlockType(
 			blocksSelection,
 			groupingBlockName
 		);
 
 		if ( newBlocks && newBlocks.length > 0 ) {
-			if ( variation !== 'group' ) {
-				// Because the block is not in the store yet we can't use
-				// updateBlockAttributes so need to manually update attributes.
-				newBlocks[ 0 ].attributes.layout =
-					variationAttributes[ variation ];
-			}
+			// Because the block is not in the store yet we can't use
+			// updateBlockAttributes so need to manually update attributes.
+			newBlocks[ 0 ].attributes.layout = layouts[ layout ];
 			replaceBlocks( clientIds, newBlocks );
 		}
 	};

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -45,6 +45,8 @@ function BlockGroupToolbar() {
 
 		if ( newBlocks && newBlocks.length > 0 ) {
 			if ( variation !== 'group' ) {
+				// Because the block is not in the store yet we can't use
+				// updateBlockAttributes so need to manually update attributes.
 				newBlocks[ 0 ].attributes.layout =
 					variationAttributes[ variation ];
 			}

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -44,10 +44,10 @@ function BlockGroupToolbar() {
 		);
 
 		if ( newBlocks && newBlocks.length > 0 ) {
-			newBlocks[ 0 ].attributes.layout =
-				variation !== 'group'
-					? variationAttributes[ variation ]
-					: undefined;
+			if ( variation !== 'group' ) {
+				newBlocks[ 0 ].attributes.layout =
+					variationAttributes[ variation ];
+			}
 			replaceBlocks( clientIds, newBlocks );
 		}
 	};

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -43,7 +43,7 @@ function BlockGroupToolbar() {
 			groupingBlockName
 		);
 
-		if ( newBlocks ) {
+		if ( newBlocks && newBlocks.length > 0 ) {
 			newBlocks[ 0 ].attributes.layout =
 				variation !== 'group'
 					? variationAttributes[ variation ]

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -74,7 +74,7 @@ function BlockGroupToolbar() {
 			/>
 			<ToolbarButton
 				icon={ row }
-				label={ _x( 'Row', 'verb' ) }
+				label={ _x( 'Row', 'single horizontal line' ) }
 				onClick={ onConvertToRow }
 			/>
 			<ToolbarButton

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -4,7 +4,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { switchToBlockType } from '@wordpress/blocks';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
-import { group } from '@wordpress/icons';
+import { group, row, stack } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -13,7 +13,7 @@ import { _x } from '@wordpress/i18n';
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
 
-function BlockGroupToolbar( { label = _x( 'Group', 'verb' ) } ) {
+function BlockGroupToolbar() {
 	const {
 		blocksSelection,
 		clientIds,
@@ -32,15 +32,28 @@ function BlockGroupToolbar( { label = _x( 'Group', 'verb' ) } ) {
 		[ clientIds ]
 	);
 
-	const onConvertToGroup = () => {
+	const variationAttributes = {
+		row: { type: 'flex' },
+		stack: { type: 'flex', orientation: 'vertical' },
+	};
+
+	const onConvertToGroup = ( variation = 'group' ) => {
 		const newBlocks = switchToBlockType(
 			blocksSelection,
 			groupingBlockName
 		);
+
 		if ( newBlocks ) {
+			newBlocks[ 0 ].attributes.layout =
+				variation !== 'group'
+					? variationAttributes[ variation ]
+					: undefined;
 			replaceBlocks( clientIds, newBlocks );
 		}
 	};
+
+	const onConvertToRow = () => onConvertToGroup( 'row' );
+	const onConvertToStack = () => onConvertToGroup( 'stack' );
 
 	// Don't render the button if the current selection cannot be grouped.
 	// A good example is selecting multiple button blocks within a Buttons block:
@@ -54,8 +67,18 @@ function BlockGroupToolbar( { label = _x( 'Group', 'verb' ) } ) {
 		<ToolbarGroup>
 			<ToolbarButton
 				icon={ group }
-				label={ label }
+				label={ _x( 'Group', 'verb' ) }
 				onClick={ onConvertToGroup }
+			/>
+			<ToolbarButton
+				icon={ row }
+				label={ _x( 'Row', 'verb' ) }
+				onClick={ onConvertToRow }
+			/>
+			<ToolbarButton
+				icon={ stack }
+				label={ _x( 'Stack', 'verb' ) }
+				onClick={ onConvertToStack }
 			/>
 		</ToolbarGroup>
 	);

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -13,6 +13,11 @@ import { _x } from '@wordpress/i18n';
 import { useConvertToGroupButtonProps } from '../convert-to-group-buttons';
 import { store as blockEditorStore } from '../../store';
 
+const variationAttributes = {
+	row: { type: 'flex' },
+	stack: { type: 'flex', orientation: 'vertical' },
+};
+
 function BlockGroupToolbar() {
 	const {
 		blocksSelection,
@@ -31,11 +36,6 @@ function BlockGroupToolbar() {
 		},
 		[ clientIds ]
 	);
-
-	const variationAttributes = {
-		row: { type: 'flex' },
-		stack: { type: 'flex', orientation: 'vertical' },
-	};
 
 	const onConvertToGroup = ( variation = 'group' ) => {
 		const newBlocks = switchToBlockType(


### PR DESCRIPTION
## What?
Adds the new `Row` and `Stack` Group block variations to the Group block toolbar that is shown when multiple blocks are selected

## Why?
To allow users to easily select which layout variation they want for the nested blocks, as [was requested here](https://github.com/WordPress/gutenberg/pull/39710#discussion_r834280690).

## How?
Adds two additional buttons to the toolbar with relevant icons, and adds the relevant layout attributes for the group type selected.

## Testing Instructions

- Add several paragraph blocks and multiselect them
- Check that the 3 different group variations appear in the toolbar
- Check that each button groups the selected blocks in the correct layout

## Screenshots or screencast 

https://user-images.githubusercontent.com/3629020/160948187-56796ee7-875e-423e-8132-709312909d53.mp4


