### PR TITLE
Optimize `getClientIdsOfDescendants` and `getClientIdsWithDescendants` selectors.

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -436,9 +436,9 @@ _Properties_
 
 ### getClientIdsOfDescendants
 
-Returns an array containing the clientIds of all descendants of the
-blocks given. Ids are returned in the same order that they appear in
-the editor.
+Returns an array containing the clientIds of all descendants of the blocks
+given. Returned ids are ordered first by the order of the ids given, then
+by the order that they appear in the editor.
 
 _Parameters_
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -225,13 +225,18 @@ export const __unstableGetClientIdsTree = createSelector(
  *
  * @return {Array} ids of descendants.
  */
-export const getClientIdsOfDescendants = ( state, clientIds ) =>
-	clientIds.flatMap( ( clientId ) =>
-		getBlockOrder( state, clientId ).flatMap( ( descendantId ) => [
-			descendantId,
-			...getClientIdsOfDescendants( state, [ descendantId ] ),
-		] )
-	);
+export const getClientIdsOfDescendants = ( state, clientIds ) => {
+	const collectedIds = [];
+	for ( const givenId of clientIds ) {
+		for ( const descendantId of getBlockOrder( state, givenId ) ) {
+			collectedIds.push(
+				descendantId,
+				...getClientIdsOfDescendants( state, [ descendantId ] )
+			);
+		}
+	}
+	return collectedIds;
+};
 
 /**
  * Returns an array containing the clientIds of the top-level blocks and
@@ -243,11 +248,16 @@ export const getClientIdsOfDescendants = ( state, clientIds ) =>
  * @return {Array} ids of top-level and descendant blocks.
  */
 export const getClientIdsWithDescendants = createSelector(
-	( state ) =>
-		getBlockOrder( state ).flatMap( ( topLevelId ) => [
-			topLevelId,
-			...getClientIdsOfDescendants( state, [ topLevelId ] ),
-		] ),
+	( state ) => {
+		const collectedIds = [];
+		for ( const topLevelId of getBlockOrder( state ) ) {
+			collectedIds.push(
+				topLevelId,
+				...getClientIdsOfDescendants( state, [ topLevelId ] )
+			);
+		}
+		return collectedIds;
+	},
 	( state ) => [ state.blocks.order ]
 );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -216,9 +216,9 @@ export const __unstableGetClientIdsTree = createSelector(
 );
 
 /**
- * Returns an array containing the clientIds of all descendants of the
- * blocks given. Ids are returned in the same order that they appear in
- * the editor.
+ * Returns an array containing the clientIds of all descendants of the blocks
+ * given. Returned ids are ordered first by the order of the ids given, then
+ * by the order that they appear in the editor.
  *
  * @param {Object} state     Global application state.
  * @param {Array}  clientIds Array of blocks to inspect.


### PR DESCRIPTION
## What?
This PR (hopefully) optimizes the performance of the `getClientIdsOfDescendants` and `getClientIdsWithDescendants` selectors, to (hopefully) counteract any extra load caused by #39985.

This PR also revises the description of `getClientIdsOfDescendants` to properly describe cases where multiple ids are passed to it.

## Why?
#39985 may have slowed them down a bit.

## How?
By using for-of loops, we can avoid creating a bunch of intermediary arrays, which should presumably speed things up a bit.

## Testing Instructions
Check the "Performances Tests" in the PR checks, I guess? Not sure how reliable that is, though.
