### PR TITLE
FSE: Allow themes to opt in to wp-block-styles using theme.json

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -16,6 +16,54 @@
  */
 class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
+	const VALID_SETTINGS = array(
+		'appearanceTools' => null,
+		'border'          => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+		),
+		'color'           => array(
+			'background'       => null,
+			'custom'           => null,
+			'customDuotone'    => null,
+			'customGradient'   => null,
+			'defaultDuotone'   => null,
+			'defaultGradients' => null,
+			'defaultPalette'   => null,
+			'duotone'          => null,
+			'gradients'        => null,
+			'link'             => null,
+			'palette'          => null,
+			'text'             => null,
+		),
+		'custom'          => null,
+		'defaultBlockStyles' => null,
+		'layout'          => array(
+			'contentSize' => null,
+			'wideSize'    => null,
+		),
+		'spacing'         => array(
+			'blockGap' => null,
+			'margin'   => null,
+			'padding'  => null,
+			'units'    => null,
+		),
+		'typography'      => array(
+			'customFontSize' => null,
+			'dropCap'        => null,
+			'fontFamilies'   => null,
+			'fontSizes'      => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
+
 	/**
 	 * The top-level keys a theme.json can have.
 	 *
@@ -30,6 +78,34 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 		'version',
 		'title',
 	);
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array  $theme_json A structure that follows the theme.json schema.
+	 * @param string $origin     Optional. What source of data this object represents.
+	 *                           One of 'default', 'theme', or 'custom'. Default 'theme'.
+	 */
+	public function __construct( $theme_json = array(), $origin = 'theme' ) {
+		parent::__construct( $theme_json, $origin );
+
+		static::maybe_opt_in_into_theme_supports( $theme_json );
+	}
+
+	/**
+	 * Enables some theme_supports if the theme.json declares support.
+	 *
+	 * @param array $theme_json A theme.json structure to modify.
+	 * @return null
+	 */
+	protected static function maybe_opt_in_into_theme_supports( $theme_json ) {
+		if (
+			isset( $theme_json['settings']['defaultBlockStyles'] ) &&
+			true === $theme_json['settings']['defaultBlockStyles']
+		) {
+			add_theme_support( 'wp-block-styles' );
+		}
+	}
 
 	/**
 	 * Returns the current theme's wanted patterns(slugs) to be

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -176,6 +176,15 @@
 				}
 			}
 		},
+		"settingsPropertiesDefaultBlockStyles": {
+			"properties": {
+				"defaultBlockStyles": {
+					"description": "Setting that adds theme support for 'wp-block-styles', which loads the theme.css file for each block.",
+					"type": "boolean",
+					"default": false
+				}
+			}
+		},
 		"settingsPropertiesLayout": {
 			"properties": {
 				"layout": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This allows themes to enable the `wp-block-styles` theme support using theme.json rather than calling `add_theme_support` in functions.php.

## Why?
Themes shouldn't need to use PHP.

## How?
I've had to overload a few things inside `WP_Theme_JSON_Gutenberg`. I think this stuff might need to be in a 6.1 directory unless this lands soon.

## Testing Instructions
- Check out this PR: https://github.com/Automattic/themes/pull/5825/files
- Switch to Archeo
- Check that this line of CSS is in the source: 
```
:where(.wp-block-group.has-background) {
   padding: 1.25em 2.375em;
}
```


cc @WordPress/block-themers 

Fixes https://github.com/WordPress/gutenberg/issues/37255