### PR TITLE
Update post content placeholder

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -85,7 +85,23 @@ function Placeholder() {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<p>{ __( 'Post Content' ) }</p>
+			<p>{ __( 'Welcome to WordPress!' ) }</p>
+			<p>{ __( 'This is a placeholder for your content.' ) }</p>
+			<p>
+				{ __(
+					'In the WordPress editor, each paragraph, image, or video is presented as a distinct “block” of content. When you view your site, this block displays the content of the post or page that you have assigned.'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Each block has controls for changing things like color, width, and alignment. These controls will show and hide automatically when you have a block selected.'
+				) }
+			</p>
+			<p>
+				{ __(
+					'Experience the flexibility that blocks bring, whether you are building your first site, or write code for a living. Start writing!'
+				) }
+			</p>
 		</div>
 	);
 }

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -85,21 +85,19 @@ function Placeholder() {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<p>{ __( 'Welcome to WordPress!' ) }</p>
-			<p>{ __( 'This is a placeholder for your content.' ) }</p>
 			<p>
 				{ __(
-					'In the WordPress editor, each paragraph, image, or video is presented as a distinct “block” of content. When you view your site, this block displays the content of the post or page that you have assigned.'
+					'This is the Post Content block, it will display all the blocks in any single post or page.'
 				) }
 			</p>
 			<p>
 				{ __(
-					'Each block has controls for changing things like color, width, and alignment. These controls will show and hide automatically when you have a block selected.'
+					'That might be a simple arrangement like consecutive paragraphs in a blog post, or a more elaborate composition that includes image galleries, videos, tables, columns, and any other block types.'
 				) }
 			</p>
 			<p>
 				{ __(
-					'Experience the flexibility that blocks bring, whether you are building your first site, or write code for a living. Start writing!'
+					'If there are any Custom Post Types registered at your site, the Post Content block can display the contents of those entries as well.'
 				) }
 			</p>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a longer text as the post content placeholder.
Partial for https://github.com/WordPress/gutenberg/issues/40074

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current post content placeholder does not look like real content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a longer text as the post content placeholder in edit.js.

## Testing Instructions

1. Activate a full site editing theme
2. In the Site Editor, open or create a template for a single post or page, that has a post content block
3. Confirm that the new placeholder content displays correctly.

## Screenshots or screencast <!-- if applicable -->

Before:

![the site editor with the text "Post Content" representing the content](https://user-images.githubusercontent.com/7422055/162377154-1434ed26-0676-4199-b1a0-5900bb3d7cbf.png)


After:

![the site editor with the new placeholder content visible](https://user-images.githubusercontent.com/7422055/162376534-05c82d66-2cc8-4508-b32f-30726f27c9b8.png)
