### PR TITLE
solved social icon alignment issue on front end

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -1,3 +1,10 @@
+.wp-block-group .wp-block-social-links {
+	&.alignleft,
+	&.alignright {
+		float: none;
+	}
+}
+
 .wp-block-social-links {
 	padding-left: 0;
 	padding-right: 0;
@@ -139,3 +146,4 @@
 		padding-right: calc((2/3) * 1em);
 	}
 }
+


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

This is occur when we wrap social icon block inside group block and changing social icon alignment from left or right
and applying background color using float:none property we solved this issue.

This pull request fixes a bug in which social icon alignment with full wrap background color as mentioned in #40131.


