### PR TITLE
Fixed the issue of extra padding of the heading

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -103,7 +103,6 @@ $block-padding: 14px; // Used to define space between block footprint and surrou
 $block-bg-padding--v: 1.25rem;
 $block-bg-padding--h: 2.375rem;
 
-
 /**
  * React Native specific.
  * These variables do not appear to be used anywhere else.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -100,9 +100,8 @@ $block-padding: 14px; // Used to define space between block footprint and surrou
  */
 
 // Padding for blocks with a background color (e.g. paragraph or group).
-$block-bg-padding--v: 1.25rem;
-$block-bg-padding--h: 2.375rem;
-
+$block-bg-padding--v: 0.5em;
+$block-bg-padding--h: 1em;
 
 /**
  * React Native specific.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -100,8 +100,9 @@ $block-padding: 14px; // Used to define space between block footprint and surrou
  */
 
 // Padding for blocks with a background color (e.g. paragraph or group).
-$block-bg-padding--v: 0.5em;
-$block-bg-padding--h: 1em;
+$block-bg-padding--v: 1.25rem;
+$block-bg-padding--h: 2.375rem;
+
 
 /**
  * React Native specific.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -100,8 +100,8 @@ $block-padding: 14px; // Used to define space between block footprint and surrou
  */
 
 // Padding for blocks with a background color (e.g. paragraph or group).
-$block-bg-padding--v: 1.25em;
-$block-bg-padding--h: 2.375em;
+$block-bg-padding--v: 1.25rem;
+$block-bg-padding--h: 2.375rem;
 
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixed the extra padding that was added in the heading block H1 tag.

## Why?
When we used the H1 tag in the heading block and added the background color of this H1 tag, the design was getting spoiled due to too much extra padding. We have solved that issue in this PR.

## Testing Instructions

1. Go to the editor.
2. Add a heading block.
3. Select the H1 tag for the heading.
4. Click on accordion color from the setting sidebar.
5. Choose any background color.

## Screenshots or screencast 

After creating PR the issue is solved.

![image](https://user-images.githubusercontent.com/72435501/162392858-6b5b0cee-8bab-44f0-bac2-4236d6f36dcd.png)


## Environment info
WordPress Version:- 5.9.3
WordPress Theme :- Twenty Twenty-Two /  Twenty Twenty-One
Browser: Google Chrome 100.0.4896.75 (Official Build) (arm64)
OS Version: Mac 12.2.1
