### PR TITLE
Avatar Block: Do not show User Selection inside Comments Loop, on the Site Editor

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -222,7 +222,8 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 };
 
 export default function Edit( props ) {
-	if ( props?.context?.commentId ) {
+	// We set commentId as null if we are on the Site Editor. See "../src/comment-template/edit.js L215"
+	if ( props?.context?.commentId || props?.context?.commentId === null ) {
 		return <CommentEdit { ...props } />;
 	}
 	return <UserEdit { ...props } />;

--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -222,7 +222,7 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 };
 
 export default function Edit( props ) {
-	// We set commentId as null if we are on the Site Editor. See "../src/comment-template/edit.js L215"
+	// Don't show the Comment Edit controls if we have a comment ID set, or if we're in the Site Editor (where it is `null`).
 	if ( props?.context?.commentId || props?.context?.commentId === null ) {
 		return <CommentEdit { ...props } />;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update the conditional in order not to render the `User selection option` on the `avatar` block if we are inside a comment on the Editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In the Site Editor, as we work with placeholders instead of real comments, we don't have any comment id context.
Because of that, we show the `User selection` option even if we are inside a Comments block. 
This creates inconsistency, as you can select a user for the Avatar on all comments, and, that won't happen on the Frontend.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
If the comment is a placeholder, we set the comment id is null. If we are outside a comment, the comment id is undefined. We just check both cases in order to show/not show the `User selection` option.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Before PR
- 1. Go to Site Editor
- 2. Add a Comment Query Loop
- 3. Click on the Avatar, check that you can select a user.
- 4. Add an Avatar outside a Comment Query Loop, check that you can select a user.

After PR
- 1. Go to Site Editor
- 2. Add a Comment Query Loop
- 3. Click on the Avatar, check that you cannot select a user.
- 4. Add an Avatar outside a Comment Query Loop, check that you can select a user.

## Screenshots or screencast <!-- if applicable -->

### Before the PR:

![inside_comment_avatar_before](https://user-images.githubusercontent.com/37012961/162002932-b814082b-27b0-4517-a9d7-8e65a4a02251.png)

 Then you can select any user avatar for all comments:
![consequences_editor](https://user-images.githubusercontent.com/37012961/162003026-bd1e0925-00c1-471c-aa7d-ffb659220bac.png)

But the frontend will work as expected, omitting the option of giving a user avatar to all comments:
![frontend_not_respecting](https://user-images.githubusercontent.com/37012961/162003194-fb23ca93-6188-457b-a025-e56d31e14cdf.png)

### After the PR:

An external avatar (outside of a comments loop), with user selection:
![external_avatar](https://user-images.githubusercontent.com/37012961/162003440-0654b4fe-4afd-4b05-a303-b2fd7c6153cb.png)

Avatars inside comments loop now cannot select an user:

![inside_comment_avatar_fixed](https://user-images.githubusercontent.com/37012961/162003549-fa6cfdc9-eb27-4fed-965b-71b4ecf9d9f5.png)
