### PR TITLE
Update the placeholder for post excerpt

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -59,9 +59,16 @@ export default function PostExcerptEditor( {
 	if ( ! postType || ! postId ) {
 		return (
 			<div { ...blockProps }>
-				{ __(
-					'Welcome to WordPress! This is a placeholder for your excerpt. In the WordPress editor, each paragraph, image, or video is presented as a distinct “block” of content. When you view your site, this block displays the excerpt of the post or page that you have assigned.'
-				) }
+				<p>
+					{ __(
+						'This is the Post Excerpt block, it will display the excerpt from single posts.'
+					) }
+				</p>
+				<p>
+					{ __(
+						'If there are any Custom Post Types with support for excerpts, the Post Excerpt block can display the excerpts of those entries as well.'
+					) }
+				</p>
 			</div>
 		);
 	}

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -57,7 +57,13 @@ export default function PostExcerptEditor( {
 		return document.body.textContent || document.body.innerText || '';
 	}, [ renderedExcerpt ] );
 	if ( ! postType || ! postId ) {
-		return <div { ...blockProps }>{ __( 'Post Excerpt' ) }</div>;
+		return (
+			<div { ...blockProps }>
+				{ __(
+					'Welcome to WordPress! This is a placeholder for your excerpt. In the WordPress editor, each paragraph, image, or video is presented as a distinct “block” of content. When you view your site, this block displays the excerpt of the post or page that you have assigned.'
+				) }
+			</div>
+		);
 	}
 	if ( isProtected && ! userCanEdit ) {
 		return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a longer post excerpt placeholder
For https://github.com/WordPress/gutenberg/issues/40074

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The current placeholder does not look like an excerpt.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

1. Activate a full site editing theme
2. In the Site Editor, open or create a template and place a post excerpt outside a query. (Or open the single post and replace content with excerpt)
3. Confirm that the new placeholder content displays correctly.

## Screenshots or screencast <!-- if applicable -->
