### PR TITLE
Try fixing template part tests again

### DIFF
--- a/packages/e2e-test-utils/src/templates.js
+++ b/packages/e2e-test-utils/src/templates.js
@@ -31,8 +31,10 @@ export async function deleteAllTemplates( type ) {
 			continue;
 		}
 
+		let response;
+
 		try {
-			await rest( {
+			response = await rest( {
 				path: `${ path }/${ template.id }?force=true`,
 				method: 'DELETE',
 			} );
@@ -40,8 +42,17 @@ export async function deleteAllTemplates( type ) {
 			// Disable reason - the error provides valuable feedback about issues with tests.
 			// eslint-disable-next-line no-console
 			console.warn(
-				'deleteAllTemplates failed to delete template with the following error',
+				`deleteAllTemplates failed to delete template (id: ${ template.wp_id }) with the following error`,
 				responseError
+			);
+		}
+
+		if ( ! response.deleted ) {
+			// Disable reason - the error provides valuable feedback about issues with tests.
+			// eslint-disable-next-line no-console
+			console.warn(
+				`deleteAllTemplates failed to delete template (id: ${ template.wp_id }) with the following response`,
+				response
 			);
 		}
 	}

--- a/packages/e2e-tests/specs/site-editor/template-part.test.js
+++ b/packages/e2e-tests/specs/site-editor/template-part.test.js
@@ -21,9 +21,11 @@ describe( 'Template Part', () => {
 		await deleteAllTemplates( 'wp_template' );
 		await deleteAllTemplates( 'wp_template_part' );
 	} );
-	afterAll( async () => {
+	afterEach( async () => {
 		await deleteAllTemplates( 'wp_template' );
 		await deleteAllTemplates( 'wp_template_part' );
+	} );
+	afterAll( async () => {
 		await activateTheme( 'twentytwentyone' );
 	} );
 


### PR DESCRIPTION
## What?
Follow up to #39965.

The test is still failing regularly.

This error seems to be the main cause now:
```
TypeError: Cannot read properties of null (reading 'frameElement') at BlockPopover
```
I'm not particularly familiar with that code or why it might be happening.

The assertion still sometimes fail with too many paragraphs, which indicates the test is still not cleaning up correctly.

I'm changing the test in this PR to use an `afterEach` instead of `afterAll`. The e2e tests in this project typically rely on a clean slate before each test case. I'm also adding some extra logging if deleting templates or template parts fails for any reason.