### PR TITLE
Fix comments no results placeholder not appearing

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -252,12 +252,13 @@ export default function CommentTemplateEdit( {
 		( select ) => {
 			const { getEntityRecords } = select( coreStore );
 			const { getBlocks } = select( blockEditorStore );
-
 			return {
 				// Request only top-level comments. Replies are embedded.
-				topLevelComments: commentQuery
-					? getEntityRecords( 'root', 'comment', commentQuery )
-					: null,
+				topLevelComments: getEntityRecords(
+					'root',
+					'comment',
+					commentQuery
+				),
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -272,14 +273,6 @@ export default function CommentTemplateEdit( {
 			: topLevelComments
 	);
 
-	if ( ! topLevelComments ) {
-		return (
-			<p { ...blockProps }>
-				<Spinner />
-			</p>
-		);
-	}
-
 	if ( ! postId ) {
 		commentTree = getCommentsPlaceholder( {
 			perPage: commentsPerPage,
@@ -288,7 +281,15 @@ export default function CommentTemplateEdit( {
 		} );
 	}
 
-	if ( ! commentTree.length ) {
+	if ( ! topLevelComments ) {
+		return (
+			<p { ...blockProps }>
+				<Spinner />
+			</p>
+		);
+	}
+
+	if ( topLevelComments.length === 0 && commentTree.length === 0 ) {
 		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
 	}
 

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -254,11 +254,9 @@ export default function CommentTemplateEdit( {
 			const { getBlocks } = select( blockEditorStore );
 			return {
 				// Request only top-level comments. Replies are embedded.
-				topLevelComments: getEntityRecords(
-					'root',
-					'comment',
-					commentQuery
-				),
+				topLevelComments: commentQuery
+					? getEntityRecords( 'root', 'comment', commentQuery )
+					: null,
 				blocks: getBlocks( clientId ),
 			};
 		},
@@ -273,14 +271,6 @@ export default function CommentTemplateEdit( {
 			: topLevelComments
 	);
 
-	if ( ! postId ) {
-		commentTree = getCommentsPlaceholder( {
-			perPage: commentsPerPage,
-			threadComments,
-			threadCommentsDepth,
-		} );
-	}
-
 	if ( ! topLevelComments ) {
 		return (
 			<p { ...blockProps }>
@@ -289,7 +279,15 @@ export default function CommentTemplateEdit( {
 		);
 	}
 
-	if ( topLevelComments.length === 0 && commentTree.length === 0 ) {
+	if ( ! postId ) {
+		commentTree = getCommentsPlaceholder( {
+			perPage: commentsPerPage,
+			threadComments,
+			threadCommentsDepth,
+		} );
+	}
+
+	if ( ! commentTree.length ) {
 		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
 	}
 

--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -288,7 +288,11 @@ export default function CommentTemplateEdit( {
 	}
 
 	if ( ! commentTree.length ) {
-		return <p { ...blockProps }> { __( 'No results found.' ) }</p>;
+		return (
+			<p { ...blockProps } data-testid="noresults">
+				{ __( 'No results found.' ) }
+			</p>
+		);
 	}
 
 	return (

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -55,7 +55,7 @@ export const useCommentQueryArgs = ( { postId } ) => {
 					per_page: perPage,
 					page,
 			  }
-			: null;
+			: {};
 	}, [ postId, perPage, page ] );
 };
 

--- a/packages/block-library/src/comment-template/hooks.js
+++ b/packages/block-library/src/comment-template/hooks.js
@@ -55,7 +55,7 @@ export const useCommentQueryArgs = ( { postId } ) => {
 					per_page: perPage,
 					page,
 			  }
-			: {};
+			: null;
 	}, [ postId, perPage, page ] );
 };
 
@@ -96,9 +96,10 @@ const useDefaultPageIndex = ( { defaultPage, postId, perPage, queryArgs } ) => {
 			method: 'HEAD',
 			parse: false,
 		} ).then( ( res ) => {
+			const pages = parseInt( res.headers.get( 'X-WP-TotalPages' ) );
 			setDefaultPages( {
 				...defaultPages,
-				[ key ]: parseInt( res.headers.get( 'X-WP-TotalPages' ) ),
+				[ key ]: pages <= 1 ? 1 : pages, // If there are 0 pages, it means that there are no comments, but there is no 0th page.
 			} );
 		} );
 	}, [ defaultPage, postId, perPage, setDefaultPages ] );

--- a/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
@@ -24,6 +24,20 @@ describe( 'Comment Query Loop', () => {
 			'newest'
 		);
 	} );
+	it( 'We show no results message if there are no comments', async () => {
+		await trashAllComments();
+		await createNewPost();
+		// Insert the Query Comment Loop block.
+		await insertBlock( 'Comments Query Loop' );
+		// await page.waitForResponse(response => response.status() === 200);
+		await page.waitForSelector( '[data-testid="noresults"]' );
+		expect(
+			await page.evaluate(
+				( el ) => el.innerText,
+				await page.$( '[data-testid="noresults"]' )
+			)
+		).toEqual( 'No results found.' );
+	} );
 	it( 'Pagination links are working as expected', async () => {
 		await createNewPost();
 		// Insert the Query Comment Loop block.

--- a/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/comments-query.test.js
@@ -27,9 +27,7 @@ describe( 'Comment Query Loop', () => {
 	it( 'We show no results message if there are no comments', async () => {
 		await trashAllComments();
 		await createNewPost();
-		// Insert the Query Comment Loop block.
 		await insertBlock( 'Comments Query Loop' );
-		// await page.waitForResponse(response => response.status() === 200);
 		await page.waitForSelector( '[data-testid="noresults"]' );
 		expect(
 			await page.evaluate(
@@ -40,9 +38,7 @@ describe( 'Comment Query Loop', () => {
 	} );
 	it( 'Pagination links are working as expected', async () => {
 		await createNewPost();
-		// Insert the Query Comment Loop block.
 		await insertBlock( 'Comments Query Loop' );
-		// Insert the Comment Loop form.
 		await insertBlock( 'Post Comments Form' );
 		await publishPost();
 		// Visit the post that was just published.
@@ -103,9 +99,7 @@ describe( 'Comment Query Loop', () => {
 	it( 'Pagination links are not appearing if break comments is not enabled', async () => {
 		await setOption( 'page_comments', '0' );
 		await createNewPost();
-		// Insert the Query Comment Loop block.
 		await insertBlock( 'Comments Query Loop' );
-		// Insert the Comment Loop form.
 		await insertBlock( 'Post Comments Form' );
 		await publishPost();
 		// Visit the post that was just published.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Display "No results" placeholder when there are no comments related to a post while you are in the post editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Right now, if you do not have any comments in the post, or any comments at all on the site, and you add a Comment Query Loop, you have an infinite loading spinner and a SQL error warning.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Forcing the API call (I don't really love this solution), even if CommentQuery var is null. Then check if the response is an empty array.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. ) Remove all comments.
2. ) Go to a post editor. Add the Comment Query Loop. It should appear no results found.
3. ) Go to Site Editor -> Any Template. Add the Comment Query Loop. Check that the placeholder is rendered.
