### PR TITLE
Theme Export: Change the schema url

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -104,11 +104,11 @@ function gutenberg_generate_block_templates_export_file() {
 	// If a version is defined, add a schema.
 	if ( $theme_json_raw['version'] ) {
 		global $wp_version;
-		$theme_json_version = substr( $wp_version, 0, strpos( $wp_version, '-' ) );
+		$theme_json_version = 'wp/' . substr( $wp_version, 0, 3 );
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) ) {
 			$theme_json_version = 'trunk';
 		}
-		$schema         = array( '$schema' => 'https://schemas.wp.org/wp/' . $theme_json_version . '/theme.json' );
+		$schema         = array( '$schema' => 'https://schemas.wp.org/' . $theme_json_version . '/theme.json' );
 		$theme_json_raw = array_merge( $schema, $theme_json_raw );
 	}
 


### PR DESCRIPTION
## What?
This fixes a mistake from https://github.com/WordPress/gutenberg/pull/39775. Rather than using a complicated split to work out the version number, we can just take the first three digits of the version number...

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/39775