### PR TITLE
Conditionally set secondary sidebar landmark region labels

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -170,13 +170,15 @@ function Layout( { styles } ) {
 		[ entitiesSavedStatesCallback ]
 	);
 
+	const secondarySidebarLabel = isListViewOpened
+		? __( 'List View' )
+		: __( 'Block Library' );
+
 	const secondarySidebar = () => {
 		if ( mode === 'visual' && isInserterOpened ) {
-			interfaceLabels.secondarySidebar = __( 'Block Library' );
 			return <InserterSidebar />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
-			interfaceLabels.secondarySidebar = __( 'List View' );
 			return <ListViewSidebar />;
 		}
 		return null;
@@ -206,7 +208,10 @@ function Layout( { styles } ) {
 			<SettingsSidebar />
 			<InterfaceSkeleton
 				className={ className }
-				labels={ interfaceLabels }
+				labels={ {
+					...interfaceLabels,
+					secondarySidebar: secondarySidebarLabel,
+				} }
 				header={
 					<Header
 						setEntitiesSavedStatesCallback={

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -51,7 +51,6 @@ import StartPageOptions from '../start-page-options';
 import { store as editPostStore } from '../../store';
 
 const interfaceLabels = {
-	secondarySidebar: __( 'Block library' ),
 	/* translators: accessibility text for the editor top bar landmark region. */
 	header: __( 'Editor top bar' ),
 	/* translators: accessibility text for the editor content landmark region. */
@@ -173,9 +172,11 @@ function Layout( { styles } ) {
 
 	const secondarySidebar = () => {
 		if ( mode === 'visual' && isInserterOpened ) {
+			interfaceLabels.secondarySidebar = __( 'Block Library' );
 			return <InserterSidebar />;
 		}
 		if ( mode === 'visual' && isListViewOpened ) {
+			interfaceLabels.secondarySidebar = __( 'List View' );
 			return <ListViewSidebar />;
 		}
 		return null;

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -179,13 +179,15 @@ function Editor( { onError } ) {
 		templateType !== undefined &&
 		entityId !== undefined;
 
+	const secondarySidebarLabel = isListViewOpen
+		? __( 'List View' )
+		: __( 'Block Library' );
+
 	const secondarySidebar = () => {
 		if ( isInserterOpen ) {
-			interfaceLabels.secondarySidebar = __( 'Block Library' );
 			return <InserterSidebar />;
 		}
 		if ( isListViewOpen ) {
-			interfaceLabels.secondarySidebar = __( 'List View' );
 			return <ListViewSidebar />;
 		}
 		return null;
@@ -213,7 +215,10 @@ function Editor( { onError } ) {
 										<KeyboardShortcuts.Register />
 										<SidebarComplementaryAreaFills />
 										<InterfaceSkeleton
-											labels={ interfaceLabels }
+											labels={ {
+												...interfaceLabels,
+												secondarySidebar: secondarySidebarLabel,
+											} }
 											className={
 												showIconLabels &&
 												'show-icon-labels'

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -47,7 +47,6 @@ import { GlobalStylesProvider } from '../global-styles/global-styles-provider';
 import useTitle from '../routes/use-title';
 
 const interfaceLabels = {
-	secondarySidebar: __( 'Block Library' ),
 	drawer: __( 'Navigation Sidebar' ),
 };
 
@@ -182,9 +181,11 @@ function Editor( { onError } ) {
 
 	const secondarySidebar = () => {
 		if ( isInserterOpen ) {
+			interfaceLabels.secondarySidebar = __( 'Block Library' );
 			return <InserterSidebar />;
 		}
 		if ( isListViewOpen ) {
+			interfaceLabels.secondarySidebar = __( 'List View' );
 			return <ListViewSidebar />;
 		}
 		return null;

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -85,7 +85,7 @@ function Interface( { blockEditorSettings } ) {
 		}
 	}, [ isInserterOpened, isListViewOpened, isHugeViewport ] );
 
-	interfaceLabels.secondarySidebar = isListViewOpened
+	const secondarySidebarLabel = isListViewOpened
 		? __( 'List View' )
 		: __( 'Block Library' );
 
@@ -93,7 +93,10 @@ function Interface( { blockEditorSettings } ) {
 
 	return (
 		<InterfaceSkeleton
-			labels={ interfaceLabels }
+			labels={ {
+				...interfaceLabels,
+				secondarySidebar: secondarySidebarLabel,
+			} }
 			header={ <Header /> }
 			secondarySidebar={ hasSecondarySidebar && <SecondarySidebar /> }
 			sidebar={

--- a/packages/edit-widgets/src/components/layout/interface.js
+++ b/packages/edit-widgets/src/components/layout/interface.js
@@ -85,6 +85,10 @@ function Interface( { blockEditorSettings } ) {
 		}
 	}, [ isInserterOpened, isListViewOpened, isHugeViewport ] );
 
+	interfaceLabels.secondarySidebar = isListViewOpened
+		? __( 'List View' )
+		: __( 'Block Library' );
+
 	const hasSecondarySidebar = isListViewOpened || isInserterOpened;
 
 	return (


### PR DESCRIPTION
## What?
Resolves #40250.

PR correctly sets secondary sidebar region labels depending on the sidebar open.

## Testing Instructions
1. Go to Post, Widgets, or Site Editor.
2. Open List View.
3. Inspect (via DevTools) the page and search for `.interface-interface-skeleton__secondary-sidebar` class.
4. Toggle between Block Inserter and List View.
5. Confirm that the region label is updated on the sidebar change.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-04-13 at 11 20 54](https://user-images.githubusercontent.com/240569/163121738-b6a18777-53cf-4427-90c4-b214695d478b.png)

