### PR TITLE
i18n: Add context to 'None' strings

### DIFF
--- a/packages/block-editor/src/components/block-alignment-control/ui.js
+++ b/packages/block-editor/src/components/block-alignment-control/ui.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import {
 	ToolbarDropdownMenu,
 	ToolbarGroup,
@@ -31,7 +31,7 @@ import useAvailableAlignments from './use-available-alignments';
 const BLOCK_ALIGNMENTS_CONTROLS = {
 	none: {
 		icon: alignNone,
-		title: __( 'None' ),
+		title: _x( 'None', 'Alignment option' ),
 	},
 	left: {
 		icon: positionLeft,

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -186,7 +186,7 @@ function AudioEdit( {
 							{ value: 'metadata', label: __( 'Metadata' ) },
 							{
 								value: 'none',
-								label: _x( 'None', '"Preload" value' ),
+								label: _x( 'None', 'Preload value' ),
 							},
 						] }
 					/>


### PR DESCRIPTION
## What?
Adds context to the alignment option's "None" string to make translation easier.

P.S. I also updated the context in the Audio block to match one from the [Video block](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/video/edit-common-settings.js#L11).

Closes #22094.
Similar to #34341.
