### PR TITLE
[Block Library - Query Loop]: Fix some missing term sanitizations

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -77,16 +77,18 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 		if ( ! empty( $block->context['query']['categoryIds'] ) || ! empty( $block->context['query']['tagIds'] ) ) {
 			$tax_query = array();
 			if ( ! empty( $block->context['query']['categoryIds'] ) ) {
-				$tax_query[] = array(
+				$category_ids = array_filter( array_map( 'intval', $block->context['query']['categoryIds'] ) );
+				$tax_query[]  = array(
 					'taxonomy'         => 'category',
-					'terms'            => $block->context['query']['categoryIds'],
+					'terms'            => $category_ids,
 					'include_children' => false,
 				);
 			}
 			if ( ! empty( $block->context['query']['tagIds'] ) ) {
+				$tag_ids     = array_filter( array_map( 'intval', $block->context['query']['tagIds'] ) );
 				$tax_query[] = array(
 					'taxonomy'         => 'post_tag',
-					'terms'            => $block->context['query']['tagIds'],
+					'terms'            => $tag_ids,
 					'include_children' => false,
 				);
 			}
@@ -95,10 +97,8 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 		if ( ! empty( $block->context['query']['taxQuery'] ) ) {
 			$query['tax_query'] = array();
 			foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
-				if ( ! empty( $terms ) ) {
-					$term_ids = array_map( 'intval', $terms );
-					$term_ids = array_filter( $term_ids );
-
+				if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
+					$term_ids             = array_filter( array_map( 'intval', $terms ) );
 					$query['tax_query'][] = array(
 						'taxonomy'         => $taxonomy,
 						'terms'            => $term_ids,

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -101,7 +101,7 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 
 					$query['tax_query'][] = array(
 						'taxonomy'         => $taxonomy,
-						'terms'            => $terms,
+						'terms'            => $term_ids,
 						'include_children' => false,
 					);
 				}

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -77,18 +77,16 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 		if ( ! empty( $block->context['query']['categoryIds'] ) || ! empty( $block->context['query']['tagIds'] ) ) {
 			$tax_query = array();
 			if ( ! empty( $block->context['query']['categoryIds'] ) ) {
-				$category_ids = array_filter( array_map( 'intval', $block->context['query']['categoryIds'] ) );
-				$tax_query[]  = array(
+				$tax_query[] = array(
 					'taxonomy'         => 'category',
-					'terms'            => $category_ids,
+					'terms'            => array_filter( array_map( 'intval', $block->context['query']['categoryIds'] ) ),
 					'include_children' => false,
 				);
 			}
 			if ( ! empty( $block->context['query']['tagIds'] ) ) {
-				$tag_ids     = array_filter( array_map( 'intval', $block->context['query']['tagIds'] ) );
 				$tax_query[] = array(
 					'taxonomy'         => 'post_tag',
-					'terms'            => $tag_ids,
+					'terms'            => array_filter( array_map( 'intval', $block->context['query']['tagIds'] ) ),
 					'include_children' => false,
 				);
 			}
@@ -98,10 +96,9 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 			$query['tax_query'] = array();
 			foreach ( $block->context['query']['taxQuery'] as $taxonomy => $terms ) {
 				if ( is_taxonomy_viewable( $taxonomy ) && ! empty( $terms ) ) {
-					$term_ids             = array_filter( array_map( 'intval', $terms ) );
 					$query['tax_query'][] = array(
 						'taxonomy'         => $taxonomy,
-						'terms'            => $term_ids,
+						'terms'            => array_filter( array_map( 'intval', $terms ) ),
 						'include_children' => false,
 					);
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a bug found by @hellofromtonya [here](https://github.com/WordPress/gutenberg/pull/38063#discussion_r839847066).

> $term_ids isn't being used. Shouldn't it be used to set the IDs for $query['tax_query'][]['terms']?

It should use the sanitized value(`$term_ids`).

## Notes

The changes of this PR when merged, need to be added to the core PR here: https://github.com/WordPress/wordpress-develop/pull/2488.


## Testing instructions
1. Everything should work as before.
