### PR TITLE
Try to fix flaky playwright tests not being reported

### DIFF
--- a/.github/report-flaky-tests/action.yml
+++ b/.github/report-flaky-tests/action.yml
@@ -8,8 +8,8 @@ inputs:
         description: 'The flaky-test label name'
         required: true
         default: 'flaky-test'
-    artifact-name:
-        description: 'The name of the uploaded artifact'
+    artifact-name-prefix:
+        description: 'The prefix name of the uploaded artifact'
         required: true
         default: 'flaky-tests-report'
 runs:

--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -29,13 +29,15 @@ const metaData = {
 ( async function run() {
 	const token = core.getInput( 'repo-token', { required: true } );
 	const label = core.getInput( 'label', { required: true } );
-	const artifactName = core.getInput( 'artifact-name', { required: true } );
+	const artifactNamePrefix = core.getInput( 'artifact-name-prefix', {
+		required: true,
+	} );
 
 	const octokit = github.getOctokit( token );
 
 	const flakyTests = await downloadReportFromArtifact(
 		octokit,
-		artifactName
+		artifactNamePrefix
 	);
 
 	if ( ! flakyTests ) {
@@ -191,7 +193,7 @@ async function fetchAllIssuesLabeledFlaky( octokit, label ) {
 	return issues;
 }
 
-async function downloadReportFromArtifact( octokit, artifactName ) {
+async function downloadReportFromArtifact( octokit, artifactNamePrefix ) {
 	const {
 		data: { artifacts },
 	} = await octokit.rest.actions.listWorkflowRunArtifacts( {
@@ -199,8 +201,8 @@ async function downloadReportFromArtifact( octokit, artifactName ) {
 		run_id: github.context.payload.workflow_run.id,
 	} );
 
-	const matchArtifact = artifacts.find(
-		( artifact ) => artifact.name === artifactName
+	const matchArtifact = artifacts.find( ( artifact ) =>
+		artifact.name.startsWith( artifactNamePrefix )
 	);
 
 	if ( ! matchArtifact ) {

--- a/.github/workflows/end2end-test-playwright.yml
+++ b/.github/workflows/end2end-test-playwright.yml
@@ -63,6 +63,6 @@ jobs:
               uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
               if: always()
               with:
-                  name: flaky-tests-report
+                  name: flaky-tests-report-playwright
                   path: flaky-tests
                   if-no-files-found: ignore

--- a/.github/workflows/end2end-test.yml
+++ b/.github/workflows/end2end-test.yml
@@ -61,6 +61,6 @@ jobs:
               uses: actions/upload-artifact@e448a9b857ee2131e752b06002bf0e093c65e571 # v2.2.2
               if: always()
               with:
-                  name: flaky-tests-report
+                  name: flaky-tests-report-${{ matrix.part }}
                   path: flaky-tests
                   if-no-files-found: ignore

--- a/.github/workflows/flaky-tests.yml
+++ b/.github/workflows/flaky-tests.yml
@@ -2,9 +2,7 @@ name: Report Flaky Tests
 
 on:
     workflow_run:
-        # We should also add 'End-to-End Tests Playwright' here but that
-        # wil run this workflow whenever either one of them completes.
-        workflows: ['End-to-End Tests']
+        workflows: ['End-to-End Tests', 'End-to-End Tests Playwright']
         types:
             - completed
 
@@ -31,4 +29,4 @@ jobs:
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
                   label: '[Type] Flaky Test'
-                  artifact-name: flaky-tests-report
+                  artifact-name-prefix: flaky-tests-report


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Try to fix [flaky playwright tests](https://github.com/WordPress/gutenberg/runs/5986816257?check_suite_focus=true) not being [reported](https://github.com/WordPress/gutenberg/issues/34805).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To allow flaky playwright tests to be reported to issues so that we can keep track of them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Honestly, this PR is just a guess. There's a warning in the [`upload-artifact`](https://github.com/actions/upload-artifact) action doc:

> Warning: Be careful when uploading to the same artifact via multiple jobs as artifacts may become corrupted. When uploading a file with an identical name and path in multiple jobs, uploads may fail with 503 errors due to conflicting uploads happening at the same time. Ensure uploads to identical locations to not interfere with each other.

This PR tries to address that by choosing a different name for each job and use `artifactNamePrefix` instead `of `artifactName`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Unfortunately, don't have a reliable way to test it for now.

