### PR TITLE
Add the missing class-wp-style-engine-gutenberg.php in the plugin build

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -86,7 +86,7 @@ build_files=$(
 	build/edit-widgets/blocks/*/block.json \
 	build/widgets/blocks/*.php \
 	build/widgets/blocks/*/block.json \
-	build/style-engine/class-wp-style-engine-gutenberg.php \
+	build/style-engine/*.php \
 )
 
 

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -86,6 +86,7 @@ build_files=$(
 	build/edit-widgets/blocks/*/block.json \
 	build/widgets/blocks/*.php \
 	build/widgets/blocks/*/block.json \
+	build/style-engine/class-wp-style-engine-gutenberg.php \
 )
 
 


### PR DESCRIPTION
## What?
Updates plugin ZIP creation to include the missing `class-wp-style-engine-gutenberg.php` files.

Fixes the [Gutenberg 13.0.0 RC1](https://github.com/WordPress/gutenberg/releases/tag/v13.0.0-rc.1) that lacks this file and causes the following error:

```
Fatal error: Uncaught Error: Class 'WP_Style_Engine_Gutenberg' not found in wp-content/plugins/gutenberg/lib/block-supports/spacing.php:55 
```

Related PRs:

* https://github.com/WordPress/gutenberg/pull/39446
* https://github.com/WordPress/gutenberg/pull/39736

cc @ramonjd @andrewserong @Mamaduka who worked on the original PRs
