### PR TITLE
Theme JSON compat: refer to static instead of self for ROOT_BLOCK_SELECTOR const

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -103,7 +103,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 				$block_rules     .= static::to_ruleset( $selector_duotone, $declarations_duotone );
 			}
 
-			if ( self::ROOT_BLOCK_SELECTOR === $selector ) {
+			if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
 				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
 				$block_rules .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
 				$block_rules .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';


### PR DESCRIPTION

## What?
`self::ROOT_BLOCK_SELECTOR` should be `static::ROOT_BLOCK_SELECTOR`

## Why?
While porting the get_block_classes in https://github.com/WordPress/gutenberg/pull/38816 a `self::ROOT_BLOCK_SELECTOR` made it in. It should be static to retain the inheritance powers introduced in https://github.com/WordPress/gutenberg/pull/38671

## How?
Renamed `self::` to `static::`

## Testing Instructions
Add new post with some Group blocks.
Publish said post.
Check out the frontend:
- Do things look as they should?
- Are the global styles printed out in the document? Check the contents of `<style id='global-styles-inline-css'>` in the source.


Props to @aaronrobertshaw  for spotting






