### PR TITLE
useBlockLock: Always check inherited 'templateLock' status

### DIFF
--- a/packages/block-editor/src/components/block-lock/menu-item.js
+++ b/packages/block-editor/src/components/block-lock/menu-item.js
@@ -13,7 +13,7 @@ import useBlockLock from './use-block-lock';
 import BlockLockModal from './modal';
 
 export default function BlockLockMenuItem( { clientId } ) {
-	const { canLock, isLocked } = useBlockLock( clientId, true );
+	const { canLock, isLocked } = useBlockLock( clientId );
 
 	const [ isModalOpen, toggleModal ] = useReducer(
 		( isActive ) => ! isActive,

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -25,7 +25,7 @@ import { store as blockEditorStore } from '../../store';
 
 export default function BlockLockModal( { clientId, onClose } ) {
 	const [ lock, setLock ] = useState( { move: false, remove: false } );
-	const { canEdit, canMove, canRemove } = useBlockLock( clientId, true );
+	const { canEdit, canMove, canRemove } = useBlockLock( clientId );
 	const { isReusable } = useSelect(
 		( select ) => {
 			const { getBlockName } = select( blockEditorStore );

--- a/packages/block-editor/src/components/block-lock/use-block-lock.js
+++ b/packages/block-editor/src/components/block-lock/use-block-lock.js
@@ -11,13 +11,11 @@ import { store as blockEditorStore } from '../../store';
 /**
  * Return details about the block lock status.
  *
- * @param {string}  clientId    The block client Id.
- * @param {boolean} checkParent Optional. The status is derived from the parent `templateLock`
- *                              when the current block's lock state isn't defined.
+ * @param {string} clientId The block client Id.
  *
  * @return {Object} Block lock status
  */
-export default function useBlockLock( clientId, checkParent = false ) {
+export default function useBlockLock( clientId ) {
 	return useSelect(
 		( select ) => {
 			const {
@@ -28,9 +26,7 @@ export default function useBlockLock( clientId, checkParent = false ) {
 				getBlockName,
 				getBlockRootClientId,
 			} = select( blockEditorStore );
-			const rootClientId = checkParent
-				? getBlockRootClientId( clientId )
-				: null;
+			const rootClientId = getBlockRootClientId( clientId );
 
 			const canEdit = canEditBlock( clientId );
 			const canMove = canMoveBlock( clientId, rootClientId );
@@ -44,6 +40,6 @@ export default function useBlockLock( clientId, checkParent = false ) {
 				isLocked: ! canEdit || ! canMove || ! canRemove,
 			};
 		},
-		[ clientId, checkParent ]
+		[ clientId ]
 	);
 }


### PR DESCRIPTION
## What?
PR updates `useBlockLock` to always check the parent's inherited `templateLock` status.

Props, @talldan, for discovering the issue.

## Why?
The `templateLock` provides default lock status on post type or block level. Without this check, blocks can be incorrectly represented as locked or unlocked.

## How?
Removed `checkParent` argument.

## Testing Instructions
1. Use the example post type below.
2. Create post type.
3. Confirm blocks in the template are locked by default.
4. Confirm that blocks can be unlocked individually.

<details>
<summary>Exampe Post Type</summary>

```php
add_action( 'init', function() {
	$template = array(
		array( 'core/image' ),
		array(
			'core/paragraph',
			array(
				'placeholder' => 'Add a description',
			),
		),
		array( 'core/quote' ),
		array( 'core/columns' ),
	);

	$args = array(
		'label'             => 'Books',
		'public'             => true,
		'publicly_queryable' => true,
		'show_ui'            => true,
		'show_in_menu'       => true,
		'show_in_rest'       => true,
		'query_var'          => true,
		'rewrite'            => array( 'slug' => 'book' ),
		'capability_type'    => 'post',
		'has_archive'        => true,
		'hierarchical'       => false,
		'menu_position'      => null,
		'supports'           => array( 'title', 'editor' ),
		'template'           => $template,
		'template_lock'      => 'all',
	);

	register_post_type( 'book', $args );
} );
```

</details>

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-04-12 at 13 55 22](https://user-images.githubusercontent.com/240569/162933968-62635356-ef74-4420-a294-e06c9a0836ba.png)

