### PR TITLE
Fix template part / reusable block click through on non-safari browsers

### DIFF
--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -10,7 +10,6 @@
 		border: none;
 		border-radius: $radius-block-ui;
 		z-index: z-index(".block-editor-block-content-overlay__overlay");
-		pointer-events: none;
 	}
 
 	&:hover:not(.is-dragging-blocks).overlay-active::before,


### PR DESCRIPTION
## What?
Partial fix for #35079 (it's still broken in Safari)

Fixes some situations where the BlockContentOverlay was allowing click through to child elements when it wasn't supposed to.

Unfortunately Safari is still broken. The brokenness seems to be a quirk of browsers allowing inline elements (especially links) to receive clicks even when `pointer-events: none` is set (https://bugs.webkit.org/show_bug.cgi?id=239486).

## How?
Follows the suggestion in https://github.com/WordPress/gutenberg/issues/40309#issuecomment-1097986308 (props @MarieComet).

When a template part / reusable block or its child are unselected, BlockContentOverlay renders a `:before` pseudo-element as an overlay (which can be seen on hover) and also sets `pointer-events: none` on all its children.

The `:before` overlay also had `pointer-events: none` set, but I don't know why. It seems like it could effectively be used to block clicks. So I've deleted that line and the overlay is now being used to prevent click through.

## Testing Instructions
1. Create a reusable block with a Site Title block in it
2. Deselect all blocks
3. Try selecting the site title

Expected - the reusable block is selected (not the site title).
