### PR TITLE
Add useSelectors hook for getting a store's selectors

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -6,7 +6,7 @@ import { castArray, first, last, every } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import {
 	hasBlockSupport,
 	switchToBlockType,
@@ -30,8 +30,8 @@ export default function BlockActions( {
 		getBlocksByClientId,
 		canMoveBlocks,
 		canRemoveBlocks,
-	} = useSelect( blockEditorStore );
-	const { getDefaultBlockName, getGroupingBlockName } = useSelect(
+	} = useSelectors( blockEditorStore );
+	const { getDefaultBlockName, getGroupingBlockName } = useSelectors(
 		blocksStore
 	);
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-handler.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -16,7 +16,7 @@ import { store as blockEditorStore } from '../../../store';
  * @param {string} clientId Block client ID.
  */
 export function useFocusHandler( clientId ) {
-	const { isBlockSelected } = useSelect( blockEditorStore );
+	const { isBlockSelected } = useSelectors( blockEditorStore );
 	const { selectBlock, selectionChange } = useDispatch( blockEditorStore );
 
 	return useRefEffect(

--- a/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -15,7 +15,9 @@ import { store as blockEditorStore } from '../../../store';
  * @param {string} clientId Block client ID.
  */
 export function useNavModeExit( clientId ) {
-	const { isNavigationMode, isBlockSelected } = useSelect( blockEditorStore );
+	const { isNavigationMode, isBlockSelected } = useSelectors(
+		blockEditorStore
+	);
 	const { setNavigationMode, selectBlock } = useDispatch( blockEditorStore );
 	return useRefEffect(
 		( node ) => {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -3,7 +3,7 @@
  */
 import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -24,7 +24,7 @@ export function useEventHandlers( clientId ) {
 		( select ) => select( blockEditorStore ).isBlockSelected( clientId ),
 		[ clientId ]
 	);
-	const { getBlockRootClientId, getBlockIndex } = useSelect(
+	const { getBlockRootClientId, getBlockIndex } = useSelectors(
 		blockEditorStore
 	);
 	const { insertDefaultBlock, removeBlock } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -3,7 +3,7 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -26,7 +26,7 @@ export function useInBetweenInserter() {
 		isMultiSelecting,
 		getSelectedBlockClientIds,
 		getTemplateLock,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -17,7 +17,7 @@ import { store as blockEditorStore } from '../../store';
  * @return {import('react').RefCallback} Ref callback.
  */
 export function useBlockSelectionClearer() {
-	const { hasSelectedBlock, hasMultiSelection } = useSelect(
+	const { hasSelectedBlock, hasMultiSelection } = useSelectors(
 		blockEditorStore
 	);
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { dragHandle } from '@wordpress/icons';
 import { Button, Flex, FlexItem } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import {
 	BACKSPACE,
@@ -101,7 +101,7 @@ function BlockSelectionButton( { clientId, rootClientId, blockElement } ) {
 		getPreviousBlockClientId,
 		getNextBlockClientId,
 		isNavigationMode,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const {
 		selectBlock,
 		clearSelectedBlock,

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -6,7 +6,7 @@ import { first, last } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
@@ -40,7 +40,7 @@ export default function BlockTools( {
 		[]
 	);
 	const isMatch = useShortcutEventMatch();
-	const { getSelectedBlockClientIds, getBlockRootClientId } = useSelect(
+	const { getSelectedBlockClientIds, getBlockRootClientId } = useSelectors(
 		blockEditorStore
 	);
 	const {

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -11,7 +11,7 @@ import {
 	documentHasSelection,
 	documentHasUncollapsedSelection,
 } from '@wordpress/dom';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useRefEffect } from '@wordpress/compose';
@@ -23,8 +23,8 @@ import { getPasteEventData } from '../../utils/pasting';
 import { store as blockEditorStore } from '../../store';
 
 export function useNotifyCopy() {
-	const { getBlockName } = useSelect( blockEditorStore );
-	const { getBlockType } = useSelect( blocksStore );
+	const { getBlockName } = useSelectors( blockEditorStore );
+	const { getBlockType } = useSelectors( blocksStore );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 
 	return useCallback( ( eventType, selectedBlockClientIds ) => {
@@ -78,7 +78,7 @@ export function useClipboardHandler() {
 		getSelectedBlockClientIds,
 		hasMultiSelection,
 		getSettings,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const { flashBlock, removeBlocks, replaceBlocks } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
 /**
@@ -40,7 +40,7 @@ export default function useInnerBlockTemplateSync(
 	templateLock,
 	templateInsertUpdatesSelection
 ) {
-	const { getSelectedBlocksInitialCaretPosition } = useSelect(
+	const { getSelectedBlocksInitialCaretPosition } = useSelectors(
 		blockEditorStore
 	);
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/components/inserter/hooks/use-clipboard-block.native.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-clipboard-block.native.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { rawHandler, store as blocksStore } from '@wordpress/blocks';
 import { getClipboard } from '@wordpress/components';
 
@@ -11,8 +11,8 @@ import { getClipboard } from '@wordpress/components';
 import { store as blockEditorStore } from '../../../store';
 
 export default function useClipboardBlock( destinationRootClientId ) {
-	const { canInsertBlockType } = useSelect( blockEditorStore );
-	const { getBlockType } = useSelect( blocksStore );
+	const { canInsertBlockType } = useSelectors( blockEditorStore );
+	const { getBlockType } = useSelectors( blocksStore );
 
 	const clipboard = getClipboard();
 	const clipboardBlock = rawHandler( { HTML: clipboard } )[ 0 ];

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -6,7 +6,7 @@ import { castArray } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 import { _n, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -45,7 +45,7 @@ function useInsertionPoint( {
 	onSelect,
 	shouldFocusBlock = true,
 } ) {
-	const { getSelectedBlock } = useSelect( blockEditorStore );
+	const { getSelectedBlock } = useSelectors( blockEditorStore );
 	const { destinationRootClientId, destinationIndex } = useSelect(
 		( select ) => {
 			const {

--- a/packages/block-editor/src/components/inserter/menu.native.js
+++ b/packages/block-editor/src/components/inserter/menu.native.js
@@ -7,7 +7,7 @@ import { AccessibilityInfo, TouchableHighlight, Platform } from 'react-native';
  * WordPress dependencies
  */
 import { useEffect, useState, useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import {
 	BottomSheet,
@@ -80,7 +80,7 @@ function InserterMenu( {
 		}
 	);
 
-	const { getBlockOrder, getBlockCount } = useSelect( blockEditorStore );
+	const { getBlockOrder, getBlockCount } = useSelectors( blockEditorStore );
 
 	useEffect( () => {
 		// Show/Hide insertion point on Mount/Dismount

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalToolsPanel as ToolsPanel } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -18,7 +18,7 @@ export default function BlockSupportToolsPanel( { children, group, label } ) {
 		getMultiSelectedBlockClientIds,
 		getSelectedBlockClientId,
 		hasMultiSelection,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 
 	const panelId = getSelectedBlockClientId();
 	const resetAll = useCallback(

--- a/packages/block-editor/src/components/list-view/use-block-selection.js
+++ b/packages/block-editor/src/components/list-view/use-block-selection.js
@@ -8,7 +8,7 @@ import { difference } from 'lodash';
  */
 import { speak } from '@wordpress/a11y';
 import { __, sprintf } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { UP, DOWN, HOME, END } from '@wordpress/keycodes';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -31,9 +31,9 @@ export default function useBlockSelection() {
 		getSelectedBlockClientIds,
 		hasMultiSelection,
 		hasSelectedBlock,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 
-	const { getBlockType } = useSelect( blocksStore );
+	const { getBlockType } = useSelectors( blocksStore );
 
 	const updateBlockSelection = useCallback(
 		async ( event, clientId, destinationClientId ) => {

--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import {
 	useThrottle,
@@ -201,7 +201,7 @@ export default function useListViewDropZone() {
 		getBlockCount,
 		getDraggedBlockClientIds,
 		canInsertBlocks,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const [ target, setTarget ] = useState();
 	const { rootClientId: targetRootClientId, blockIndex: targetBlockIndex } =
 		target || {};

--- a/packages/block-editor/src/components/rich-text/use-caret-in-format.js
+++ b/packages/block-editor/src/components/rich-text/use-caret-in-format.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import { store as blockEditorStore } from '../../store';
 export function useCaretInFormat( { value } ) {
 	const hasActiveFormats =
 		value.activeFormats && !! value.activeFormats.length;
-	const { isCaretWithinFormattedText } = useSelect( blockEditorStore );
+	const { isCaretWithinFormattedText } = useSelectors( blockEditorStore );
 	const { enterFormattedText, exitFormattedText } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
+++ b/packages/block-editor/src/components/rich-text/use-undo-automatic-change.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 
@@ -11,7 +11,9 @@ import { BACKSPACE, DELETE, ESCAPE } from '@wordpress/keycodes';
 import { store as blockEditorStore } from '../../store';
 
 export function useUndoAutomaticChange() {
-	const { didAutomaticChange, getSettings } = useSelect( blockEditorStore );
+	const { didAutomaticChange, getSettings } = useSelectors(
+		blockEditorStore
+	);
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			const { keyCode } = event;

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { useCallback, useState } from '@wordpress/element';
 import {
 	useThrottle,
@@ -100,7 +100,7 @@ export default function useBlockDropZone( {
 		[ targetRootClientId ]
 	);
 
-	const { getBlockListSettings } = useSelect( blockEditorStore );
+	const { getBlockListSettings } = useSelectors( blockEditorStore );
 	const { showInsertionPoint, hideInsertionPoint } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -7,7 +7,7 @@ import {
 	getBlockTransforms,
 	pasteHandler,
 } from '@wordpress/blocks';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { getFilesFromDataTransfer } from '@wordpress/dom';
 
 /**
@@ -221,7 +221,7 @@ export default function useOnBlockDrop( targetRootClientId, targetBlockIndex ) {
 		canInsertBlockType,
 		getBlockIndex,
 		getClientIdsOfDescendants,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const {
 		insertBlocks,
 		moveBlocksToPosition,

--- a/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-arrow-nav.js
@@ -16,7 +16,7 @@ import {
 	isRTL,
 } from '@wordpress/dom';
 import { UP, DOWN, LEFT, RIGHT } from '@wordpress/keycodes';
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -125,7 +125,7 @@ export default function useArrowNav() {
 		getNextBlockClientId,
 		getSettings,
 		hasMultiSelection,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	return useRefEffect( ( node ) => {
 		// Here a DOMRect is stored while moving the caret vertically so
 		// vertical position of the start position can be restored. This is to

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -7,7 +7,7 @@ import { first, last } from 'lodash';
  * WordPress dependencies
  */
 import { isEntirelySelected } from '@wordpress/dom';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
 import { useRefEffect } from '@wordpress/compose';
 
@@ -21,7 +21,7 @@ export default function useSelectAll() {
 		getBlockOrder,
 		getSelectedBlockClientIds,
 		getBlockRootClientId,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const { multiSelect } = useDispatch( blockEditorStore );
 	const isMatch = useShortcutEventMatch();
 

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -3,7 +3,7 @@
  */
 import { focus, isFormElement } from '@wordpress/dom';
 import { TAB, ESCAPE } from '@wordpress/keycodes';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { useRefEffect, useMergeRefs } from '@wordpress/compose';
 import { useRef } from '@wordpress/element';
 
@@ -21,7 +21,7 @@ export default function useTabNav() {
 		hasMultiSelection,
 		getSelectedBlockClientId,
 		getBlockCount,
-	} = useSelect( blockEditorStore );
+	} = useSelectors( blockEditorStore );
 	const { setNavigationMode } = useDispatch( blockEditorStore );
 	const isNavigationMode = useSelect(
 		( select ) => select( blockEditorStore ).isNavigationMode(),

--- a/packages/block-library/src/buttons/edit.native.js
+++ b/packages/block-library/src/buttons/edit.native.js
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock, getBlockSupport } from '@wordpress/blocks';
 import { useResizeObserver } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { alignmentHelpers } from '@wordpress/components';
 
@@ -79,7 +79,7 @@ export default function ButtonsEdit( {
 		return preferredStyleVariations?.value?.[ buttonBlockName ];
 	}, [] );
 
-	const { getBlockOrder } = useSelect( blockEditorStore );
+	const { getBlockOrder } = useSelectors( blockEditorStore );
 	const { insertBlock, removeBlock, selectBlock } = useDispatch(
 		blockEditorStore
 	);

--- a/packages/block-library/src/embed/embed-preview.native.js
+++ b/packages/block-library/src/embed/embed-preview.native.js
@@ -16,7 +16,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { memo, useState } from '@wordpress/element';
 import { SandBox } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -43,7 +43,7 @@ const EmbedPreview = ( {
 	isDefaultEmbedInfo,
 } ) => {
 	const [ isCaptionSelected, setIsCaptionSelected ] = useState( false );
-	const { locale } = useSelect( blockEditorStore ).getSettings();
+	const { locale } = useSelectors( blockEditorStore ).getSettings();
 
 	const wrapperStyle = styles[ 'embed-preview__wrapper' ];
 	const wrapperAlignStyle =

--- a/packages/block-library/src/freeform/edit.js
+++ b/packages/block-library/src/freeform/edit.js
@@ -11,7 +11,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { ToolbarGroup } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -46,7 +46,7 @@ export default function ClassicEdit( {
 	setAttributes,
 	onReplace,
 } ) {
-	const { getMultiSelectedBlockClientIds } = useSelect( blockEditorStore );
+	const { getMultiSelectedBlockClientIds } = useSelectors( blockEditorStore );
 	const didMount = useRef( false );
 
 	useEffect( () => {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -17,7 +17,7 @@ import {
 	ToolbarButton,
 } from '@wordpress/components';
 import { useViewportMatch, usePrevious } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import {
 	BlockControls,
 	InspectorControls,
@@ -85,7 +85,7 @@ export default function Image( {
 	const captionRef = useRef();
 	const prevUrl = usePrevious( url );
 	const { allowResize = true } = context;
-	const { getBlock } = useSelect( blockEditorStore );
+	const { getBlock } = useSelectors( blockEditorStore );
 
 	const { image, multiImageSelection } = useSelect(
 		( select ) => {

--- a/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
+++ b/packages/customize-widgets/src/components/customize-widgets/use-clear-selected-block.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelectors, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
@@ -22,7 +22,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  * @param {Object} popoverRef     The ref object of the popover node container.
  */
 export default function useClearSelectedBlock( sidebarControl, popoverRef ) {
-	const { hasSelectedBlock, hasMultiSelection } = useSelect(
+	const { hasSelectedBlock, hasMultiSelection } = useSelectors(
 		blockEditorStore
 	);
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -827,6 +827,18 @@ _Returns_
 
 -   `Function`: A custom react hook.
 
+### useSelectors
+
+Retrieve the controls of a store, so that it can be used to get data in event callbacks.
+
+_Parameters_
+
+-   _storeName_ `string`: Key of the store to get controls for. **Don't use `useSelect` for calling the selectors in the render function because your component won't re-render on a data change. You need to use useSelect in that case.** `js import { useSelect } from '@wordpress/data'; function Paste( { children } ) { const { getSettings } = useSelect( 'my-shop' ); function onPaste() { // Do something with the settings. const settings = getSettings(); } return <div onPaste={ onPaste }>{ children }</div>; }`
+
+_Returns_
+
+-   `Object`: The store's selectors.
+
 ### withDispatch
 
 Higher-order component used to add dispatch props using registered action

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -800,7 +800,8 @@ doesn't change and other props are passed in that do change, the price will
 not change because the dependency is just the currency.
 
 When data is only used in an event callback, the data should not be retrieved
-on render, so it may be useful to get the selectors function instead.
+on render, so you need to use useSelectors instead. For backwards compatibility
+only, this function still supports getting the selectors by passing a store.
 
 **Don't use `useSelect` this way when calling the selectors in the render
 function because your component won't re-render on a data change.**
@@ -820,12 +821,12 @@ function Paste( { children } ) {
 
 _Parameters_
 
--   _mapSelect_ `Function|StoreDescriptor|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
+-   _mapSelect_ `Function|StoreDescriptor|string`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. (deprecated) When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
 -   _deps_ `Array`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 
--   `Function`: A custom react hook.
+-   `any`: The current map output or a store's selectors.
 
 ### useSelectors
 

--- a/packages/data/src/components/use-selectors/index.js
+++ b/packages/data/src/components/use-selectors/index.js
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import useRegistry from '../registry-provider/use-registry';
+
+/**
+ *
+ * Retrieve the controls of a store, so that it can be used to get data in event callbacks.
+ *
+ * @param {string} storeName Key of the store to get controls for.
+ *
+ * **Don't use `useSelect` for calling the selectors in the render
+ * function because your component won't re-render on a data change.
+ * You need to use useSelect in that case.**
+ *
+ * ```js
+ * import { useSelect } from '@wordpress/data';
+ *
+ * function Paste( { children } ) {
+ *   const { getSettings } = useSelect( 'my-shop' );
+ *   function onPaste() {
+ *     // Do something with the settings.
+ *     const settings = getSettings();
+ *   }
+ *   return <div onPaste={ onPaste }>{ children }</div>;
+ * }
+ * ```
+ *
+ * @return {Object} The store's selectors.
+ */
+export default function useSelectors( storeName ) {
+	const registry = useRegistry();
+
+	return registry.select( storeName );
+}

--- a/packages/data/src/index.js
+++ b/packages/data/src/index.js
@@ -20,6 +20,7 @@ export {
 	useRegistry,
 } from './components/registry-provider';
 export { default as useSelect } from './components/use-select';
+export { default as useSelectors } from './components/use-selectors';
 export { useDispatch } from './components/use-dispatch';
 export { AsyncModeProvider } from './components/async-mode-provider';
 export { createRegistry } from './registry';

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -13,7 +13,7 @@ import {
 	__experimentalConfirmDialog as ConfirmDialog,
 } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
@@ -26,7 +26,7 @@ import { store as editPostStore } from '../../../store';
 export default function DeleteTemplate() {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 	const { setIsEditingTemplate } = useDispatch( editPostStore );
-	const { getEditorSettings } = useSelect( editorStore );
+	const { getEditorSettings } = useSelectors( editorStore );
 	const { updateEditorSettings, editPost } = useDispatch( editorStore );
 	const { deleteEntityRecord } = useDispatch( coreStore );
 	const { template } = useSelect( ( select ) => {

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -8,7 +8,7 @@ import { mapValues } from 'lodash';
  */
 import { __ } from '@wordpress/i18n';
 import { TextControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -26,7 +26,7 @@ export default function EditTemplateTitle() {
 	}, [] );
 
 	const { editEntityRecord } = useDispatch( coreStore );
-	const { getEditorSettings } = useSelect( editorStore );
+	const { getEditorSettings } = useSelectors( editorStore );
 	const { updateEditorSettings } = useDispatch( editorStore );
 
 	if ( template.has_theme_file ) {

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import {
 	useShortcut,
 	store as keyboardShortcutsStore,
@@ -17,12 +17,12 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editPostStore } from '../../store';
 
 function KeyboardShortcuts() {
-	const { getBlockSelectionStart } = useSelect( blockEditorStore );
+	const { getBlockSelectionStart } = useSelectors( blockEditorStore );
 	const {
 		getEditorMode,
 		isEditorSidebarOpened,
 		isListViewOpened,
-	} = useSelect( editPostStore );
+	} = useSelectors( editPostStore );
 	const isModeToggleDisabled = useSelect( ( select ) => {
 		const { richEditingEnabled, codeEditingEnabled } = select(
 			editorStore

--- a/packages/edit-site/src/components/editor/global-styles-renderer.js
+++ b/packages/edit-site/src/components/editor/global-styles-renderer.js
@@ -7,7 +7,7 @@ import { filter } from 'lodash';
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelectors } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ import { useGlobalStylesOutput } from '../global-styles/use-global-styles-output
 
 function useGlobalStylesRenderer() {
 	const [ styles, settings ] = useGlobalStylesOutput();
-	const { getSettings } = useSelect( editSiteStore );
+	const { getSettings } = useSelectors( editSiteStore );
 	const { updateSettings } = useDispatch( editSiteStore );
 
 	useEffect( () => {

--- a/packages/edit-site/src/components/global-styles/global-styles-provider.js
+++ b/packages/edit-site/src/components/global-styles/global-styles-provider.js
@@ -14,7 +14,7 @@ import {
  * WordPress dependencies
  */
 import { useMemo, useCallback } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -65,7 +65,7 @@ function useGlobalStylesUserConfig() {
 		};
 	}, [] );
 
-	const { getEditedEntityRecord } = useSelect( coreStore );
+	const { getEditedEntityRecord } = useSelectors( coreStore );
 	const { editEntityRecord } = useDispatch( coreStore );
 	const config = useMemo( () => {
 		return {

--- a/packages/edit-site/src/components/header/document-actions/index.js
+++ b/packages/edit-site/src/components/header/document-actions/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalGetBlockLabel as getBlockLabel,
 	getBlockType,
 } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useSelectors } from '@wordpress/data';
 import {
 	Dropdown,
 	Button,
@@ -31,7 +31,7 @@ function getBlockDisplayText( block ) {
 }
 
 function useSecondaryText() {
-	const { getBlock } = useSelect( blockEditorStore );
+	const { getBlock } = useSelectors( blockEditorStore );
 	const activeEntityBlockId = useSelect(
 		( select ) =>
 			select(

--- a/packages/edit-site/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-site/src/components/keyboard-shortcuts/index.js
@@ -6,7 +6,7 @@ import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as interfaceStore } from '@wordpress/interface';
@@ -22,8 +22,8 @@ function KeyboardShortcuts( { openEntitiesSavedStates } ) {
 	const {
 		__experimentalGetDirtyEntityRecords,
 		isSavingEntityRecord,
-	} = useSelect( coreStore );
-	const { getEditorMode } = useSelect( editSiteStore );
+	} = useSelectors( coreStore );
+	const { getEditorMode } = useSelectors( editSiteStore );
 	const isListViewOpen = useSelect(
 		( select ) => select( editSiteStore ).isListViewOpened(),
 		[]

--- a/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
+++ b/packages/edit-site/src/components/template-part-converter/convert-to-regular.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect, useSelectors } from '@wordpress/data';
 import {
 	BlockSettingsMenuControls,
 	store as blockEditorStore,
@@ -10,7 +10,7 @@ import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 export default function ConvertToRegularBlocks( { clientId } ) {
-	const { getBlocks } = useSelect( blockEditorStore );
+	const { getBlocks } = useSelectors( blockEditorStore );
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 
 	const canRemove = useSelect(

--- a/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/save-shortcut.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelectors, useDispatch } from '@wordpress/data';
 import { parse } from '@wordpress/blocks';
 
 /**
@@ -12,9 +12,11 @@ import { store as editorStore } from '../../store';
 
 function SaveShortcut( { resetBlocksOnSave } ) {
 	const { resetEditorBlocks, savePost } = useDispatch( editorStore );
-	const { isEditedPostDirty, getPostEdits, isPostSavingLocked } = useSelect(
-		editorStore
-	);
+	const {
+		isEditedPostDirty,
+		getPostEdits,
+		isPostSavingLocked,
+	} = useSelectors( editorStore );
 
 	useShortcut( 'core/editor/save', ( event ) => {
 		event.preventDefault();

--- a/packages/editor/src/components/local-autosave-monitor/index.js
+++ b/packages/editor/src/components/local-autosave-monitor/index.js
@@ -8,7 +8,7 @@ import { once, uniqueId, omit } from 'lodash';
  */
 import { useCallback, useEffect, useRef } from '@wordpress/element';
 import { ifCondition, usePrevious } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useSelectors } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { parse } from '@wordpress/blocks';
 import { store as noticesStore } from '@wordpress/notices';
@@ -59,7 +59,7 @@ function useAutosaveNotice() {
 		} ),
 		[]
 	);
-	const { getEditedPostAttribute } = useSelect( editorStore );
+	const { getEditedPostAttribute } = useSelectors( editorStore );
 
 	const { createWarningNotice, removeNotice } = useDispatch( noticesStore );
 	const { editPost, resetEditorBlocks } = useDispatch( editorStore );

--- a/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
+++ b/packages/eslint-plugin/rules/__tests__/data-no-store-string-literals.js
@@ -26,7 +26,7 @@ const valid = [
 	// Direct function calls.
 	`import { useDispatch } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; useDispatch( coreStore );`,
 	`import { dispatch } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; dispatch( coreStore );`,
-	`import { useSelect } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; useSelect( coreStore );`,
+	`import { useSelectors } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; useSelectors( coreStore );`,
 	`import { select } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; select( coreStore );`,
 	`import { resolveSelect } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; resolveSelect( coreStore );`,
 	`import { resolveSelect as resolveSelectAlias } from '@wordpress/data'; import { store as coreStore } from '@wordpress/core-data'; resolveSelectAlias( coreStore );`,

--- a/packages/keyboard-shortcuts/src/hooks/use-shortcut-event-match.js
+++ b/packages/keyboard-shortcuts/src/hooks/use-shortcut-event-match.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelectors } from '@wordpress/data';
 import { isKeyboardEvent } from '@wordpress/keycodes';
 
 /**
@@ -12,11 +12,11 @@ import { store as keyboardShortcutsStore } from '../store';
 /**
  * Returns a function to check if a keyboard event matches a shortcut name.
  *
- * @return {Function} A function to to check if a keyboard event matches a
+ * @return {Function} A function to check if a keyboard event matches a
  *                    predefined shortcut combination.
  */
 export default function useShortcutEventMatch() {
-	const { getAllShortcutKeyCombinations } = useSelect(
+	const { getAllShortcutKeyCombinations } = useSelectors(
 		keyboardShortcutsStore
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Create a new function that can be called instead of `useSelect` to get a store's selectors.

```js
export default function useSelectors( storeName ) {
	const registry = useRegistry();

	return registry.select( storeName );
}
```
[Remove complexity](https://github.com/WordPress/gutenberg/pull/40201/files?w=1#diff-842c1e34fc3a1df56dc553d99766a9f86a3e0e141a99632471ed462e2b04035f) from `useSelect` now that the function only does 1 thing.

## Why?
In the previous code, 1 function is used to cover 2 use cases, switching between them with the first parameter's type. This never changes dynamically, code never depends on the function being able to do 2 things.

The original use case is to get data needed during render.

The 2nd use case simply returns a store's selectors, so they can be called in event handlers.

This use case does not need most of the hooks the original use is calling. However because of how hooks work, they needed to be called anyway in this path.

In the new function, the only remaining hook call for getting the controls is to `useRegistry`. All the other logic inside `useSelect` is completely irrelevant.

It also [allows to simplify `useSelect`](https://github.com/WordPress/gutenberg/commit/31b0c2679a63218ed45728021913fd5a60b0ddc5#diff-842c1e34fc3a1df56dc553d99766a9f86a3e0e141a99632471ed462e2b04035f). It won't need any of the checks on the type of argument anymore, and can simply return the map output. For now I kept this out of this branch to make it easier to provide BC.

I didn't test the impact of not having to call these hooks, but I guess it's not 0. Especially if many components use this.

## How?
* Add a new function that only gets the selectors.
* Make all usages of `useSelect` use this function instead.
* Remove complexity from `useSelect` that was only there to make the function do 2 things.

## Testing Instructions
I tried to locate all relevant uses of the function, so depending on test coverage it should be relatively easy to confirm I didn't miss any.

~~Awaiting feedback on what to do with the public API, it could be that `useSelect` would preserve its duplicate function. If that's the case then this change should involve very little risk.~~ For now I indeed kept `useSelect` unchanged so that this PR is unblocked. Perhaps in a follow up it's possible to add the simplified form already and keep a copy of the older one for BC.


## TODO 
The function is exposed with the old signature as a public API. While in practice it should work to check the argument and call the other function, it's being picked up by linting as a rules of hooks violation. Which it technically is, but in practice it only depends on the type which stays stable over time. Still seems like a non optimal solution and a bad example to set.

One option is to leave the old behavior in place in `useSelect`. That would also make it safer in case a usage was missed in this PR.

Alternatively keep an old copy of `useSelect` and export that as a public API. Then internal use could already use the simplified function.

