### PR TITLE
Translate pattern metadata (title & description)

### DIFF
--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -181,10 +181,10 @@ function gutenberg_register_theme_block_patterns() {
 					// Translate the pattern metadata.
 					$text_domain = $theme->get( 'TextDomain' );
 					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
-					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Title of the pattern', $text_domain );
+					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Pattern title', $text_domain );
 					if ( ! empty( $pattern_data['description'] ) ) {
 						//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
-						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Description of the pattern', $text_domain );
+						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', $text_domain );
 					}
 
 					// The actual pattern content is the output of the file.

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -172,7 +172,7 @@ function gutenberg_register_theme_block_patterns() {
 					}
 
 					// Translate the pattern metadata.
-					$text_domain           = wp_get_theme()->get( 'TextDomain' );
+					$text_domain = wp_get_theme()->get( 'TextDomain' );
 					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
 					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Title of the pattern', $text_domain );
 					if ( ! empty( $pattern_data['description'] ) ) {

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -171,6 +171,13 @@ function gutenberg_register_theme_block_patterns() {
 						}
 					}
 
+					// Translate the pattern metadata.
+					$text_domain           = wp_get_theme()->get( 'TextDomain' );
+					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Title of the pattern', $text_domain );
+					if ( ! empty( $pattern_data['description'] ) ) {
+						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Description of the pattern', $text_domain );
+					}
+
 					// The actual pattern content is the output of the file.
 					ob_start();
 					include $file;

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -173,8 +173,10 @@ function gutenberg_register_theme_block_patterns() {
 
 					// Translate the pattern metadata.
 					$text_domain           = wp_get_theme()->get( 'TextDomain' );
+					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
 					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Title of the pattern', $text_domain );
 					if ( ! empty( $pattern_data['description'] ) ) {
+						//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
 						$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Description of the pattern', $text_domain );
 					}
 

--- a/lib/compat/wordpress-6.0/block-patterns.php
+++ b/lib/compat/wordpress-6.0/block-patterns.php
@@ -87,10 +87,17 @@ function gutenberg_register_theme_block_patterns() {
 	);
 
 	// Register patterns for the active theme. If the theme is a child theme,
-	// let it override any patterns from the parent theme that shares the same
-	// slug.
-	foreach ( wp_get_active_and_valid_themes() as $theme ) {
-		$dirpath = $theme . '/patterns/';
+	// let it override any patterns from the parent theme that shares the same slug.
+	$themes     = array();
+	$stylesheet = get_stylesheet();
+	$template   = get_template();
+	if ( $stylesheet !== $template ) {
+		$themes[] = wp_get_theme( $stylesheet );
+	}
+	$themes[] = wp_get_theme( $template );
+
+	foreach ( $themes as $theme ) {
+		$dirpath = $theme->get_stylesheet_directory() . '/patterns/';
 		if ( file_exists( $dirpath ) ) {
 			$files = glob( $dirpath . '*.php' );
 			if ( $files ) {
@@ -172,7 +179,7 @@ function gutenberg_register_theme_block_patterns() {
 					}
 
 					// Translate the pattern metadata.
-					$text_domain = wp_get_theme()->get( 'TextDomain' );
+					$text_domain = $theme->get( 'TextDomain' );
 					//phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralText, WordPress.WP.I18n.NonSingularStringLiteralContext, WordPress.WP.I18n.NonSingularStringLiteralDomain, WordPress.WP.I18n.LowLevelTranslationFunction
 					$pattern_data['title'] = translate_with_gettext_context( $pattern_data['title'], 'Title of the pattern', $text_domain );
 					if ( ! empty( $pattern_data['description'] ) ) {


### PR DESCRIPTION
Related https://github.com/wp-cli/i18n-command/pull/312

## What?

https://github.com/WordPress/gutenberg/pull/36751 introduced the ability to automatically register patterns from the `/patterns` directory of the theme. This PR enables translation for the title & description of the pattern.

## Why?

Users expect patterns metadata to be translated.

## How?

This PR uses `translate_with_gettext_context` to pull the strings provided by the theme in the correct user locale before the pattern is registered.

## Testing Instructions

### 1 - Create the pattern

- Install and activate the TwentyTwentyTwo theme.
- Add the following pattern under `patterns/my-test-heading.php`:

```php
<?php
/**
 * Title: My test title
 * Description: My test description
 * Slug: twentytwentytwo/my-test-heading
 * Categories: text
 */

?>
<!-- wp:heading -->
<h2>Hello!</h2>
<!-- /wp:heading -->
<!-- wp:paragraph -->
<p>2 + 2 = <?php echo 2 + 2; ?></p>
<!-- /wp:paragraph -->
```

### 2 - Provide a translation

- Go to "Settings > General" and set the language of your site to "Spanish".
- Go to "Dashbord > Updates" and make sure you have the translations section updated (it contains the TwentyTwentyTwo strings in Spanish).
- Unzip the [twentytwentytwo-es_ES.mo.zip](https://github.com/WordPress/gutenberg/files/8419989/twentytwentytwo-es_ES.mo.zip) attached to this PR into `wp-content/languages/themes/`.

<details>
<summary>Alternatively, you can create the .mo file yourself for any language, here's how:</summary>

- Go to `wp-content/languages/themes/` and paste the following at the end of the `twentytwentytwo-es_ES.po` file:

```po
#: patterns/my-test-heading.php
msgctxt "Pattern title"
msgid "My test title"
msgstr "Mi título de test"

#: patterns/my-test-heading.php
msgctxt "Pattern description"
msgid "My test description"
msgstr "Mi descripción de test"
```
- Run the `wp i18n make-mo <path-to-your-po-file> <path-to-the-directory>` command to convert the `.po` file into the `.mo` one in the same directory.

</details>

### 3 - Do the testing

- Go to an inserted and search for "test".
- Verify that the pattern title is translated accordingly to the site language (switch between English and Spanish).
