### PR TITLE
Backport changes for Theme Export from 6.0

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -16,7 +16,7 @@
  * @return Bool Whether this file is in an ignored directory.
  */
 function gutenberg_is_theme_directory_ignored( $path ) {
-	$directories_to_ignore = array( '.git', 'node_modules', 'vendor' );
+	$directories_to_ignore = array( '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 	foreach ( $directories_to_ignore as $directory ) {
 		if ( strpos( $path, $directory ) === 0 ) {
 			return true;

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -417,8 +417,8 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	 * // => true
 	 * ```
 	 *
-	 * @param array      $data The data to inspect.
-	 * @param bool|array $path Boolean or path to a boolean.
+	 * @param array      $data    The data to inspect.
+	 * @param bool|array $path    Boolean or path to a boolean.
 	 * @param bool       $default Default value if the referenced path is missing.
 	 * @return boolean
 	 */
@@ -429,7 +429,7 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 
 		if ( is_array( $path ) ) {
 			$value = _wp_array_get( $data, $path );
-			if ( isset( $value ) ) {
+			if ( null !== $value ) {
 				return $value;
 			}
 		}
@@ -440,11 +440,10 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	/**
 	 * Returns a valid theme.json as provided by a theme.
 	 *
-	 * Unlike get_raw_data() this returns the presets flattened,
-	 * as provided by a theme. This also uses appearanceTools
-	 * instead of their opt-ins if all of them are true.
+	 * Unlike get_raw_data() this returns the presets flattened, as provided by a theme.
+	 * This also uses appearanceTools instead of their opt-ins if all of them are true.
 	 *
-	 * @return array
+	 * @return string[]
 	 */
 	public function get_data() {
 		$output = $this->theme_json;

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php
@@ -61,13 +61,15 @@ class WP_Theme_JSON_Resolver_6_0 extends WP_Theme_JSON_Resolver_5_9 {
 	 * the theme.json takes precedence.
 	 *
 	 * @param array $deprecated Deprecated argument.
-	 * @param array $settings Contains a key called with_supports to determine whether to include theme supports in the data.
+	 * @param array $options Contains a key called with_supports to determine whether to include theme supports in the data.
 	 * @return WP_Theme_JSON_Gutenberg Entity that holds theme data.
 	 */
-	public static function get_theme_data( $deprecated = array(), $settings = array( 'with_supports' => true ) ) {
+	public static function get_theme_data( $deprecated = array(), $options = array() ) {
 		if ( ! empty( $deprecated ) ) {
 			_deprecated_argument( __METHOD__, '5.9' );
 		}
+
+		$options = wp_parse_args( $options, array( 'with_supports' => true ) );
 
 		if ( null === static::$theme ) {
 			$theme_json_data = static::read_json_file( static::get_file_path_from_theme( 'theme.json' ) );
@@ -87,7 +89,7 @@ class WP_Theme_JSON_Resolver_6_0 extends WP_Theme_JSON_Resolver_5_9 {
 			}
 		}
 
-		if ( ! $settings['with_supports'] ) {
+		if ( ! $options['with_supports'] ) {
 			return static::$theme;
 		}
 


### PR DESCRIPTION
This copies fixes from https://github.com/WordPress/wordpress-develop/pull/2534 back into Gutenberg.