### PR TITLE
mapResolveSelectors: exclude all meta-selectors, handle selectors without resolvers

### DIFF
--- a/packages/data/src/redux-store/test/index.js
+++ b/packages/data/src/redux-store/test/index.js
@@ -4,7 +4,7 @@
 import { createRegistry } from '../../registry';
 import { createRegistryControl } from '../../factory';
 
-jest.useFakeTimers();
+jest.useRealTimers();
 
 describe( 'controls', () => {
 	let registry;
@@ -90,7 +90,6 @@ describe( 'controls', () => {
 			} );
 
 			registry.select( 'store' ).getItems();
-			jest.runAllTimers();
 		} );
 	} );
 	describe( 'selectors have expected value for the `hasResolver` property', () => {
@@ -250,6 +249,7 @@ describe( 'resolveSelect', () => {
 			},
 			selectors: {
 				getItems: () => 'items',
+				getItemsNoResolver: () => 'items-no-resolver',
 			},
 			resolvers: {
 				getItems: () => {
@@ -264,16 +264,26 @@ describe( 'resolveSelect', () => {
 	it( 'resolves when the resolution succeeded', async () => {
 		shouldFail = false;
 		const promise = registry.resolveSelect( 'store' ).getItems();
-		jest.runAllTimers();
-		await expect( promise ).resolves.toEqual( 'items' );
+		await expect( promise ).resolves.toBe( 'items' );
 	} );
 
 	it( 'rejects when the resolution failed', async () => {
 		shouldFail = true;
 		const promise = registry.resolveSelect( 'store' ).getItems();
-		jest.runAllTimers();
 		await expect( promise ).rejects.toEqual(
 			new Error( 'cannot fetch items' )
 		);
+	} );
+
+	it( 'resolves when calling a sync selector without resolver', async () => {
+		const promise = registry.resolveSelect( 'store' ).getItemsNoResolver();
+		await expect( promise ).resolves.toBe( 'items-no-resolver' );
+	} );
+
+	it( 'returns only store native selectors and excludes all meta ones', () => {
+		expect( Object.keys( registry.resolveSelect( 'store' ) ) ).toEqual( [
+			'getItems',
+			'getItemsNoResolver',
+		] );
 	} );
 } );


### PR DESCRIPTION
Fixes two bugs in `wp.data.resolveSelect`:
- when called with a selector that has no resolver, the returned Promise would never resolve and would wait forever. This PR fixes that by returning a Promise that resolves immediately with the synchronous result of the selector.
- the dictionary returned from `resolveSelector` is supposed to not contain the store's meta-selectors (the ones that query resolution status). There should be only the "native" selectors. That used to work, but then a handful of new meta-selectors were added, and `resolveSelect` wasn't updated. This PR fixes that.

The PR contains two new unit tests that illustrate both issues nicely. In the unit test suite, I also switched from Jest fake timers to real ones, saving us a few calls to `jest.runAllTimers`.