### PR TITLE
Allow using a custom domainpath for viewscripts

### DIFF
--- a/lib/compat/wordpress-6.1/blocks.php
+++ b/lib/compat/wordpress-6.1/blocks.php
@@ -79,7 +79,7 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 				'ver'        => false,
 				'in_footer'  => false,
 
-				// Additional arg to allow translations for the script's textdomain.
+				// Additional args to allow translations for the script's textdomain.
 				'textdomain' => '',
 			)
 		);
@@ -109,7 +109,7 @@ if ( ! function_exists( 'wp_enqueue_block_view_script' ) ) {
 
 			// If a textdomain is defined, use it to set the script translations.
 			if ( ! empty( $args['textdomain'] ) && in_array( 'wp-i18n', $args['deps'], true ) ) {
-				wp_set_script_translations( $args['handle'], $args['textdomain'] );
+				wp_set_script_translations( $args['handle'], $args['textdomain'], $args['domainpath'] );
 			}
 
 			return $content;


### PR DESCRIPTION
## What?
Allow using a custom `domainpath` for translations in view-scripts.

## Why?
See discussion in https://github.com/WordPress/gutenberg/pull/36176#discussion_r844814652

## How?
Adds a new `domainpath` arg. The `domainpath` name was chooses for consistency with the [Core patches on trac](https://core.trac.wordpress.org/ticket/54647).
