### PR TITLE
Webfonts: Fix webfont loading in the Site Editor

### DIFF
--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -30,7 +30,8 @@ function gutenberg_register_webfonts_from_theme_json() {
 			// Merge the variation settings with the global settings.
 			$settings['typography']                 = empty( $settings['typography'] ) ? array() : $settings['typography'];
 			$settings['typography']['fontFamilies'] = empty( $settings['typography']['fontFamilies'] ) ? array() : $settings['typography']['fontFamilies'];
-			$settings['typography']['fontFamilies'] = array_merge( $settings['typography']['fontFamilies'], $variation['settings']['typography']['fontFamilies'] );
+			$settings['typography']['fontFamilies']['theme'] = empty( $settings['typography']['fontFamilies'] ) ? array() : $settings['typography']['fontFamilies']['theme'];
+			$settings['typography']['fontFamilies']['theme'] = array_merge( $settings['typography']['fontFamilies']['theme'], $variation['settings']['typography']['fontFamilies']['theme'] );
 
 			// Make sure there are no duplicates.
 			$settings['typography']['fontFamilies'] = array_unique( $settings['typography']['fontFamilies'] );

--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -28,8 +28,8 @@ function gutenberg_register_webfonts_from_theme_json() {
 			}
 
 			// Merge the variation settings with the global settings.
-			$settings['typography']                 = empty( $settings['typography'] ) ? array() : $settings['typography'];
-			$settings['typography']['fontFamilies'] = empty( $settings['typography']['fontFamilies'] ) ? array() : $settings['typography']['fontFamilies'];
+			$settings['typography']                          = empty( $settings['typography'] ) ? array() : $settings['typography'];
+			$settings['typography']['fontFamilies']          = empty( $settings['typography']['fontFamilies'] ) ? array() : $settings['typography']['fontFamilies'];
 			$settings['typography']['fontFamilies']['theme'] = empty( $settings['typography']['fontFamilies'] ) ? array() : $settings['typography']['fontFamilies']['theme'];
 			$settings['typography']['fontFamilies']['theme'] = array_merge( $settings['typography']['fontFamilies']['theme'], $variation['settings']['typography']['fontFamilies']['theme'] );
 


### PR DESCRIPTION
## What?
This ensures that all Webfonts from all variations are loaded in the Site Editor

## Why?
We need to load all Webfonts for every variation so that when a user previews the variation they see their fonts.

## How?
The merging of Webfonts assumed that they `fontFamilies` were stored under `settings > typography > fontFamilies` but they are actually under settings > typography > fontFamilies > theme`.

## Testing Instructions
- Check out this PR: https://github.com/WordPress/wordpress-develop/pull/2440
- Switch to TT2
- Load the Site Editor
- Switch between the different style variations:
<img width="331" alt="Screenshot 2022-04-12 at 10 24 11" src="https://user-images.githubusercontent.com/275961/162927585-d940391c-e9b2-4247-884f-39f9df33ae86.png">

- Confirm that you see the different font files load in the network tab
<img width="503" alt="Screenshot 2022-04-12 at 10 24 05" src="https://user-images.githubusercontent.com/275961/162927548-cb5dc6d2-39a5-4463-93f3-1f84eb7ab76b.png">
