### PR TITLE
Reuse the JS entities configuration in the TypeScript type system

### DIFF
--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { addEntities } from './actions';
 import type * as Records from './entity-types';
-import type { Context, Taxonomy, Type } from './entity-types';
+import type { Context, Post, Taxonomy, Type, Updatable } from './entity-types';
 import type { EntityConfigTypeFromConst } from './entity-types/entities';
 
 export const DEFAULT_ENTITY_KEY = 'id';
@@ -313,7 +313,7 @@ export const additionalEntityConfigLoaders = [
  * @return {Object} Updated edits.
  */
 export const prePersistPostType = ( persistedRecord, edits ) => {
-	const newEdits = {} as any;
+	const newEdits = {} as Partial< Updatable< Post< 'edit' > > >;
 
 	if ( persistedRecord?.status === 'auto-draft' ) {
 		// Saving an auto-draft should create a draft by default.

--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -13,162 +13,292 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { addEntities } from './actions';
-import type { Post, Taxonomy, Type, Updatable } from './entity-types';
+import type * as Records from './entity-types';
+import type { Context, Taxonomy, Type } from './entity-types';
+import type { EntityConfigTypeFromConst } from './entity-types/entities';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
+const attachmentConfig = {
+	name: 'media',
+	kind: 'root',
+	baseURL: '/wp/v2/media',
+	baseURLParams: { context: 'edit' },
+	plural: 'mediaItems',
+	label: __( 'Media' ),
+} as const;
+
+type AttachmentConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof attachmentConfig,
+	Records.Attachment< C >
+>;
+
+const siteConfig = {
+	label: __( 'Site' ),
+	name: 'site',
+	kind: 'root',
+	baseURL: '/wp/v2/settings',
+	getTitle: ( record: Records.Settings< 'edit' > ) => {
+		return get( record, [ 'title' ], __( 'Site Title' ) );
+	},
+} as const;
+
+type SiteConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof siteConfig,
+	Records.Settings< C >
+>;
+
+const postTypeConfig = {
+	label: __( 'Post Type' ),
+	name: 'postType',
+	kind: 'root',
+	key: 'slug',
+	baseURL: '/wp/v2/types',
+	baseURLParams: { context: 'edit' },
+	rawAttributes: POST_RAW_ATTRIBUTES,
+} as const;
+
+type TypeConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof postTypeConfig,
+	Records.Type< C >
+>;
+
+const taxonomyConfig = {
+	name: 'taxonomy',
+	kind: 'root',
+	key: 'slug',
+	baseURL: '/wp/v2/taxonomies',
+	baseURLParams: { context: 'edit' },
+	plural: 'taxonomies',
+	label: __( 'Taxonomy' ),
+} as const;
+
+type TaxonomyConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof taxonomyConfig,
+	Records.Taxonomy< C >
+>;
+
+const sidebarConfig = {
+	name: 'sidebar',
+	kind: 'root',
+	baseURL: '/wp/v2/sidebars',
+	plural: 'sidebars',
+	transientEdits: { blocks: true },
+	label: __( 'Widget areas' ),
+} as const;
+
+type SidebarConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof sidebarConfig,
+	Records.Sidebar< C >
+>;
+
+const widgetConfig = {
+	name: 'widget',
+	kind: 'root',
+	baseURL: '/wp/v2/widgets',
+	baseURLParams: { context: 'edit' },
+	plural: 'widgets',
+	transientEdits: { blocks: true },
+	label: __( 'Widgets' ),
+} as const;
+
+type WidgetConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof widgetConfig,
+	Records.Widget< C >
+>;
+
+const widgetTypeConfig = {
+	name: 'widgetType',
+	kind: 'root',
+	baseURL: '/wp/v2/widget-types',
+	baseURLParams: { context: 'edit' },
+	plural: 'widgetTypes',
+	label: __( 'Widget types' ),
+} as const;
+
+type WidgetTypeConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof widgetTypeConfig,
+	Records.WidgetType< C >
+>;
+
+const userConfig = {
+	label: __( 'User' ),
+	name: 'user',
+	kind: 'root',
+	baseURL: '/wp/v2/users',
+	baseURLParams: { context: 'edit' },
+	plural: 'users',
+} as const;
+
+type UserConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof userConfig,
+	Records.User< C >
+>;
+
+const commentConfig = {
+	name: 'comment',
+	kind: 'root',
+	baseURL: '/wp/v2/comments',
+	baseURLParams: { context: 'edit' },
+	plural: 'comments',
+	label: __( 'Comment' ),
+} as const;
+
+type CommentConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof commentConfig,
+	Records.Comment< C >
+>;
+
+const menuConfig = {
+	name: 'menu',
+	kind: 'root',
+	baseURL: '/wp/v2/menus',
+	baseURLParams: { context: 'edit' },
+	plural: 'menus',
+	label: __( 'Menu' ),
+} as const;
+
+type NavMenuConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof menuConfig,
+	Records.NavMenu< C >
+>;
+
+const menuItemConfig = {
+	name: 'menuItem',
+	kind: 'root',
+	baseURL: '/wp/v2/menu-items',
+	baseURLParams: { context: 'edit' },
+	plural: 'menuItems',
+	label: __( 'Menu Item' ),
+	rawAttributes: [ 'title', 'content' ],
+} as const;
+
+type NavMenuItemConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof menuItemConfig,
+	Records.NavMenu< C >
+>;
+
+const menuLocationConfig = {
+	name: 'menuLocation',
+	kind: 'root',
+	baseURL: '/wp/v2/menu-locations',
+	baseURLParams: { context: 'edit' },
+	plural: 'menuLocations',
+	label: __( 'Menu Location' ),
+	key: 'name',
+} as const;
+
+type MenuLocationConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof menuLocationConfig,
+	Records.MenuLocation< C >
+>;
+
+const globalStyleConfig = {
+	label: __( 'Global Styles' ),
+	name: 'globalStyles',
+	kind: 'root',
+	baseURL: '/wp/v2/global-styles',
+	baseURLParams: { context: 'edit' },
+	plural: 'globalStylesVariations', // should be different than name
+	getTitle: ( record: any ) => record?.title?.rendered || record?.title,
+} as const;
+
+const themeConfig = {
+	label: __( 'Themes' ),
+	name: 'theme',
+	kind: 'root',
+	baseURL: '/wp/v2/themes',
+	baseURLParams: { context: 'edit' },
+	key: 'stylesheet',
+} as const;
+
+type ThemeConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof themeConfig,
+	Records.Theme< C >
+>;
+
+const pluginConfig = {
+	label: __( 'Plugins' ),
+	name: 'plugin',
+	kind: 'root',
+	baseURL: '/wp/v2/plugins',
+	baseURLParams: { context: 'edit' },
+	key: 'plugin',
+} as const;
+
+type PluginConfig< C extends Context > = EntityConfigTypeFromConst<
+	typeof pluginConfig,
+	Records.Plugin< C >
+>;
+
 export const rootEntitiesConfig = [
 	{
 		label: __( 'Base' ),
+		kind: 'root',
 		name: '__unstableBase',
-		kind: 'root',
 		baseURL: '/',
-		baseURLParams: {
-			_fields: [
-				'description',
-				'gmt_offset',
-				'home',
-				'name',
-				'site_icon',
-				'site_icon_url',
-				'site_logo',
-				'timezone_string',
-				'url',
-			].join( ',' ),
-		},
 	},
-	{
-		label: __( 'Site' ),
-		name: 'site',
-		kind: 'root',
-		baseURL: '/wp/v2/settings',
-		getTitle: ( record ) => {
-			return get( record, [ 'title' ], __( 'Site Title' ) );
-		},
-	},
-	{
-		label: __( 'Post Type' ),
-		name: 'postType',
-		kind: 'root',
-		key: 'slug',
-		baseURL: '/wp/v2/types',
-		baseURLParams: { context: 'edit' },
-		rawAttributes: POST_RAW_ATTRIBUTES,
-	},
-	{
-		name: 'media',
-		kind: 'root',
-		baseURL: '/wp/v2/media',
-		baseURLParams: { context: 'edit' },
-		plural: 'mediaItems',
-		label: __( 'Media' ),
-		rawAttributes: [ 'caption', 'title', 'description' ],
-	},
-	{
-		name: 'taxonomy',
-		kind: 'root',
-		key: 'slug',
-		baseURL: '/wp/v2/taxonomies',
-		baseURLParams: { context: 'edit' },
-		plural: 'taxonomies',
-		label: __( 'Taxonomy' ),
-	},
-	{
-		name: 'sidebar',
-		kind: 'root',
-		baseURL: '/wp/v2/sidebars',
-		baseURLParams: { context: 'edit' },
-		plural: 'sidebars',
-		transientEdits: { blocks: true },
-		label: __( 'Widget areas' ),
-	},
-	{
-		name: 'widget',
-		kind: 'root',
-		baseURL: '/wp/v2/widgets',
-		baseURLParams: { context: 'edit' },
-		plural: 'widgets',
-		transientEdits: { blocks: true },
-		label: __( 'Widgets' ),
-	},
-	{
-		name: 'widgetType',
-		kind: 'root',
-		baseURL: '/wp/v2/widget-types',
-		baseURLParams: { context: 'edit' },
-		plural: 'widgetTypes',
-		label: __( 'Widget types' ),
-	},
-	{
-		label: __( 'User' ),
-		name: 'user',
-		kind: 'root',
-		baseURL: '/wp/v2/users',
-		baseURLParams: { context: 'edit' },
-		plural: 'users',
-	},
-	{
-		name: 'comment',
-		kind: 'root',
-		baseURL: '/wp/v2/comments',
-		baseURLParams: { context: 'edit' },
-		plural: 'comments',
-		label: __( 'Comment' ),
-	},
-	{
-		name: 'menu',
-		kind: 'root',
-		baseURL: '/wp/v2/menus',
-		baseURLParams: { context: 'edit' },
-		plural: 'menus',
-		label: __( 'Menu' ),
-	},
-	{
-		name: 'menuItem',
-		kind: 'root',
-		baseURL: '/wp/v2/menu-items',
-		baseURLParams: { context: 'edit' },
-		plural: 'menuItems',
-		label: __( 'Menu Item' ),
-		rawAttributes: [ 'title', 'content' ],
-	},
-	{
-		name: 'menuLocation',
-		kind: 'root',
-		baseURL: '/wp/v2/menu-locations',
-		baseURLParams: { context: 'edit' },
-		plural: 'menuLocations',
-		label: __( 'Menu Location' ),
-		key: 'name',
-	},
-	{
-		label: __( 'Global Styles' ),
-		name: 'globalStyles',
-		kind: 'root',
-		baseURL: '/wp/v2/global-styles',
-		baseURLParams: { context: 'edit' },
-		plural: 'globalStylesVariations', // Should be different than name.
-		getTitle: ( record ) => record?.title?.rendered || record?.title,
-	},
-	{
-		label: __( 'Themes' ),
-		name: 'theme',
-		kind: 'root',
-		baseURL: '/wp/v2/themes',
-		baseURLParams: { context: 'edit' },
-		key: 'stylesheet',
-	},
-	{
-		label: __( 'Plugins' ),
-		name: 'plugin',
-		kind: 'root',
-		baseURL: '/wp/v2/plugins',
-		baseURLParams: { context: 'edit' },
-		key: 'plugin',
-	},
+	siteConfig,
+	postTypeConfig,
+	attachmentConfig,
+	taxonomyConfig,
+	sidebarConfig,
+	widgetConfig,
+	widgetTypeConfig,
+	userConfig,
+	commentConfig,
+	menuConfig,
+	menuItemConfig,
+	menuLocationConfig,
+	globalStyleConfig,
+	themeConfig,
+	pluginConfig,
 ];
+
+type PostTypeConfig = {
+	kind: 'postType';
+	key: 'id';
+	defaultContext: 'edit';
+};
+
+type PostConfig< C extends Context > = PostTypeConfig & {
+	name: 'post';
+	recordType: Records.Post< C >;
+};
+type PageConfig< C extends Context > = PostTypeConfig & {
+	name: 'page';
+	recordType: Records.Page< C >;
+};
+type WpTemplateConfig< C extends Context > = PostTypeConfig & {
+	name: 'wp_template';
+	recordType: Records.WpTemplate< C >;
+};
+type WpTemplatePartConfig< C extends Context > = PostTypeConfig & {
+	name: 'wp_template_part';
+	recordType: Records.WpTemplatePart< C >;
+};
+
+export type CoreEntityConfig< C extends Context > =
+	| SiteConfig< C >
+	| TypeConfig< C >
+	| AttachmentConfig< C >
+	| TaxonomyConfig< C >
+	| SidebarConfig< C >
+	| WidgetConfig< C >
+	| WidgetTypeConfig< C >
+	| UserConfig< C >
+	| CommentConfig< C >
+	| NavMenuConfig< C >
+	| NavMenuItemConfig< C >
+	| MenuLocationConfig< C >
+	| ThemeConfig< C >
+	| PluginConfig< C >
+	| PostConfig< C >
+	| PageConfig< C >
+	| WpTemplateConfig< C >
+	| WpTemplatePartConfig< C >;
 
 export const additionalEntityConfigLoaders = [
 	{ kind: 'postType', loadEntities: loadPostTypeEntities },
@@ -183,7 +313,7 @@ export const additionalEntityConfigLoaders = [
  * @return {Object} Updated edits.
  */
 export const prePersistPostType = ( persistedRecord, edits ) => {
-	const newEdits = {} as Partial< Updatable< Post< 'edit' > > >;
+	const newEdits = {} as any;
 
 	if ( persistedRecord?.status === 'auto-draft' ) {
 		// Saving an auto-draft should create a draft by default.
@@ -292,7 +422,7 @@ export const getMethodName = (
 	const nameSuffix =
 		upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
 	const suffix =
-		usePlural && entityConfig?.plural
+		usePlural && 'plural' in entityConfig && entityConfig?.plural
 			? upperFirst( camelCase( entityConfig.plural ) )
 			: nameSuffix;
 	return `${ prefix }${ kindPrefix }${ suffix }`;

--- a/packages/core-data/src/entity-types/entities.ts
+++ b/packages/core-data/src/entity-types/entities.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import type { Context } from './helpers';
+
+/**
+ * HTTP Query parameters sent with the API request to fetch the entity records.
+ */
+export type EntityQuery<
+	C extends Context,
+	Fields extends string[] | undefined = undefined
+> = Record< string, any > & {
+	context?: C;
+	/**
+	 * The requested fields. If specified, the REST API will remove from the response
+	 * any fields not on that list.
+	 */
+	_fields?: Fields;
+};
+
+/**
+ * Helper type that transforms "raw" entity configuration from entities.ts
+ * into a format that makes searching by root and kind easy and extensible.
+ *
+ * This is the foundation of return type inference in calls such as:
+ * `getEntityRecord( "root", "comment", 15 )`.
+ *
+ * @see EntityRecordOf
+ * @see getEntityRecord
+ */
+export type EntityConfigTypeFromConst<
+	E extends {
+		kind: string;
+		name: string;
+		baseURLParams?: EntityQuery< any >;
+		key?: string;
+	},
+	R
+> = {
+	kind: E[ 'kind' ];
+	name: E[ 'name' ];
+	recordType: R;
+	key: E[ 'key' ] extends string ? E[ 'key' ] : 'id';
+	defaultContext: E[ 'baseURLParams' ] extends {
+		context: infer C;
+	}
+		? C
+		: 'view';
+};


### PR DESCRIPTION
## What?

This is a subset of https://github.com/WordPress/gutenberg/pull/39025 – a mega branch that proposes TypeScript signatures for all `@wordpress/core-data` selectors.

This PR adds Entity configuration types to `core-data/src/entities.ts`. 

## Why?
Consider the `getEntityRecord` selector:

https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/selectors.js#L157-L171

Different entity kinds, like `root`, `postType`, `taxonomy`, are associated with different entity names. For example, `kind: root, name: plugin` is a valid combination, but `kind: postType, name: plugin` is not. Other valid combinations are configured in the `entities.ts` file via a JavaScript object.

An ideal `getEntityRecord` function signature would only accept valid combinations, then require the `key` to be either `number` or a `string`, and return the list of corresponding entity records.

Again, ideally, there would only be a single source of truth for all the information. I'd rather avoid rewriting them in TypeScript  as in my experience this adds maintenance burden, leads to difficult bugs, and gets out of sync sooner or later.

This PR, then, takes all the JavaScript configuration details, and brings them into the TypeScript type system [using the `as const` assertion](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions):

```ts
const pluginConfig = {
	label: __( 'Plugins' ),
	name: 'plugin',
	kind: 'root',
	baseURL: '/wp/v2/plugins',
	baseURLParams: { context: 'edit' },
	key: 'plugin',
} as const;

// typeof pluginConfig['name'] is not string, it's "plugin"
```

Then, it transforms these const types into an Entity Config type like this:

```ts
type PluginConfig< C extends Context > = EntityConfigTypeFromConst<
	typeof pluginConfig,
	Records.Plugin< C >
>;
// PluginConfig['kind'] is "root"
// PluginConfig['defaultContext'] is "edit"
```

That `PluginConfig` type can then be reused to create a `getEntityRecord` signature as seen in https://github.com/WordPress/gutenberg/pull/39025.

### Why have a new config type when the consts could be used directly?

Good question! It's needed because entity configuration comes from three different sources:

* Hardcoded types in `entities.ts`
* Implicit knowledge about the entities loaded using the [_entity loaders_](https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/entities.ts#L182-L185), e.g. that the default context of all `kind=postType` is `edit` as seen in [`loadPostTypeEntities`](https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/entities.ts#L222-L251)
* Any additional configuration provided by Gutenberg extenders.

A somewhat eccentric metaphor would be picturing it as a MySQL query that joins three tables:

```sql
SELECT
	kind,
	name,
	recordType,
	DEFAULT(key, 'id') as key,
	DEFAULT(baseURLParams['context'], 'view') as defaultContext
FROM rootEntitiesConfig_declared_in_entities_js d
INNER JOIN record_types r ON d.kind = r.kind AND d.name = r.name
UNION
SELECT VALUES
	ROW ( 'postType', 'post', 'id', 'Post', 'edit' ),
	ROW ( 'postType', 'page', 'id', 'Page', 'edit' ),
	ROW ( 'postType', 'wp_template', 'WpTemplate', 'id', 'edit' ),
	ROW ( 'postType', 'wp_template_part', 'WpTemplatePart', 'id', 'edit' ),
AS what_we_intrinsically_know_from_additionalEntityConfigLoaders
UNION
SELECT
	kind,
	name,
	recordType,
	key,
	defaultContext
FROM additional_configuration_provided_by_extenders
```

A common format like the `PluginConfig` makes reasoning about all these data sources much easier down the road, e.g. it enables the following succinct formulation of the Kind type:

```ts
export type KindOf< R extends EntityRecord > = EntityConfigOf< R >[ 'kind' ];
```

### The downside of `as const` is that it provides no autocompletion or type constraints to the developer writing new types

That's true! It is the price to pay for having a single source of truth. I think it's a worthy trade-off, but there may be a way that enables both using [a clever trick I found on StackOverflow](https://github.com/WordPress/gutenberg/pull/39481#issuecomment-1068996646):

![CleanShot 2022-04-04 at 14 00 07](https://user-images.githubusercontent.com/205419/161539322-d8ec3094-f20e-44b2-9ecb-808d2d53e7b6.png)

The downside of that approach is that it requires a few complex types that muddy the big picture. [See the related TypeScript playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBA6glsAFgGQRATgQwDYGcA8AKgDRTKnKECuY2EAfFALxRQBQrrhUEAHsBAB2AE1xRcwdHEEBzAD5RBVALYAjDFAWqA9trqZBmxVWzYjVERABm0iMKgB+KNwBkZKAC4OnAN7fOnADaAApQ0lAA1hAg2lbOALoe7AEpnPBIqAJYeEQh8RQU1LQMUG4AFIR5PPxColAAguhYIPgGIIxOlDR0SRYRgtoA7oIAlP5QAL5sbKCQUAAiEBBgAEoQmMLagtgthIwsfgHo65vbIFAhYYZRMXGEiQtLqydbO7nB8fRsU2xWFgDGwDgWygmFwAGEthIiABJQRZKyYf4MMpjQ6cY7AKjoQx-QSA4GCfDjAJdYrVAQiMSBPoDYbxcyCfpDQSBfIkzjICm1MQSKSyIw6PTrQwKJRqDCkbh8Sl1dIoNDZAiEOEIpEQApkIp0ej0MraJKEEZJRbLNYbV67Rjo1KY7GGbSgsRtcZTH6zaAwgBicGwWQAQmDoAdxh6kgAif7aCThozh7RIDDh4jjYRwXC0TAgABymGUECSfOkMkZwmstmEKYCgnQSXF6nQVc4NYAqoJCUkAIxGABMTdYuCoqgA8qoAFaeKA2lKYQuSYsAbld40wTTn-JkbPG2FXtagZXD9VjCnD-vDIy3AWUcF4dl3STK9Y0CiLsgv7IC2kazSS36z+GnAJZ3EedZFdL4fjYPgwG0dBgCgKNBAkKBwWHABlQgAH0vRhSgAFEVmYJ1ISQ4B8G9X0AyDPURjKG0wygeNE3QZN-BrLt+1bdstg4-w0wzHcczzAtGMhGN+0HEdxySQDWGAw9w38CZ+3vC4FNIU9ww-VgdzXNSj20qBr1vYRVMCTsNK0-svyaLMkkCDkp1BCNwymTh4m+MZpmmIA).

## Test plan

Confirm the checks are green and that no entity configuration got changed when I split the large array into atomic declarations. The changes here should only affect the type system so there is nothing to test in the browser.

cc @dmsnell @jsnajdr @youknowriad @sarayourfriend @getdave @draganescu @scruffian 