### PR TITLE
Block Library: Deprecate the Post Comments block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -485,9 +485,9 @@ This block is deprecated. Please use the Comments Query Loop block instead. ([So
 -	**Supports:** ~~html~~, ~~inserter~~
 -	**Attributes:** commentId
 
-## Post Comments
+## Post Comments (deprecated)
 
-Display a post's comments. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments))
+This block is deprecated. Please use the Comments Query Loop block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/post-comments))
 
 -	**Name:** core/post-comments
 -	**Category:** theme

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -491,7 +491,7 @@ Display a post's comments. ([Source](https://github.com/WordPress/gutenberg/tree
 
 -	**Name:** core/post-comments
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~inserter~~
 -	**Attributes:** textAlign
 
 ## Post Comments Count

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -33,7 +33,8 @@
 				"background": true,
 				"text": true
 			}
-		}
+		},
+		"inserter": false
 	},
 	"style": [
 		"wp-block-post-comments",

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -2,9 +2,9 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "core/post-comments",
-	"title": "Post Comments",
+	"title": "Post Comments (deprecated)",
 	"category": "theme",
-	"description": "Display a post's comments.",
+	"description": "This block is deprecated. Please use the Comments Query Loop block instead.",
 	"textdomain": "default",
 	"attributes": {
 		"textAlign": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Removes the Post Comments block from the inserter, now that we have Comments Query Loop to replace it.

## Why?

That block is being replaced with Comments Query Loop.

## How?

Simply adding `"inserter": false` in block.json. The title and description have been updated as well to reflect that the block is deprecated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open a Post or Page, or go to any template.
2. Check that the Post Comments block doesn't appear anymore.
3. Add a Post Comments block using the Code Editor.
4. Check that the title and description of the block tell the block is deprecated.

## Screenshots or screencast

Searching in the block inserter:

![Screenshot 2022-04-08 at 11 01 42](https://user-images.githubusercontent.com/6917969/162403600-a1bd77a7-083b-4c8b-a1a1-82551a5e835a.png)

Block information card:

![Screenshot 2022-04-08 at 11 03 06](https://user-images.githubusercontent.com/6917969/162403667-ab6dd2e6-26f6-4138-8a74-5aef5e8a6f29.png)

