### PR TITLE
Style Engine: add typography to backend

### DIFF
--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -52,7 +52,7 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		return $attributes;
 	}
 
-	$style_engine                    = WP_Style_Engine_Gutenberg::get_instance();
+	$style_engine                    = gutenberg_get_style_engine();
 	$skip_padding                    = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
 	$skip_margin                     = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$spacing_block_styles            = array();

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -175,7 +175,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	$style_engine  = WP_Style_Engine_Gutenberg::get_instance();
+	$style_engine  = gutenberg_get_style_engine();
 	$inline_styles = $style_engine->generate(
 		array( 'typography' => $styles ),
 		array(
@@ -183,10 +183,10 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		)
 	);
 
-	$classnames = $style_engine->generate(
+	$classnames = $style_engine->get_classnames(
 		array( 'typography' => $classes ),
 		array(
-			'classnames' => true,
+			'use_schema' => true,
 		)
 	);
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -107,7 +107,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
 		if ( $has_named_font_size ) {
-			$classes[] = sprintf( 'has-%s-font-size', _wp_to_kebab_case( $block_attributes['fontSize'] ) );
+			$classes['fontSize'] = _wp_to_kebab_case( $block_attributes['fontSize'] );
 		} elseif ( $has_custom_font_size ) {
 			$styles['fontSize'] = $block_attributes['style']['typography']['fontSize'];
 		}
@@ -118,7 +118,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
 		if ( $has_named_font_family ) {
-			$classes[] = sprintf( 'has-%s-font-family', _wp_to_kebab_case( $block_attributes['fontFamily'] ) );
+			$classes['fontFamily'] = _wp_to_kebab_case( $block_attributes['fontFamily'] );
 		} elseif ( $has_custom_font_family ) {
 			$font_family_custom = $block_attributes['style']['typography']['fontFamily'];
 			// Before using classes, the value was serialized as a CSS Custom Property.
@@ -175,10 +175,6 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( ! empty( $classes ) ) {
-		$attributes['class'] = implode( ' ', $classes );
-	}
-
 	$style_engine  = WP_Style_Engine_Gutenberg::get_instance();
 	$inline_styles = $style_engine->generate(
 		array( 'typography' => $styles ),
@@ -186,6 +182,17 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 			'inline' => true,
 		)
 	);
+
+	$classnames = $style_engine->generate(
+		array( 'typography' => $classes ),
+		array(
+			'classnames' => true,
+		)
+	);
+
+	if ( ! empty( $classnames ) ) {
+		$attributes['class'] = $classnames;
+	}
 
 	if ( ! empty( $inline_styles ) ) {
 		$attributes['style'] = $inline_styles;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -107,7 +107,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
 		if ( $has_named_font_size ) {
-			$classes['fontSize'] = _wp_to_kebab_case( $block_attributes['fontSize'] );
+			$classes['fontSize'] = $block_attributes['fontSize'];
 		} elseif ( $has_custom_font_size ) {
 			$styles['fontSize'] = $block_attributes['style']['typography']['fontSize'];
 		}
@@ -118,7 +118,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
 		if ( $has_named_font_family ) {
-			$classes['fontFamily'] = _wp_to_kebab_case( $block_attributes['fontFamily'] );
+			$classes['fontFamily'] = $block_attributes['fontFamily'];
 		} elseif ( $has_custom_font_family ) {
 			$font_family_custom = $block_attributes['style']['typography']['fontFamily'];
 			// Before using classes, the value was serialized as a CSS Custom Property.
@@ -184,10 +184,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	);
 
 	$classnames = $style_engine->get_classnames(
-		array( 'typography' => $classes ),
-		array(
-			'use_schema' => true,
-		)
+		array( 'typography' => $classes )
 	);
 
 	if ( ! empty( $classnames ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -175,15 +175,15 @@ class WP_Style_Engine {
 			// Generate inline style rules.
 			if ( isset( $options['inline'] ) && true === $options['inline'] ) {
 				foreach ( $rules as $rule => $value ) {
-					$filtered_css = esc_html( safecss_filter_attr( "{$rule}:{$value}" ) );
+					$filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
 					if ( ! empty( $filtered_css ) ) {
-						$output .= $filtered_css . ';';
+						$output .= $filtered_css . '; ';
 					}
 				}
 			}
 		}
 
-		return $output;
+		return trim( $output );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -36,16 +36,58 @@ class WP_Style_Engine {
 	 *                    For example, `'padding' => 'array( 'top' => '1em' )` will return `array( 'padding-top' => '1em' )`
 	 */
 	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
-		'spacing' => array(
+		'spacing'    => array(
 			'padding' => array(
 				'property_key' => 'padding',
 				'path'         => array( 'spacing', 'padding' ),
-				'value_func'   => 'static::get_css_box_rules',
+				'value_func'   => 'static::get_css_rules',
 			),
 			'margin'  => array(
 				'property_key' => 'margin',
 				'path'         => array( 'spacing', 'margin' ),
-				'value_func'   => 'static::get_css_box_rules',
+				'value_func'   => 'static::get_css_rules',
+			),
+		),
+		'typography' => array(
+			'fontSize'       => array(
+				'property_key' => 'font-size',
+				'path'         => array( 'typography', 'fontSize' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontFamily'     => array(
+				'property_key' => 'font-family',
+				'path'         => array( 'typography', 'fontFamily' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontStyle'      => array(
+				'property_key' => 'font-style',
+				'path'         => array( 'typography', 'fontStyle' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontWeight'     => array(
+				'property_key' => 'font-weight',
+				'path'         => array( 'typography', 'fontWeight' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'lineHeight'     => array(
+				'property_key' => 'line-height',
+				'path'         => array( 'typography', 'lineHeight' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'textDecoration' => array(
+				'property_key' => 'text-decoration',
+				'path'         => array( 'typography', 'textDecoration' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'textTransform'  => array(
+				'property_key' => 'text-transform',
+				'path'         => array( 'typography', 'textTransform' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'letterSpacing'  => array(
+				'property_key' => 'letter-spacing',
+				'path'         => array( 'typography', 'letterSpacing' ),
+				'value_func'   => 'static::get_css_rules',
 			),
 		),
 	);
@@ -145,20 +187,23 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Returns a CSS ruleset for box model styles such as margins, padding, and borders.
+	 * Default style value parser that returns a CSS ruleset.
+	 * If the input contains an array, it will treated like a box model
+	 * for styles such as margins, padding, and borders
 	 *
 	 * @param string|array $style_value    A single raw Gutenberg style attributes value for a CSS property.
 	 * @param string       $style_property The CSS property for which we're creating a rule.
 	 *
 	 * @return array The class name for the added style.
 	 */
-	public static function get_css_box_rules( $style_value, $style_property ) {
+	public static function get_css_rules( $style_value, $style_property ) {
 		$rules = array();
 
 		if ( ! $style_value ) {
 			return $rules;
 		}
 
+		// We assume box model-like properties.
 		if ( is_array( $style_value ) ) {
 			foreach ( $style_value as $key => $value ) {
 				$rules[ "$style_property-$key" ] = $value;

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -129,14 +129,11 @@ class WP_Style_Engine {
 	 * Returns a classname built using a provided schema.
 	 *
 	 * @param array $block_styles An array of styles from a block's attributes.
-	 *                            Some of the values may contain slugs that need to be parsed using a schema.
-	 * @param array $options = array(
-	 *     'use_schema' => (boolean) Whether to use the internal classname schema in BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * );.
+	 *                            Some values may contain slugs that need to be parsed using a schema.
 	 *
 	 * @return string A CSS classname.
 	 */
-	public function get_classnames( $block_styles, $options = array() ) {
+	public function get_classnames( $block_styles ) {
 		$output = '';
 
 		if ( empty( $block_styles ) ) {

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -131,7 +131,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;',
 			),
 
-			'inline_valid_multiple_style'                  => array(
+			'inline_valid_multiple_spacing_style'          => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'padding' => array(
@@ -152,6 +152,25 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'inline' => true,
 				),
 				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;margin-top:12rem;margin-left:2vh;margin-bottom:2px;margin-right:10em;',
+			),
+
+			'inline_valid_multiple_typography_style'       => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'       => 'clamp(2em, 2vw, 4em)',
+						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+						'fontStyle'      => 'italic',
+						'fontWeight'     => '800',
+						'lineHeight'     => '1.3',
+						'textDecoration' => 'underline',
+						'textTransform'  => 'uppercase',
+						'letterSpacing'  => '2',
+					),
+				),
+				'options'         => array(
+					'inline' => true,
+				),
+				'expected_output' => 'font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -13,12 +13,12 @@ require __DIR__ . '/../class-wp-style-engine.php';
  */
 class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
-	 * Tests various manifestations of the $block_styles argument.
+	 * Tests generating styles based on various manifestations of the $block_styles argument.
 	 *
-	 * @dataProvider data_block_styles_fixtures
+	 * @dataProvider data_generate_css_fixtures
 	 */
 	function test_generate_css( $block_styles, $options, $expected_output ) {
-		$style_engine     = WP_Style_Engine::get_instance();
+		$style_engine     = wp_get_style_engine();
 		$generated_styles = $style_engine->generate(
 			$block_styles,
 			$options
@@ -31,7 +31,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_block_styles_fixtures() {
+	public function data_generate_css_fixtures() {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
@@ -42,7 +42,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'inline_invalid_block_styles_empty'            => array(
 				'block_styles'    => array(),
 				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
@@ -63,7 +62,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'pageBreakAfter' => 'verso',
 				),
 				'options'         => array(
-					'path'   => array( 'pageBreakAfter', 'verso' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
@@ -76,62 +74,24 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
 			),
 
-			'inline_invalid_multiple_style_unknown_property' => array(
-				'block_styles'    => array(
-					'spacing' => array(
-						'gavin' => '1000vw',
-					),
-				),
-				'options'         => array(
-					'inline' => true,
-				),
-				'expected_output' => '',
-			),
-
-			'inline_valid_single_style_string'             => array(
+			'inline_valid_style_string'                    => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'margin' => '111px',
 					),
 				),
 				'options'         => array(
-					'path'   => array( 'spacing', 'margin' ),
 					'inline' => true,
 				),
 				'expected_output' => 'margin: 111px;',
 			),
 
-			'inline_valid_single_style'                    => array(
-				'block_styles'    => array(
-					'spacing' => array(
-						'padding' => array(
-							'top'    => '42px',
-							'left'   => '2%',
-							'bottom' => '44px',
-							'right'  => '5rem',
-						),
-						'margin'  => array(
-							'top'    => '12rem',
-							'left'   => '2vh',
-							'bottom' => '2px',
-							'right'  => '10em',
-						),
-					),
-				),
-				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
-					'inline' => true,
-				),
-				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem;',
-			),
-
-			'inline_valid_multiple_spacing_style'          => array(
+			'inline_valid_box_model_style'                 => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'padding' => array(
@@ -154,7 +114,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 			),
 
-			'inline_valid_multiple_typography_style'       => array(
+			'inline_valid_typography_style'                => array(
 				'block_styles'    => array(
 					'typography' => array(
 						'fontSize'       => 'clamp(2em, 2vw, 4em)',
@@ -171,6 +131,47 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'inline' => true,
 				),
 				'expected_output' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+			),
+		);
+	}
+
+	/**
+	 * Tests generating classnames based on various manifestations of the $block_styles argument.
+	 *
+	 * @dataProvider data_get_classnames_fixtures
+	 */
+	function test_get_classnames( $block_styles, $options, $expected_output ) {
+		$style_engine     = wp_get_style_engine();
+		$generated_styles = $style_engine->get_classnames(
+			$block_styles,
+			$options
+		);
+		$this->assertSame( $expected_output, $generated_styles );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_classnames_fixtures() {
+		return array(
+			'default_return_value'        => array(
+				'block_styles'    => array(),
+				'options'         => null,
+				'expected_output' => '',
+			),
+			'valid_classnames_use_schema' => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'   => 'fantastic',
+						'fontFamily' => 'totally-awesome',
+					),
+				),
+				'options'         => array(
+					'use_schema' => true,
+				),
+				'expected_output' => 'has-fantastic-font-size has-totally-awesome-font-family',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -104,7 +104,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'path'   => array( 'spacing', 'margin' ),
 					'inline' => true,
 				),
-				'expected_output' => 'margin:111px;',
+				'expected_output' => 'margin: 111px;',
 			),
 
 			'inline_valid_single_style'                    => array(
@@ -128,7 +128,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
-				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;',
+				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem;',
 			),
 
 			'inline_valid_multiple_spacing_style'          => array(
@@ -151,7 +151,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;margin-top:12rem;margin-left:2vh;margin-bottom:2px;margin-right:10em;',
+				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 			),
 
 			'inline_valid_multiple_typography_style'       => array(
@@ -170,7 +170,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+				'expected_output' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
 			),
 		);
 	}

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -62,7 +62,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding:111px;margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px;',
+			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
 		);
 
 		$this->assertSame( $expected, $actual );
@@ -152,7 +152,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding-top:1px;padding-right:2px;padding-bottom:3px;padding-left:4px;',
+			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
 		);
 
 		$this->assertSame( $expected, $actual );


### PR DESCRIPTION
Tracking Issue: https://github.com/WordPress/gutenberg/issues/38167

## What?

Following on from https://github.com/WordPress/gutenberg/pull/39446 that introduced spacing to the Style Engine backend, this PR takes on typography ⚔️ 

## Why?

To introduce the Style Engine incrementally at first, and not change any output for now.

## How?

1. Using an existing method to output inline styles `generate`
2. Creating a new method `get_classnames` to output classnames inc. slugs.

## Testing Instructions

For dynamic blocks (Site Title, Navigation, Post Title, Post Date for example), check that the typography is output correctly on the frontend.

I've been testing so far with the Site Title block. To test with all controls you can update that [block's JSON](https://github.com/WordPress/gutenberg/blob/eaa2e0a91a8ccac43fa2e39f60c37713bff165d7/packages/block-library/src/site-title/block.json) supports with the following:

```json
		"typography": {
			"fontSize": true,
			"lineHeight": true,
			"__experimentalFontFamily": true,
			"__experimentalTextTransform": true,
			"__experimentalFontStyle": true,
			"__experimentalFontWeight": true,
			"__experimentalLetterSpacing": true,
			"__experimentalTextDecoration": true,
			"__experimentalDefaultControls": {
				"fontSize": true,
				"lineHeight": true,
				"fontAppearance": true,
				"letterSpacing": true,
				"textTransform": true
			}
		}
```

Test:

- Preset color classnames and font sizez
- Inline styles

Some test code (using TwentyTwentyTwo theme)

```html
<!-- wp:site-title {"style":{"typography":{"lineHeight":1.7,"textTransform":"uppercase","letterSpacing":"113px","textDecoration":"line-through"},"color":{"background":"#c2c9d0"}},"fontSize":"large","fontFamily":"source-serif-pro"} /-->
```

Deprecated HTML with presets
```html
<!-- wp:navigation {"orientation":"horizontal","style":{"typography":{"textTransform":"var:preset|text-transform|lowercase","textDecoration":"var:preset|text-decoration|strikethrough","fontStyle":"var:preset|font-style|italic","fontFamily":"var:preset|font-family|someAwesomeFont-right-here","fontWeight":"var:preset|font-weight|100"}}} -->
<!-- wp:navigation-link {"label":"WordPress","url":"https://www.wordpress.org/"} /-->
<!-- /wp:navigation -->
```
## Screenshots or screencast <!-- if applicable -->
