### PR TITLE
Add a context param to sidebar entity request

### DIFF
--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -79,6 +79,7 @@ export const rootEntitiesConfig = [
 		name: 'sidebar',
 		kind: 'root',
 		baseURL: '/wp/v2/sidebars',
+		baseURLParams: { context: 'edit' },
 		plural: 'sidebars',
 		transientEdits: { blocks: true },
 		label: __( 'Widget areas' ),


### PR DESCRIPTION
Adds a `context=edit` query parameter to `sidebar` entity definition. The server endpoint supports `context`, other entity requests use the `context` param, and also this change makes the request match with what the [`edit-widgets` page preloads during initialization](https://github.com/WordPress/wordpress-develop/blob/e34d775476f6412bf6a583324d03dfc72c90dfb3/src/wp-admin/widgets-form-blocks.php#L22). That preload is currently wasted, because the actual request is different.

Related Core PR that improves the preloads: https://github.com/WordPress/wordpress-develop/pull/2531