### PR TITLE
Group: Fix variation isActive check to cover case where type is not set, but inherit is

### DIFF
--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -13,6 +13,7 @@ const variations = [
 		scope: [ 'transform' ],
 		isActive: ( blockAttributes ) =>
 			! blockAttributes.layout ||
+			! blockAttributes.layout?.type ||
 			blockAttributes.layout?.type === 'default',
 		icon: group,
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following on from #40036, I noticed that if the "Inherit default layout" option is toggled for the Group block, then none of the variations is registered as active, so the Group variation is not highlighted in the list of variations in the block editor sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When we toggle the Inherit flag, an option is set in the `layout` object, however `type` is also undefined, so that current `isActive` check wasn't factoring in this case.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is to add an additional check for if there is a layout object, and if there is, but the `type` is empty, then the Group variation must be active.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Group block to a post, it should default to the Group variation being selected
2. Toggle the "Inherit default layout" toggle
3. Notice that the Group block should still be highlighted as selected in the list of variations
4. Check that switching to Row and Stack variations still works as before

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/161876878-4d8fa94b-a0bf-4f03-a79e-42a9d3db568c.png) | ![image](https://user-images.githubusercontent.com/14988353/161876893-0fab1d50-9912-493c-893b-b8382243a68b.png) |