### PR TITLE
Keep "Open in New Tab" when changing link of Button block.

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -235,8 +235,8 @@ function LinkControl( {
 			internalTextValue !== value?.title
 		) {
 			onChange( {
+				...value,
 				url: currentInputValue,
-				opensInNewTab: value?.opensInNewTab || undefined,
 				title: internalTextValue,
 			} );
 		}

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -236,6 +236,7 @@ function LinkControl( {
 		) {
 			onChange( {
 				url: currentInputValue,
+				opensInNewTab: value?.opensInNewTab || undefined,
 				title: internalTextValue,
 			} );
 		}

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -235,7 +235,10 @@ function ButtonEdit( props ) {
 						} ) => {
 							setAttributes( { url: newURL } );
 
-							if ( opensInNewTab !== newOpensInNewTab ) {
+							if (
+								'undefined' !== typeof newOpensInNewTab &&
+								opensInNewTab !== newOpensInNewTab
+							) {
 								onToggleOpenInNewTab( newOpensInNewTab );
 							}
 						} }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -235,10 +235,7 @@ function ButtonEdit( props ) {
 						} ) => {
 							setAttributes( { url: newURL } );
 
-							if (
-								'undefined' !== typeof newOpensInNewTab &&
-								opensInNewTab !== newOpensInNewTab
-							) {
+							if ( opensInNewTab !== newOpensInNewTab ) {
 								onToggleOpenInNewTab( newOpensInNewTab );
 							}
 						} }


### PR DESCRIPTION
## What?
Fix #40243.

## Why?
When editing a link in a Button block, `linkTarget` is reset even though only the url is changed.

This is a bit strange behavior.

So I created a PR that when only the URL is edited, it does not affect the `linkTarget` that has already been set.

## How?
~When `opensInNewTab` is `undefined` in the information returned by `onChange` of `<LinkControl>`, the update process of `linkTarget` is not performed.~

`opensInNewTab` was not being passed in `handleSubmit()` of `<LinkControl>`.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Button Block.
3. Set the URL for the link and turn on "Open in new tab".
4. Edit the URL using the "Edit" button and click the "Submit" button to save.

## Screenshots or screencast <!-- if applicable -->

This PR improves the behavior as follows

https://user-images.githubusercontent.com/31400297/162872672-3041c299-af71-4914-a533-28b2072aaf10.mp4


