### PR TITLE
Try: Fix embed iframe sizing issue.

### DIFF
--- a/packages/components/src/sandbox/index.js
+++ b/packages/components/src/sandbox/index.js
@@ -74,14 +74,14 @@ const style = `
 	}
 	html,
 	body,
-	body > div,
-	body > div iframe {
+	body > div {
 		width: 100%;
 	}
 	html.wp-has-aspect-ratio,
 	body.wp-has-aspect-ratio,
 	body.wp-has-aspect-ratio > div,
 	body.wp-has-aspect-ratio > div iframe {
+		width: 100%;
 		height: 100%;
 		overflow: hidden; /* If it has an aspect ratio, it shouldn't scroll. */
 	}


### PR DESCRIPTION
## What?

Pinterest embeds are broken in the block editor, they appear cropped:

<img width="686" alt="bug" src="https://user-images.githubusercontent.com/1204802/162680875-6d078fef-2d33-4855-a689-edeca98da52c.png">

This happens because we have a rule that sets the iframe to be 100% wide inside, regardless of what original dimensions are set. This is fine for when the responsive embedding property is set so it can scale to an aspect ratio, but from what I can tell in the code, we apply this rule regardless of that. 

This PR moves the width rule to only apply when responsive embed classes are present. Which appears to have changed recently, so I could use a sanity check both on the code and the assumed behavior.

Nevertheless, this PR fixes the issue in the process:

<img width="707" alt="after" src="https://user-images.githubusercontent.com/1204802/162681249-e505ca00-e6af-4b58-8d80-d00ffc1e4ed7.png">

Perhaps most importantly, this makes it match the frontend:

<img width="636" alt="front" src="https://user-images.githubusercontent.com/1204802/162681277-e71b6368-e8f0-4ebe-8717-f26f8a6c6440.png">

Right now in trunk, the edit view doesn't match the frontend at all. That feels like a baseline to restore.

## Testing Instructions

Paste a Pinterest embed such as `https://www.pinterest.com/pin/1023865296507001702/` in the editor, and it should not be cropped and look the same on the frontend.
