### PR TITLE
Stabilize useEntityRecord and useEntityRecords

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useEntityBlockEditor,
 	useEntityProp,
-	__experimentalUseEntityRecord as useEntityRecord,
+	useEntityRecord as useEntityRecord,
 } from '@wordpress/core-data';
 import {
 	Placeholder,

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -5,7 +5,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	useEntityBlockEditor,
 	useEntityProp,
-	useEntityRecord as useEntityRecord,
+	useEntityRecord,
 } from '@wordpress/core-data';
 import {
 	Placeholder,

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -17,7 +17,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -17,7 +17,7 @@ import { useInstanceId } from '@wordpress/compose';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData

--- a/packages/block-library/src/navigation/use-navigation-entities.js
+++ b/packages/block-library/src/navigation/use-navigation-entities.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -4,7 +4,7 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { __experimentalUseEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 

--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -4,7 +4,7 @@
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
-import { useEntityRecords as useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 import { createBlock as create } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -18,7 +18,7 @@ import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	__experimentalUseEntityRecords as useEntityRecords,
+	useEntityRecords as useEntityRecords,
 } from '@wordpress/core-data';
 
 /**

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -18,7 +18,7 @@ import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	useEntityRecords as useEntityRecords,
+	useEntityRecords,
 } from '@wordpress/core-data';
 
 /**

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -16,10 +16,7 @@ import { ToolbarButton, Spinner, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState, memo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import {
-	store as coreStore,
-	useEntityRecords,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 
 /**
  * Internal dependencies

--- a/packages/core-data/src/hooks/constants.ts
+++ b/packages/core-data/src/hooks/constants.ts
@@ -1,5 +1,4 @@
-/* eslint-disable-next-line no-shadow */
-export enum Status {
+export const enum Status {
 	Idle = 'IDLE',
 	Resolving = 'RESOLVING',
 	Error = 'ERROR',

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -5,7 +5,7 @@ import useQuerySelect from './use-query-select';
 import { store as coreStore } from '../';
 import type { Status } from './constants';
 
-interface EntityRecordResolution< RecordType > {
+export interface EntityRecordResolution< RecordType > {
 	/** The requested entity record */
 	record: RecordType | null;
 
@@ -23,17 +23,22 @@ interface EntityRecordResolution< RecordType > {
 	status: Status;
 }
 
-interface Options {
+export interface Options {
+	/**
+	 * Whether to run the query or short-circuit and return null.
+	 *
+	 * @default true
+	 */
 	enabled: boolean;
 }
 
 /**
  * Resolves the specified entity record.
  *
- * @param  kind                   Kind of the requested entity.
- * @param  name                   Name of the requested  entity.
- * @param  recordId               Record ID of the requested entity.
- * @param  options                Hook options.
+ * @param  kind                   Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
+ * @param  name                   Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
+ * @param  recordId               ID of the requested entity record.
+ * @param  options                Optional hook options.
  * @param  [options.enabled=true] Whether to run the query or short-circuit and return null. Defaults to true.
  * @example
  * ```js
@@ -57,7 +62,7 @@ interface Options {
  * application, the page and the resolution details will be retrieved from
  * the store state using `getEntityRecord()`, or resolved if missing.
  *
- * @return {EntityRecordResolution<RecordType>} Entity record data.
+ * @return Entity record data.
  * @template RecordType
  */
 export default function useEntityRecord< RecordType >(

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -60,7 +60,7 @@ interface Options {
  * @return {EntityRecordResolution<RecordType>} Entity record data.
  * @template RecordType
  */
-export default function __experimentalUseEntityRecord< RecordType >(
+export default function useEntityRecord< RecordType >(
 	kind: string,
 	name: string,
 	recordId: string | number,

--- a/packages/core-data/src/hooks/use-entity-record.ts
+++ b/packages/core-data/src/hooks/use-entity-record.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import useQuerySelect from './use-query-select';
@@ -85,4 +90,17 @@ export default function useEntityRecord< RecordType >(
 		record,
 		...rest,
 	};
+}
+
+export function __experimentalUseEntityRecord(
+	kind: string,
+	name: string,
+	recordId: any,
+	options: any
+) {
+	deprecated( `wp.data.__experimentalUseEntityRecord`, {
+		alternative: 'wp.data.useEntityRecord',
+		since: '6.1',
+	} );
+	return useEntityRecord( kind, name, recordId, options );
 }

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -75,7 +75,7 @@ interface Options {
  * @return Entity records data.
  * @template RecordType
  */
-export default function __experimentalUseEntityRecords< RecordType >(
+export default function useEntityRecords< RecordType >(
 	kind: string,
 	name: string,
 	queryArgs: Record< string, unknown > = {},

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -8,42 +8,25 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import useQuerySelect from './use-query-select';
 import { store as coreStore } from '../';
-import type { Status } from './constants';
+import type { Options, EntityRecordResolution } from './use-entity-record';
 
-interface EntityRecordsResolution< RecordType > {
+type EntityRecordsResolution< RecordType > = Omit<
+	EntityRecordResolution< RecordType >,
+	'record'
+> & {
 	/** The requested entity record */
 	records: RecordType[] | null;
+};
 
-	/**
-	 * Is the record still being resolved?
-	 */
-	isResolving: boolean;
-
-	/**
-	 * Is the record resolved by now?
-	 */
-	hasResolved: boolean;
-
-	/** Resolution status */
-	status: Status;
-}
-
-interface Options {
-	/**
-	 * Whether to run the query or short-circuit and return null.
-	 *
-	 * @default true
-	 */
-	enabled: boolean;
-}
+const EMPTY_ARRAY = [];
 
 /**
  * Resolves the specified entity records.
  *
- * @param  kind      Kind of the requested entities.
- * @param  name      Name of the requested entities.
- * @param  queryArgs HTTP query for the requested entities.
- * @param  options   Hook options.
+ * @param  kind      Kind of the entity, e.g. `root` or a `postType`. See rootEntitiesConfig in ../entities.ts for a list of available kinds.
+ * @param  name      Name of the entity, e.g. `plugin` or a `post`. See rootEntitiesConfig in ../entities.ts for a list of available names.
+ * @param  queryArgs Optional HTTP query description for how to fetch the data, passed to the requested API endpoint.
+ * @param  options   Optional hook options.
  * @example
  * ```js
  * import { useEntityRecord } from '@wordpress/core-data';
@@ -91,7 +74,8 @@ export default function useEntityRecords< RecordType >(
 		( query ) => {
 			if ( ! options.enabled ) {
 				return {
-					data: [],
+					// Avoiding returning a new reference on every execution.
+					data: EMPTY_ARRAY,
 				};
 			}
 			return query( coreStore ).getEntityRecords( kind, name, queryArgs );

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -87,4 +88,17 @@ export default function useEntityRecords< RecordType >(
 		records,
 		...rest,
 	};
+}
+
+export function __experimentalUseEntityRecords(
+	kind: string,
+	name: string,
+	queryArgs: any,
+	options: any
+) {
+	deprecated( `wp.data.__experimentalUseEntityRecords`, {
+		alternative: 'wp.data.useEntityRecords',
+		since: '6.1',
+	} );
+	return useEntityRecords( kind, name, queryArgs, options );
 }

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -68,8 +68,8 @@ export const store = createReduxStore( STORE_NAME, storeConfig() );
 register( store );
 
 export { default as EntityProvider } from './entity-provider';
-export { default as __experimentalUseEntityRecord } from './hooks/use-entity-record';
-export { default as __experimentalUseEntityRecords } from './hooks/use-entity-records';
+export { default as useEntityRecord } from './hooks/use-entity-record';
+export { default as useEntityRecords } from './hooks/use-entity-records';
 export * from './entity-provider';
 export * from './fetch';
 export * from './entity-types';

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -68,8 +68,14 @@ export const store = createReduxStore( STORE_NAME, storeConfig() );
 register( store );
 
 export { default as EntityProvider } from './entity-provider';
-export { default as useEntityRecord } from './hooks/use-entity-record';
-export { default as useEntityRecords } from './hooks/use-entity-records';
+export {
+	default as useEntityRecord,
+	__experimentalUseEntityRecord,
+} from './hooks/use-entity-record';
+export {
+	default as useEntityRecords,
+	__experimentalUseEntityRecords,
+} from './hooks/use-entity-records';
 export * from './entity-provider';
 export * from './fetch';
 export * from './entity-types';

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	__experimentalUseEntityRecords as useEntityRecords,
+	useEntityRecords as useEntityRecords,
 } from '@wordpress/core-data';
 
 /**

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	store as coreStore,
-	useEntityRecords,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 
 /**
  * @typedef {Object} NavigationEntitiesData

--- a/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
+++ b/packages/edit-navigation/src/components/block-placeholder/use-navigation-entities.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	useEntityRecords as useEntityRecords,
+	useEntityRecords,
 } from '@wordpress/core-data';
 
 /**

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	__experimentalUseEntityRecords as useEntityRecords,
+	useEntityRecords as useEntityRecords,
 } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import {
-	store as coreStore,
-	useEntityRecords,
-} from '@wordpress/core-data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	VisuallyHidden,

--- a/packages/edit-site/src/components/list/table.js
+++ b/packages/edit-site/src/components/list/table.js
@@ -4,7 +4,7 @@
 import { useSelect } from '@wordpress/data';
 import {
 	store as coreStore,
-	useEntityRecords as useEntityRecords,
+	useEntityRecords,
 } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import {

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -18,7 +18,7 @@ import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { __experimentalUseEntityRecord as useEntityRecord } from '@wordpress/core-data';
+import { useEntityRecord as useEntityRecord } from '@wordpress/core-data';
 
 /**
  * Internal dependencies

--- a/packages/widgets/src/blocks/legacy-widget/edit/index.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/index.js
@@ -18,7 +18,7 @@ import { brush as brushIcon } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { useState, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { useEntityRecord as useEntityRecord } from '@wordpress/core-data';
+import { useEntityRecord } from '@wordpress/core-data';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Description

Part of https://github.com/WordPress/gutenberg/pull/38135, related to https://github.com/WordPress/gutenberg/pull/40162

Stabilizes the `__experimentalUseEntityRecord` and `__experimentalUseEntityRecords` hooks. They have been used in other core packages without any problems. 

This Pull Request does the following:

* Removes the __experimental prefix from function declarations, exports, and usages
* Adjusts the documentation and a few TypeScript signatures as @dmsnell proposed in https://github.com/WordPress/gutenberg/pull/38782
* Returns an EMPTY_ARRAY constant instead of a new array reference each time, as @Mamaduka proposed in https://github.com/WordPress/gutenberg/pull/39288#discussion_r828322141
* Changes `enum Status` to `const enum Status` to reduce the footprint of generated code at no additional cost, as @dmsnell proposed in https://github.com/WordPress/gutenberg/pull/38782

## Test plan

Confirm all the checks are green – no runtime logic is expected to change as a result of this PR aside of the EMPTY_ARRAY adjustment.

