### PR TITLE
Add block styles slot to the site editor so block style previews can be rendered

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -5,7 +5,11 @@ import { useEffect, useState, useMemo, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Popover, Button, Notice } from '@wordpress/components';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
-import { BlockContextProvider, BlockBreadcrumb } from '@wordpress/block-editor';
+import {
+	BlockContextProvider,
+	BlockBreadcrumb,
+	BlockStyles,
+} from '@wordpress/block-editor';
 import {
 	InterfaceSkeleton,
 	ComplementaryArea,
@@ -236,6 +240,7 @@ function Editor( { onError } ) {
 											content={
 												<>
 													<EditorNotices />
+													<BlockStyles.Slot scope="core/block-inspector" />
 													{ editorMode === 'visual' &&
 														template && (
 															<BlockEditor


### PR DESCRIPTION
## What?
Adds `BlockStyles.Slot` to the site editor

## Why?
Currently block style previews are not rendered when they are hovered or focused in the site editor. Fixes: #40064

## How?
Adds `BlockStyles.Slot` into the site editor content area

## Testing Instructions

- In the site editor add a button block, and make sure that the block style preview popup renders when you focus or mouseover a button style

## Screenshots or screencast 
Before:

https://user-images.githubusercontent.com/3629020/162880211-91492ce3-d831-460f-b540-d145cf2d5475.mp4

After:

https://user-images.githubusercontent.com/3629020/162880240-040aaf9f-cb03-4f36-8936-12fc882c1ff0.mp4





