### PR TITLE
Add a debounce to the custom color onChange event

### DIFF
--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -1,15 +1,18 @@
 /**
  * External dependencies
  */
-import { kebabCase, debounce } from 'lodash';
+import { kebabCase } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { lineSolid, moreVertical, plus } from '@wordpress/icons';
-import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
+import {
+	__experimentalUseFocusOutside as useFocusOutside,
+	useDebounce,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -198,7 +201,7 @@ function PaletteEditListView( {
 		};
 	}, [] );
 
-	const debounceOnChange = useCallback( debounce( onChange, 200 ), [] );
+	const debounceOnChange = useDebounce( onChange, 100 );
 
 	return (
 		<VStack spacing={ 3 }>

--- a/packages/components/src/palette-edit/index.js
+++ b/packages/components/src/palette-edit/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { kebabCase } from 'lodash';
+import { kebabCase, debounce } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { lineSolid, moreVertical, plus } from '@wordpress/icons';
 import { __experimentalUseFocusOutside as useFocusOutside } from '@wordpress/compose';
@@ -197,6 +197,9 @@ function PaletteEditListView( {
 			}
 		};
 	}, [] );
+
+	const debounceOnChange = useCallback( debounce( onChange, 200 ), [] );
+
 	return (
 		<VStack spacing={ 3 }>
 			<ItemGroup isRounded>
@@ -212,7 +215,7 @@ function PaletteEditListView( {
 							}
 						} }
 						onChange={ ( newElement ) => {
-							onChange(
+							debounceOnChange(
 								elements.map(
 									( currentElement, currentIndex ) => {
 										if ( currentIndex === index ) {


### PR DESCRIPTION
## What?
Adds a debounce wrapper to the onChange event for the custom color Option onChange prop.

## Why?
Because updating the text of the custom color causes an update of custom colors array, each keystroke is causing a rerender of the full list.

Fixes: #38833

## How?
Debounces the onChange method by 200ms to reduce the number of rerenders.

There may be a smarter way to do this, but because the index of the current item also needs to be passed into the callback I couldn't see any alternative to the current lambda that is being used for the onChange prop.

## Testing Instructions

- Edit TwentyTwentyTwo's Homepage template
- In the sidebar, go to "Colors"
- In the last section, go to "Custom" colors (or custom gradients), choose to add some colors (or custom gradients)
- Try to type a name for any of them and check that the UI is responsive to keyboard input
