### PR TITLE
[RNMobile] Upgrade to AztecAndroid 1.5.7

### DIFF
--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '2.3.0'
         espressoVersion = '3.0.1'
-        aztecVersion = 'v1.5.4'
+        aztecVersion = '975-e69dca965397a9f2978c8722976bee2f9de597ba'
     }
 }
 

--- a/packages/react-native-aztec/android/build.gradle
+++ b/packages/react-native-aztec/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jSoupVersion = '1.10.3'
         wordpressUtilsVersion = '2.3.0'
         espressoVersion = '3.0.1'
-        aztecVersion = '975-e69dca965397a9f2978c8722976bee2f9de597ba'
+        aztecVersion = 'v1.5.7'
     }
 }
 


### PR DESCRIPTION
### Related PRs
- https://github.com/wordpress-mobile/AztecEditor-Android/pull/975
- https://github.com/wordpress-mobile/gutenberg-mobile/pull/4735
- https://github.com/wordpress-mobile/WordPress-Android/pull/16270

## What?
Update AztecAndroid to v.1.5.6

## Why?
To keep this dependency up to date.

## How?
Bump the version number (easy part 🙂 ) and test our rich text blocks (not-so-easy part 😅 ).

## Testing Instructions
Generally test the writing experience with rich text blocks. Our [manual writing flow tests](https://github.com/wordpress-mobile/test-cases/tree/trunk/test-cases/gutenberg/writing-flow) are probably a good source of guidance for what may be worth testing here although I don't think we necessarily need to go through all of them.
