### PR TITLE
List View: Disable dragging when block movement is locked

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.js
+++ b/packages/block-editor/src/components/block-draggable/index.js
@@ -23,19 +23,16 @@ const BlockDraggable = ( {
 	const { srcRootClientId, isDraggable, icon } = useSelect(
 		( select ) => {
 			const {
+				canMoveBlocks,
 				getBlockRootClientId,
-				getTemplateLock,
 				getBlockName,
 			} = select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
-			const templateLock = rootClientId
-				? getTemplateLock( rootClientId )
-				: null;
 			const blockName = getBlockName( clientIds[ 0 ] );
 
 			return {
 				srcRootClientId: rootClientId,
-				isDraggable: 'all' !== templateLock,
+				isDraggable: canMoveBlocks( clientIds, rootClientId ),
 				icon: getBlockType( blockName )?.icon,
 			};
 		},

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -40,7 +40,7 @@ function ListViewBlockSelectButton(
 	// inside the `useOnBlockDrop` hook.
 	const onDragStartHandler = ( event ) => {
 		event.dataTransfer.clearData();
-		onDragStart( event );
+		onDragStart?.( event );
 	};
 
 	function onKeyDownHandler( event ) {


### PR DESCRIPTION
## What?
Resolves #40072.

PR disabled dragging in the "List View" when block movement is locked.

## Why?
The user shouldn't be able to perform this action.

## How?
Replaces `templateLock` check with `canMoveBlocks` selector. The `canMoveBlocks` handles template lock checks for us.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Heading Block.
3. Lock the block movement.
4. Try dragging it in the "List View"

Template Lock
1. Insert example Group block
2. Try dragging inner paragraphs

```
<!-- wp:group {"templateLock":"all"} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>First paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Second paragraph</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/161918779-a4aed276-76d8-4107-bed0-8494d147bd4b.mp4


