### PR TITLE
Webfonts API: Return font family slug when registering a webfont

### DIFF
--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -121,7 +121,7 @@ class WP_Webfonts {
 	 * @since 6.0.0
 	 *
 	 * @param array $webfont Webfont to be registered.
-	 * @return bool True if successfully registered, else false.
+	 * @return string|bool The font family slug if successfully registered, else false.
 	 */
 	public function register_webfont( array $webfont ) {
 		$webfont = $this->validate_webfont( $webfont );
@@ -139,7 +139,7 @@ class WP_Webfonts {
 		}
 
 		$this->registered_webfonts[ $slug ][] = $webfont;
-		return true;
+		return $slug;
 	}
 
 	/**

--- a/lib/experimental/class-wp-webfonts.php
+++ b/lib/experimental/class-wp-webfonts.php
@@ -121,7 +121,7 @@ class WP_Webfonts {
 	 * @since 6.0.0
 	 *
 	 * @param array $webfont Webfont to be registered.
-	 * @return string|bool The font family slug if successfully registered, else false.
+	 * @return string|false The font family slug if successfully registered, else false.
 	 */
 	public function register_webfont( array $webfont ) {
 		$webfont = $this->validate_webfont( $webfont );

--- a/lib/experimental/webfonts.php
+++ b/lib/experimental/webfonts.php
@@ -63,11 +63,20 @@ if ( ! function_exists( 'wp_register_webfonts' ) ) {
 	 * @param array[] $webfonts Webfonts to be registered.
 	 *                        This contains an array of webfonts to be registered.
 	 *                        Each webfont is an array.
+	 * @return string[] The font family slug of the registered webfonts.
 	 */
 	function wp_register_webfonts( array $webfonts ) {
+		$registered_webfont_slugs = array();
+
 		foreach ( $webfonts as $webfont ) {
-			wp_register_webfont( $webfont );
+			$slug = wp_register_webfont( $webfont );
+
+			if ( is_string( $slug ) ) {
+				$registered_webfont_slugs[ $slug ] = true;
+			}
 		}
+
+		return array_keys( $registered_webfont_slugs );
 	}
 }
 
@@ -94,7 +103,7 @@ if ( ! function_exists( 'wp_register_webfont' ) ) {
 	 * @since 6.0.0
 	 *
 	 * @param array $webfont Webfont to be registered.
-	 * @return bool True if successfully registered, else false.
+	 * @return string|bool The font family slug if successfully registered, else false.
 	 */
 	function wp_register_webfont( array $webfont ) {
 		return wp_webfonts()->register_webfont( $webfont );

--- a/lib/experimental/webfonts.php
+++ b/lib/experimental/webfonts.php
@@ -103,7 +103,7 @@ if ( ! function_exists( 'wp_register_webfont' ) ) {
 	 * @since 6.0.0
 	 *
 	 * @param array $webfont Webfont to be registered.
-	 * @return string|bool The font family slug if successfully registered, else false.
+	 * @return string|false The font family slug if successfully registered, else false.
 	 */
 	function wp_register_webfont( array $webfont ) {
 		return wp_webfonts()->register_webfont( $webfont );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Return the font family slug when registering a webfont.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are cases where you want to be aware of the font family slug. One example is https://github.com/Automattic/jetpack/pull/23810/files#diff-67965f8a19767c6775dd0d0949ed5830c22bda270ec3c1835f801649e98596c2R70.

Returning the slug removes the need to call `WP_Webfonts::get_font_slug` after registering a webfont.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply returning the `$slug` variable from the `register_webfont` method is enough.

## Testing Instructions

You should check that the font family slug is returned after calling `wp_register_webfont` and `wp_register_webfonts`.