### PR TITLE
Add duotone to placeholders for site logo and featured image

### DIFF
--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -29,7 +29,7 @@
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"color": {
-			"__experimentalDuotone": "img, .wp-block-post-featured-image__placeholder",
+			"__experimentalDuotone": "img, .wp-block-post-featured-image__placeholder, .components-placeholder__illustration, .components-placeholder::before",
 			"text": false,
 			"background": false
 		},

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -29,7 +29,7 @@
 	"supports": {
 		"align": [ "left", "right", "center", "wide", "full" ],
 		"color": {
-			"__experimentalDuotone": "img",
+			"__experimentalDuotone": "img, .wp-block-post-featured-image__placeholder",
 			"text": false,
 			"background": false
 		},

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -34,7 +34,7 @@
 		"align": true,
 		"alignWide": false,
 		"color": {
-			"__experimentalDuotone": "img",
+			"__experimentalDuotone": "img, .components-placeholder__illustration, .components-placeholder::before",
 			"text": false,
 			"background": false
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Make sure the duotone is visible on placeholders for featured image and site logo.
Closes https://github.com/WordPress/gutenberg/issues/40061

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To show that a duotone is applied to the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding additional CSS selectors to `"__experimentalDuotone"` in block-json.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a Post or Page. -->
2. Insert site logo and featured image block. If there are images already added to the blocks, remove them.
3. Apply a duotone to the placeholder.

## Screenshots or screencast <!-- if applicable -->
Featured image on top,
site logo,
selected site logo
![featured image and site logo block with duotone visible.](https://user-images.githubusercontent.com/7422055/161911276-bcf8a278-7a4f-41ed-b4cc-0f095b9dc911.png)


