### PR TITLE
Add paste handling to #39303

### DIFF
--- a/packages/components/src/border-box-control/test/index.js
+++ b/packages/components/src/border-box-control/test/index.js
@@ -61,13 +61,13 @@ const queryButton = ( name ) => {
 };
 
 const updateLinkedWidthInput = ( value ) => {
-	const widthInput = screen.getByRole( 'spinbutton' );
+	const widthInput = screen.getByRole( 'textbox' );
 	widthInput.focus();
 	fireEvent.change( widthInput, { target: { value } } );
 };
 
 const updateSplitWidthInput = ( value, index = 0 ) => {
-	const splitInputs = screen.getAllByRole( 'spinbutton' );
+	const splitInputs = screen.getAllByRole( 'textbox' );
 	splitInputs[ index ].focus();
 	fireEvent.change( splitInputs[ index ], { target: { value } } );
 };
@@ -79,7 +79,7 @@ describe( 'BorderBoxControl', () => {
 
 			const label = screen.getByText( props.label );
 			const colorButton = screen.getByLabelText( toggleLabelRegex );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 			const unitSelect = screen.getByRole( 'combobox' );
 			const slider = screen.getByRole( 'slider' );
 			const linkedButton = screen.getByLabelText( 'Unlink sides' );
@@ -108,14 +108,14 @@ describe( 'BorderBoxControl', () => {
 
 		it( 'should show correct width value when flat border value provided', () => {
 			renderBorderBoxControl( { value: defaultBorder } );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 
 			expect( widthInput.value ).toBe( '1' );
 		} );
 
 		it( 'should show correct width value when consistent split borders provided', () => {
 			renderBorderBoxControl( { value: defaultBorders } );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 
 			expect( widthInput.value ).toBe( '1' );
 		} );
@@ -126,7 +126,7 @@ describe( 'BorderBoxControl', () => {
 			// First render of control with mixed values should show split view.
 			clickButton( 'Link sides' );
 
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 			expect( widthInput ).toHaveAttribute( 'placeholder', 'Mixed' );
 		} );
 
@@ -143,7 +143,7 @@ describe( 'BorderBoxControl', () => {
 
 			// First render of control with mixed values should show split view.
 			clickButton( 'Link sides' );
-			const linkedInput = screen.getByRole( 'spinbutton' );
+			const linkedInput = screen.getByRole( 'textbox' );
 
 			expect( linkedInput.value ).toBe( '5' );
 		} );
@@ -171,7 +171,7 @@ describe( 'BorderBoxControl', () => {
 			renderBorderBoxControl( { value: mixedBorders } );
 
 			const colorButtons = screen.getAllByLabelText( toggleLabelRegex );
-			const widthInputs = screen.getAllByRole( 'spinbutton' );
+			const widthInputs = screen.getAllByRole( 'textbox' );
 			const unitSelects = screen.getAllByRole( 'combobox' );
 			const sliders = screen.queryAllByRole( 'slider' );
 			const linkedButton = screen.getByLabelText( 'Link sides' );
@@ -186,7 +186,7 @@ describe( 'BorderBoxControl', () => {
 		it( 'should render correct width values in appropriate inputs', () => {
 			renderBorderBoxControl( { value: mixedBorders } );
 
-			const widthInputs = screen.getAllByRole( 'spinbutton' );
+			const widthInputs = screen.getAllByRole( 'textbox' );
 
 			expect( widthInputs[ 0 ].value ).toBe( '1' ); // Top.
 			expect( widthInputs[ 1 ].value ).toBe( '0.75' ); // Left.
@@ -198,7 +198,7 @@ describe( 'BorderBoxControl', () => {
 			renderBorderBoxControl( { value: defaultBorders } );
 			clickButton( 'Unlink sides' );
 
-			const widthInputs = screen.getAllByRole( 'spinbutton' );
+			const widthInputs = screen.getAllByRole( 'textbox' );
 			expect( widthInputs[ 0 ].value ).toBe( '1' ); // Top.
 			expect( widthInputs[ 1 ].value ).toBe( '1' ); // Left.
 			expect( widthInputs[ 2 ].value ).toBe( '1' ); // Right.

--- a/packages/components/src/border-control/test/index.js
+++ b/packages/components/src/border-control/test/index.js
@@ -59,7 +59,7 @@ const clickButton = ( name ) => {
 };
 
 const setWidthInput = ( value ) => {
-	const widthInput = screen.getByRole( 'spinbutton' );
+	const widthInput = screen.getByRole( 'textbox' );
 	widthInput.focus();
 	fireEvent.change( widthInput, { target: { value } } );
 };
@@ -73,7 +73,7 @@ describe( 'BorderControl', () => {
 
 			const label = screen.getByText( props.label );
 			const colorButton = screen.getByLabelText( toggleLabelRegex );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 			const unitSelect = screen.getByRole( 'combobox' );
 			const slider = screen.queryByRole( 'slider' );
 
@@ -106,7 +106,7 @@ describe( 'BorderControl', () => {
 
 		it( 'should render placeholder in UnitControl', () => {
 			renderBorderControl( { placeholder: 'Mixed' } );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 
 			expect( widthInput ).toHaveAttribute( 'placeholder', 'Mixed' );
 		} );
@@ -271,7 +271,7 @@ describe( 'BorderControl', () => {
 			} );
 
 			rerenderBorderControl( rerender, { withSlider: true } );
-			const widthInput = screen.getByRole( 'spinbutton' );
+			const widthInput = screen.getByRole( 'textbox' );
 
 			expect( widthInput.value ).toEqual( '5' );
 		} );

--- a/packages/components/src/box-control/test/index.js
+++ b/packages/components/src/box-control/test/index.js
@@ -26,14 +26,11 @@ describe( 'BoxControl', () => {
 		it( 'should update values when interacting with input', () => {
 			const { container } = render( <BoxControl /> );
 			const input = container.querySelector( 'input' );
-			const unitSelect = container.querySelector( 'select' );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100%' } } );
-			fireEvent.keyDown( input, { keyCode: ENTER } );
+			fireEvent.change( input, { target: { value: '100' } } );
 
 			expect( input.value ).toBe( '100' );
-			expect( unitSelect.value ).toBe( '%' );
 		} );
 	} );
 
@@ -45,7 +42,7 @@ describe( 'BoxControl', () => {
 			const reset = getByText( /Reset/ );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
@@ -75,7 +72,7 @@ describe( 'BoxControl', () => {
 			const reset = getByText( /Reset/ );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
@@ -112,7 +109,7 @@ describe( 'BoxControl', () => {
 			const reset = getByText( /Reset/ );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
@@ -133,11 +130,11 @@ describe( 'BoxControl', () => {
 			const unitSelect = screen.getByLabelText( 'Select unit' );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100%' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
-			expect( unitSelect.value ).toBe( '%' );
+			expect( unitSelect.value ).toBe( 'px' );
 
 			fireEvent.change( input, { target: { value: '' } } );
 			fireEvent.blur( input );
@@ -165,7 +162,7 @@ describe( 'BoxControl', () => {
 			const unitSelect = container.querySelector( 'select' );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
@@ -198,7 +195,7 @@ describe( 'BoxControl', () => {
 			const unitSelect = container.querySelector( 'select' );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '100px' } } );
+			fireEvent.change( input, { target: { value: '100' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( input.value ).toBe( '100' );
@@ -261,7 +258,7 @@ describe( 'BoxControl', () => {
 	} );
 
 	describe( 'onChange updates', () => {
-		it( 'should call onChange when values contain more than just CSS units', () => {
+		it( 'should call onChange when input is changed', () => {
 			const setState = jest.fn();
 
 			render( <BoxControl onChange={ setState } /> );
@@ -271,14 +268,14 @@ describe( 'BoxControl', () => {
 			} );
 
 			input.focus();
-			fireEvent.change( input, { target: { value: '7.5rem' } } );
+			fireEvent.change( input, { target: { value: '7.5' } } );
 			fireEvent.keyDown( input, { keyCode: ENTER } );
 
 			expect( setState ).toHaveBeenCalledWith( {
-				top: '7.5rem',
-				right: '7.5rem',
-				bottom: '7.5rem',
-				left: '7.5rem',
+				top: '7.5px',
+				right: '7.5px',
+				bottom: '7.5px',
+				left: '7.5px',
 			} );
 		} );
 

--- a/packages/components/src/box-control/unit-control.js
+++ b/packages/components/src/box-control/unit-control.js
@@ -38,7 +38,6 @@ export default function BoxUnitControl( {
 					isFirst={ isFirst }
 					isLast={ isLast }
 					isOnly={ isOnly }
-					isPressEnterToChange
 					isResetValueOnUnitChange={ false }
 					value={ value }
 					{ ...props }

--- a/packages/components/src/focal-point-picker/test/index.js
+++ b/packages/components/src/focal-point-picker/test/index.js
@@ -95,7 +95,7 @@ describe( 'FocalPointPicker', () => {
 			const { rerender, getByRole } = render(
 				<Picker value={ { x: 0.25, y: 0.5 } } />
 			);
-			const xInput = getByRole( 'spinbutton', { name: 'Left' } );
+			const xInput = getByRole( 'textbox', { name: 'Left' } );
 			rerender( <Picker value={ { x: 0.93, y: 0.5 } } /> );
 			expect( xInput.value ).toBe( '93' );
 		} );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -167,7 +167,7 @@ function UnforwardedUnitControl(
 		};
 	}
 
-	const refInputSuffix = useRef< HTMLSelectElement | null >( null );
+	const refInputSuffix = useRef< HTMLSelectElement >( null );
 	const inputSuffix = ! disableUnits ? (
 		<UnitSelectControl
 			ref={ refInputSuffix }

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -159,6 +159,9 @@ function UnforwardedUnitControl(
 	if ( ! disableUnits && isUnitSelectTabbable && units.length ) {
 		handleOnKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {
 			props.onKeyDown?.( event );
+			// Bails if the meta key is pressed to not interfere with shortcuts,
+			// the prime example being pastes.
+			if ( event.metaKey ) return;
 			// Does the key match the first character of any units?
 			if ( reFirstCharacterOfUnits.test( event.key ) ) {
 				// Moves focus to the UnitSelectControl.

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -41,7 +41,7 @@ function UnforwardedUnitControl(
 	forwardedRef: ForwardedRef< any >
 ) {
 	const {
-		__unstableStateReducer: stateReducerProp,
+		__unstableStateReducer,
 		autoComplete = 'off',
 		className,
 		disabled = false,
@@ -212,6 +212,7 @@ function UnforwardedUnitControl(
 				suffix={ inputSuffix }
 				value={ parsedQuantity ?? '' }
 				step={ step }
+				__unstableStateReducer={ __unstableStateReducer }
 			/>
 		</Root>
 	);

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -197,6 +197,7 @@ function UnforwardedUnitControl(
 		<Root className="components-unit-control-wrapper" style={ style }>
 			<ValueInput
 				aria-label={ label }
+				type={ isPressEnterToChange ? 'text' : 'number' }
 				{ ...omit( props, [ 'children' ] ) }
 				autoComplete={ autoComplete }
 				className={ classes }

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -2,10 +2,8 @@
  * External dependencies
  */
 import type {
-	FocusEventHandler,
 	KeyboardEvent,
 	ForwardedRef,
-	SyntheticEvent,
 	ChangeEvent,
 	PointerEvent,
 } from 'react';
@@ -23,7 +21,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../ui/context';
-import * as inputControlActionTypes from '../input-control/reducer/actions';
 import { Root, ValueInput } from './styles/unit-control-styles';
 import UnitSelectControl from './unit-select-control';
 import {
@@ -34,7 +31,6 @@ import {
 } from './utils';
 import { useControlledState } from '../utils/hooks';
 import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
-import type { StateReducer } from '../input-control/reducer/state';
 
 function UnforwardedUnitControl(
 	unitControlProps: WordPressComponentProps<
@@ -61,7 +57,6 @@ function UnforwardedUnitControl(
 		unit: unitProp,
 		units: unitsProp = CSS_UNITS,
 		value: valueProp,
-		onBlur: onBlurProp,
 		...props
 	} = unitControlProps;
 
@@ -77,10 +72,18 @@ function UnforwardedUnitControl(
 	// ensures it fallback to `undefined` in case a consumer of `UnitControl`
 	// still passes `null` as a `value`.
 	const nonNullValueProp = valueProp ?? undefined;
-	const units = useMemo(
-		() => getUnitsWithCurrentUnit( nonNullValueProp, unitProp, unitsProp ),
-		[ nonNullValueProp, unitProp, unitsProp ]
-	);
+	const [ units, reFirstCharacterOfUnits ] = useMemo( () => {
+		const list = getUnitsWithCurrentUnit(
+			nonNullValueProp,
+			unitProp,
+			unitsProp
+		);
+		const firstCharacters = list.reduce( ( carry, { value } ) => {
+			const first = value.substr( 0, 1 );
+			return carry.includes( first ) ? carry : `${ carry }|${ first }`;
+		}, list[ 0 ].value.substr( 0, 1 ) );
+		return [ list, new RegExp( `^(?:${ firstCharacters })$` ) ];
+	}, [ nonNullValueProp, unitProp, unitsProp ] );
 	const [ parsedQuantity, parsedUnit ] = getParsedQuantityAndUnit(
 		nonNullValueProp,
 		unitProp,
@@ -100,9 +103,6 @@ function UnforwardedUnitControl(
 			setUnit( parsedUnit );
 		}
 	}, [ parsedUnit ] );
-
-	// Stores parsed value for hand-off in state reducer.
-	const refParsedQuantity = useRef< number | undefined >( undefined );
 
 	const classes = classnames( 'components-unit-control', className );
 
@@ -155,90 +155,22 @@ function UnforwardedUnitControl(
 		setUnit( nextUnitValue );
 	};
 
-	const mayUpdateUnit = ( event: SyntheticEvent< HTMLInputElement > ) => {
-		if ( ! isNaN( Number( event.currentTarget.value ) ) ) {
-			refParsedQuantity.current = undefined;
-			return;
-		}
-		const [
-			validParsedQuantity,
-			validParsedUnit,
-		] = getValidParsedQuantityAndUnit(
-			event.currentTarget.value,
-			units,
-			parsedQuantity,
-			unit
-		);
-
-		refParsedQuantity.current = validParsedQuantity;
-
-		if ( isPressEnterToChange && validParsedUnit !== unit ) {
-			const data = Array.isArray( units )
-				? units.find( ( option ) => option.value === validParsedUnit )
-				: undefined;
-			const changeProps = { event, data };
-
-			onChangeProp?.(
-				`${ validParsedQuantity ?? '' }${ validParsedUnit }`,
-				changeProps
-			);
-			onUnitChange?.( validParsedUnit, changeProps );
-
-			setUnit( validParsedUnit );
-		}
-	};
-
-	const handleOnBlur: FocusEventHandler< HTMLInputElement > = ( event ) => {
-		mayUpdateUnit( event );
-		onBlurProp?.( event );
-	};
-
-	const handleOnKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {
-		const { key } = event;
-		if ( key === 'Enter' ) {
-			mayUpdateUnit( event );
-		}
-	};
-
-	/**
-	 * "Middleware" function that intercepts updates from InputControl.
-	 * This allows us to tap into actions to transform the (next) state for
-	 * InputControl.
-	 *
-	 * @param  state  State from InputControl
-	 * @param  action Action triggering state change
-	 * @return The updated state to apply to InputControl
-	 */
-	const unitControlStateReducer: StateReducer = ( state, action ) => {
-		const nextState = { ...state };
-
-		/*
-		 * On commits (when pressing ENTER and on blur if
-		 * isPressEnterToChange is true), if a parse has been performed
-		 * then use that result to update the state.
-		 */
-		if ( action.type === inputControlActionTypes.COMMIT ) {
-			if ( refParsedQuantity.current !== undefined ) {
-				nextState.value = (
-					refParsedQuantity.current ?? ''
-				).toString();
-				refParsedQuantity.current = undefined;
+	let handleOnKeyDown;
+	if ( ! disableUnits && isUnitSelectTabbable && units.length ) {
+		handleOnKeyDown = ( event: KeyboardEvent< HTMLInputElement > ) => {
+			props.onKeyDown?.( event );
+			// Does the key match the first character of any units?
+			if ( reFirstCharacterOfUnits.test( event.key ) ) {
+				// Moves focus to the UnitSelectControl.
+				refInputSuffix.current?.focus();
 			}
-		}
-
-		return nextState;
-	};
-
-	let stateReducer: StateReducer = unitControlStateReducer;
-	if ( stateReducerProp ) {
-		stateReducer = ( state, action ) => {
-			const baseState = unitControlStateReducer( state, action );
-			return stateReducerProp( baseState, action );
 		};
 	}
 
+	const refInputSuffix = useRef< HTMLSelectElement | null >( null );
 	const inputSuffix = ! disableUnits ? (
 		<UnitSelectControl
+			ref={ refInputSuffix }
 			aria-label={ __( 'Select unit' ) }
 			disabled={ disabled }
 			isUnitSelectTabbable={ isUnitSelectTabbable }
@@ -246,7 +178,7 @@ function UnforwardedUnitControl(
 			size={ size }
 			unit={ unit }
 			units={ units }
-			onBlur={ onBlurProp }
+			onBlur={ unitControlProps.onBlur }
 		/>
 	) : null;
 
@@ -265,7 +197,6 @@ function UnforwardedUnitControl(
 		<Root className="components-unit-control-wrapper" style={ style }>
 			<ValueInput
 				aria-label={ label }
-				type={ isPressEnterToChange ? 'text' : 'number' }
 				{ ...omit( props, [ 'children' ] ) }
 				autoComplete={ autoComplete }
 				className={ classes }
@@ -273,7 +204,6 @@ function UnforwardedUnitControl(
 				disableUnits={ disableUnits }
 				isPressEnterToChange={ isPressEnterToChange }
 				label={ label }
-				onBlur={ handleOnBlur }
 				onKeyDown={ handleOnKeyDown }
 				onChange={ handleOnQuantityChange }
 				ref={ forwardedRef }
@@ -281,7 +211,6 @@ function UnforwardedUnitControl(
 				suffix={ inputSuffix }
 				value={ parsedQuantity ?? '' }
 				step={ step }
-				__unstableStateReducer={ stateReducer }
 			/>
 		</Root>
 	);

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -81,7 +81,7 @@ function UnforwardedUnitControl(
 		const firstCharacters = list.reduce( ( carry, { value } ) => {
 			const first = value.substr( 0, 1 );
 			return carry.includes( first ) ? carry : `${ carry }|${ first }`;
-		}, list[ 0 ].value.substr( 0, 1 ) );
+		}, list[ 0 ]?.value.substr( 0, 1 ) );
 		return [ list, new RegExp( `^(?:${ firstCharacters })$` ) ];
 	}, [ nonNullValueProp, unitProp, unitsProp ] );
 	const [ parsedQuantity, parsedUnit ] = getParsedQuantityAndUnit(

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -82,7 +82,7 @@ function UnforwardedUnitControl(
 			const first = value.substr( 0, 1 );
 			return carry.includes( first ) ? carry : `${ carry }|${ first }`;
 		}, list[ 0 ]?.value.substr( 0, 1 ) );
-		return [ list, new RegExp( `^(?:${ firstCharacters })$` ) ];
+		return [ list, new RegExp( `^(?:${ firstCharacters })$`, 'i' ) ];
 	}, [ nonNullValueProp, unitProp, unitsProp ] );
 	const [ parsedQuantity, parsedUnit ] = getParsedQuantityAndUnit(
 		nonNullValueProp,

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -188,6 +188,7 @@ function UnforwardedUnitControl(
 			};
 
 			if ( quantityPasted ) {
+				const entry = `${ quantityPasted }`.replace( /^0*/, '' );
 				let {
 					value,
 					selectionStart: headIndex,
@@ -198,12 +199,12 @@ function UnforwardedUnitControl(
 				if ( headIndex !== tailIndex ) {
 					// Replaces selection with the pasted quantity.
 					const selected = value.substring( headIndex, tailIndex );
-					value = value.replace( selected, `${ quantityPasted }` );
+					value = value.replace( selected, `${ entry }` );
 				} else {
 					// Inserts the pasted quantity at caret.
 					const head = value.substring( 0, headIndex );
 					const tail = value.substring( headIndex, value.length );
-					value = `${ head }${ quantityPasted }${ tail }`;
+					value = `${ head }${ entry }${ tail }`;
 				}
 				onChangeProp?.( `${ value }${ unitPasted }`, changeProps );
 			}

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -408,7 +408,7 @@ describe( 'UnitControl', () => {
 		it( 'should update unit value when a new raw value is passed', async () => {
 			const { user } = render( <ControlledSyncUnits /> );
 
-			const [ inputA, inputB ] = screen.getAllByRole( 'spinbutton' );
+			const [ inputA, inputB ] = screen.getAllByRole( 'textbox' );
 			const [ selectA, selectB ] = screen.getAllByRole( 'combobox' );
 
 			const [ remOptionA ] = screen.getAllByRole( 'option', {

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -215,7 +215,7 @@ describe( 'UnitControl', () => {
 			expect( input.value ).toBe( '300' );
 			expect( state ).toBe( 50 );
 
-			user.keyboard( '{Escape}' );
+			await user.keyboard( '{Escape}' );
 
 			expect( input.value ).toBe( '50' );
 			expect( state ).toBe( 50 );

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -526,8 +526,8 @@ describe( 'UnitControl', () => {
 		} );
 	} );
 
-	describe( 'Unit switching convenience', () => {
-		it( 'should focus unit select when a charater matches the first of one of the units', async () => {
+	describe( 'Unit switching by typed or pasted input', () => {
+		it( 'should focus unit select when a character matches the first of one of the units', async () => {
 			const { user } = render( <UnitControl value={ '10%' } /> );
 
 			const input = getInput();
@@ -535,6 +535,25 @@ describe( 'UnitControl', () => {
 			await user.type( input, '55 e' );
 
 			expect( document.activeElement ).toBe( getSelect() );
+		} );
+
+		it( 'should update the unit when a pasted value contains a valid unit', async () => {
+			const { user } = render( <UnitControl /> );
+
+			await user.click( getInput() );
+			await user.paste( '1rem' );
+
+			expect( getSelect().value ).toBe( 'rem' );
+		} );
+
+		it( 'should forward the paste event', async () => {
+			const spyPaste = jest.fn();
+			const { user } = render( <UnitControl onPaste={ spyPaste } /> );
+
+			await user.click( getInput() );
+			await user.paste( '1rem' );
+
+			expect( spyPaste ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/packages/components/src/unit-control/unit-select-control.tsx
+++ b/packages/components/src/unit-control/unit-select-control.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ForwardedRef } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -12,15 +17,18 @@ import { UnitSelect, UnitLabel } from './styles/unit-control-styles';
 import { CSS_UNITS, hasUnits } from './utils';
 import type { UnitSelectControlProps } from './types';
 
-export default function UnitSelectControl( {
-	className,
-	isUnitSelectTabbable: isTabbable = true,
-	onChange,
-	size = 'default',
-	unit = 'px',
-	units = CSS_UNITS,
-	...props
-}: WordPressComponentProps< UnitSelectControlProps, 'select', false > ) {
+function UnitSelectControl(
+	{
+		className,
+		isUnitSelectTabbable: isTabbable = true,
+		onChange,
+		size = 'default',
+		unit = 'px',
+		units = CSS_UNITS,
+		...props
+	}: WordPressComponentProps< UnitSelectControlProps, 'select', false >,
+	ref: ForwardedRef< any >
+) {
 	if ( ! hasUnits( units ) || units?.length === 1 ) {
 		return (
 			<UnitLabel
@@ -43,6 +51,7 @@ export default function UnitSelectControl( {
 
 	return (
 		<UnitSelect
+			ref={ ref }
 			className={ classes }
 			onChange={ handleOnChange }
 			selectSize={ size }
@@ -58,3 +67,4 @@ export default function UnitSelectControl( {
 		</UnitSelect>
 	);
 }
+export default forwardRef( UnitSelectControl );


### PR DESCRIPTION
Drafted because ~~some tests need fixed and~~ we probably want to add new tests to cover the paste handling.

## What?
Enables changing the unit of `UnitControl` by pasting a string with units into its text input. In trunk it's already possible if `isPressEnterToChange` is `true` and this PR enables it regardless of that prop. Builds on #39303.

## Why?
In #39303, the proposed revamp of a convenience feature had the undesired effect of removing the ability to change the unit by pasting. This restores it.

## How?
Adds an `onPaste` handler to the text input that parses the pasted string and handles updating the quantity and unit if a valid unit was contained in the pasted string.

## Testing Instructions
1. Open a Post or Page.
2. Insert a group block.
3. Tab to or click the field labeled Padding in the block’s settings.
5. Paste a value with a unit such as `3%`, `2vw`, `1rem`.
6. Verify that the quantity and value are updated.
7. With an existing value in the input.
8. Put the caret at either the start or end of the input.
9. Paste a value with a unit.
10. Verify that the new quantity is inserted at the caret and the unit select updates.
11. Enter a multiple character value like `111` in the input.
12. Select a portion of the input.
13. Paste a value with a unit.
14. Verify that the new quantity replaces the selection and the unit select updates.

## Screenshots or screencast <!-- if applicable -->
TBD