### PR TITLE
Comments Query Loop: Fix pagination setting not being applied on frontend

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -35,24 +35,25 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 			$comment_args['hierarchical'] = false;
 		}
 
-		$per_page     = get_option( 'comments_per_page' );
-		$default_page = get_option( 'default_comments_page' );
+		if ( get_option( 'page_comments' ) === '1' ) {
+			$per_page     = get_option( 'comments_per_page' );
+			$default_page = get_option( 'default_comments_page' );
+			if ( $per_page > 0 ) {
+				$comment_args['number'] = $per_page;
 
-		if ( $per_page > 0 ) {
-			$comment_args['number'] = $per_page;
-
-			$page = (int) get_query_var( 'cpage' );
-			if ( $page ) {
-				$comment_args['paged'] = $page;
-			} elseif ( 'oldest' === $default_page ) {
-				$comment_args['paged'] = 1;
-			} elseif ( 'newest' === $default_page ) {
-				$comment_args['paged'] = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
-			}
-			// Set the `cpage` query var to ensure the previous and next pagination links are correct
-			// when inheriting the Discussion Settings.
-			if ( 0 === $page && isset( $comment_args['paged'] ) && $comment_args['paged'] > 0 ) {
-				set_query_var( 'cpage', $comment_args['paged'] );
+				$page = (int) get_query_var( 'cpage' );
+				if ( $page ) {
+					$comment_args['paged'] = $page;
+				} elseif ( 'oldest' === $default_page ) {
+					$comment_args['paged'] = 1;
+				} elseif ( 'newest' === $default_page ) {
+					$comment_args['paged'] = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+				}
+				// Set the `cpage` query var to ensure the previous and next pagination links are correct
+				// when inheriting the Discussion Settings.
+				if ( 0 === $page && isset( $comment_args['paged'] ) && $comment_args['paged'] > 0 ) {
+					set_query_var( 'cpage', $comment_args['paged'] );
+				}
 			}
 		}
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -35,7 +35,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 			$comment_args['hierarchical'] = false;
 		}
 
-		if ( get_option( 'page_comments' ) === '1' ) {
+		if ( get_option( 'page_comments' ) === '1' || get_option( 'page_comments' ) === true ) {
 			$per_page     = get_option( 'comments_per_page' );
 			$default_page = get_option( 'default_comments_page' );
 			if ( $per_page > 0 ) {

--- a/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
@@ -24,10 +24,8 @@ describe( 'Comment Query Loop', () => {
 			'newest'
 		);
 	} );
-	beforeEach( async () => {
-		await createNewPost();
-	} );
 	it( 'Pagination links are working as expected', async () => {
+		await createNewPost();
 		// Insert the Query Comment Loop block.
 		await insertBlock( 'Comments Query Loop' );
 		// Insert the Comment Loop form.
@@ -87,6 +85,41 @@ describe( 'Comment Query Loop', () => {
 		expect(
 			await page.$( '.wp-block-comments-pagination-next' )
 		).not.toBeNull();
+	} );
+	it( 'Pagination links are not appearing if break comments is not enabled', async () => {
+		await setOption( 'page_comments', '0' );
+		await createNewPost();
+		// Insert the Query Comment Loop block.
+		await insertBlock( 'Comments Query Loop' );
+		// Insert the Comment Loop form.
+		await insertBlock( 'Post Comments Form' );
+		await publishPost();
+		// Visit the post that was just published.
+		await page.click(
+			'.post-publish-panel__postpublish-buttons .is-primary'
+		);
+
+		// Create three comments for that post.
+		for ( let i = 0; i < 3; i++ ) {
+			await page.waitForSelector( 'textarea#comment' );
+			await page.click( 'textarea#comment' );
+			await page.type(
+				`textarea#comment`,
+				`This is an automated comment - ${ i }`
+			);
+			await pressKeyTimes( 'Tab', 1 );
+			await Promise.all( [
+				page.keyboard.press( 'Enter' ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			] );
+		}
+		// We check that there are no comments page link.
+		expect(
+			await page.$( '.wp-block-comments-pagination-previous' )
+		).toBeNull();
+		expect(
+			await page.$( '.wp-block-comments-pagination-next' )
+		).toBeNull();
 	} );
 	afterAll( async () => {
 		await trashAllComments();

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -18,7 +18,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		update_option( 'page_comments', '1' );
+		update_option( 'page_comments', true );
 		update_option( 'comments_per_page', self::$per_page );
 		update_option( 'comment_order', 'ASC' );
 
@@ -45,7 +45,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	function test_build_comment_query_vars_from_block_with_context_no_pagination() {
-		update_option( 'page_comments', '0' );
+		update_option( 'page_comments', false );
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
 		);
@@ -69,7 +69,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'hierarchical'              => 'threaded',
 			)
 		);
-		update_option( 'page_comments', '1' );
+		update_option( 'page_comments', true );
 	}
 
 	function test_build_comment_query_vars_from_block_with_context() {

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -18,7 +18,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		update_option( 'page_comments', true );
+		update_option( 'page_comments', '1' );
 		update_option( 'comments_per_page', self::$per_page );
 		update_option( 'comment_order', 'ASC' );
 
@@ -42,6 +42,34 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'comment_content'      => 'Hello world',
 			)
 		);
+	}
+
+	function test_build_comment_query_vars_from_block_with_context_no_pagination() {
+		update_option( 'page_comments', '0' );
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
+		);
+
+		$block = new WP_Block(
+			$parsed_blocks[0],
+			array(
+				'postId' => self::$custom_post->ID,
+			)
+		);
+
+		$this->assertEquals(
+			build_comment_query_vars_from_block( $block ),
+			array(
+				'orderby'                   => 'comment_date_gmt',
+				'order'                     => 'ASC',
+				'status'                    => 'approve',
+				'no_found_rows'             => false,
+				'update_comment_meta_cache' => false,
+				'post_id'                   => self::$custom_post->ID,
+				'hierarchical'              => 'threaded',
+			)
+		);
+		update_option( 'page_comments', '1' );
 	}
 
 	function test_build_comment_query_vars_from_block_with_context() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Read and apply the Discussion setting "Break comments into pages..." on Comment Query Loop block.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

### Before the PR. 

If we had the Comments Pagination disabled on Discussion settings, Comments Query Loop was not respecting that option, showing pagination on the frontend.
![Screenshot 2022-04-07 at 14 31 44](https://user-images.githubusercontent.com/37012961/162199165-752e2861-a627-4564-adf5-67d8edb3f58f.png)

### After the PR.

If we disable the Comments Pagination on Discussion settings, pagination won't appear on frontend, respecting that option.
![Screenshot 2022-04-07 at 14 34 00](https://user-images.githubusercontent.com/37012961/162199852-7e02176b-e844-425f-bb46-3dd333b5830b.png)


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding the Discussion option variable to the conditional that handles the pagination.
By adding a test that ensures this case is covered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
In trunk:
- Go to Discussion Settings. Disable break comments. Set a small number of comments so you don't need to create too many.
- Go to a Post, Page, or Site Editor. Add the comment query loop.
- Check that pagination is still happening.

In the PR branch:
In trunk:
- Go to Discussion Settings. Disable break comments. Set a small number of comments so you don't need to create too many.
- Go to a Post, Page or Site Editor. Add the comment query loop.
- Check that pagination is not happening.


## Screenshots or screencast <!-- if applicable -->
