### PR TITLE
Block supports: unregister block in PHP unit tests

### DIFF
--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -7,11 +7,21 @@
  */
 
 class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		$this->test_block_name = null;
+	}
+
+	function tearDown() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tearDown();
+	}
 
 	function test_border_color_slug_with_numbers_is_kebab_cased_properly() {
-		$block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
+		$this->test_block_name = 'test/border-color-slug-with-numbers-is-kebab-cased-properly';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -33,7 +43,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'borderColor' => 'red',
 			'style'       => array(
@@ -52,13 +62,12 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_border_with_skipped_serialization_block_supports() {
-		$block_name = 'test/border-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/border-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -78,7 +87,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'border' => array(
@@ -94,13 +103,12 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_radius_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/radius-with-individual-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -120,7 +128,7 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'border' => array(
@@ -138,6 +146,5 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -8,7 +8,7 @@
 
 class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $test_block_name;
 

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -7,6 +7,11 @@
  */
 
 class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $test_block_name;
+
 	function setUp() {
 		parent::setUp();
 		$this->test_block_name = null;

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -7,10 +7,21 @@
  */
 
 class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		$this->test_block_name = null;
+	}
+
+	function tearDown() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tearDown();
+	}
 
 	function test_color_slugs_with_numbers_are_kebab_cased_properly() {
+		$this->test_block_name = 'test/color-slug-with-numbers';
 		register_block_type(
-			'test/color-slug-with-numbers',
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -34,7 +45,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/color-slug-with-numbers' );
+		$block_type = $registry->get_registered( $this->test_block_name );
 
 		$block_atts = array(
 			'textColor'       => 'fg1',
@@ -46,13 +57,12 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( 'test/color-slug-with-numbers' );
 	}
 
 	function test_color_with_skipped_serialization_block_supports() {
-		$block_name = 'test/color-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/color-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -71,7 +81,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		);
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'color' => array(
@@ -85,13 +95,12 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_gradient_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
+		$this->test_block_name = 'test/gradient-with-individual-skipped-serialization-block-support';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -110,7 +119,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		);
 
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'color' => array(
@@ -126,6 +135,5 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -8,7 +8,7 @@
 
 class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $test_block_name;
 

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -7,6 +7,11 @@
  */
 
 class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $test_block_name;
+
 	function setUp() {
 		parent::setUp();
 		$this->test_block_name = null;

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -7,11 +7,21 @@
  */
 
 class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		$this->test_block_name = null;
+	}
+
+	function tearDown() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tearDown();
+	}
 
 	function test_spacing_style_is_applied() {
-		$block_name = 'test/spacing-style-is-applied';
+		$this->test_block_name = 'test/spacing-style-is-applied';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -29,7 +39,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -51,13 +61,12 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_spacing_with_skipped_serialization_block_supports() {
-		$block_name = 'test/spacing-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/spacing-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -76,7 +85,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -96,13 +105,12 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_margin_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/margin-with-individual-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -121,7 +129,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'spacing' => array(
@@ -143,6 +151,5 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 }

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -8,7 +8,7 @@
 
 class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $test_block_name;
 

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -7,6 +7,11 @@
  */
 
 class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $test_block_name;
+
 	function setUp() {
 		parent::setUp();
 		$this->test_block_name = null;

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -7,6 +7,11 @@
  */
 
 class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
+	/**
+	 * @var string
+	 */
+	private $test_block_name;
+
 	function setUp() {
 		parent::setUp();
 		$this->test_block_name = null;

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -8,7 +8,7 @@
 
 class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 	/**
-	 * @var string
+	 * @var string|null
 	 */
 	private $test_block_name;
 

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -7,10 +7,21 @@
  */
 
 class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		$this->test_block_name = null;
+	}
+
+	function tearDown() {
+		unregister_block_type( $this->test_block_name );
+		$this->test_block_name = null;
+		parent::tearDown();
+	}
 
 	function test_font_size_slug_with_numbers_is_kebab_cased_properly() {
+		$this->test_block_name = 'test/font-size-slug-with-numbers';
 		register_block_type(
-			'test/font-size-slug-with-numbers',
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -26,7 +37,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( 'test/font-size-slug-with-numbers' );
+		$block_type = $registry->get_registered( $this->test_block_name );
 
 		$block_atts = array( 'fontSize' => 'h1' );
 
@@ -34,13 +45,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$expected = array( 'class' => 'has-h-1-font-size' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( 'test/font-size-slug-with-numbers' );
 	}
 
 	function test_font_family_with_legacy_inline_styles_using_a_value() {
-		$block_name = 'test/font-family-with-inline-styles-using-value';
+		$this->test_block_name = 'test/font-family-with-inline-styles-using-value';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -56,20 +66,19 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'fontFamily' => 'serif' ) ) );
 
 		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'style' => 'font-family: serif;' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_typography_with_skipped_serialization_block_supports() {
-		$block_name = 'test/typography-with-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/typography-with-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -89,7 +98,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array(
 			'style' => array(
 				'typography' => array(
@@ -105,13 +114,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_letter_spacing_with_individual_skipped_serialization_block_supports() {
-		$block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
+		$this->test_block_name = 'test/letter-spacing-with-individua-skipped-serialization-block-supports';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -130,20 +138,19 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'letterSpacing' => '22px' ) ) );
 
 		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
 		$expected = array();
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_font_family_with_legacy_inline_styles_using_a_css_var() {
-		$block_name = 'test/font-family-with-inline-styles-using-css-var';
+		$this->test_block_name = 'test/font-family-with-inline-styles-using-css-var';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -159,20 +166,19 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'style' => array( 'typography' => array( 'fontFamily' => 'var:preset|font-family|h1' ) ) );
 
 		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'style' => 'font-family: var(--wp--preset--font-family--h-1);' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
 
 	function test_font_family_with_class() {
-		$block_name = 'test/font-family-with-class';
+		$this->test_block_name = 'test/font-family-with-class';
 		register_block_type(
-			$block_name,
+			$this->test_block_name,
 			array(
 				'api_version' => 2,
 				'attributes'  => array(
@@ -188,14 +194,12 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 			)
 		);
 		$registry   = WP_Block_Type_Registry::get_instance();
-		$block_type = $registry->get_registered( $block_name );
+		$block_type = $registry->get_registered( $this->test_block_name );
 		$block_atts = array( 'fontFamily' => 'h1' );
 
 		$actual   = gutenberg_apply_typography_support( $block_type, $block_atts );
 		$expected = array( 'class' => 'has-h-1-font-family' );
 
 		$this->assertSame( $expected, $actual );
-		unregister_block_type( $block_name );
 	}
-
 }


### PR DESCRIPTION
## What?
Unregister the block in the `tearDown` method. 🔨 

See discussion: https://github.com/WordPress/wordpress-develop/pull/2500#discussion_r844275468

## Why?
The block will be unregistered even if the test fails. 😱 

## Testing Instructions
The PHP unit tests should pass. ✅  

## Hummus recipe

- 250g chick peas
- 2 tablespoons unhulled tahini
- Juice of 1 lemon
- 1 teaspoon of apple cider vinegar
- 1/2 teaspoon miso paste
- Pepper and salt to taste
- 1/3 cup olive oil
- Water to suit your viscosity preference
- Small clove of garlic

Blend well. Eat with carrots. 


