### PR TITLE
URLInput now always has an ID and accessible label

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -455,6 +455,7 @@ class URLInput extends Component {
 			placeholder,
 			onKeyDown: this.onKeyDown,
 			role: 'combobox',
+			'aria-label': label ? undefined : __( 'URL' ), // Ensure input always has an accessible label
 			'aria-expanded': showSuggestions,
 			'aria-autocomplete': 'list',
 			'aria-owns': suggestionsListboxId,
@@ -464,11 +465,6 @@ class URLInput extends Component {
 					: undefined,
 			ref: this.inputRef,
 		};
-
-		// Set aria-label automatically if no discrete label specified
-		if ( ! label ) {
-			inputProps[ 'aria-label' ] = __( 'URL' );
-		}
 
 		if ( renderControl ) {
 			return renderControl( controlProps, inputProps, loading );

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -418,7 +418,7 @@ class URLInput extends Component {
 
 	renderControl() {
 		const {
-			label,
+			label = null,
 			className,
 			isFullWidth,
 			instanceId,
@@ -435,8 +435,10 @@ class URLInput extends Component {
 			suggestionOptionIdPrefix,
 		} = this.state;
 
+		const inputId = `url-input-control-${ instanceId }`;
+
 		const controlProps = {
-			id: `url-input-control-${ instanceId }`,
+			id: inputId,
 			label,
 			className: classnames( 'block-editor-url-input', className, {
 				'is-full-width': isFullWidth,
@@ -453,7 +455,6 @@ class URLInput extends Component {
 			placeholder,
 			onKeyDown: this.onKeyDown,
 			role: 'combobox',
-			'aria-label': __( 'URL' ),
 			'aria-expanded': showSuggestions,
 			'aria-autocomplete': 'list',
 			'aria-owns': suggestionsListboxId,
@@ -464,9 +465,17 @@ class URLInput extends Component {
 			ref: this.inputRef,
 		};
 
+		// Set aria-label automatically if no discrete label specified
+		if ( ! label ) {
+			inputProps[ 'aria-label' ] = __( 'URL' );
+		}
+
 		if ( renderControl ) {
 			return renderControl( controlProps, inputProps, loading );
 		}
+
+		// If renderControl is falsey, set the input's ID
+		inputProps.id = inputId;
 
 		return (
 			<BaseControl { ...controlProps }>

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -438,7 +438,7 @@ class URLInput extends Component {
 		const inputId = `url-input-control-${ instanceId }`;
 
 		const controlProps = {
-			id: inputId,
+			id: inputId, // Passes attribute to label for the for attribute
 			label,
 			className: classnames( 'block-editor-url-input', className, {
 				'is-full-width': isFullWidth,
@@ -446,6 +446,7 @@ class URLInput extends Component {
 		};
 
 		const inputProps = {
+			id: inputId,
 			value,
 			required: true,
 			className: 'block-editor-url-input__input',
@@ -469,9 +470,6 @@ class URLInput extends Component {
 		if ( renderControl ) {
 			return renderControl( controlProps, inputProps, loading );
 		}
-
-		// If renderControl is falsey, set the input's ID
-		inputProps.id = inputId;
 
 		return (
 			<BaseControl { ...controlProps }>


### PR DESCRIPTION
## What?
Related Issue: https://github.com/WordPress/gutenberg/issues/39999

This PR ensures the URLInput block control always has a correct ID attribute and accessible label. Previously there were scenarios in which this input would have no ID even with a specified label or where the input would receive 2 labels (one aria-label from the component, the other the label prop value). 

## Why?
Currently, this input is not properly accessible. If a developer is using this component and provides a label prop, the label outputs but it's `for` attribute points to an ID that doesn't exist. 

renderControl is an experimental method and I imagine the condition fails to call it because of this, which is what creates the bug we're observing here. 

## How?
- Label initialized to null for simpler falsey comparisons
- inputID is now applied to the inputProps if renderControl is falsey
- Duplicate aria-label no longer outputs if a label prop is specified.

## Testing Instructions

**Default**
1. Create a new test page
2. Add a Button block
3. Inspect the HTML and note the presence of ID attribute and aria-label

**Custom**
1. Create a custom block that implements URLInput in the editing experience
2. Specify a label prop
3. Use the block in the editor and note the label for the attribute matches the input's ID
