### PR TITLE
useSelect: update unit tests to testing-library

### DIFF
--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import TestRenderer, { act } from 'react-test-renderer';
+import { act, render } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -22,15 +22,6 @@ describe( 'useSelect', () => {
 		registry = createRegistry();
 	} );
 
-	const getTestComponent = ( mapSelectSpy, dependencyKey ) => ( props ) => {
-		const dependencies = props[ dependencyKey ];
-		mapSelectSpy.mockImplementation( ( select ) => ( {
-			results: select( 'testStore' ).testSelector( props.keyName ),
-		} ) );
-		const data = useSelect( mapSelectSpy, [ dependencies ] );
-		return <div>{ data.results }</div>;
-	};
-
 	it( 'passes the relevant data to the component', () => {
 		registry.registerStore( 'testStore', {
 			reducer: () => ( { foo: 'bar' } ),
@@ -38,19 +29,22 @@ describe( 'useSelect', () => {
 				testSelector: ( state, key ) => state[ key ],
 			},
 		} );
+
 		const selectSpy = jest.fn();
-		const TestComponent = jest
-			.fn()
-			.mockImplementation( getTestComponent( selectSpy, 'keyName' ) );
-		let renderer;
-		act( () => {
-			renderer = TestRenderer.create(
-				<RegistryProvider value={ registry }>
-					<TestComponent keyName="foo" />
-				</RegistryProvider>
-			);
+		const TestComponent = jest.fn( ( props ) => {
+			selectSpy.mockImplementation( ( select ) => ( {
+				results: select( 'testStore' ).testSelector( props.keyName ),
+			} ) );
+			const data = useSelect( selectSpy, [ props.keyName ] );
+			return <div role="status">{ data.results }</div>;
 		} );
-		const testInstance = renderer.root;
+
+		const rendered = render(
+			<RegistryProvider value={ registry }>
+				<TestComponent keyName="foo" />
+			</RegistryProvider>
+		);
+
 		// 2 times expected
 		// - 1 for initial mount
 		// - 1 for after mount before subscription set.
@@ -58,9 +52,7 @@ describe( 'useSelect', () => {
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Ensure expected state was rendered.
-		expect( testInstance.findByType( 'div' ).props ).toEqual( {
-			children: 'bar',
-		} );
+		expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 'bar' );
 	} );
 
 	it( 'uses memoized selector if dependencies do not change', () => {
@@ -71,73 +63,62 @@ describe( 'useSelect', () => {
 			},
 		} );
 
-		const selectSpyFoo = jest.fn().mockImplementation( () => 'foo' );
-		const selectSpyBar = jest.fn().mockImplementation( () => 'bar' );
-		const TestComponent = jest.fn().mockImplementation( ( props ) => {
+		const selectSpyFoo = jest.fn( () => 'foo' );
+		const selectSpyBar = jest.fn( () => 'bar' );
+		const TestComponent = jest.fn( ( props ) => {
 			const mapSelect = props.change ? selectSpyFoo : selectSpyBar;
 			const data = useSelect( mapSelect, [ props.keyName ] );
-			return <div>{ data }</div>;
+			return <div role="status">{ data }</div>;
 		} );
-		let renderer;
-		act( () => {
-			renderer = TestRenderer.create(
-				<RegistryProvider value={ registry }>
-					<TestComponent keyName="foo" change={ true } />
-				</RegistryProvider>
-			);
-		} );
-		const testInstance = renderer.root;
+
+		const rendered = render(
+			<RegistryProvider value={ registry }>
+				<TestComponent keyName="foo" change={ true } />
+			</RegistryProvider>
+		);
 
 		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 0 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 1 );
 
 		// Ensure expected state was rendered.
-		expect( testInstance.findByType( 'div' ).props ).toEqual( {
-			children: 'foo',
-		} );
+		expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 'foo' );
 
 		// Rerender with non dependency changed.
-		act( () => {
-			renderer.update(
-				<RegistryProvider value={ registry }>
-					<TestComponent keyName="foo" change={ false } />
-				</RegistryProvider>
-			);
-		} );
+		rendered.rerender(
+			<RegistryProvider value={ registry }>
+				<TestComponent keyName="foo" change={ false } />
+			</RegistryProvider>
+		);
 
 		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 0 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 
 		// Ensure expected state was rendered.
-		expect( testInstance.findByType( 'div' ).props ).toEqual( {
-			children: 'foo',
-		} );
+		expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 'foo' );
 
 		// Rerender with dependency changed.
-		act( () => {
-			renderer.update(
-				<RegistryProvider value={ registry }>
-					<TestComponent keyName="bar" change={ false } />
-				</RegistryProvider>
-			);
-		} );
+		rendered.rerender(
+			<RegistryProvider value={ registry }>
+				<TestComponent keyName="bar" change={ false } />
+			</RegistryProvider>
+		);
 
 		expect( selectSpyFoo ).toHaveBeenCalledTimes( 2 );
 		expect( selectSpyBar ).toHaveBeenCalledTimes( 2 );
 		expect( TestComponent ).toHaveBeenCalledTimes( 3 );
 
 		// Ensure expected state was rendered.
-		expect( testInstance.findByType( 'div' ).props ).toEqual( {
-			children: 'bar',
-		} );
+		expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 'bar' );
 	} );
+
 	describe( 'rerenders as expected with various mapSelect return types', () => {
 		const getComponent = ( mapSelectSpy ) => () => {
 			const data = useSelect( mapSelectSpy, [] );
-			return <div data={ data } />;
+			return <div role="status" data-d={ JSON.stringify( data ) } />;
 		};
+
 		let TestComponent;
 		const mapSelectSpy = jest.fn( ( select ) =>
 			select( 'testStore' ).testSelector()
@@ -156,6 +137,7 @@ describe( 'useSelect', () => {
 			} );
 			TestComponent = getComponent( mapSelectSpy );
 		} );
+
 		afterEach( () => {
 			selectorSpy.mockClear();
 			mapSelectSpy.mockClear();
@@ -180,18 +162,14 @@ describe( 'useSelect', () => {
 			( type, testValues ) => {
 				const [ valueA, valueB ] = testValues;
 				selectorSpy.mockReturnValue( valueA );
-				let renderer;
-				act( () => {
-					renderer = TestRenderer.create(
-						<RegistryProvider value={ registry }>
-							<TestComponent />
-						</RegistryProvider>
-					);
-				} );
-				const testInstance = renderer.root;
+				const rendered = render(
+					<RegistryProvider value={ registry }>
+						<TestComponent />
+					</RegistryProvider>
+				);
 				// Ensure expected state was rendered.
-				expect( testInstance.findByType( 'div' ).props.data ).toEqual(
-					valueA
+				expect( rendered.getByRole( 'status' ).dataset.d ).toBe(
+					JSON.stringify( valueA )
 				);
 
 				// Update the returned value from the selector and trigger the
@@ -200,15 +178,15 @@ describe( 'useSelect', () => {
 					selectorSpy.mockReturnValue( valueB );
 					registry.dispatch( 'testStore' ).forceUpdate();
 				} );
-				expect( testInstance.findByType( 'div' ).props.data ).toEqual(
-					valueB
+				expect( rendered.getByRole( 'status' ).dataset.d ).toBe(
+					JSON.stringify( valueB )
 				);
 				expect( mapSelectSpy ).toHaveBeenCalledTimes( 3 );
 			}
 		);
 	} );
 
-	describe( 're-calls the selector as minimal times as possible', () => {
+	describe( 're-calls the selector as few times as possible', () => {
 		const counterStore = {
 			actions: {
 				increment: () => ( { type: 'INCREMENT' } ),
@@ -231,8 +209,6 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-1', counterStore );
 			registry.registerStore( 'store-2', counterStore );
 
-			let renderer;
-
 			const selectCount1 = jest.fn();
 			const selectCount2 = jest.fn();
 
@@ -248,23 +224,19 @@ describe( 'useSelect', () => {
 					[]
 				);
 
-				return <div data={ count1 } />;
+				return <div role="status">{ count1 }</div>;
 			} );
 
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
-				);
-			} );
-
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 1 );
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 0 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 0 );
 
 			act( () => {
 				registry.dispatch( 'store-2' ).increment();
@@ -273,7 +245,7 @@ describe( 'useSelect', () => {
 			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 3 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 0 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 0 );
 
 			act( () => {
 				registry.dispatch( 'store-1' ).increment();
@@ -282,18 +254,16 @@ describe( 'useSelect', () => {
 			expect( selectCount1 ).toHaveBeenCalledTimes( 3 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 3 );
 			expect( TestComponent ).toHaveBeenCalledTimes( 3 );
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 1 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 1 );
 
 			// Test if the unsubscribers get called correctly.
-			renderer.unmount();
+			rendered.unmount();
 		} );
 
 		it( 'can subscribe to multiple stores at once', () => {
 			registry.registerStore( 'store-1', counterStore );
 			registry.registerStore( 'store-2', counterStore );
 			registry.registerStore( 'store-3', counterStore );
-
-			let renderer;
 
 			const selectCount1And2 = jest.fn();
 
@@ -307,44 +277,35 @@ describe( 'useSelect', () => {
 					[]
 				);
 
-				return <div data={ { count1, count2 } } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
+				return (
+					<div role="status">
+						{ count1 },{ count2 }
+					</div>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
 			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				count2: 0,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( '0,0' );
 
 			act( () => {
 				registry.dispatch( 'store-2' ).increment();
 			} );
 
 			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				count2: 1,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( '0,1' );
 
 			act( () => {
 				registry.dispatch( 'store-3' ).increment();
 			} );
 
 			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				count2: 1,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( '0,1' );
 		} );
 
 		it( 're-calls the selector when deps changed', () => {
@@ -352,7 +313,7 @@ describe( 'useSelect', () => {
 			registry.registerStore( 'store-2', counterStore );
 			registry.registerStore( 'store-3', counterStore );
 
-			let renderer, dep, setDep;
+			let dep, setDep;
 			const selectCount1AndDep = jest.fn();
 
 			const TestComponent = jest.fn( () => {
@@ -366,44 +327,41 @@ describe( 'useSelect', () => {
 					[ dep ]
 				);
 
-				return <div data={ state } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
+				return (
+					<div role="status">
+						count:{ state.count1 },dep:{ state.dep }
+					</div>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
 			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				dep: 0,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count:0,dep:0'
+			);
 
 			act( () => {
 				setDep( 1 );
 			} );
 
 			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 4 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				dep: 1,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count:0,dep:1'
+			);
 
 			act( () => {
 				registry.dispatch( 'store-1' ).increment();
 			} );
 
 			expect( selectCount1AndDep ).toHaveBeenCalledTimes( 5 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 1,
-				dep: 1,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count:1,dep:1'
+			);
 		} );
 
 		it( 'handles registry selectors', () => {
@@ -423,7 +381,6 @@ describe( 'useSelect', () => {
 			} );
 			registry.registerStore( 'store-2', counterStore );
 
-			let renderer;
 			const selectCount1And2 = jest.fn();
 
 			const TestComponent = jest.fn( () => {
@@ -434,46 +391,43 @@ describe( 'useSelect', () => {
 					[]
 				);
 
-				return <div data={ state } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
+				return (
+					<div role="status">
+						count1:{ state.count1 },count2:{ state.count2 }
+					</div>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
 			expect( selectCount1And2 ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				count2: 0,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count1:0,count2:0'
+			);
 
 			act( () => {
 				registry.dispatch( 'store-2' ).increment();
 			} );
 
 			expect( selectCount1And2 ).toHaveBeenCalledTimes( 3 );
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				count2: 1,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count1:0,count2:1'
+			);
 		} );
 
 		it( 'handles conditional statements in selectors', () => {
 			registry.registerStore( 'store-1', counterStore );
 			registry.registerStore( 'store-2', counterStore );
 
-			let renderer, shouldSelectCount1, toggle;
 			const selectCount1 = jest.fn();
 			const selectCount2 = jest.fn();
 
 			const TestComponent = jest.fn( () => {
-				[ shouldSelectCount1, toggle ] = useReducer(
+				const [ shouldSelectCount1, toggle ] = useReducer(
 					( should ) => ! should,
 					false
 				);
@@ -492,32 +446,31 @@ describe( 'useSelect', () => {
 					[ shouldSelectCount1 ]
 				);
 
-				return <div data={ state } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
+				return (
+					<>
+						<div role="status">{ state }</div>
+						<button onClick={ toggle }>Toggle</button>
+					</>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 0 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
 				'count2'
 			);
 
-			act( () => {
-				toggle();
-			} );
+			rendered.getByText( 'Toggle' ).click();
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 2 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 2 );
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
 				'count1'
 			);
 		} );
@@ -528,8 +481,6 @@ describe( 'useSelect', () => {
 			const subRegistry = createRegistry( {}, registry );
 			subRegistry.registerStore( 'child-store', counterStore );
 
-			let renderer;
-
 			const TestComponent = jest.fn( () => {
 				const state = useSelect(
 					( select ) => ( {
@@ -539,106 +490,95 @@ describe( 'useSelect', () => {
 					[]
 				);
 
-				return <div data={ state } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<RegistryProvider value={ subRegistry }>
-							<TestComponent />
-						</RegistryProvider>
-					</RegistryProvider>
+				return (
+					<div role="status">
+						parent:{ state.parentCount },child:{ state.childCount }
+					</div>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<RegistryProvider value={ subRegistry }>
+						<TestComponent />
+					</RegistryProvider>
+				</RegistryProvider>
+			);
 
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				parentCount: 0,
-				childCount: 0,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'parent:0,child:0'
+			);
 
 			act( () => {
 				registry.dispatch( 'parent-store' ).increment();
 			} );
 
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				parentCount: 1,
-				childCount: 0,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'parent:1,child:0'
+			);
 		} );
 
 		it( 'handles non-existing stores', () => {
 			registry.registerStore( 'store-1', counterStore );
 
-			let renderer;
-
 			const TestComponent = jest.fn( () => {
 				const state = useSelect(
 					( select ) => ( {
 						count1: select( 'store-1' ).getCounter(),
-						blank: select( 'non-existing-store' )?.getCounter(),
+						count2: select( 'store-2' )?.getCounter() ?? 'blank',
 					} ),
 					[]
 				);
 
-				return <div data={ state } />;
-			} );
-
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
+				return (
+					<div role="status">
+						count1:{ state.count1 },count2:{ state.count2 }
+					</div>
 				);
 			} );
 
-			const testInstance = renderer.root;
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 0,
-				blank: undefined,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count1:0,count2:blank'
+			);
 
 			act( () => {
 				registry.dispatch( 'store-1' ).increment();
 			} );
 
-			expect( testInstance.findByType( 'div' ).props.data ).toEqual( {
-				count1: 1,
-				blank: undefined,
-			} );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'count1:1,count2:blank'
+			);
 
 			// Test if the unsubscribers get called correctly.
-			renderer.unmount();
+			rendered.unmount();
 		} );
 
 		it( 'handles registration of a non-existing store during rendering', () => {
-			let renderer;
-
 			const TestComponent = jest.fn( () => {
 				const state = useSelect(
 					( select ) =>
-						select( 'not-yet-registered-store' )?.getCounter(),
+						select( 'not-yet-registered-store' )?.getCounter() ??
+						'blank',
 					[]
 				);
 
-				return <div data={ state } />;
+				return <div role="status">{ state }</div>;
 			} );
 
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
-				);
-			} );
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
-			const testInstance = renderer.root;
-
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
-				undefined
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'blank'
 			);
 
 			act( () => {
@@ -649,23 +589,21 @@ describe( 'useSelect', () => {
 			} );
 
 			// This is not ideal, but is the way it's working before and we want to prevent breaking changes.
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
-				undefined
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'blank'
 			);
 
 			act( () => {
 				registry.dispatch( 'not-yet-registered-store' ).increment();
 			} );
 
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 1 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 1 );
 
 			// Test if the unsubscribers get called correctly.
-			renderer.unmount();
+			rendered.unmount();
 		} );
 
 		it( 'handles registration of a non-existing store of sub-registry during rendering', () => {
-			let renderer;
-
 			const subRegistry = createRegistry( {}, registry );
 
 			const TestComponent = jest.fn( () => {
@@ -673,27 +611,23 @@ describe( 'useSelect', () => {
 					( select ) =>
 						select(
 							'not-yet-registered-child-store'
-						)?.getCounter(),
+						)?.getCounter() ?? 'blank',
 					[]
 				);
 
-				return <div data={ state } />;
+				return <div role="status">{ state }</div>;
 			} );
 
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<RegistryProvider value={ subRegistry }>
-							<TestComponent />
-						</RegistryProvider>
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<RegistryProvider value={ subRegistry }>
+						<TestComponent />
 					</RegistryProvider>
-				);
-			} );
+				</RegistryProvider>
+			);
 
-			const testInstance = renderer.root;
-
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
-				undefined
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'blank'
 			);
 
 			act( () => {
@@ -704,8 +638,8 @@ describe( 'useSelect', () => {
 			} );
 
 			// This is not ideal, but is the way it's working before and we want to prevent breaking changes.
-			expect( testInstance.findByType( 'div' ).props.data ).toBe(
-				undefined
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent(
+				'blank'
 			);
 
 			act( () => {
@@ -714,15 +648,13 @@ describe( 'useSelect', () => {
 					.increment();
 			} );
 
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 1 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( '1' );
 
 			// Test if the unsubscribers get called correctly.
-			renderer.unmount();
+			rendered.unmount();
 		} );
 
 		it( 'handles custom generic stores without a unsubscribe function', () => {
-			let renderer;
-
 			const customStore = {
 				name: 'generic-store',
 				instantiate() {
@@ -762,28 +694,24 @@ describe( 'useSelect', () => {
 					[]
 				);
 
-				return <div data={ state } />;
+				return <div role="status">{ state }</div>;
 			} );
 
-			act( () => {
-				renderer = TestRenderer.create(
-					<RegistryProvider value={ registry }>
-						<TestComponent />
-					</RegistryProvider>
-				);
-			} );
+			const rendered = render(
+				<RegistryProvider value={ registry }>
+					<TestComponent />
+				</RegistryProvider>
+			);
 
-			const testInstance = renderer.root;
-
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 0 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 0 );
 
 			act( () => {
 				registry.dispatch( customStore ).increment();
 			} );
 
-			expect( testInstance.findByType( 'div' ).props.data ).toBe( 1 );
+			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 1 );
 
-			expect( () => renderer.unmount() ).not.toThrow();
+			expect( () => rendered.unmount() ).not.toThrow();
 		} );
 	} );
 } );


### PR DESCRIPTION
Updates `useSelect` unit tests to use `@testing-library/react` API instead of using the React test renderer directly.

I'm working on some improvements to `useSelect` async mode (see #40093) and I'll need to add more unit tests to cover the functionality. This is the first step.