### PR TITLE
Rename `wp_translate_settings_using_i18n_schema` to `translate_settings_using_i18n_schema`

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-resolver-5-9.php
@@ -106,7 +106,7 @@ class WP_Theme_JSON_Resolver_5_9 {
 			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
-		return wp_translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );
+		return translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );
 	}
 
 	/**

--- a/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
+++ b/lib/compat/wordpress-5.9/translate-settings-using-i18n-schema.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'wp_translate_settings_using_i18n_schema' ) ) {
+if ( ! function_exists( 'translate_settings_using_i18n_schema' ) ) {
 	/**
 	 * Translates the provided settings value using its i18n schema.
 	 *
@@ -15,7 +15,7 @@ if ( ! function_exists( 'wp_translate_settings_using_i18n_schema' ) ) {
 	 *
 	 * @return string|string[]|array[] Translated settings.
 	 */
-	function wp_translate_settings_using_i18n_schema( $i18n_schema, $settings, $textdomain ) {
+	function translate_settings_using_i18n_schema( $i18n_schema, $settings, $textdomain ) {
 		if ( empty( $i18n_schema ) || empty( $settings ) || empty( $textdomain ) ) {
 			return $settings;
 		}
@@ -27,7 +27,7 @@ if ( ! function_exists( 'wp_translate_settings_using_i18n_schema' ) ) {
 		if ( is_array( $i18n_schema ) && is_array( $settings ) ) {
 			$translated_settings = array();
 			foreach ( $settings as $value ) {
-				$translated_settings[] = wp_translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
+				$translated_settings[] = translate_settings_using_i18n_schema( $i18n_schema[0], $value, $textdomain );
 			}
 			return $translated_settings;
 		}
@@ -36,9 +36,9 @@ if ( ! function_exists( 'wp_translate_settings_using_i18n_schema' ) ) {
 			$translated_settings = array();
 			foreach ( $settings as $key => $value ) {
 				if ( isset( $i18n_schema->$key ) ) {
-					$translated_settings[ $key ] = wp_translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
+					$translated_settings[ $key ] = translate_settings_using_i18n_schema( $i18n_schema->$key, $value, $textdomain );
 				} elseif ( isset( $i18n_schema->$group_key ) ) {
-					$translated_settings[ $key ] = wp_translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
+					$translated_settings[ $key ] = translate_settings_using_i18n_schema( $i18n_schema->$group_key, $value, $textdomain );
 				} else {
 					$translated_settings[ $key ] = $value;
 				}

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php
@@ -32,7 +32,7 @@ class WP_Theme_JSON_Resolver_6_0 extends WP_Theme_JSON_Resolver_5_9 {
 			static::$i18n_schema = null === $i18n_schema ? array() : $i18n_schema;
 		}
 
-		return wp_translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );
+		return translate_settings_using_i18n_schema( static::$i18n_schema, $theme_json, $domain );
 	}
 
 	/**

--- a/phpunit/translate-settings-using-i18n-schema.php
+++ b/phpunit/translate-settings-using-i18n-schema.php
@@ -61,7 +61,7 @@ class Tests_L10n_TranslateSettingsUsingI18nSchema extends WP_UnitTestCase {
 				),
 			),
 		);
-		$result      = wp_translate_settings_using_i18n_schema(
+		$result      = translate_settings_using_i18n_schema(
 			$i18n_schema,
 			$settings,
 			$textdomain


### PR DESCRIPTION
## What?

This PR renames the `wp_` prefix for the `wp_translate_settings_using_i18n_schema` function.

## Why?

The core function doesn't have the `wp_` prefix, and landed in 5.9 as `translate_settings_using_i18n_schema`. As a result, by checking for the existance of `wp_*` core function (which does not exist) we're always loading the Gutenberg one.

## Testing Instructions

For WordPress 6.0 and 5.9:

- Use TwentyTwentyTwo.
- Go to "Settings > General" and set your language to a different one (chose one that you know has the theme strings translated into it). For example, Spanish.
- Go to "Dashboard > Updates" and make sure you don't have any translations unapplied.
- Load a post, create a paragraph block and select it. Verify that the colors and font sizes in the design tools of the block sidebar are displayed in your language of choice.
