### PR TITLE
E2E Tests: Use templates endpoint to delete templates

### DIFF
--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { rest, batch } from './rest-api';
+import { rest } from './rest-api';
 
 const PATH_MAPPING = {
 	wp_template: '/wp/v2/templates',
@@ -22,12 +22,31 @@ export async function deleteAllTemplates( type ) {
 
 	const templates = await rest( { path } );
 
-	await batch(
-		templates
-			.filter( ( template ) => !! template.wp_id )
-			.map( ( template ) => ( {
+	if ( ! templates?.length ) {
+		return;
+	}
+
+	const responses = [];
+
+	for ( const template of templates ) {
+		if ( ! template?.wp_id ) {
+			continue;
+		}
+
+		try {
+			await rest( {
+				path: `${ path }/${ template.id }?force=true`,
 				method: 'DELETE',
-				path: `/wp/v2/posts/${ template.wp_id }?force=true`,
-			} ) )
-	);
+			} );
+		} catch ( responseError ) {
+			// Disable reason - the error provides valuable feedback about issues with tests.
+			// eslint-disable-next-line no-console
+			console.warn(
+				'deleteAllTemplates failed to delete template with the following error',
+				responseError
+			);
+		}
+	}
+
+	return responses;
 }

--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -26,8 +26,6 @@ export async function deleteAllTemplates( type ) {
 		return;
 	}
 
-	const responses = [];
-
 	for ( const template of templates ) {
 		if ( ! template?.wp_id ) {
 			continue;
@@ -47,6 +45,4 @@ export async function deleteAllTemplates( type ) {
 			);
 		}
 	}
-
-	return responses;
 }


### PR DESCRIPTION
## What?
Alternative to #39898.

Hopefully fixes #37764, though I still feel like there might be other issues with this test. Let's merge this and see.

When debugging the `deleteAllTemplates` util, I noticed it was regularly returning the following responses in the batch api request that performs the delete:
```json
{"body": {"code": "rest_post_invalid_id", "data": {"status": 404}, "message": "Invalid post ID."}, "headers": [], "status": 404}
```

It seems like the post endpoint can't be reliably used to delete template parts, so in this PR I'm switching to the templates endpoints (the same as we use in the editor for deleting template/template parts).
