### PR TITLE
Global Styles Sidebar: tweak preview box

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -44,6 +44,8 @@ const secondFrame = {
 const normalizedWidth = 248;
 const normalizedHeight = 152;
 
+const normalizedColorSwatchSize = 32;
+
 const StylesPreview = ( { label, isFocused } ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useStyle( 'typography.fontFamily' );
@@ -134,10 +136,15 @@ const StylesPreview = ( { label, isFocused } ) => {
 								<div
 									key={ slug }
 									style={ {
-										height: 30 * ratio,
-										width: 30 * ratio,
+										height:
+											normalizedColorSwatchSize * ratio,
+										width:
+											normalizedColorSwatchSize * ratio,
 										background: color,
-										borderRadius: 15 * ratio,
+										borderRadius:
+											( normalizedColorSwatchSize *
+												ratio ) /
+											2,
 									} }
 								/>
 							) ) }

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -131,7 +131,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 						>
 							Aa
 						</div>
-						<VStack spacing={ 2 * ratio }>
+						<VStack spacing={ 4 * ratio }>
 							{ highlightedColors.map( ( { slug, color } ) => (
 								<div
 									key={ slug }

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -41,7 +41,8 @@ const secondFrame = {
 	},
 };
 
-const normalizedWidth = 250;
+const normalizedWidth = 248;
+const normalizedHeight = 152;
 
 const StylesPreview = ( { label, isFocused } ) => {
 	const [ fontWeight ] = useStyle( 'typography.fontWeight' );
@@ -81,7 +82,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 			className="edit-site-global-styles-preview__iframe"
 			head={ <EditorStyles styles={ styles } /> }
 			style={ {
-				height: 150 * ratio,
+				height: normalizedHeight * ratio,
 				visibility: ! width ? 'hidden' : 'visible',
 			} }
 			onMouseEnter={ () => setIsHovered( true ) }
@@ -91,7 +92,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 			{ containerResizeListener }
 			<motion.div
 				style={ {
-					height: 150 * ratio,
+					height: normalizedHeight * ratio,
 					width: '100%',
 					background: gradientValue ?? backgroundColor,
 					cursor: 'pointer',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR tweaks a few aspects around the preview box in the Global Styles sidebar, as flagged in #38934:

- outer size of the box changed to `248x152`
- size of color swatches changed to `32x32`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is in order to follow the design specs highlighted in #38934 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Changed `normalizedWidth` from `250` to `248` px
- Changed the height from `150` to `152` px, and extracted to a new local `normalizedHeight` variable
- Changed the size of the color swatch to `32` px, and extracted to a new local `normalizedColorSwatchSize` variable

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Select a theme that supports Full Site Editing
- Visit the site editor (from any WPAdmin screen, select "Appearance" and then "Editor" in the WPAdmin menu on the left)
- Notice the size of the preview box in the Global Styles sidebar on the right part of the screen — it should be `248 x 152` px
- Within that preview box, notice the size of the color swatch — it should be a circle with a diameter of `32` px 

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2022-04-01 at 15 55 02](https://user-images.githubusercontent.com/1083581/161277753-782a51c7-2dcd-474a-b98a-6e49ff954254.png)

![Screenshot 2022-04-01 at 15 55 17](https://user-images.githubusercontent.com/1083581/161277813-5c446cb3-8172-4c56-88ab-ea6b55af2915.png)

