### PR TITLE
Site Logo: Correctly reset the site icon

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -416,7 +416,7 @@ export default function LogoEdit( {
 		} );
 	};
 
-	const setIcon = ( newValue ) => 
+	const setIcon = ( newValue ) =>
 		// The new value needs to be `null` to reset the Site Icon.
 		editEntityRecord( 'root', 'site', undefined, {
 			site_icon: newValue ?? null,

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -416,12 +416,11 @@ export default function LogoEdit( {
 		} );
 	};
 
-	const setIcon = ( newValue ) => {
+	const setIcon = ( newValue ) => 
 		// The new value needs to be `null` to reset the Site Icon.
-		editEntityRecord( 'root', 'site', undefined, { 
+		editEntityRecord( 'root', 'site', undefined, {
 			site_icon: newValue ?? null,
 		} );
-	};
 
 	let alt = null;
 	if ( mediaItemData ) {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -416,14 +416,12 @@ export default function LogoEdit( {
 		} );
 	};
 
-	const setIcon = ( newValue ) =>{
-		 
+	const setIcon = ( newValue ) => {
 		newValue = newValue === undefined ? null : newValue;
 		editEntityRecord( 'root', 'site', undefined, {
 			site_icon: newValue,
-		} ); 
-		
-	}
+		} );
+	};
 
 	let alt = null;
 	if ( mediaItemData ) {

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -417,9 +417,9 @@ export default function LogoEdit( {
 	};
 
 	const setIcon = ( newValue ) => {
-		newValue = newValue === undefined ? null : newValue;
-		editEntityRecord( 'root', 'site', undefined, {
-			site_icon: newValue,
+		// The new value needs to be `null` to reset the Site Icon.
+		editEntityRecord( 'root', 'site', undefined, { 
+			site_icon: newValue ?? null,
 		} );
 	};
 

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -416,10 +416,14 @@ export default function LogoEdit( {
 		} );
 	};
 
-	const setIcon = ( newValue ) =>
+	const setIcon = ( newValue ) =>{
+		 
+		newValue = newValue === undefined ? null : newValue;
 		editEntityRecord( 'root', 'site', undefined, {
 			site_icon: newValue,
-		} );
+		} ); 
+		
+	}
 
 	let alt = null;
 	if ( mediaItemData ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If the logo image is reset or the site logo option "Use as site icon" is toggled off, the site icon is still used in the navigation sidebar in the site editor as per issue [39922](https://github.com/WordPress/gutenberg/issues/39922 "39922"). this pull request consist fix for site icon when it logo reset or "use as site icon" option is unchecked.

Fixes #39922.

## Testing Instructions
Please follow step by step instructions to test this PR.
 1. Upload a site logo.
 2. Enable it as the site icon, save.
 3. Refresh and see that the site icon replaces the WordPress logo in the navigation sidebar.
 4. Disable the "Use as site icon" option, save.
 5. See that the site icon still replaces the WP logo.
 6. Reset the site logo image from the block toolbar, save.
 7. See that the site icon still replaces the WP logo.