### PR TITLE
Block title: return display title from the selector

### DIFF
--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -68,10 +68,7 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 
 describe( 'BlockTitle', () => {
 	it( 'renders nothing if name is falsey', () => {
-		useSelect.mockImplementation( () => ( {
-			name: null,
-			attributes: null,
-		} ) );
+		useSelect.mockImplementation( () => null );
 
 		const wrapper = shallow( <BlockTitle /> );
 


### PR DESCRIPTION
## What?
Porting over some of the ideas from https://github.com/WordPress/gutenberg/pull/32118

## Why?
...

## How?
Performing most of the selector work in `useSelect` and returning the label only.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
