### PR TITLE
Global Styles Sidebar: wrap the preview box in the CardMedia component

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -10,6 +10,7 @@ import {
 	CardBody,
 	Card,
 	CardDivider,
+	CardMedia,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight, Icon } from '@wordpress/icons';
@@ -37,7 +38,9 @@ function ScreenRoot() {
 			<CardBody>
 				<VStack spacing={ 2 }>
 					<Card>
-						<StylesPreview />
+						<CardMedia>
+							<StylesPreview />
+						</CardMedia>
 					</Card>
 					{ !! variations?.length && (
 						<NavigationButton path="/variations">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR aims at improving the way the border around the preview box in the Global Styles sidebar is rendered, as flagged in #38934 under the _"Smooth the corners of the styles box."_ point.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is in order to follow the design specs highlighted in #38934 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Until now, the `<StylesPreview />` component has been a direct child of `<Card />`. Since the border on the `Card` component is implemented via `box-shadow` (see #35245 for some conversations around that), the `<StylesPreview />` component has been rendering on top of the rounded corners of the `<Card />` component, causing those rounded corners to look _glitchy_.

This PR avoids the issue by wrapping `<StylesPreview />` in a `<CardMedia />` component. The `<CardMedia />` component, in fact, is able to apply the same corner radius to itself and therefore, with the addition of the `overflow: hidden` rule, is able to fix the issue described in the paragraph above.

_Note: as explained in #35245 and #38934, it's still possible that browser rendering engines can introduce some sub-pixel / anti-aliasing artefacts, especially with the technique that is currently employed by the `Card` component for rendering its border via the `box-shadow` property._

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On `trunk`:

- Select a theme that supports Full Site Editing
- Visit the site editor (from any WPAdmin screen, select "Appearance" and then "Editor" in the WPAdmin menu on the left)
- Notice the corners of the preview box in the Global Styles sidebar on the right part of the screen. Observe how the border, along the corners, is not being rendered correctly (it's partially "hidden" by the overlapping squared corners of the box contents)

Apply the changes from this PR, and this time notice how the borders of the preview box are being rendered in a "smoother" way, without being overlapped by the contents of the box itself.

_(Note: this fix may be difficult to appreciate depending on the resolution of the screen used to review them. One way to make the fix more noticeable is to change the value of [the `cardBorderRadius` option](https://github.com/WordPress/gutenberg/blob/30f900ec5e925bdd218a8845db533765834e9e0b/packages/components/src/utils/config-values.js#L64) to a higher value, e.g. `6px`)_

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| ![Screenshot 2022-04-01 at 16 44 22](https://user-images.githubusercontent.com/1083581/161286694-2ec65a37-2fe8-4e37-b74a-0530f7fac16b.png) | ![Screenshot 2022-04-01 at 16 48 46](https://user-images.githubusercontent.com/1083581/161287482-aabf8856-b45b-48f1-82be-da19e9fdd25c.png) |


With a higher value for `border-radius` (to demo/highlight the fix better):

| Before | After |
|---|---|
| ![Screenshot 2022-04-01 at 16 45 02](https://user-images.githubusercontent.com/1083581/161286821-e9f1129e-cb19-4e61-bf6b-ad56eaec2517.png) | ![Screenshot 2022-04-01 at 16 48 09](https://user-images.githubusercontent.com/1083581/161287355-f457331f-95cf-4594-8050-5a6da8950a17.png) |


