### PR TITLE
Fix flaky issue reporter not splitting `...` separator

### DIFF
--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -92,9 +92,27 @@ const metaData = {
 						TEST_RESULTS_LIST.open.length,
 					body.indexOf( TEST_RESULTS_LIST.close )
 				)
+				/**
+				 * Split the text from:
+				 * ```
+				 * <!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->
+				 * ...
+				 * <!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->
+				 * <!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->
+				 * ```
+				 *
+				 * into:
+				 * ```
+				 * [
+				 *   '<!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->',
+				 *   '<!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->',
+				 *   '<!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->',
+				 * ]
+				 * ```
+				 */
 				.split(
 					new RegExp(
-						`(?<=${ TEST_RESULT.close })\n(?:...\n)?(?=${ TEST_RESULT.open })`
+						`(?<=${ TEST_RESULT.close })\n(?:\.\.\.\n)?(?=${ TEST_RESULT.open })`
 					)
 				);
 			// GitHub issues has character limits on issue's body,

--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -94,7 +94,7 @@ const metaData = {
 				)
 				.split(
 					new RegExp(
-						`(?<=${ TEST_RESULT.close })\n(?=${ TEST_RESULT.open })`
+						`(?<=${ TEST_RESULT.close })\n(?:...\n)?(?=${ TEST_RESULT.open })`
 					)
 				);
 			// GitHub issues has character limits on issue's body,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continue from https://github.com/WordPress/gutenberg/pull/39928. Fix not taking the `...` separator into account.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See the original PR for more info.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Simply change the RegExp to include the `...` token.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Unfortunately, there isn't any reliable way to test it for now 😅 .
