### PR TITLE
[RichText]: Try add prop to handle content as text

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -109,6 +109,7 @@ function RichTextWrapper(
 		disableLineBreaks,
 		unstableOnFocus,
 		__unstableAllowPrefixTransformations,
+		__unstableHandleAsText,
 		...props
 	},
 	forwardedRef
@@ -260,6 +261,7 @@ function RichTextWrapper(
 		__unstableAfterParse: addEditorOnlyFormats,
 		__unstableBeforeSerialize: removeEditorOnlyFormats,
 		__unstableAddInvisibleFormats: addInvisibleFormats,
+		__unstableHandleAsText,
 	} );
 	const autocompleteProps = useBlockEditorAutocompleteProps( {
 		onReplace,

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -57,6 +57,7 @@ export default function PostTitleEdit( {
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }
+					__unstableHandleAsText
 					{ ...blockProps }
 				/>
 			) : (

--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -196,6 +196,7 @@ export default function PostTitle() {
 			} );
 		},
 		__unstableDisableFormats: true,
+		__unstableHandleAsText: true,
 		preserveWhiteSpace: true,
 	} );
 

--- a/packages/rich-text/src/component/index.js
+++ b/packages/rich-text/src/component/index.js
@@ -36,6 +36,7 @@ export function useRichText( {
 	__unstableAfterParse,
 	__unstableBeforeSerialize,
 	__unstableAddInvisibleFormats,
+	__unstableHandleAsText,
 } ) {
 	const registry = useRegistry();
 	const [ , forceRender ] = useReducer( () => ( {} ) );
@@ -80,6 +81,7 @@ export function useRichText( {
 	function setRecordFromProps() {
 		_value.current = value;
 		record.current = create( {
+			text: __unstableHandleAsText ? value : undefined,
 			html: value,
 			multilineTag,
 			multilineWrapperTags:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/39395
Related: https://github.com/WordPress/gutenberg/issues/38668

The above two problems are related to the removal of `TextareaAutosize` for the post's title to use RichText [in this PR](https://github.com/WordPress/gutenberg/pull/31569). 
The first issue is about having an `img` tag/html in the title that cause the editor to crash and the second issue is that if a title contains `html` it is rendered and therefore not editable.

I tried debugging this but I'm not 100% sure what the best solution would be, but here is my attempt and understanding.

When the `title` was using `TextareaAutosize`, it showed the title and treated it as a `string`, even if it contained html. Now with RichText, it [renders the content as `html`](https://github.com/WordPress/gutenberg/blob/trunk/packages/rich-text/src/component/index.js#L83) so internally it finds and creates more `nodes`. This results in issue: **38668** not showing the html, so we cannot edit it. Also the `PostTitle` block comes into play, because even with the previous implementation, there is a mismatch between the `main title` and the block. `Post Title` block uses `PlainText`(RichText implementation) and always displays the rendered content.

Regarding the first issue(39395) about crashing with `img` tag this happens because with have set `__unstableDisableFormats` to `true` and an `img` tag is the `core/image` format. So in the initial creation of the rich text record we end up adding [OBJECT_REPLACEMENT_CHARACTER here](https://github.com/WordPress/gutenberg/blob/trunk/packages/rich-text/src/create.js#L473) and in later update this crashes as it expects formats to be present, but we have [emptied them here](https://github.com/WordPress/gutenberg/blob/trunk/packages/rich-text/src/component/index.js#L89).




<!-- In a few words, what is the PR actually doing? -->

## How?
So this PR adds an new unstable prop to RichText(`__unstableHandleAsText`) where we have a RichText that could contain `html` but it will be treated as text in the editor.

The problem I see now is that while we will be able to edit `html` in the title, it's not a wysiwyg experience.

Noting that you're able to `quick edit` the title in the posts' list and you can add `html` there.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Add some html like `<img src='/favicon.png'>Hello!` in the title
2. Update and refresh.
3. The html should be there

## Notes
I'll have to think this through more if we can approach this differently, but any feedback is more than welcome. 

