### PR TITLE
[Icons]: Add new list item icon

### DIFF
--- a/packages/block-library/src/list-item/index.js
+++ b/packages/block-library/src/list-item/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { list as icon } from '@wordpress/icons';
+import { listItem as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -2,23 +2,24 @@
 
 ## Unreleased
 
+### New Features
+
+-   Add new `row` and `copy` icons. ([#39690](https://github.com/WordPress/gutenberg/pull/39690))
+-   Add new `listItem` icon. ([#39929](https://github.com/WordPress/gutenberg/pull/39929))
+
 ## 8.1.0 (2022-03-23)
 
 ## 8.0.0 (2022-03-11)
 
 ### Breaking Changes
 
--   Changed `dragHandle` footprint from 18x18 to 24x24 to match other icons.  ([#39342](https://github.com/WordPress/gutenberg/pull/39342))
-
-### New Features
-
-- Add new `row` and `copy` icons. 
+-   Changed `dragHandle` footprint from 18x18 to 24x24 to match other icons. ([#39342](https://github.com/WordPress/gutenberg/pull/39342))
 
 ## 7.0.0 (2022-02-23)
 
 ### New Features
 
-- Added new icon: `post`, and refreshed the existing `pin` icon. ([#39139](https://github.com/WordPress/gutenberg/pull/39139))
+-   Added new icon: `post`, and refreshed the existing `pin` icon. ([#39139](https://github.com/WordPress/gutenberg/pull/39139))
 
 ### Breaking Changes
 

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -118,6 +118,7 @@ export { default as lineSolid } from './library/line-solid';
 export { default as link } from './library/link';
 export { default as linkOff } from './library/link-off';
 export { default as list } from './library/list';
+export { default as listItem } from './library/list-item';
 export { default as listView } from './library/list-view';
 export { default as lock } from './library/lock';
 export { default as login } from './library/login';

--- a/packages/icons/src/library/list-item.js
+++ b/packages/icons/src/library/list-item.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const listItem = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M12 11v1.5h8V11h-8zm-6-1c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" />
+	</SVG>
+);
+
+export default listItem;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/39628

Adds a new list item icon to be used for the new `List Item` block(list v2), provided by @jasmussen [here](https://github.com/WordPress/gutenberg/issues/39628#issuecomment-1084195811).
<img width="732" alt="Screenshot 2022-03-31 at 09 26 14" src="https://user-images.githubusercontent.com/1204802/161000921-145ac505-9bb3-43f3-a52b-6fa09b30b08d.png">

