### PR TITLE
Try: Improve Stack and Row setup states.

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/style.scss
+++ b/packages/block-editor/src/components/button-block-appender/style.scss
@@ -3,11 +3,15 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	padding: $grid-unit-10;
 	width: 100%;
 	height: auto;
 	color: $gray-900;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
+
+	// Needs specificity to override button styles.
+	&.components-button.components-button {
+		padding: $grid-unit-15;
+	}
 
 	.is-dark-theme & {
 		color: $light-gray-placeholder;

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -112,8 +112,35 @@
 		list-style: none;
 		line-height: inherit;
 
-		.block-editor-default-block-appender__content {
-			display: block;
+		// Handle both group (block), and row/stack (flex).
+		&,
+		.block-editor-default-block-appender__content,
+		.block-editor-inserter {
+			display: inherit;
+			width: 100%;
+			flex-direction: inherit;
+			flex: 1;
+		}
+
+		// Affect Row and Stack variants.
+		// @todo: this should only affect the stack and row setup states.
+		gap: inherit;
+
+		&::after {
+			content: "";
+			display: flex;
+			border: $border-width dashed currentColor;
+			opacity: 0.4;
+			border-radius: $radius-block-ui;
+			flex: 1;
+			pointer-events: none;
+			min-height: $grid-unit-60;
+		}
+
+		// Let the parent be selectable in the placeholder area.
+		pointer-events: none;
+		.block-editor-inserter {
+			pointer-events: all;
 		}
 	}
 }

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -111,6 +111,10 @@
 		align-self: center;
 		list-style: none;
 		line-height: inherit;
+
+		.block-editor-default-block-appender__content {
+			display: block;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/default-block-appender/style.scss
+++ b/packages/block-editor/src/components/default-block-appender/style.scss
@@ -111,37 +111,6 @@
 		align-self: center;
 		list-style: none;
 		line-height: inherit;
-
-		// Handle both group (block), and row/stack (flex).
-		&,
-		.block-editor-default-block-appender__content,
-		.block-editor-inserter {
-			display: inherit;
-			width: 100%;
-			flex-direction: inherit;
-			flex: 1;
-		}
-
-		// Affect Row and Stack variants.
-		// @todo: this should only affect the stack and row setup states.
-		gap: inherit;
-
-		&::after {
-			content: "";
-			display: flex;
-			border: $border-width dashed currentColor;
-			opacity: 0.4;
-			border-radius: $radius-block-ui;
-			flex: 1;
-			pointer-events: none;
-			min-height: $grid-unit-60;
-		}
-
-		// Let the parent be selectable in the placeholder area.
-		pointer-events: none;
-		.block-editor-inserter {
-			pointer-events: all;
-		}
 	}
 }
 

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -34,7 +39,7 @@ const htmlElementMessages = {
 	),
 };
 
-function GroupEdit( { attributes, setAttributes, clientId } ) {
+function GroupEdit( { attributes, setAttributes, clientId, className } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
 		( select ) => {
 			const { getBlock, getSettings } = select( blockEditorStore );
@@ -52,7 +57,14 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { type = 'default' } = usedLayout;
 	const layoutSupportEnabled = themeSupportsLayout || type !== 'default';
 
-	const blockProps = useBlockProps();
+	const classes = classnames( className, {
+		'is-layout-flex': type === 'flex',
+	} );
+
+	const blockProps = useBlockProps( {
+		className: classes,
+	} );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		layoutSupportEnabled
 			? blockProps

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
@@ -39,7 +34,7 @@ const htmlElementMessages = {
 	),
 };
 
-function GroupEdit( { attributes, setAttributes, clientId, className } ) {
+function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
 		( select ) => {
 			const { getBlock, getSettings } = select( blockEditorStore );
@@ -57,12 +52,8 @@ function GroupEdit( { attributes, setAttributes, clientId, className } ) {
 	const { type = 'default' } = usedLayout;
 	const layoutSupportEnabled = themeSupportsLayout || type !== 'default';
 
-	const classes = classnames( className, {
-		'is-layout-flex': type === 'flex',
-	} );
-
 	const blockProps = useBlockProps( {
-		className: classes,
+		className: `is-layout-${ type }`,
 	} );
 
 	const innerBlocksProps = useInnerBlocksProps(

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -22,3 +22,34 @@
 		margin-bottom: $block-padding + $grid-unit-05;
 	}
 }
+
+// Affect the appender of the Row and Stack variants.
+.is-layout-flex.block-editor-block-list__block .block-list-appender:only-child {
+	gap: inherit;
+
+	&,
+	.block-editor-default-block-appender__content,
+	.block-editor-inserter {
+		display: inherit;
+		width: 100%;
+		flex-direction: inherit;
+		flex: 1;
+	}
+
+	&::after {
+		content: "";
+		display: flex;
+		border: $border-width dashed currentColor;
+		opacity: 0.4;
+		border-radius: $radius-block-ui;
+		flex: 1;
+		pointer-events: none;
+		min-height: $grid-unit-60;
+	}
+
+	// Let the parent be selectable in the placeholder area.
+	pointer-events: none;
+	.block-editor-inserter {
+		pointer-events: all;
+	}
+}


### PR DESCRIPTION
## What?

This PR takes a small step towards improving Row and Stack setup states. Before, there was no visible indication of what the Row or Stack blocks were meant for, and block spacing and padding did not affect the setup state:
![before](https://user-images.githubusercontent.com/1204802/161501862-33ebcf7e-31e0-45e0-b702-801e62c8cee2.gif)

After, dashed outlines indicate direction and purpose, and spacing and padding affect even the setup state:

![after](https://user-images.githubusercontent.com/1204802/161501870-3693259e-792b-4012-a48a-8efbf97571a2.gif)

Note that this PR does not touch the vanilla flow based Group variation, nor is it meant to affect any other blocks that use the Button Block appender.

## Why?

The Row and Stack setup states are in a bad place. There's zero indication that these blocks are in fact flex-based containers affected by block spacing controls and other flex behaviors, or that the Row block is horizontal in direction. 

## How?

A dashed line is output to indicate where a second block could sit, giving more of an indication of what the block is all about. 

If this one can land, a next step could potentially be to introduce a dedicated placeholder state, a la this:

<img width="1640" alt="Group" src="https://user-images.githubusercontent.com/1204802/161025388-3f972bde-9ef7-4560-a703-4cea1f7ec067.png">
<img width="1640" alt="Row" src="https://user-images.githubusercontent.com/1204802/161025394-c7ab96a1-8d1f-480b-a80b-941d7c1940f3.png">

<img width="1640" alt="Stack" src="https://user-images.githubusercontent.com/1204802/161025403-ab6b4bf1-c63a-44c8-be47-fc50a9f7f3df.png">

Normally a placeholder like that is something to be careful with introducing, and introducing mainly for content-first blocks, otherwise they have a risk of generating layout shifts.

The group is a little unique in that vein, since through transforms and grouping tools such as [this multi-select toolbar transform](#39920), it seems likely that you'll be using the group as a side-efffect of those tools. Meaning, when you insert the block directly, we can afford to show more context.

## Testing Instructions

Test Group, Row and Stack blocks.

**Note:** this PR isn't shippable as is. It's a little hacky, but most importantly it affects all appenders not just those of the Row and Stack blocks. I would appreciate help here: can we add a CSS class to the Row and Stack blocks, even if just editor-only, so we can scope the extra rules?