### PR TITLE
Style Engine: add typography and color to backend 

### DIFF
--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -82,14 +82,14 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
-		$custom_text_color          = isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null;
+		$custom_text_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'text' ), null );
 		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|background-color|{$block_attributes['backgroundColor']}" : null;
-		$custom_background_color          = isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null;
+		$custom_background_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
@@ -97,7 +97,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|background|{$block_attributes['gradient']}" : null;
-		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null;
+		$custom_gradient_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -96,6 +96,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	// Gradients.
+
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$color_block_styles['gradient'] = array(
 			'value' => isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null,
@@ -105,12 +106,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	$attributes   = array();
 	$style_engine = gutenberg_get_style_engine();
-	$styles       = $style_engine->generate(
-		array( 'color' => $color_block_styles ),
-		array(
-			'inline' => true,
-		)
-	);
+	$styles       = $style_engine->generate( array( 'color' => $color_block_styles ) );
 
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -81,27 +81,24 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
-		$color_block_styles['text'] = array(
-			'value' => isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null,
-			'slug'  => array_key_exists( 'textColor', $block_attributes ) ? $block_attributes['textColor'] : null,
-		);
+		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
+		$custom_text_color          = isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null;
+		$color_block_styles['text'] = $preset_text_color ?: $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
-		$color_block_styles['background'] = array(
-			'value' => isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null,
-			'slug'  => array_key_exists( 'backgroundColor', $block_attributes ) ? $block_attributes['backgroundColor'] : null,
-		);
+		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|background-color|{$block_attributes['backgroundColor']}" : null;
+		$custom_background_color          = isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null;
+		$color_block_styles['background'] = $preset_background_color ?: $custom_background_color;
 	}
 
 	// Gradients.
 
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
-		$color_block_styles['gradient'] = array(
-			'value' => isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null,
-			'slug'  => array_key_exists( 'gradient', $block_attributes ) ? $block_attributes['gradient'] : null,
-		);
+		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|background|{$block_attributes['gradient']}" : null;
+		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null;
+		$color_block_styles['gradient'] = $preset_gradient_color ?: $custom_gradient_color;
 	}
 
 	$attributes   = array();

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -83,14 +83,14 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
 		$preset_text_color          = array_key_exists( 'textColor', $block_attributes ) ? "var:preset|color|{$block_attributes['textColor']}" : null;
 		$custom_text_color          = isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null;
-		$color_block_styles['text'] = $preset_text_color ?: $custom_text_color;
+		$color_block_styles['text'] = $preset_text_color ? $preset_text_color : $custom_text_color;
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
 		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|background-color|{$block_attributes['backgroundColor']}" : null;
 		$custom_background_color          = isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null;
-		$color_block_styles['background'] = $preset_background_color ?: $custom_background_color;
+		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
 
 	// Gradients.
@@ -98,7 +98,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
 		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|background|{$block_attributes['gradient']}" : null;
 		$custom_gradient_color          = isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null;
-		$color_block_styles['gradient'] = $preset_gradient_color ?: $custom_gradient_color;
+		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 
 	$attributes   = array();

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -76,66 +76,48 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	$has_text_colors_support       = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'text' ), true ) );
 	$has_background_colors_support = true === $color_support || ( is_array( $color_support ) && _wp_array_get( $color_support, array( 'background' ), true ) );
 	$has_gradients_support         = _wp_array_get( $color_support, array( 'gradients' ), false );
-	$classes                       = array();
-	$styles                        = array();
+	$color_block_styles            = array();
 
 	// Text colors.
 	// Check support for text colors.
 	if ( $has_text_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'text' ) ) {
-		$has_named_text_color  = array_key_exists( 'textColor', $block_attributes );
-		$has_custom_text_color = isset( $block_attributes['style']['color']['text'] );
-
-		// Apply required generic class.
-		if ( $has_custom_text_color || $has_named_text_color ) {
-			$classes[] = 'has-text-color';
-		}
-		// Apply color class or inline style.
-		if ( $has_named_text_color ) {
-			$classes[] = sprintf( 'has-%s-color', _wp_to_kebab_case( $block_attributes['textColor'] ) );
-		} elseif ( $has_custom_text_color ) {
-			$styles[] = sprintf( 'color: %s;', $block_attributes['style']['color']['text'] );
-		}
+		$color_block_styles['text'] = array(
+			'value' => isset( $block_attributes['style']['color']['text'] ) ? $block_attributes['style']['color']['text'] : null,
+			'slug'  => array_key_exists( 'textColor', $block_attributes ) ? $block_attributes['textColor'] : null,
+		);
 	}
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
-		$has_named_background_color  = array_key_exists( 'backgroundColor', $block_attributes );
-		$has_custom_background_color = isset( $block_attributes['style']['color']['background'] );
-
-		// Apply required background class.
-		if ( $has_custom_background_color || $has_named_background_color ) {
-			$classes[] = 'has-background';
-		}
-		// Apply background color classes or styles.
-		if ( $has_named_background_color ) {
-			$classes[] = sprintf( 'has-%s-background-color', _wp_to_kebab_case( $block_attributes['backgroundColor'] ) );
-		} elseif ( $has_custom_background_color ) {
-			$styles[] = sprintf( 'background-color: %s;', $block_attributes['style']['color']['background'] );
-		}
+		$color_block_styles['background'] = array(
+			'value' => isset( $block_attributes['style']['color']['background'] ) ? $block_attributes['style']['color']['background'] : null,
+			'slug'  => array_key_exists( 'backgroundColor', $block_attributes ) ? $block_attributes['backgroundColor'] : null,
+		);
 	}
 
 	// Gradients.
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
-		$has_named_gradient  = array_key_exists( 'gradient', $block_attributes );
-		$has_custom_gradient = isset( $block_attributes['style']['color']['gradient'] );
-
-		if ( $has_named_gradient || $has_custom_gradient ) {
-			$classes[] = 'has-background';
-		}
-		// Apply required background class.
-		if ( $has_named_gradient ) {
-			$classes[] = sprintf( 'has-%s-gradient-background', _wp_to_kebab_case( $block_attributes['gradient'] ) );
-		} elseif ( $has_custom_gradient ) {
-			$styles[] = sprintf( 'background: %s;', $block_attributes['style']['color']['gradient'] );
-		}
+		$color_block_styles['gradient'] = array(
+			'value' => isset( $block_attributes['style']['color']['gradient'] ) ? $block_attributes['style']['color']['gradient'] : null,
+			'slug'  => array_key_exists( 'gradient', $block_attributes ) ? $block_attributes['gradient'] : null,
+		);
 	}
 
-	$attributes = array();
-	if ( ! empty( $classes ) ) {
-		$attributes['class'] = implode( ' ', $classes );
+	$attributes   = array();
+	$style_engine = gutenberg_get_style_engine();
+	$styles       = $style_engine->generate(
+		array( 'color' => $color_block_styles ),
+		array(
+			'inline' => true,
+		)
+	);
+
+	if ( ! empty( $styles['classnames'] ) ) {
+		$attributes['class'] = $styles['classnames'];
 	}
-	if ( ! empty( $styles ) ) {
-		$attributes['style'] = implode( ' ', $styles );
+
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
 	}
 
 	return $attributes;

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -88,7 +88,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 
 	// Background colors.
 	if ( $has_background_colors_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'background' ) ) {
-		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|background-color|{$block_attributes['backgroundColor']}" : null;
+		$preset_background_color          = array_key_exists( 'backgroundColor', $block_attributes ) ? "var:preset|color|{$block_attributes['backgroundColor']}" : null;
 		$custom_background_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'background' ), null );
 		$color_block_styles['background'] = $preset_background_color ? $preset_background_color : $custom_background_color;
 	}
