### PR TITLE
Revert "Try: Summary panel excerpt max-height."

### DIFF
--- a/packages/editor/src/components/post-excerpt/style.scss
+++ b/packages/editor/src/components/post-excerpt/style.scss
@@ -13,10 +13,4 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 2px solid transparent;
 	}
-
-	// Add a max-height to the excerpt panel.
-	p {
-		max-height: 320px;
-		overflow: auto;
-	}
 }


### PR DESCRIPTION
Reverts WordPress/gutenberg#40090

We are going to exclude `Post summary` panel from `6.0` as it's kind of big change in the last minute and it might need a bit more testing/feedback in the plugin.

We'll add it back right after 😄 .