### PR TITLE
Embed block: use preview html for flickr embed previews in editor

### DIFF
--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -66,7 +66,7 @@ export const isFromWordPress = ( html ) =>
 	html && html.includes( 'class="wp-embedded-content"' );
 
 export const getPhotoHtml = ( photo ) => {
-	// If full image url not found use thumbnail_url: https://github.com/WordPress/gutenberg/pull/40187
+	// If full image url not found use thumbnail.
 	const imageUrl = photo.url || photo.thumbnail_url;
 
 	// 100% width for the preview so it fits nicely into the document, some "thumbnails" are

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -66,9 +66,11 @@ export const isFromWordPress = ( html ) =>
 	html && html.includes( 'class="wp-embedded-content"' );
 
 export const getPhotoHtml = ( photo ) => {
+	// If full image url not found use thumbnail_url: https://github.com/WordPress/gutenberg/pull/40187
+	const imageUrl = photo.url || photo.thumbnail_url;
+
 	// 100% width for the preview so it fits nicely into the document, some "thumbnails" are
-	// actually the full size photo. If thumbnails not found, use full image.
-	const imageUrl = photo.thumbnail_url || photo.url;
+	// actually the full size photo.
 	const photoPreview = (
 		<p>
 			<img src={ imageUrl } alt={ photo.title } width="100%" />


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
This commit is fixing an issue where flickr embeds are displayed with low quality images in the block editor.

The issue was reported [here](https://github.com/WordPress/gutenberg/issues/11962).

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The issue was that thumbnail image (low resolution image) was used for flickr's embed previews. On top of that the preview was stretched to 100% width of the parent element, which most of the time meant more than width of the preview's thumbnail image. This resulted in flickr embed previews appear "pixelated" in the editor. 
Flickr oEmbed previews returned by their oEmbed API are marked as 'photo' types. According to our source code we prefer to use the thumbnail url, over preview's html when embed's type is 'photo'.
![Screenshot 2022-04-08 at 14 25 48](https://user-images.githubusercontent.com/2019970/162435304-bb78b88e-8060-4c4b-a1f5-5eb6d3e479a5.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I fixed this by introducing new block attribute of 'preferHtml' which, when set to `true`, forces the use of preview's html even when an embed is of 'photo' type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open Post or Page editor.
2. Copy any flickr share url of your liking, e.g. `https://flic.kr/p/oj7o7q`
3. Paste it into your block editor.
4. After the fix the preview should not appear to be a "pixelated" image, it should look the same way as when you preview the page with the embed in it.

## Screenshots or screencast <!-- if applicable -->

#### Before fix
![flickr-before-fix](https://user-images.githubusercontent.com/2019970/162438298-7d29dc2d-7a53-4068-aa7e-917140491126.gif)

#### After fix
![flickr-after-fix](https://user-images.githubusercontent.com/2019970/162438330-a411acc1-976d-4a06-bbf9-57fe820dd3ed.gif)
