### PR TITLE
useSelect: add async mode test suite and fix two bugs

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -118,6 +118,7 @@ export default function useSelect( mapSelect, deps ) {
 	const queueContext = useMemoOne( () => ( { queue: true } ), [ registry ] );
 	const [ , forceRender ] = useReducer( ( s ) => s + 1, 0 );
 
+	const latestRegistry = useRef( registry );
 	const latestMapSelect = useRef();
 	const latestIsAsync = useRef( isAsync );
 	const latestMapOutput = useRef();
@@ -145,10 +146,15 @@ export default function useSelect( mapSelect, deps ) {
 
 	if ( _mapSelect ) {
 		mapOutput = latestMapOutput.current;
+		const hasReplacedRegistry = latestRegistry.current !== registry;
 		const hasReplacedMapSelect = latestMapSelect.current !== _mapSelect;
 		const lastMapSelectFailed = !! latestMapOutputError.current;
 
-		if ( hasReplacedMapSelect || lastMapSelectFailed ) {
+		if (
+			hasReplacedRegistry ||
+			hasReplacedMapSelect ||
+			lastMapSelectFailed
+		) {
 			try {
 				mapOutput = wrapSelect( _mapSelect );
 			} catch ( error ) {
@@ -171,6 +177,7 @@ export default function useSelect( mapSelect, deps ) {
 			return;
 		}
 
+		latestRegistry.current = registry;
 		latestMapSelect.current = _mapSelect;
 		latestMapOutput.current = mapOutput;
 		latestMapOutputError.current = undefined;

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -219,7 +219,7 @@ export default function useSelect( mapSelect, deps ) {
 
 		// Catch any possible state changes during mount before the subscription
 		// could be set.
-		onChange();
+		onStoreChange();
 
 		const unsubscribers = listeningStores.current.map( ( storeName ) =>
 			registry.__unstableSubscribeStore( storeName, onChange )


### PR DESCRIPTION
This PR adds a suite of unit tests for `useSelect` that test behavior when async mode is enabled. They verify that updates are correctly executed as scheduled, and that they are cancelled when needed -- unmount, mode change, etc.

One example of what kind of bugs they can catch is the changes in #19286 that fixed the render queue two years ago. If you try to revert these changes on your working copy, the unit tests will start failing.

The PR also fixes two bugs that I discovered while writing these tests:
- there is an `onChange()` invocation in an effect that subscribes to the store. Its purpose is to catch missed updates that happened between the initial render and running the effect. This invocation should always be synchronous, even in async mode. But it was async in async mode.
- when the `registry` changes, it should trigger a new call to `mapSelect`. But that was not happening. Right after `registry` changed, there was one inconsistent render where there was new `registry` and the old memoized value of `mapSelect`, from the old `registry`. It was immediately fixed in effect when invoking `onChange`, but still, the inconsistent render was there.
