### PR TITLE
Global Styles: Fix alignment of Global Styles color controls

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-colors.js
+++ b/packages/edit-site/src/components/global-styles/screen-colors.js
@@ -35,7 +35,7 @@ function BackgroundColorItem( { name, parentMenu } ) {
 	return (
 		<NavigationButton path={ parentMenu + '/colors/background' }>
 			<HStack justify="flex-start">
-				<ColorIndicatorWrapper>
+				<ColorIndicatorWrapper expanded={ false }>
 					<ColorIndicator
 						colorValue={ gradientValue ?? backgroundColor }
 					/>
@@ -58,7 +58,7 @@ function TextColorItem( { name, parentMenu } ) {
 	return (
 		<NavigationButton path={ parentMenu + '/colors/text' }>
 			<HStack justify="flex-start">
-				<ColorIndicatorWrapper>
+				<ColorIndicatorWrapper expanded={ false }>
 					<ColorIndicator colorValue={ color } />
 				</ColorIndicatorWrapper>
 				<FlexItem>{ __( 'Text' ) }</FlexItem>
@@ -79,7 +79,7 @@ function LinkColorItem( { name, parentMenu } ) {
 	return (
 		<NavigationButton path={ parentMenu + '/colors/link' }>
 			<HStack justify="flex-start">
-				<ColorIndicatorWrapper>
+				<ColorIndicatorWrapper expanded={ false }>
 					<ColorIndicator colorValue={ color } />
 				</ColorIndicatorWrapper>
 				<FlexItem>{ __( 'Links' ) }</FlexItem>


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/39982

## What?
Fixes broken layout of global styles color controls caused by https://github.com/WordPress/gutenberg/pull/39982.

## Why?
Looks nicer when text isn't forced outside the control.

## How?
Maintains the change in approach added in https://github.com/WordPress/gutenberg/pull/39982 however this PR sets the `expanded` prop on the `ColorIndicatorWrapper` to `false` so that it adapts better while keeping the vertical alignment intended by the original PR.

## Testing Instructions
1. Load the site editor and expand Colors under the Global Styles sidebar
2. Note the overflowing text labels for Text, Background, and Links
3. Checkout this PR and navigate back to the same panel
4. Note the text labels are now contained within each control control's item.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="283" alt="Screen Shot 2022-04-06 at 3 35 08 pm" src="https://user-images.githubusercontent.com/60436221/161903603-8824bc1b-7ce2-45f0-b5d5-5c8162be1dfb.png"> | <img width="283" alt="Screen Shot 2022-04-06 at 3 36 18 pm" src="https://user-images.githubusercontent.com/60436221/161903607-01cb7136-440c-4eb1-b72e-5f4adcbf975c.png"> | 
