### PR TITLE
Post Comments Form: Allow to add it to the Site Editor

### DIFF
--- a/packages/block-library/src/comments-query-loop/edit.js
+++ b/packages/block-library/src/comments-query-loop/edit.js
@@ -11,6 +11,7 @@ import CommentsInspectorControls from './edit/comments-inspector-controls';
 const TEMPLATE = [
 	[ 'core/comment-template' ],
 	[ 'core/comments-pagination' ],
+	[ 'core/post-comments-form' ],
 ];
 
 export default function CommentsQueryLoopEdit( { attributes, setAttributes } ) {

--- a/packages/block-library/src/comments-query-loop/edit.js
+++ b/packages/block-library/src/comments-query-loop/edit.js
@@ -11,7 +11,6 @@ import CommentsInspectorControls from './edit/comments-inspector-controls';
 const TEMPLATE = [
 	[ 'core/comment-template' ],
 	[ 'core/comments-pagination' ],
-	[ 'core/post-comments-form' ],
 ];
 
 export default function CommentsQueryLoopEdit( { attributes, setAttributes } ) {

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -34,6 +34,8 @@ export default function PostCommentsFormEdit( {
 		} ),
 	} );
 
+	const isInSiteEditor = postType === undefined || postId === undefined;
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -45,7 +47,7 @@ export default function PostCommentsFormEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				{ ! commentStatus && (
+				{ ! commentStatus && ! isInSiteEditor && (
 					<Warning>
 						{ __(
 							'Post Comments Form block: comments are not enabled for this post type.'
@@ -53,7 +55,7 @@ export default function PostCommentsFormEdit( {
 					</Warning>
 				) }
 
-				{ 'open' !== commentStatus && (
+				{ 'open' !== commentStatus && ! isInSiteEditor && (
 					<Warning>
 						{ sprintf(
 							/* translators: 1: Post type (i.e. "post", "page") */
@@ -65,7 +67,8 @@ export default function PostCommentsFormEdit( {
 					</Warning>
 				) }
 
-				{ 'open' === commentStatus && __( 'Post Comments Form' ) }
+				{ ( 'open' === commentStatus || isInSiteEditor ) &&
+					__( 'Post Comments Form' ) }
 			</div>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #37182.

Allow Post Comments Form to be added in FSE (Editor)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
If we land the Comments Query blocks, we should have the form to add comments included in the same template.
Right now, when you add the block in the site editor you get this message:
![Screenshot 2022-04-06 at 18 45 46](https://user-images.githubusercontent.com/37012961/162025836-840f1044-48f2-489b-9e10-20c4d5f7ffef.png)

This happens because of this check, which shows the same error message if the comments are disabled on a `post` or `page`:
```js
const [ commentStatus ] = useEntityProp(
		'postType',
		postType,
		'comment_status',
		postId
	);
....
{ ! commentStatus && (
	<Warning>
		{ __(
			'Post Comments Form block: comments are not enabled for this post type.'
		) }
	</Warning>
) }

{ 'open' !== commentStatus && (
	<Warning>
		{ sprintf(
			/* translators: 1: Post type (i.e. "post", "page") */
			__(
				'Post Comments Form block: comments to this %s are not allowed.'
			),
			postType
		) }
	</Warning>
) }

{ 'open' === commentStatus && __( 'Post Comments Form' ) }
```

When we are in the site editor, both `postType` and `postId` variables are `undefined` so this check will show us both errors.

The frontend instead is loading the form in a correct way.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By including the possibility of being inside the editor (`postType` or `postId` variables are `undefined`).
In that case, we show the default `post comments form` placeholder.
```js
const isInSiteEditor = postType === undefined || postId === undefined;
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Before the PR:
- 1. Go to Site Editor. Edit the Single.php template.
- 2. Add a Post Comments Form.
- 3. Check that both errors appear.
- 4. Check that the form is rendered on the frontend and works fine.

After the PR:
- 1. Go to Site Editor. Edit the Single.php template.
- 2. Add a Post Comments Form.
- 3. Check that there are no errors. The default comment form block placeholder appears.
- 4. Check that the form is rendered on the frontend and works fine.
