### PR TITLE
Remove redundant block name from "settings" panels

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -17,7 +17,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Archives settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -159,7 +159,7 @@ function AudioEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Audio settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Autoplay' ) }
 						onChange={ toggleAttribute( 'autoplay' ) }

--- a/packages/block-library/src/audio/edit.native.js
+++ b/packages/block-library/src/audio/edit.native.js
@@ -177,7 +177,7 @@ function AudioEdit( {
 		>
 			<View>
 				<InspectorControls>
-					<PanelBody title={ __( 'Audio settings' ) }>
+					<PanelBody title={ __( 'Settings' ) }>
 						<ToggleControl
 							label={ __( 'Autoplay' ) }
 							onChange={ toggleAttribute( 'autoplay' ) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -128,7 +128,7 @@ export default function CategoriesEdit( {
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
-				<PanelBody title={ __( 'Categories settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Display as dropdown' ) }
 						checked={ displayAsDropdown }

--- a/packages/block-library/src/file/inspector.js
+++ b/packages/block-library/src/file/inspector.js
@@ -68,7 +68,7 @@ export default function FileBlockInspector( {
 						) }
 					</PanelBody>
 				) }
-				<PanelBody title={ __( 'Text link settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<SelectControl
 						label={ __( 'Link to' ) }
 						value={ textLinkHref }
@@ -80,8 +80,6 @@ export default function FileBlockInspector( {
 						checked={ openInNewWindow }
 						onChange={ changeOpenInNewWindow }
 					/>
-				</PanelBody>
-				<PanelBody title={ __( 'Download button settings' ) }>
 					<ToggleControl
 						label={ __( 'Show download button' ) }
 						checked={ showDownloadButton }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -478,7 +478,7 @@ function GalleryEdit( props ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Gallery settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					{ images.length > 1 && (
 						<RangeControl
 							label={ __( 'Columns' ) }

--- a/packages/block-library/src/gallery/v1/edit.js
+++ b/packages/block-library/src/gallery/v1/edit.js
@@ -420,7 +420,7 @@ function GalleryEdit( props ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Gallery settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					{ images.length > 1 && (
 						<RangeControl
 							label={ __( 'Columns' ) }

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -670,7 +670,7 @@ export class ImageEdit extends Component {
 
 		const getInspectorControls = () => (
 			<InspectorControls>
-				<PanelBody title={ __( 'Image settings' ) } />
+				<PanelBody title={ __( 'Settings' ) } />
 				<PanelBody style={ styles.panelBody }>
 					<BlockStyles clientId={ clientId } url={ url } />
 				</PanelBody>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -370,7 +370,7 @@ export default function Image( {
 				</BlockControls>
 			) }
 			<InspectorControls>
-				<PanelBody title={ __( 'Image settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					{ ! multiImageSelection && (
 						<TextareaControl
 							label={ __( 'Alt text (alternative text)' ) }

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -35,7 +35,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 	return (
 		<div { ...useBlockProps() }>
 			<InspectorControls>
-				<PanelBody title={ __( 'Latest comments settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Display avatar' ) }
 						checked={ displayAvatar }

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -11,7 +11,7 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Login/out settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Display login as form' ) }
 						checked={ displayLoginAsForm }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -238,7 +238,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 	};
 
 	const mediaTextGeneralSettings = (
-		<PanelBody title={ __( 'Media & Text settings' ) }>
+		<PanelBody title={ __( 'Settings' ) }>
 			<ToggleControl
 				label={ __( 'Stack on mobile' ) }
 				checked={ isStackedOnMobile }

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -186,7 +186,7 @@ class MediaTextEdit extends Component {
 
 		return (
 			<InspectorControls>
-				<PanelBody title={ __( 'Media & Text settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Crop image to fill entire column' ) }
 						checked={ imageFill }

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -69,7 +69,7 @@ function PostAuthorEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Author Settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					{ ! isDescendentOfQueryLoop && !! authors?.length && (
 						<SelectControl
 							label={ __( 'Author' ) }

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -114,7 +114,7 @@ export default function PostExcerptEditor( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Post Excerpt Settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleControl
 						label={ __( 'Show link on new line' ) }
 						checked={ showMoreOnNewLine }

--- a/packages/block-library/src/rss/edit.js
+++ b/packages/block-library/src/rss/edit.js
@@ -109,7 +109,7 @@ export default function RSSEdit( { attributes, setAttributes } ) {
 				<ToolbarGroup controls={ toolbarControls } />
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'RSS settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<RangeControl
 						label={ __( 'Number of items' ) }
 						value={ itemsToShow }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -75,7 +75,7 @@ export default function SpacerControls( {
 } ) {
 	return (
 		<InspectorControls>
-			<PanelBody title={ __( 'Spacer settings' ) }>
+			<PanelBody title={ __( 'Settings' ) }>
 				{ orientation === 'horizontal' && (
 					<DimensionInput
 						label={ __( 'Width' ) }

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -451,7 +451,7 @@ function TableEdit( {
 			{ ! isEmpty && (
 				<InspectorControls>
 					<PanelBody
-						title={ __( 'Table settings' ) }
+						title={ __( 'Settings' ) }
 						className="blocks-table-settings"
 					>
 						<ToggleControl

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -110,7 +110,7 @@ function TagCloudEdit( { attributes, setAttributes, taxonomies } ) {
 
 	const inspectorControls = (
 		<InspectorControls>
-			<PanelBody title={ __( 'Tag Cloud settings' ) }>
+			<PanelBody title={ __( 'Settings' ) }>
 				<SelectControl
 					label={ __( 'Taxonomy' ) }
 					options={ getTaxonomyOptions() }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -191,7 +191,7 @@ function VideoEdit( {
 				/>
 			</BlockControls>
 			<InspectorControls>
-				<PanelBody title={ __( 'Video settings' ) }>
+				<PanelBody title={ __( 'Settings' ) }>
 					<VideoCommonSettings
 						setAttributes={ setAttributes }
 						attributes={ attributes }

--- a/packages/block-library/src/video/edit.native.js
+++ b/packages/block-library/src/video/edit.native.js
@@ -248,7 +248,7 @@ class VideoEdit extends Component {
 					) }
 					{ isSelected && (
 						<InspectorControls>
-							<PanelBody title={ __( 'Video settings' ) }>
+							<PanelBody title={ __( 'Settings' ) }>
 								<VideoCommonSettings
 									setAttributes={ setAttributes }
 									attributes={ attributes }


### PR DESCRIPTION
## What?

Across the core block library, we have numerous settings panels containing various block-specific controls, many of which are named `[block name] settings`, for example "Media & Text settings", "Latest Comments settings" or "Archives settings".

Aside from being clunky to read, the block name is redundant since it's the top card of the block inspector, shown right above the very same panel:

<img width="277" alt="media and text" src="https://user-images.githubusercontent.com/1204802/162972184-a765a363-e7e8-48cb-b2fe-0ed269ac85e2.png">

<img width="283" alt="archives" src="https://user-images.githubusercontent.com/1204802/162972193-1a273540-5ed5-46f7-989e-98f0d8ccbbcb.png">

<img width="281" alt="latest comments" src="https://user-images.githubusercontent.com/1204802/162972208-a4e6875f-0ec4-4916-bbb7-f4935b671cef.png">

This PR removes the block name across virtually all blocks in the library. In addition, it fixes a few inconsistencies where some panels would use sentence case, some would use title case, and still others would use sentence case but with blocks capitalized.

## Why?

In reducing redundancy, it reduces noise, and allows for a generic "Settings" panel to be consistent across blocks.

## Testing Instructions

Test the block inspectors for the following blocks:

* File
* Image
* Gallery
* Audio
* Media & Text
* Video
* Spacer
* Archives
* Categories
* Table
* Latest Comments
* RSS
* Tag Cloud
* Post Excerpt
* Author
* Login/out

## Screenshots or screencast <!-- if applicable -->

The following screenshots all show the inspector with this PR applied:
<img width="288" alt="image" src="https://user-images.githubusercontent.com/1204802/162973293-be19ea9a-bf4a-404d-a0db-8921016279af.png">

<img width="281" alt="gallery" src="https://user-images.githubusercontent.com/1204802/162973305-dcec78ea-0ec3-40ee-9819-1c37c41f4f50.png">

<img width="284" alt="audio" src="https://user-images.githubusercontent.com/1204802/162973321-14c64cb7-7b7a-4d55-8456-847057b163cc.png">

<img width="284" alt="media   text" src="https://user-images.githubusercontent.com/1204802/162973328-14361fa9-59e9-46d5-a492-d2c310f8cab5.png">

<img width="290" alt="video" src="https://user-images.githubusercontent.com/1204802/162973332-09a6073d-d186-437b-ad68-e3a6915a439f.png">

<img width="282" alt="spacer" src="https://user-images.githubusercontent.com/1204802/162973344-ba298f03-6c82-40bf-b9e7-2eab21eb92ad.png">

<img width="280" alt="file" src="https://user-images.githubusercontent.com/1204802/162973358-efce76d1-6900-41b1-bf73-999fd109f72d.png">

<img width="281" alt="archives" src="https://user-images.githubusercontent.com/1204802/162973367-c7a109c4-5398-48cb-91c3-4be31b6acc9a.png">

<img width="278" alt="categories" src="https://user-images.githubusercontent.com/1204802/162973377-631b9c33-d730-4fd8-aa8b-26bd325b74f3.png">

<img width="280" alt="table" src="https://user-images.githubusercontent.com/1204802/162973386-ccdc60b1-b188-4c1c-a178-b6fc24900e83.png">

<img width="285" alt="latest comments" src="https://user-images.githubusercontent.com/1204802/162973399-83fdc9ba-24d0-49ea-9013-3d0ee3dbd88e.png">

<img width="285" alt="rss" src="https://user-images.githubusercontent.com/1204802/162973412-2720aabc-925e-4e72-84a7-c98306014e22.png">

<img width="285" alt="tag cloud" src="https://user-images.githubusercontent.com/1204802/162973421-c93577bd-b260-48de-aef0-fbd36f548ff0.png">

<img width="277" alt="post excerpt" src="https://user-images.githubusercontent.com/1204802/162973431-54cf41f9-3733-4229-94ee-d88b23bdf3fc.png">

<img width="280" alt="author" src="https://user-images.githubusercontent.com/1204802/162973443-40a6ea05-ffc7-4c5f-8741-5a79026aabab.png">

<img width="278" alt="login" src="https://user-images.githubusercontent.com/1204802/162973453-84c4652d-4557-432d-bc6a-f3cf63ee496c.png">

