### PR TITLE
Column: Add border support to column blocks

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -41,6 +41,18 @@
 				"padding": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"__experimentalLayout": true
 	}
 }

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -43,12 +43,10 @@
 		},
 		"__experimentalBorder": {
 			"color": true,
-			"radius": true,
 			"style": true,
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
-				"radius": true,
 				"style": true,
 				"width": true
 			}

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -71,25 +71,6 @@
 			}
 		}
 	}
-
-	// Hide individual left and right borders when the "stack on mobile" option
-	// is enabled and on the mobile viewport. This still allows for simple
-	// uniform flat border to retain its left/right borders.
-	&:where(:not(.is-not-stacked-on-mobile)) {
-		@media (max-width: #{ ($break-medium - 1) }) {
-			& > .wp-block-column[style*="border-left-width"],
-			& > .wp-block-column[style*="border-left-style"],
-			& > .wp-block-column[class*="has-border-left-color"] {
-				border-left-width: 0 !important;
-			}
-
-			& > .wp-block-column[style*="border-right-width"],
-			& > .wp-block-column[class*="has-border-right-color"],
-			& > .wp-block-column[style*="border-right-style"] {
-				border-right-width: 0 !important;
-			}
-		}
-	}
 }
 
 // Add low specificity default padding to columns blocks with backgrounds.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -71,6 +71,20 @@
 			}
 		}
 	}
+
+	&:where(:not(.is-not-stacked-on-mobile)) {
+		@media (max-width: #{ ($break-medium - 1) }) {
+			& > .wp-block-column[class*="has-border-"], // Clear when color defined.
+			& > .wp-block-column[style*="border-style"], // Clear when border style set.
+			& > .wp-block-column[style*="border-width"],
+			& > .wp-block-column[style*="border-top-width"],
+			& > .wp-block-column[style*="border-right-width"],
+			& > .wp-block-column[style*="border-bottom-width"],
+			& > .wp-block-column[style*="border-left-width"] {
+				border-width: 0 !important;
+			}
+		}
+	}
 }
 
 // Add low specificity default padding to columns blocks with backgrounds.

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -72,16 +72,21 @@
 		}
 	}
 
+	// Hide individual left and right borders when the "stack on mobile" option
+	// is enabled and on the mobile viewport. This still allows for simple
+	// uniform flat border to retain its left/right borders.
 	&:where(:not(.is-not-stacked-on-mobile)) {
 		@media (max-width: #{ ($break-medium - 1) }) {
-			& > .wp-block-column[class*="has-border-"], // Clear when color defined.
-			& > .wp-block-column[style*="border-style"], // Clear when border style set.
-			& > .wp-block-column[style*="border-width"],
-			& > .wp-block-column[style*="border-top-width"],
+			& > .wp-block-column[style*="border-left-width"],
+			& > .wp-block-column[style*="border-left-style"],
+			& > .wp-block-column[class*="has-border-left-color"] {
+				border-left-width: 0 !important;
+			}
+
 			& > .wp-block-column[style*="border-right-width"],
-			& > .wp-block-column[style*="border-bottom-width"],
-			& > .wp-block-column[style*="border-left-width"] {
-				border-width: 0 !important;
+			& > .wp-block-column[class*="has-border-right-color"],
+			& > .wp-block-column[style*="border-right-style"] {
+				border-right-width: 0 !important;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/21889

Related:
- https://github.com/WordPress/gutenberg/issues/21889
- https://github.com/WordPress/gutenberg/pull/37770
- https://github.com/WordPress/gutenberg/pull/31737

## What?

Opts into border support for individual column blocks.

## Why?

To achieve [block patterns and designs](https://github.com/WordPress/gutenberg/issues/21889#issuecomment-673829155) where columns use borders as visual separators.

<img src="https://user-images.githubusercontent.com/4550351/90201130-46b66d80-de1d-11ea-8cca-12e5b1ee781f.png" />

<img src="https://user-images.githubusercontent.com/4550351/90201637-c3961700-de1e-11ea-90d2-500892152156.png" />

## How?

Leverages the new `BorderBoxControl` and individual border side block supports to offer control over inner `Column` block borders.

## Questions

1. Do individual columns benefit at all from offering border-radius support?
2. Does the lack of responsive styling options for block supports block the addition of border support for column blocks?
    - This PR originally had [some trial CSS styles](https://github.com/WordPress/gutenberg/commit/935574abdd21723c0dd60cf177b54c9c31cac1fe) to force `0` width border when stacked on mobile.
3. Would forcing the overriding of border support provided inner column styles be too restrictive? Given the inline styles in play this would require the use of `!important`

## Testing Instructions
1. Checkout this PR branch, create a new post, add `Columns` and some inner `Column` blocks with content
2. Experiment setting borders on the inner `Column` blocks
    - It may help to remove block spacing for the columns and add padding so that the borders are evenly between columns. (This might be another point of friction for Column borders)
3. Test with and without the `Columns` block stacking on mobile
4. Check frontend/editor both on desktop and mobile viewports

<details>
<summary>Example columns code</summary>

```html
<!-- wp:columns {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"},"blockGap":"0px"}}} -->
<div class="wp-block-columns" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:column {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"}}}} -->
<div class="wp-block-column" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:image {"id":193,"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img src="http://localhost:4759/wp-content/uploads/2022/03/jorge-gardner-xwJgnoopjjg-unsplash.jpg" alt="" class="wp-image-193"/><figcaption>Image in column 1</figcaption></figure>
<!-- /wp:image --></div>
<!-- /wp:column -->

<!-- wp:column {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"}}}} -->
<div class="wp-block-column" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"}}}} -->
<div class="wp-block-column" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:paragraph {"align":"left"} -->
<p class="has-text-align-left">Duis aute irure dolor in reprehenderit in voluptate</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
</details>

## Screenshots or screencast <!-- if applicable -->

##### Demo

https://user-images.githubusercontent.com/60436221/161205549-92320b9c-a7d5-49e1-86d6-0162c59c155a.mp4

##### Responsive Styling Issue

Example of behaviour without forcing borders on mobile to be hidden

https://user-images.githubusercontent.com/60436221/161205574-9f6116a1-096f-4f4f-83ae-be229a838c57.mp4


