### PR TITLE
docgen: Unwrap wrapped selectors when inferring types of JSDoc params

### DIFF
--- a/packages/docgen/test/get-type-annotation.js
+++ b/packages/docgen/test/get-type-annotation.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 const getTypeAnnotation = require( '../lib/get-type-annotation' );
+const engine = require( '../lib/engine' );
 
 const getSimpleTypeNode = require( './fixtures/type-annotations/simple-types/get-node' );
 const getArraysGenericTypesUnionsAndIntersctionsNode = require( './fixtures/type-annotations/arrays-generic-types-unions-intersections/get-node' );
@@ -316,6 +317,50 @@ describe( 'Type annotations', () => {
 			expect( getTypeAnnotation( { tag: 'type' }, node, 0 ) ).toBe(
 				'( string | number )[]'
 			);
+		} );
+	} );
+
+	describe( 'statically-wrapped function exceptions', () => {
+		it( 'should find types for inner function with `createSelector`', () => {
+			const { tokens } = engine(
+				'test.ts',
+				`/**
+					 * Returns the number of things
+					 *
+					 * @param state - stores all the things
+					 */
+					export const getCount = createSelector( ( state: string[] ) => state.length );
+					`
+			);
+
+			expect(
+				getTypeAnnotation(
+					{ tag: 'param', name: 'state' },
+					tokens[ 0 ],
+					0
+				)
+			).toBe( 'string[]' );
+		} );
+
+		it( 'should find types for inner function with `createRegistrySelector`', () => {
+			const { tokens } = engine(
+				'test.ts',
+				`/**
+					 * Returns the number of things
+					 *
+					 * @param state - stores all the things
+					 */
+					export const getCount = createRegistrySelector( ( select ) => ( state: number ) => state );
+					`
+			);
+
+			expect(
+				getTypeAnnotation(
+					{ tag: 'param', name: 'state' },
+					tokens[ 0 ],
+					0
+				)
+			).toBe( 'number' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## What

In #40025 we ran into an obstacle when transitioning code into TypeScript,
namely that our `docgen` tool is unable to find the associated types for
parameters which are documented in JSDoc comments if the parameters are
for the returned function from a call to some wrapping function.

In this patch we're adding two special cases for selectors that call
`createSelector` and `createRegistrySelector` to allow our `docgen` tool
to analyze those inner functions which represent the actual selector.

Fundamentally we should be asking TypeScript for the inferred types of
the function and its parameters but given that we don't have a current
mechanism to do that this issue remains a blocker for broader TypeScript
work. Because of that we're introducing hard-coded special cases for
these common selector wrappers so that we can unblock the TypeScript
work without introducing a generic compromise with potentially-harmful
side-effects, such as might happen if we were to always return the
first argument of a call expression.

## Why

We don't want to block helpful TypeScript updates until we can rebuild
our documentation generation tooling.

## Testing

The easiest way to see the impact of this change is to checkout #40025
and try to run `npm run api-docs:ref`. It should fail with nebulous errors
about improper syntax.

If you merge this branch however, then run `npm build:packages` (to
re-generate `docgen`) and then `npm run api-docs:ref` again you should
notice that it succeeds and in inspecting the generated `README` updates
see that the types for the selectors come through even for those
selectors which are wrapped.

There should be no functional or built-code changes in this PR.