### PR TITLE
ToggleGroupControl: rewrite backdrop animation with framer-motion

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -12,25 +12,22 @@ import {
 } from '@wordpress/components';
 import { InspectorControls, useSetting } from '@wordpress/block-editor';
 
-const SCALE_OPTIONS = (
-	<>
-		<ToggleGroupControlOption
-			value="cover"
-			label={ _x( 'Cover', 'Scale option for Image dimension control' ) }
-		/>
-		<ToggleGroupControlOption
-			value="contain"
-			label={ _x(
-				'Contain',
-				'Scale option for Image dimension control'
-			) }
-		/>
-		<ToggleGroupControlOption
-			value="fill"
-			label={ _x( 'Fill', 'Scale option for Image dimension control' ) }
-		/>
-	</>
-);
+const SCALE_OPTIONS = [
+	{
+		value: 'cover',
+		label: _x( 'Cover', 'Scale option for Image dimension control' ),
+	},
+	{
+		value: 'contain',
+		label: _x( 'Contain', 'Scale option for Image dimension control' ),
+	},
+	{
+		value: 'fill',
+		label: _x( 'Fill', 'Scale option for Image dimension control' ),
+	},
+].map( ( props ) => (
+	<ToggleGroupControlOption key={ props.value } { ...props } />
+) );
 
 const DEFAULT_SCALE = 'cover';
 const DEFAULT_SIZE = 'full';
@@ -140,7 +137,7 @@ const DimensionControls = ( {
 								scale: value,
 							} )
 						}