@@ -96,7 +96,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	// Gradients.
 
 	if ( $has_gradients_support && ! gutenberg_should_skip_block_supports_serialization( $block_type, 'color', 'gradients' ) ) {
-		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|background|{$block_attributes['gradient']}" : null;
+		$preset_gradient_color          = array_key_exists( 'gradient', $block_attributes ) ? "var:preset|gradient|{$block_attributes['gradient']}" : null;
 		$custom_gradient_color          = _wp_array_get( $block_attributes, array( 'style', 'color', 'gradient' ), null );
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -101,8 +101,8 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 		$color_block_styles['gradient'] = $preset_gradient_color ? $preset_gradient_color : $custom_gradient_color;
 	}
 
-	$attributes   = array();
-	$styles       = gutenberg_style_engine_generate( array( 'color' => $color_block_styles ) );
+	$attributes = array();
+	$styles     = gutenberg_style_engine_generate( array( 'color' => $color_block_styles ) );
 
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/lib/block-supports/colors.php
+++ b/lib/block-supports/colors.php
@@ -102,8 +102,7 @@ function gutenberg_apply_colors_support( $block_type, $block_attributes ) {
 	}
 
 	$attributes   = array();
-	$style_engine = gutenberg_get_style_engine();
-	$styles       = $style_engine->generate( array( 'color' => $color_block_styles ) );
+	$styles       = gutenberg_style_engine_generate( array( 'color' => $color_block_styles ) );
 
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -52,7 +52,7 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		return $attributes;
 	}
 
-	$style_engine                    = WP_Style_Engine_Gutenberg::get_instance();
+	$style_engine                    = gutenberg_get_style_engine();
 	$skip_padding                    = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
 	$skip_margin                     = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$spacing_block_styles            = array();

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -58,15 +58,15 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	$spacing_block_styles            = array();
 	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
 	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
-	$inline_styles                   = $style_engine->generate(
+	$styles                          = $style_engine->generate(
 		array( 'spacing' => $spacing_block_styles ),
 		array(
 			'inline' => true,
 		)
 	);
 
-	if ( ! empty( $inline_styles ) ) {
-		$attributes['style'] = $inline_styles;
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
 	}
 
 	return $attributes;

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -59,10 +59,7 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
 	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
 	$styles                          = $style_engine->generate(
-		array( 'spacing' => $spacing_block_styles ),
-		array(
-			'inline' => true,
-		)
+		array( 'spacing' => $spacing_block_styles )
 	);
 
 	if ( ! empty( $styles['css'] ) ) {

--- a/lib/block-supports/spacing.php
+++ b/lib/block-supports/spacing.php
@@ -52,13 +52,12 @@ function gutenberg_apply_spacing_support( $block_type, $block_attributes ) {
 		return $attributes;
 	}
 
-	$style_engine                    = gutenberg_get_style_engine();
 	$skip_padding                    = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'padding' );
 	$skip_margin                     = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'margin' );
 	$spacing_block_styles            = array();
 	$spacing_block_styles['padding'] = $has_padding_support && ! $skip_padding ? _wp_array_get( $block_styles, array( 'spacing', 'padding' ), null ) : null;
 	$spacing_block_styles['margin']  = $has_margin_support && ! $skip_margin ? _wp_array_get( $block_styles, array( 'spacing', 'margin' ), null ) : null;
