### PR TITLE
Fixing the flaky template editor mode test

### DIFF
--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -271,7 +271,7 @@ class PostEditorTemplateMode {
 		await this.pageUtils.openDocumentSettingsSidebar();
 
 		const templatePanelButton = this.editorSettingsSidebar.locator(
-			'role=button[name="Template"i]'
+			'role=button[name=/Template.*/i]'
 		);
 		const isExpanded =
 			( await templatePanelButton.getAttribute( 'aria-expanded' ) ) !==

--- a/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
+++ b/test/e2e/specs/editor/various/post-editor-template-mode.spec.js
@@ -271,7 +271,7 @@ class PostEditorTemplateMode {
 		await this.pageUtils.openDocumentSettingsSidebar();
 
 		const templatePanelButton = this.editorSettingsSidebar.locator(
-			'role=button[name=/Template.*/i]'
+			'role=button[name=/^Template/i]'
 		);
 		const isExpanded =
 			( await templatePanelButton.getAttribute( 'aria-expanded' ) ) !==


### PR DESCRIPTION
Extracted from #32765

Hopefully fixes #34805, fixes #38595, and fixes #38594.

## What?

In the React 18 upgrade PR, I noticed that the template mode test is a bit flaky. The reason for that was that sometimes the template panel title is "Template", sometimes it's "Template: %template_name%" and when loading the sidebar, it can move from one to the other once the template is loaded. This PR solves the flakiness.
 
## How?

Since the "expandTemplatePanel" is a generic function that should work across use-cases, it should be able to work no matter the current name of the template panel. This PR uses a Regex to do that.

## Testing Instructions

Nothing to test, the playwright tests should be stable.