-						isBlock
+						isAdaptiveWidth
 					>
 						{ SCALE_OPTIONS }
 					</ToggleGroupControl>

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `ToggleGroupControl`: rewrite backdrop animation with `framer-motion` ([#40107](https://github.com/WordPress/gutenberg/pull/40107)).
+
 ## 19.8.0 (2022-04-08)
 
 ### Enhancements
@@ -10,6 +14,7 @@
 -   `ToggleGroupControl`: Reintroduce backdrop animation ([#40021](https://github.com/WordPress/gutenberg/pull/40021)).
 -   `Card`: Adjust border radius effective size ([#40032](https://github.com/WordPress/gutenberg/pull/40032)).
 -   `InputControl`: Improved TypeScript type annotations ([#40119](https://github.com/WordPress/gutenberg/pull/40119)).
+-   `ToggleGroupControl`: rewrite backdrop animation with `framer-motion` ([#40107](https://github.com/WordPress/gutenberg/pull/40107)).
 
 ### Internal
 
@@ -27,6 +32,7 @@
 -   `ItemGroup`: Ensure that the Item's text color is not overriden by the user agent's button color ([#40055](https://github.com/WordPress/gutenberg/pull/40055)).
 -   `Surface`: Use updated UI text color `#1e1e1e` instead of `#000` ([#40055](https://github.com/WordPress/gutenberg/pull/40055)).
 -   `CustomSelectControl`: Make chevron consistent with `SelectControl` ([#40049](https://github.com/WordPress/gutenberg/pull/40049)).
+-   `ToggleGroupControl`: fix rendering glitch when used in combination with `Popover` ([#40107](https://github.com/WordPress/gutenberg/pull/40107)).
 
 ## 19.7.0 (2022-03-23)
 

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -30,8 +30,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   display: inline-flex;
   min-height: 36px;
   min-width: 0;
-  padding: 2px;
-  position: relative;
 }
 
 .emotion-6:hover {
@@ -46,17 +44,27 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 .emotion-8 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  margin: 2px;
+}
+
+.emotion-10 {
   background: #1e1e1e;
   border-radius: 2px;
   box-shadow: none;
   left: 0;
   position: absolute;
-  top: 2px;
-  bottom: 2px;
+  top: 0;
+  bottom: 0;
   z-index: 1;
 }
 
-.emotion-10 {
+.emotion-12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -69,7 +77,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   flex: 1;
 }
 
-.emotion-12 {
+.emotion-14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -110,28 +118,28 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-12 {
+  .emotion-14 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-12::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-12:active {
+.emotion-14:active {
   background: #fff;
 }
 
-.emotion-13 {
+.emotion-15 {
   color: #fff;
 }
 
-.emotion-13:active {
+.emotion-15:active {
   background: transparent;
 }
 
-.emotion-14 {
+.emotion-16 {
   font-size: 13px;
   line-height: 1;
 }
@@ -157,84 +165,85 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       id="toggle-group-control-1"
       role="radiogroup"
     >
-      <iframe
-        aria-hidden="true"
-        frameborder="0"
-        src="about:blank"
-        style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
-        tabindex="-1"
-      />
       <div
         class="emotion-8 emotion-9"
-        role="presentation"
-      />
-      <div
-        class="emotion-10 emotion-11"
-        data-active="true"
-        data-toggle-group-control-option-wrapper="true"
       >
-        <button
-          aria-checked="true"
-          aria-label="Uppercase"
-          class="emotion-12 components-toggle-group-control-option-base emotion-13"
-          data-value="uppercase"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-2"
-          role="radio"
-          tabindex="0"
-        >
-          <div
-            class="emotion-14 emotion-15"
-          >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
-              />
-            </svg>
-          </div>
-        </button>
-      </div>
-      <div
-        class="emotion-10 emotion-11"
-        data-active="false"
-        data-toggle-group-control-option-wrapper="true"
-      >
-        <button
-          aria-checked="false"
-          aria-label="Lowercase"
-          class="emotion-12 components-toggle-group-control-option-base"
-          data-value="lowercase"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-1-3"
-          role="radio"
+        <iframe
+          aria-hidden="true"
+          frameborder="0"
+          src="about:blank"
+          style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
           tabindex="-1"
+        />
+        <div
+          class="emotion-10 emotion-11"
+          role="presentation"
+          style="width: 0px; transform: translateX(0px) translateZ(0);"
+        />
+        <div
+          class="emotion-12 emotion-13"
         >
-          <div
-            class="emotion-14 emotion-15"
+          <button
+            aria-checked="true"
+            aria-label="Uppercase"
+            class="emotion-14 components-toggle-group-control-option-base emotion-15"
+            data-value="uppercase"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-1-2"
+            role="radio"
+            tabindex="0"
           >
-            <svg
-              aria-hidden="true"
-              focusable="false"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <div
+              class="emotion-16 emotion-17"
             >
-              <path
-                d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
-              />
-            </svg>
-          </div>
-        </button>
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
+        <div
+          class="emotion-12 emotion-13"
+        >
+          <button
+            aria-checked="false"
+            aria-label="Lowercase"
+            class="emotion-14 components-toggle-group-control-option-base"
+            data-value="lowercase"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-1-3"
+            role="radio"
+            tabindex="-1"
+          >
+            <div
+              class="emotion-16 emotion-17"
+            >
+              <svg
+                aria-hidden="true"
+                focusable="false"
+                height="24"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
+                />
+              </svg>
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -271,8 +280,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   display: inline-flex;
   min-height: 36px;
   min-width: 0;
-  padding: 2px;
-  position: relative;
 }
 
 .emotion-6:hover {
@@ -287,6 +294,27 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 .emotion-8 {
+  position: relative;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  margin: 2px;
+}
+
+.emotion-10 {
+  background: #1e1e1e;
+  border-radius: 2px;
+  box-shadow: none;
+  left: 0;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 1;
+}
+
+.emotion-12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -299,7 +327,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-14 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -340,20 +368,20 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-10 {
+  .emotion-14 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-14::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10:active {
+.emotion-14:active {
   background: #fff;
 }
 
-.emotion-11 {
+.emotion-15 {
   font-size: 13px;
   line-height: 1;
 }
@@ -379,58 +407,63 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       id="toggle-group-control-0"
       role="radiogroup"
     >
-      <iframe
-        aria-hidden="true"
-        frameborder="0"
-        src="about:blank"
-        style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
-        tabindex="-1"
-      />
       <div
         class="emotion-8 emotion-9"
-        data-active="false"
-        data-toggle-group-control-option-wrapper="true"
       >
-        <button
-          aria-checked="false"
-          aria-label="R"
-          class="emotion-10 components-toggle-group-control-option-base"
-          data-value="rigas"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-0"
-          role="radio"
-          tabindex="0"
-        >
-          <div
-            class="emotion-11 emotion-12"
-          >
-            R
-          </div>
-        </button>
-      </div>
-      <div
-        class="emotion-8 emotion-9"
-        data-active="false"
-        data-toggle-group-control-option-wrapper="true"
-      >
-        <button
-          aria-checked="false"
-          aria-label="J"
-          class="emotion-10 components-toggle-group-control-option-base"
-          data-value="jack"
-          data-wp-c16t="true"
-          data-wp-component="ToggleGroupControlOptionBase"
-          id="toggle-group-control-0-1"
-          role="radio"
+        <iframe
+          aria-hidden="true"
+          frameborder="0"
+          src="about:blank"
+          style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
           tabindex="-1"
+        />
+        <div
+          class="emotion-10 emotion-11"
+          role="presentation"
+          style="width: 0px; transform: translateX(0px) translateZ(0);"
+        />
+        <div
+          class="emotion-12 emotion-13"
         >
-          <div
-            class="emotion-11 emotion-12"
+          <button
+            aria-checked="false"
+            aria-label="R"
+            class="emotion-14 components-toggle-group-control-option-base"
+            data-value="rigas"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-0-0"
+            role="radio"
+            tabindex="0"
           >
-            J
-          </div>
-        </button>
+            <div
+              class="emotion-15 emotion-16"
+            >
+              R
+            </div>
+          </button>
+        </div>
+        <div
+          class="emotion-12 emotion-13"
+        >
+          <button
+            aria-checked="false"
+            aria-label="J"
+            class="emotion-14 components-toggle-group-control-option-base"
+            data-value="jack"
+            data-wp-c16t="true"
+            data-wp-component="ToggleGroupControlOptionBase"
+            id="toggle-group-control-0-1"
+            role="radio"
+            tabindex="-1"
+          >
+            <div
+              class="emotion-15 emotion-16"
+            >
+              J
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -32,14 +32,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   min-width: 0;
   padding: 2px;
   position: relative;
-  -webkit-transition: -webkit-transform 100ms linear;
-  transition: transform 100ms linear;
-}
-
-@media ( prefers-reduced-motion: reduce ) {
-  .emotion-6 {
-    transition-duration: 0ms;
-  }
 }
 
 .emotion-6:hover {
@@ -56,20 +48,12 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 .emotion-8 {
   background: #1e1e1e;
   border-radius: 2px;
-  box-shadow: transparent;
+  box-shadow: none;
   left: 0;
   position: absolute;
   top: 2px;
   bottom: 2px;
-  -webkit-transition: -webkit-transform 160ms ease;
-  transition: transform 160ms ease;
   z-index: 1;
-}
-
-@media ( prefers-reduced-motion: reduce ) {
-  .emotion-8 {
-    transition-duration: 0ms;
-  }
 }
 
 .emotion-10 {
@@ -183,11 +167,11 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       <div
         class="emotion-8 emotion-9"
         role="presentation"
-        style="transform: translateX(0px); transition: none; width: 0px;"
       />
       <div
         class="emotion-10 emotion-11"
         data-active="true"
+        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="true"
@@ -221,6 +205,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       <div
         class="emotion-10 emotion-11"
         data-active="false"
+        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"
@@ -288,14 +273,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   min-width: 0;
   padding: 2px;
   position: relative;
-  -webkit-transition: -webkit-transform 100ms linear;
-  transition: transform 100ms linear;
-}
-
-@media ( prefers-reduced-motion: reduce ) {
-  .emotion-6 {
-    transition-duration: 0ms;
-  }
 }
 
 .emotion-6:hover {
@@ -412,6 +389,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       <div
         class="emotion-8 emotion-9"
         data-active="false"
+        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"
@@ -434,6 +412,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       <div
         class="emotion-8 emotion-9"
         data-active="false"
+        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -30,6 +30,8 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   display: inline-flex;
   min-height: 36px;
   min-width: 0;
+  padding: 2px;
+  position: relative;
 }
 
 .emotion-6:hover {
@@ -44,27 +46,17 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 .emotion-8 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  margin: 2px;
-}
-
-.emotion-10 {
   background: #1e1e1e;
   border-radius: 2px;
   box-shadow: none;
   left: 0;
   position: absolute;
-  top: 0;
-  bottom: 0;
+  top: 2px;
+  bottom: 2px;
   z-index: 1;
 }
 
-.emotion-12 {
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -77,7 +69,7 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
   flex: 1;
 }
 
-.emotion-14 {
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -118,28 +110,28 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-14 {
+  .emotion-12 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-14::-moz-focus-inner {
+.emotion-12::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-14:active {
+.emotion-12:active {
   background: #fff;
 }
 
-.emotion-15 {
+.emotion-13 {
   color: #fff;
 }
 
-.emotion-15:active {
+.emotion-13:active {
   background: transparent;
 }
 
-.emotion-16 {
+.emotion-14 {
   font-size: 13px;
   line-height: 1;
 }
@@ -165,85 +157,84 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       id="toggle-group-control-1"
       role="radiogroup"
     >
+      <iframe
+        aria-hidden="true"
+        frameborder="0"
+        src="about:blank"
+        style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+        tabindex="-1"
+      />
       <div
         class="emotion-8 emotion-9"
+        role="presentation"
+      />
+      <div
+        class="emotion-10 emotion-11"
+        data-active="true"
+        data-toggle-group-control-option-wrapper="true"
       >
-        <iframe
-          aria-hidden="true"
-          frameborder="0"
-          src="about:blank"
-          style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+        <button
+          aria-checked="true"
+          aria-label="Uppercase"
+          class="emotion-12 components-toggle-group-control-option-base emotion-13"
+          data-value="uppercase"
+          data-wp-c16t="true"
+          data-wp-component="ToggleGroupControlOptionBase"
+          id="toggle-group-control-1-2"
+          role="radio"
+          tabindex="0"
+        >
+          <div
+            class="emotion-14 emotion-15"
+          >
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
+              />
+            </svg>
+          </div>
+        </button>
+      </div>
+      <div
+        class="emotion-10 emotion-11"
+        data-active="false"
+        data-toggle-group-control-option-wrapper="true"
+      >
+        <button
+          aria-checked="false"
+          aria-label="Lowercase"
+          class="emotion-12 components-toggle-group-control-option-base"
+          data-value="lowercase"
+          data-wp-c16t="true"
+          data-wp-component="ToggleGroupControlOptionBase"
+          id="toggle-group-control-1-3"
+          role="radio"
           tabindex="-1"
-        />
-        <div
-          class="emotion-10 emotion-11"
-          role="presentation"
-          style="width: 0px; transform: translateX(0px) translateZ(0);"
-        />
-        <div
-          class="emotion-12 emotion-13"
         >
-          <button
-            aria-checked="true"
-            aria-label="Uppercase"
-            class="emotion-14 components-toggle-group-control-option-base emotion-15"
-            data-value="uppercase"
-            data-wp-c16t="true"
-            data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-1-2"
-            role="radio"
-            tabindex="0"
+          <div
+            class="emotion-14 emotion-15"
           >
-            <div
-              class="emotion-16 emotion-17"
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
             >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M6.1 6.8L2.1 18h1.6l1.1-3h4.3l1.1 3h1.6l-4-11.2H6.1zm-.8 6.8L7 8.9l1.7 4.7H5.3zm15.1-.7c-.4-.5-.9-.8-1.6-1 .4-.2.7-.5.8-.9.2-.4.3-.9.3-1.4 0-.9-.3-1.6-.8-2-.6-.5-1.3-.7-2.4-.7h-3.5V18h4.2c1.1 0 2-.3 2.6-.8.6-.6 1-1.4 1-2.4-.1-.8-.3-1.4-.6-1.9zm-5.7-4.7h1.8c.6 0 1.1.1 1.4.4.3.2.5.7.5 1.3 0 .6-.2 1.1-.5 1.3-.3.2-.8.4-1.4.4h-1.8V8.2zm4 8c-.4.3-.9.5-1.5.5h-2.6v-3.8h2.6c1.4 0 2 .6 2 1.9.1.6-.1 1-.5 1.4z"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
-        <div
-          class="emotion-12 emotion-13"
-        >
-          <button
-            aria-checked="false"
-            aria-label="Lowercase"
-            class="emotion-14 components-toggle-group-control-option-base"
-            data-value="lowercase"
-            data-wp-c16t="true"
-            data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-1-3"
-            role="radio"
-            tabindex="-1"
-          >
-            <div
-              class="emotion-16 emotion-17"
-            >
-              <svg
-                aria-hidden="true"
-                focusable="false"
-                height="24"
-                viewBox="0 0 24 24"
-                width="24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
-                />
-              </svg>
-            </div>
-          </button>
-        </div>
+              <path
+                d="M11 16.8c-.1-.1-.2-.3-.3-.5v-2.6c0-.9-.1-1.7-.3-2.2-.2-.5-.5-.9-.9-1.2-.4-.2-.9-.3-1.6-.3-.5 0-1 .1-1.5.2s-.9.3-1.2.6l.2 1.2c.4-.3.7-.4 1.1-.5.3-.1.7-.2 1-.2.6 0 1 .1 1.3.4.3.2.4.7.4 1.4-1.2 0-2.3.2-3.3.7s-1.4 1.1-1.4 2.1c0 .7.2 1.2.7 1.6.4.4 1 .6 1.8.6.9 0 1.7-.4 2.4-1.2.1.3.2.5.4.7.1.2.3.3.6.4.3.1.6.1 1.1.1h.1l.2-1.2h-.1c-.4.1-.6 0-.7-.1zM9.2 16c-.2.3-.5.6-.9.8-.3.1-.7.2-1.1.2-.4 0-.7-.1-.9-.3-.2-.2-.3-.5-.3-.9 0-.6.2-1 .7-1.3.5-.3 1.3-.4 2.5-.5v2zm10.6-3.9c-.3-.6-.7-1.1-1.2-1.5-.6-.4-1.2-.6-1.9-.6-.5 0-.9.1-1.4.3-.4.2-.8.5-1.1.8V6h-1.4v12h1.3l.2-1c.2.4.6.6 1 .8.4.2.9.3 1.4.3.7 0 1.2-.2 1.8-.5.5-.4 1-.9 1.3-1.5.3-.6.5-1.3.5-2.1-.1-.6-.2-1.3-.5-1.9zm-1.7 4c-.4.5-.9.8-1.6.8s-1.2-.2-1.7-.7c-.4-.5-.7-1.2-.7-2.1 0-.9.2-1.6.7-2.1.4-.5 1-.7 1.7-.7s1.2.3 1.6.8c.4.5.6 1.2.6 2s-.2 1.4-.6 2z"
+              />
+            </svg>
+          </div>
+        </button>
       </div>
     </div>
   </div>
@@ -280,6 +271,8 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   display: inline-flex;
   min-height: 36px;
   min-width: 0;
+  padding: 2px;
+  position: relative;
 }
 
 .emotion-6:hover {
@@ -294,27 +287,6 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 .emotion-8 {
-  position: relative;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  width: 100%;
-  margin: 2px;
-}
-
-.emotion-10 {
-  background: #1e1e1e;
-  border-radius: 2px;
-  box-shadow: none;
-  left: 0;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-}
-
-.emotion-12 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -327,7 +299,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   flex: 1;
 }
 
-.emotion-14 {
+.emotion-10 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -368,20 +340,20 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-14 {
+  .emotion-10 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-14::-moz-focus-inner {
+.emotion-10::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-14:active {
+.emotion-10:active {
   background: #fff;
 }
 
-.emotion-15 {
+.emotion-11 {
   font-size: 13px;
   line-height: 1;
 }
@@ -407,63 +379,58 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       id="toggle-group-control-0"
       role="radiogroup"
     >
+      <iframe
+        aria-hidden="true"
+        frameborder="0"
+        src="about:blank"
+        style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+        tabindex="-1"
+      />
       <div
         class="emotion-8 emotion-9"
+        data-active="false"
+        data-toggle-group-control-option-wrapper="true"
       >
-        <iframe
-          aria-hidden="true"
-          frameborder="0"
-          src="about:blank"
-          style="display: block; opacity: 0; position: absolute; top: 0px; left: 0px; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;"
+        <button
+          aria-checked="false"
+          aria-label="R"
+          class="emotion-10 components-toggle-group-control-option-base"
+          data-value="rigas"
+          data-wp-c16t="true"
+          data-wp-component="ToggleGroupControlOptionBase"
+          id="toggle-group-control-0-0"
+          role="radio"
+          tabindex="0"
+        >
+          <div
+            class="emotion-11 emotion-12"
+          >
+            R
+          </div>
+        </button>
+      </div>
+      <div
+        class="emotion-8 emotion-9"
+        data-active="false"
+        data-toggle-group-control-option-wrapper="true"
+      >
+        <button
+          aria-checked="false"
+          aria-label="J"
+          class="emotion-10 components-toggle-group-control-option-base"
+          data-value="jack"
+          data-wp-c16t="true"
+          data-wp-component="ToggleGroupControlOptionBase"
+          id="toggle-group-control-0-1"
+          role="radio"
           tabindex="-1"
-        />
-        <div
-          class="emotion-10 emotion-11"
-          role="presentation"
-          style="width: 0px; transform: translateX(0px) translateZ(0);"
-        />
-        <div
-          class="emotion-12 emotion-13"
         >
-          <button
-            aria-checked="false"
-            aria-label="R"
-            class="emotion-14 components-toggle-group-control-option-base"
-            data-value="rigas"
-            data-wp-c16t="true"
-            data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-0-0"
-            role="radio"
-            tabindex="0"
+          <div
+            class="emotion-11 emotion-12"
           >
-            <div
-              class="emotion-15 emotion-16"
-            >
-              R
-            </div>
-          </button>
-        </div>
-        <div
-          class="emotion-12 emotion-13"
-        >
-          <button
-            aria-checked="false"
-            aria-label="J"
-            class="emotion-14 components-toggle-group-control-option-base"
-            data-value="jack"
-            data-wp-c16t="true"
-            data-wp-component="ToggleGroupControlOptionBase"
-            id="toggle-group-control-0-1"
-            role="radio"
-            tabindex="-1"
-          >
-            <div
-              class="emotion-15 emotion-16"
-            >
-              J
-            </div>
-          </button>
-        </div>
+            J
+          </div>
+        </button>
       </div>
     </div>
   </div>

--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.js.snap
@@ -167,11 +167,11 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       <div
         class="emotion-8 emotion-9"
         role="presentation"
+        style="width: 100px; transform: translateX(2px) translateZ(0);"
       />
       <div
         class="emotion-10 emotion-11"
         data-active="true"
-        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="true"
@@ -205,7 +205,6 @@ exports[`ToggleGroupControl should render correctly with icons 1`] = `
       <div
         class="emotion-10 emotion-11"
         data-active="false"
-        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"
@@ -287,6 +286,17 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 .emotion-8 {
+  background: #1e1e1e;
+  border-radius: 2px;
+  box-shadow: none;
+  left: 0;
+  position: absolute;
+  top: 2px;
+  bottom: 2px;
+  z-index: 1;
+}
+
+.emotion-10 {
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -299,7 +309,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
   flex: 1;
 }
 
-.emotion-10 {
+.emotion-12 {
   -webkit-align-items: center;
   -webkit-box-align: center;
   -ms-flex-align: center;
@@ -340,20 +350,20 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
 }
 
 @media ( prefers-reduced-motion: reduce ) {
-  .emotion-10 {
+  .emotion-12 {
     transition-duration: 0ms;
   }
 }
 
-.emotion-10::-moz-focus-inner {
+.emotion-12::-moz-focus-inner {
   border: 0;
 }
 
-.emotion-10:active {
+.emotion-12:active {
   background: #fff;
 }
 
-.emotion-11 {
+.emotion-13 {
   font-size: 13px;
   line-height: 1;
 }
@@ -388,13 +398,17 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
       />
       <div
         class="emotion-8 emotion-9"
+        role="presentation"
+        style="width: 100px; transform: translateX(2px) translateZ(0);"
+      />
+      <div
+        class="emotion-10 emotion-11"
         data-active="false"
-        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"
           aria-label="R"
-          class="emotion-10 components-toggle-group-control-option-base"
+          class="emotion-12 components-toggle-group-control-option-base"
           data-value="rigas"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
@@ -403,21 +417,20 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
           tabindex="0"
         >
           <div
-            class="emotion-11 emotion-12"
+            class="emotion-13 emotion-14"
           >
             R
           </div>
         </button>
       </div>
       <div
-        class="emotion-8 emotion-9"
+        class="emotion-10 emotion-11"
         data-active="false"
-        data-toggle-group-control-option-wrapper="true"
       >
         <button
           aria-checked="false"
           aria-label="J"
-          class="emotion-10 components-toggle-group-control-option-base"
+          class="emotion-12 components-toggle-group-control-option-base"
           data-value="jack"
           data-wp-c16t="true"
           data-wp-component="ToggleGroupControlOptionBase"
@@ -426,7 +439,7 @@ exports[`ToggleGroupControl should render correctly with text options 1`] = `
           tabindex="-1"
         >
           <div
-            class="emotion-11 emotion-12"
+            class="emotion-13 emotion-14"
           >
             J
           </div>

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -63,6 +63,8 @@ function ToggleGroupControlOptionBase(
 		value,
 		children,
 		showTooltip = false,
+		activeIndex,
+		length,
 		...radioProps
 	} = {
 		...toggleGroupControlContext,
@@ -79,12 +81,7 @@ function ToggleGroupControlOptionBase(
 	);
 
 	return (
-		<LabelView
-			className={ labelViewClasses }
-			data-active={ isActive }
-			// Necessary for the ToggleGroupControlBackdrop component to render properly
-			data-toggle-group-control-option-wrapper="true"
-		>
+		<LabelView className={ labelViewClasses }>
 			<WithToolTip
 				showTooltip={ showTooltip }
 				text={ radioProps[ 'aria-label' ] }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -79,7 +79,12 @@ function ToggleGroupControlOptionBase(
 	);
 
 	return (
-		<LabelView className={ labelViewClasses } data-active={ isActive }>
+		<LabelView
+			className={ labelViewClasses }
+			data-active={ isActive }
+			// Necessary for the ToggleGroupControlBackdrop component to render properly
+			data-toggle-group-control-option-wrapper="true"
+		>
 			<WithToolTip
 				showTooltip={ showTooltip }
 				text={ radioProps[ 'aria-label' ] }
@@ -89,6 +94,7 @@ function ToggleGroupControlOptionBase(
 					as="button"
 					aria-label={ radioProps[ 'aria-label' ] }
 					className={ classes }
+					// Useful to find the `Radio` holding the selected value from outside this component
 					data-value={ value }
 					ref={ forwardedRef }
 					value={ value }

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -63,8 +63,6 @@ function ToggleGroupControlOptionBase(
 		value,
 		children,
 		showTooltip = false,
-		activeIndex,
-		length,
 		...radioProps
 	} = {
 		...toggleGroupControlContext,

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -81,7 +81,7 @@ function ToggleGroupControlOptionBase(
 	);
 
 	return (
-		<LabelView className={ labelViewClasses }>
+		<LabelView className={ labelViewClasses } data-active={ isActive }>
 			<WithToolTip
 				showTooltip={ showTooltip }
 				text={ radioProps[ 'aria-label' ] }

--- a/packages/components/src/toggle-group-control/toggle-group-control/README.md
+++ b/packages/components/src/toggle-group-control/toggle-group-control/README.md
@@ -4,7 +4,7 @@
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-`ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use [`ToggleGroupControlOption`](/packages/components/src/toggle-group-control/toggle-group-control-option/README.md) component.
+`ToggleGroupControl` is a form component that lets users choose options represented in horizontal segments. To render options for this control use the [`ToggleGroupControlOption`](/packages/components/src/toggle-group-control/toggle-group-control-option/README.md) or the [`ToggleGroupControlOptionIcon`](/packages/components/src/toggle-group-control/toggle-group-control-option-icon//README.md) components.
 
 Only use this control when you know for sure the labels of items inside won't wrap. For items with longer labels, you can consider a [`SelectControl`](/packages/components/src/select-control/README.md) or a [`CustomSelectControl`](/packages/components/src/custom-select-control/README.md) component instead.
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -105,9 +105,11 @@ function ToggleGroupControl(
 					{ ...otherProps }
 					ref={ forwardedRef }
 				>
-					{ resizeListener }
-					<ToggleGroupControlBackdrop containerSizes={ sizes } />
-					{ children }
+					<styles.Liner>
+						{ resizeListener }
+						<ToggleGroupControlBackdrop containerSizes={ sizes } />
+						{ children }
+					</styles.Liner>
 				</RadioGroup>
 			</ToggleGroupControlContext.Provider>
 		</BaseControl>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -10,7 +10,7 @@ import useResizeAware from 'react-resize-aware';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo } from '@wordpress/element';
+import { Children, useMemo } from '@wordpress/element';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
 
 /**
@@ -85,10 +85,23 @@ function ToggleGroupControl(
 			),
 		[ className, cx, isBlock ]
 	);
+
+	let length = 0;
+	let activeIndex = -1;
+	Children.forEach( children, ( option, index ) => {
+		length += 1;
+		if ( option.props.value === radio.state ) activeIndex = index;
+	} );
+
 	return (
 		<BaseControl help={ help }>
 			<ToggleGroupControlContext.Provider
-				value={ { ...radio, isBlock: ! isAdaptiveWidth } }
+				value={ {
+					...radio,
+					isBlock: ! isAdaptiveWidth,
+					length,
+					activeIndex,
+				} }
 			>
 				{ ! hideLabelFromVision && (
 					<div>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -107,12 +107,7 @@ function ToggleGroupControl(
 					ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
 				>
 					{ resizeListener }
-					<ToggleGroupControlBackdrop
-						{ ...radio }
-						containerRef={ containerRef }
-						containerWidth={ sizes.width }
-						isAdaptiveWidth={ isAdaptiveWidth }
-					/>
+					<ToggleGroupControlBackdrop containerSizes={ sizes } />
 					{ children }
 				</RadioGroup>
 			</ToggleGroupControlContext.Provider>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -10,8 +10,8 @@ import useResizeAware from 'react-resize-aware';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useRef, useMemo } from '@wordpress/element';
-import { useMergeRefs, useInstanceId, usePrevious } from '@wordpress/compose';
+import { useMemo } from '@wordpress/element';
+import { useInstanceId, usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -48,7 +48,6 @@ function ToggleGroupControl(
 		...otherProps
 	} = useContextSystem( props, 'ToggleGroupControl' );
 	const cx = useCx();
-	const containerRef = useRef();
 	const [ resizeListener, sizes ] = useResizeAware();
 	const baseId = useInstanceId(
 		ToggleGroupControl,
@@ -104,7 +103,7 @@ function ToggleGroupControl(
 					as={ View }
 					className={ classes }
 					{ ...otherProps }
-					ref={ useMergeRefs( [ containerRef, forwardedRef ] ) }
+					ref={ forwardedRef }
 				>
 					{ resizeListener }
 					<ToggleGroupControlBackdrop containerSizes={ sizes } />

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -86,22 +86,23 @@ function ToggleGroupControl(
 		[ className, cx, isBlock ]
 	);
 
-	let length = 0;
-	let activeIndex = -1;
+	const optionSizes = useMemo< number[] | undefined >( () => {
+		return radio.items?.map( ( item ) => {
+			if ( ! item.ref.current ) return 0;
+			const { width } = getComputedStyle( item.ref.current );
+			return parseFloat( width );
+		} );
+	}, [ radio.items, radio.items.length, sizes.width ] );
+
+	let activeIndex;
 	Children.forEach( children, ( option, index ) => {
-		length += 1;
 		if ( option.props.value === radio.state ) activeIndex = index;
 	} );
 
 	return (
 		<BaseControl help={ help }>
 			<ToggleGroupControlContext.Provider
-				value={ {
-					...radio,
-					isBlock: ! isAdaptiveWidth,
-					length,
-					activeIndex,
-				} }
+				value={ { ...radio, isBlock: ! isAdaptiveWidth } }
 			>
 				{ ! hideLabelFromVision && (
 					<div>
@@ -119,7 +120,10 @@ function ToggleGroupControl(
 					ref={ forwardedRef }
 				>
 					{ resizeListener }
-					<ToggleGroupControlBackdrop containerSizes={ sizes } />
+					<ToggleGroupControlBackdrop
+						activeIndex={ activeIndex }
+						optionSizes={ optionSizes }
+					/>
 					{ children }
 				</RadioGroup>
 			</ToggleGroupControlContext.Provider>

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -118,11 +118,9 @@ function ToggleGroupControl(
 					{ ...otherProps }
 					ref={ forwardedRef }
 				>
-					<styles.Liner>
-						{ resizeListener }
-						<ToggleGroupControlBackdrop containerSizes={ sizes } />
-						{ children }
-					</styles.Liner>
+					{ resizeListener }
+					<ToggleGroupControlBackdrop containerSizes={ sizes } />
+					{ children }
 				</RadioGroup>
 			</ToggleGroupControlContext.Provider>
 		</BaseControl>

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -19,8 +19,6 @@ export const ToggleGroupControl = css`
 	display: inline-flex;
 	min-height: ${ CONFIG.controlHeight };
 	min-width: 0;
-	padding: 2px;
-	position: relative;
 	&:hover {
 		border-color: ${ COLORS.ui.borderHover };
 	}
@@ -35,8 +33,15 @@ export const ToggleGroupControl = css`
 
 export const block = css`
 	display: flex;
-	width: 100%;
 `;
+
+export const Liner = styled( 'div' )`
+	position: relative;
+	display: flex;
+	width: 100%;
+	margin: 2px;
+`;
+
 
 export const AnimatedBackdrop = styled( motion.div )`
 	background: ${ COLORS.gray[ 900 ] };
@@ -44,7 +49,7 @@ export const AnimatedBackdrop = styled( motion.div )`
 	box-shadow: none;
 	left: 0;
 	position: absolute;
-	top: 2px;
-	bottom: 2px;
+	top: 0;
+	bottom: 0;
 	z-index: 1;
 `;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -9,7 +9,7 @@ import { motion } from 'framer-motion';
 /**
  * Internal dependencies
  */
-import { CONFIG, COLORS, reduceMotion } from '../../utils';
+import { CONFIG, COLORS } from '../../utils';
 
 export const ToggleGroupControl = css`
 	background: ${ COLORS.ui.background };
@@ -21,8 +21,6 @@ export const ToggleGroupControl = css`
 	min-width: 0;
 	padding: 2px;
 	position: relative;
-	transition: transform ${ CONFIG.transitionDurationFastest } linear;
-	${ reduceMotion( 'transition' ) }
 	&:hover {
 		border-color: ${ COLORS.ui.borderHover };
 	}

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -3,6 +3,8 @@
  */
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
+// eslint-disable-next-line no-restricted-imports
+import { motion } from 'framer-motion';
 
 /**
  * Internal dependencies
@@ -38,15 +40,13 @@ export const block = css`
 	width: 100%;
 `;
 
-export const BackdropView = styled.div`
+export const AnimatedBackdrop = styled( motion.div )`
 	background: ${ COLORS.gray[ 900 ] };
 	border-radius: ${ CONFIG.controlBorderRadius };
-	box-shadow: ${ CONFIG.toggleGroupControlBackdropBoxShadow };
+	box-shadow: none;
 	left: 0;
 	position: absolute;
 	top: 2px;
 	bottom: 2px;
-	transition: transform ${ CONFIG.transitionDurationFast } ease;
-	${ reduceMotion( 'transition' ) }
 	z-index: 1;
 `;

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -11,6 +11,8 @@ import { motion } from 'framer-motion';
  */
 import { CONFIG, COLORS } from '../../utils';
 
+export const inset = 2;
+
 export const ToggleGroupControl = css`
 	background: ${ COLORS.ui.background };
 	border: 1px solid;
@@ -19,7 +21,7 @@ export const ToggleGroupControl = css`
 	display: inline-flex;
 	min-height: ${ CONFIG.controlHeight };
 	min-width: 0;
-	padding: 2px;
+	padding: ${ inset }px;
 	position: relative;
 	&:hover {
 		border-color: ${ COLORS.ui.borderHover };

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -19,6 +19,8 @@ export const ToggleGroupControl = css`
 	display: inline-flex;
 	min-height: ${ CONFIG.controlHeight };
 	min-width: 0;
+	padding: 2px;
+	position: relative;
 	&:hover {
 		border-color: ${ COLORS.ui.borderHover };
 	}
@@ -33,15 +35,8 @@ export const ToggleGroupControl = css`
 
 export const block = css`
 	display: flex;
-`;
-
-export const Liner = styled( 'div' )`
-	position: relative;
-	display: flex;
 	width: 100%;
-	margin: 2px;
 `;
-
 
 export const AnimatedBackdrop = styled( motion.div )`
 	background: ${ COLORS.gray[ 900 ] };
@@ -49,7 +44,7 @@ export const AnimatedBackdrop = styled( motion.div )`
 	box-shadow: none;
 	left: 0;
 	position: absolute;
-	top: 0;
-	bottom: 0;
+	top: 2px;
+	bottom: 2px;
 	z-index: 1;
 `;

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -18,11 +18,11 @@ import { CONFIG } from '../../utils';
 import { AnimatedBackdrop } from './styles';
 
 const TRANSITION_CONFIG = {
-	type: 'spring',
-	bounce: 0,
+	type: 'tween',
+	ease: [ 0.25, 0.1, 0.25, 1 ],
 	// Transition durations in the config are expressed as a string in milliseconds,
 	// while `framer-motion` needs them as integers in seconds.
-	duration: parseInt( CONFIG.transitionDurationSlow, 10 ) / 1000,
+	duration: parseInt( CONFIG.transitionDurationFast, 10 ) / 1000,
 };
 
 function ToggleGroupControlBackdrop( {

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -22,7 +22,7 @@ const TRANSITION_CONFIG = {
 	bounce: 0,
 	// Transition durations in the config are expressed as a string in milliseconds,
 	// while `framer-motion` needs them as integers in seconds.
-	duration: parseInt( CONFIG.transitionDuration, 10 ) / 1000,
+	duration: parseInt( CONFIG.transitionDurationSlow, 10 ) / 1000,
 };
 
 function ToggleGroupControlBackdrop( {

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -22,7 +22,7 @@ const TRANSITION_CONFIG = {
 	bounce: 0.2,
 	// Transition durations in the config are expressed as a string in milliseconds,
 	// while `framer-motion` needs them as integers in seconds.
-	duration: parseInt( CONFIG.transitionDurationFast, 10 ) / 1000,
+	duration: parseInt( CONFIG.transitionDuration, 10 ) / 1000,
 };
 
 function ToggleGroupControlBackdrop( {

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -19,7 +19,7 @@ import { AnimatedBackdrop } from './styles';
 
 const TRANSITION_CONFIG = {
 	type: 'spring',
-	bounce: 0.2,
+	bounce: 0,
 	// Transition durations in the config are expressed as a string in milliseconds,
 	// while `framer-motion` needs them as integers in seconds.
 	duration: parseInt( CONFIG.transitionDuration, 10 ) / 1000,

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -42,7 +42,9 @@ function ToggleGroupControlBackdrop( {
 	const selectedItemIndex = items.findIndex(
 		// All valid children (e.g. extending `ToggleGroupControlOptionBase`)
 		// have a `data-value` attribute.
-		( item ) => item.ref.current?.dataset.value === state
+		( item ) =>
+			typeof state !== 'undefined' &&
+			item.ref.current?.dataset.value === `${ state }`
 	);
 
 	// `useLayoutEffect` is necessary because we need to wait for the DOM

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -60,11 +60,13 @@ function ToggleGroupControlBackdrop( {
 				// can't be any element with `position: relative` or `position: absolute`.
 				// See https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft
 
-				const wrapperElement = item.ref.current;
+				const toggleGroupOptionWrapper = item.ref.current?.closest(
+					'[data-toggle-group-control-option-wrapper="true"]'
+				) as HTMLElement | null;
 
 				return {
-					left: wrapperElement?.offsetLeft ?? -1,
-					width: wrapperElement?.offsetWidth ?? 0,
+					left: toggleGroupOptionWrapper?.offsetLeft ?? -1,
+					width: toggleGroupOptionWrapper?.offsetWidth ?? 0,
 				};
 			} )
 		);

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -5,15 +5,9 @@
 import { useReducedMotion } from 'framer-motion';
 
 /**
- * WordPress dependencies
- */
-import { memo } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import type { ToggleGroupControlBackdropProps } from '../types';
-import { useToggleGroupControlContext } from '../context';
 import { CONFIG } from '../../utils';
 import { AnimatedBackdrop, inset } from './styles';
 
@@ -25,18 +19,26 @@ const TRANSITION_CONFIG = {
 	duration: parseInt( CONFIG.transitionDurationFast, 10 ) / 1000,
 };
 
-function ToggleGroupControlBackdrop( {
-	containerSizes: { width: containerWidth },
+const sumToNth = ( list: number[], toIndex: number ) => {
+	let sum = 0;
+	for ( let i = toIndex; i > 0; sum += list[ --i ] );
+	return sum;
+};
+
+export default function ToggleGroupControlBackdrop( {
+	activeIndex = -1,
+	optionSizes,
 }: ToggleGroupControlBackdropProps ) {
 	const shouldReduceMotion = useReducedMotion();
-	const { activeIndex, length } = useToggleGroupControlContext();
 
-	containerWidth ??= 0;
-	const containerInsideWidth = Math.max( 0, containerWidth - inset * 2 );
-	const width = containerInsideWidth / length;
-	const x = `${ inset + activeIndex * width }px`;
+	if ( activeIndex < 0 || ! optionSizes || ! optionSizes[ activeIndex ] ) {
+		return null;
+	}
 
-	return activeIndex >= 0 ? (
+	const width = optionSizes[ activeIndex ];
+	const x = inset + sumToNth( optionSizes, activeIndex );
+
+	return (
 		<AnimatedBackdrop
 			role="presentation"
 			transition={
@@ -50,7 +52,5 @@ function ToggleGroupControlBackdrop( {
 			animate={ { width, x } }
 			initial={ false }
 		/>
-	) : null;
+	);
 }
-
-export default memo( ToggleGroupControlBackdrop );

--- a/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/toggle-group-control-backdrop.tsx
@@ -15,7 +15,7 @@ import { memo } from '@wordpress/element';
 import type { ToggleGroupControlBackdropProps } from '../types';
 import { useToggleGroupControlContext } from '../context';
 import { CONFIG } from '../../utils';
-import { AnimatedBackdrop } from './styles';
+import { AnimatedBackdrop, inset } from './styles';
 
 const TRANSITION_CONFIG = {
 	type: 'tween',
@@ -32,8 +32,9 @@ function ToggleGroupControlBackdrop( {
 	const { activeIndex, length } = useToggleGroupControlContext();
 
 	containerWidth ??= 0;
-	const width = containerWidth / length;
-	const x = `${ activeIndex * width }px`;
+	const containerInsideWidth = Math.max( 0, containerWidth - inset * 2 );
+	const width = containerInsideWidth / length;
+	const x = `${ inset + activeIndex * width }px`;
 
 	return activeIndex >= 0 ? (
 		<AnimatedBackdrop

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ReactNode, ReactText } from 'react';
+import type { ReactElement, ReactNode, ReactText } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type { RadioStateReturn } from 'reakit';
 
@@ -9,12 +9,10 @@ import type { RadioStateReturn } from 'reakit';
  * Internal dependencies
  */
 import type { FormElementProps } from '../utils/types';
-import type { ToggleGroupControlOption } from './toggle-group-control-option';
-import type { ToggleGroupControlOptionIcon } from './toggle-group-control-option-icon';
 
 type AllowedToggleGroupControlOptionChild =
-	| typeof ToggleGroupControlOption
-	| typeof ToggleGroupControlOptionIcon;
+	| ReactElement< ToggleGroupControlOptionProps >
+	| ReactElement< ToggleGroupControlOptionIconProps >;
 
 export type ToggleGroupControlOptionBaseProps = {
 	children: ReactNode;
@@ -120,7 +118,9 @@ export type ToggleGroupControlContextProps = RadioStateReturn & {
 	 *
 	 * @default false
 	 */
+	activeIndex: number;
 	isBlock?: boolean;
+	length: number;
 };
 
 export type ToggleGroupControlBackdropProps = {

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { MutableRefObject, ReactNode, ReactText } from 'react';
+import type { ReactNode, ReactText } from 'react';
 // eslint-disable-next-line no-restricted-imports
 import type { RadioStateReturn } from 'reakit';
 

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -9,6 +9,12 @@ import type { RadioStateReturn } from 'reakit';
  * Internal dependencies
  */
 import type { FormElementProps } from '../utils/types';
+import type { ToggleGroupControlOption } from './toggle-group-control-option';
+import type { ToggleGroupControlOptionIcon } from './toggle-group-control-option-icon';
+
+type AllowedToggleGroupControlOptionChild =
+	| typeof ToggleGroupControlOption
+	| typeof ToggleGroupControlOptionIcon;
 
 export type ToggleGroupControlOptionBaseProps = {
 	children: ReactNode;
@@ -98,7 +104,9 @@ export type ToggleGroupControlProps = Omit<
 	/**
 	 * React children
 	 */
-	children: ReactNode;
+	children:
+		| AllowedToggleGroupControlOptionChild
+		| AllowedToggleGroupControlOptionChild[];
 	/**
 	 * If this property is added, a help text will be generated
 	 * using help property as the content.

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -116,8 +116,8 @@ export type ToggleGroupControlContextProps = RadioStateReturn & {
 };
 
 export type ToggleGroupControlBackdropProps = {
-	containerRef: MutableRefObject< HTMLElement | undefined >;
-	containerWidth?: number | null;
-	isAdaptiveWidth?: boolean;
-	state?: any;
+	containerSizes: {
+		width: number | null;
+		height: number | null;
+	};
 };

--- a/packages/components/src/toggle-group-control/types.ts
+++ b/packages/components/src/toggle-group-control/types.ts
@@ -118,14 +118,10 @@ export type ToggleGroupControlContextProps = RadioStateReturn & {
 	 *
 	 * @default false
 	 */
-	activeIndex: number;
 	isBlock?: boolean;
-	length: number;
 };
 
 export type ToggleGroupControlBackdropProps = {
-	containerSizes: {
-		width: number | null;
-		height: number | null;
-	};
+	activeIndex: number | undefined;
+	optionSizes: number[] | undefined;
 };

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -33,7 +33,6 @@ const TOGGLE_GROUP_CONTROL_PROPS = {
 	toggleGroupControlBackdropBackgroundColor:
 		CONTROL_PROPS.controlSurfaceColor,
 	toggleGroupControlBackdropBorderColor: COLORS.ui.border,
-	toggleGroupControlBackdropBoxShadow: 'transparent',
 	toggleGroupControlButtonColorActive: CONTROL_PROPS.controlBackgroundColor,
 };
 

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -77,6 +77,7 @@ export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
 	surfaceBorderSubtleColor: 'rgba(0, 0, 0, 0.05)',
 	surfaceBackgroundTertiaryColor: COLORS.white,
 	surfaceColor: COLORS.white,
+	transitionDurationSlow: '250ms',
 	transitionDuration: '200ms',
 	transitionDurationFast: '160ms',
 	transitionDurationFaster: '120ms',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Completely rewrite the `ToggleGroupControl` 's animated backdrop using `framer-motion` and a couple of different approaches to reading size and position of DOM elements.

Fixes https://github.com/WordPress/gutenberg/issues/37506

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Current implementation is complex, difficult to read, imperative (based off arbitrary timeouts), and [buggy](https://github.com/WordPress/gutenberg/issues/37506)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Main changes are:

- use `framer-motion` to handle the animation
- Simplify the backdrop positioning and sizing calculations:
    - use `offsetLeft` instead of `getBoundingClientRect().left` in order to get the gap relative to the offset parent (instead of the viewport)
    - calculate all item sizes before hand, so that the animation can run smooth while the user interacts with the component
    - use `useLayoutEffect` in order to make sure that all DOM updates have taken effect before calculating sizes and offsets

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Make sure that the backdrop animation works as expected in Storybook and in the editor (in particular testing for the scenario highlighted in #37506)

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/1083581/162028461-cf223330-cbe0-43df-b128-94ad0d24f5f3.mp4


https://user-images.githubusercontent.com/1083581/162048005-b7976479-b33c-4128-8127-08a90dee414f.mp4

