### PR TITLE
Use the `symbol` icon for Reusable Block menu item

### DIFF
--- a/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
+++ b/packages/reusable-blocks/src/components/reusable-blocks-menu-items/reusable-block-convert-button.js
@@ -15,7 +15,7 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { reusableBlock } from '@wordpress/icons';
+import { symbol } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -113,7 +113,7 @@ export default function ReusableBlockConvertButton( {
 			{ ( { onClose } ) => (
 				<>
 					<MenuItem
-						icon={ reusableBlock }
+						icon={ symbol }
 						onClick={ () => {
 							setIsModalOpen( true );
 						} }


### PR DESCRIPTION
Before:

<img src="https://user-images.githubusercontent.com/846565/161512907-9dd5f624-0779-4d46-9fe9-9ac8e7579b0c.png" width="350">

After:

<img src="https://user-images.githubusercontent.com/846565/161513055-b55138d9-0165-4ccc-809b-4c5b96d38b66.png" width="350">

As an aside, I noticed the old icon is named "Reusable block". We should probably consider renaming that.