### PR TITLE
Updated "Areas" to "Template Parts" in FSE editor.

### DIFF
--- a/packages/edit-site/src/components/template-details/template-areas.js
+++ b/packages/edit-site/src/components/template-details/template-areas.js
@@ -144,7 +144,7 @@ export default function TemplateAreas( { closeTemplateDetailsDropdown } ) {
 
 	return (
 		<MenuGroup
-			label={ __( 'Areas' ) }
+			label={ __( 'Template Parts' ) }
 			className="edit-site-template-details__group edit-site-template-details__template-areas"
 		>
 			{ templateParts.map( ( { templatePart, block } ) => (


### PR DESCRIPTION
fixed #39924

## What?
When editing a template, and you click on the dropdown for the template editor, 'Areas' should be renamed to 'Template Parts'. 

## Why?
It can be very confusing for a user to distinguish the reason for those template parts being there, without being explicitly guided on how they are related to the site that they are building. 

## How?
Changed the text, 'Areas' to 'Template Parts'. 

## Testing Instructions
Below step by step instructions on how to generate this issue.
1. Open a Post or Page with FSE editor.
2. Open the dropdown option above the header to change template.
3. It shows popup with "Areas" label.


