### PR TITLE
Increment `theme.json` version to 3

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-migrations.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-migrations.md
@@ -2,6 +2,10 @@
 
 This guide documents the changes between different `theme.json` versions and how to upgrade. Using older versions will continue to be supported. Upgrading is recommended because new development will continue in the newer versions.
 
+## Migrating from v2 to v3
+
+Update `version` to `3`. No other changes necessary.
+
 ## Migrating from v1 to v2
 
 Upgrading to v2 enables some new features and adjusts the naming of some old features to be more consistent with one another.

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-schema-gutenberg.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-schema-gutenberg.php
@@ -77,6 +77,10 @@ class WP_Theme_JSON_Schema_Gutenberg {
 			$theme_json = self::migrate_v1_to_v2( $theme_json );
 		}
 
+		if ( 2 === $theme_json['version'] ) {
+			$theme_json['version'] = 3;
+		}
+
 		return $theme_json;
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php
@@ -198,6 +198,13 @@ class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
 	);
 
 	/**
+	 * The latest version of the schema in use.
+	 *
+	 * @var int
+	 */
+	const LATEST_SCHEMA = 3;
+
+	/**
 	 * Returns the current theme's wanted patterns(slugs) to be
 	 * registered from Pattern Directory.
 	 *

--- a/lib/compat/wordpress-6.0/theme.json
+++ b/lib/compat/wordpress-6.0/theme.json
@@ -1,5 +1,5 @@
 {
-	"version": 2,
+	"version": 3,
 	"settings": {
 		"appearanceTools": false,
 		"border": {

--- a/phpunit/class-gutenberg-rest-global-styles-controller-test.php
+++ b/phpunit/class-gutenberg-rest-global-styles-controller-test.php
@@ -87,7 +87,7 @@ class Gutenberg_REST_Global_Styles_Controller_Test extends WP_Test_REST_Controll
 		$data     = $response->get_data();
 		$expected = array(
 			array(
-				'version'  => 2,
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 				'settings' => array(
 					'color' => array(
 						'palette' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2263,7 +2263,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$actual   = $theme_json->get_raw_data();
 		$expected = array(
-			'version' => 2,
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
 				'spacing' => array(
 					'blockGap' => 'valid value',
@@ -2329,7 +2329,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$theme->merge( $user );
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2381,7 +2381,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2429,7 +2429,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$actual   = $user->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'color' => array(
 					'palette' => array(
@@ -2459,7 +2459,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'theme'
 		);
 		$actual_v2   = $theme_v2->get_data();
-		$expected_v2 = array( 'version' => 2 );
+		$expected_v2 = array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA );
 		$this->assertEqualSetsWithIndex( $expected_v2, $actual_v2 );
 
 		$theme_v1    = new WP_Theme_JSON_Gutenberg(
@@ -2469,7 +2469,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'theme'
 		);
 		$actual_v1   = $theme_v1->get_data();
-		$expected_v1 = array( 'version' => 2 );
+		$expected_v1 = array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA );
 		$this->assertEqualSetsWithIndex( $expected_v1, $actual_v1 );
 	}
 
@@ -2490,7 +2490,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$actual   = $theme->get_data();
 		$expected = array(
-			'version'  => 2,
+			'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'settings' => array(
 				'appearanceTools' => true,
 				'blocks'          => array(


### PR DESCRIPTION
## What?

This PR increments the `theme.json` version to 3.

## Why?

We've added some new things to the `theme.json` schema, so we need to publish a new one to document in which WordPress version a specific setting can be found.

There's no modifications or removals in the existing schema, only additions:

- `title` top-level key
- `patterns` top-level key
- `settings.color.defaultDuotone` setting key

The behavior is the same as before, this serves to semantically mark the new files. This version change will be documented in the block editor handbook as well with a PR sent to the Gutenberg repository.

## How?

Updates the version in the `theme.json` file bundled with Gutenberg and in the theme.json class.

Related PR to core at https://github.com/WordPress/wordpress-develop/pull/2565

## Testing Instructions

Does not have any effect at runtime.
