### PR TITLE
Add color, border and margin support to the post content block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -527,7 +527,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), spacing (margin, padding), ~~html~~
 -	**Attributes:** 
 
 ## Post Date

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -12,7 +12,8 @@
 		"html": false,
 		"__experimentalLayout": true,
 		"spacing": {
-			"margin": [ "top", "bottom" ]
+			"margin": [ "top", "bottom" ],
+			"padding": true
 		},
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -10,7 +10,30 @@
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,
-		"__experimentalLayout": true
+		"__experimentalLayout": true,
+		"spacing": {
+			"margin": [ "top", "bottom" ]
+		},
+		"color": {
+			"gradients": true,
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		}
 	},
 	"editorStyle": "wp-block-post-content-editor"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add color, border and margin support to the post content block.
-Does not add Typography settings because font family is blocked awaiting the web fonts api.
Partial for https://github.com/WordPress/gutenberg/issues/35118, https://github.com/WordPress/gutenberg/issues/40074


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To let users have a uniform style of post content on archive pages or anywhere where the post content block is used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds top and bottom margin, border, background, text color, link color and gradient support in block.json.

## Testing Instructions
1. Activate a full site editing theme
2. Select or add a post content block in the site editor
3. Test that the block has the new settings and that they work
4. Save and view the front and make sure all settings are applied correctly.

## Screenshots or screencast <!-- if applicable -->
Blog page, Twenty Twenty-two (excerpt block is replaced with post content block)
![blog page with post content with a gradient background and orange text](https://user-images.githubusercontent.com/7422055/161894327-80d2f99f-0140-482d-ac78-99f01e37e50f.png)
