### PR TITLE
Promote Avatar and Discussion settings to stable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /packages/block-library/src/page-list           @tellthemachines
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments-query-loop @michalczaplinski
+/packages/block-library/src/avatar              @c4rl0sbr4v0
 
 # Duotone
 /lib/block-supports/duotone.php                       @ajlende

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -123,35 +123,33 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 	return $query;
 }
 
-if ( ! function_exists( 'extend_block_editor_settings_with_discussion_settings' ) ) {
-	/**
-	 * Workaround for getting discussion settings as block editor settings
-	 * so any user can access to them without needing to be an admin.
-	 *
-	 * @param array $settings Default editor settings.
-	 *
-	 * @return array Filtered editor settings.
-	 */
-	function extend_block_editor_settings_with_discussion_settings( $settings ) {
+/**
+ * Workaround for getting discussion settings as block editor settings
+ * so any user can access to them without needing to be an admin.
+ *
+ * @param array $settings Default editor settings.
+ *
+ * @return array Filtered editor settings.
+ */
+function gutenberg_extend_block_editor_settings_with_discussion_settings( $settings ) {
 
-		$settings['discussionSettings'] = array(
-			'commentOrder'        => get_option( 'comment_order' ),
-			'commentsPerPage'     => get_option( 'comments_per_page' ),
-			'defaultCommentsPage' => get_option( 'default_comments_page' ),
-			'pageComments'        => get_option( 'page_comments' ),
-			'threadComments'      => get_option( 'thread_comments' ),
-			'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
-			'avatarURL'           => get_avatar_url(
-				'',
-				array(
-					'size'          => 96,
-					'force_default' => true,
-					'default'       => get_option( 'avatar_default' ),
-				)
-			),
-		);
+	$settings['discussionSettings'] = array(
+		'commentOrder'        => get_option( 'comment_order' ),
+		'commentsPerPage'     => get_option( 'comments_per_page' ),
+		'defaultCommentsPage' => get_option( 'default_comments_page' ),
+		'pageComments'        => get_option( 'page_comments' ),
+		'threadComments'      => get_option( 'thread_comments' ),
+		'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
+		'avatarURL'           => get_avatar_url(
+			'',
+			array(
+				'size'          => 96,
+				'force_default' => true,
+				'default'       => get_option( 'avatar_default' ),
+			)
+		),
+	);
 
-		return $settings;
-	}
+	return $settings;
 }
-add_filter( 'block_editor_settings_all', 'extend_block_editor_settings_with_discussion_settings' );
+add_filter( 'block_editor_settings_all', 'gutenberg_extend_block_editor_settings_with_discussion_settings' );

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -122,3 +122,36 @@ function gutenberg_build_query_vars_from_query_block( $block, $page ) {
 	}
 	return $query;
 }
+
+if ( ! function_exists( 'extend_block_editor_settings_with_discussion_settings' ) ) {
+	/**
+	 * Workaround for getting discussion settings as block editor settings
+	 * so any user can access to them without needing to be an admin.
+	 *
+	 * @param array $settings Default editor settings.
+	 *
+	 * @return array Filtered editor settings.
+	 */
+	function extend_block_editor_settings_with_discussion_settings( $settings ) {
+
+		$settings['discussionSettings'] = array(
+			'commentOrder'        => get_option( 'comment_order' ),
+			'commentsPerPage'     => get_option( 'comments_per_page' ),
+			'defaultCommentsPage' => get_option( 'default_comments_page' ),
+			'pageComments'        => get_option( 'page_comments' ),
+			'threadComments'      => get_option( 'thread_comments' ),
+			'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
+			'avatarURL'           => get_avatar_url(
+				'',
+				array(
+					'size'          => 96,
+					'force_default' => true,
+					'default'       => get_option( 'avatar_default' ),
+				)
+			),
+		);
+
+		return $settings;
+	}
+}
+add_filter( 'block_editor_settings_all', 'extend_block_editor_settings_with_discussion_settings' );

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -95,39 +95,6 @@ if ( ! function_exists( 'get_comments_pagination_arrow' ) ) {
 	}
 }
 
