### PR TITLE
[RNMobile] - Add optional wait in getBlockAtPosition

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -135,7 +135,7 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 	it( 'should be able to merge blocks with unknown html elements', async () => {
 		await editorPage.setHtmlContent(
 			[
-				testData.unknownElementBlock,
+				testData.unknownElementParagraphBlock,
 				testData.lettersInParagraphBlock,
 			].join( '\n\n' )
 		);

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-paragraph.test.js
@@ -133,15 +133,12 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 	} );
 
 	it( 'should be able to merge blocks with unknown html elements', async () => {
-		await editorPage.setHtmlContent( `
-<!-- wp:paragraph -->
-<p><unknownhtmlelement>abc</unknownhtmlelement>D</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>E</p>
-<!-- /wp:paragraph -->` );
-
+		await editorPage.setHtmlContent(
+			[
+				testData.unknownElementBlock,
+				testData.lettersInParagraphBlock,
+			].join( '\n\n' )
+		);
 		// // Merge paragraphs.
 		const secondParagraphBlockElement = await editorPage.getBlockAtPosition(
 			blockNames.paragraph,
@@ -165,15 +162,12 @@ describe( 'Gutenberg Editor tests for Paragraph Block', () => {
 
 	// Based on https://github.com/wordpress-mobile/gutenberg-mobile/pull/1507
 	it( 'should handle multiline paragraphs from web', async () => {
-		await editorPage.setHtmlContent( `
-<!-- wp:paragraph -->
-<p>multiple lines<br><br></p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p></p>
-<!-- /wp:paragraph -->` );
-
+		await editorPage.setHtmlContent(
+			[
+				testData.multiLinesParagraphBlock,
+				testData.paragraphBlockEmpty,
+			].join( '\n\n' )
+		);
 		// // Merge paragraphs.
 		const secondParagraphBlockElement = await editorPage.getBlockAtPosition(
 			blockNames.paragraph,

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -170,7 +170,7 @@ exports.multiLinesParagraphBlock = `<!-- wp:paragraph -->
 <p>multiple lines<br>multiple lines<br>multiple lines</p>
 <!-- /wp:paragraph -->`;
 
-exports.unknownElementBlock = `<!-- wp:paragraph -->
+exports.unknownElementParagraphBlock = `<!-- wp:paragraph -->
 <p><unknownhtmlelement>abc</unknownhtmlelement>D</p>
 <!-- /wp:paragraph -->`;
 

--- a/packages/react-native-editor/__device-tests__/helpers/test-data.js
+++ b/packages/react-native-editor/__device-tests__/helpers/test-data.js
@@ -165,3 +165,15 @@ exports.moreBlockEmpty = `<!-- wp:more -->
 exports.paragraphBlockEmpty = `<!-- wp:paragraph -->
 <p></p>
 <!-- /wp:paragraph -->`;
+
+exports.multiLinesParagraphBlock = `<!-- wp:paragraph -->
+<p>multiple lines<br>multiple lines<br>multiple lines</p>
+<!-- /wp:paragraph -->`;
+
+exports.unknownElementBlock = `<!-- wp:paragraph -->
+<p><unknownhtmlelement>abc</unknownhtmlelement>D</p>
+<!-- /wp:paragraph -->`;
+
+exports.lettersInParagraphBlock = `<!-- wp:paragraph -->
+<p>ABCD</p>
+<!-- /wp:paragraph -->`;

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -51,9 +51,31 @@ class EditorPage {
 	async getBlockAtPosition(
 		blockName,
 		position = 1,
-		options = { autoscroll: false }
+		options = { autoscroll: false, useWaitForVisible: false }
 	) {
-		const blockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }")]`;
+		let blockLocator;
+
+		// Make it optional to use waitForVisible() so we can handle this test by test. 
+		// This condition can be removed once we have gone through all test cases.
+		if ( options.useWaitForVisible ) {
+			let elementType;
+			switch ( blockName ) {
+				case blockNames.cover:
+					elementType = 'XCUIElementTypeButton';
+					break;
+				default:
+					elementType = 'XCUIElementTypeOther';
+					break;
+			}
+
+			blockLocator = isAndroid()
+				? `//android.view.ViewGroup[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }")]`
+				: `(//${ elementType }[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }")])[1]`;
+
+			await waitForVisible( this.driver, blockLocator );
+		} else {
+			blockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockName } Block. Row ${ position }")]`;
+		}
 		const elements = await this.driver.elementsByXPath( blockLocator );
 		const lastElementFound = elements[ elements.length - 1 ];
 		if ( elements.length === 0 && options.autoscroll ) {
@@ -429,6 +451,10 @@ class EditorPage {
 			: '//XCUIElementTypeButton';
 		const blockActionsMenuButtonIdentifier = `Open Block Actions Menu`;
 		const blockActionsMenuButtonLocator = `${ buttonElementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ blockActionsMenuButtonIdentifier }")]`;
+		const blockActionsMenuButton = await waitForVisible(
+			this.driver,
+			blockActionsMenuButtonLocator
+		);
 
 		if ( isAndroid() ) {
 			const block = await this.getBlockAtPosition( blockName, position );
@@ -443,14 +469,12 @@ class EditorPage {
 			}
 		}
 
-		const blockActionsMenuButton = await this.driver.elementByXPath(
-			blockActionsMenuButtonLocator
-		);
 		await blockActionsMenuButton.click();
 
 		const removeActionButtonIdentifier = 'Remove block';
 		const removeActionButtonLocator = `${ buttonElementName }[contains(@${ this.accessibilityIdXPathAttrib }, "${ removeActionButtonIdentifier }")]`;
-		const removeActionButton = await this.driver.elementByXPath(
+		const removeActionButton = await waitForVisible(
+			this.driver,
 			removeActionButtonLocator
 		);
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -55,7 +55,7 @@ class EditorPage {
 	) {
 		let blockLocator;
 
-		// Make it optional to use waitForVisible() so we can handle this test by test. 
+		// Make it optional to use waitForVisible() so we can handle this test by test.
 		// This condition can be removed once we have gone through all test cases.
 		if ( options.useWaitForVisible ) {
 			let elementType;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
I have been testing paragraph tests in [this draft PR](https://github.com/WordPress/gutenberg/pull/39798). However, the changes became too big so I am breaking it down to a few smaller PRs. This PR is the first part of a few PRs in an attempt to fix the flakiness on tests that are using the paragraph blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The paragraph tests are currently flaky and don't work when running locally. When it fails in the CI, it is harder to debug it locally to know if it's an issue with the test or something else. This change is the first part to make it work consistently both when testing locally and in CI. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. Moves all test data in `gutenberg-editor-paragraph.test.js` to `test-data.js` file to be consistent with other test files
2. Create a condition in `getBlockAtPosition()` to use the new helper `waitForVisible()`. It is optional because from testing found that adding this here works for some tests but not all. In order to not have to update all tests at the same time, adding this condition so we can try it out test by test. Once we have checked all the tests, this condition can be removed/updated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
Check that test still work in the CI.

## Screenshots or screencast <!-- if applicable -->
