### PR TITLE
fixed Empty space when an empty image block

### DIFF
--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -27,7 +27,7 @@ export default function save( { attributes } ) {
 	} = attributes;
 
 	const newRel = isEmpty( rel ) ? undefined : rel;
-	if(! attributes.url){
+	if ( ! url )  {
 		return null;
 	}
 
@@ -67,9 +67,9 @@ export default function save( { attributes } ) {
 			) }
 		</>
 	);
-		return (
-			<figure { ...useBlockProps.save( { className: classes } ) }>
-				{ figure }
-			</figure>
-		);
+	return (
+		<figure { ...useBlockProps.save( { className: classes } ) }>
+			{ figure }
+		</figure>
+	);
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -27,6 +27,9 @@ export default function save( { attributes } ) {
 	} = attributes;
 
 	const newRel = isEmpty( rel ) ? undefined : rel;
+	if(! attributes.url){
+		return null;
+	}
 
 	const classes = classnames( {
 		[ `align${ align }` ]: align,
@@ -64,12 +67,9 @@ export default function save( { attributes } ) {
 			) }
 		</>
 	);
-	if ( attributes.url ) {
 		return (
 			<figure { ...useBlockProps.save( { className: classes } ) }>
 				{ figure }
 			</figure>
 		);
-	}
-	return null;
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -26,10 +26,11 @@ export default function save( { attributes } ) {
 		title,
 	} = attributes;
 
-	const newRel = isEmpty( rel ) ? undefined : rel;
-	if ( ! url )  {
+	if ( ! url ) {
 		return null;
 	}
+	const newRel = isEmpty( rel ) ? undefined : rel;
+	
 
 	const classes = classnames( {
 		[ `align${ align }` ]: align,

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -64,7 +64,7 @@ export default function save( { attributes } ) {
 			) }
 		</>
 	);
-	if(attributes.url){
+	if ( attributes.url ) {
 		return (
 			<figure { ...useBlockProps.save( { className: classes } ) }>
 				{ figure }
@@ -72,5 +72,4 @@ export default function save( { attributes } ) {
 		);
 	}
 	return null;
-	
 }

--- a/packages/block-library/src/image/save.js
+++ b/packages/block-library/src/image/save.js
@@ -64,10 +64,13 @@ export default function save( { attributes } ) {
 			) }
 		</>
 	);
-
-	return (
-		<figure { ...useBlockProps.save( { className: classes } ) }>
-			{ figure }
-		</figure>
-	);
+	if(attributes.url){
+		return (
+			<figure { ...useBlockProps.save( { className: classes } ) }>
+				{ figure }
+			</figure>
+		);
+	}
+	return null;
+	
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixed https://github.com/WordPress/gutenberg/issues/39612
## What?

Remove Empty space on the front end when an empty image block is added.

## Why?

It will add an 

unnecessary empty image tag on front end layout

## How?

check condition if an image is set then only it will display the image tag

## Testing Instructions

1. Open the Post page

2. Insert Image block but do not add any image

3. Front end you can check there is no empty figure tag

## Screenshots or screencast <!-- if applicable -->
<img width="750" alt="image-block-backend" src="https://user-images.githubusercontent.com/82029773/161078710-919a62c6-9773-4099-b3cc-40dd99fcee82.png">
<img width="1085" alt="image-block-frontend" src="https://user-images.githubusercontent.com/82029773/161078671-1e4ad962-156f-4181-b3fd-8ad31ac1a127.png">

