### PR TITLE
Add new persistence api to the preferences package

### DIFF
--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Breaking change
+
+-   The preferences package is no longer compatible with the `@wordpress/data` persistence plugin. Please use the new `setPersistenceLayer` API. ([#39795](https://github.com/WordPress/gutenberg/pull/39795))
+
+### Enhancement
+
+-   A new `setPersistenceLayer` action has been introduced. ([#39795](https://github.com/WordPress/gutenberg/pull/39795))
+
 ## 1.2.0 (2022-04-08)
 
 ## 1.1.0 (2022-03-23)

--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancement
 
--   A new `setPersistenceLayer` action has been introduced. ([#39795](https://github.com/WordPress/gutenberg/pull/39795))
+-   A new `setPersistenceLayer` action has been introduced. ([#40246](https://github.com/WordPress/gutenberg/pull/40246))
 
 ## 1.2.0 (2022-04-08)
 

--- a/packages/preferences/CHANGELOG.md
+++ b/packages/preferences/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Breaking change
-
--   The preferences package is no longer compatible with the `@wordpress/data` persistence plugin. Please use the new `setPersistenceLayer` API. ([#39795](https://github.com/WordPress/gutenberg/pull/39795))
-
 ### Enhancement
 
 -   A new `setPersistenceLayer` action has been introduced. ([#39795](https://github.com/WordPress/gutenberg/pull/39795))

--- a/packages/preferences/README.md
+++ b/packages/preferences/README.md
@@ -109,11 +109,11 @@ wp.data.dispatch( 'core/preferences' ).setPersistenceLayer( {
 } );
 ```
 
-For application that persist data to an asynchronous API, a concern will be that loading preferences can lead to slower application start up.
+For application that persist data to an asynchronous API, a concern is that loading preferences can lead to slower application start up.
 
 A recommendation is to pre-load any persistence layer data and keep it in a local cache particularly if you're using an asynchronous API to persist data.
 
-While `get` is only called currently when `setPersistenceLayer` is triggered.
+Note: currently `get` is called only when `setPersistenceLayer` is triggered. This may change in the future, so it's sensible to optimize `get` using a local cache, as shown in the example below.
 
 ```js
 // Preloaded data from the server.
@@ -133,8 +133,6 @@ wp.data.dispatch( 'core/preferences' ).setPersistenceLayer( {
 	},
 } );
 ```
-
-See the `@wordpress/database-persistence-layer` package for a reference implementation.
 
 ### Components
 

--- a/packages/preferences/README.md
+++ b/packages/preferences/README.md
@@ -1,6 +1,6 @@
 # Preferences
 
-Utilities for storing WordPress preferences.
+A key/value store for application preferences.
 
 ## Installation
 
@@ -12,11 +12,27 @@ npm install @wordpress/preferences --save
 
 _This package assumes that your code will run in an **ES2015+** environment. If you're using an environment that has limited or no support for such language features and APIs, you should include [the polyfill shipped in `@wordpress/babel-preset-default`](https://github.com/WordPress/gutenberg/tree/HEAD/packages/babel-preset-default#polyfill) in your code._
 
+## Key concepts
+
+### Scope
+
+Many API calls require a 'scope' parameter that acts like a namespace. If you have multiple parameters with the same key but they apply to different parts of your application, using scopes is the best way to segregate them.
+
+### Key
+
+Each preference is set against a key that should be a string.
+
+### Value
+
+Values can be of any type, but the types supported may be limited by the persistence layer configure. For example of preferences are saved to browser localStorage in JSON format, only JSON serializable types should be used.
+
+### Defaults
+
+Defaults are the value returned when a preference is `undefined`. These are not persisted, they are only kept in memory. They should be during the initialization of an application.
+
 ## Examples
 
 ### Data store
-
-Preferences are persisted values of any kind.
 
 Set the default preferences for any features on initialization by dispatching an action:
 
@@ -38,7 +54,7 @@ function initialize() {
 }
 ```
 
-Or the `get` selector to get a preference value, and the `set` action to update a preference to any value:
+Use the `get` selector to get a preference value, and the `set` action to update a preference:
 
 ```js
 wp.data
@@ -65,6 +81,60 @@ wp.data
 	.select( 'core/preferences' )
 	.get( 'namespace/editor-or-plugin-name', 'myPreferenceName' ); // false
 ```
+
+#### Setting up a persistence layer
+
+By default, this package only stores values in-memory. But it can be configured to persist preferences to browser storage or a database via an optional persistence layer.
+
+Use the `setPersistenceLayer` action to configure how the store persists its preference values.
+
+```js
+wp.data.dispatch( 'core/preferences' ).setPersistenceLayer( {
+	// `get` is asynchronous to support persisting preferences using a REST API.
+	// it will immediately be called by `setPersistenceLayer` and the returned
+	// value used as the initial state of the preferences.
+	async get() {
+		return JSON.parse( window.localStorage.getItem( 'MY_PREFERENCES' ) );
+	},
+
+	// `set` is synchronous. It's ok to use asynchronous code, but the
+	// preferences store won't wait for a promise to resolve, the function is
+	// 'fire and forget'.
+	set( preferences ) {
+		window.localStorage.setItem(
+			'MY_PREFERENCES',
+			JSON.stringify( preferences )
+		);
+	},
+} );
+```
+
+For application that persist data to an asynchronous API, a concern will be that loading preferences can lead to slower application start up.
+
+A recommendation is to pre-load any persistence layer data and keep it in a local cache particularly if you're using an asynchronous API to persist data.
+
+While `get` is only called currently when `setPersistenceLayer` is triggered.
+
+```js
+// Preloaded data from the server.
+let cache = preloadedData;
+wp.data.dispatch( 'core/preferences' ).setPersistenceLayer( {
+	async get() {
+		if ( cache ) {
+			return cache;
+		}
+
+		// Call to a made-up async API.
+		return await api.preferences.get();
+	},
+	set( preferences ) {
+		cache = preferences;
+		api.preferences.set( { data: preferences } );
+	},
+} );
+```
+
+See the `@wordpress/database-persistence-layer` package for a reference implementation.
 
 ### Components
 
@@ -125,6 +195,27 @@ _Parameters_
 
 -   _scope_ `string`: The preference scope (e.g. core/edit-post).
 -   _defaults_ `Object<string, *>`: A key/value map of preference names to values.
+
+_Returns_
+
+-   `Object`: Action object.
+
+#### setPersistenceLayer
+
+Sets the persistence layer.
+
+When a persistence layer is set, the preferences store will:
+
+-   call `get` immediately and update the store state to the value returned.
+-   call `set` with all preferences whenever a preference changes value.
+
+`setPersistenceLayer` should ideally be dispatched at the start of an
+application's lifecycle, before any other actions have been dispatched to
+the preferences store.
+
+_Parameters_
+
+-   _persistenceLayer_ `WPPreferencesPersistenceLayer`: The persistence layer.
 
 _Returns_
 

--- a/packages/preferences/src/store/actions.js
+++ b/packages/preferences/src/store/actions.js
@@ -47,3 +47,36 @@ export function setDefaults( scope, defaults ) {
 		defaults,
 	};
 }
+
+/** @typedef {() => Promise<Object>} WPPreferencesPersistenceLayerGet */
+/** @typedef {(*) => void} WPPreferencesPersistenceLayerSet */
+/**
+ * @typedef WPPreferencesPersistenceLayer
+ *
+ * @property {WPPreferencesPersistenceLayerGet} get An async function that gets data from the persistence layer.
+ * @property {WPPreferencesPersistenceLayerSet} set A  function that sets data in the persistence layer.
+ */
+
+/**
+ * Sets the persistence layer.
+ *
+ * When a persistence layer is set, the preferences store will:
+ * - call `get` immediately and update the store state to the value returned.
+ * - call `set` with all preferences whenever a preference changes value.
+ *
+ * `setPersistenceLayer` should ideally be dispatched at the start of an
+ * application's lifecycle, before any other actions have been dispatched to
+ * the preferences store.
+ *
+ * @param {WPPreferencesPersistenceLayer} persistenceLayer The persistence layer.
+ *
+ * @return {Object} Action object.
+ */
+export async function setPersistenceLayer( persistenceLayer ) {
+	const persistedData = await persistenceLayer.get();
+	return {
+		type: 'SET_PERSISTENCE_LAYER',
+		persistenceLayer,
+		persistedData,
+	};
+}

--- a/packages/preferences/src/store/index.js
+++ b/packages/preferences/src/store/index.js
@@ -1,11 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, registerStore } from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
-/**
- * Internal dependencies
- */
 /**
  * Internal dependencies
  */
@@ -25,14 +22,6 @@ export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	actions,
 	selectors,
-	persist: [ 'preferences' ],
 } );
 
-// Once we build a more generic persistence plugin that works across types of stores
-// we'd be able to replace this with a register call.
-registerStore( STORE_NAME, {
-	reducer,
-	actions,
-	selectors,
-	persist: [ 'preferences' ],
-} );
+register( store );

--- a/packages/preferences/src/store/index.js
+++ b/packages/preferences/src/store/index.js
@@ -1,8 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import { createReduxStore, registerStore } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
 /**
  * Internal dependencies
  */
@@ -22,6 +25,14 @@ export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	actions,
 	selectors,
+	persist: [ 'preferences' ],
 } );
 
-register( store );
+// Once we build a more generic persistence plugin that works across types of stores
+// we'd be able to replace this with a register call.
+registerStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+	persist: [ 'preferences' ],
+} );

--- a/packages/preferences/src/store/test/actions.js
+++ b/packages/preferences/src/store/test/actions.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { setPersistenceLayer } from '../actions';
+
+describe( 'setPersistenceLayer', () => {
+	it( 'returns an action that contains the persistence layer and the result of calling `persistenceLayer.get`', async () => {
+		const result = {
+			testA: 1,
+			testB: 2,
+		};
+		const testPersistenceLayer = {
+			async get() {
+				return result;
+			},
+			set() {},
+		};
+
+		const action = await setPersistenceLayer( testPersistenceLayer );
+
+		expect( action ).toEqual( {
+			type: 'SET_PERSISTENCE_LAYER',
+			persistenceLayer: testPersistenceLayer,
+			persistedData: result,
+		} );
+	} );
+} );

--- a/packages/preferences/src/store/test/reducer.js
+++ b/packages/preferences/src/store/test/reducer.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { preferences } from '../reducer';
+
+describe( 'withPersistenceLayer( preferences )', () => {
+	it( 'updates the store state to the persisted data when called with the `SET_PERSISTENCE_LAYER` action', () => {
+		const persistedData = {
+			a: 1,
+			b: 2,
+		};
+
+		const action = {
+			type: 'SET_PERSISTENCE_LAYER',
+			persistedData,
+		};
+
+		expect( preferences( {}, action ) ).toEqual( persistedData );
+	} );
+
+	it( 'calls the persistence layer `set` function with the updated store state whenever the `SET_PREFERENCE_VALUE` action is dispatched', () => {
+		const set = jest.fn();
+		const persistenceLayer = {
+			set,
+		};
+
+		const setPersistenceLayerAction = {
+			type: 'SET_PERSISTENCE_LAYER',
+			persistenceLayer,
+			persistedData: {},
+		};
+
+		// Set the persistence layer.
+		preferences( {}, setPersistenceLayerAction );
+
+		// Update a value.
+		const setPreferenceValueAction = {
+			type: 'SET_PREFERENCE_VALUE',
+			name: 'myPreference',
+			value: 'myValue',
+		};
+
+		const state = preferences( {}, setPreferenceValueAction );
+
+		expect( set ).toHaveBeenCalledWith( state );
+	} );
+} );


### PR DESCRIPTION
## What?
This PR contains only the changes to the preferences package from #39795. It should hopefully be easier to review.

So you know where this PR fits in, #39795 demonstrates the following:
- A new API in the preferences package for configuring a persistence layer (these are the changes in this PR)
- A new package with a persistence layer that saves preferences primarily to user meta. It also backs up to local storage in cases where an HTTP request might be interrupted or the user goes offline.
- Migration code to port the current local storage preferences to the new persistence layer.
- An inline script to configure preferences to use the new persistence package.

## Why?
After #39632 is merged, all Gutenberg preferences will be managed by the preferences package. It has become the logical place to add this API. Doing so will finally allow us to solve https://github.com/WordPress/gutenberg/issues/15105, which is a long standing problem for users.

Another goal is to deprecate the `registerStore` function and the existing persistence plugin that's part of `@wordpress/data` (https://github.com/WordPress/gutenberg/blob/trunk/packages/data/src/plugins/persistence/README.md).

## How?
A new action has been added to the preferences package for configuring the persistence layer:
```jsx
wp.data.dispatch( 'core/preferences' ).setPersistenceLayer( 
    {
        async get() { // returns preferences from a source (local storage, rest api etc.) }, 
        set() { // sets preferences at a source }
    }
);
```

And in the preferences reducer a higher-order reducer is used to call the persistence layer `get` and `set` functions.

## Testing Instructions
The best way to test is to checkout the `try/preferences-configurable-persistence-layer` branch from #39795.

1. Open up an editor and change a preference (e.g. top toolbar)
2. Open up another browser, login to the same account, and open up the same editor

Expected: top toolbar should be active