### PR TITLE
Webfonts API: Do not trigger warning on already enqueued font families

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -152,15 +152,7 @@ class WP_Webfonts {
 		$slug = $this->get_font_slug( $font_family_name );
 
 		if ( isset( $this->enqueued_webfonts[ $slug ] ) ) {
-			trigger_error(
-				sprintf(
-					/* translators: %s unique slug to identify the font family of the webfont */
-					__( 'The "%s" font family is already enqueued.', 'gutenberg' ),
-					$slug
-				)
-			);
-
-			return false;
+			return true;
 		}
 
 		if ( ! isset( $this->registered_webfonts[ $slug ] ) ) {


### PR DESCRIPTION
## What?

Do not trigger an error if trying to enqueue a font family that was already enqueued.

## Why?

It's super annoying. If the font family is already enqueued, let's just move on with our lives.

When implementing a web font scanning logic for example, the same font might be referenced by multiple blocks, and having to check whether the font was already enqueued before just to avoid the warning is redundant -- we do have guards inside the enqueueing method.

## Testing Instructions

```php
add_action(
  'after_setup_theme',
  function() {
    wp_register_webfont(
      array(
        'font-family'  => 'Roboto',
        'font-style'   => 'normal',
        'font-stretch' => 'normal',
        'font-weight'  => '400',
        'src'          => get_theme_file_uri( '/assets/fonts/Roboto-regular.ttf' ),
      )
    );

    wp_enqueue_webfont( 'Roboto' );
    wp_enqueue_webfont( 'Roboto' );
  }
);
```

Notice we're calling `wp_enqueue_webfont` twice. When opening the site, it should not yell at you because you called enqueue twice for the same family.