### PR TITLE
Try: Fix regression with mover and block control sizes.

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -22,6 +22,10 @@
 		@include break-small() {
 			flex-direction: column;
 		}
+
+		// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+		// This is best fixed by making the mover control area a proper single toolbar group.
+		padding: 0;
 	}
 
 	&.is-horizontal .block-editor-block-mover__move-button-container,

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -1,5 +1,12 @@
 .block-editor-block-switcher {
 	position: relative;
+
+	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+	// This is best fixed by making the mover control area a proper single toolbar group.
+	// It needs specificity due to style inherited from .components-accessible-toolbar .components-button.has-icon.has-icon.
+	.components-button.components-dropdown-menu__toggle.has-icon.has-icon {
+		min-width: $grid-unit-60;
+	}
 }
 
 // Show an indicator triangle.
@@ -7,7 +14,6 @@
 .block-editor-block-switcher__toggle {
 	position: relative;
 }
-
 
 .components-button.block-editor-block-switcher__toggle,
 .components-button.block-editor-block-switcher__no-switcher-icon {

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -1,11 +1,12 @@
 .block-editor-block-switcher {
 	position: relative;
+	padding: 0 ($grid-unit-15 * 0.5);
 
 	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
 	// This is best fixed by making the mover control area a proper single toolbar group.
 	// It needs specificity due to style inherited from .components-accessible-toolbar .components-button.has-icon.has-icon.
 	.components-button.components-dropdown-menu__toggle.has-icon.has-icon {
-		min-width: $grid-unit-60;
+		min-width: $button-size;
 	}
 }
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -95,6 +95,12 @@
 	.block-editor-block-lock-toolbar {
 		margin-left: -$grid-unit-15 * 0.5 !important;
 	}
+
+	// @todo: override toolbar group inherited paddings from components/block-tools/style.scss.
+	// This is best fixed by making the mover control area a proper single toolbar group.
+	.components-toolbar-group {
+		padding: 0;
+	}
 }
 
 .block-editor-block-toolbar,


### PR DESCRIPTION
## What?

Addresses feedback in https://github.com/WordPress/gutenberg/pull/39920#issuecomment-1087830600.

Changes there made the mover control and block locking icons too wide:


This PR, although slightly hacky, fixes it:

![dimensions](https://user-images.githubusercontent.com/1204802/161700291-2c8ebc35-c70f-4920-a7a1-d9543f09aa2b.gif)

## Why?

This is a quick bandaid. A better solution is to refactor the mover control to be a single toolbar group, so it can benefit from the very same simplified spacing metrics which were the cause of the regression. See also [this codepen](https://codepen.io/joen/pen/LYeZqep):

<img width="477" alt="Screenshot 2022-04-05 at 09 23 11" src="https://user-images.githubusercontent.com/1204802/161700472-941b7189-0e2e-4464-ac22-510b6a2d6d67.png">

In the meantime, this might be a good bandaid. The code surrounding those controls is already a bit messy.

## Testing Instructions

Test block toolbars, notably the mover control in a few case:

* only one block
* multiple blocks
* multiple blocks multiselected
* a locked block
* a locked block multi selected