### PR TITLE
Icons Package: fix line icons styling

### DIFF
--- a/packages/icons/src/library/line-dashed.js
+++ b/packages/icons/src/library/line-dashed.js
@@ -4,7 +4,7 @@
 import { Path, SVG } from '@wordpress/primitives';
 
 const lineDashed = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
 			d="M5 11.25h3v1.5H5v-1.5zm5.5 0h3v1.5h-3v-1.5zm8.5 0h-3v1.5h3v-1.5z"

--- a/packages/icons/src/library/line-dotted.js
+++ b/packages/icons/src/library/line-dotted.js
@@ -4,7 +4,7 @@
 import { Path, SVG } from '@wordpress/primitives';
 
 const lineDotted = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
 			d="M5.25 11.25h1.5v1.5h-1.5v-1.5zm3 0h1.5v1.5h-1.5v-1.5zm4.5 0h-1.5v1.5h1.5v-1.5zm1.5 0h1.5v1.5h-1.5v-1.5zm4.5 0h-1.5v1.5h1.5v-1.5z"

--- a/packages/icons/src/library/line-solid.js
+++ b/packages/icons/src/library/line-solid.js
@@ -4,7 +4,7 @@
 import { Path, SVG } from '@wordpress/primitives';
 
 const lineSolid = (
-	<SVG xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="none">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M5 11.25h14v1.5H5z" />
 	</SVG>
 );


### PR DESCRIPTION
## What?
All three line icons (`lineDashed`, `lineDotted`, `lineSolid`) are missing the viewbox and have hardcoded height/width and fill. This seems to be counter to what the others are set as and causes issues when passing a size to the component. I noticed this when using one of them in a project [here](https://github.com/Automattic/wp-calypso/tree/trunk/packages/help-center). All the other icons are changing size except the lines.

## Why?
Mostly all other icons listed in this package refrain from setting height/width and fill.

## How?
Simply remove the height/width, add the viewbox, and removed the fill. Removing the height/weight is not completely necessary but I chose to do so to match the rest of the icons. The important piece is the viewbox.

## Testing Instructions
I personally tested this in my project, but you can also see it in the Storybook

## Screenshots or screencast <!-- if applicable -->

| **Before** | **After** |
| - | - |
| <img width="261" alt="Markup 2022-04-13 at 13 57 11" src="https://user-images.githubusercontent.com/33258733/163181932-fd9c97bb-e717-4085-8e05-afa583dc9424.png"> | <img width="254" alt="Markup 2022-04-13 at 13 51 40" src="https://user-images.githubusercontent.com/33258733/163182024-0ff9517f-5e24-4c35-8024-8034fa422adf.png"> |
 