### PR TITLE
add min/max in `LetterSpacingControl` component

### DIFF
--- a/packages/block-editor/src/components/letter-spacing-control/index.js
+++ b/packages/block-editor/src/components/letter-spacing-control/index.js
@@ -13,6 +13,20 @@ import { __ } from '@wordpress/i18n';
 import useSetting from '../../components/use-setting';
 
 /**
+ * Minimum space between letters
+ *
+ * @type {number}
+ */
+const MIN_LETTER_SPACE = 0.1;
+
+/**
+ * Maximum space between letters
+ *
+ * @type {number}
+ */
+const MAX_LETTER_SPACE = 100;
+
+/**
  * Control for letter-spacing.
  *
  * @param {Object}                  props                      Component props.
@@ -38,6 +52,8 @@ export default function LetterSpacingControl( {
 			__unstableInputWidth={ __unstableInputWidth }
 			units={ units }
 			onChange={ onChange }
+			min={ MIN_LETTER_SPACE }
+			max={ MAX_LETTER_SPACE }
 		/>
 	);
 }


### PR DESCRIPTION
Fixes: #39993 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In this PR, I have added `min` and `max` control to `LetterSpacingControl`
component. This will help in avoiding letters overlapping in case of -ve value
and too much spacing in case of bigger letter spacing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a new post or page.
2. Add site-title block and write some text.
3. Change letter spacing to some negative value.
4. Save and publish.
5. Open same post and see no letters overlapping.

## Screenshots or screencast <!-- if applicable -->
