### PR TITLE
Block Editor: Introduce the 'useBlockLock' hook

### DIFF
--- a/packages/block-editor/src/components/block-lock/index.js
+++ b/packages/block-editor/src/components/block-lock/index.js
@@ -1,3 +1,4 @@
 export { default as BlockLockMenuItem } from './menu-item';
 export { default as BlockLockModal } from './modal';
 export { default as BlockLockToolbar } from './toolbar';
+export { default as useBlockLock } from './use-block-lock';

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -4,36 +4,17 @@
 import { __ } from '@wordpress/i18n';
 import { useReducer } from '@wordpress/element';
 import { MenuItem } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
 import { lock, unlock } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import useBlockLock from './use-block-lock';
 import BlockLockModal from './modal';
-import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockMenuItem( { clientId } ) {
-	const { canLockBlock, isLocked } = useSelect(
-		( select ) => {
-			const {
-				canMoveBlock,
-				canRemoveBlock,
-				canLockBlockType,
-				getBlockName,
-				getBlockRootClientId,
-			} = select( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
-
-			return {
-				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
-				isLocked:
-					! canMoveBlock( clientId, rootClientId ) ||
-					! canRemoveBlock( clientId, rootClientId ),
-			};
-		},
-		[ clientId ]
-	);
+	const { canMove, canRemove, canLockBlock } = useBlockLock( clientId, true );
+	const isLocked = ! canMove || ! canRemove;
 
 	const [ isModalOpen, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,

--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -13,7 +13,7 @@ import useBlockLock from './use-block-lock';
 import BlockLockModal from './modal';
 
 export default function BlockLockMenuItem( { clientId } ) {
-	const { canMove, canRemove, canLockBlock } = useBlockLock( clientId, true );
+	const { canMove, canRemove, canLock } = useBlockLock( clientId, true );
 	const isLocked = ! canMove || ! canRemove;
 
 	const [ isModalOpen, toggleModal ] = useReducer(
@@ -21,7 +21,7 @@ export default function BlockLockMenuItem( { clientId } ) {
 		false
 	);
 
-	if ( ! canLockBlock ) {
+	if ( ! canLock ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -13,32 +13,18 @@ import {
 } from '@wordpress/components';
 import { lock as lockIcon, unlock as unlockIcon } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import useBlockLock from './use-block-lock';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockModal( { clientId, onClose } ) {
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
-	const { canMove, canRemove } = useSelect(
-		( select ) => {
-			const {
-				canMoveBlock,
-				canRemoveBlock,
-				getBlockRootClientId,
-			} = select( blockEditorStore );
-			const rootClientId = getBlockRootClientId( clientId );
-
-			return {
-				canMove: canMoveBlock( clientId, rootClientId ),
-				canRemove: canRemoveBlock( clientId, rootClientId ),
-			};
-		},
-		[ clientId ]
-	);
+	const { canMove, canRemove } = useBlockLock( clientId, true );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const instanceId = useInstanceId(

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -15,14 +15,14 @@ import useBlockDisplayInformation from '../use-block-display-information';
 
 export default function BlockLockToolbar( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { canMove, canRemove, canLockBlock } = useBlockLock( clientId );
+	const { canMove, canRemove, canLock } = useBlockLock( clientId );
 
 	const [ isModalOpen, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,
 		false
 	);
 
-	if ( ! canLockBlock ) {
+	if ( ! canLock ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -5,34 +5,17 @@ import { __, sprintf } from '@wordpress/i18n';
 import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { useReducer } from '@wordpress/element';
 import { lock } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import BlockLockModal from './modal';
+import useBlockLock from './use-block-lock';
 import useBlockDisplayInformation from '../use-block-display-information';
-import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockToolbar( { clientId } ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { canMove, canRemove, canLockBlock } = useSelect(
-		( select ) => {
-			const {
-				canMoveBlock,
-				canRemoveBlock,
-				canLockBlockType,
-				getBlockName,
-			} = select( blockEditorStore );
-
-			return {
-				canMove: canMoveBlock( clientId ),
-				canRemove: canRemoveBlock( clientId ),
-				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
-			};
-		},
-		[ clientId ]
-	);
+	const { canMove, canRemove, canLockBlock } = useBlockLock( clientId );
 
 	const [ isModalOpen, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -9,12 +9,12 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 
 /**
- * Return details about the block lock state.
+ * Return details about the block lock status.
  *
  * @param {string}  clientId  The block client Id.
- * @param {boolean} checkRoot Optional check for root client ID of block list.
+ * @param {boolean} checkRoot Optional. Use root client ID when checking lock status.
  *
- * @return {Object} Block lock state
+ * @return {Object} Block lock status
  */
 export default function useBlockLock( clientId, checkRoot = false ) {
 	return useSelect(

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -33,7 +33,7 @@ export default function useBlockLock( clientId, checkRoot = false ) {
 			return {
 				canMove: canMoveBlock( clientId, rootClientId ),
 				canRemove: canRemoveBlock( clientId, rootClientId ),
-				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
+				canLock: canLockBlockType( getBlockName( clientId ) ),
 			};
 		},
 		[ clientId, checkRoot ]

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+
+/**
+ * Return details about the block lock state.
+ *
+ * @param {string}  clientId  The block client Id.
+ * @param {boolean} checkRoot Optional check for root client ID of block list.
+ *
+ * @return {Object} Block lock state
+ */
+export default function useBlockLock( clientId, checkRoot = false ) {
+	return useSelect(
+		( select ) => {
+			const {
+				canMoveBlock,
+				canRemoveBlock,
+				canLockBlockType,
+				getBlockName,
+				getBlockRootClientId,
+			} = select( blockEditorStore );
+			const rootClientId = checkRoot
+				? getBlockRootClientId( clientId )
+				: null;
+
+			return {
+				canMove: canMoveBlock( clientId, rootClientId ),
+				canRemove: canRemoveBlock( clientId, rootClientId ),
+				canLockBlock: canLockBlockType( getBlockName( clientId ) ),
+			};
+		},
+		[ clientId, checkRoot ]
+	);
+}

--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
@@ -19,7 +18,7 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
-import { store as blockEditorStore } from '../../store';
+import { useBlockLock } from '../block-lock';
 
 function ListViewBlockSelectButton(
 	{
@@ -36,14 +35,8 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const isLocked = useSelect(
-		( select ) => {
-			const { canMoveBlock, canRemoveBlock } = select( blockEditorStore );
-
-			return ! canMoveBlock( clientId ) || ! canRemoveBlock( clientId );
-		},
-		[ clientId ]
-	);
+	const { canMove, canRemove } = useBlockLock( clientId );
+	const isLocked = ! canMove || ! canRemove;
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.


### PR DESCRIPTION
## What?
The follow-up to https://github.com/WordPress/gutenberg/pull/40088#discussion_r843690260.

PR introduces a new `useBlockLock` and makes it easier to access block status.

## Why?
The new hook will reduce the boilerplate code required to get block lock status.

## Testing Instructions
E2E tests are passing.