### PR TITLE
Don't run preg_match() on null values

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -167,10 +167,10 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 	// because we only want to match against the value, not the CSS attribute.
 	if ( is_array( $gap_value ) ) {
 		foreach ( $gap_value as $key => $value ) {
-			$gap_value[ $key ] = preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$gap_value[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
 		}
 	} else {
-		$gap_value = preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 	}
 
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,


### PR DESCRIPTION
PHP 8.1 has deprecated passing null as the second parameter to `preg_match()`, generating the following Deprecated notice: `preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated`.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoids a PHP Deprecated notice

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
PHP 8.1 has deprecated passing null values to preg_match(), which is the default condition here.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check the `$block_gap` is a non-falsey value before processing it. 
This style is already used for this variable value further down the stack:
https://github.com/WordPress/gutenberg/blob/6de16981c7fef3db7cc4a9d6cfcb0ad85c916c62/lib/block-supports/layout.php#L73

The changes in this PR could also be written as:
```diff
-		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
+		$gap_value = ! $gap_value || preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
```
both are logically the same here (although different around a 0 or false, which is not supported here due to the above mentioned code), as it's only checking to see if it contains invalid characters. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Unknown.

Have a block that does not contain the `blockGap` key: ` _wp_array_get( $block, array( 'attrs', 'style', 'spacing', 'blockGap' ) )`.

## Screenshots or screencast <!-- if applicable -->
