### PR TITLE
Add/vertical alignment to row block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -10,12 +10,12 @@ Items marked with a strikeout (~~strikeout~~) are explicitly disabled.
 
 ## Archives
 
-Display a monthly archive of your posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/archives))
+Display a date archive of your posts. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/archives))
 
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** displayAsDropdown, showPostCounts
+-	**Attributes:** archiveType, displayAsDropdown, showPostCounts
 
 ## Audio
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -258,7 +258,7 @@ Combine blocks into a group. ([Source](https://github.com/WordPress/gutenberg/tr
 -	**Name:** core/group
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** tagName, templateLock
+-	**Attributes:** tagName, templateLock, verticalAlignment
 
 ## Heading
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -15,7 +15,7 @@ Display a date archive of your posts. ([Source](https://github.com/WordPress/gut
 -	**Name:** core/archives
 -	**Category:** widgets
 -	**Supports:** align, ~~html~~
--	**Attributes:** archiveType, displayAsDropdown, showPostCounts
+-	**Attributes:** displayAsDropdown, showPostCounts, type
 
 ## Audio
 

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -4,7 +4,7 @@
 	"name": "core/archives",
 	"title": "Archives",
 	"category": "widgets",
-	"description": "Display a monthly archive of your posts.",
+	"description": "Display a date archive of your posts.",
 	"textdomain": "default",
 	"attributes": {
 		"displayAsDropdown": {
@@ -14,6 +14,10 @@
 		"showPostCounts": {
 			"type": "boolean",
 			"default": false
+		},
+		"archiveType": {
+			"type": "string",
+			"default": "monthly"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/archives/block.json
+++ b/packages/block-library/src/archives/block.json
@@ -15,7 +15,7 @@
 			"type": "boolean",
 			"default": false
 		},
-		"archiveType": {
+		"type": {
 			"type": "string",
 			"default": "monthly"
 		}

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -1,13 +1,18 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, ToggleControl, Disabled } from '@wordpress/components';
+import {
+	PanelBody,
+	ToggleControl,
+	SelectControl,
+	Disabled,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
 export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showPostCounts, displayAsDropdown } = attributes;
+	const { showPostCounts, displayAsDropdown, archiveType } = attributes;
 
 	return (
 		<>
@@ -29,6 +34,19 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							setAttributes( {
 								showPostCounts: ! showPostCounts,
 							} )
+						}
+					/>
+					<SelectControl
+						label={ __( 'Group by:' ) }
+						options={ [
+							{ label: __( 'Year' ), value: 'yearly' },
+							{ label: __( 'Month' ), value: 'monthly' },
+							{ label: __( 'Week' ), value: 'weekly' },
+							{ label: __( 'Day' ), value: 'daily' },
+						] }
+						value={ archiveType }
+						onChange={ ( value ) =>
+							setAttributes( { archiveType: value } )
 						}
 					/>
 				</PanelBody>

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -12,7 +12,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
 export default function ArchivesEdit( { attributes, setAttributes } ) {
-	const { showPostCounts, displayAsDropdown, archiveType } = attributes;
+	const { showPostCounts, displayAsDropdown, type } = attributes;
 
 	return (
 		<>
@@ -44,9 +44,9 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							{ label: __( 'Week' ), value: 'weekly' },
 							{ label: __( 'Day' ), value: 'daily' },
 						] }
-						value={ archiveType }
+						value={ type }
 						onChange={ ( value ) =>
-							setAttributes( { archiveType: value } )
+							setAttributes( { type: value } )
 						}
 					/>
 				</PanelBody>

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -16,8 +16,8 @@
  */
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
-
-	$class = '';
+	$type            = isset( $attributes['archiveType'] ) ? $attributes['archiveType'] : 'monthly';
+	$class           = '';
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 
@@ -30,7 +30,7 @@ function render_block_core_archives( $attributes ) {
 		$dropdown_args = apply_filters(
 			'widget_archives_dropdown_args',
 			array(
-				'type'            => 'monthly',
+				'type'            => $type,
 				'format'          => 'option',
 				'show_post_count' => $show_post_count,
 			)
@@ -79,7 +79,7 @@ function render_block_core_archives( $attributes ) {
 	$archives_args = apply_filters(
 		'widget_archives_args',
 		array(
-			'type'            => 'monthly',
+			'type'            => $type,
 			'show_post_count' => $show_post_count,
 		)
 	);

--- a/packages/block-library/src/archives/index.php
+++ b/packages/block-library/src/archives/index.php
@@ -16,7 +16,7 @@
  */
 function render_block_core_archives( $attributes ) {
 	$show_post_count = ! empty( $attributes['showPostCounts'] );
-	$type            = isset( $attributes['archiveType'] ) ? $attributes['archiveType'] : 'monthly';
+	$type            = isset( $attributes['type'] ) ? $attributes['type'] : 'monthly';
 	$class           = '';
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -15,6 +15,9 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
+		},
+		"verticalAlignment": {
+			"type": "string"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
 import {
+	BlockControls,
+	BlockVerticalAlignmentControl,
 	InnerBlocks,
 	useBlockProps,
 	InspectorControls,
@@ -47,12 +54,27 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		[ clientId ]
 	);
 	const defaultLayout = useSetting( 'layout' ) || {};
-	const { tagName: TagName = 'div', templateLock, layout = {} } = attributes;
+	const {
+		tagName: TagName = 'div',
+		templateLock,
+		layout = {},
+		verticalAlignment,
+	} = attributes;
 	const usedLayout = !! layout && layout.inherit ? defaultLayout : layout;
 	const { type = 'default' } = usedLayout;
 	const layoutSupportEnabled = themeSupportsLayout || type !== 'default';
 
-	const blockProps = useBlockProps();
+	const classNames = classnames( {
+		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
+	} );
+
+	const onVerticalAlignmentChange = ( alignment ) => {
+		setAttributes( { verticalAlignment: alignment } );
+	};
+
+	const blockProps = useBlockProps( {
+		className: classNames,
+	} );
 	const innerBlocksProps = useInnerBlocksProps(
 		layoutSupportEnabled
 			? blockProps
@@ -68,6 +90,12 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 
 	return (
 		<>
+			<BlockControls>
+				<BlockVerticalAlignmentControl
+					onChange={ onVerticalAlignmentChange }
+					value={ verticalAlignment }
+				/>
+			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<SelectControl
 					label={ __( 'HTML element' ) }

--- a/packages/block-library/src/group/style.scss
+++ b/packages/block-library/src/group/style.scss
@@ -1,4 +1,17 @@
 .wp-block-group {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	// We use !important to override the default group block style set to align-items: center.
+	&.is-vertically-aligned-top {
+		align-items: flex-start !important;
+	}
+
+	&.is-vertically-aligned-center {
+		align-items: center !important;
+	}
+
+	&.is-vertically-aligned-bottom {
+		align-items: flex-end !important;
+	}
 }

--- a/test/integration/fixtures/blocks/core__archives.json
+++ b/test/integration/fixtures/blocks/core__archives.json
@@ -5,7 +5,8 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsDropdown": false,
-			"showPostCounts": false
+			"showPostCounts": false,
+			"archiveType": "monthly"
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/test/integration/fixtures/blocks/core__archives.json
+++ b/test/integration/fixtures/blocks/core__archives.json
@@ -6,7 +6,7 @@
 		"attributes": {
 			"displayAsDropdown": false,
 			"showPostCounts": false,
-			"archiveType": "monthly"
+			"type": "monthly"
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/test/integration/fixtures/blocks/core__archives__showPostCounts.json
+++ b/test/integration/fixtures/blocks/core__archives__showPostCounts.json
@@ -5,7 +5,8 @@
 		"isValid": true,
 		"attributes": {
 			"displayAsDropdown": false,
-			"showPostCounts": true
+			"showPostCounts": true,
+			"archiveType": "monthly"
 		},
 		"innerBlocks": [],
 		"originalContent": ""

--- a/test/integration/fixtures/blocks/core__archives__showPostCounts.json
+++ b/test/integration/fixtures/blocks/core__archives__showPostCounts.json
@@ -6,7 +6,7 @@
 		"attributes": {
 			"displayAsDropdown": false,
 			"showPostCounts": true,
-			"archiveType": "monthly"
+			"type": "monthly"
 		},
 		"innerBlocks": [],
 		"originalContent": ""


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/38498

## What?
This PR adds a new block control for vertical alignment to the group block.

## Why?
See https://github.com/WordPress/gutenberg/issues/38498

## How?
This adds a new `verticalAlignment` (https://github.com/WordPress/gutenberg/blob/190a207971655295ba8efffd9805cac1768fae84/packages/block-editor/src/components/block-vertical-alignment-control/index.js#L17) to the group block, and the according `align-items` styles. 

## Testing Instructions
1. In a new post, add a new Row block
2. Add some content to the block
3. Set some padding to the block and with they increase the block height (by for instance adding a `height` property from the browser inspector)
4. Add some background color to the block to make the changes visible
5. Change the "Vertical alignment" values in the block control toolbar
