### PR TITLE
Add `comment_class()` call to the Comment Template block

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -39,6 +39,8 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$comment_depth -= 1;
 		}
 
+		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
+		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		$content .= sprintf( '<li %1$s>' . $block_content . '</li>', $comment_classes );

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -15,6 +15,10 @@
 function block_core_comment_template_render_comments( $comments, $block ) {
 	global $comment_depth;
 
+	if ( empty( $comment_depth ) ) {
+		$comment_depth = 1;
+	}
+
 	$content = '';
 	foreach ( $comments as $comment ) {
 
@@ -61,8 +65,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
  * defined by the block's inner blocks.
  */
 function render_block_core_comment_template( $attributes, $content, $block ) {
-	global $comment_depth;
-
 	// Bail out early if the post ID is not set for some reason.
 	if ( empty( $block->context['postId'] ) ) {
 		return '';
@@ -85,8 +87,6 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes();
-
-	$comment_depth = 1;
 
 	return sprintf(
 		'<ol %1$s>%2$s</ol>',

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -35,7 +35,9 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 		}
 
-		$content .= '<li>' . $block_content . '</li>';
+		$comment_classes = comment_class( 'hi', $comment->comment_ID );
+
+		$content .= sprintf( '<li %1$s>' . $block_content . '</li>', $comment_classes );
 	}
 
 	return $content;

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -47,7 +47,7 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
-		$content .= sprintf( '<li %1$s>' . $block_content . '</li>', $comment_classes );
+		$content .= sprintf( '<li %1$s>%2$s</li>', $comment_classes, $block_content );
 	}
 
 	return $content;

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -37,14 +37,14 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$comment_depth += 1;
 			$inner_content  = block_core_comment_template_render_comments(
 				$children,
-				$block,
+				$block
 			);
 			$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 			$comment_depth -= 1;
 		}
 
 		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
-		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters
+		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		$content .= sprintf( '<li %1$s>' . $block_content . '</li>', $comment_classes );

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -141,7 +141,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol ><li ><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			'<ol ><li class="comment even thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
 	}
@@ -191,7 +191,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			gutenberg_render_block_core_comment_template( null, null, $block ),
-			'<ol ><li ><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
+			'<ol ><li class="comment odd alt thread-odd thread-alt depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li class="comment even depth-2"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li class="comment odd alt depth-3"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
 		);
 	}
 	/**

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -141,7 +141,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol ><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			'<ol ><li ><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
 	}
@@ -191,7 +191,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			gutenberg_render_block_core_comment_template( null, null, $block ),
-			'<ol ><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
+			'<ol ><li ><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
 		);
 	}
 	/**


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/40306

## Why?
Adding the `comment_class()` for each comment in the Comment Template.

More details in https://github.com/WordPress/gutenberg/issues/40306 and [this article](https://github.com/WordPress/gutenberg/issues/40306) (also linked in the issue).

## How?
Adding the relevant function call in the `index.php` of the Comment Template block.

## Screenshots or screencast 

<img width="700" alt="Screenshot 2022-04-13 at 18 48 25" src="https://user-images.githubusercontent.com/5417266/163287789-5a68b939-a336-4478-ab66-583b3cba58fd.png">

