### PR TITLE
Update the Post Tags block icon

### DIFF
--- a/packages/block-library/src/post-terms/variations.js
+++ b/packages/block-library/src/post-terms/variations.js
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { postCategories as icon } from '@wordpress/icons';
+import { postCategories, tag } from '@wordpress/icons';
 
 const variations = [
 	{
 		name: 'category',
 		title: __( 'Post Categories' ),
 		description: __( "Display a post's categories." ),
-		icon,
+		icon: postCategories,
 		isDefault: true,
 		attributes: { term: 'category' },
 		isActive: ( blockAttributes ) => blockAttributes.term === 'category',
@@ -19,7 +19,7 @@ const variations = [
 		name: 'post_tag',
 		title: __( 'Post Tags' ),
 		description: __( "Display a post's tags." ),
-		icon,
+		icon: tag,
 		attributes: { term: 'post_tag' },
 		isActive: ( blockAttributes ) => blockAttributes.term === 'post_tag',
 	},

--- a/packages/block-library/src/post-terms/variations.js
+++ b/packages/block-library/src/post-terms/variations.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { postCategories, tag } from '@wordpress/icons';
+import { postCategories, postTerms } from '@wordpress/icons';
 
 const variations = [
 	{
@@ -19,7 +19,7 @@ const variations = [
 		name: 'post_tag',
 		title: __( 'Post Tags' ),
 		description: __( "Display a post's tags." ),
-		icon: tag,
+		icon: postTerms,
 		attributes: { term: 'post_tag' },
 		isActive: ( blockAttributes ) => blockAttributes.term === 'post_tag',
 	},


### PR DESCRIPTION
Post Tags is currently using the same icon as Post Categories.

Before:
<img width="1267" alt="Screenshot 2022-04-06 at 14 31 20" src="https://user-images.githubusercontent.com/846565/161987609-92820685-417c-47c1-b981-30fd198da738.png">

After:
<img width="1192" alt="Screenshot 2022-04-06 at 14 35 01" src="https://user-images.githubusercontent.com/846565/161987641-1e6c9c21-cad4-4748-be0c-8a2456292041.png">

