### PR TITLE
Try: Summary panel excerpt max-height.

### DIFF
--- a/packages/editor/src/components/post-excerpt/style.scss
+++ b/packages/editor/src/components/post-excerpt/style.scss
@@ -13,4 +13,10 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
+
+	// Add a max-height to the excerpt panel.
+	p {
+		max-height: 320px;
+		overflow: auto;
+	}
 }


### PR DESCRIPTION
## What?

Followup to #39973. Applies a max-height to the excerpt. Before:

<img width="1392" alt="before" src="https://user-images.githubusercontent.com/1204802/161950507-3fa49c4f-3598-44a9-9ed0-b39c4616bf88.png">

After:

![max-height](https://user-images.githubusercontent.com/1204802/161950554-f2dbbf50-c5a4-499c-a229-6aff48e51ef5.gif)

A thought occurs that maybe the excerpt shouldn't employ the `p` tag, but rather a `div` perhaps? Right now it's treated as a multiline paragraph.

## Testing Instructions

Try adding a lot of text in the excerpt panel.
