### PR TITLE
Column Block: Add blockGap support.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -95,7 +95,7 @@ A single column within a columns block. ([Source](https://github.com/WordPress/g
 
 -	**Name:** core/column
 -	**Category:** text
--	**Supports:** anchor, color (background, gradients, link, text), spacing (padding), ~~html~~, ~~reusable~~
+-	**Supports:** anchor, color (background, gradients, link, text), spacing (blockGap, padding), ~~html~~, ~~reusable~~
 -	**Attributes:** allowedBlocks, templateLock, verticalAlignment, width
 
 ## Columns

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -35,6 +35,7 @@
 			}
 		},
 		"spacing": {
+			"blockGap": true,
 			"padding": true,
 			"__experimentalDefaultControls": {
 				"padding": true


### PR DESCRIPTION
## What?
This PR simply adds blockGap support to Column blocks.

## Why?
[#39422](https://github.com/WordPress/gutenberg/pull/39422) enabled layout on Column blocks. As a result, all blocks within a Column block now have blockGap applied. While this is fine, I think we should go the extra step end ensure that blockGap control is then enabled for the Column block. Since #39422 will be included with WordPress 6.0, I feel we should try and get this PR included as well with Gutenberg 13.0. 

I know we are close to the deadline but just caught this in my testing. 😬

## Testing Instructions
1. Insert a Columns block
2. Add a few blocks to a Column block
3. Enable "Block Spacing" under dimension control and confirm it works as expected. 

![column-blockgap](https://user-images.githubusercontent.com/4832319/162100751-e44d0a0c-89ad-46d1-8461-e88350f35969.gif)

