### PR TITLE
Disable vertical alignment controls for navigation and social links

### DIFF
--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -111,6 +111,7 @@
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
+			"allowVerticalAlignment": false,
 			"default": {
 				"type": "flex"
 			}

--- a/packages/block-library/src/social-links/block.json
+++ b/packages/block-library/src/social-links/block.json
@@ -51,6 +51,7 @@
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,
+			"allowVerticalAlignment": false,
 			"default": {
 				"type": "flex"
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Disable vertical alignment controls for navigation and social links.
Follow up to https://github.com/WordPress/gutenberg/pull/40013

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Social links: The icons are all the same size, so the vertical alignment does nothing.
Navigation: Disabling it gives us time to make it work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By setting allowVerticalAlignment to false in block.json

## Testing Instructions

1. Add a copy of each block.
2. Confirm that the vertical alignment settings are not available in the block toolbar.

## Screenshots or screencast <!-- if applicable -->
