### PR TITLE
Add select-parent button to block toolbar "More options" menu.

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -220,7 +220,7 @@ export function BlockSettingsDropdown( {
 									>
 										{ sprintf(
 											/* translators: %s: Name of the block's parent. */
-											__( 'Select parent (%s)' ),
+											__( 'Select parent block (%s)' ),
 											parentBlockType.title
 										) }
 									</MenuItem>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -6,12 +6,17 @@ import { castArray, flow, noop } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { getBlockType, serialize } from '@wordpress/blocks';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { moreVertical } from '@wordpress/icons';
-import { Children, cloneElement, useCallback } from '@wordpress/element';
-import { serialize } from '@wordpress/blocks';
+import {
+	Children,
+	cloneElement,
+	useCallback,
+	useRef,
+} from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useCopyToClipboard } from '@wordpress/compose';
 
@@ -19,12 +24,14 @@ import { useCopyToClipboard } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockActions from '../block-actions';
+import BlockIcon from '../block-icon';
 import BlockModeToggle from './block-mode-toggle';
 import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
 import { store as blockEditorStore } from '../../store';
 import useBlockDisplayTitle from '../block-title/use-block-display-title';
+import { useShowMoversGestures } from '../block-toolbar/utils';
 
 const POPOVER_PROPS = {
 	className: 'block-editor-block-settings-menu__popover',
@@ -47,7 +54,10 @@ export function BlockSettingsDropdown( {
 	const count = blockClientIds.length;
 	const firstBlockClientId = blockClientIds[ 0 ];
 	const {
+		firstParentClientId,
+		hasReducedUI,
 		onlyBlock,
+		parentBlockType,
 		previousBlockClientId,
 		nextBlockClientId,
 		selectedBlockClientIds,
@@ -55,12 +65,23 @@ export function BlockSettingsDropdown( {
 		( select ) => {
 			const {
 				getBlockCount,
+				getBlockName,
+				getBlockParents,
 				getPreviousBlockClientId,
 				getNextBlockClientId,
 				getSelectedBlockClientIds,
+				getSettings,
 			} = select( blockEditorStore );
+
+			const parents = getBlockParents( firstBlockClientId );
+			const _firstParentClientId = parents[ parents.length - 1 ];
+			const parentBlockName = getBlockName( _firstParentClientId );
+
 			return {
+				firstParentClientId: _firstParentClientId,
+				hasReducedUI: getSettings().hasReducedUI,
 				onlyBlock: 1 === getBlockCount(),
+				parentBlockType: getBlockType( parentBlockName ),
 				previousBlockClientId: getPreviousBlockClientId(
 					firstBlockClientId
 				),
@@ -86,6 +107,10 @@ export function BlockSettingsDropdown( {
 			),
 		};
 	}, [] );
+
+	const { selectBlock, toggleBlockHighlight } = useDispatch(
+		blockEditorStore
+	);
 
 	const updateSelectionAfterDuplicate = useCallback(
 		__experimentalSelectBlock
@@ -135,6 +160,19 @@ export function BlockSettingsDropdown( {
 	);
 	const removeBlockLabel = count === 1 ? label : __( 'Remove blocks' );
 
+	// Allows highlighting the parent block outline when focusing or hovering
+	// the parent block selector within the child.
+	const selectParentButtonRef = useRef();
+	const { gestures: showParentOutlineGestures } = useShowMoversGestures( {
+		ref: selectParentButtonRef,
+		onChange( isFocused ) {
+			if ( isFocused && hasReducedUI ) {
+				return;
+			}
+			toggleBlockHighlight( firstParentClientId, isFocused );
+		},
+	} );
+
 	return (
 		<BlockActions
 			clientIds={ clientIds }
@@ -167,6 +205,26 @@ export function BlockSettingsDropdown( {
 								<__unstableBlockSettingsMenuFirstItem.Slot
 									fillProps={ { onClose } }
 								/>
+								{ firstParentClientId !== undefined && (
+									<MenuItem
+										{ ...showParentOutlineGestures }
+										ref={ selectParentButtonRef }
+										icon={
+											<BlockIcon
+												icon={ parentBlockType.icon }
+											/>
+										}
+										onClick={ () =>
+											selectBlock( firstParentClientId )
+										}
+									>
+										{ sprintf(
+											/* translators: %s: Name of the block's parent. */
+											__( 'Select parent (%s)' ),
+											parentBlockType.title
+										) }
+									</MenuItem>
+								) }
 								{ count === 1 && (
 									<BlockHTMLConvertButton
 										clientId={ firstBlockClientId }


### PR DESCRIPTION
## What?
Split out and updated from the obsolete #23800, this PR adds a "Select parent" button to the block toolbar's ellipsis menu.

## Why?
In a [brief discussion](https://github.com/WordPress/gutenberg/pull/23800#issuecomment-868416253) at the end of #23800, it was suggested that a select-parent option in the block toolbar ellipsis menu might still be useful, even after the improvements to the one on the left of the block toolbar.

Specifically, the thin-viewport/mobile version of the UI does not show the standard select-parent button, so this ellipsis menu option can serve as a substitute in that context.

## How?
This PR just adds a button to the block toolbar ellipsis menu that behaves pretty much identically to the one visible on the left of the standard desktop viewport block toolbar.

## Testing Instructions
1. Insert a Group block.
2. Insert 2 Paragraph blocks inside the Group.
3. Select one of the Paragraph blocks.
4. Open the "More options" ellipsis menu in the block toolbar.
5. Check that the "Select parent" option includes the name and icon of the parent block.
6. Check that hovering the option highlights the border of the parent block.

## Notes
I've noticed that merely focusing the ellipsis menu option does not make the parent block outline show, which is different from the behavior of the icon-button on the left of the block toolbar. I can't find a reason for this, thought I suspect it has something to do with a quirk of how `useShowMoversGestures` works. (Speaking of which, that hook really needs a refactor, since even its name no longer makes sense after all the changes that have been made to the block toolbar since the hook's creation. I'll probably do that as a separate PR at some point.)

## Screenshot
![image](https://user-images.githubusercontent.com/19592990/162022769-7061badb-e135-4c16-8df8-aa9c855966ea.png)
![image](https://user-images.githubusercontent.com/19592990/162022931-6fa3d441-880b-4767-a212-a123c03e10bf.png)
