### PR TITLE
Hide block movers in new navigation sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -53,7 +53,6 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			<ListView
 				id={ id }
 				showNestedBlocks
-				showBlockMovers
 				expandNested={ false }
 				__experimentalFeatures
 				__experimentalPersistentListViewFeatures


### PR DESCRIPTION
## What?
As a temporary measure while #39802 is a problem, this hides the block movers in the new site editor navigation sidebar.

## Why?
It's good to not ship features that have known accessibility issues. 😄 

The block movers in List View are pretty raw having been inactive for a long time. It'd be good to test and fix any issues with them before introducing them. I'm also unsure of the motivation behind enabling them in this new feature, but keeping them inactive in the main List View sidebar.

## How?
Deletes the `showBlockMovers` prop.

## Testing Instructions
You'll need an existing Navigation Menu to test, so if you don't have any, create one first in the navigation block. Then:
1. Open the site editor
2. In the top right corner click the Navigation Menus button
3. Choose a menu with items if one isn't already displayed.
4. See that the block movers aren't there.

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screen Shot 2022-04-05 at 3 43 31 pm](https://user-images.githubusercontent.com/677833/161704075-818150a9-9fc8-4d85-bd5e-b687c7a89017.png)

#### After
![Screen Shot 2022-04-05 at 3 42 43 pm](https://user-images.githubusercontent.com/677833/161703973-e57ab299-e2e4-48fe-beef-197109297395.png)

