### PR TITLE
Add: Space to indent list item

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -7,7 +7,7 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { isRTL, __ } from '@wordpress/i18n';
+import { isRTL, __, _x } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { ToolbarButton } from '@wordpress/components';
 import {
@@ -24,6 +24,7 @@ import { useMergeRefs } from '@wordpress/compose';
 import {
 	useEnter,
 	useBackspace,
+	useSpace,
 	useIndentListItem,
 	useOutdentListItem,
 } from './hooks';
@@ -45,6 +46,7 @@ function IndentUI( { clientId } ) {
 				icon={ isRTL() ? formatIndentRTL : formatIndent }
 				title={ __( 'Indent' ) }
 				describedBy={ __( 'Indent list item' ) }
+				shortcut={ _x( 'Space', 'keyboard key' ) }
 				isDisabled={ ! canIndent }
 				onClick={ indentListItem }
 			/>
@@ -67,11 +69,16 @@ export default function ListItemEdit( {
 	} );
 	const useEnterRef = useEnter( { content, clientId } );
 	const useBackspaceRef = useBackspace( { clientId } );
+	const useSpaceRef = useSpace( clientId );
 	return (
 		<>
 			<li { ...innerBlocksProps }>
 				<RichText
-					ref={ useMergeRefs( [ useEnterRef, useBackspaceRef ] ) }
+					ref={ useMergeRefs( [
+						useEnterRef,
+						useBackspaceRef,
+						useSpaceRef,
+					] ) }
 					identifier="content"
 					tagName="div"
 					onChange={ ( nextContent ) =>

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -46,7 +46,6 @@ function IndentUI( { clientId } ) {
 				icon={ isRTL() ? formatIndentRTL : formatIndent }
 				title={ __( 'Indent' ) }
 				describedBy={ __( 'Indent list item' ) }
-				shortcut={ _x( 'Space', 'keyboard key' ) }
 				isDisabled={ ! canIndent }
 				onClick={ indentListItem }
 			/>

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -7,7 +7,7 @@ import {
 	useInnerBlocksProps,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { isRTL, __, _x } from '@wordpress/i18n';
+import { isRTL, __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 import { ToolbarButton } from '@wordpress/components';
 import {

--- a/packages/block-library/src/list-item/hooks/index.js
+++ b/packages/block-library/src/list-item/hooks/index.js
@@ -2,3 +2,4 @@ export { default as useOutdentListItem } from './use-outdent-list-item';
 export { default as useIndentListItem } from './use-indent-list-item';
 export { default as useEnter } from './use-enter';
 export { default as useBackspace } from './use-backspace';
+export { default as useSpace } from './use-space';

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+import { SPACE } from '@wordpress/keycodes';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useIndentListItem from './use-indent-list-item';
+
+export default function useSpace( clientId ) {
+	const { getSelectionStart, getSelectionEnd } = useSelect(
+		blockEditorStore
+	);
+	const [ canIndent, indentListItem ] = useIndentListItem( clientId );
+
+	return useRefEffect(
+		( element ) => {
+			function onKeyDown( event ) {
+				if ( event.defaultPrevented || event.keyCode !== SPACE ) {
+					return;
+				}
+				if ( canIndent ) {
+					const selectionStart = getSelectionStart();
+					const selectionEnd = getSelectionEnd();
+					if (
+						selectionStart.offset === 0 &&
+						selectionEnd.offset === 0
+					) {
+						event.preventDefault();
+						indentListItem();
+					}
+				}
+			}
+
+			element.addEventListener( 'keydown', onKeyDown );
+			return () => {
+				element.removeEventListener( 'keydown', onKeyDown );
+			};
+		},
+		[ canIndent, indentListItem ]
+	);
+}

--- a/packages/block-library/src/list-item/hooks/use-space.js
+++ b/packages/block-library/src/list-item/hooks/use-space.js
@@ -20,19 +20,21 @@ export default function useSpace( clientId ) {
 	return useRefEffect(
 		( element ) => {
 			function onKeyDown( event ) {
-				if ( event.defaultPrevented || event.keyCode !== SPACE ) {
+				if (
+					event.defaultPrevented ||
+					event.keyCode !== SPACE ||
+					! canIndent
+				) {
 					return;
 				}
-				if ( canIndent ) {
-					const selectionStart = getSelectionStart();
-					const selectionEnd = getSelectionEnd();
-					if (
-						selectionStart.offset === 0 &&
-						selectionEnd.offset === 0
-					) {
-						event.preventDefault();
-						indentListItem();
-					}
+				const selectionStart = getSelectionStart();
+				const selectionEnd = getSelectionEnd();
+				if (
+					selectionStart.offset === 0 &&
+					selectionEnd.offset === 0
+				) {
+					event.preventDefault();
+					indentListItem();
 				}
 			}
 


### PR DESCRIPTION
This PR adds functionality to indent a list item when space is pressed in be beginning of a list item.
Fixes: https://github.com/WordPress/gutenberg/issues/39875

## Testing Instructions
I verified that by pressing space in the begging of a list item I can indent it.
