### PR TITLE
Update patterns REST controllers namespace to stable

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-pattern-categories-controller.php
@@ -26,7 +26,7 @@ class WP_REST_Block_Pattern_Categories_Controller extends WP_REST_Controller {
 	 * @since 6.0.0
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/categories';
 	}
 

--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -24,7 +24,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->namespace = '__experimental';
+		$this->namespace = 'wp/v2';
 		$this->rest_base = 'block-patterns/patterns';
 	}
 

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -456,14 +456,14 @@ export const __experimentalGetCurrentThemeGlobalStylesVariations = () => async (
 
 export const getBlockPatterns = () => async ( { dispatch } ) => {
 	const patterns = await apiFetch( {
-		path: '/__experimental/block-patterns/patterns',
+		path: '/wp/v2/block-patterns/patterns',
 	} );
 	dispatch( { type: 'RECEIVE_BLOCK_PATTERNS', patterns } );
 };
 
 export const getBlockPatternCategories = () => async ( { dispatch } ) => {
 	const categories = await apiFetch( {
-		path: '/__experimental/block-patterns/categories',
+		path: '/wp/v2/block-patterns/categories',
 	} );
 	dispatch( { type: 'RECEIVE_BLOCK_PATTERN_CATEGORIES', categories } );
 };

--- a/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
+++ b/phpunit/class-wp-rest-block-pattern-categories-controller-test.php
@@ -49,7 +49,7 @@ class WP_REST_Block_Pattern_Categories_Controller_Test extends WP_Test_REST_Cont
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey(
-			'/__experimental/block-patterns/categories',
+			'/wp/v2/block-patterns/categories',
 			$routes,
 			'The categories route does not exist'
 		);
@@ -61,7 +61,7 @@ class WP_REST_Block_Pattern_Categories_Controller_Test extends WP_Test_REST_Cont
 		$expected_names  = array( 'test', 'query' );
 		$expected_fields = array( 'name', 'label' );
 
-		$request            = new WP_REST_Request( 'GET', '/__experimental/block-patterns/categories' );
+		$request            = new WP_REST_Request( 'GET', '/wp/v2/block-patterns/categories' );
 		$request['_fields'] = 'name,label';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();

--- a/phpunit/class-wp-rest-block-patterns-controller-test.php
+++ b/phpunit/class-wp-rest-block-patterns-controller-test.php
@@ -65,7 +65,7 @@ class WP_REST_Block_Patterns_Controller_Test extends WP_Test_REST_Controller_Tes
 	public function test_register_routes() {
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey(
-			'/__experimental/block-patterns/patterns',
+			'/wp/v2/block-patterns/patterns',
 			$routes,
 			'The patterns route does not exist'
 		);
@@ -77,7 +77,7 @@ class WP_REST_Block_Patterns_Controller_Test extends WP_Test_REST_Controller_Tes
 		$expected_names  = array( 'test/one', 'test/two' );
 		$expected_fields = array( 'name', 'content' );
 
-		$request            = new WP_REST_Request( 'GET', '/__experimental/block-patterns/patterns' );
+		$request            = new WP_REST_Request( 'GET', '/wp/v2/block-patterns/patterns' );
 		$request['_fields'] = 'name,content';
 		$response           = rest_get_server()->dispatch( $request );
 		$data               = $response->get_data();


### PR DESCRIPTION
We need to update the patterns REST namespace as it has changed in the backport to core: https://github.com/WordPress/wordpress-develop/pull/2567