### PR TITLE
Reusable Blocks: Hide 'Convert to Blocks' when locked

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useEntityBlockEditor,
 	useEntityProp,
@@ -25,6 +25,7 @@ import {
 	InspectorControls,
 	useBlockProps,
 	Warning,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as reusableBlocksStore } from '@wordpress/reusable-blocks';
 import { ungroup } from '@wordpress/icons';
@@ -39,6 +40,11 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		ref
 	);
 	const isMissing = hasResolved && ! record;
+
+	const canRemove = useSelect(
+		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+		[ clientId ]
+	);
 
 	const {
 		__experimentalConvertBlockToStatic: convertBlockToStatic,
@@ -104,14 +110,18 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		<RecursionProvider>
 			<div { ...blockProps }>
 				<BlockControls>
-					<ToolbarGroup>
-						<ToolbarButton
-							onClick={ () => convertBlockToStatic( clientId ) }
-							label={ __( 'Convert to regular blocks' ) }
-							icon={ ungroup }
-							showTooltip
-						/>
-					</ToolbarGroup>
+					{ canRemove && (
+						<ToolbarGroup>
+							<ToolbarButton
+								onClick={ () =>
+									convertBlockToStatic( clientId )
+								}
+								label={ __( 'Convert to regular blocks' ) }
+								icon={ ungroup }
+								showTooltip
+							/>
+						</ToolbarGroup>
+					) }
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody>

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -109,8 +109,8 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 	return (
 		<RecursionProvider>
 			<div { ...blockProps }>
-				<BlockControls>
-					{ canRemove && (
+				{ canRemove && (
+					<BlockControls>
 						<ToolbarGroup>
 							<ToolbarButton
 								onClick={ () =>
@@ -121,8 +121,8 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 								showTooltip
 							/>
 						</ToolbarGroup>
-					) }
-				</BlockControls>
+					</BlockControls>
+				) }
 				<InspectorControls>
 					<PanelBody>
 						<TextControl

--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-blocks-manage-button.js
@@ -18,13 +18,14 @@ import { store as coreStore } from '@wordpress/core-data';
 import { store as reusableBlocksStore } from '../../store';
 
 function ReusableBlocksManageButton( { clientId } ) {
-	const { isVisible } = useSelect(
+	const { canRemove, isVisible } = useSelect(
 		( select ) => {
-			const { getBlock } = select( blockEditorStore );
+			const { getBlock, canRemoveBlock } = select( blockEditorStore );
 			const { canUser } = select( coreStore );
 			const reusableBlock = getBlock( clientId );
 
 			return {
+				canRemove: canRemoveBlock( clientId ),
 				isVisible:
 					!! reusableBlock &&
 					isReusableBlock( reusableBlock ) &&
@@ -53,9 +54,11 @@ function ReusableBlocksManageButton( { clientId } ) {
 			>
 				{ __( 'Manage Reusable blocks' ) }
 			</MenuItem>
-			<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
-				{ __( 'Convert to regular blocks' ) }
-			</MenuItem>
+			{ canRemove && (
+				<MenuItem onClick={ () => convertBlockToStatic( clientId ) }>
+					{ __( 'Convert to regular blocks' ) }
+				</MenuItem>
+			) }
 		</BlockSettingsMenuControls>
 	);
 }


### PR DESCRIPTION
## What?
Part of #29864.
Similar to #39541.

When block removal is locked, disable the "Convert to regular blocks" action.

## Why?
The action removes the Reusable block.

## Testing Instructions

1. Open a Post or Page.
2. Insert a Reusable block.
3. Lock block removal.
4. Confirm that the "Convert to regular blocks" action is disabled.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/161032049-a9923f77-95fc-478f-ae5d-a2c74a2ac9c0.mp4