-if ( ! function_exists( 'extend_block_editor_settings_with_discussion_settings' ) ) {
-	/**
-	 * Workaround for getting discussion settings as block editor settings
-	 * so any user can access to them without needing to be an admin.
-	 *
-	 * @param array $settings Default editor settings.
-	 *
-	 * @return array Filtered editor settings.
-	 */
-	function extend_block_editor_settings_with_discussion_settings( $settings ) {
-
-		$settings['__experimentalDiscussionSettings'] = array(
-			'commentOrder'        => get_option( 'comment_order' ),
-			'commentsPerPage'     => get_option( 'comments_per_page' ),
-			'defaultCommentsPage' => get_option( 'default_comments_page' ),
-			'pageComments'        => get_option( 'page_comments' ),
-			'threadComments'      => get_option( 'thread_comments' ),
-			'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
-			'avatarURL'           => get_avatar_url(
-				'',
-				array(
-					'size'          => 96,
-					'force_default' => true,
-					'default'       => get_option( 'avatar_default' ),
-				)
-			),
-		);
-
-		return $settings;
-	}
-}
-add_filter( 'block_editor_settings_all', 'extend_block_editor_settings_with_discussion_settings' );
-
 if ( ! function_exists( 'gutenberg_rest_comment_set_children_as_embeddable' ) ) {
 	/**
 	 * Mark the `children` attr of comments as embeddable so they can be included in

--- a/packages/block-library/src/avatar/hooks.js
+++ b/packages/block-library/src/avatar/hooks.js
@@ -19,8 +19,8 @@ function getAvatarSizes( sizes ) {
 function useDefaultAvatar() {
 	const { avatarURL: defaultAvatarUrl } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
+		const { discussionSettings } = getSettings();
+		return discussionSettings;
 	} );
 	return defaultAvatarUrl;
 }

--- a/packages/block-library/src/comment-author-avatar/edit.js
+++ b/packages/block-library/src/comment-author-avatar/edit.js
@@ -42,8 +42,8 @@ export default function Edit( {
 	const maxSizeBuffer = Math.floor( maxSize * 2.5 );
 	const { avatarURL } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
+		const { discussionSettings } = getSettings();
+		return discussionSettings;
 	} );
 
 	const inspectorControls = (

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -241,7 +241,7 @@ export default function CommentTemplateEdit( {
 		commentsPerPage,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		return getSettings().__experimentalDiscussionSettings;
+		return getSettings().discussionSettings;
 	} );
 
 	const commentQuery = useCommentQueryArgs( {

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -33,8 +33,8 @@ export const useCommentQueryArgs = ( { postId } ) => {
 		defaultCommentsPage: defaultPage,
 	} = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
+		const { discussionSettings } = getSettings();
+		return discussionSettings;
 	} );
 
 	// Get the number of the default page.

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -144,6 +144,7 @@ export const __experimentalGetCoreBlocks = () => [
 	// Register all remaining core blocks.
 	archives,
 	audio,
+	avatar,
 	button,
 	buttons,
 	calendar,
@@ -252,7 +253,6 @@ export const __experimentalRegisterExperimentalCoreBlocks = process.env
 	? ( { enableFSEBlocks } = {} ) => {
 			[
 				// Experimental blocks.
-				avatar,
 				homeLink,
 				postAuthorName,
 				queryNoResults,

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -101,7 +101,6 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		() => ( {
 			...pick( settings, [
 				'__experimentalBlockDirectory',
-				'__experimentalDiscussionSettings',
 				'__experimentalFeatures',
 				'__experimentalPreferredStyleVariations',
 				'__experimentalSetIsInserterOpened',
@@ -116,6 +115,7 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 				'disableCustomColors',
 				'disableCustomFontSizes',
 				'disableCustomGradients',
+				'discussionSettings',
 				'enableCustomLineHeight',
 				'enableCustomSpacing',
 				'enableCustomUnits',


### PR DESCRIPTION
We found a bug on Avatar that should be fixed first. (Avatar User setting field should not appear in site editor inside a comments query loop.) 

#40100 fixes it.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Promote Avatar block to stable.
Promote Discussion Settings to stable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After some testing (we have still one bug pending). We consider the Avatar block ready to be stable. This way we can use it for creating patterns.

Moving Discussion Settings function to stable will allow us to access those settings on the editor, so both Avatar and future Comments blocks will be able to use them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
- Test that Avatar is working fine both in Editor, Site Editor and Frontend.
- Test that Comments blocks are also using the Discussion settings on render, both in Editor and Frontend.
