### PR TITLE
[RNMobile] Spacer block: Fix import of `MIN_SPACER_SIZE` constant

### DIFF
--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_SIZE } from './edit';
+import { MIN_SPACER_SIZE } from './edit.js';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };

--- a/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
+++ b/packages/block-library/src/spacer/test/__snapshots__/index.native.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spacer block decrements height 1`] = `
+"<!-- wp:spacer {\\"height\\":\\"99px\\"} -->
+<div style=\\"height:99px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Spacer block increments height 1`] = `
+"<!-- wp:spacer {\\"height\\":\\"101px\\"} -->
+<div style=\\"height:101px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Spacer block inserts block 1`] = `
+"<!-- wp:spacer -->
+<div style=\\"height:100px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Spacer block updates height to 25vh 1`] = `
+"<!-- wp:spacer {\\"height\\":\\"25vh\\"} -->
+<div style=\\"height:25vh\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;
+
+exports[`Spacer block updates height to 50px 1`] = `
+"<!-- wp:spacer {\\"height\\":\\"50px\\"} -->
+<div style=\\"height:50px\\" aria-hidden=\\"true\\" class=\\"wp-block-spacer\\"></div>
+<!-- /wp:spacer -->"
+`;

--- a/packages/block-library/src/spacer/test/index.native.js
+++ b/packages/block-library/src/spacer/test/index.native.js
@@ -1,0 +1,180 @@
+/**
+ * External dependencies
+ */
+import {
+	fireEvent,
+	getEditorHtml,
+	initializeEditor,
+	waitFor,
+} from 'test/helpers';
+
+/**
+ * WordPress dependencies
+ */
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+} );
+
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
+
+describe( 'Spacer block', () => {
+	it( 'inserts block', async () => {
+		const {
+			getByA11yLabel,
+			getByTestId,
+			getByText,
+		} = await initializeEditor();
+
+		fireEvent.press( getByA11yLabel( 'Add block' ) );
+
+		const blockList = getByTestId( 'InserterUI-Blocks' );
+		// onScroll event used to force the FlatList to render all items
+		fireEvent.scroll( blockList, {
+			nativeEvent: {
+				contentOffset: { y: 0, x: 0 },
+				contentSize: { width: 100, height: 100 },
+				layoutMeasurement: { width: 100, height: 100 },
+			},
+		} );
+
+		fireEvent.press( await waitFor( () => getByText( 'Spacer' ) ) );
+
+		expect( getByA11yLabel( /Spacer Block\. Row 1/ ) ).toBeVisible();
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'updates height to 50px', async () => {
+		const initialHtml = `<!-- wp:spacer -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->`;
+		const {
+			getByA11yLabel,
+			getByDisplayValue,
+			getByTestId,
+			getByText,
+		} = await initializeEditor( {
+			initialHtml,
+		} );
+
+		// Select Spacer block
+		const spacerBlock = getByA11yLabel( /Spacer Block\. Row 1/ );
+		fireEvent.press( spacerBlock );
+
+		// Open block settings
+		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
+		await waitFor(
+			() => getByTestId( 'block-settings-modal' ).props.isVisible
+		);
+
+		// Update height attribute
+		fireEvent.press( getByText( '100' ) );
+		const heightTextInput = getByDisplayValue( '100' );
+		fireEvent.changeText( heightTextInput, '50' );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'updates height to 25vh', async () => {
+		const initialHtml = `<!-- wp:spacer -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->`;
+		const {
+			getByA11yLabel,
+			getByDisplayValue,
+			getByTestId,
+			getByText,
+		} = await initializeEditor( {
+			initialHtml,
+		} );
+
+		// Select Spacer block
+		const spacerBlock = getByA11yLabel( /Spacer Block\. Row 1/ );
+		fireEvent.press( spacerBlock );
+
+		// Open block settings
+		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
+		await waitFor(
+			() => getByTestId( 'block-settings-modal' ).props.isVisible
+		);
+
+		// Set vh unit
+		fireEvent.press( getByText( 'px' ) );
+		fireEvent.press( getByText( 'Viewport height (vh)' ) );
+
+		// Update height attribute
+		fireEvent.press( getByText( '100' ) );
+		const heightTextInput = getByDisplayValue( '100' );
+		fireEvent.changeText( heightTextInput, '25' );
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'increments height', async () => {
+		const initialHtml = `<!-- wp:spacer -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->`;
+		const { getByA11yLabel, getByTestId } = await initializeEditor( {
+			initialHtml,
+		} );
+
+		// Select Spacer block
+		const spacerBlock = getByA11yLabel( /Spacer Block\. Row 1/ );
+		fireEvent.press( spacerBlock );
+
+		// Open block settings
+		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
+		await waitFor(
+			() => getByTestId( 'block-settings-modal' ).props.isVisible
+		);
+
+		// Increment height
+		fireEvent(
+			getByA11yLabel( /Height\. Value is 100 Pixels \(px\)/ ),
+			'accessibilityAction',
+			{
+				nativeEvent: { actionName: 'increment' },
+			}
+		);
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+
+	it( 'decrements height', async () => {
+		const initialHtml = `<!-- wp:spacer -->
+		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
+		<!-- /wp:spacer -->`;
+		const { getByA11yLabel, getByTestId } = await initializeEditor( {
+			initialHtml,
+		} );
+
+		// Select Spacer block
+		const spacerBlock = getByA11yLabel( /Spacer Block\. Row 1/ );
+		fireEvent.press( spacerBlock );
+
+		// Open block settings
+		fireEvent.press( getByA11yLabel( 'Open Settings' ) );
+		await waitFor(
+			() => getByTestId( 'block-settings-modal' ).props.isVisible
+		);
+
+		// Increment height
+		fireEvent(
+			getByA11yLabel( /Height\. Value is 100 Pixels \(px\)/ ),
+			'accessibilityAction',
+			{
+				nativeEvent: { actionName: 'decrement' },
+			}
+		);
+
+		expect( getEditorHtml() ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix import of `MIN_SPACER_SIZE` constant in Spacer block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After the changes introduced in https://github.com/WordPress/gutenberg/pull/39577, the `MIN_SPACER_SIZE` constant is now used as the `min` prop passed to the `UnitControl` component ([reference](https://github.com/WordPress/gutenberg/blob/c8db178fc64a91579c7e02a737ac4386786b7a13/packages/block-library/src/spacer/controls.native.js#L70)). However, the current import statement ([reference](https://github.com/WordPress/gutenberg/blob/c8db178fc64a91579c7e02a737ac4386786b7a13/packages/block-library/src/spacer/controls.native.js#L17)) is pointing to the native version of the `edit` file instead of the web version, where the constant is defined ([reference](https://github.com/WordPress/gutenberg/blob/093773ed5761d86c7657d3109e2d0d9260990920/packages/block-library/src/spacer/edit.js#L19)).

This implies that the value used in the `min` prop is `undefined`, which leads to a crash in the app when the `UnitControl` component is focused.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use `./edit.js` as the import path instead of `./edit` to assure we load the constant from the right `edit` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the app.
1. Create a post or page.
1. Add a Spacer block.
1. Open the block's settings.
1. Change the height value using the keyboard.
1. Observe that the height attribute is updated as expected and that no error is thrown.

## Screenshots or screencast <!-- if applicable -->
N/A
