### PR TITLE
Block Locking: Styling changes for modal

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -11,7 +11,7 @@ import {
 	Icon,
 	Modal,
 } from '@wordpress/components';
-import { dragHandle, trash } from '@wordpress/icons';
+import { lock as lockIcon, unlock as unlockIcon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 
@@ -112,7 +112,13 @@ export default function BlockLockModal( { clientId, onClose } ) {
 								label={
 									<>
 										{ __( 'Disable movement' ) }
-										<Icon icon={ dragHandle } />
+										<Icon
+											icon={
+												lock.move
+													? lockIcon
+													: unlockIcon
+											}
+										/>
 									</>
 								}
 								checked={ lock.move }
@@ -129,7 +135,13 @@ export default function BlockLockModal( { clientId, onClose } ) {
 								label={
 									<>
 										{ __( 'Prevent removal' ) }
-										<Icon icon={ trash } />
+										<Icon
+											icon={
+												lock.remove
+													? lockIcon
+													: unlockIcon
+											}
+										/>
 									</>
 								}
 								checked={ lock.remove }

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -54,15 +54,8 @@ export default function BlockLockModal( { clientId, onClose } ) {
 	}, [ canMove, canRemove ] );
 
 	const isAllChecked = Object.values( lock ).every( Boolean );
-
-	let ariaChecked;
-	if ( isAllChecked ) {
-		ariaChecked = 'true';
-	} else if ( Object.values( lock ).some( Boolean ) ) {
-		ariaChecked = 'mixed';
-	} else {
-		ariaChecked = 'false';
-	}
+	const isIndeterminate =
+		Object.values( lock ).some( Boolean ) && ! isAllChecked;
 
 	return (
 		<Modal
@@ -98,7 +91,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 							<span id={ instanceId }>{ __( 'Lock all' ) }</span>
 						}
 						checked={ isAllChecked }
-						aria-checked={ ariaChecked }
+						indeterminate={ isIndeterminate }
 						onChange={ ( newValue ) =>
 							setLock( {
 								move: newValue,

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -13,7 +13,6 @@
 }
 
 .block-editor-block-lock-modal__options-title {
-	border-bottom: 1px solid $gray-300;
 	padding: $grid-unit-15 0;
 
 	.components-checkbox-control__label {
@@ -27,9 +26,8 @@
 	}
 }
 .block-editor-block-lock-modal__checklist-item {
-	border-bottom: 1px solid $gray-300;
 	margin-bottom: 0;
-	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-15;
+	padding: $grid-unit-15 0 $grid-unit-15 $grid-unit-40;
 
 	.components-base-control__field {
 		align-items: center;
@@ -47,6 +45,11 @@
 			margin-right: $grid-unit-15;
 			fill: $gray-900;
 		}
+	}
+
+	&:hover {
+		background-color: $gray-100;
+		border-radius: $radius-block-ui;
 	}
 }
 


### PR DESCRIPTION
## What?
PR addresses general block locking modal feedback from https://github.com/WordPress/gutenberg/pull/39950#issuecomment-1084917076.

Changes made in this PR:

* Removes the separator lines
* Increase padding so nested items line up correctly.
* Swap the existing icons for locked/unlocked icon indicators.
* Add hover state.
* Use [a new method](https://github.com/WordPress/gutenberg/pull/39462/) for Checkbox indeterminate state. This will fix how the `minus` icon is displayed.


## Testing Instructions
1. Open a Post or Page
2. Insert a Heading Block.
3. Open lock modal from Block options.
4. Confirm updates work as expected.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-04-03 at 15 46 16](https://user-images.githubusercontent.com/240569/161426411-49f3a29d-f370-4ded-a81a-5f9ddfa0b0ec.png)

