### PR TITLE
Block Toolbar: Fix lock icon focus

### DIFF
--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -63,8 +63,7 @@
 		padding-left: 0 !important;
 
 		&:focus::before {
-			left: 0 !important;
-			right: $grid-unit-15 !important;
+			right: $grid-unit-10 !important;
 		}
 	}
 }


### PR DESCRIPTION
## What?
It is just a minor issue I noticed while working on a different thing.

PR fixes the lock icon focus outline in the Block Toolbar.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Block
3. Lock it.
4. Focus the lock icon in the toolbar.
5. Confirm correct focus.

## Screenshots or screencast <!-- if applicable -->
Before
![CleanShot 2022-04-13 at 12 53 13](https://user-images.githubusercontent.com/240569/163139715-0dca3a6f-4bb6-448c-9498-00583dfed4a0.png)

After
![CleanShot 2022-04-13 at 12 54 02](https://user-images.githubusercontent.com/240569/163139737-b7b1b848-1528-4bfd-833a-3c0176ddae35.png)

