### PR TITLE
Cover: Always allow transform from Group block, add handling for Row and Stack variations

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -70,20 +70,22 @@ const transforms = {
 					anchor,
 					backgroundColor,
 					gradient,
-					layout,
 					style,
 				} = attributes;
+
 				// If no background or gradient color is provided, default to 50% opacity.
 				// This matches the styling of a Cover block with a background image,
 				// in the state where a background image has been removed.
 				const dimRatio =
 					backgroundColor ||
+					gradient ||
 					style?.color?.background ||
 					style?.color?.gradient
 						? undefined
 						: 50;
 
-				const newAttributes = {
+				// Move the background or gradient color to the parent Cover block.
+				const parentAttributes = {
 					align,
 					anchor,
 					dimRatio,
@@ -93,26 +95,29 @@ const transforms = {
 					customGradient: style?.color?.gradient,
 				};
 
-				// For variations that use a flex layout (e.g. Row and Stack),
-				// wrap the block in a Cover instead of converting directly to the cover block.
-				if ( layout?.type === 'flex' ) {
-					return createBlock( 'core/cover', newAttributes, [
-						createBlock( 'core/group', attributes, innerBlocks ),
-					] );
-				}
+				const attributesWithoutBackgroundColors = {
+					...attributes,
+					backgroundColor: undefined,
+					gradient: undefined,
+					style: {
+						...attributes?.style,
+						color: {
+							...attributes?.style?.color,
+							background: undefined,
+							gradient: undefined,
+						},
+					},
+				};
 
-				return createBlock(
-					'core/cover',
-					newAttributes,
-					innerBlocks?.length
-						? innerBlocks
-						: [
-								createBlock( 'core/paragraph', {
-									fontSize: 'large',
-									align: 'center',
-								} ),
-						  ]
-				);
+				// Preserve the block by nesting it within the Cover block,
+				// instead of converting the Group block directly to the Cover block.
+				return createBlock( 'core/cover', parentAttributes, [
+					createBlock(
+						'core/group',
+						attributesWithoutBackgroundColors,
+						innerBlocks
+					),
+				] );
 			},
 		},
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #40209 

## What?
<!-- In a few words, what is the PR actually doing? -->

As raised in #40209, remove the condition that the transform from a Group block to a Cover block option is conditional on a background color being present. Also, add handling to preserve the Stack and Row variations by wrapping those blocks in a Cover block, instead of converting directly to the cover block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Without this option, users wishing to move blocks from a Group to a Cover block need to copy / paste / drag blocks around, so this should make it a little easier to transition a set of blocks over to the Cover block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the condition that a Group block must have a background color in order to be eligible to transform to the Cover block
* Set a default opacity (`dimRatio`) of `50%` if there is no background color — this is needed because the default background is black, and if we otherwise set opacity to `0` then it would not be obvious how to get the color to appear once a user does add a color. Let me know if you can think of a better default other than this medium gray (it's consistent with the settings for if someone removes an image from a cover block).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a few blocks to a post or page (e.g. a heading, a paragraph, a button)
2. Select the blocks and group them
3. With the group block selected, select to transform to a Cover block
4. Repeat the above steps with the Row and Stack variations
5. Make sure it still works if the Group block has a background color or gradient set

## Screenshots or screencast <!-- if applicable -->

| Transform from Group block | Transform from Row variation |
| --- | --- |
| ![transform-from-group](https://user-images.githubusercontent.com/14988353/162677847-d9d0e3d0-239d-4941-85cb-f3d75fcc20db.gif) | ![transform-from-row](https://user-images.githubusercontent.com/14988353/162678589-41fb3d96-4645-4d4a-a5a8-a98d33575d50.gif) |

Note: I've used the Bug label as this _feels_ like a UX issue, but could arguably be an enhancement.