### PR TITLE
Turn the wrap to multiple lines option off by default on the row block

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -15,7 +15,7 @@ import { store as blockEditorStore } from '../../store';
 
 const layouts = {
 	group: undefined,
-	row: { type: 'flex' },
+	row: { type: 'flex', flexWrap: 'nowrap' },
 	stack: { type: 'flex', orientation: 'vertical' },
 };
 

--- a/packages/block-library/src/group/variations.js
+++ b/packages/block-library/src/group/variations.js
@@ -19,7 +19,7 @@ const variations = [
 		name: 'group-row',
 		title: __( 'Row' ),
 		description: __( 'Blocks shown in a row.' ),
-		attributes: { layout: { type: 'flex' } },
+		attributes: { layout: { type: 'flex', flexWrap: 'nowrap' } },
 		scope: [ 'inserter', 'transform' ],
 		isActive: ( blockAttributes ) =>
 			blockAttributes.layout?.type === 'flex' &&


### PR DESCRIPTION
## What?
Fixes #39651

Turns the 'Allow wrap to multiple lines' option off by default for newly added Row blocks.

## Why?
As mentioned in the issue, this setting is unexpected for the row block.

## How?
Adds the `flexWrap: 'nowrap'` to the Row variation attributes.

Doing it this way means it won't affect other blocks that use the flex layout where wrapping by default makes sense. It also won't change existing content that uses the row block.

## Testing Instructions
1. Add a row block
2. Observe the 'Allow wrap to multiple lines' option is switched off

## Screenshots or screencast <!-- if applicable -->
### Before
![Screen Shot 2022-04-08 at 9 32 50 am](https://user-images.githubusercontent.com/677833/162345755-c0e2cec6-4548-47b0-8a35-89c3f5b31345.png)

### After
![Screen Shot 2022-04-08 at 9 32 19 am](https://user-images.githubusercontent.com/677833/162345768-2407b8fd-61c6-4b27-b61e-a312aa47fbe3.png)

