### PR TITLE
Gallery block: Add css var to enable theme authors to set a default gallery gap

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -111,7 +111,7 @@
 		"units": [ "px", "em", "rem", "vh", "vw" ],
 		"spacing": {
 			"blockGap": true,
-			"__experimentalSkipSerialization": true,
+			"__experimentalSkipSerialization": [ "blockGap" ],
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}

--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -111,6 +111,7 @@
 		"units": [ "px", "em", "rem", "vh", "vw" ],
 		"spacing": {
 			"blockGap": true,
+			"__experimentalSkipSerialization": true,
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -6,9 +6,11 @@ import { useContext, createPortal } from '@wordpress/element';
 
 export default function GapStyles( { blockGap, clientId } ) {
 	const styleElement = useContext( BlockList.__unstableElementContext );
+	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
+	// gap on the gallery.
 	const gapValue = blockGap
 		? blockGap
-		: `var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ))`;
+		: `var( --gallery-block--gutter-size, var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ) ) )`;
 	const gap = `#block-${ clientId } { 
 		--wp--style--unstable-gallery-gap: ${ gapValue };
 		gap: ${ gapValue } 

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -6,10 +6,13 @@ import { useContext, createPortal } from '@wordpress/element';
 
 export default function GapStyles( { blockGap, clientId } ) {
 	const styleElement = useContext( BlockList.__unstableElementContext );
-
-	const gap = blockGap
-		? `#block-${ clientId } { --wp--style--unstable-gallery-gap: ${ blockGap } }`
-		: `#block-${ clientId } { --wp--style--unstable-gallery-gap: var( --wp--style--block-gap, 0.5em ) }`;
+	const gapValue = blockGap
+		? blockGap
+		: `var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ))`;
+	const gap = `#block-${ clientId } { 
+		--wp--style--unstable-gallery-gap: ${ gapValue };
+		gap: ${ gapValue } 
+	}`;
 
 	const GapStyle = () => {
 		return <style>{ gap }</style>;

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -10,7 +10,7 @@ export default function GapStyles( { blockGap, clientId } ) {
 	// gap on the gallery.
 	const gapValue = blockGap
 		? blockGap
-		: `var( --gallery-block--gutter-size, var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ) ) )`;
+		: `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
 	const gap = `#block-${ clientId } { 
 		--wp--style--unstable-gallery-gap: ${ gapValue };
 		gap: ${ gapValue } 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -48,9 +48,9 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.
-	$gap       = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
-	$class     = wp_unique_id( 'wp-block-gallery-' );
-	$content   = preg_replace(
+	$gap     = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+	$class   = wp_unique_id( 'wp-block-gallery-' );
+	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
 		'class="' . $class . ' ',
 		$content,

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -58,7 +58,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	);
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
-	$gap_value = $gap ? $gap : 'var( --gallery-block--gutter-size, var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ) ) )';
+	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
 	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -56,7 +56,9 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
-	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ))';
+	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
+	// gap on the gallery.
+	$gap_value = $gap ? $gap : 'var( --gallery-block--gutter-size, var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ) ) )';
 	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -56,8 +56,8 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
-	$gap_value = $gap ? $gap : 'var( --wp--style--block-gap, 0.5em )';
-	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '}';
+	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --wp--style--block-gap, 0.5em ))';
+	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.
 	// See https://core.trac.wordpress.org/ticket/53494.


### PR DESCRIPTION
## What?
Adds back support for the deprecated `--gallery-block--gutter-size`  css var, and also support for a new `--wp--style--gallery-gap-default` css var to allow theme authors to define a default gallery gap that can be overridden by any user applied gap.

## Why?
As [noted here](https://github.com/WordPress/gutenberg/pull/38164#issuecomment-1083815716) the recent change to add gap support was a breaking change for some themes as it removed the `--gallery-block--gutter-size` and did not provide an alternative way for themes to define a default gap setting.

## How?
Disables the default serialization of the layout to allow it to be manually applied by the Gallery block allowing for fallbacks to any theme set css vars

## Testing Instructions

- Somewhere in a theme file defines the following custom css:
 ```css
figure.wp-block-gallery.has-nested-images {
	--gallery-block--gutter-size: 3px; 
}
```
- Add a Gallery block and make sure the default gap is set to 3px in editor and frontend, and that this default is overridden if a blockGap is specified in the block settings
- Change the custom css to:
```css
figure.wp-block-gallery.has-nested-images {
	--wp--style--gallery-gap-default: 10px; 
}
``` 
- Add a new Gallery block and make sure gap now defaults to 10px in editor and frontend, and that this is overridden if a blockGap is set on the block


## Screenshots 
Before:
<img width="775" alt="Screen Shot 2022-04-04 at 3 58 30 PM" src="https://user-images.githubusercontent.com/3629020/161471534-8b95b9f8-89ff-494f-81bd-0a58aab8facb.png">

After:
<img width="769" alt="Screen Shot 2022-04-04 at 3 57 21 PM" src="https://user-images.githubusercontent.com/3629020/161471584-45ed9f2b-003f-4355-a2f5-fd24ccfb30f6.png">

