### PR TITLE
Media & Text: Remove font size declaration from template

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -46,7 +46,6 @@ const TEMPLATE = [
 	[
 		'core/paragraph',
 		{
-			fontSize: 'large',
 			placeholder: _x( 'Content…', 'content placeholder' ),
 		},
 	],


### PR DESCRIPTION
## What?
The Media & Text block includes a Paragraph block in its template that has a default font size of `large`. This is both an accessibility issue, and creates frustrations for both editors and developers.

## Why?
WCAG 2.1 (Level A) [Success Criterion 1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships) Info and Relationships states that “[…] Information and relationships that are implied by visual or auditory formatting are preserved when the presentation format changes”. By making the paragraph a larger font size, the block is effectively meeting the requirements of [Failure F2](https://www.w3.org/WAI/WCAG21/Techniques/failures/F2) by emphasizing text without using semantic markup to convey the visual significance of the text to users of assistive technology.

Additionally, if a developer has removed custom font sizes from `core/paragraph` or the theme itself using theme.json, this class gets applied and then is not removable.

This addresses #21126

## How?
This simply removes the font size declaration in the Media & Text block's template.

## Testing Instructions
1. Open a Post or a Page
3. Insert a Media & Text block
4. Add some text content to override the placeholder content
5. Confirm that the first paragraph in the block no longer has the `.has-large-font-size` class added by default.
