### PR TITLE
Fix collapsing issue with the URL input suggestion container

### DIFF
--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -71,7 +71,8 @@ $input-size: 300px;
 .block-editor-url-input .components-spinner {
 	display: none;
 	@include break-small() {
-		display: inherit;
+		display: flex;
+		flex-direction: column;
 	}
 }
 

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -71,13 +71,13 @@ $input-size: 300px;
 .block-editor-url-input .components-spinner {
 	display: none;
 	@include break-small() {
-		display: flex;
-		flex-direction: column;
+		display: grid;
 	}
 }
 
 .block-editor-url-input__suggestion {
-	padding: 4px $input-padding;
+	min-height: $button-size;
+	height: auto;
 	color: $gray-700;
 	display: block;
 	font-size: $default-font-size;


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/38079.

## Why?
See Fixes https://github.com/WordPress/gutenberg/issues/38079 for the issue description.

## How?
The PR adds `display:flex` and `flex-direction: coloum` to the `.block-editor-url-input__suggestions` element.
The avoids collapsing of URLs when post titles have long names.

## Testing Instructions
1. Create and publish posts that have longer post titles 
2. In a new page/post, create a gallery block and upload a couple of images
3. Edit one of the image's URL
4. When you start typing and the suggestions appear, they shouldn't collapse.

## Screenshots or screencast <!-- if applicable -->

### Before
<img width="838" alt="CleanShot 2022-04-07 at 14 54 07@2x" src="https://user-images.githubusercontent.com/33403964/162203394-242dbf9c-1615-4762-9569-cdf10fe1e44e.png">


### After
<img width="839" alt="CleanShot 2022-04-07 at 14 53 28@2x" src="https://user-images.githubusercontent.com/33403964/162203295-1393ff71-d74e-484c-807a-661261b0c5bd.png">