-	$styles                          = $style_engine->generate(
+	$styles                          = gutenberg_style_engine_generate(
 		array( 'spacing' => $spacing_block_styles )
 	);
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -123,7 +123,6 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	if ( $has_line_height_support && ! $should_skip_line_height ) {
 			$typography_block_styles['lineHeight'] = _wp_array_get( $block_attributes, array( 'style', 'typography', 'lineHeight' ), null );
-;
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
@@ -179,7 +178,7 @@ function gutenberg_typography_get_preset_inline_style_value( $style_value, $css_
 	// We have a preset CSS variable as the style.
 	// Get the style value from the string and return CSS style.
 	$index_to_splice = strrpos( $style_value, '|' ) + 1;
-	$slug = _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
+	$slug            = _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
 
 	// Return the actual CSS inline style value e.g. `var(--wp--preset--text-decoration--underline);`.
 	return sprintf( 'var(--wp--preset--%s--%s);', $css_property, $slug );

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -175,7 +175,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	$style_engine  = WP_Style_Engine_Gutenberg::get_instance();
+	$style_engine  = gutenberg_get_style_engine();
 	$inline_styles = $style_engine->generate(
 		array( 'typography' => $styles ),
 		array(
@@ -183,10 +183,10 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		)
 	);
 
-	$classnames = $style_engine->generate(
+	$classnames = $style_engine->get_classnames(
 		array( 'typography' => $classes ),
 		array(
-			'classnames' => true,
+			'use_schema' => true,
 		)
 	);
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -107,7 +107,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
 		if ( $has_named_font_size ) {
-			$classes[] = sprintf( 'has-%s-font-size', _wp_to_kebab_case( $block_attributes['fontSize'] ) );
+			$classes['fontSize'] = _wp_to_kebab_case( $block_attributes['fontSize'] );
 		} elseif ( $has_custom_font_size ) {
 			$styles['fontSize'] = $block_attributes['style']['typography']['fontSize'];
 		}
@@ -118,7 +118,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
 		if ( $has_named_font_family ) {
-			$classes[] = sprintf( 'has-%s-font-family', _wp_to_kebab_case( $block_attributes['fontFamily'] ) );
+			$classes['fontFamily'] = _wp_to_kebab_case( $block_attributes['fontFamily'] );
 		} elseif ( $has_custom_font_family ) {
 			$font_family_custom = $block_attributes['style']['typography']['fontFamily'];
 			// Before using classes, the value was serialized as a CSS Custom Property.
@@ -175,10 +175,6 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		}
 	}
 
-	if ( ! empty( $classes ) ) {
-		$attributes['class'] = implode( ' ', $classes );
-	}
-
 	$style_engine  = WP_Style_Engine_Gutenberg::get_instance();
 	$inline_styles = $style_engine->generate(
 		array( 'typography' => $styles ),
@@ -186,6 +182,17 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 			'inline' => true,
 		)
 	);
+
+	$classnames = $style_engine->generate(
+		array( 'typography' => $classes ),
+		array(
+			'classnames' => true,
+		)
+	);
+
+	if ( ! empty( $classnames ) ) {
+		$attributes['class'] = $classnames;
+	}
 
 	if ( ! empty( $inline_styles ) ) {
 		$attributes['style'] = $inline_styles;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -100,48 +100,43 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	$typography_block_styles = array();
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
-		$typography_block_styles['fontSize'] = array(
-			'value' => isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null,
-			'slug'  => array_key_exists( 'fontSize', $block_attributes ) ? $block_attributes['fontSize'] : null,
-		);
+		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
+		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
+		$typography_block_styles['fontSize'] = $preset_font_size ?: $custom_font_size;
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {
-		$typography_block_styles['fontFamily']['slug'] = array_key_exists( 'fontFamily', $block_attributes ) ? $block_attributes['fontFamily'] : null;
-		if ( isset( $block_attributes['style']['typography']['fontFamily'] ) ) {
-			// Before using classes, the value was serialized as a CSS Custom Property.
-			// We don't need to check for a preset when it lands in core.
-			$font_family_value                              = gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' );
-			$typography_block_styles['fontFamily']['value'] = $font_family_value;
-		}
+		$preset_font_family                    = array_key_exists( 'fontFamily', $block_attributes ) ? "var:preset|font-family|{$block_attributes['fontFamily']}" : null;
+		$custom_font_family                    = isset( $block_attributes['style']['typography']['fontFamily'] ) ? gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' ) : null;
+		$typography_block_styles['fontFamily'] = $preset_font_family ?: $custom_font_family;
 	}
 
 	if ( $has_font_style_support && ! $should_skip_font_style && isset( $block_attributes['style']['typography']['fontStyle'] ) ) {
-		$typography_block_styles['fontStyle']['value'] =
+		$typography_block_styles['fontStyle'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontStyle'], 'font-style' );
 	}
 
 	if ( $has_font_weight_support && ! $should_skip_font_weight && isset( $block_attributes['style']['typography']['fontWeight'] ) ) {
-		$typography_block_styles['fontWeight']['value'] =
+		$typography_block_styles['fontWeight'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontWeight'], 'font-weight' );
 	}
 
 	if ( $has_line_height_support && ! $should_skip_line_height && isset( $block_attributes['style']['typography']['lineHeight'] ) ) {
-			$typography_block_styles['lineHeight']['value'] = $block_attributes['style']['typography']['lineHeight'];
+			$typography_block_styles['lineHeight'] = $block_attributes['style']['typography']['lineHeight'];
 	}
 
 	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
-		$typography_block_styles['textDecoration']['value'] =
+		$typography_block_styles['textDecoration'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['textDecoration'], 'text-decoration' );
 	}
 
 	if ( $has_text_transform_support && ! $should_skip_text_transform && isset( $block_attributes['style']['typography']['textTransform'] ) ) {
-		$typography_block_styles['textTransform']['value'] =
+		$typography_block_styles['textTransform'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['textTransform'], 'text-transform' );
 	}
 
 	if ( $has_letter_spacing_support && ! $should_skip_letter_spacing && isset( $block_attributes['style']['typography']['letterSpacing'] ) ) {
-		$typography_block_styles['letterSpacing']['value'] =
+		$typography_block_styles['letterSpacing'] =
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['letterSpacing'], 'letter-spacing' );
 	}
 

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -102,13 +102,13 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
 		$preset_font_size                    = array_key_exists( 'fontSize', $block_attributes ) ? "var:preset|font-size|{$block_attributes['fontSize']}" : null;
 		$custom_font_size                    = isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null;
-		$typography_block_styles['fontSize'] = $preset_font_size ?: $custom_font_size;
+		$typography_block_styles['fontSize'] = $preset_font_size ? $preset_font_size : $custom_font_size;
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {
 		$preset_font_family                    = array_key_exists( 'fontFamily', $block_attributes ) ? "var:preset|font-family|{$block_attributes['fontFamily']}" : null;
 		$custom_font_family                    = isset( $block_attributes['style']['typography']['fontFamily'] ) ? gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' ) : null;
-		$typography_block_styles['fontFamily'] = $preset_font_family ?: $custom_font_family;
+		$typography_block_styles['fontFamily'] = $preset_font_family ? $preset_font_family : $custom_font_family;
 	}
 
 	if ( $has_font_style_support && ! $should_skip_font_style && isset( $block_attributes['style']['typography']['fontStyle'] ) ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -79,10 +79,6 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$attributes = array();
-	$classes    = array();
-	$styles     = array();
-
 	$has_font_family_support     = _wp_array_get( $typography_supports, array( '__experimentalFontFamily' ), false );
 	$has_font_size_support       = _wp_array_get( $typography_supports, array( 'fontSize' ), false );
 	$has_font_style_support      = _wp_array_get( $typography_supports, array( '__experimentalFontStyle' ), false );
@@ -102,97 +98,68 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	$should_skip_text_transform  = gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'textTransform' );
 	$should_skip_letter_spacing  = gutenberg_should_skip_block_supports_serialization( $block_type, 'typography', 'letterSpacing' );
 
+	$typography_block_styles = array();
 	if ( $has_font_size_support && ! $should_skip_font_size ) {
-		$has_named_font_size  = array_key_exists( 'fontSize', $block_attributes );
-		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
-
-		if ( $has_named_font_size ) {
-			$classes['fontSize'] = $block_attributes['fontSize'];
-		} elseif ( $has_custom_font_size ) {
-			$styles['fontSize'] = $block_attributes['style']['typography']['fontSize'];
-		}
+		$typography_block_styles['fontSize'] = array(
+			'value' => isset( $block_attributes['style']['typography']['fontSize'] ) ? $block_attributes['style']['typography']['fontSize'] : null,
+			'slug'  => array_key_exists( 'fontSize', $block_attributes ) ? $block_attributes['fontSize'] : null,
+		);
 	}
 
 	if ( $has_font_family_support && ! $should_skip_font_family ) {
-		$has_named_font_family  = array_key_exists( 'fontFamily', $block_attributes );
-		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
-
-		if ( $has_named_font_family ) {
-			$classes['fontFamily'] = $block_attributes['fontFamily'];
-		} elseif ( $has_custom_font_family ) {
-			$font_family_custom = $block_attributes['style']['typography']['fontFamily'];
+		$typography_block_styles['fontFamily']['slug'] = array_key_exists( 'fontFamily', $block_attributes ) ? $block_attributes['fontFamily'] : null;
+		if ( isset( $block_attributes['style']['typography']['fontFamily'] ) ) {
 			// Before using classes, the value was serialized as a CSS Custom Property.
 			// We don't need to check for a preset when it lands in core.
-			$font_family_value    = gutenberg_typography_get_preset_inline_style_value( $font_family_custom, 'font-family' );
-			$styles['fontFamily'] = $font_family_value;
+			$font_family_value                              = gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontFamily'], 'font-family' );
+			$typography_block_styles['fontFamily']['value'] = $font_family_value;
 		}
 	}
 
-	if ( $has_font_style_support && ! $should_skip_font_style ) {
-		$font_style       = _wp_array_get( $block_attributes, array( 'style', 'typography', 'fontStyle' ), null );
-		$font_style_value = gutenberg_typography_get_preset_inline_style_value( $font_style, 'font-style' );
-		if ( $font_style_value ) {
-			$styles['fontStyle'] = $font_style_value;
-		}
+	if ( $has_font_style_support && ! $should_skip_font_style && isset( $block_attributes['style']['typography']['fontStyle'] ) ) {
+		$typography_block_styles['fontStyle']['value'] =
+			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontStyle'], 'font-style' );
 	}
 
-	if ( $has_font_weight_support && ! $should_skip_font_weight ) {
-		$font_weight       = _wp_array_get( $block_attributes, array( 'style', 'typography', 'fontWeight' ), null );
-		$font_weight_value = gutenberg_typography_get_preset_inline_style_value( $font_weight, 'font-weight' );
-		if ( $font_weight_value ) {
-			$styles['fontWeight'] = $font_weight_value;
-		}
+	if ( $has_font_weight_support && ! $should_skip_font_weight && isset( $block_attributes['style']['typography']['fontWeight'] ) ) {
+		$typography_block_styles['fontWeight']['value'] =
+			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['fontWeight'], 'font-weight' );
 	}
 
-	if ( $has_line_height_support && ! $should_skip_line_height ) {
-		$has_line_height = isset( $block_attributes['style']['typography']['lineHeight'] );
-		if ( $has_line_height ) {
-			$styles['lineHeight'] = $block_attributes['style']['typography']['lineHeight'];
-		}
+	if ( $has_line_height_support && ! $should_skip_line_height && isset( $block_attributes['style']['typography']['lineHeight'] ) ) {
+			$typography_block_styles['lineHeight']['value'] = $block_attributes['style']['typography']['lineHeight'];
 	}
 
-	if ( $has_text_decoration_support && ! $should_skip_text_decoration ) {
-		$text_decoration       = _wp_array_get( $block_attributes, array( 'style', 'typography', 'textDecoration' ), null );
-		$text_decoration_value = gutenberg_typography_get_preset_inline_style_value( $text_decoration, 'text-decoration' );
-		if ( $text_decoration_value ) {
-			$styles['textDecoration'] = $text_decoration_value;
-		}
+	if ( $has_text_decoration_support && ! $should_skip_text_decoration && isset( $block_attributes['style']['typography']['textDecoration'] ) ) {
+		$typography_block_styles['textDecoration']['value'] =
+			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['textDecoration'], 'text-decoration' );
 	}
 
-	if ( $has_text_transform_support && ! $should_skip_text_transform ) {
-		$text_transform       = _wp_array_get( $block_attributes, array( 'style', 'typography', 'textTransform' ), null );
-		$text_transform_value = gutenberg_typography_get_preset_inline_style_value( $text_transform, 'text-transform' );
-		if ( $text_transform_value ) {
-			$styles['textTransform'] = $text_transform_value;
-		}
+	if ( $has_text_transform_support && ! $should_skip_text_transform && isset( $block_attributes['style']['typography']['textTransform'] ) ) {
+		$typography_block_styles['textTransform']['value'] =
+			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['textTransform'], 'text-transform' );
 	}
 
-	if ( $has_letter_spacing_support && ! $should_skip_letter_spacing ) {
-		$letter_spacing       = _wp_array_get( $block_attributes, array( 'style', 'typography', 'letterSpacing' ), null );
-		$letter_spacing_value = gutenberg_typography_get_preset_inline_style_value( $letter_spacing, 'letter-spacing' );
-		if ( $letter_spacing_value ) {
-			$styles['letterSpacing'] = $letter_spacing_value;
-		}
+	if ( $has_letter_spacing_support && ! $should_skip_letter_spacing && isset( $block_attributes['style']['typography']['letterSpacing'] ) ) {
+		$typography_block_styles['letterSpacing']['value'] =
+			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['letterSpacing'], 'letter-spacing' );
 	}
 
-	$style_engine  = gutenberg_get_style_engine();
-	$inline_styles = $style_engine->generate(
-		array( 'typography' => $styles ),
+	$attributes   = array();
+	$style_engine = gutenberg_get_style_engine();
+	$styles       = $style_engine->generate(
+		array( 'typography' => $typography_block_styles ),
 		array(
 			'inline' => true,
 		)
 	);
 
-	$classnames = $style_engine->get_classnames(
-		array( 'typography' => $classes )
-	);
-
-	if ( ! empty( $classnames ) ) {
-		$attributes['class'] = $classnames;
+	if ( ! empty( $styles['classnames'] ) ) {
+		$attributes['class'] = $styles['classnames'];
 	}
 
-	if ( ! empty( $inline_styles ) ) {
-		$attributes['style'] = $inline_styles;
+	if ( ! empty( $styles['css'] ) ) {
+		$attributes['style'] = $styles['css'];
 	}
 
 	return $attributes;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -107,7 +107,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_size = isset( $block_attributes['style']['typography']['fontSize'] );
 
 		if ( $has_named_font_size ) {
-			$classes['fontSize'] = _wp_to_kebab_case( $block_attributes['fontSize'] );
+			$classes['fontSize'] = $block_attributes['fontSize'];
 		} elseif ( $has_custom_font_size ) {
 			$styles['fontSize'] = $block_attributes['style']['typography']['fontSize'];
 		}
@@ -118,7 +118,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		$has_custom_font_family = isset( $block_attributes['style']['typography']['fontFamily'] );
 
 		if ( $has_named_font_family ) {
-			$classes['fontFamily'] = _wp_to_kebab_case( $block_attributes['fontFamily'] );
+			$classes['fontFamily'] = $block_attributes['fontFamily'];
 		} elseif ( $has_custom_font_family ) {
 			$font_family_custom = $block_attributes['style']['typography']['fontFamily'];
 			// Before using classes, the value was serialized as a CSS Custom Property.
@@ -184,10 +184,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 	);
 
 	$classnames = $style_engine->get_classnames(
-		array( 'typography' => $classes ),
-		array(
-			'use_schema' => true,
-		)
+		array( 'typography' => $classes )
 	);
 
 	if ( ! empty( $classnames ) ) {

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -147,12 +147,7 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	$attributes   = array();
 	$style_engine = gutenberg_get_style_engine();
-	$styles       = $style_engine->generate(
-		array( 'typography' => $typography_block_styles ),
-		array(
-			'inline' => true,
-		)
-	);
+	$styles       = $style_engine->generate( array( 'typography' => $typography_block_styles ) );
 
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -140,9 +140,8 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 			gutenberg_typography_get_preset_inline_style_value( $block_attributes['style']['typography']['letterSpacing'], 'letter-spacing' );
 	}
 
-	$attributes   = array();
-	$style_engine = gutenberg_get_style_engine();
-	$styles       = $style_engine->generate( array( 'typography' => $typography_block_styles ) );
+	$attributes = array();
+	$styles     = gutenberg_style_engine_generate( array( 'typography' => $typography_block_styles ) );
 
 	if ( ! empty( $styles['classnames'] ) ) {
 		$attributes['class'] = $styles['classnames'];

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -175,15 +175,15 @@ class WP_Style_Engine {
 			// Generate inline style rules.
 			if ( isset( $options['inline'] ) && true === $options['inline'] ) {
 				foreach ( $rules as $rule => $value ) {
-					$filtered_css = esc_html( safecss_filter_attr( "{$rule}:{$value}" ) );
+					$filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
 					if ( ! empty( $filtered_css ) ) {
-						$output .= $filtered_css . ';';
+						$output .= $filtered_css . '; ';
 					}
 				}
 			}
 		}
 
-		return $output;
+		return trim( $output );
 	}
 
 	/**

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -36,16 +36,58 @@ class WP_Style_Engine {
 	 *                    For example, `'padding' => 'array( 'top' => '1em' )` will return `array( 'padding-top' => '1em' )`
 	 */
 	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
-		'spacing' => array(
+		'spacing'    => array(
 			'padding' => array(
 				'property_key' => 'padding',
 				'path'         => array( 'spacing', 'padding' ),
-				'value_func'   => 'static::get_css_box_rules',
+				'value_func'   => 'static::get_css_rules',
 			),
 			'margin'  => array(
 				'property_key' => 'margin',
 				'path'         => array( 'spacing', 'margin' ),
-				'value_func'   => 'static::get_css_box_rules',
+				'value_func'   => 'static::get_css_rules',
+			),
+		),
+		'typography' => array(
+			'fontSize'       => array(
+				'property_key' => 'font-size',
+				'path'         => array( 'typography', 'fontSize' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontFamily'     => array(
+				'property_key' => 'font-family',
+				'path'         => array( 'typography', 'fontFamily' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontStyle'      => array(
+				'property_key' => 'font-style',
+				'path'         => array( 'typography', 'fontStyle' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'fontWeight'     => array(
+				'property_key' => 'font-weight',
+				'path'         => array( 'typography', 'fontWeight' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'lineHeight'     => array(
+				'property_key' => 'line-height',
+				'path'         => array( 'typography', 'lineHeight' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'textDecoration' => array(
+				'property_key' => 'text-decoration',
+				'path'         => array( 'typography', 'textDecoration' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'textTransform'  => array(
+				'property_key' => 'text-transform',
+				'path'         => array( 'typography', 'textTransform' ),
+				'value_func'   => 'static::get_css_rules',
+			),
+			'letterSpacing'  => array(
+				'property_key' => 'letter-spacing',
+				'path'         => array( 'typography', 'letterSpacing' ),
+				'value_func'   => 'static::get_css_rules',
 			),
 		),
 	);
@@ -145,20 +187,23 @@ class WP_Style_Engine {
 	}
 
 	/**
-	 * Returns a CSS ruleset for box model styles such as margins, padding, and borders.
+	 * Default style value parser that returns a CSS ruleset.
+	 * If the input contains an array, it will treated like a box model
+	 * for styles such as margins, padding, and borders
 	 *
 	 * @param string|array $style_value    A single raw Gutenberg style attributes value for a CSS property.
 	 * @param string       $style_property The CSS property for which we're creating a rule.
 	 *
 	 * @return array The class name for the added style.
 	 */
-	public static function get_css_box_rules( $style_value, $style_property ) {
+	public static function get_css_rules( $style_value, $style_property ) {
 		$rules = array();
 
 		if ( ! $style_value ) {
 			return $rules;
 		}
 
+		// We assume box model-like properties.
 		if ( is_array( $style_value ) ) {
 			foreach ( $style_value as $key => $value ) {
 				$rules[ "$style_property-$key" ] = $value;

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -175,15 +175,14 @@ class WP_Style_Engine {
 	 * Styles are bundled based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
 	 *
 	 * @param array $block_styles An array of styles from a block's attributes.
-	 * @param array $options      An optional array of options.
 	 *
 	 * @return array|null array(
 	 *     'styles'     => (string) A CSS ruleset formatted to be placed in an HTML `style` attribute or tag.
 	 *     'classnames' => (string) Classnames separated by a space.
 	 * );
 	 */
-	public function generate( $block_styles, $options = array() ) {
-		if ( empty( $block_styles ) ) {
+	public function generate( $block_styles ) {
+		if ( empty( $block_styles ) || ! is_array( $block_styles ) ) {
 			return null;
 		}
 

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -129,14 +129,11 @@ class WP_Style_Engine {
 	 * Returns a classname built using a provided schema.
 	 *
 	 * @param array $block_styles An array of styles from a block's attributes.
-	 *                            Some of the values may contain slugs that need to be parsed using a schema.
-	 * @param array $options = array(
-	 *     'use_schema' => (boolean) Whether to use the internal classname schema in BLOCK_STYLE_DEFINITIONS_METADATA.
-	 * );.
+	 *                            Some values may contain slugs that need to be parsed using a schema.
 	 *
 	 * @return string A CSS classname.
 	 */
-	public function get_classnames( $block_styles, $options = array() ) {
+	public function get_classnames( $block_styles ) {
 		$output = '';
 
 		if ( empty( $block_styles ) ) {

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -144,29 +144,27 @@ class WP_Style_Engine {
 			return $classnames;
 		}
 
-		// Remove falsy values.
-		$filtered_style = array_filter(
-			$style,
-			function( $value ) {
-				return ! empty( $value );
-			}
-		);
+		$required_classnames = array();
 
 		if ( ! empty( $style_definition['classnames'] ) ) {
 			foreach ( $style_definition['classnames'] as $classname => $property ) {
-				// Only add the required classname if there's a valid style value or classname slug.
-				if ( true === $property && ! empty( $filtered_style ) ) {
-					$classnames[] = $classname;
+				if ( true === $property ) {
+					$required_classnames[] = $classname;
 				}
 
-				if ( isset( $filtered_style[ $property ] ) ) {
+				if ( isset( $style[ $property ] ) ) {
 					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
 					// One day, if there are no stored schemata, we could allow custom patterns or
 					// generate classnames based on other properties
 					// such as a path or a value or a prefix passed in options.
-					$classnames[] = sprintf( $classname, _wp_to_kebab_case( $filtered_style[ $property ] ) );
+					$classnames[] = sprintf( $classname, _wp_to_kebab_case( $style[ $property ] ) );
 				}
 			}
+		}
+
+		// Only add the required classnames if there's a valid style value or classname slug.
+		if ( ! empty( $required_classnames ) && ( $style['value'] || ! empty( $classnames ) ) ) {
+			$classnames = array_merge( $required_classnames, $classnames );
 		}
 
 		return $classnames;

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -29,11 +29,11 @@ class WP_Style_Engine {
 	 * Style definitions that contain the instructions to
 	 * parse/output valid Gutenberg styles from a block's attributes.
 	 * For every style definition, the follow properties are valid:
-	 *
+	 *  - classnames   => an array of classnames to be returned for block styles. The key is a classname or pattern.
+	 *                    A value of `true` means the classname should be applied always. Otherwise a valid CSS property
+	 *                    to match the incoming value, e.g., "color" to match var:preset|color|somePresetName.
 	 *  - property_key => the key that represents a valid CSS property, e.g., "margin" or "border".
 	 *  - path         => a path that accesses the corresponding style value in the block style object.
-	 *  - value_func   => a function to generate an array of valid CSS rules for a particular style object.
-	 *                    For example, `'padding' => 'array( 'top' => '1em' )` will return `array( 'padding-top' => '1em' )`
 	 */
 	const BLOCK_STYLE_DEFINITIONS_METADATA = array(
 		'color'      => array(
@@ -240,8 +240,8 @@ class WP_Style_Engine {
 
 	/**
 	 * Default style value parser that returns a CSS ruleset.
-	 * If the input contains an array, it will treated like a box model
-	 * for styles such as margins, padding, and borders
+	 * If the input contains an array, it will be treated like a box model
+	 * for styles such as margins and padding
 	 *
 	 * @param string|array $style_value    A single raw Gutenberg style attributes value for a CSS property.
 	 * @param string       $style_property The CSS property for which we're creating a rule.

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -16,6 +16,11 @@ if ( class_exists( 'WP_Style_Engine' ) ) {
  *
  * Consolidates rendering block styles to reduce duplication and streamline
  * CSS styles generation.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please, use gutenberg_style_engine_get_styles instead.
+ *
+ * @access private
  */
 class WP_Style_Engine {
 	/**
@@ -169,10 +174,9 @@ class WP_Style_Engine {
 	 * @return array        An array of CSS rules.
 	 */
 	protected static function get_css( $style_value, $style_definition ) {
-		$css = array();
 		// Low-specificity check to see if the value is a CSS preset.
 		if ( is_string( $style_value ) && strpos( $style_value, 'var:' ) !== false ) {
-			return $css;
+			return array();
 		}
 
 		// If required in the future, style definitions could define a callable `value_func` to generate custom CSS rules.
@@ -269,12 +273,22 @@ class WP_Style_Engine {
 }
 
 /**
- * This function returns the Style Engine instance.
+ * Global public interface method to WP_Style_Engine->generate.
  *
- * @return WP_Style_Engine
+ * Returns an CSS ruleset.
+ * Styles are bundled based on the instructions in BLOCK_STYLE_DEFINITIONS_METADATA.
+ *
+ * @param array $block_styles An array of styles from a block's attributes.
+ *
+ * @return array|null array(
+ *     'styles'     => (string) A CSS ruleset formatted to be placed in an HTML `style` attribute or tag.
+ *     'classnames' => (string) Classnames separated by a space.
+ * );
  */
-function wp_get_style_engine() {
+function wp_style_engine_generate( $block_styles ) {
 	if ( class_exists( 'WP_Style_Engine' ) ) {
-		return WP_Style_Engine::get_instance();
+		$style_engine = WP_Style_Engine::get_instance();
+		return $style_engine->generate( $block_styles );
 	}
+	return null;
 }

--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -55,7 +55,7 @@ class WP_Style_Engine {
 				'path'         => array( 'color', 'background' ),
 				'classnames'   => array(
 					'has-background'          => true,
-					'has-%s-background-color' => 'background-color',
+					'has-%s-background-color' => 'color',
 				),
 			),
 			'gradient'   => array(
@@ -63,7 +63,7 @@ class WP_Style_Engine {
 				'path'         => array( 'color', 'gradient' ),
 				'classnames'   => array(
 					'has-background'             => true,
-					'has-%s-gradient-background' => 'background',
+					'has-%s-gradient-background' => 'gradient',
 				),
 			),
 		),
@@ -135,6 +135,22 @@ class WP_Style_Engine {
 	}
 
 	/**
+	 * Extracts the slug in kebab case from a preset string, e.g., "heavenly-blue" from 'var:preset|color|heavenlyBlue'.
+	 *
+	 * @param string $style_value  A single css preset value.
+	 * @param string $property_key The CSS property that is the second element of the preset string. Used for matching.
+	 *
+	 * @return string|null The slug, or null if not found.
+	 */
+	protected static function get_slug_from_preset_value( $style_value, $property_key ) {
+		if ( is_string( $style_value ) && strpos( $style_value, "var:preset|{$property_key}|" ) !== false ) {
+			$index_to_splice = strrpos( $style_value, '|' ) + 1;
+			return _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
+		}
+		return null;
+	}
+
+	/**
 	 * Returns classnames, and generates classname(s) from a CSS preset property pattern, e.g., 'var:preset|color|heavenly-blue'.
 	 *
 	 * @param array         $style_value      A single raw style value or css preset property from the generate() $block_styles array.
@@ -150,9 +166,9 @@ class WP_Style_Engine {
 					$classnames[] = $classname;
 				}
 
-				if ( is_string( $style_value ) && strpos( $style_value, "var:preset|{$property_key}|" ) !== false ) {
-					$index_to_splice = strrpos( $style_value, '|' ) + 1;
-					$slug            = _wp_to_kebab_case( substr( $style_value, $index_to_splice ) );
+				$slug = static::get_slug_from_preset_value( $style_value, $property_key );
+
+				if ( $slug ) {
 					// Right now we expect a classname pattern to be stored in BLOCK_STYLE_DEFINITIONS_METADATA.
 					// One day, if there are no stored schemata, we could allow custom patterns or
 					// generate classnames based on other properties

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -131,7 +131,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;',
 			),
 
-			'inline_valid_multiple_style'                  => array(
+			'inline_valid_multiple_spacing_style'          => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'padding' => array(
@@ -152,6 +152,25 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'inline' => true,
 				),
 				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;margin-top:12rem;margin-left:2vh;margin-bottom:2px;margin-right:10em;',
+			),
+
+			'inline_valid_multiple_typography_style'       => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'       => 'clamp(2em, 2vw, 4em)',
+						'fontFamily'     => 'Roboto,Oxygen-Sans,Ubuntu,sans-serif',
+						'fontStyle'      => 'italic',
+						'fontWeight'     => '800',
+						'lineHeight'     => '1.3',
+						'textDecoration' => 'underline',
+						'textTransform'  => 'uppercase',
+						'letterSpacing'  => '2',
+					),
+				),
+				'options'         => array(
+					'inline' => true,
+				),
+				'expected_output' => 'font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -13,12 +13,12 @@ require __DIR__ . '/../class-wp-style-engine.php';
  */
 class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
-	 * Tests various manifestations of the $block_styles argument.
+	 * Tests generating styles based on various manifestations of the $block_styles argument.
 	 *
-	 * @dataProvider data_block_styles_fixtures
+	 * @dataProvider data_generate_css_fixtures
 	 */
 	function test_generate_css( $block_styles, $options, $expected_output ) {
-		$style_engine     = WP_Style_Engine::get_instance();
+		$style_engine     = wp_get_style_engine();
 		$generated_styles = $style_engine->generate(
 			$block_styles,
 			$options
@@ -31,7 +31,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_block_styles_fixtures() {
+	public function data_generate_css_fixtures() {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
@@ -42,7 +42,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'inline_invalid_block_styles_empty'            => array(
 				'block_styles'    => array(),
 				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
@@ -63,7 +62,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'pageBreakAfter' => 'verso',
 				),
 				'options'         => array(
-					'path'   => array( 'pageBreakAfter', 'verso' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
@@ -76,62 +74,24 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					),
 				),
 				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
 				'expected_output' => '',
 			),
 
-			'inline_invalid_multiple_style_unknown_property' => array(
-				'block_styles'    => array(
-					'spacing' => array(
-						'gavin' => '1000vw',
-					),
-				),
-				'options'         => array(
-					'inline' => true,
-				),
-				'expected_output' => '',
-			),
-
-			'inline_valid_single_style_string'             => array(
+			'inline_valid_style_string'                    => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'margin' => '111px',
 					),
 				),
 				'options'         => array(
-					'path'   => array( 'spacing', 'margin' ),
 					'inline' => true,
 				),
 				'expected_output' => 'margin: 111px;',
 			),
 
-			'inline_valid_single_style'                    => array(
-				'block_styles'    => array(
-					'spacing' => array(
-						'padding' => array(
-							'top'    => '42px',
-							'left'   => '2%',
-							'bottom' => '44px',
-							'right'  => '5rem',
-						),
-						'margin'  => array(
-							'top'    => '12rem',
-							'left'   => '2vh',
-							'bottom' => '2px',
-							'right'  => '10em',
-						),
-					),
-				),
-				'options'         => array(
-					'path'   => array( 'spacing', 'padding' ),
-					'inline' => true,
-				),
-				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem;',
-			),
-
-			'inline_valid_multiple_spacing_style'          => array(
+			'inline_valid_box_model_style'                 => array(
 				'block_styles'    => array(
 					'spacing' => array(
 						'padding' => array(
@@ -154,7 +114,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 			),
 
-			'inline_valid_multiple_typography_style'       => array(
+			'inline_valid_typography_style'                => array(
 				'block_styles'    => array(
 					'typography' => array(
 						'fontSize'       => 'clamp(2em, 2vw, 4em)',
@@ -171,6 +131,47 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'inline' => true,
 				),
 				'expected_output' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+			),
+		);
+	}
+
+	/**
+	 * Tests generating classnames based on various manifestations of the $block_styles argument.
+	 *
+	 * @dataProvider data_get_classnames_fixtures
+	 */
+	function test_get_classnames( $block_styles, $options, $expected_output ) {
+		$style_engine     = wp_get_style_engine();
+		$generated_styles = $style_engine->get_classnames(
+			$block_styles,
+			$options
+		);
+		$this->assertSame( $expected_output, $generated_styles );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_get_classnames_fixtures() {
+		return array(
+			'default_return_value'        => array(
+				'block_styles'    => array(),
+				'options'         => null,
+				'expected_output' => '',
+			),
+			'valid_classnames_use_schema' => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'   => 'fantastic',
+						'fontFamily' => 'totally-awesome',
+					),
+				),
+				'options'         => array(
+					'use_schema' => true,
+				),
+				'expected_output' => 'has-fantastic-font-size has-totally-awesome-font-family',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -104,7 +104,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'path'   => array( 'spacing', 'margin' ),
 					'inline' => true,
 				),
-				'expected_output' => 'margin:111px;',
+				'expected_output' => 'margin: 111px;',
 			),
 
 			'inline_valid_single_style'                    => array(
@@ -128,7 +128,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'path'   => array( 'spacing', 'padding' ),
 					'inline' => true,
 				),
-				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;',
+				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem;',
 			),
 
 			'inline_valid_multiple_spacing_style'          => array(
@@ -151,7 +151,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'padding-top:42px;padding-left:2%;padding-bottom:44px;padding-right:5rem;margin-top:12rem;margin-left:2vh;margin-bottom:2px;margin-right:10em;',
+				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 			),
 
 			'inline_valid_multiple_typography_style'       => array(
@@ -170,7 +170,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'font-family:Roboto,Oxygen-Sans,Ubuntu,sans-serif;font-style:italic;font-weight:800;line-height:1.3;text-decoration:underline;text-transform:uppercase;letter-spacing:2;',
+				'expected_output' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -66,9 +66,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'valid_inline_css_and_classnames'              => array(
 				'block_styles'    => array(
 					'color'   => array(
-						'text' => array(
-							'slug' => 'texas-flood',
-						),
+						'text' => 'var:preset|color|texas-flood',
 					),
 					'spacing' => array(
 						'margin' => '111px',
@@ -122,23 +120,13 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'valid_classnames_deduped'                     => array(
 				'block_styles'    => array(
 					'color'      => array(
-						'text'       => array(
-							'slug' => 'copper-socks',
-						),
-						'background' => array(
-							'slug' => 'splendid-carrot',
-						),
-						'gradient'   => array(
-							'slug' => 'like-wow-dude',
-						),
+						'text'       => 'var:preset|color|copper-socks',
+						'background' => 'var:preset|background-color|splendid-carrot',
+						'gradient'   => 'var:preset|background|like-wow-dude',
 					),
 					'typography' => array(
-						'fontSize'   => array(
-							'slug' => 'fantastic',
-						),
-						'fontFamily' => array(
-							'slug' => 'totally-awesome',
-						),
+						'fontSize'   => 'var:preset|font-size|fantastic',
+						'fontFamily' => 'var:preset|font-family|totally-awesome',
 					),
 				),
 				'expected_output' => array(
@@ -148,14 +136,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 			'valid_classnames_with_null_style_values'      => array(
 				'block_styles'    => array(
 					'color' => array(
-						'text'       => array(
-							'value' => '#fff',
-							'slug'  => null,
-						),
-						'background' => array(
-							'value' => null,
-							'slug'  => null,
-						),
+						'text'       => '#fff',
+						'background' => null,
 					),
 				),
 				'expected_output' => array(
@@ -163,18 +145,20 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'classnames' => 'has-text-color',
 				),
 			),
-			'invalid_classnames_slug_key'                  => array(
+			'invalid_classnames_preset_value'              => array(
 				'block_styles'    => array(
-					'color' => array(
-						'text'       => array(
-							'cheese' => 'pizza',
-						),
-						'background' => array(
-							'tomato' => 'sauce',
-						),
+					'color'   => array(
+						'text'       => 'var:cheese|color|fantastic',
+						'background' => 'var:preset|fromage|fantastic',
+					),
+					'spacing' => array(
+						'margin'  => 'var:cheese|spacing|margin',
+						'padding' => 'var:preset|spacing|padding',
 					),
 				),
-				'expected_output' => array(),
+				'expected_output' => array(
+					'classnames' => 'has-text-color has-background',
+				),
 			),
 			'invalid_classnames_options'                   => array(
 				'block_styles'    => array(

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -13,11 +13,11 @@ require __DIR__ . '/../class-wp-style-engine.php';
  */
 class WP_Style_Engine_Test extends WP_UnitTestCase {
 	/**
-	 * Tests generating styles based on various manifestations of the $block_styles argument.
+	 * Tests generating styles and classnames based on various manifestations of the $block_styles argument.
 	 *
-	 * @dataProvider data_generate_css_fixtures
+	 * @dataProvider data_generate_styles_fixtures
 	 */
-	function test_generate_css( $block_styles, $options, $expected_output ) {
+	function test_generate_styles( $block_styles, $options, $expected_output ) {
 		$style_engine     = wp_get_style_engine();
 		$generated_styles = $style_engine->generate(
 			$block_styles,
@@ -31,12 +31,12 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function data_generate_css_fixtures() {
+	public function data_generate_styles_fixtures() {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
 				'options'         => null,
-				'expected_output' => '',
+				'expected_output' => null,
 			),
 
 			'inline_invalid_block_styles_empty'            => array(
@@ -44,7 +44,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => '',
+				'expected_output' => null,
 			),
 
 			'inline_invalid_block_styles_unknown_style'    => array(
@@ -54,7 +54,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => '',
+				'expected_output' => array(),
 			),
 
 			'inline_invalid_block_styles_unknown_definition' => array(
@@ -64,7 +64,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => '',
+				'expected_output' => array(),
 			),
 
 			'inline_invalid_block_styles_unknown_property' => array(
@@ -76,11 +76,16 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => '',
+				'expected_output' => array(),
 			),
 
-			'inline_valid_style_string'                    => array(
+			'valid_inline_css_and_classnames'              => array(
 				'block_styles'    => array(
+					'color'   => array(
+						'text' => array(
+							'slug' => 'texas-flood',
+						),
+					),
 					'spacing' => array(
 						'margin' => '111px',
 					),
@@ -88,7 +93,10 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'margin: 111px;',
+				'expected_output' => array(
+					'css'        => 'margin: 111px;',
+					'classnames' => 'has-text-color has-texas-flood-color',
+				),
 			),
 
 			'inline_valid_box_model_style'                 => array(
@@ -111,7 +119,9 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
+				'expected_output' => array(
+					'css' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
+				),
 			),
 
 			'inline_valid_typography_style'                => array(
@@ -130,48 +140,50 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(
 					'inline' => true,
 				),
-				'expected_output' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+				'expected_output' => array(
+					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
+				),
 			),
-		);
-	}
-
-	/**
-	 * Tests generating classnames based on various manifestations of the $block_styles argument.
-	 *
-	 * @dataProvider data_get_classnames_fixtures
-	 */
-	function test_get_classnames( $block_styles, $options, $expected_output ) {
-		$style_engine     = wp_get_style_engine();
-		$generated_styles = $style_engine->get_classnames(
-			$block_styles,
-			$options
-		);
-		$this->assertSame( $expected_output, $generated_styles );
-	}
-
-	/**
-	 * Data provider.
-	 *
-	 * @return array
-	 */
-	public function data_get_classnames_fixtures() {
-		return array(
-			'default_return_value'        => array(
-				'block_styles'    => array(),
-				'options'         => null,
-				'expected_output' => '',
-			),
-			'valid_classnames_use_schema' => array(
+			'valid_classnames_deduped'                     => array(
 				'block_styles'    => array(
+					'color'      => array(
+						'text'       => array(
+							'slug' => 'copper-socks',
+						),
+						'background' => array(
+							'slug' => 'splendid-carrot',
+						),
+						'gradient'   => array(
+							'slug' => 'like-wow-dude',
+						),
+					),
 					'typography' => array(
-						'fontSize'   => 'fantastic',
-						'fontFamily' => 'totally-awesome',
+						'fontSize'   => array(
+							'slug' => 'fantastic',
+						),
+						'fontFamily' => array(
+							'slug' => 'totally-awesome',
+						),
 					),
 				),
-				'options'         => array(
-					'use_schema' => true,
+				'options'         => array(),
+				'expected_output' => array(
+					'classnames' => 'has-text-color has-copper-socks-color has-background has-splendid-carrot-background-color has-like-wow-dude-gradient-background has-fantastic-font-size has-totally-awesome-font-family',
 				),
-				'expected_output' => 'has-fantastic-font-size has-totally-awesome-font-family',
+			),
+			'invalid_classnames_options'                   => array(
+				'block_styles'    => array(
+					'typography' => array(
+						'fontSize'   => array(
+							'tomodachi' => 'friends',
+						),
+						'fontFamily' => array(
+							'oishii' => 'tasty',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(),
 			),
 		);
 	}

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -41,9 +41,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 
 			'inline_invalid_block_styles_empty'            => array(
 				'block_styles'    => array(),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => null,
 			),
 
@@ -51,9 +49,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'block_styles'    => array(
 					'pageBreakAfter' => 'verso',
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -61,9 +57,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'block_styles'    => array(
 					'pageBreakAfter' => 'verso',
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -73,9 +67,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'gap' => '1000vw',
 					),
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -90,9 +82,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'margin' => '111px',
 					),
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(
 					'css'        => 'margin: 111px;',
 					'classnames' => 'has-text-color has-texas-flood-color',
@@ -116,9 +106,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(
 					'css' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 				),
@@ -137,9 +125,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'letterSpacing'  => '2',
 					),
 				),
-				'options'         => array(
-					'inline' => true,
-				),
+				'options'         => array(),
 				'expected_output' => array(
 					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
 				),
@@ -169,6 +155,25 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'options'         => array(),
 				'expected_output' => array(
 					'classnames' => 'has-text-color has-copper-socks-color has-background has-splendid-carrot-background-color has-like-wow-dude-gradient-background has-fantastic-font-size has-totally-awesome-font-family',
+				),
+			),
+			'valid_classnames_with_null_style_values'      => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text'       => array(
+							'value' => '#fff',
+							'slug'  => null,
+						),
+						'background' => array(
+							'value' => null,
+							'slug'  => null,
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(
+					'css'        => 'color: #fff;',
+					'classnames' => 'has-text-color',
 				),
 			),
 			'invalid_classnames_options'                   => array(

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -17,12 +17,9 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_generate_styles_fixtures
 	 */
-	function test_generate_styles( $block_styles, $options, $expected_output ) {
+	function test_generate_styles( $block_styles, $expected_output ) {
 		$style_engine     = wp_get_style_engine();
-		$generated_styles = $style_engine->generate(
-			$block_styles,
-			$options
-		);
+		$generated_styles = $style_engine->generate( $block_styles );
 		$this->assertSame( $expected_output, $generated_styles );
 	}
 
@@ -35,13 +32,11 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 		return array(
 			'default_return_value'                         => array(
 				'block_styles'    => array(),
-				'options'         => null,
 				'expected_output' => null,
 			),
 
 			'inline_invalid_block_styles_empty'            => array(
-				'block_styles'    => array(),
-				'options'         => array(),
+				'block_styles'    => 'hello world!',
 				'expected_output' => null,
 			),
 
@@ -49,7 +44,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'block_styles'    => array(
 					'pageBreakAfter' => 'verso',
 				),
-				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -57,7 +51,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'block_styles'    => array(
 					'pageBreakAfter' => 'verso',
 				),
-				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -67,7 +60,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'gap' => '1000vw',
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(),
 			),
 
@@ -82,7 +74,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'margin' => '111px',
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(
 					'css'        => 'margin: 111px;',
 					'classnames' => 'has-text-color has-texas-flood-color',
@@ -106,7 +97,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(
 					'css' => 'padding-top: 42px; padding-left: 2%; padding-bottom: 44px; padding-right: 5rem; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
 				),
@@ -125,7 +115,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						'letterSpacing'  => '2',
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(
 					'css' => 'font-family: Roboto,Oxygen-Sans,Ubuntu,sans-serif; font-style: italic; font-weight: 800; line-height: 1.3; text-decoration: underline; text-transform: uppercase; letter-spacing: 2;',
 				),
@@ -152,7 +141,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(
 					'classnames' => 'has-text-color has-copper-socks-color has-background has-splendid-carrot-background-color has-like-wow-dude-gradient-background has-fantastic-font-size has-totally-awesome-font-family',
 				),
@@ -170,7 +158,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(
 					'css'        => 'color: #fff;',
 					'classnames' => 'has-text-color',
@@ -187,7 +174,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(),
 			),
 			'invalid_classnames_options'                   => array(
@@ -201,7 +187,6 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 						),
 					),
 				),
-				'options'         => array(),
 				'expected_output' => array(),
 			),
 		);

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -176,6 +176,20 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 					'classnames' => 'has-text-color',
 				),
 			),
+			'invalid_classnames_slug_key'                  => array(
+				'block_styles'    => array(
+					'color' => array(
+						'text'       => array(
+							'cheese' => 'pizza',
+						),
+						'background' => array(
+							'tomato' => 'sauce',
+						),
+					),
+				),
+				'options'         => array(),
+				'expected_output' => array(),
+			),
 			'invalid_classnames_options'                   => array(
 				'block_styles'    => array(
 					'typography' => array(

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -120,8 +120,8 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 				'block_styles'    => array(
 					'color'      => array(
 						'text'       => 'var:preset|color|copper-socks',
-						'background' => 'var:preset|background-color|splendid-carrot',
-						'gradient'   => 'var:preset|background|like-wow-dude',
+						'background' => 'var:preset|color|splendid-carrot',
+						'gradient'   => 'var:preset|gradient|like-wow-dude',
 					),
 					'typography' => array(
 						'fontSize'   => 'var:preset|font-size|fantastic',

--- a/packages/style-engine/phpunit/class-wp-style-engine-test.php
+++ b/packages/style-engine/phpunit/class-wp-style-engine-test.php
@@ -18,8 +18,7 @@ class WP_Style_Engine_Test extends WP_UnitTestCase {
 	 * @dataProvider data_generate_styles_fixtures
 	 */
 	function test_generate_styles( $block_styles, $expected_output ) {
-		$style_engine     = wp_get_style_engine();
-		$generated_styles = $style_engine->generate( $block_styles );
+		$generated_styles = wp_style_engine_generate( $block_styles );
 		$this->assertSame( $expected_output, $generated_styles );
 	}
 

--- a/phpunit/block-supports/colors-test.php
+++ b/phpunit/block-supports/colors-test.php
@@ -59,7 +59,7 @@ class WP_Block_Supports_Colors_Test extends WP_UnitTestCase {
 		);
 
 		$actual   = gutenberg_apply_colors_support( $block_type, $block_atts );
-		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-background has-gr-3-gradient-background' );
+		$expected = array( 'class' => 'has-text-color has-fg-1-color has-background has-bg-2-background-color has-gr-3-gradient-background' );
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/phpunit/block-supports/spacing-test.php
+++ b/phpunit/block-supports/spacing-test.php
@@ -62,7 +62,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding:111px;margin-top:1px;margin-right:2px;margin-bottom:3px;margin-left:4px;',
+			'style' => 'padding: 111px; margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;',
 		);
 
 		$this->assertSame( $expected, $actual );
@@ -152,7 +152,7 @@ class WP_Block_Supports_Spacing_Test extends WP_UnitTestCase {
 
 		$actual   = gutenberg_apply_spacing_support( $block_type, $block_atts );
 		$expected = array(
-			'style' => 'padding-top:1px;padding-right:2px;padding-bottom:3px;padding-left:4px;',
+			'style' => 'padding-top: 1px; padding-right: 2px; padding-bottom: 3px; padding-left: 4px;',
 		);
 
 		$this->assertSame( $expected, $actual );


### PR DESCRIPTION
Tracking Issue: https://github.com/WordPress/gutenberg/issues/38167

## What?

An alternative to

- https://github.com/WordPress/gutenberg/pull/40082

that takes into account classname generation from slugs, as well as required classnames such as `has-text-color`, which is applied to blocks even with a custom text color.


## Why?
We need to cater for block support classnames that both:

- require slug substitution
- should display regardless of whether there is preset or inline CSS

## How?
By accepting an array for the block style value that contains metadata.

Example usage:

```php
$block_styles = array(
    'color' => array(
        'text'       => '#ccc',
        'background' => 'var:preset|background-color|burned-toast',
    ),
    'typography' => array(
        'fontSize' =>'var:preset|font-size|biiiiiig',

    ),
    'spacing' => array(
        'margin' = array(
            'top'    => '12rem',
            'left'   => '2vh',
            'bottom' => '2px',
            'right'  => '10em',
        ),
    ),
);


$styles = gutenberg_get_style_engine()->generate( block_styles );

/*
$styles outputs:

array(
    'css' => 'color: #ccc; margin-top: 12rem; margin-left: 2vh; margin-bottom: 2px; margin-right: 10em;',
    'classnames' => 'has-text-color has-background has-burned-toast-background-color has-biiiiiig-font-size',
)
*/
```

## Testing Instructions

For dynamic blocks (Site Title, Navigation, Post Title, Post Date for example), check that the color, spacing and typography block supports CSS and classnames are output correctly on the frontend.

<details>
<summary>Some example block code (using TwentyTwentyTwo theme presets)</summary>

```html
<!-- wp:site-title {"style":{"typography":{"lineHeight":1.7,"textTransform":"uppercase","letterSpacing":"113px","textDecoration":"line-through"},"color":{"background":"#c2c9d0"},"spacing":{"padding":{"top":"130px","right":"130px","bottom":"130px","left":"130px"},"margin":{"top":"133px","right":"133px","bottom":"133px","left":"133px"}},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"textColor":"secondary","fontSize":"large","fontFamily":"source-serif-pro"} /-->

<!-- wp:navigation {"ref":50,"layout":{"type":"flex","orientation":"horizontal"},"style":{"typography":{"textTransform":"lowercase","textDecoration":"line-through","fontStyle":"italic","fontWeight":"100"}},"fontFamily":"someAwesomeFont-right-here"} /-->

<!-- wp:search {"label":"Search","buttonText":"Search","textColor":"pale-pink"} /-->

<!-- wp:navigation {"ref":50,"textColor":"pale-pink","overlayBackgroundColor":"vivid-purple","overlayTextColor":"luminous-vivid-orange","style":{"typography":{"fontStyle":"italic","fontWeight":"800","lineHeight":3.4,"textDecoration":"line-through","textTransform":"lowercase"}},"fontSize":"large"} /-->

<!-- wp:post-title {"style":{"typography":{"textTransform":"uppercase","fontStyle":"italic","fontWeight":"800","fontSize":"52px"},"spacing":{"margin":{"bottom":"137px"}},"elements":{"link":{"color":{"text":"#e13f3f"}}},"color":{"text":"#ea2020"}},"backgroundColor":"foreground"} /-->

<!-- wp:post-date {"style":{"typography":{"letterSpacing":"77px"}},"fontSize":"medium"} /-->

<!-- wp:post-date {"style":{"typography":{"letterSpacing":"-5px","fontStyle":"italic","fontWeight":"300","lineHeight":6.1,"textTransform":"lowercase"}},"gradient":"pale-ocean","fontSize":"x-large","fontFamily":"system-font"} /-->
```

</details>

Run `npm run test-unit-php /var/www/html/wp-content/plugins/gutenberg/packages/style-engine/phpunit/class-wp-style-engine-test.php`
