### PR TITLE
List View: Display lock status

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -8,6 +8,9 @@ import classnames from 'classnames';
  */
 import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { Icon, lock } from '@wordpress/icons';
+import { SPACE, ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -16,7 +19,7 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
-import { SPACE, ENTER } from '@wordpress/keycodes';
+import { store as blockEditorStore } from '../../store';
 
 function ListViewBlockSelectButton(
 	{
@@ -33,6 +36,14 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
+	const isLocked = useSelect(
+		( select ) => {
+			const { canMoveBlock, canRemoveBlock } = select( blockEditorStore );
+
+			return ! canMoveBlock( clientId ) || ! canRemoveBlock( clientId );
+		},
+		[ clientId ]
+	);
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -75,6 +86,11 @@ function ListViewBlockSelectButton(
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">
 						{ blockInformation.anchor }
+					</span>
+				) }
+				{ isLocked && (
+					<span className="block-editor-list-view-block-select-button__lock">
+						<Icon icon={ lock } />
 					</span>
 				) }
 			</Button>

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -7,12 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	Button,
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { lock, moreVertical } from '@wordpress/icons';
+import { moreVertical } from '@wordpress/icons';
 import {
 	useState,
 	useRef,
@@ -20,7 +19,7 @@ import {
 	useCallback,
 	memo,
 } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
 /**
@@ -67,15 +66,6 @@ function ListViewBlock( {
 		position,
 		siblingBlockCount,
 		level
-	);
-
-	const isLocked = useSelect(
-		( select ) => {
-			const { canMoveBlock, canRemoveBlock } = select( blockEditorStore );
-
-			return ! canMoveBlock( clientId ) || ! canRemoveBlock( clientId );
-		},
-		[ clientId ]
 	);
 
 	const blockAriaLabel = blockInformation
@@ -282,28 +272,6 @@ function ListViewBlock( {
 						</TreeGridItem>
 					</TreeGridCell>
 				</>
-			) }
-
-			{ isLocked && (
-				<TreeGridCell
-					className="block-editor-list-view-block__lock-cell"
-					aria-selected={ !! isSelected }
-				>
-					{ ( { ref, tabIndex, onFocus } ) => (
-						<Button
-							disabled
-							ref={ ref }
-							tabIndex={ tabIndex }
-							onFocus={ onFocus }
-							icon={ lock }
-							label={ sprintf(
-								/* translators: %s: block name */
-								__( 'Locked %s' ),
-								blockInformation.title
-							) }
-						/>
-					) }
-				</TreeGridCell>
 			) }
 
 			{ showBlockActions && (

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -11,7 +11,7 @@ import {
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { moreVertical } from '@wordpress/icons';
+import { lock, moreVertical, Icon } from '@wordpress/icons';
 import {
 	useState,
 	useRef,
@@ -19,7 +19,7 @@ import {
 	useCallback,
 	memo,
 } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
 /**
@@ -66,6 +66,15 @@ function ListViewBlock( {
 		position,
 		siblingBlockCount,
 		level
+	);
+
+	const isLocked = useSelect(
+		( select ) => {
+			const { canMoveBlock, canRemoveBlock } = select( blockEditorStore );
+
+			return ! canMoveBlock( clientId ) || ! canRemoveBlock( clientId );
+		},
+		[ clientId ]
 	);
 
 	const blockAriaLabel = blockInformation
@@ -272,6 +281,21 @@ function ListViewBlock( {
 						</TreeGridItem>
 					</TreeGridCell>
 				</>
+			) }
+
+			{ isLocked && (
+				<TreeGridCell
+					className="block-editor-list-view-block__lock-cell"
+					aria-selected={ !! isSelected }
+				>
+					{ ( { tabIndex, onFocus } ) => (
+						<Icon
+							icon={ lock }
+							tabIndex={ tabIndex }
+							onFocus={ onFocus }
+						/>
+					) }
+				</TreeGridCell>
 			) }
 
 			{ showBlockActions && (

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -7,11 +7,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
+	Button,
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
-import { lock, moreVertical, Icon } from '@wordpress/icons';
+import { lock, moreVertical } from '@wordpress/icons';
 import {
 	useState,
 	useRef,
@@ -288,11 +289,18 @@ function ListViewBlock( {
 					className="block-editor-list-view-block__lock-cell"
 					aria-selected={ !! isSelected }
 				>
-					{ ( { tabIndex, onFocus } ) => (
-						<Icon
-							icon={ lock }
+					{ ( { ref, tabIndex, onFocus } ) => (
+						<Button
+							disabled
+							ref={ ref }
 							tabIndex={ tabIndex }
 							onFocus={ onFocus }
+							icon={ lock }
+							label={ sprintf(
+								/* translators: %s: block name */
+								__( 'Locked %s' ),
+								blockInformation.title
+							) }
 						/>
 					) }
 				</TreeGridCell>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -196,18 +196,6 @@
 		}
 	}
 
-	.block-editor-list-view-block__lock-cell {
-		line-height: 0;
-		width: 24px;
-		min-width: 24px;
-		padding: 0;
-		vertical-align: middle;
-
-		.components-button:disabled {
-			opacity: 1;
-		}
-	}
-
 	.block-editor-list-view-block__mover-cell-alignment-wrapper {
 		display: flex;
 		height: 100%;
@@ -304,6 +292,15 @@
 
 	&.is-selected .block-editor-list-view-block-select-button__anchor {
 		background: rgba($black, 0.3);
+	}
+
+	.block-editor-list-view-block-select-button__lock {
+		line-height: 0;
+		width: 24px;
+		min-width: 24px;
+		margin-left: auto;
+		padding: 0;
+		vertical-align: middle;
 	}
 }
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -202,6 +202,10 @@
 		min-width: 24px;
 		padding: 0;
 		vertical-align: middle;
+
+		.components-button:disabled {
+			opacity: 1;
+		}
 	}
 
 	.block-editor-list-view-block__mover-cell-alignment-wrapper {

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -196,6 +196,14 @@
 		}
 	}
 
+	.block-editor-list-view-block__lock-cell {
+		line-height: 0;
+		width: 24px;
+		min-width: 24px;
+		padding: 0;
+		vertical-align: middle;
+	}
+
 	.block-editor-list-view-block__mover-cell-alignment-wrapper {
 		display: flex;
 		height: 100%;


### PR DESCRIPTION
## What?
Resolves #40070.

Display block lock status in the "List View."

## Why?
Lock status makes it easier to see which blocks are locked.

## How?
Adds new `TreeGridCell` only displayed when the block is locked.

P.S. I noticed that when one block is locked, the other block's content cells get different widths.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Block.
3. Lock one of the attributes.
4. Confirm that the lock icon is displayed for the block in "List View."

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-04-06 at 14 54 44](https://user-images.githubusercontent.com/240569/161959646-94b6e3b7-6660-4d82-acb6-fddaeca5fb67.png)


