### PR TITLE
Comment meta data isn’t queued for lazy loading.

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -293,11 +293,10 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 	function build_comment_query_vars_from_block( $block ) {
 
 		$comment_args = array(
-			'orderby'                   => 'comment_date_gmt',
-			'order'                     => 'ASC',
-			'status'                    => 'approve',
-			'no_found_rows'             => false,
-			'update_comment_meta_cache' => false, // We lazy-load comment meta for performance.
+			'orderby'       => 'comment_date_gmt',
+			'order'         => 'ASC',
+			'status'        => 'approve',
+			'no_found_rows' => false,
 		);
 
 		if ( ! empty( $block->context['postId'] ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related #40241 

## What?
<!-- In a few words, what is the PR actually doing? -->

Primes comment meta data cache within calls to `WP_Comment_Query`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the FSE blocks lack calls to `wp_queue_comments_for_comment_meta_lazyload()`.

Without these calls each time a comment first uses meta data a database request will be made.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Kicking the can down the load by not lazy loading the meta data.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm not sure sorry, can't see if it currently affects any blocks in core but it's likely to affect any custom blocks developers create that make use of meta data.

