### PR TITLE
Fix comments query loop pagination not respecting Discussion Settings

### DIFF
--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -79,6 +79,8 @@ export default function QueryPaginationEdit( {
 		return null;
 	}
 
+	// Else if paging comments is enabled display a pagination placeholder to enable styling
+	// all pagination controls regardless of available data and pagination state.
 	return (
 		<>
 			{ hasNextPreviousBlocks && (

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -80,7 +80,7 @@ export default function QueryPaginationEdit( {
 		return (
 			<Warning>
 				{ __(
-					'Paging comments is disabled in the Discussion Settings'
+					'Comments Pagination block: paging comments is disabled in the Discussion Settings'
 				) }
 			</Warning>
 		);

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -53,6 +53,7 @@ export default function QueryPaginationEdit( {
 			].includes( innerBlock.name );
 		} );
 	}, [] );
+
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -63,6 +64,21 @@ export default function QueryPaginationEdit( {
 		],
 		__experimentalLayout: usedLayout,
 	} );
+
+	// Get the Discussion settings
+	const { pageComments } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		const { __experimentalDiscussionSettings } = getSettings();
+		return __experimentalDiscussionSettings;
+	} );
+
+	// If paging comments is not enabled in the Discussion Settings then hide the pagination
+	// controls. We don't want to remove them from the template so that when the user enables
+	// paging comments, the controls will be visible.
+	if ( ! pageComments ) {
+		return null;
+	}
+
 	return (
 		<>
 			{ hasNextPreviousBlocks && (

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -66,11 +66,11 @@ export default function QueryPaginationEdit( {
 	} );
 
 	// Get the Discussion settings
-	const { pageComments } = useSelect( ( select ) => {
+	const pageComments = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { __experimentalDiscussionSettings } = getSettings();
-		return __experimentalDiscussionSettings;
-	} );
+		return __experimentalDiscussionSettings?.pageComments;
+	}, [] );
 
 	// If paging comments is not enabled in the Discussion Settings then hide the pagination
 	// controls. We don't want to remove them from the template so that when the user enables

--- a/packages/block-library/src/comments-pagination/edit.js
+++ b/packages/block-library/src/comments-pagination/edit.js
@@ -7,6 +7,7 @@ import {
 	useBlockProps,
 	useInnerBlocksProps,
 	store as blockEditorStore,
+	Warning,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
@@ -76,11 +77,15 @@ export default function QueryPaginationEdit( {
 	// controls. We don't want to remove them from the template so that when the user enables
 	// paging comments, the controls will be visible.
 	if ( ! pageComments ) {
-		return null;
+		return (
+			<Warning>
+				{ __(
+					'Paging comments is disabled in the Discussion Settings'
+				) }
+			</Warning>
+		);
 	}
 
-	// Else if paging comments is enabled display a pagination placeholder to enable styling
-	// all pagination controls regardless of available data and pagination state.
 	return (
 		<>
 			{ hasNextPreviousBlocks && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes so that Comments Query Loop block respects Discussion settings if comments pagination is disabled.

Fixes #39444

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, if in the Discussion Settings paginating comments was not enabled PHP on the front-end would correctly render all comments and would not render the pagination. In the editor, these settings were not respected. Pagination was rendered and the set `per_page` value would be reflected in the number of rendered comments.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
On the editor side, I've added checking if paginating comments was enabled and if so I made the comments-pagination/editor not render and made sure that 

## Gotchas! 💣 💥 
- Custom query on the backend has no problem with fetching any number of comments. On the editor side though we were using WP REST endpoint to fetch comments and it has a hard limit of max 100 comments per page. We've decided after a conversation on #core-editor Slack that for the purpose of layout design and setup this limit should be enough and we shouldn't aggregate all pages to render all possible data.
- We shouldn't remove the pagination from the template if pagination was disabled at the time of adding the block as it wouldn't show up after the page/post was saved and comments pagination was enabled later. - _this was my first take..._
- In theory Discussion settings allow setting more than 100 items per page. This would fail in the Editor as if we tried to fetch from WP REST API more than 100 items per page it would throw an error but would work alright on the editor. - _added a guard for that_


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Follow the steps from #39444
3. _With disabled comments pagination in the Discussion Settings_
3. The pagination should not show up and all comments (up to 100) should show up

cc: @c4rl0sbr4v0 @Mamaduka 