### PR TITLE
MultiSelectSidebar: Fix spacing of color panel items

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -70,6 +70,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				<InspectorControls.Slot
 					__experimentalGroup="color"
 					label={ __( 'Color' ) }
+					className="color-block-support-panel__inner-wrapper"
 				/>
 				<InspectorControls.Slot
 					__experimentalGroup="typography"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: https://github.com/WordPress/gutenberg/issues/40040

## What?
<!-- In a few words, what is the PR actually doing? -->

While testing #40036 it was reported that spacing of the color panel items in the multi-select inspector was off. It looks like following #34027 we needed to add the class name to the slot at the multi-select level, too, to remove the spacing between items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes the additional spacing between color items (like Background and Text) in the multi select sidebar, as reported in #40040

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the same classname used in the individual sidebar for the color slot that gets rendered for the multi select sidebar (this class removes the row gap between items).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add at least two paragraphs to a post
2. Select both paragraphs at the same time
3. Observe that in this PR the spacing is correct as in the screenshots below
4. Adjusting the colors should still work as before

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/161881097-88aae2e9-e030-4819-ae7a-04e822faa030.png) | ![image](https://user-images.githubusercontent.com/14988353/161881112-4754ef6a-d128-4f00-ba07-24b1beed51ae.png) |