### PR TITLE
Scope Nav Menu sidebar to Plugin only

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -113,6 +113,26 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 
 	const isTemplatePart = templateType === 'wp_template_part';
 
+	const NavMenuSidebarToggle = () => (
+		<ToolbarGroup>
+			<ToolbarButton
+				className="components-toolbar__control"
+				label={ __( 'Open list view' ) }
+				onClick={ openNavigationSidebar }
+				icon={ listView }
+			/>
+		</ToolbarGroup>
+	);
+
+	// Conditionally include NavMenu sidebar in Plugin only.
+	// Optimise for dead code elimination.
+	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
+	let MaybeNavMenuSidebarToggle = 'Fragment';
+
+	if ( process.env.IS_GUTENBERG_PLUGIN ) {
+		MaybeNavMenuSidebarToggle = NavMenuSidebarToggle;
+	}
+
 	return (
 		<BlockEditorProvider
 			settings={ settings }
@@ -178,14 +198,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					<__unstableBlockNameContext.Consumer>
 						{ ( blockName ) =>
 							blockName === 'core/navigation' && (
-								<ToolbarGroup>
-									<ToolbarButton
-										className="components-toolbar__control"
-										label={ __( 'Open list view' ) }
-										onClick={ openNavigationSidebar }
-										icon={ listView }
-									/>
-								</ToolbarGroup>
+								<MaybeNavMenuSidebarToggle />
 							)
 						}
 					</__unstableBlockNameContext.Consumer>

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -58,6 +58,16 @@ export function SidebarComplementaryAreaFills() {
 	if ( ! isEditorSidebarOpened ) {
 		sidebarName = hasBlockSelection ? SIDEBAR_BLOCK : SIDEBAR_TEMPLATE;
 	}
+
+	// Conditionally include NavMenu sidebar in Plugin only.
+	// Optimise for dead code elimination.
+	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
+	let MaybeNavigationMenuSidebar = 'Fragment';
+
+	if ( process.env.IS_GUTENBERG_PLUGIN ) {
+		MaybeNavigationMenuSidebar = NavigationMenuSidebar;
+	}
+
 	return (
 		<>
 			<DefaultSidebar
@@ -78,7 +88,7 @@ export function SidebarComplementaryAreaFills() {
 				) }
 			</DefaultSidebar>
 			<GlobalStylesSidebar />
-			<NavigationMenuSidebar />
+			<MaybeNavigationMenuSidebar />
 		</>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR scopes the new Nav Menu sidebar to be a Plugin only feature in order to ensure it does not get included in WordPress 6.0.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Please see reasons in https://github.com/WordPress/gutenberg/issues/40080.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I'm using `process.env.IS_GUTENBERG_PLUGIN` to scope the Nav Sidebar code itself and the toggle button in the Nav block toolbar.

I have tried to optimise for dead code elimination by rendering either the component itself or a `React.Fragment`. By using the true component only by way of a conditional Webpack will eliminate the dead code _within_ the `if()` when we're not building for the Gutenberg Plugin.

There may be a better way to achieve this - cc'ing @talldan who I believe created the `IS_GUTENBERG_PLUGIN` functionality.

## Testing Instructions

- Goto Site Editor
- Check that by default
    - the Nav sidebar is shown
    - you can see the sidebar toggle control in the Nav block toolbar.
- Open the root `package.json` file and update the following line to be `false`
https://github.com/WordPress/gutenberg/blob/21421dc55dd2087cc629a16627866a452aecfe38/package.json#L22
- 🚨 **Rebuild** the Gutenberg Plugin `npm run dev`.
- Goto Site Editor and check that
    - you _cannot_ see the Nav Sidebar pinned item anymore.
    - the toggle is _no longer_ present in the Nav block toolbar.

⚠️ Don't forget to flip your `package.json` back to `true` again after you test this PR 😄 

## Screenshots or screencast <!-- if applicable -->

The following screenshots show the elements that should be excluded by this PR:
<img width="761" alt="Screen Shot 2022-04-06 at 07 10 11" src="https://user-images.githubusercontent.com/444434/161907046-80780867-6e0f-4ee3-a09f-331a58d330b2.png">

