### PR TITLE
Fix flaky test results overflowing the character limits of GitHub's issue

### DIFF
--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -98,12 +98,12 @@ const metaData = {
 					)
 				);
 			// GitHub issues has character limits on issue's body,
-			// so we only preserve the first and the four latest results.
-			if ( testResultsList.length > 5 ) {
+			// so we only preserve the first and the 9 latest results.
+			if ( testResultsList.length > 10 ) {
 				testResultsList = [
 					testResultsList[ 0 ],
 					'...',
-					...testResultsList.slice( -4 ),
+					...testResultsList.slice( -9 ),
 				];
 			}
 

--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -65,6 +65,7 @@ const metaData = {
 			if ( isTrunk ) {
 				const headCommit = github.context.sha;
 				const baseCommit = meta.baseCommit || github.context.sha;
+				meta.baseCommit = baseCommit;
 
 				try {
 					const { data } = await octokit.rest.repos.compareCommits( {
@@ -85,14 +86,33 @@ const metaData = {
 				}
 			}
 
+			let testResultsList = body
+				.slice(
+					body.indexOf( TEST_RESULTS_LIST.open ) +
+						TEST_RESULTS_LIST.open.length,
+					body.indexOf( TEST_RESULTS_LIST.close )
+				)
+				.split(
+					new RegExp(
+						`(?<=${ TEST_RESULT.close })\n(?=${ TEST_RESULT.open })`
+					)
+				);
+			// GitHub issues has character limits on issue's body,
+			// so we only preserve the first and the four latest results.
+			if ( testResultsList.length > 5 ) {
+				testResultsList = [
+					testResultsList[ 0 ],
+					'...',
+					...testResultsList.slice( -4 ),
+				];
+			}
+
 			// Reconstruct the body with the description + previous errors + new error.
 			body =
 				renderIssueDescription( { meta, testTitle, testPath } ) +
-				body.slice(
-					body.indexOf( TEST_RESULTS_LIST.open ),
-					body.indexOf( TEST_RESULTS_LIST.close )
-				) +
 				[
+					TEST_RESULTS_LIST.open,
+					...testResultsList,
 					renderTestErrorMessage( {
 						testRunner,
 						testPath,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Truncate the flaky results to only show the first one + the latest 5 ones in the flaky reports.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I found out that some [flaky test issues](https://github.com/WordPress/gutenberg/issues/39121) are not getting updated with the latest results even when there're new results. This is also blocking us from correctly analyzing the flaky rates of the issues.

I guess the reason is that GitHub has a character limit for the issue's body and we're just over the limits.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By parsing the issue's body and reconstructing them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I don't have any strategy to test it, unfortunately. Maybe someone could just help me proofread it 😅 ?
