### PR TITLE
Update Cover Block background-attachment: fixed iOS bug handling to properly work with iOS 13+

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -18,7 +18,7 @@
 		// Mobile Safari does not support fixed background attachment properly.
 		// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
 		// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
-		@supports (-webkit-overflow-scrolling: touch) {
+		@supports (-webkit-touch-callout: inherit) {
 			background-attachment: scroll;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update `@supports`check disabling `background-attachment: fixed` for iOS devices to support latest versions of iPadOS and desktop mode.

Fixes #17718

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The current solution was disabled when iPad Safari was rendering pages in `desktop mode`. Support for `-webkit-overflow-scrolling: touch` was removed in desktop mode in iOS 13 as mentioned in #17718

## How?

As suggested in #17718 we change the `@supports` check from `-webkit-overflow-scrolling: touch` to `-webkit-touch-callout: inherit`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new page with a Cover Block, set a background image and **toggle the fixed background option**. 
2. View the page on an iPad (device or simulator).
3. Toggle between desktop and mobile views. 

The block should render the same.

Currently, the block in desktop mode would render oversized as it would try to use `backgorund-position: fixed` but the parallax effect would not work.

 (a smaller image might make the issue more apparent) 

## Screenshots or screencast <!-- if applicable -->

| how to toggle | before | after |
| -- | -- | -- |
| ![Screenshot 2022-04-06 at 09 48 22](https://user-images.githubusercontent.com/112270/161923358-63b61326-6653-4746-b3d8-493efb74174a.jpg) |  ![Screenshot 2022-04-06 at 09 37 59](https://user-images.githubusercontent.com/112270/161924182-89235a68-2946-4359-99e5-5883b8445079.jpg) |  ![Screenshot 2022-04-06 at 09 38 34](https://user-images.githubusercontent.com/112270/161924329-757c8ff2-10bb-4711-81d6-3e2ba4d5adce.jpg) |



