### PR TITLE
List View: Only show ellipsis on first selected item or when focused

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -56,6 +56,11 @@ function ListViewBlock( {
 	const cellRef = useRef( null );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const { clientId } = block;
+	const isFirstSelectedBlock =
+		isSelected && selectedClientIds[ 0 ] === clientId;
+	const isLastSelectedBlock =
+		isSelected &&
+		selectedClientIds[ selectedClientIds.length - 1 ] === clientId;
 
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
@@ -102,7 +107,7 @@ function ListViewBlock( {
 
 	const listViewBlockSettingsClassName = classnames(
 		'block-editor-list-view-block__menu-cell',
-		{ 'is-visible': isHovered || isSelected }
+		{ 'is-visible': isHovered || isFirstSelectedBlock }
 	);
 
 	// If ListView has experimental features related to the Persistent List View,
@@ -177,6 +182,8 @@ function ListViewBlock( {
 
 	const classes = classnames( {
 		'is-selected': isSelected,
+		'is-first-selected': isFirstSelectedBlock,
+		'is-last-selected': isLastSelectedBlock,
 		'is-branch-selected':
 			withExperimentalPersistentListViewFeatures && isBranchSelected,
 		'is-dragging': isDragged,

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -46,11 +46,17 @@
 	}
 
 	// Border radius for corners of the selected item.
-	&.is-selected td:first-child {
-		border-radius: $radius-block-ui 0 0 $radius-block-ui;
+	&.is-first-selected td:first-child {
+		border-top-left-radius: $radius-block-ui;
 	}
-	&.is-selected td:last-child {
-		border-radius: 0 $radius-block-ui $radius-block-ui 0;
+	&.is-first-selected td:last-child {
+		border-top-right-radius: $radius-block-ui;
+	}
+	&.is-last-selected td:first-child {
+		border-bottom-left-radius: $radius-block-ui;
+	}
+	&.is-last-selected td:last-child {
+		border-bottom-right-radius: $radius-block-ui;
 	}
 	&.is-branch-selected:not(.is-selected) {
 		// Lighten a CSS variable without introducing a new SASS variable
@@ -58,18 +64,24 @@
 			linear-gradient(transparentize($white, 0.1), transparentize($white, 0.1)),
 			linear-gradient(var(--wp-admin-theme-color), var(--wp-admin-theme-color));
 	}
-	&.is-branch-selected.is-selected td:first-child {
-		border-radius: $radius-block-ui 0 0 0;
+	&.is-branch-selected.is-first-selected td:first-child {
+		border-top-left-radius: $radius-block-ui;
 	}
-	&.is-branch-selected.is-selected td:last-child {
-		border-radius: 0 $radius-block-ui 0 0;
+	&.is-branch-selected.is-first-selected td:last-child {
+		border-top-right-radius: $radius-block-ui;
 	}
 	&[aria-expanded="false"] {
-		&.is-branch-selected.is-selected td:first-child {
-			border-radius: $radius-block-ui 0 0 $radius-block-ui;
+		&.is-branch-selected.is-first-selected td:first-child {
+			border-top-left-radius: $radius-block-ui;
 		}
-		&.is-branch-selected.is-selected td:last-child {
-			border-radius: 0 $radius-block-ui $radius-block-ui 0;
+		&.is-branch-selected.is-first-selected td:last-child {
+			border-top-right-radius: $radius-block-ui;
+		}
+		&.is-branch-selected.is-last-selected td:first-child {
+			border-bottom-left-radius: $radius-block-ui;
+		}
+		&.is-branch-selected.is-last-selected td:last-child {
+			border-bottom-right-radius: $radius-block-ui;
 		}
 	}
 	&.is-branch-selected:not(.is-selected) td {
@@ -167,17 +179,23 @@
 	.block-editor-list-view-block__mover-cell {
 		line-height: 0;
 		width: $button-size;
-		opacity: 0;
 		vertical-align: middle;
 		@include reduce-motion("transition");
+
+		> * {
+			opacity: 0;
+		}
 
 		// Show on hover, visible, and show above to keep the hit area size.
 		&:hover,
 		&.is-visible {
 			position: relative;
 			z-index: 1;
-			opacity: 1;
-			@include edit-post__fade-in-animation;
+
+			> * {
+				opacity: 1;
+				@include edit-post__fade-in-animation;
+			}
 		}
 
 		&,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #40066

## What?
<!-- In a few words, what is the PR actually doing? -->

In the List View component, only show the icon for the ellipsis / settings menu on the first selected item in a multi selection, to reduce clutter in the interface. So that the settings are still accessible for any other selected item, the icon is revealed when an item is hovered or focused.

This PR also tweaks the border radii so that only the first and last selected items have rounded borders, so that the selection looks a bit more like a single selected unit.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #40066, when many items are selected in the List View, the settings icon appearing on every row makes the interface look a little cluttered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the `ListViewBlock` component, check if the current block is the first or last selected.
* Update the visibility of the settings menu to check whether it's the first selected block, instead of just whether or not it's selected.
* To fix the border radii issues reported by @jasmussen for multiple selected blocks, this PR also introduces two additional classnames `is-first-selected` and `is-last-selected` so that the border radii is set correctly on only the first and last selected blocks. If there is only one selected block, it will receive both of these class names, so the border radii should still be correct.
* The opacity of the settings menu is shifted to be on the children of the cell it appears in, instead of on the cell itself, so that the background color is not hidden in addition to the settings menu button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add many blocks (and some nested ones) to a post or page
2. Open up the list view and shift-select multiple blocks
3. Observe that the ellipsis menu is only visible on the first block in the selection
4. Tab through the list view and when a selected item is focused, it should also display the settings icon
5. When hovering via the mouse, it should also display the icon
6. Check that the branch / expanded / collapsed rendering still works correctly for nested blocks

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/162358332-6566a393-8593-43a5-bb8d-b72722fa20da.png) | ![image](https://user-images.githubusercontent.com/14988353/162358350-a71b4bf5-9fa0-4908-97e1-66843873c200.png) |

Screen grab:

![multi-select-and-ellipsis-menu](https://user-images.githubusercontent.com/14988353/162358162-b1de494e-4669-4343-be89-cdb3bbce0682.gif)

