### PR TITLE
Try to optimize `getClientIdsOfDescendants` using `createSelector` memoization.

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -225,18 +225,21 @@ export const __unstableGetClientIdsTree = createSelector(
  *
  * @return {Array} ids of descendants.
  */
-export const getClientIdsOfDescendants = ( state, clientIds ) => {
-	const collectedIds = [];
-	for ( const givenId of clientIds ) {
-		for ( const descendantId of getBlockOrder( state, givenId ) ) {
-			collectedIds.push(
-				descendantId,
-				...getClientIdsOfDescendants( state, [ descendantId ] )
-			);
+export const getClientIdsOfDescendants = createSelector(
+	( state, clientIds ) => {
+		const collectedIds = [];
+		for ( const givenId of clientIds ) {
+			for ( const descendantId of getBlockOrder( state, givenId ) ) {
+				collectedIds.push(
+					descendantId,
+					...getClientIdsOfDescendants( state, [ descendantId ] )
+				);
+			}
 		}
-	}
-	return collectedIds;
-};
+		return collectedIds;
+	},
+	( state ) => [ state.blocks.order ]
+);
 
 /**
  * Returns an array containing the clientIds of the top-level blocks and


### PR DESCRIPTION
## What?
Follow-up to #40054, which appears to have had minimal effect on performance.

This PR attempts to optimize `getClientIdsOfDescendants` using memoization. 

## Why?
#39985 seems to have reduced performance a bit, and #40054 doesn't seem to have done much to counteract that.

## How?
This PR wraps `getClientIdsOfDescendants` in `createSelector`, which should help memoize the selector. `getClientIdsWithDescendants` was already using `createSelector`, so I think this makes sense.

## Testing Instructions
Check the "Performances Tests" in the PR checks to get an initial impression. If it looks promising, I guess try merging this and monitor the "Block Select" metric at http://codehealth.vercel.app/ over the next several commits in `trunk`.