### PR TITLE
Style Engine: remove since 6.0 comment

### DIFF
--- a/lib/style-engine/class-wp-style-engine-gutenberg.php
+++ b/lib/style-engine/class-wp-style-engine-gutenberg.php
@@ -16,8 +16,6 @@ if ( class_exists( 'WP_Style_Engine_Gutenberg' ) ) {
  *
  * Consolidates rendering block styles to reduce duplication and streamline
  * CSS styles generation.
- *
- * @since 6.0.0
  */
 class WP_Style_Engine_Gutenberg {
 	/**


### PR DESCRIPTION

## What?
Remove the `@ since 6.0` comment. 


## Why?
The Style Engine is not going into WordPress 6.0.

See: https://github.com/WordPress/gutenberg/issues/39889#issuecomment-1085066651

## How?

Using the delete key.

## Testing Instructions
👀 

