### PR TITLE
Components: migrate `ConfirmDialog` component's Stories from knobs to controls

### DIFF
--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -93,9 +93,8 @@ UncontrolledAndWithExplicitOnCancel.args = {
 	cancelOutput: 'Cancelled',
 };
 
-// Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel to be passed
-// It's expected that the user will then use it to hide the dialog, too (see the
-// `setIsOpen` calls below).
+// Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
+// It's also necessary to explicitely close the dialog when needed. See `setIsOpen` calls below.
 export const Controlled = () => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ confirmVal, setConfirmVal ] = useState(

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -40,9 +40,6 @@ export default {
 				),
 			},
 		},
-		title: {
-			type: 'string',
-		},
 		confirmButtonText: {
 			type: 'string',
 		},
@@ -71,7 +68,6 @@ const Template = ( args ) => {
 	return (
 		<>
 			<ConfirmDialog
-				title={ args.title }
 				onConfirm={ () => setConfirmVal( confirmOutput ) }
 				onCancel={
 					args.cancelOutput
@@ -92,12 +88,6 @@ const Template = ( args ) => {
 // Simplest usage: just declare the component with the required `onConfirm` prop.
 export const _default = Template.bind( {} );
 _default.args = {};
-
-// To add a title, pass the `title` prop
-export const WithTitle = Template.bind( {} );
-WithTitle.args = {
-	title: 'Example Title',
-};
 
 // To customize button text, pass the `cancelButtonText` and/or `confirmButtonText` props.
 export const withCustomButtonLabels = Template.bind( {} );

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -110,6 +110,7 @@ VeeeryLongMessage.args = {
 	children: daText().repeat( 20 ),
 };
 
+// You can pass explicit cacncel actions with the `onCancel` prop.
 export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
 UncontrolledAndWithExplicitOnCancel.args = {
 	confirmOutput: 'Confirmed!',
@@ -117,7 +118,7 @@ UncontrolledAndWithExplicitOnCancel.args = {
 };
 
 // Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
-// It's also necessary to explicitely close the dialog when needed. See `setIsOpen` calls below.
+// It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.
 export const Controlled = () => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ confirmVal, setConfirmVal ] = useState(

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -25,6 +25,11 @@ const daText = () =>
 
 const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
+	const modalText = args.jsxMessage ? (
+		<Heading level={ 2 }>{ args.text }</Heading>
+	) : (
+		args.text
+	);
 
 	return (
 		<>
@@ -33,8 +38,9 @@ const Template = ( args ) => {
 				cancelButtonText={ args.cancelButtonText }
 				confirmButtonText={ args.confirmButtonText }
 			>
-				{ args.text }
+				{ modalText }
 			</ConfirmDialog>
+
 			<Heading level={ 1 }>{ confirmVal }</Heading>
 		</>
 	);
@@ -54,17 +60,11 @@ withCustomButtonLabels.args = {
 	confirmButtonText: 'Yes please!',
 };
 
-export const WithJSXMessage = () => {
-	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
-
-	return (
-		<>
-			<ConfirmDialog onConfirm={ () => setConfirmVal( 'Confirmed!' ) }>
-				<Heading level={ 2 }>{ daText() }</Heading>
-			</ConfirmDialog>
-			<Heading level={ 1 }>{ confirmVal }</Heading>
-		</>
-	);
+// To use a JSX message, wrap your text in the appropriate JSX tags.
+export const WithJSXMessage = Template.bind( {} );
+WithJSXMessage.args = {
+	text: daText(),
+	jsxMessage: true,
 };
 
 export const VeeeryLongMessage = Template.bind( {} );

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -73,19 +73,29 @@ const meta = {
 export default meta;
 
 const Template = ( args ) => {
+	const [ isOpen, setIsOpen ] = useState( false );
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
-	const confirmOutput = args.confirmOutput ?? 'Confirmed!';
 	const children = args.jsxChildren ?? args.children;
 
+	const handleConfirm = () => {
+		setConfirmVal( 'Confirmed!' );
+		setIsOpen( false );
+	};
+
+	const handleCancel = () => {
+		setConfirmVal( 'Cancelled' );
+		setIsOpen( false );
+	};
 	return (
 		<>
+			<Button variant="primary" onClick={ () => setIsOpen( true ) }>
+				Open ConfirmDialog
+			</Button>
+
 			<ConfirmDialog
-				onConfirm={ () => setConfirmVal( confirmOutput ) }
-				onCancel={
-					args.cancelOutput
-						? () => setConfirmVal( args.cancelOutput )
-						: undefined
-				}
+				isOpen={ isOpen }
+				onConfirm={ handleConfirm }
+				onCancel={ handleCancel }
 				cancelButtonText={ args.cancelButtonText }
 				confirmButtonText={ args.confirmButtonText }
 			>

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -77,7 +77,7 @@ const Template = ( args ) => {
 	);
 };
 
-// Simplest usage: just declare the component with the required `onConfirm` prop.
+// Simplest usage: just declare the component with the required `onConfirm` prop. Note: the `onCancel` prop is optional here, unless you'd like to render the component in Controlled mode (see below)
 export const _default = Template.bind( {} );
 _default.args = {};
 
@@ -88,39 +88,51 @@ withCustomButtonLabels.args = {
 	confirmButtonText: 'Yes please!',
 };
 
-// Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
-// It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.
-export const Controlled = () => {
+const controlledSnippet = `() => {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ confirmVal, setConfirmVal ] = useState(
-		"Hasn't confirmed or cancelled yet"
-	);
-
+	const [ confirmVal, setConfirmVal ] = useState('');
+	
 	const handleConfirm = () => {
 		setConfirmVal( 'Confirmed!' );
 		setIsOpen( false );
 	};
-
+	
 	const handleCancel = () => {
 		setConfirmVal( 'Cancelled' );
 		setIsOpen( false );
 	};
-
+	
 	return (
 		<>
-			<ConfirmDialog
-				isOpen={ isOpen }
-				onConfirm={ handleConfirm }
-				onCancel={ handleCancel }
-			>
-				Would you like to privately publish the post now?
-			</ConfirmDialog>
-
-			<Heading level={ 1 }>{ confirmVal }</Heading>
-
-			<Button variant="primary" onClick={ () => setIsOpen( true ) }>
-				Open ConfirmDialog
-			</Button>
+		<ConfirmDialog
+		isOpen={ isOpen }
+		onConfirm={ handleConfirm }
+		onCancel={ handleCancel }
+		>
+		Would you like to privately publish the post now?
+		</ConfirmDialog>
+		
+		<Heading level={ 1 }>{ confirmVal }</Heading>
+		
+		<Button variant="primary" onClick={ () => setIsOpen( true ) }>
+		Open ConfirmDialog
+		</Button>
 		</>
-	);
+		);
+	};`;
+
+export const Controlled = Template.bind( {} );
+Controlled.args = {};
+Controlled.parameters = {
+	docs: {
+		description: {
+			story:
+				"Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed. It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.",
+		},
+		source: {
+			code: controlledSnippet,
+			language: 'jsx',
+			type: 'auto',
+		},
+	},
 };

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -118,15 +118,6 @@ withCustomButtonLabels.args = {
 	confirmButtonText: 'Yes please!',
 };
 
-// JSX elements can be passed as children to further customize the dialog.
-export const WithJSXMessage = Template.bind( {} );
-WithJSXMessage.args = {
-	jsxChildren: '<Heading level={ 2 }>A JSX Heading</Heading>',
-};
-WithJSXMessage.parameters = {
-	controls: { exclude: 'children' },
-};
-
 // Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
 // It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.
 export const Controlled = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -18,45 +18,40 @@ import { ConfirmDialog } from '..';
 export default {
 	component: ConfirmDialog,
 	title: 'Components (Experimental)/ConfirmDialog',
-	parameters: {
-		knobs: { disable: false },
-	},
 };
 
 const daText = () =>
 	text( 'message', 'Would you like to privately publish the post now?' );
-const daCancelText = () => text( 'cancel button', 'No thanks' );
-const daConfirmText = () => text( 'confirm button', 'Yes please!' );
 
-// Simplest usage: just declare the component with the required `onConfirm` prop.
-export const _default = () => {
-	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
-
-	return (
-		<>
-			<ConfirmDialog onConfirm={ () => setConfirmVal( 'Confirmed!' ) }>
-				{ daText() }
-			</ConfirmDialog>
-			<Heading level={ 1 }>{ confirmVal }</Heading>
-		</>
-	);
-};
-
-export const WithCustomButtonLabels = () => {
+const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
 
 	return (
 		<>
 			<ConfirmDialog
 				onConfirm={ () => setConfirmVal( 'Confirmed!' ) }
-				cancelButtonText={ daCancelText() }
-				confirmButtonText={ daConfirmText() }
+				cancelButtonText={ args.cancelButtonText }
+				confirmButtonText={ args.confirmButtonText }
 			>
-				{ daText() }
+				{ args.text }
 			</ConfirmDialog>
 			<Heading level={ 1 }>{ confirmVal }</Heading>
 		</>
 	);
+};
+
+// Simplest usage: just declare the component with the required `onConfirm` prop.
+export const _default = Template.bind( {} );
+_default.args = {
+	text: daText(),
+};
+
+// To customize button text, decplace the `cancelButtonText` and/or `confirmButtonText` props.
+export const withCustomButtonLabels = Template.bind( {} );
+withCustomButtonLabels.args = {
+	text: daText(),
+	cancelButtonText: 'No thanks',
+	confirmButtonText: 'Yes please!',
 };
 
 export const WithJSXMessage = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -127,11 +127,6 @@ WithJSXMessage.parameters = {
 	controls: { exclude: 'children' },
 };
 
-export const VeeeryLongMessage = Template.bind( {} );
-VeeeryLongMessage.args = {
-	children: daText().repeat( 20 ),
-};
-
 // Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
 // It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.
 export const Controlled = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -23,7 +23,7 @@ export default {
 	title: 'Components (Experimental)/ConfirmDialog',
 	argTypes: {
 		children: {
-			type: 'reactNode',
+			type: 'string',
 		},
 		jsxChildren: {
 			type: 'select',
@@ -57,7 +57,9 @@ export default {
 		children: daText(),
 	},
 	parameters: {
-		controls: { exclude: [ 'jsxChildren' ] },
+		// Exclude jsxChildren by default becuase it's only used in one story.
+		// Because controls don't rerender the component, isOpen isn't actually useful.
+		controls: { exclude: [ 'jsxChildren', 'isOpen' ] },
 	},
 };
 
@@ -89,21 +91,17 @@ const Template = ( args ) => {
 
 // Simplest usage: just declare the component with the required `onConfirm` prop.
 export const _default = Template.bind( {} );
-_default.args = {
-	children: daText(),
-};
+_default.args = {};
 
 // To add a title, pass the `title` prop
 export const WithTitle = Template.bind( {} );
 WithTitle.args = {
 	title: 'Example Title',
-	children: daText(),
 };
 
 // To customize button text, pass the `cancelButtonText` and/or `confirmButtonText` props.
 export const withCustomButtonLabels = Template.bind( {} );
 withCustomButtonLabels.args = {
-	children: daText(),
 	cancelButtonText: 'No thanks',
 	confirmButtonText: 'Yes please!',
 };
@@ -114,7 +112,7 @@ WithJSXMessage.args = {
 	jsxChildren: '<Heading level={ 2 }>A JSX Heading</Heading>',
 };
 WithJSXMessage.parameters = {
-	controls: { exclude: [ 'children' ] },
+	controls: { exclude: [ 'children', 'isOpen' ] },
 };
 
 export const VeeeryLongMessage = Template.bind( {} );
@@ -124,7 +122,6 @@ VeeeryLongMessage.args = {
 
 export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
 UncontrolledAndWithExplicitOnCancel.args = {
-	children: daText(),
 	confirmOutput: 'Confirmed!',
 	cancelOutput: 'Cancelled',
 };

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { text } from '@storybook/addon-knobs';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -14,9 +9,6 @@ import { useState } from '@wordpress/element';
 import Button from '../../button';
 import { Heading } from '../../heading';
 import { ConfirmDialog } from '..';
-
-const daText = () =>
-	text( 'message', 'Would you like to privately publish the post now?' );
 
 const meta = {
 	component: ConfirmDialog,
@@ -59,7 +51,7 @@ const meta = {
 		},
 	},
 	args: {
-		children: daText(),
+		children: 'Would you like to privately publish the post now?',
 	},
 	parameters: {
 		// Exclude jsxChildren by default becuase it's only used in one story.
@@ -143,7 +135,7 @@ export const Controlled = () => {
 				onConfirm={ handleConfirm }
 				onCancel={ handleCancel }
 			>
-				{ daText() }
+				Would you like to privately publish the post now?
 			</ConfirmDialog>
 
 			<Heading level={ 1 }>{ confirmVal }</Heading>

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -15,12 +15,30 @@ import Button from '../../button';
 import { Heading } from '../../heading';
 import { ConfirmDialog } from '..';
 
+const daText = () =>
+	text( 'message', 'Would you like to privately publish the post now?' );
+
 export default {
 	component: ConfirmDialog,
 	title: 'Components (Experimental)/ConfirmDialog',
 	argTypes: {
 		children: {
 			type: 'reactNode',
+		},
+		jsxChildren: {
+			type: 'select',
+			options: [
+				'<b>Bold text</b>',
+				'<i>Italic text</i>',
+				'<Heading level={ 2 }>A JSX Heading</Heading>',
+			],
+			mapping: {
+				'<b>Bold text</b>': <b>Bold text</b>,
+				'<i>Italic text</i>': <i>Italic text</i>,
+				'<Heading level={ 2 }>A JSX Heading</Heading>': (
+					<Heading level={ 2 }>A JSX Heading</Heading>
+				),
+			},
 		},
 		title: {
 			type: 'string',
@@ -35,19 +53,18 @@ export default {
 			type: 'boolean',
 		},
 	},
+	args: {
+		children: daText(),
+	},
+	parameters: {
+		controls: { exclude: [ 'jsxChildren' ] },
+	},
 };
-
-const daText = () =>
-	text( 'message', 'Would you like to privately publish the post now?' );
 
 const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
 	const confirmOutput = args.confirmOutput ?? 'Confirmed!';
-	const modalText = args.jsxMessage ? (
-		<Heading level={ 2 }>{ args.children }</Heading>
-	) : (
-		args.children
-	);
+	const children = args.jsxChildren ?? args.children;
 
 	return (
 		<>
@@ -62,7 +79,7 @@ const Template = ( args ) => {
 				cancelButtonText={ args.cancelButtonText }
 				confirmButtonText={ args.confirmButtonText }
 			>
-				{ modalText }
+				{ children }
 			</ConfirmDialog>
 
 			<Heading level={ 1 }>{ confirmVal }</Heading>
@@ -91,15 +108,13 @@ withCustomButtonLabels.args = {
 	confirmButtonText: 'Yes please!',
 };
 
-// To use a JSX message, wrap your text in the appropriate JSX tags.
+// JSX elements can be passed as children to further customize the dialog.
 export const WithJSXMessage = Template.bind( {} );
 WithJSXMessage.args = {
-	children: daText(),
-	jsxMessage: true,
+	jsxChildren: '<Heading level={ 2 }>A JSX Heading</Heading>',
 };
-// Hide the jsxMessage control, as it isn't an actual prop
 WithJSXMessage.parameters = {
-	controls: { exclude: [ 'jsxMessage' ] },
+	controls: { exclude: [ 'children' ] },
 };
 
 export const VeeeryLongMessage = Template.bind( {} );

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -67,17 +67,9 @@ export const WithJSXMessage = () => {
 	);
 };
 
-export const VeeeryLongMessage = () => {
-	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
-
-	return (
-		<>
-			<ConfirmDialog onConfirm={ () => setConfirmVal( 'Confirmed!' ) }>
-				{ daText().repeat( 20 ) }
-			</ConfirmDialog>
-			<Heading level={ 1 }>{ confirmVal }</Heading>
-		</>
-	);
+export const VeeeryLongMessage = Template.bind( {} );
+VeeeryLongMessage.args = {
+	text: daText().repeat( 20 ),
 };
 
 export const UncontrolledAndWithExplicitOnCancel = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -18,20 +18,22 @@ import { ConfirmDialog } from '..';
 const daText = () =>
 	text( 'message', 'Would you like to privately publish the post now?' );
 
-export default {
+const meta = {
 	component: ConfirmDialog,
 	title: 'Components (Experimental)/ConfirmDialog',
 	argTypes: {
 		children: {
-			type: 'string',
+			control: { type: 'text' },
 		},
 		jsxChildren: {
-			type: 'select',
-			options: [
-				'<b>Bold text</b>',
-				'<i>Italic text</i>',
-				'<Heading level={ 2 }>A JSX Heading</Heading>',
-			],
+			control: {
+				type: 'select',
+				options: [
+					'<b>Bold text</b>',
+					'<i>Italic text</i>',
+					'<Heading level={ 2 }>A JSX Heading</Heading>',
+				],
+			},
 			mapping: {
 				'<b>Bold text</b>': <b>Bold text</b>,
 				'<i>Italic text</i>': <i>Italic text</i>,
@@ -41,13 +43,19 @@ export default {
 			},
 		},
 		confirmButtonText: {
-			type: 'string',
+			control: { type: 'text' },
 		},
 		cancelButtonText: {
-			type: 'string',
+			control: { type: 'text' },
 		},
 		isOpen: {
-			type: 'boolean',
+			control: { type: null },
+		},
+		onConfirm: {
+			control: { type: null },
+		},
+		onCancel: {
+			control: { type: null },
 		},
 	},
 	args: {
@@ -55,10 +63,13 @@ export default {
 	},
 	parameters: {
 		// Exclude jsxChildren by default becuase it's only used in one story.
-		// Because controls don't rerender the component, isOpen isn't actually useful.
-		controls: { exclude: [ 'jsxChildren', 'isOpen' ] },
+		controls: {
+			exclude: 'jsxChildren',
+		},
 	},
 };
+
+export default meta;
 
 const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
@@ -102,7 +113,7 @@ WithJSXMessage.args = {
 	jsxChildren: '<Heading level={ 2 }>A JSX Heading</Heading>',
 };
 WithJSXMessage.parameters = {
-	controls: { exclude: [ 'children', 'isOpen' ] },
+	controls: { exclude: 'children' },
 };
 
 export const VeeeryLongMessage = Template.bind( {} );
@@ -110,7 +121,7 @@ VeeeryLongMessage.args = {
 	children: daText().repeat( 20 ),
 };
 
-// You can pass explicit cacncel actions with the `onCancel` prop.
+// You can pass explicit cancel actions with the `onCancel` prop.
 export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
 UncontrolledAndWithExplicitOnCancel.args = {
 	confirmOutput: 'Confirmed!',

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -122,13 +122,6 @@ VeeeryLongMessage.args = {
 	children: daText().repeat( 20 ),
 };
 
-// You can pass explicit cancel actions with the `onCancel` prop.
-export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
-UncontrolledAndWithExplicitOnCancel.args = {
-	confirmOutput: 'Confirmed!',
-	cancelOutput: 'Cancelled',
-};
-
 // Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed.
 // It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.
 export const Controlled = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -18,6 +18,23 @@ import { ConfirmDialog } from '..';
 export default {
 	component: ConfirmDialog,
 	title: 'Components (Experimental)/ConfirmDialog',
+	argTypes: {
+		children: {
+			type: 'reactNode',
+		},
+		title: {
+			type: 'string',
+		},
+		confirmButtonText: {
+			type: 'string',
+		},
+		cancelButtonText: {
+			type: 'string',
+		},
+		isOpen: {
+			type: 'boolean',
+		},
+	},
 };
 
 const daText = () =>
@@ -27,9 +44,9 @@ const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
 	const confirmOutput = args.confirmOutput ?? 'Confirmed!';
 	const modalText = args.jsxMessage ? (
-		<Heading level={ 2 }>{ args.text }</Heading>
+		<Heading level={ 2 }>{ args.children }</Heading>
 	) : (
-		args.text
+		args.children
 	);
 
 	return (
@@ -56,20 +73,20 @@ const Template = ( args ) => {
 // Simplest usage: just declare the component with the required `onConfirm` prop.
 export const _default = Template.bind( {} );
 _default.args = {
-	text: daText(),
+	children: daText(),
 };
 
 // To add a title, pass the `title` prop
 export const WithTitle = Template.bind( {} );
 WithTitle.args = {
 	title: 'Example Title',
-	text: daText(),
+	children: daText(),
 };
 
 // To customize button text, pass the `cancelButtonText` and/or `confirmButtonText` props.
 export const withCustomButtonLabels = Template.bind( {} );
 withCustomButtonLabels.args = {
-	text: daText(),
+	children: daText(),
 	cancelButtonText: 'No thanks',
 	confirmButtonText: 'Yes please!',
 };
@@ -77,18 +94,22 @@ withCustomButtonLabels.args = {
 // To use a JSX message, wrap your text in the appropriate JSX tags.
 export const WithJSXMessage = Template.bind( {} );
 WithJSXMessage.args = {
-	text: daText(),
+	children: daText(),
 	jsxMessage: true,
+};
+// Hide the jsxMessage control, as it isn't an actual prop
+WithJSXMessage.parameters = {
+	controls: { exclude: [ 'jsxMessage' ] },
 };
 
 export const VeeeryLongMessage = Template.bind( {} );
 VeeeryLongMessage.args = {
-	text: daText().repeat( 20 ),
+	children: daText().repeat( 20 ),
 };
 
 export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
 UncontrolledAndWithExplicitOnCancel.args = {
-	text: daText(),
+	children: daText(),
 	confirmOutput: 'Confirmed!',
 	cancelOutput: 'Cancelled',
 };

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -79,7 +79,49 @@ const Template = ( args ) => {
 
 // Simplest usage: just declare the component with the required `onConfirm` prop. Note: the `onCancel` prop is optional here, unless you'd like to render the component in Controlled mode (see below)
 export const _default = Template.bind( {} );
+const _defaultSnippet = `() => {
+  const [ isOpen, setIsOpen ] = useState( false );
+  const [ confirmVal, setConfirmVal ] = useState('');
+
+  const handleConfirm = () => {
+    setConfirmVal( 'Confirmed!' );
+    setIsOpen( false );
+  };
+
+  const handleCancel = () => {
+    setConfirmVal( 'Cancelled' );
+    setIsOpen( false );
+  };
+
+  return (
+    <>
+    <ConfirmDialog
+      isOpen={ isOpen }
+      onConfirm={ handleConfirm }
+      onCancel={ handleCancel }
+    >
+      Would you like to privately publish the post now?
+    </ConfirmDialog>
+
+    <Heading level={ 1 }>{ confirmVal }</Heading>
+
+    <Button variant="primary" onClick={ () => setIsOpen( true ) }>
+      Open ConfirmDialog
+    </Button>
+    </>
+    );
+  };`;
 _default.args = {};
+_default.parameters = {
+	docs: {
+		source: {
+			code: _defaultSnippet,
+			language: 'jsx',
+			type: 'auto',
+			format: 'true',
+		},
+	},
+};
 
 // To customize button text, pass the `cancelButtonText` and/or `confirmButtonText` props.
 export const withCustomButtonLabels = Template.bind( {} );
@@ -88,49 +130,27 @@ withCustomButtonLabels.args = {
 	confirmButtonText: 'Yes please!',
 };
 
-const controlledSnippet = `() => {
-	const [ isOpen, setIsOpen ] = useState( false );
-	const [ confirmVal, setConfirmVal ] = useState('');
-	
-	const handleConfirm = () => {
-		setConfirmVal( 'Confirmed!' );
-		setIsOpen( false );
-	};
-	
-	const handleCancel = () => {
-		setConfirmVal( 'Cancelled' );
-		setIsOpen( false );
-	};
-	
-	return (
-		<>
-		<ConfirmDialog
-		isOpen={ isOpen }
-		onConfirm={ handleConfirm }
-		onCancel={ handleCancel }
-		>
-		Would you like to privately publish the post now?
-		</ConfirmDialog>
-		
-		<Heading level={ 1 }>{ confirmVal }</Heading>
-		
-		<Button variant="primary" onClick={ () => setIsOpen( true ) }>
-		Open ConfirmDialog
-		</Button>
-		</>
-		);
-	};`;
+const uncontrolledSnippet = `<>
+  <ConfirmDialog
+    onConfirm={ handleConfirm }
+  >
+    Would you like to privately publish the post now?
+  </ConfirmDialog>
+  
+  <Heading level={ 1 } />
+</>
+`;
 
-export const Controlled = Template.bind( {} );
-Controlled.args = {};
-Controlled.parameters = {
+export const Uncontrolled = Template.bind( {} );
+Uncontrolled.args = {};
+Uncontrolled.parameters = {
 	docs: {
 		description: {
 			story:
-				"Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel` to be passed. It's also necessary to explicitly close the dialog when needed. See `setIsOpen` calls below.",
+				'To render in Uncontrolled Mode, omit passing a boolean to the `isOpen` prop. This will allow the component to close itself without the need for an explicit callback. In Uncontrolled mode, `onCancel` is optional.',
 		},
 		source: {
-			code: controlledSnippet,
+			code: uncontrolledSnippet,
 			language: 'jsx',
 			type: 'auto',
 		},

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -74,7 +74,7 @@ export default meta;
 
 const Template = ( args ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
-	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
+	const [ confirmVal, setConfirmVal ] = useState( '' );
 	const children = args.jsxChildren ?? args.children;
 
 	const handleConfirm = () => {

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -17,23 +17,6 @@ const meta = {
 		children: {
 			control: { type: 'text' },
 		},
-		jsxChildren: {
-			control: {
-				type: 'select',
-				options: [
-					'<b>Bold text</b>',
-					'<i>Italic text</i>',
-					'<Heading level={ 2 }>A JSX Heading</Heading>',
-				],
-			},
-			mapping: {
-				'<b>Bold text</b>': <b>Bold text</b>,
-				'<i>Italic text</i>': <i>Italic text</i>,
-				'<Heading level={ 2 }>A JSX Heading</Heading>': (
-					<Heading level={ 2 }>A JSX Heading</Heading>
-				),
-			},
-		},
 		confirmButtonText: {
 			control: { type: 'text' },
 		},
@@ -54,10 +37,6 @@ const meta = {
 		children: 'Would you like to privately publish the post now?',
 	},
 	parameters: {
-		// Exclude jsxChildren by default becuase it's only used in one story.
-		controls: {
-			exclude: 'jsxChildren',
-		},
 		docs: { source: { state: 'open' } },
 	},
 };
@@ -67,7 +46,6 @@ export default meta;
 const Template = ( args ) => {
 	const [ isOpen, setIsOpen ] = useState( false );
 	const [ confirmVal, setConfirmVal ] = useState( '' );
-	const children = args.jsxChildren ?? args.children;
 
 	const handleConfirm = () => {
 		setConfirmVal( 'Confirmed!' );
@@ -91,7 +69,7 @@ const Template = ( args ) => {
 				cancelButtonText={ args.cancelButtonText }
 				confirmButtonText={ args.confirmButtonText }
 			>
-				{ children }
+				{ args.children }
 			</ConfirmDialog>
 
 			<Heading level={ 1 }>{ confirmVal }</Heading>

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -35,6 +35,7 @@ const Template = ( args ) => {
 	return (
 		<>
 			<ConfirmDialog
+				title={ args.title }
 				onConfirm={ () => setConfirmVal( confirmOutput ) }
 				onCancel={
 					args.cancelOutput
@@ -58,7 +59,14 @@ _default.args = {
 	text: daText(),
 };
 
-// To customize button text, decplace the `cancelButtonText` and/or `confirmButtonText` props.
+// To add a title, pass the `title` prop
+export const WithTitle = Template.bind( {} );
+WithTitle.args = {
+	title: 'Example Title',
+	text: daText(),
+};
+
+// To customize button text, pass the `cancelButtonText` and/or `confirmButtonText` props.
 export const withCustomButtonLabels = Template.bind( {} );
 withCustomButtonLabels.args = {
 	text: daText(),

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -66,6 +66,7 @@ const meta = {
 		controls: {
 			exclude: 'jsxChildren',
 		},
+		docs: { source: { state: 'open' } },
 	},
 };
 

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -25,6 +25,7 @@ const daText = () =>
 
 const Template = ( args ) => {
 	const [ confirmVal, setConfirmVal ] = useState( "Hasn't confirmed yet" );
+	const confirmOutput = args.confirmOutput ?? 'Confirmed!';
 	const modalText = args.jsxMessage ? (
 		<Heading level={ 2 }>{ args.text }</Heading>
 	) : (
@@ -34,7 +35,12 @@ const Template = ( args ) => {
 	return (
 		<>
 			<ConfirmDialog
-				onConfirm={ () => setConfirmVal( 'Confirmed!' ) }
+				onConfirm={ () => setConfirmVal( confirmOutput ) }
+				onCancel={
+					args.cancelOutput
+						? () => setConfirmVal( args.cancelOutput )
+						: undefined
+				}
 				cancelButtonText={ args.cancelButtonText }
 				confirmButtonText={ args.confirmButtonText }
 			>
@@ -72,22 +78,11 @@ VeeeryLongMessage.args = {
 	text: daText().repeat( 20 ),
 };
 
-export const UncontrolledAndWithExplicitOnCancel = () => {
-	const [ confirmVal, setConfirmVal ] = useState(
-		"Hasn't confirmed or cancelled yet"
-	);
-
-	return (
-		<>
-			<ConfirmDialog
-				onConfirm={ () => setConfirmVal( 'Confirmed!' ) }
-				onCancel={ () => setConfirmVal( 'Cancelled' ) }
-			>
-				{ daText() }
-			</ConfirmDialog>
-			<Heading level={ 1 }>{ confirmVal }</Heading>
-		</>
-	);
+export const UncontrolledAndWithExplicitOnCancel = Template.bind( {} );
+UncontrolledAndWithExplicitOnCancel.args = {
+	text: daText(),
+	confirmOutput: 'Confirmed!',
+	cancelOutput: 'Cancelled',
 };
 
 // Controlled `ConfirmDialog`s require both `onConfirm` *and* `onCancel to be passed

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -63,11 +63,10 @@ const Template = ( args ) => {
 			</Button>
 
 			<ConfirmDialog
+				{ ...args }
 				isOpen={ isOpen }
 				onConfirm={ handleConfirm }
 				onCancel={ handleCancel }
-				cancelButtonText={ args.cancelButtonText }
-				confirmButtonText={ args.confirmButtonText }
 			>
 				{ args.children }
 			</ConfirmDialog>

--- a/packages/components/src/confirm-dialog/stories/index.js
+++ b/packages/components/src/confirm-dialog/stories/index.js
@@ -129,30 +129,3 @@ withCustomButtonLabels.args = {
 	cancelButtonText: 'No thanks',
 	confirmButtonText: 'Yes please!',
 };
-
-const uncontrolledSnippet = `<>
-  <ConfirmDialog
-    onConfirm={ handleConfirm }
-  >
-    Would you like to privately publish the post now?
-  </ConfirmDialog>
-  
-  <Heading level={ 1 } />
-</>
-`;
-
-export const Uncontrolled = Template.bind( {} );
-Uncontrolled.args = {};
-Uncontrolled.parameters = {
-	docs: {
-		description: {
-			story:
-				'To render in Uncontrolled Mode, omit passing a boolean to the `isOpen` prop. This will allow the component to close itself without the need for an explicit callback. In Uncontrolled mode, `onCancel` is optional.',
-		},
-		source: {
-			code: uncontrolledSnippet,
-			language: 'jsx',
-			type: 'auto',
-		},
-	},
-};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Migrate the Stories for the `ConfirmDialog` component from knobs to the more modern controls API. The one exception is the `Controlled` story, which benefits more from the current format's code snippet, so doesn't have any active Controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See https://github.com/WordPress/gutenberg/issues/35665 for more details, but due to knobs being deprecated, all components will eventually need to be migrated.

## Testing Instructions
1. `npm run storybook:dev`
2. Confirm that Knobs are no longer available, and Controls have taken their place
3. Confirm the DocsPage looks correct with no errors. The data will be somewhat incomplete, but this should be addressed in a future PR when the stories are migrated to TypeScript.
