### PR TITLE
DOM: Allow copying text from non-text input elements

### DIFF
--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -57,9 +57,9 @@ _Returns_
 
 ### documentHasUncollapsedSelection
 
-Check whether the current document has any sort of selection. This includes
-ranges of text across elements and any selection inside `<input>` and
-`<textarea>` elements.
+Check whether the current document has any sort of (uncollapsed) selection.
+This includes ranges of text across elements and any selection inside
+textual `<input>` and `<textarea>` elements.
 
 _Parameters_
 
@@ -67,7 +67,7 @@ _Parameters_
 
 _Returns_
 
--   `boolean`: Whether there is any sort of "selection" in the document.
+-   `boolean`: Whether there is any recognizable text selection in the document.
 
 ### focus
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -28,8 +28,8 @@ _Returns_
 
 ### documentHasSelection
 
-Check whether the current document has a selection. This checks for both
-focus in an input field and general text selection.
+Check whether the current document has a selection. This includes focus in
+input fields, textareas, and general rich-text selection.
 
 _Parameters_
 

--- a/packages/dom/src/dom/document-has-selection.js
+++ b/packages/dom/src/dom/document-has-selection.js
@@ -2,12 +2,12 @@
  * Internal dependencies
  */
 import isTextField from './is-text-field';
-import isNumberInput from './is-number-input';
+import isHTMLInputElement from './is-html-input-element';
 import documentHasTextSelection from './document-has-text-selection';
 
 /**
- * Check whether the current document has a selection. This checks for both
- * focus in an input field and general text selection.
+ * Check whether the current document has a selection. This includes focus in
+ * input fields, textareas, and general rich-text selection.
  *
  * @param {Document} doc The document to check.
  *
@@ -16,8 +16,8 @@ import documentHasTextSelection from './document-has-text-selection';
 export default function documentHasSelection( doc ) {
 	return (
 		!! doc.activeElement &&
-		( isTextField( doc.activeElement ) ||
-			isNumberInput( doc.activeElement ) ||
+		( isHTMLInputElement( doc.activeElement ) ||
+			isTextField( doc.activeElement ) ||
 			documentHasTextSelection( doc ) )
 	);
 }

--- a/packages/dom/src/dom/document-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/document-has-uncollapsed-selection.js
@@ -5,13 +5,13 @@ import documentHasTextSelection from './document-has-text-selection';
 import inputFieldHasUncollapsedSelection from './input-field-has-uncollapsed-selection';
 
 /**
- * Check whether the current document has any sort of selection. This includes
- * ranges of text across elements and any selection inside `<input>` and
- * `<textarea>` elements.
+ * Check whether the current document has any sort of (uncollapsed) selection.
+ * This includes ranges of text across elements and any selection inside
+ * textual `<input>` and `<textarea>` elements.
  *
  * @param {Document} doc The document to check.
  *
- * @return {boolean} Whether there is any sort of "selection" in the document.
+ * @return {boolean} Whether there is any recognizable text selection in the document.
  */
 export default function documentHasUncollapsedSelection( doc ) {
 	return (

--- a/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import isTextField from './is-text-field';
-import isNumberInput from './is-number-input';
+import isHTMLInputElement from './is-html-input-element';
 
 /**
  * Check whether the given element, assumed an input field or textarea,
@@ -18,9 +18,25 @@ import isNumberInput from './is-number-input';
  * @return {boolean} Whether the input/textareaa element has some "selection".
  */
 export default function inputFieldHasUncollapsedSelection( element ) {
-	if ( ! isTextField( element ) && ! isNumberInput( element ) ) {
+	if ( ! isTextField( element ) && ! isHTMLInputElement( element ) ) {
 		return false;
 	}
+
+	// Unfortunately, the HTML spec states that the `selectionStart` and
+	// `selectionEnd` attributes of `input` elements DO NOT APPLY to most
+	// non-text input types. This effectively means that we cannot inspect the
+	// selection state of numeric inputs, even email inputs, etc.
+	//
+	// The trade-off that this function makes is to assume that any such opaque
+	// element always has an uncollapsed selection. This should cause the block
+	// editor to defer to the browser's native selection handling (e.g. copying
+	// and pasting), thereby reducing friction for the user.
+	//
+	// See: https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+	if ( ! isTextField( element ) ) {
+		return true;
+	}
+
 	try {
 		const {
 			selectionStart,

--- a/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
+++ b/packages/dom/src/dom/input-field-has-uncollapsed-selection.js
@@ -5,54 +5,46 @@ import isTextField from './is-text-field';
 import isHTMLInputElement from './is-html-input-element';
 
 /**
- * Check whether the given element, assumed an input field or textarea,
- * contains a (uncollapsed) selection of text.
+ * Check whether the given input field or textarea contains a (uncollapsed)
+ * selection of text.
  *
- * Note: this is perhaps an abuse of the term "selection", since these elements
- * manage selection differently and aren't covered by Selection#collapsed.
+ * CAVEAT: Only specific text-based HTML inputs support the selection APIs
+ * needed to determine whether they have a collapsed or uncollapsed selection.
+ * This function defaults to returning `true` when the selection cannot be
+ * inspected, such as with `<input type="time">`. The rationale is that this
+ * should cause the block editor to defer to the browser's native selection
+ * handling (e.g. copying and pasting), thereby reducing friction for the user.
  *
- * See: https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#Related_objects.
+ * See: https://html.spec.whatwg.org/multipage/input.html#do-not-apply
  *
  * @param {Element} element The HTML element.
  *
  * @return {boolean} Whether the input/textareaa element has some "selection".
  */
 export default function inputFieldHasUncollapsedSelection( element ) {
-	if ( ! isTextField( element ) && ! isHTMLInputElement( element ) ) {
+	if ( ! isHTMLInputElement( element ) && ! isTextField( element ) ) {
 		return false;
 	}
 
-	// Unfortunately, the HTML spec states that the `selectionStart` and
-	// `selectionEnd` attributes of `input` elements DO NOT APPLY to most
-	// non-text input types. This effectively means that we cannot inspect the
-	// selection state of numeric inputs, even email inputs, etc.
-	//
-	// The trade-off that this function makes is to assume that any such opaque
-	// element always has an uncollapsed selection. This should cause the block
-	// editor to defer to the browser's native selection handling (e.g. copying
-	// and pasting), thereby reducing friction for the user.
-	//
-	// See: https://html.spec.whatwg.org/multipage/input.html#do-not-apply
-	if ( ! isTextField( element ) ) {
-		return true;
-	}
-
+	// Safari throws a type error when trying to get `selectionStart` and
+	// `selectionEnd` on non-text <input> elements, so a try/catch construct is
+	// necessary.
 	try {
 		const {
 			selectionStart,
 			selectionEnd,
 		} = /** @type {HTMLInputElement | HTMLTextAreaElement} */ ( element );
-
-		return selectionStart !== null && selectionStart !== selectionEnd;
+		return (
+			// `null` means the input type doesn't implement selection, thus we
+			// cannot determine whether the selection is collapsed, so we
+			// default to true.
+			selectionStart === null ||
+			// when not null, compare the two points
+			selectionStart !== selectionEnd
+		);
 	} catch ( error ) {
-		// Safari throws an exception when trying to get `selectionStart`
-		// on non-text <input> elements (which, understandably, don't
-		// have the text selection API). We catch this via a try/catch
-		// block, as opposed to a more explicit check of the element's
-		// input types, because of Safari's non-standard behavior. This
-		// also means we don't have to worry about the list of input
-		// types that support `selectionStart` changing as the HTML spec
-		// evolves over time.
-		return false;
+		// This is Safari's way of saying that the input type doesn't implement
+		// selection, so we default to true.
+		return true;
 	}
 }

--- a/packages/dom/src/dom/is-html-input-element.js
+++ b/packages/dom/src/dom/is-html-input-element.js
@@ -5,5 +5,5 @@
  */
 export default function isHTMLInputElement( node ) {
 	/* eslint-enable jsdoc/valid-types */
-	return !! node && node.nodeName === 'INPUT';
+	return node?.nodeName === 'INPUT';
 }

--- a/packages/dom/src/dom/is-text-field.js
+++ b/packages/dom/src/dom/is-text-field.js
@@ -27,6 +27,7 @@ export default function isTextField( node ) {
 		'submit',
 		'number',
 		'email',
+		'time',
 	];
 	return (
 		( isHTMLInputElement( node ) &&

--- a/packages/dom/src/dom/is-text-field.js
+++ b/packages/dom/src/dom/is-text-field.js
@@ -26,6 +26,7 @@ export default function isTextField( node ) {
 		'reset',
 		'submit',
 		'number',
+		'email',
 	];
 	return (
 		( isHTMLInputElement( node ) &&

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -125,6 +125,8 @@ describe( 'DOM', () => {
 			'range',
 			'reset',
 			'submit',
+			'email',
+			'time',
 		];
 
 		/**
@@ -132,13 +134,7 @@ describe( 'DOM', () => {
 		 *
 		 * @type {string[]}
 		 */
-		const TEXT_INPUT_TYPES = [
-			'text',
-			'password',
-			'search',
-			'url',
-			'email',
-		];
+		const TEXT_INPUT_TYPES = [ 'text', 'password', 'search', 'url' ];
 
 		it( 'should return false for non-text input elements', () => {
 			NON_TEXT_INPUT_TYPES.forEach( ( type ) => {


### PR DESCRIPTION
## What?

Fixes #32148.

This pull request guarantees that a user is able to copy the contents of any `<input>` elements inside blocks using their browser's native actions (<kbd>Ctrl-C</kbd>, <kbd>Command-C</kbd>).

<img width="383" alt="Captura de ecrã 2022-04-08, às 16 10 29" src="https://user-images.githubusercontent.com/150562/162473526-0ed9fff9-351a-44b4-ab27-9f619ecf7cab.png">

## Why?

This pull request fixes a bug in which certain types of input were not copiable — specifically, any "non-text" input, such as `number` or even `email`. Typically, when this bug occurred, the block editor would ignore the browser's native copying behaviour, thus resulting in the copying of the entire block — instead of just the selected content in the input element.

## How?

The selection state of non-text input elements is opaque to Gutenberg, [per the HTML spec](https://html.spec.whatwg.org/multipage/input.html#do-not-apply). Unaware of this
nuance, `inputFieldHasUncollapsedSelection( element )` would incorrectly report that some non-text input element had no text selected when in fact it did. This caused the block editor to take over `copy` events to copy whole blocks, preventing the user from copying what they had actually selected inside the input element in question.

**The trade-off in this commit** is to always assume that there could be an uncollapsed selection in an active element if that element's selection state is opaque.

### Caveat

The trade-off means that, if the user places the caret inside a non-text input element but has no text selected (according to the jargon, this means that the selection is _collapsed_), then pressing the copy shortcut will no longer let the block editor copy the whole block. Text inputs (`input="text"` or `"url"`) and rich-text elements should not be affected by this.

## Testing Instructions

For specifics, see instructions in #32148.

- **Fixed:** Ensure that the contents of non-text inputs can be copied using the native keyboard shortcut. Try this using `<TextControl type="number"` inside a block, as well as `type="email"`, `type="time"`.
- **Unchanged:** Ensure that the contents of text inputs can be copied using the native keyboard shortcut. Try this using `<TextControl type="text"` inside a block, as well as `type="url"`.
- **Unchanged:** Ensure that an entire block can be copied with the native keyboard shortcut when the caret is placed inside a text input with no selection.
- **Unchanged:** Ensure that copying is otherwise unaffected: the copying of rich-text content, of whole blocks, of multiple blocks, etc.

<details>
<summary><strong>Attached:</strong> The diff I applied to the Paragraph block for my own testing</summary>
<pre><code>diff --git a/packages/block-library/src/paragraph/edit.js b/packages/block-library/src/paragraph/edit.js
index c6a2988a3d..8795d868f8 100644
--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -7,10 +7,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __, _x, isRTL } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 import {
 	ToolbarDropdownMenu,
 	ToggleControl,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	TextControl,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -56,6 +58,11 @@ function ParagraphBlock( {
 } ) {
 	const { align, content, direction, dropCap, placeholder } = attributes;
 	const isDropCapFeatureEnabled = useSetting( 'typography.dropCap' );
+
+	const [ fooText, setFooText ] = useState( 'hello' );
+	const [ fooEmail, setFooEmail ] = useState( 'foo@foo.bar' );
+	const [ fooNumber, setFooNumber ] = useState( 42 );
+
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			'has-drop-cap': dropCap,
@@ -149,6 +156,21 @@ function ParagraphBlock( {
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>
+			&lt;TextControl
+				type="text"
+				value={ fooText }
+				onChange={ ( v ) => ( console.log( v ), setFooText( v ) ) }
+			/>
+			&lt;TextControl
+				type="email"
+				value={ fooEmail }
+				onChange={ ( v ) => ( console.log( v ), setFooEmail( v ) ) }
+			/>
+			&lt;TextControl
+				type="time"
+				value={ fooNumber }
+				onChange={ ( v ) => ( console.log( v ), setFooNumber( v ) ) }
+			/>
 		</>
 	);
 }
</code></pre>
</details>