### PR TITLE
Fix list-view focus radius.

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -15,7 +15,8 @@
 	// Use position relative for row animation.
 	position: relative;
 
-	&.is-selected {
+	// The background has to be applied to the td, not tr, or border-radius won't work.
+	&.is-selected td {
 		background: var(--wp-admin-theme-color);
 	}
 	&.is-selected .block-editor-list-view-block-contents,
@@ -40,27 +41,41 @@
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) $white;
 	}
 
+	&.is-dragging {
+		display: none;
+	}
+
+	// Border radius for corners of the selected item.
+	&.is-selected td:first-child {
+		border-radius: $radius-block-ui 0 0 $radius-block-ui;
+	}
+	&.is-selected td:last-child {
+		border-radius: 0 $radius-block-ui $radius-block-ui 0;
+	}
 	&.is-branch-selected:not(.is-selected) {
 		// Lighten a CSS variable without introducing a new SASS variable
 		background:
 			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
 			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
 	}
-	&.is-branch-selected.is-selected .block-editor-list-view-block-contents {
-		border-radius: 2px 2px 0 0;
+	&.is-branch-selected.is-selected td:first-child {
+		border-radius: $radius-block-ui 0 0 0;
+	}
+	&.is-branch-selected.is-selected td:last-child {
+		border-radius: 0 $radius-block-ui 0 0;
 	}
 	&[aria-expanded="false"] {
-		&.is-branch-selected.is-selected .block-editor-list-view-block-contents {
-			border-radius: 2px;
+		&.is-branch-selected.is-selected td:first-child {
+			border-radius: $radius-block-ui 0 0 $radius-block-ui;
+		}
+		&.is-branch-selected.is-selected td:last-child {
+			border-radius: 0 $radius-block-ui $radius-block-ui 0;
 		}
 	}
-	&.is-branch-selected:not(.is-selected) .block-editor-list-view-block-contents {
+	&.is-branch-selected:not(.is-selected) td {
 		border-radius: 0;
 	}
 
-	&.is-dragging {
-		display: none;
-	}
 
 	// List View renders a fixed number of items and relies on each item having a fixed height of 36px.
 	// If this value changes, we should also change the itemHeight value set in useFixedWindowList.
@@ -73,7 +88,7 @@
 		padding: ($grid-unit-15 * 0.5) $grid-unit-15 ($grid-unit-15 * 0.5) 0;
 		text-align: left;
 		color: $gray-900;
-		border-radius: 2px;
+		border-radius: $radius-block-ui;
 		position: relative;
 		white-space: nowrap;
 
@@ -106,7 +121,7 @@
 			left: 0;
 			border-radius: inherit;
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-			z-index: 1;
+			z-index: 2;
 			pointer-events: none;
 
 			// Hide focus styles while a user is dragging blocks/files etc.


### PR DESCRIPTION
## What?

#35170 enabled the ellipsis in list view. In doing so, instead of having a single `td` element in a `tr`, there were two, and so the blue background color was moved from `td` to `tr`.

Unfortunately, `tr` is unaffected by border radius, so the 2px border radius stopped working:
<img width="392" alt="Screenshot 2022-04-01 at 09 18 16" src="https://user-images.githubusercontent.com/1204802/161218290-d1222a9b-8a25-4ec2-ac5a-d5ab2a613bd9.png">

This PR fixes that, mostly:
<img width="365" alt="Screenshot 2022-04-01 at 09 36 47" src="https://user-images.githubusercontent.com/1204802/161218301-7695a21e-0472-423e-a14d-906291fa0273.png">

I haven't found a good way to apply the bottom two corners of the light blue background, so those are still square.

## Testing Instructions

Test the list view and observe rounded corners.