### PR TITLE
[Mobile] - Quote block V2 support

### DIFF
--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -47,6 +47,7 @@ function BlockForType( {
 	onDeleteBlock,
 	onReplace,
 	parentWidth,
+	parentBlockAlignment,
 	wrapperProps,
 	blockWidth,
 	baseGlobalStyles,
@@ -95,6 +96,7 @@ function BlockForType( {
 				contentStyle={ contentStyle }
 				onDeleteBlock={ onDeleteBlock }
 				blockWidth={ blockWidth }
+				parentBlockAlignment={ parentBlockAlignment }
 			/>
 			<View onLayout={ getBlockWidth } />
 		</GlobalStylesContext.Provider>

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -179,6 +179,14 @@ const devOnly = ( block ) => ( !! __DEV__ ? block : null );
 const iOSOnly = ( block ) =>
 	Platform.OS === 'ios' ? block : devOnly( block );
 
+// To be removed once Quote V2 is released on the web editor.
+function quoteCheck( quoteBlock, blocksFlags ) {
+	if ( blocksFlags?.__experimentalEnableQuoteBlockV2 ) {
+		quoteBlock.settings = quoteBlock?.settingsV2;
+	}
+	return quoteBlock;
+}
+
 // Hide the Classic block and SocialLink block
 addFilter(
 	'blocks.registerBlockType',
@@ -230,8 +238,10 @@ addFilter(
  *
  * registerCoreBlocks();
  * ```
+ * @param {Object} blocksFlags Experimental flags
+ *
  */
-export const registerCoreBlocks = () => {
+export const registerCoreBlocks = ( blocksFlags ) => {
 	// When adding new blocks to this list please also consider updating /src/block-support/supported-blocks.json in the Gutenberg-Mobile repo
 	[
 		paragraph,
@@ -244,7 +254,7 @@ export const registerCoreBlocks = () => {
 		nextpage,
 		separator,
 		list,
-		quote,
+		quoteCheck( quote, blocksFlags ),
 		mediaText,
 		preformatted,
 		gallery,

--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -238,7 +238,7 @@ addFilter(
  *
  * registerCoreBlocks();
  * ```
- * @param {Object} blocksFlags Experimental flags
+ * @param {Object} [blocksFlags] Experimental flags
  *
  */
 export const registerCoreBlocks = ( blocksFlags ) => {

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -14,6 +14,8 @@ import { useSelect } from '@wordpress/data';
 
 const name = 'core/paragraph';
 
+const allowedParentBlockAlignments = [ 'left', 'center', 'right' ];
+
 function ParagraphBlock( {
 	attributes,
 	mergeBlocks,
@@ -21,6 +23,7 @@ function ParagraphBlock( {
 	setAttributes,
 	style,
 	clientId,
+	parentBlockAlignment,
 } ) {
 	const isRTL = useSelect( ( select ) => {
 		return !! select( blockEditorStore ).getSettings().isRTL;
@@ -40,6 +43,15 @@ function ParagraphBlock( {
 	const onAlignmentChange = useCallback( ( nextAlign ) => {
 		setAttributes( { align: nextAlign } );
 	}, [] );
+
+	const parentTextAlignment = allowedParentBlockAlignments.includes(
+		parentBlockAlignment
+	)
+		? parentBlockAlignment
+		: undefined;
+
+	const textAlignment = align || parentTextAlignment;
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -82,7 +94,7 @@ function ParagraphBlock( {
 				onReplace={ onReplace }
 				onRemove={ onReplace ? () => onReplace( [] ) : undefined }
 				placeholder={ placeholder || __( 'Start writing…' ) }
-				textAlign={ align }
+				textAlign={ textAlignment }
 				__unstableEmbedURLOnPaste
 			/>
 		</>

--- a/packages/block-library/src/quote/index.js
+++ b/packages/block-library/src/quote/index.js
@@ -16,7 +16,7 @@ import settingsV2 from './v2';
 
 const { name } = metadata;
 
-export { metadata, name };
+export { metadata, name, settingsV2 };
 
 export const settingsV1 = {
 	icon,

--- a/packages/block-library/src/quote/v2/edit.js
+++ b/packages/block-library/src/quote/v2/edit.js
@@ -74,6 +74,7 @@ export default function QuoteEdit( {
 	insertBlocksAfter,
 	clientId,
 	className,
+	style,
 } ) {
 	const { citation, align } = attributes;
 
@@ -88,6 +89,7 @@ export default function QuoteEdit( {
 		className: classNames( className, {
 			[ `has-text-align-${ align }` ]: align,
 		} ),
+		...( ! isWebPlatform && { style } ),
 	} );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -128,6 +130,7 @@ export default function QuoteEdit( {
 						__unstableOnSplitAtEnd={ () =>
 							insertBlocksAfter( createBlock( 'core/paragraph' ) )
 						}
+						{ ...( ! isWebPlatform ? { textAlign: align } : {} ) }
 					/>
 				) }
 			</BlockQuotation>

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -28,7 +28,9 @@ const unsupportedBlock = `
 jest.useFakeTimers( 'legacy' );
 
 describe( 'Editor', () => {
-	beforeAll( registerCoreBlocks );
+	beforeAll( () => {
+		registerCoreBlocks();
+	} );
 
 	it( 'detects unsupported block and sends hasUnsupportedBlocks true to native', () => {
 		RNReactNativeGutenbergBridge.editorDidMount = jest.fn();

--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -37,6 +37,12 @@ export const BlockQuotation = forwardRef( ( { ...props }, ref ) => {
 				},
 			} );
 		}
+		if ( child && child.props.identifier === 'value' ) {
+			return cloneElement( child, {
+				tagsToEliminate: [ 'div' ],
+				style: colorStyle,
+			} );
+		}
 		return child;
 	} );
 	return (

--- a/packages/primitives/src/block-quotation/index.native.js
+++ b/packages/primitives/src/block-quotation/index.native.js
@@ -5,24 +5,26 @@ import { View } from 'react-native';
 /**
  * WordPress dependencies
  */
-import { Children, cloneElement } from '@wordpress/element';
-import { withPreferredColorScheme } from '@wordpress/compose';
+import { Children, cloneElement, forwardRef } from '@wordpress/element';
+import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
 import styles from './style.scss';
 
-export const BlockQuotation = withPreferredColorScheme( ( props ) => {
-	const { getStylesFromColorScheme, style } = props;
+export const BlockQuotation = forwardRef( ( { ...props }, ref ) => {
+	const { style } = props;
 
 	const blockQuoteStyle = [
-		getStylesFromColorScheme(
+		usePreferredColorSchemeStyle(
 			styles.wpBlockQuoteLight,
 			styles.wpBlockQuoteDark
 		),
 		style?.color && {
 			borderLeftColor: style.color,
 		},
+		style,
+		style?.backgroundColor && styles.paddingWithBackground,
 	];
 	const colorStyle = style?.color ? { color: style.color } : {};
 
@@ -35,13 +37,11 @@ export const BlockQuotation = withPreferredColorScheme( ( props ) => {
 				},
 			} );
 		}
-		if ( child && child.props.identifier === 'value' ) {
-			return cloneElement( child, {
-				tagsToEliminate: [ 'div' ],
-				style: colorStyle,
-			} );
-		}
 		return child;
 	} );
-	return <View style={ blockQuoteStyle }>{ newChildren }</View>;
+	return (
+		<View ref={ ref } style={ blockQuoteStyle }>
+			{ newChildren }
+		</View>
+	);
 } );

--- a/packages/primitives/src/block-quotation/style.native.scss
+++ b/packages/primitives/src/block-quotation/style.native.scss
@@ -1,7 +1,8 @@
 %wpBlockQuote-shared {
 	border-left-width: 4px;
 	border-left-style: solid;
-	padding-left: 8px;
+	padding-left: $block-edge-to-content;
+	padding-top: $dashed-border-space;
 	margin-left: 0;
 }
 
@@ -18,4 +19,8 @@
 .wpBlockQuoteCitation {
 	margin-top: 16px;
 	font-size: 14px;
+}
+
+.paddingWithBackground {
+	padding-top: $block-edge-to-content - $block-selected-margin;
 }

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/WPAndroidGlue/GutenbergProps.kt
@@ -50,6 +50,8 @@ data class GutenbergProps @JvmOverloads constructor(
                     ?.let { putSerializable(PROP_IS_FSE_THEME, it) }
             theme.getSerializable(PROP_GALLERY_WITH_IMAGE_BLOCKS)
                     ?.let { putSerializable(PROP_GALLERY_WITH_IMAGE_BLOCKS, it) }
+            theme.getSerializable(PROP_QUOTE_BLOCK_V2)
+                    ?.let { putSerializable(PROP_QUOTE_BLOCK_V2, it) }
         }
     }
 
@@ -90,6 +92,7 @@ data class GutenbergProps @JvmOverloads constructor(
         private const val PROP_FEATURES = "rawFeatures"
         private const val PROP_IS_FSE_THEME = "isFSETheme"
         private const val PROP_GALLERY_WITH_IMAGE_BLOCKS = "galleryWithImageBlocks"
+        private const val PROP_QUOTE_BLOCK_V2 = "quoteBlockV2"
 
         const val PROP_LOCALE = "locale"
         const val PROP_CAPABILITIES = "capabilities"

--- a/packages/react-native-bridge/ios/Gutenberg.swift
+++ b/packages/react-native-bridge/ios/Gutenberg.swift
@@ -204,6 +204,10 @@ public class Gutenberg: UIResponder {
             settingsUpdates["galleryWithImageBlocks"] = galleryWithImageBlocks
         }
 
+        if let quoteBlockV2 = editorSettings?.quoteBlockV2 {
+            settingsUpdates["quoteBlockV2"] = quoteBlockV2
+        }
+
         if let rawStyles = editorSettings?.rawStyles {
             settingsUpdates["rawStyles"] = rawStyles
         }

--- a/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
+++ b/packages/react-native-bridge/ios/GutenbergBridgeDataSource.swift
@@ -78,6 +78,7 @@ public extension GutenbergBridgeDataSource {
 public protocol GutenbergEditorSettings {
     var isFSETheme: Bool { get }
     var galleryWithImageBlocks: Bool { get }
+    var quoteBlockV2: Bool { get }
     var rawStyles: String? { get }
     var rawFeatures: String? { get }
     var colors: [[String: String]]? { get }

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -58,9 +58,13 @@ const gutenbergSetup = () => {
 
 const setupInitHooks = () => {
 	addAction( 'native.pre-render', 'core/react-native-editor', ( props ) => {
-		registerBlocks();
-
 		const capabilities = props.capabilities ?? {};
+		const blocksFlags = {
+			__experimentalEnableQuoteBlockV2: props?.quoteBlockV2,
+		};
+
+		registerBlocks( blocksFlags );
+
 		// Unregister non-supported blocks by capabilities
 		if (
 			getBlockType( 'core/block' ) !== undefined &&
@@ -115,12 +119,12 @@ const setupInitHooks = () => {
 };
 
 let blocksRegistered = false;
-const registerBlocks = () => {
+const registerBlocks = ( blocksFlags ) => {
 	if ( blocksRegistered ) {
 		return;
 	}
 
-	registerCoreBlocks();
+	registerCoreBlocks( blocksFlags );
 
 	blocksRegistered = true;
 };

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -190,7 +190,8 @@ describe( 'Register Gutenberg', () => {
 			{},
 			{ component: EditorComponent }
 		);
-		const blockList = screen.getByTestId( 'block-list-wrapper' );
+		// Inner blocks create BlockLists so let's take into account selecting the main one
+		const blockList = screen.getAllByTestId( 'block-list-wrapper' )[ 0 ];
 
 		expect( blockList ).toBeVisible();
 		expect( console ).toHaveLoggedWith( 'Hermes is: true' );

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -190,8 +190,7 @@ describe( 'Register Gutenberg', () => {
 			{},
 			{ component: EditorComponent }
 		);
-		// Inner blocks create BlockLists so let's take into account selecting the main one
-		const blockList = screen.getAllByTestId( 'block-list-wrapper' )[ 0 ];
+		const blockList = screen.getByTestId( 'block-list-wrapper' );
 
 		expect( blockList ).toBeVisible();
 		expect( console ).toHaveLoggedWith( 'Hermes is: true' );


### PR DESCRIPTION
- **Gutenberg Mobile PR**: https://github.com/wordpress-mobile/gutenberg-mobile/pull/4744
- **WordPressKit iOS PR**: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/493
- **WordPress iOS PR**: https://github.com/wordpress-mobile/WordPress-iOS/pull/18326
- **WordPress-FluxC-Android**: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2349
- **WordPress Android PR**: https://github.com/wordpress-mobile/WordPress-Android/pull/16286

## What?
This PR adds support for the new V2 version of the Quote block behind a feature flag `__experimentalEnableQuoteBlockV2`.

## Why?
To be in sync with the web editor, both versions of the Quote block will ship, V2 will be behind a feature flag.

## How?
It changes the shared code by adding a missing text alignment needed in mobile as well as the style prop to be able to render colors.

Adds a new feature in the Paragraph block to inherit the parent's alignment if there's any set. 

Within `BlockQuotation` removes some unneeded code that was used in the previous quote format. As well as setting the styles in the container. It also updates the style paddings to take into account inner blocks.

To support both versions, a feature flag `__experimentalEnableQuoteBlockV2` will be used to enable the new version once it's available on the web editor as well. This flag is passed down from the parents apps through the block editor settings endpoint.

While registering the blocks, it will check if the flag is enabled, if it is, it will use the new settings for Quote V2.

**Note**: These checks will be removed in the next version that will ship the new Quote block by default.

## Testing Instructions

**Preconditions**: 
- Use a self-hosted site and install the latest Gutenberg plugin version >= 13.0.0. You can install the latest version [here](https://github.com/WordPress/gutenberg/releases).
- Go to your site's admin page > Gutenberg > Experiments.
- Enable `Quote block v2`.

### Test case 1 - Quote V2 is enabled

- After following the precondintions instructions above
- Using either of the builds [WP iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/18326#issuecomment-1092763937) / [WP Android](https://github.com/wordpress-mobile/WordPress-Android/pull/16286#issuecomment-1093021898)
- Open the editor
- Add a Quote block
- Preview the post and check the Quote block is showing correctly
- **Expect** to see the **new version with inner blocks**. (Sometimes you need to close the editor and open it again due to the endpoint being called when the editor is being opened)

### Test case 1 - Quote V2 is disabled

- Disable the `Quote block v2` experiment in your sites admin page (check the instructions in the preconditions section)
- Using either of the builds [WP iOS](https://github.com/wordpress-mobile/WordPress-iOS/pull/18326#issuecomment-1092763937) / [WP Android](https://github.com/wordpress-mobile/WordPress-Android/pull/16286#issuecomment-1093021898)
- Open the editor
- Add a Quote block
- Preview the post and check the Quote block is showing correctly
- **Expect** to see the **older version**. (Sometimes you need to close the editor and open it again due to the endpoint being called when the editor is being opened)

## Screenshots or screencast <!-- if applicable -->
iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161292092-d693e075-3f8a-4b0b-b0a0-846e1550c059.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161292102-413304d1-44da-4755-afa5-7af310f7477c.gif" width="200" /></kbd>

### Quote block with inner blocks

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161290649-01e093ab-1ec9-4063-80c6-1fa8fef36e48.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161290657-879ebbef-b61a-48fc-9cf8-1f0b9adb47ac.png" width="200" /></kbd>

### Quote block with text and background colors.

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161290859-35992203-1db6-470e-830b-57992144997b.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161290871-90f19a11-86b6-4172-a223-9e62107f42ac.png" width="200" /></kbd>

### Quote block with alignment set

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161291027-59cdc1fb-d7a1-487a-bb2d-5f4f62e16afa.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161291035-168f15ef-807c-443e-a7b9-40275470f29a.png" width="200" /></kbd>

### Quote block with another kind of inner block e.g. Image

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161291126-afc38785-0b84-408f-a20e-3571dd819e93.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161291136-4e47f0c8-41a8-4141-9526-0d7bbd0979e2.png" width="200" /></kbd>