### PR TITLE
Add `__experimentalEnableQuoteBlockV2` flag

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -23,11 +23,11 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		'mobile' === $_GET['context']
 	) {
 		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
-			$settings['__experimentalStyles']             = gutenberg_get_global_styles();
+			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 		}
 
 		// To be set to true when the web makes quote v2 (inner blocks) the default.
-		// See https://github.com/WordPress/gutenberg/pull/25892
+		// See https://github.com/WordPress/gutenberg/pull/25892.
 		$settings['__experimentalEnableQuoteBlockV2'] = false;
 	}
 

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -28,7 +28,7 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 
 		// To be set to true when the web makes quote v2 (inner blocks) the default.
 		// See https://github.com/WordPress/gutenberg/pull/25892.
-		$settings['__experimentalEnableQuoteBlockV2'] = false;
+		$settings['__experimentalEnableQuoteBlockV2'] = gutenberg_is_quote_v2_enabled();
 	}
 
 	return $settings;

--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -20,10 +20,15 @@ function gutenberg_get_block_editor_settings_mobile( $settings ) {
 		defined( 'REST_REQUEST' ) &&
 		REST_REQUEST &&
 		isset( $_GET['context'] ) &&
-		'mobile' === $_GET['context'] &&
-		WP_Theme_JSON_Resolver_Gutenberg::theme_has_support()
+		'mobile' === $_GET['context']
 	) {
-		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
+		if ( WP_Theme_JSON_Resolver_Gutenberg::theme_has_support() ) {
+			$settings['__experimentalStyles']             = gutenberg_get_global_styles();
+		}
+
+		// To be set to true when the web makes quote v2 (inner blocks) the default.
+		// See https://github.com/WordPress/gutenberg/pull/25892
+		$settings['__experimentalEnableQuoteBlockV2'] = false;
 	}
 
 	return $settings;

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -152,6 +152,11 @@ if ( ! function_exists( 'gutenberg_rest_comment_set_children_as_embeddable' ) ) 
 }
 add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );
 
+/**
+ * Returns whether the quote v2 is enabled by the user.
+ *
+ * @return boolean
+ */
 function gutenberg_is_quote_v2_enabled() {
 	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-quote-v2', get_option( 'gutenberg-experiments' ) );
 }

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -152,6 +152,10 @@ if ( ! function_exists( 'gutenberg_rest_comment_set_children_as_embeddable' ) ) 
 }
 add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable' );
 
+function gutenberg_is_quote_v2_enabled() {
+	return get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-quote-v2', get_option( 'gutenberg-experiments' ) );
+}
+
 /**
  * Sets a global JS variable used to trigger the availability of the experimental blocks.
  */
@@ -160,7 +164,7 @@ function gutenberg_enable_experimental_blocks() {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableListBlockV2 = true', 'before' );
 	}
 
-	if ( get_option( 'gutenberg-experiments' ) && array_key_exists( 'gutenberg-quote-v2', get_option( 'gutenberg-experiments' ) ) ) {
+	if ( gutenberg_is_quote_v2_enabled() ) {
 		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableQuoteBlockV2 = true', 'before' );
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -157,7 +157,7 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 				),
 
 				'__experimentalEnableQuoteBlockV2'       => array(
-					'description' => _( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
+					'description' => __( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
 					'type'        => 'boolean',
 					'context'     => array( 'mobile' ),
 				),

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -156,6 +156,12 @@ class WP_REST_Block_Editor_Settings_Controller extends WP_REST_Controller {
 					'context'     => array( 'mobile' ),
 				),
 
+				'__experimentalEnableQuoteBlockV2'       => array(
+					'description' => _( 'Whether the V2 of the quote block that uses inner blocks should be enabled.', 'gutenberg' ),
+					'type'        => 'boolean',
+					'context'     => array( 'mobile' ),
+				),
+
 				'alignWide'                              => array(
 					'description' => __( 'Enable/Disable Wide/Full Alignments.', 'gutenberg' ),
 					'type'        => 'boolean',


### PR DESCRIPTION
## What?

This PR adds a mechanism for mobile to know when the site supports the Quote v2 (inner blocks).

## Why?

Mobile needs to know when to load the v1 and the v2 of the quote block.

## How?

By adding a `__experimentalEnableQuoteBlockV2` flag to the block editor settings endpoint. It's set to `false` and it'll be set to `true` by #25892 ([see context](https://github.com/WordPress/gutenberg/pull/25892#issuecomment-1090074133))

## How to test

- Comment lines 22 and 23 [here](https://github.com/WordPress/gutenberg/blob/69e18aa2d3d12b6d2d5993b034e106328c2be9e6/lib/experimental/block-editor-settings-mobile.php#L22) so the code runs for any request, and not only for a 'mobile' request. 
- Go to "Gutenberg > Experiments" and enable the quote v2 experiment.
- Load the post editor, open the devtools, and execute `wp.apiFetch({path: '/wp-block-editor/v1/settings/', method: 'GET'})`. The expected result is that the flag `__experimentalEnableQuoteBlockV2` is present and is `true`.
- Go to "Gutenberg > Experiments" and disable the quote v2 experiment.
- Load the post editor, open the devtools, and execute `wp.apiFetch({path: '/wp-block-editor/v1/settings/', method: 'GET'})`. The expected result is that the flag `__experimentalEnableQuoteBlockV2` is present and is `false`.
