### PR TITLE
[RNMobile] Update drag & drop animations

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -239,6 +239,7 @@ const BlockDraggableWrapper = ( { children } ) => {
  * @return {Function} Render function which includes the parameter `isDraggable` to determine if the block can be dragged.
  */
 const BlockDraggable = ( { clientId, children } ) => {
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const wasBeingDragged = useRef( false );
 
 	const draggingAnimation = {
@@ -257,6 +258,7 @@ const BlockDraggable = ( { clientId, children } ) => {
 			1,
 			BLOCK_OPACITY_ANIMATION_CONFIG
 		);
+		runOnJS( selectBlock )( clientId );
 	};
 
 	const { isDraggable, isBeingDragged } = useSelect(

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -49,7 +49,7 @@ const BLOCK_OPACITY_ANIMATION_CONFIG = { duration: 350 };
  * @return {Function} Render function that passes `onScroll` event handler.
  */
 const BlockDraggableWrapper = ( { children } ) => {
-	const currentClientId = useRef();
+	const currentBlockLayout = useRef();
 
 	const wrapperStyles = usePreferredColorSchemeStyle(
 		styles[ 'draggable-wrapper__container' ],
@@ -118,7 +118,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		} );
 
 		const foundClientId = blockLayout?.clientId;
-		currentClientId.current = foundClientId;
+		currentBlockLayout.current = blockLayout;
 		if ( foundClientId ) {
 			startDraggingBlocks( [ foundClientId ] );
 			runOnUI( startScrolling )( position.y );
@@ -129,11 +129,11 @@ const BlockDraggableWrapper = ( { children } ) => {
 	};
 
 	const onStopDragging = () => {
-		if ( currentClientId.current ) {
+		if ( currentBlockLayout.current ) {
 			onBlockDrop( {
 				// Dropping is only allowed at root level
 				srcRootClientId: '',
-				srcClientIds: [ currentClientId.current ],
+				srcClientIds: [ currentBlockLayout.current.clientId ],
 				type: 'block',
 			} );
 		}

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -8,9 +8,6 @@ import Animated, {
 	useAnimatedStyle,
 	useSharedValue,
 	withTiming,
-	scrollTo,
-	useAnimatedReaction,
-	Easing,
 } from 'react-native-reanimated';
 
 /**
@@ -33,18 +30,7 @@ import useBlockDropZone from '../use-block-drop-zone';
 import styles from './style.scss';
 
 const CHIP_OFFSET_TO_TOUCH_POSITION = 32;
-const BLOCK_COLLAPSED_HEIGHT = 20;
-const EXTRA_OFFSET_WHEN_CLOSE_TO_TOP_EDGE = 80;
-const SCROLL_ANIMATION_DURATION = 350;
-const COLLAPSE_HEIGHT_ANIMATION_CONFIG = {
-	duration: 350,
-	easing: Easing.out( Easing.exp ),
-};
-const EXPAND_HEIGHT_ANIMATION_CONFIG = {
-	duration: 350,
-	easing: Easing.in( Easing.exp ),
-};
-const COLLAPSE_OPACITY_ANIMATION_CONFIG = { duration: 150 };
+const BLOCK_OPACITY_ANIMATION_CONFIG = { duration: 350 };
 
 /**
  * Block draggable wrapper component
@@ -93,7 +79,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 		scale: useSharedValue( 0 ),
 	};
 	const isDragging = useSharedValue( false );
-	const scrollAnimation = useSharedValue( 0 );
 
 	const [
 		startScrolling,
@@ -136,24 +121,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		currentClientId.current = foundClientId;
 		if ( foundClientId ) {
 			startDraggingBlocks( [ foundClientId ] );
-
-			const isBlockOutOfScrollView = blockLayout.y < scroll.offsetY.value;
-			// If the dragging block is out of the scroll view, we have to
-			// scroll the block list to show the origin position of the block.
-			if ( isBlockOutOfScrollView ) {
-				scrollAnimation.value = scroll.offsetY.value;
-				const scrollOffsetTarget = Math.max(
-					0,
-					blockLayout.y - EXTRA_OFFSET_WHEN_CLOSE_TO_TOP_EDGE
-				);
-				scrollAnimation.value = withTiming(
-					scrollOffsetTarget,
-					{ duration: SCROLL_ANIMATION_DURATION },
-					() => startScrolling( position.y )
-				);
-			} else {
-				runOnUI( startScrolling )( position.y );
-			}
+			runOnUI( startScrolling )( position.y );
 		} else {
 			// We stop dragging if no block is found.
 			runOnUI( stopDragging )();
@@ -172,16 +140,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 		onBlockDragEnd();
 		stopDraggingBlocks();
 	};
-
-	// This hook is used for animating the scroll via a shared value.
-	useAnimatedReaction(
-		() => scrollAnimation.value,
-		( value ) => {
-			if ( isDragging.value ) {
-				scrollTo( animatedScrollRef, 0, value, false );
-			}
-		}
-	);
 
 	const onChipLayout = ( { nativeEvent: { layout } } ) => {
 		chip.width.value = layout.width;
@@ -281,49 +239,23 @@ const BlockDraggableWrapper = ( { children } ) => {
  * @return {Function} Render function which includes the parameter `isDraggable` to determine if the block can be dragged.
  */
 const BlockDraggable = ( { clientId, children } ) => {
-	const { blocksLayouts, findBlockLayoutByClientId } = useBlockListContext();
+	const wasBeingDragged = useRef( false );
 
-	const collapseAnimation = {
-		opacity: useSharedValue( 0 ),
-		height: useSharedValue( 0 ),
-		initialHeight: useSharedValue( 0 ),
+	const draggingAnimation = {
+		opacity: useSharedValue( 1 ),
 	};
 
-	const startBlockDragging = () => {
-		const blockLayout = findBlockLayoutByClientId(
-			blocksLayouts.current,
-			clientId
+	const startDraggingBlock = () => {
+		draggingAnimation.opacity.value = withTiming(
+			0.4,
+			BLOCK_OPACITY_ANIMATION_CONFIG
 		);
-		if ( blockLayout?.height > 0 ) {
-			collapseAnimation.initialHeight.value = blockLayout.height;
-			collapseAnimation.height.value = blockLayout.height;
-			collapseAnimation.opacity.value = withTiming(
-				1,
-				COLLAPSE_OPACITY_ANIMATION_CONFIG,
-				( completed ) => {
-					if ( completed ) {
-						collapseAnimation.height.value = withTiming(
-							BLOCK_COLLAPSED_HEIGHT,
-							COLLAPSE_HEIGHT_ANIMATION_CONFIG
-						);
-					}
-				}
-			);
-		}
 	};
 
-	const stopBlockDragging = () => {
-		collapseAnimation.height.value = withTiming(
-			collapseAnimation.initialHeight.value,
-			EXPAND_HEIGHT_ANIMATION_CONFIG,
-			( completed ) => {
-				if ( completed ) {
-					collapseAnimation.opacity.value = withTiming(
-						0,
-						COLLAPSE_OPACITY_ANIMATION_CONFIG
-					);
-				}
-			}
+	const stopDraggingBlock = () => {
+		draggingAnimation.opacity.value = withTiming(
+			1,
+			BLOCK_OPACITY_ANIMATION_CONFIG
 		);
 	};
 
@@ -349,53 +281,27 @@ const BlockDraggable = ( { clientId, children } ) => {
 
 	useEffect( () => {
 		if ( isBeingDragged ) {
-			startBlockDragging();
-		} else {
-			stopBlockDragging();
+			startDraggingBlock();
+			wasBeingDragged.current = true;
+		} else if ( wasBeingDragged.current ) {
+			stopDraggingBlock();
+			wasBeingDragged.current = false;
 		}
 	}, [ isBeingDragged ] );
 
-	const containerStyles = useAnimatedStyle( () => {
-		const canAnimateHeight =
-			collapseAnimation.height.value !== 0 &&
-			collapseAnimation.opacity.value !== 0;
+	const wrapperStyles = useAnimatedStyle( () => {
 		return {
-			height: canAnimateHeight ? collapseAnimation.height.value : 'auto',
+			opacity: draggingAnimation.opacity.value,
 		};
 	} );
-
-	const blockStyles = useAnimatedStyle( () => {
-		return {
-			display: collapseAnimation.opacity.value !== 0 ? 'none' : 'flex',
-			opacity: 1 - collapseAnimation.opacity.value,
-		};
-	} );
-
-	const placeholderDynamicStyles = useAnimatedStyle( () => {
-		return {
-			display: collapseAnimation.opacity.value === 0 ? 'none' : 'flex',
-			opacity: collapseAnimation.opacity.value,
-		};
-	} );
-	const placeholderStaticStyles = usePreferredColorSchemeStyle(
-		styles[ 'draggable-placeholder__container' ],
-		styles[ 'draggable-placeholder__container--dark' ]
-	);
-	const placeholderStyles = [
-		placeholderStaticStyles,
-		placeholderDynamicStyles,
-	];
 
 	if ( ! isDraggable ) {
 		return children( { isDraggable: false } );
 	}
 
 	return (
-		<Animated.View style={ containerStyles }>
-			<Animated.View style={ blockStyles }>
-				{ children( { isDraggable: true } ) }
-			</Animated.View>
-			<Animated.View style={ placeholderStyles } pointerEvents="none" />
+		<Animated.View style={ wrapperStyles }>
+			{ children( { isDraggable: true } ) }
 		</Animated.View>
 	);
 };

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -7,6 +7,7 @@ import Animated, {
 	useAnimatedRef,
 	useAnimatedStyle,
 	useSharedValue,
+	withDelay,
 	withTiming,
 } from 'react-native-reanimated';
 
@@ -31,6 +32,7 @@ import styles from './style.scss';
 
 const CHIP_OFFSET_TO_TOUCH_POSITION = 32;
 const BLOCK_OPACITY_ANIMATION_CONFIG = { duration: 350 };
+const BLOCK_OPACITY_ANIMATION_DELAY = 250;
 
 /**
  * Block draggable wrapper component
@@ -254,9 +256,9 @@ const BlockDraggable = ( { clientId, children } ) => {
 	};
 
 	const stopDraggingBlock = () => {
-		draggingAnimation.opacity.value = withTiming(
-			1,
-			BLOCK_OPACITY_ANIMATION_CONFIG
+		draggingAnimation.opacity.value = withDelay(
+			BLOCK_OPACITY_ANIMATION_DELAY,
+			withTiming( 1, BLOCK_OPACITY_ANIMATION_CONFIG )
 		);
 		runOnJS( selectBlock )( clientId );
 	};

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -131,11 +131,12 @@ const BlockDraggableWrapper = ( { children } ) => {
 	};
 
 	const onStopDragging = () => {
-		if ( currentBlockLayout.current ) {
+		const currentClientId = currentBlockLayout.current?.clientId;
+		if ( currentClientId ) {
 			onBlockDrop( {
 				// Dropping is only allowed at root level
 				srcRootClientId: '',
-				srcClientIds: [ currentBlockLayout.current.clientId ],
+				srcClientIds: [ currentClientId ],
 				type: 'block',
 			} );
 		}

--- a/packages/block-editor/src/components/block-draggable/style.native.scss
+++ b/packages/block-editor/src/components/block-draggable/style.native.scss
@@ -17,18 +17,3 @@
 .draggable-chip__container--dark {
 	background-color: $app-background-dark-alt;
 }
-
-.draggable-placeholder__container {
-	position: absolute;
-	top: 0;
-	left: $solid-border-space;
-	right: $solid-border-space;
-	bottom: 0;
-	z-index: 10;
-	background-color: $gray-lighten-30;
-	border-radius: 8px;
-}
-
-.draggable-placeholder__container--dark {
-	background-color: $gray-darken-30;
-}


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4742.
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4741.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following the design feedback outlined in [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4691#issuecomment-1088038628), the animations of dragging and dropping a block have been updated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

These changes will improve the user experience when using the drag & drop feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Both dragging and dropping animations defined in the `BlockDraggable` component have been refactored and in general simplified. Additionally, now when a block is dropped it gets automatically selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the app.
1. Add several blocks.
1. Long-press on a block to activate the dragging mode.
1. Drag the block around the block list.
1. Drop the block in a different position within the block list.
1. Observe that the block is now located in the specified position.

## Screenshots or screencast <!-- if applicable -->

Android|iOS
--|--
<video src=https://user-images.githubusercontent.com/14905380/162022481-0fa7cd6e-2270-4452-a40e-f915ba904bda.mp4>|<video src=https://user-images.githubusercontent.com/14905380/162022387-5df42eb8-86bc-4b04-b335-739b069e2a87.mp4>


