### PR TITLE
Post Terms: Use variation title in placeholder

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -12,6 +12,7 @@ import {
 	InspectorControls,
 	BlockControls,
 	useBlockProps,
+	useBlockDisplayInformation,
 } from '@wordpress/block-editor';
 import { Spinner, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -25,6 +26,7 @@ import usePostTerms from './use-post-terms';
 
 export default function PostTermsEdit( {
 	attributes,
+	clientId,
 	context,
 	setAttributes,
 } ) {
@@ -46,6 +48,7 @@ export default function PostTermsEdit( {
 		term: selectedTerm,
 	} );
 	const hasPost = postId && postType;
+	const blockInformation = useBlockDisplayInformation( clientId );
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -54,7 +57,7 @@ export default function PostTermsEdit( {
 	} );
 
 	if ( ! hasPost || ! term ) {
-		return <div { ...blockProps }>{ __( 'Post Terms' ) }</div>;
+		return <div { ...blockProps }>{ blockInformation.title }</div>;
 	}
 
 	return (


### PR DESCRIPTION
## What?
Resolves #39781.

Use the block variation title instead of static text in the "Post Terms" block's placeholder state.

## Why?
This makes it easier to see which block variations are used inside the template.

## Testing Instructions
1. Using TT2 theme.
2. Got to Site Editor -> Single Post template.
3. Confirm that the "Post Terms" placeholder displays variation titles.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
| --- | --- |
|![CleanShot 2022-04-06 at 16 32 52](https://user-images.githubusercontent.com/240569/161975455-5d9b7877-cf1f-4cac-b9ca-f39b0fbf5ca0.png)|![CleanShot 2022-04-06 at 16 32 28](https://user-images.githubusercontent.com/240569/161975449-db338bfc-2b0f-431f-8651-b1f4c616e511.png)|


