### PR TITLE
[Block] Transform: Comments-Query-Loop and Post-Comments-Form

### DIFF
--- a/packages/block-library/src/comments-query-loop/index.js
+++ b/packages/block-library/src/comments-query-loop/index.js
@@ -9,12 +9,14 @@ import { postComments as icon } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	icon,
+	transforms,
 	edit,
 	save,
 };

--- a/packages/block-library/src/comments-query-loop/transforms.js
+++ b/packages/block-library/src/comments-query-loop/transforms.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-comments-form' ],
+			transform: ( { content } ) => {
+				return createBlock( 'core/comments-query-loop', {
+					content,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;

--- a/packages/block-library/src/post-comments-form/index.js
+++ b/packages/block-library/src/post-comments-form/index.js
@@ -8,11 +8,13 @@ import { postCommentsForm as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
 	icon,
+	transforms,
 	edit,
 };

--- a/packages/block-library/src/post-comments-form/transforms.js
+++ b/packages/block-library/src/post-comments-form/transforms.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/comments-query-loop' ],
+			transform: ( { content } ) => {
+				return createBlock( 'core/post-comments-form', {
+					content,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: #40223 

## What?
<!-- In a few words, what is the PR actually doing? -->
In the current version of the blocks (`core/comments-query-loop` and `post-comments-form`) doesn't support transform from one block to other. In this PR, I have added a functionality to support block transformation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
0. Checkout to the PR and build the project.
1. Add a `comments-query-loop` block in your post and click on transforms and apply `post-comments-form`.
2. Add next block `post-comments-form` and apply transform `comments-query-loop`.
3. Verify if both the transformation is successful.

## Screenshots or screencast <!-- if applicable -->
Transformation from `comments-query-loop` to `post-comments-form`
<img width="701" alt="image" src="https://user-images.githubusercontent.com/21127788/162768936-92244feb-ba5e-4445-b736-ccf57f67b604.png">


Transformation from `post-comments-form` to `comments-query-loop`.
<img width="684" alt="image" src="https://user-images.githubusercontent.com/21127788/162769132-a6b3efde-3f47-44e2-aae4-9f02cee96d4e.png">


cc @paaljoachim 