### PR TITLE
Add: Raw handling to the new list block.

### DIFF
--- a/packages/block-library/src/list/v2/migrate.js
+++ b/packages/block-library/src/list/v2/migrate.js
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
  */
 import { createBlock } from '@wordpress/blocks';
 
-function createListBlockFromDOMElement( listElement ) {
+export function createListBlockFromDOMElement( listElement ) {
 	const listAttributes = {
 		ordered: 'OL' === listElement.tagName,
 		start: listElement.getAttribute( 'start' )


### PR DESCRIPTION
This PR adds simple raw handling similar to what we had before to the new list block.
Part of: https://github.com/WordPress/gutenberg/issues/39887


## Testing Instructions
I pasted the following HTML on the block editor and verified it was correctly added as list blocks:
```
<ul>
<li>1</li>
<li>2</li>
<li>3</li>
<li>4</li>
<li>5</li>
</ul>

<ul>
   <li>
      1
      <ul>
         <li>
            <strong>2</strong>
            <ul>
               <li><strong>3</strong></li>
            </ul>
         </li>
      </ul>
   </li>
   <li>4<em>a</em></li>
   <li><em>b</em>5</li>
</ul>
```