### PR TITLE
Template Parts: Hide 'Detach blocks' when locked

### DIFF
--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -13,6 +13,15 @@ export default function ConvertToRegularBlocks( { clientId } ) {
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
+	const canRemove = useSelect(
+		( select ) => select( blockEditorStore ).canRemoveBlock( clientId ),
+		[ clientId ]
+	);
+
+	if ( ! canRemove ) {
+		return null;
+	}
+
 	return (
 		<BlockSettingsMenuControls>
 			{ ( { onClose } ) => (


### PR DESCRIPTION
## What?
Part of #29864.
Similar to #39939.

When block removal is locked, disable the "Detach blocks from template part" action.

## Why?
The action removes the Template Parts block.

## Testing Instructions
1. Open the Site Editor.
2. Select Template Parts block.
3. Lock block removal.
4. Confirm that the "Detach blocks from template part" action is disabled.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/161427832-4d235cd5-08cc-4082-8228-329eab2f1178.mp4


