### PR TITLE
[RNMobile] Remove bottom padding from picker bottom sheet on Android

### DIFF
--- a/packages/components/src/mobile/picker/index.android.js
+++ b/packages/components/src/mobile/picker/index.android.js
@@ -78,7 +78,6 @@ export default class Picker extends Component {
 			<BottomSheet
 				isVisible={ isVisible }
 				onClose={ this.onClose }
-				style={ { paddingBottom: 20 } }
 				hideHeader
 				testID={ testID }
 			>


### PR DESCRIPTION
## What?
This PR removes some extra bottom padding from the bottomsheet picker on Android. I [noticed this extra padding when looking at a different issue](https://github.com/wordpress-mobile/gutenberg-mobile/issues/2001#issuecomment-1071181386), and @iamthomasbishop confirmed that we want to remove it. I'm not sure this fix gets us to the ideal state, but it seems like a definite improvement.

## Why?
It's not clear to me why this padding was added initially, but I'm guessing that some other change must have removed the need for it at some point.

## How?

## Testing Instructions
Take a look at the bottom sheet picker component and make sure nothing looks off. In particular, a few good things to make sure and check are:
1. Gallery Block -> Settings -> Link to
2. The "Choose [Media]" picker for a media block
3. Latest Posts -> Settings -> Order By [OR] Category

**It would be good to also explore other bottom sheet components to make sure I'm not unintentionally breaking something else with this change.**

## Screenshots

<details>
<summary>Gallery Block -> Settings -> Link to</summary>

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/4656348/161841820-d63eb88a-1178-470f-9157-baaeecec2ba2.png) |  ![image](https://user-images.githubusercontent.com/4656348/161842386-8a9069ab-5771-482d-ba50-5c718dbaff95.png)

</details>

<details>
<summary>Choose [Media]</summary>

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/4656348/161841680-b9357f7c-220c-45ae-8c3d-e048ab407b55.png) | ![image](https://user-images.githubusercontent.com/4656348/161842586-7c56e5b3-c1ee-4306-94d1-8a58d2fd3fbe.png)
</details>

<details>
<summary>Latest Posts Block -> Customize -> Order By [OR] Category</summary>

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/4656348/161842226-3e8e0fd2-e533-4983-9345-503eac10a1f5.png) | ![image](https://user-images.githubusercontent.com/4656348/161842817-a7a55db1-0b93-4fbd-ba74-78f3f12fa513.png)

</details>