### PR TITLE
Comments Query Loop: Add Post Comments Form block to Comments Query Loop template

### DIFF
--- a/packages/block-library/src/comments-query-loop/edit.js
+++ b/packages/block-library/src/comments-query-loop/edit.js
@@ -64,6 +64,7 @@ const TEMPLATE = [
 		],
 	],
 	[ 'core/comments-pagination' ],
+	[ 'core/post-comments-form' ],
 ];
 
 export default function CommentsQueryLoopEdit( { attributes, setAttributes } ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add the Post Comments Form block to the Comments Query Loop template to ensure it appears directly after inserting the comments in the editor.

Fixes https://github.com/WordPress/gutenberg/issues/40225

## Why?
It's reasonable to assume that, when users add the Comments Loop, they will want to use the Post Comments Form as well. They could always delete it if it isn't needed.

## How?
Just adding the Post Comments Form block to the template.

## Testing Instructions
In trunk:

1. Go to a Post, Page, or Site Editor and add the Comments Query Loop.
1. Check that only the Comment Template and the Comments Pagination blocks are added automatically. You would have to add the Post Comments Form manually.

In the PR branch:

1. Go to a Post, Page, or Site Editor and add the Comments Query Loop.
1. Check that, apart from the Comment Template and the Comments Pagination, the Post Comments Form is added automatically.