### PR TITLE
Use a description that matches the filename for the annotations e2e tests

### DIFF
--- a/packages/e2e-tests/specs/editor/plugins/annotations.test.js
+++ b/packages/e2e-tests/specs/editor/plugins/annotations.test.js
@@ -17,7 +17,7 @@ const clickOnBlockSettingsMenuItem = async ( buttonLabel ) => {
 
 const ANNOTATIONS_SELECTOR = '.annotation-text-e2e-tests';
 
-describe( 'Using Plugins API', () => {
+describe( 'Annotations', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'gutenberg-test-plugin-plugins-api' );
 	} );
@@ -97,96 +97,92 @@ describe( 'Using Plugins API', () => {
 		}, htmlContent[ 0 ] );
 	}
 
-	describe( 'Annotations', () => {
-		it( 'Allows a block to be annotated', async () => {
-			await page.keyboard.type(
-				'Title' + '\n' + 'Paragraph to annotate'
-			);
+	it( 'allows a block to be annotated', async () => {
+		await page.keyboard.type( 'Title' + '\n' + 'Paragraph to annotate' );
 
-			await clickOnMoreMenuItem( 'Annotations Sidebar' );
+		await clickOnMoreMenuItem( 'Annotations Sidebar' );
 
-			let annotations = await page.$$( ANNOTATIONS_SELECTOR );
-			expect( annotations ).toHaveLength( 0 );
+		let annotations = await page.$$( ANNOTATIONS_SELECTOR );
+		expect( annotations ).toHaveLength( 0 );
 
-			await annotateFirstBlock( 9, 13 );
+		await annotateFirstBlock( 9, 13 );
 
-			annotations = await page.$$( ANNOTATIONS_SELECTOR );
-			expect( annotations ).toHaveLength( 1 );
+		annotations = await page.$$( ANNOTATIONS_SELECTOR );
+		expect( annotations ).toHaveLength( 1 );
 
-			const text = await getAnnotatedText();
-			expect( text ).toBe( ' to ' );
+		const text = await getAnnotatedText();
+		expect( text ).toBe( ' to ' );
 
-			await clickOnBlockSettingsMenuItem( 'Edit as HTML' );
+		await clickOnBlockSettingsMenuItem( 'Edit as HTML' );
 
-			const htmlContent = await page.$$(
-				'.block-editor-block-list__block-html-textarea'
-			);
-			const html = await page.evaluate( ( el ) => {
-				return el.innerHTML;
-			}, htmlContent[ 0 ] );
+		const htmlContent = await page.$$(
+			'.block-editor-block-list__block-html-textarea'
+		);
+		const html = await page.evaluate( ( el ) => {
+			return el.innerHTML;
+		}, htmlContent[ 0 ] );
 
-			// There should be no <mark> tags in the raw content.
-			expect( html ).toBe( '&lt;p&gt;Paragraph to annotate&lt;/p&gt;' );
-		} );
+		// There should be no <mark> tags in the raw content.
+		expect( html ).toBe( '&lt;p&gt;Paragraph to annotate&lt;/p&gt;' );
+	} );
 
-		it( 'Keeps the cursor in the same location when applying annotation', async () => {
-			await page.keyboard.type( 'Title' + '\n' + 'ABC' );
-			await clickOnMoreMenuItem( 'Annotations Sidebar' );
+	it( 'keeps the cursor in the same location when applying annotation', async () => {
+		await page.keyboard.type( 'Title' + '\n' + 'ABC' );
+		await clickOnMoreMenuItem( 'Annotations Sidebar' );
 
-			await annotateFirstBlock( 1, 2 );
+		await annotateFirstBlock( 1, 2 );
 
-			// The selection should still be at the end, so test that by typing:
-			await page.keyboard.type( 'D' );
+		// The selection should still be at the end, so test that by typing:
+		await page.keyboard.type( 'D' );
 
-			await removeAnnotations();
-			const htmlContent = await page.$$( '.wp-block-paragraph' );
-			const html = await page.evaluate( ( el ) => {
-				return el.innerHTML;
-			}, htmlContent[ 0 ] );
+		await removeAnnotations();
+		const htmlContent = await page.$$( '.wp-block-paragraph' );
+		const html = await page.evaluate( ( el ) => {
+			return el.innerHTML;
+		}, htmlContent[ 0 ] );
 
-			expect( html ).toBe( 'ABCD' );
-		} );
+		expect( html ).toBe( 'ABCD' );
+	} );
 
-		it( 'Moves when typing before it', async () => {
-			await page.keyboard.type( 'Title' + '\n' + 'ABC' );
-			await clickOnMoreMenuItem( 'Annotations Sidebar' );
+	it( 'moves when typing before it', async () => {
+		await page.keyboard.type( 'Title' + '\n' + 'ABC' );
+		await clickOnMoreMenuItem( 'Annotations Sidebar' );
 
-			await annotateFirstBlock( 1, 2 );
+		await annotateFirstBlock( 1, 2 );
 
-			await page.keyboard.press( 'ArrowLeft' );
-			await page.keyboard.press( 'ArrowLeft' );
-			await page.keyboard.press( 'ArrowLeft' );
-			await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
 
-			// Put an 1 after the A, it should not be annotated.
-			await page.keyboard.type( '1' );
+		// Put an 1 after the A, it should not be annotated.
+		await page.keyboard.type( '1' );
 
-			const annotatedText = await getAnnotatedText();
-			expect( annotatedText ).toBe( 'B' );
+		const annotatedText = await getAnnotatedText();
+		expect( annotatedText ).toBe( 'B' );
 
-			await removeAnnotations();
-			const blockText = await getRichTextInnerHTML();
-			expect( blockText ).toBe( 'A1BC' );
-		} );
+		await removeAnnotations();
+		const blockText = await getRichTextInnerHTML();
+		expect( blockText ).toBe( 'A1BC' );
+	} );
 
-		it( 'Grows when typing inside it', async () => {
-			await page.keyboard.type( 'Title' + '\n' + 'ABC' );
-			await clickOnMoreMenuItem( 'Annotations Sidebar' );
+	it( 'grows when typing inside it', async () => {
+		await page.keyboard.type( 'Title' + '\n' + 'ABC' );
+		await clickOnMoreMenuItem( 'Annotations Sidebar' );
 
-			await annotateFirstBlock( 1, 2 );
+		await annotateFirstBlock( 1, 2 );
 
-			await page.keyboard.press( 'ArrowLeft' );
-			await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
+		await page.keyboard.press( 'ArrowLeft' );
 
-			// Put an 1 after the A, it should not be annotated.
-			await page.keyboard.type( '2' );
+		// Put an 1 after the A, it should not be annotated.
+		await page.keyboard.type( '2' );
 
-			const annotatedText = await getAnnotatedText();
-			expect( annotatedText ).toBe( 'B2' );
+		const annotatedText = await getAnnotatedText();
+		expect( annotatedText ).toBe( 'B2' );
 
-			await removeAnnotations();
-			const blockText = await getRichTextInnerHTML();
-			expect( blockText ).toBe( 'AB2C' );
-		} );
+		await removeAnnotations();
+		const blockText = await getRichTextInnerHTML();
+		expect( blockText ).toBe( 'AB2C' );
 	} );
 } );


### PR DESCRIPTION
## What?
Just a small change. This e2e test file had a description that looks like it was copy/pasted from the plugins api test:
https://github.com/WordPress/gutenberg/blob/0d46b3690f4a75078f431008602c071eba06c189/packages/e2e-tests/specs/editor/plugins/plugins-api.test.js#L16

That's a bit confusing if you're using search to find a particular group of tests. It seems like the description should just be 'Annotations'.