### PR TITLE
Site Editor: Don't render the secondary sidebar in text mode

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -184,10 +184,10 @@ function Editor( { onError } ) {
 		: __( 'Block Library' );
 
 	const secondarySidebar = () => {
-		if ( isInserterOpen ) {
+		if ( editorMode === 'visual' && isInserterOpen ) {
 			return <InserterSidebar />;
 		}
-		if ( isListViewOpen ) {
+		if ( editorMode === 'visual' && isListViewOpen ) {
 			return <ListViewSidebar />;
 		}
 		return null;


### PR DESCRIPTION
## What?
PR updates logic to avoid rendering secondary sidebar in Code editor mode.

## Why?
The block inserted or list view cannot be used in this mode. This matches the behavior of the post editor.

## Testing Instructions
1. Open a Site Editor
2. Open list view
3. Switch to "Code editor"
4. Confirm that the secondary sidebar isn't rendered
