### PR TITLE
Cover: Avoid adding a wrapper Group block when transforming to Group, where possible

### DIFF
--- a/packages/block-library/src/cover/test/transforms.js
+++ b/packages/block-library/src/cover/test/transforms.js
@@ -1,0 +1,272 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	createBlock,
+	getBlockTypes,
+	registerBlockType,
+	switchToBlockType,
+	unregisterBlockType,
+} from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { metadata as coverMetadata, settings as coverSettings } from '../index';
+import {
+	metadata as groupMetadata,
+	settings as groupSettings,
+} from '../../group';
+
+describe( 'transforms', () => {
+	beforeAll( () => {
+		registerBlockType( coverMetadata, coverSettings );
+		registerBlockType( groupMetadata, groupSettings );
+	} );
+
+	afterAll( () => {
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	describe( 'transform from Group to Cover', () => {
+		it( 'should return child Cover block when Group block contains only a single Cover block', () => {
+			const block = createBlock(
+				'core/group',
+				{ gradient: 'my-gradient' },
+				[ createBlock( 'core/cover', { dimRatio: 10 } ) ]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/cover' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { dimRatio: 10 },
+				innerBlocks: [],
+				name: 'core/cover',
+			} );
+		} );
+
+		it( 'should wrap Group in a Cover block and move named gradient up to the parent Cover block', () => {
+			const block = createBlock( 'core/group', {
+				gradient: 'my-gradient',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/cover' );
+			const innerGroupBlock = transformedBlocks[ 0 ].innerBlocks[ 0 ];
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { gradient: 'my-gradient' },
+				name: 'core/cover',
+			} );
+
+			expect( innerGroupBlock.name ).toBe( 'core/group' );
+			expect( innerGroupBlock.attributes ).not.toHaveProperty(
+				'gradient'
+			);
+		} );
+
+		it( 'should wrap Group in a Cover block and move custom gradient up to the parent Cover block', () => {
+			const gradient =
+				'linear-gradient(90deg,rgb(188,138,51) 0%,rgb(65,88,208) 100%)';
+			const block = createBlock( 'core/group', {
+				style: {
+					color: {
+						gradient,
+					},
+				},
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/cover' );
+			const innerGroupBlock = transformedBlocks[ 0 ].innerBlocks[ 0 ];
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { customGradient: gradient },
+				name: 'core/cover',
+			} );
+
+			expect( innerGroupBlock.name ).toBe( 'core/group' );
+			expect( innerGroupBlock.attributes ).not.toHaveProperty( 'style' );
+		} );
+
+		it( 'should wrap Group in a Cover block and move named background color up to the parent Cover block', () => {
+			const block = createBlock( 'core/group', {
+				backgroundColor: 'my-background-color',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/cover' );
+			const innerGroupBlock = transformedBlocks[ 0 ].innerBlocks[ 0 ];
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { overlayColor: 'my-background-color' },
+				name: 'core/cover',
+			} );
+
+			expect( innerGroupBlock.name ).toBe( 'core/group' );
+			expect( innerGroupBlock.attributes ).not.toHaveProperty(
+				'backgroundColor'
+			);
+		} );
+
+		it( 'should wrap Group in a Cover block and move custom background color up to the parent Cover block', () => {
+			const background = '#ff0000';
+			const block = createBlock( 'core/group', {
+				style: {
+					color: {
+						background,
+					},
+				},
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/cover' );
+			const innerGroupBlock = transformedBlocks[ 0 ].innerBlocks[ 0 ];
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { customOverlayColor: background },
+				name: 'core/cover',
+			} );
+
+			expect( innerGroupBlock.name ).toBe( 'core/group' );
+			expect( innerGroupBlock.attributes ).not.toHaveProperty( 'style' );
+		} );
+	} );
+
+	describe( 'transform from Cover to Group', () => {
+		it( 'should transform named gradient color to Group block', () => {
+			const block = createBlock( 'core/cover', {
+				gradient: 'my-gradient',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { gradient: 'my-gradient' },
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should transform custom gradient color to style object in Group block', () => {
+			const gradient =
+				'linear-gradient(90deg,rgb(188,138,51) 0%,rgb(65,88,208) 100%)';
+			const block = createBlock( 'core/cover', {
+				customGradient: gradient,
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { style: { color: { gradient } } },
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should transform named background color to backgroundColor attribute in Group block', () => {
+			const block = createBlock( 'core/cover', {
+				overlayColor: 'my-background-color',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { backgroundColor: 'my-background-color' },
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should transform custom background color to style object in Group block', () => {
+			const block = createBlock( 'core/cover', {
+				customOverlayColor: '#ff0000',
+			} );
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { style: { color: { background: '#ff0000' } } },
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should merge Cover block named gradient color into child Group block', () => {
+			const block = createBlock(
+				'core/cover',
+				{
+					gradient: 'my-gradient',
+				},
+				[ createBlock( 'core/group', { fontSize: 'medium' } ) ]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: { fontSize: 'medium', gradient: 'my-gradient' },
+				innerBlocks: [],
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should merge Cover block custom gradient color to style object in child Group block', () => {
+			const gradient =
+				'linear-gradient(90deg,rgb(188,138,51) 0%,rgb(65,88,208) 100%)';
+			const block = createBlock(
+				'core/cover',
+				{
+					customGradient: gradient,
+				},
+				[ createBlock( 'core/group', { fontSize: 'medium' } ) ]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: {
+					fontSize: 'medium',
+					style: { color: { gradient } },
+				},
+				innerBlocks: [],
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should merge Cover block named background color to backgroundColor attribute in child Group block', () => {
+			const block = createBlock(
+				'core/cover',
+				{
+					overlayColor: 'my-background-color',
+				},
+				[ createBlock( 'core/group', { fontSize: 'medium' } ) ]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: {
+					backgroundColor: 'my-background-color',
+					fontSize: 'medium',
+				},
+				innerBlocks: [],
+				name: 'core/group',
+			} );
+		} );
+
+		it( 'should merge Cover block custom background color into child Group block', () => {
+			const block = createBlock(
+				'core/cover',
+				{
+					customOverlayColor: '#ff0000',
+				},
+				[ createBlock( 'core/group', { fontSize: 'medium' } ) ]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: {
+					fontSize: 'medium',
+					style: { color: { background: '#ff0000' } },
+				},
+				innerBlocks: [],
+				name: 'core/group',
+			} );
+		} );
+	} );
+} );

--- a/packages/block-library/src/cover/test/transforms.js
+++ b/packages/block-library/src/cover/test/transforms.js
@@ -132,7 +132,7 @@ describe( 'transforms', () => {
 	} );
 
 	describe( 'transform from Cover to Group', () => {
-		it( 'should transform named gradient color to Group block', () => {
+		it( 'should transfer named gradient color to Group block', () => {
 			const block = createBlock( 'core/cover', {
 				gradient: 'my-gradient',
 			} );
@@ -145,7 +145,7 @@ describe( 'transforms', () => {
 			} );
 		} );
 
-		it( 'should transform custom gradient color to style object in Group block', () => {
+		it( 'should transfer custom gradient color to style object in Group block', () => {
 			const gradient =
 				'linear-gradient(90deg,rgb(188,138,51) 0%,rgb(65,88,208) 100%)';
 			const block = createBlock( 'core/cover', {
@@ -160,7 +160,7 @@ describe( 'transforms', () => {
 			} );
 		} );
 
-		it( 'should transform named background color to backgroundColor attribute in Group block', () => {
+		it( 'should transfer named background color to backgroundColor attribute in Group block', () => {
 			const block = createBlock( 'core/cover', {
 				overlayColor: 'my-background-color',
 			} );
@@ -173,7 +173,7 @@ describe( 'transforms', () => {
 			} );
 		} );
 
-		it( 'should transform custom background color to style object in Group block', () => {
+		it( 'should transfer custom background color to style object in Group block', () => {
 			const block = createBlock( 'core/cover', {
 				customOverlayColor: '#ff0000',
 			} );

--- a/packages/block-library/src/cover/test/transforms.js
+++ b/packages/block-library/src/cover/test/transforms.js
@@ -268,5 +268,34 @@ describe( 'transforms', () => {
 				name: 'core/group',
 			} );
 		} );
+
+		it( 'should skip merging Cover block gradient into child Group block if Group block has background color', () => {
+			const block = createBlock(
+				'core/cover',
+				{
+					gradient: 'my-gradient',
+				},
+				[
+					createBlock( 'core/group', {
+						fontSize: 'medium',
+						style: { color: { background: '#ff0000' } },
+					} ),
+				]
+			);
+
+			const transformedBlocks = switchToBlockType( block, 'core/group' );
+
+			expect( transformedBlocks[ 0 ] ).toMatchObject( {
+				attributes: {
+					fontSize: 'medium',
+					style: { color: { background: '#ff0000' } },
+				},
+				innerBlocks: [],
+				name: 'core/group',
+			} );
+			expect( transformedBlocks[ 0 ].attributes ).not.toHaveProperty(
+				'gradient'
+			);
+		} );
 	} );
 } );

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -113,18 +113,16 @@ const transforms = {
 					...attributes,
 					backgroundColor: undefined,
 					gradient: undefined,
-					style:
-						attributes?.customGradient || attributes?.style?.color
+					style: cleanEmptyObject( {
+						...attributes?.style,
+						color: style?.color
 							? {
-									...attributes?.style,
-									color: {
-										background:
-											attributes?.customOverlayColor,
-										gradient: attributes?.customGradient,
-										...attributes?.style?.color,
-									},
+									...style?.color,
+									background: undefined,
+									gradient: undefined,
 							  }
 							: undefined,
+					} ),
 				};
 
 				// Preserve the block by nesting it within the Cover block,
@@ -226,20 +224,20 @@ const transforms = {
 				const transformedColorAttributes = {
 					backgroundColor: attributes?.overlayColor,
 					gradient: attributes?.gradient,
-					style:
-						attributes?.customOverlayColor ||
-						attributes?.customGradient ||
-						attributes?.style?.color
-							? {
-									...attributes?.style,
-									color: {
+					style: cleanEmptyObject( {
+						...attributes?.style,
+						color:
+							attributes?.customOverlayColor ||
+							attributes?.customGradient ||
+							attributes?.style?.color
+								? {
 										background:
 											attributes?.customOverlayColor,
 										gradient: attributes?.customGradient,
 										...attributes?.style?.color,
-									},
-							  }
-							: undefined,
+								  }
+								: undefined,
+					} ),
 				};
 
 				// If the Cover block contains only a single Group block as a direct child,
@@ -257,20 +255,19 @@ const transforms = {
 						{
 							...transformedColorAttributes,
 							...groupAttributes,
-							style:
-								attributes?.customOverlayColor ||
-								attributes?.customGradient ||
-								attributes?.style?.color
-									? {
-											...groupAttributes?.style,
-											color: {
+							style: cleanEmptyObject( {
+								...groupAttributes?.style,
+								color:
+									transformedColorAttributes?.style?.color ||
+									groupAttributes?.style?.color
+										? {
 												...transformedColorAttributes
 													?.style?.color,
 												...groupAttributes?.style
 													?.color,
-											},
-									  }
-									: undefined,
+										  }
+										: undefined,
+							} ),
 						},
 						innerBlocks[ 0 ]?.innerBlocks
 					);

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -113,14 +113,16 @@ const transforms = {
 					...attributes,
 					backgroundColor: undefined,
 					gradient: undefined,
-					style: {
-						...attributes?.style,
-						color: {
-							...attributes?.style?.color,
-							background: undefined,
-							gradient: undefined,
-						},
-					},
+					style: attributes?.style
+						? {
+								...attributes?.style,
+								color: {
+									...attributes?.style?.color,
+									background: undefined,
+									gradient: undefined,
+								},
+						  }
+						: undefined,
 				};
 
 				// Preserve the block by nesting it within the Cover block,

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -113,16 +113,20 @@ const transforms = {
 					...attributes,
 					backgroundColor: undefined,
 					gradient: undefined,
-					style: attributes?.style
-						? {
-								...attributes?.style,
-								color: {
-									...attributes?.style?.color,
-									background: undefined,
-									gradient: undefined,
-								},
-						  }
-						: undefined,
+					style:
+						attributes?.customOverlayColor ||
+						attributes?.customGradient ||
+						attributes?.style?.color
+							? {
+									...attributes?.style,
+									color: {
+										background:
+											attributes?.customOverlayColor,
+										gradient: attributes?.customGradient,
+										...attributes?.style?.color,
+									},
+							  }
+							: undefined,
 				};
 
 				// Preserve the block by nesting it within the Cover block,

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -224,16 +224,20 @@ const transforms = {
 				const transformedColorAttributes = {
 					backgroundColor: attributes?.overlayColor,
 					gradient: attributes?.gradient,
-					style: attributes?.style
-						? {
-								...attributes?.style,
-								color: {
-									background: attributes?.customOverlayColor,
-									gradient: attributes?.customGradient,
-									...attributes?.style?.color,
-								},
-						  }
-						: undefined,
+					style:
+						attributes?.customOverlayColor ||
+						attributes?.customGradient ||
+						attributes?.style?.color
+							? {
+									...attributes?.style,
+									color: {
+										background:
+											attributes?.customOverlayColor,
+										gradient: attributes?.customGradient,
+										...attributes?.style?.color,
+									},
+							  }
+							: undefined,
 				};
 
 				// If the Cover block contains only a single Group block as a direct child,
@@ -251,16 +255,20 @@ const transforms = {
 						{
 							...transformedColorAttributes,
 							...groupAttributes,
-							style: groupAttributes?.style
-								? {
-										...groupAttributes?.style,
-										color: {
-											...transformedColorAttributes?.style
-												?.color,
-											...groupAttributes?.style?.color,
-										},
-								  }
-								: undefined,
+							style:
+								attributes?.customOverlayColor ||
+								attributes?.customGradient ||
+								attributes?.style?.color
+									? {
+											...groupAttributes?.style,
+											color: {
+												...transformedColorAttributes
+													?.style?.color,
+												...groupAttributes?.style
+													?.color,
+											},
+									  }
+									: undefined,
 						},
 						innerBlocks[ 0 ]?.innerBlocks
 					);

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -250,6 +250,22 @@ const transforms = {
 					const groupAttributes = cleanEmptyObject(
 						innerBlocks[ 0 ].attributes || {}
 					);
+
+					// If the Group block contains any kind of background color or gradient,
+					// skip merging Cover background colors, and preserve the Group block's colors.
+					if (
+						groupAttributes?.backgroundColor ||
+						groupAttributes?.gradient ||
+						groupAttributes?.style?.color?.background ||
+						groupAttributes?.style?.color?.gradient
+					) {
+						return createBlock(
+							'core/group',
+							groupAttributes,
+							innerBlocks[ 0 ]?.innerBlocks
+						);
+					}
+
 					return createBlock(
 						'core/group',
 						{

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -222,14 +222,16 @@ const transforms = {
 				const transformedColorAttributes = {
 					backgroundColor: attributes?.overlayColor,
 					gradient: attributes?.gradient,
-					style: {
-						...attributes?.style,
-						color: {
-							background: attributes?.customOverlayColor,
-							gradient: attributes?.customGradient,
-							...attributes?.style?.color,
-						},
-					},
+					style: attributes?.style
+						? {
+								...attributes?.style,
+								color: {
+									background: attributes?.customOverlayColor,
+									gradient: attributes?.customGradient,
+									...attributes?.style?.color,
+								},
+						  }
+						: undefined,
 				};
 
 				// If the Cover block contains only a single Group block as a direct child,
@@ -247,13 +249,16 @@ const transforms = {
 						{
 							...transformedColorAttributes,
 							...groupAttributes,
-							style: {
-								...groupAttributes?.style,
-								color: {
-									...transformedColorAttributes?.style?.color,
-									...groupAttributes?.style?.color,
-								},
-							},
+							style: groupAttributes?.style
+								? {
+										...groupAttributes?.style,
+										color: {
+											...transformedColorAttributes?.style
+												?.color,
+											...groupAttributes?.style?.color,
+										},
+								  }
+								: undefined,
 						},
 						innerBlocks[ 0 ]?.innerBlocks
 					);

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -114,9 +114,7 @@ const transforms = {
 					backgroundColor: undefined,
 					gradient: undefined,
 					style:
-						attributes?.customOverlayColor ||
-						attributes?.customGradient ||
-						attributes?.style?.color
+						attributes?.customGradient || attributes?.style?.color
 							? {
 									...attributes?.style,
 									color: {

--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -7,6 +7,7 @@ import { createBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE } from './shared';
+import cleanEmptyObject from '../utils/clean-empty-object';
 
 const transforms = {
 	from: [
@@ -218,7 +219,7 @@ const transforms = {
 			},
 			transform: ( attributes, innerBlocks ) => {
 				// Convert Cover overlay colors to comparable Group background colors.
-				const groupColorAttributes = {
+				const transformedColorAttributes = {
 					backgroundColor: attributes?.overlayColor,
 					gradient: attributes?.gradient,
 					style: {
@@ -238,17 +239,19 @@ const transforms = {
 					innerBlocks?.length === 1 &&
 					innerBlocks[ 0 ]?.name === 'core/group'
 				) {
+					const groupAttributes = cleanEmptyObject(
+						innerBlocks[ 0 ].attributes || {}
+					);
 					return createBlock(
 						'core/group',
 						{
-							...groupColorAttributes,
-							...innerBlocks[ 0 ].attributes,
+							...transformedColorAttributes,
+							...groupAttributes,
 							style: {
-								...innerBlocks[ 0 ].attributes?.style,
+								...groupAttributes?.style,
 								color: {
-									...groupColorAttributes?.style?.color,
-									...innerBlocks[ 0 ].attributes?.style
-										?.color,
+									...transformedColorAttributes?.style?.color,
+									...groupAttributes?.style?.color,
 								},
 							},
 						},
@@ -259,7 +262,7 @@ const transforms = {
 				// In all other cases, transform the Cover block directly to a Group block.
 				return createBlock(
 					'core/group',
-					{ ...attributes, ...groupColorAttributes },
+					{ ...attributes, ...transformedColorAttributes },
 					innerBlocks
 				);
 			},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Depends on #40497 Check that a transform matches at the time of running the transform 

## What?
<!-- In a few words, what is the PR actually doing? -->

Following on from #40212, this PR seeks to fix / improve some of the behaviour when transforming from a Cover block to a Group block. 

The changes are:

* If the Cover block contains only a single Group block as a direct child, then remove the Cover block as the wrapper, and merge in the Cover block's attributes / overlay colors with the Group block's attributes, so that the background color is preserved.
* If the Cover block contains any other mix of blocks as direct children, then convert the Cover block directly to a Group block, with the overlay colors transformed to the appropriate background color attributes on the Group block.
* If the Cover block contained a `url` attribute (so, it had some form of media as a background), then retain the existing behaviour where we defer to the Group block's default transform that adds a Group block as a wrapper — this way the user doesn't unexpectedly lose content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As noted in the review on that PR, when transforming from a Cover block to a Group block, the default transform in the Group block causes a Group block to be added as a wrapper. Repeatedly transforming between Group and Cover and back again results in repeatedly nesting the set of blocks in further levels of Group blocks. With this PR, in most cases, we should now be able to switch between Group -> Cover -> Group again without incurring additional nesting.

Note: this PR makes lots of assumptions about user intent — the _hope_ is that the changes here get the behaviour closer to what users might expect when transforming from Cover to Group, but it _is_ making assumptions, and the transform is still a destructive action, so it isn't perfect. Happy for feedback (or pushback) on the change if folks think there's a better way to go about this.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a transform from Cover to Group to the Cover block
* In the transform, transpose overlay values to the appropriate background values
* Attempt to preserve values in the merged block in a way that's logical and reduces how destructive the transform is

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create a post containing a mix of Cover blocks that contain various kinds of Group, Row, and Stack blocks as children (and other arbitrary blocks)
2. Try variations where the inner Group block has background or gradient colors, and other settings
3. Try transforming the Cover block to a Group block, and see if the result is what you expected
4. Try creating a Group block with a gradient or background color, transform to Cover, then transform back to Group — the block should be in the same(ish) state as it was originally

Tests are also included, and can be run from a terminal via:

```
npm run test-unit -- --testPathPattern packages/block-library/src/cover/test/transforms.js
```

## Screenshots or screencast <!-- if applicable -->

| Group -> Cover -> Group | Row -> Cover -> Row |
| --- | --- |
| ![2022-04-13 16 02 50](https://user-images.githubusercontent.com/14988353/163110923-411835c0-9603-4ab2-adfe-07b66783b97d.gif) | ![2022-04-13 16 09 01](https://user-images.githubusercontent.com/14988353/163111467-d98bb206-1558-4618-94a6-4a4cd7e3bd97.gif) |
