### PR TITLE
Block Toolbar: Display block title when no switcher is available

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -108,7 +108,19 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					disabled
 					className="block-editor-block-switcher__no-switcher-icon"
 					title={ blockTitle }
-					icon={ <BlockIcon icon={ icon } showColors /> }
+					icon={
+						<>
+							<BlockIcon icon={ icon } showColors />
+							{ ( isReusable || isTemplate ) && (
+								<span className="block-editor-block-switcher__toggle-text">
+									<BlockTitle
+										clientId={ clientIds }
+										maximumLength={ 35 }
+									/>
+								</span>
+							) }
+						</>
+					}
 				/>
 			</ToolbarGroup>
 		);

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -47,11 +47,12 @@
 
 .components-button.block-editor-block-switcher__no-switcher-icon {
 	display: flex;
-	padding: 6px 12px !important;
+	padding: ($grid-unit-15 * 0.5) $grid-unit-15 !important;
 
-	.block-editor-blocks-icon {
+	.block-editor-block-icon {
 		margin-right: auto;
 		margin-left: auto;
+		min-width: $icon-size !important;
 	}
 }
 
@@ -78,6 +79,7 @@
 		margin: 0 auto;
 		display: flex;
 		align-items: center;
+		min-width: 100%;
 	}
 
 	// Position the focus style correctly.

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -47,6 +47,8 @@
 
 .components-button.block-editor-block-switcher__no-switcher-icon {
 	display: flex;
+	// The `!important` is used to vastly simplify the overriding of an inherited selector.
+	// Can be removed if we refactor .block-editor-block-toolbar .components-toolbar-group .components-button.has-icon.has-icon
 	padding: ($grid-unit-15 * 0.5) $grid-unit-15 !important;
 
 	.block-editor-block-icon {

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -46,7 +46,8 @@
 }
 
 .components-button.block-editor-block-switcher__no-switcher-icon {
-	width: $block-toolbar-height;
+	display: flex;
+	padding: 6px 12px !important;
 
 	.block-editor-blocks-icon {
 		margin-right: auto;
@@ -77,7 +78,6 @@
 		margin: 0 auto;
 		display: flex;
 		align-items: center;
-		min-width: 100%;
 	}
 
 	// Position the focus style correctly.
@@ -172,7 +172,7 @@
 // The block switcher in the contextual toolbar should be bigger.
 .block-editor-block-contextual-toolbar {
 	.components-button.block-editor-block-switcher__no-switcher-icon {
-		width: $grid-unit-60;
+		min-width: $button-size;
 	}
 
 	.components-button.block-editor-block-switcher__no-switcher-icon,

--- a/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-switcher/test/__snapshots__/index.js.snap
@@ -6,19 +6,21 @@ exports[`BlockSwitcherDropdownMenu should render disabled block switcher with mu
     className="block-editor-block-switcher__no-switcher-icon"
     disabled={true}
     icon={
-      <Memo(BlockIcon)
-        icon={
-          <SVG
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <Path
-              d="M20.2 8v11c0 .7-.6 1.2-1.2 1.2H6v1.5h13c1.5 0 2.7-1.2 2.7-2.8V8zM18 16.4V4.6c0-.9-.7-1.6-1.6-1.6H4.6C3.7 3 3 3.7 3 4.6v11.8c0 .9.7 1.6 1.6 1.6h11.8c.9 0 1.6-.7 1.6-1.6zm-13.5 0V4.6c0-.1.1-.1.1-.1h11.8c.1 0 .1.1.1.1v11.8c0 .1-.1.1-.1.1H4.6l-.1-.1z"
-            />
-          </SVG>
-        }
-        showColors={true}
-      />
+      <React.Fragment>
+        <Memo(BlockIcon)
+          icon={
+            <SVG
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <Path
+                d="M20.2 8v11c0 .7-.6 1.2-1.2 1.2H6v1.5h13c1.5 0 2.7-1.2 2.7-2.8V8zM18 16.4V4.6c0-.9-.7-1.6-1.6-1.6H4.6C3.7 3 3 3.7 3 4.6v11.8c0 .9.7 1.6 1.6 1.6h11.8c.9 0 1.6-.7 1.6-1.6zm-13.5 0V4.6c0-.1.1-.1.1-.1h11.8c.1 0 .1.1.1.1v11.8c0 .1-.1.1-.1.1H4.6l-.1-.1z"
+              />
+            </SVG>
+          }
+          showColors={true}
+        />
+      </React.Fragment>
     }
   />
 </ToolbarGroup>


### PR DESCRIPTION
## What?
PR fixed the issue when the block title wasn't displayed after block removal was locked.

## Why?
Some blocks like Reusable and Template parts display titles in Block Toolbar. This change makes behavior consistent.

## Testing Instructions
1. Open a Post or Page
2. Insert a Reusable block
3. Lock block removal.
4. Confirm that title is displayed.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-04-10 at 12 47 42](https://user-images.githubusercontent.com/240569/162610378-3164e14e-1d15-40ee-892f-3e88307c99db.png)
