### PR TITLE
Unify comments link markup

### DIFF
--- a/packages/block-library/src/comments-pagination-next/index.php
+++ b/packages/block-library/src/comments-pagination-next/index.php
@@ -42,6 +42,18 @@ function render_block_core_comments_pagination_next( $attributes, $content, $blo
 	if ( ! isset( $next_comments_link ) ) {
 		return '';
 	}
+
+	/**
+	 * Ensure that next link markup is same with comment pagination number.
+	 *
+	 * @link https://github.com/WordPress/gutenberg/issues/37561
+	 */
+	$pos = strpos( $next_comments_link, 'cpage' );
+	if ( false === $pos ) {
+		$page               = get_query_var( 'cpage' );
+		$next_comments_link = add_query_arg( 'cpage', $page + 1, $next_comments_link );
+	}
+
 	return $next_comments_link;
 }
 

--- a/packages/block-library/src/comments-pagination-previous/index.php
+++ b/packages/block-library/src/comments-pagination-previous/index.php
@@ -35,6 +35,17 @@ function render_block_core_comments_pagination_previous( $attributes, $content, 
 		return '';
 	}
 
+	/**
+	 * Ensure that previous link markup is same with comment pagination number.
+	 *
+	 * @link https://github.com/WordPress/gutenberg/issues/37561
+	 */
+	$pos = strpos( $previous_comments_link, 'cpage' );
+	if ( false === $pos ) {
+		$page                   = get_query_var( 'cpage' );
+		$previous_comments_link = add_query_arg( 'cpage', $page - 1, $previous_comments_link );
+	}
+
 	return $previous_comments_link;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR changes previous link or next link in comments pagination when their link do not have the same markup with pagination number link.

<!-- In a few words, what is the PR actually doing? -->

## Why?
Fixes #37561

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
