### PR TITLE
Fix focus loss happening when installing blocks from the directory

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/index.js
@@ -93,6 +93,7 @@ function DownloadableBlockListItem( { composite, item, onClick } ) {
 
 	return (
 		<CompositeItem
+			__experimentalIsFocusable
 			role="option"
 			as={ Button }
 			{ ...composite }

--- a/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
+++ b/packages/block-directory/src/components/downloadable-block-list-item/test/index.js
@@ -59,7 +59,8 @@ describe( 'DownloadableBlockListItem', () => {
 			<DownloadableBlockListItem onClick={ jest.fn() } item={ plugin } />
 		);
 		const button = getByRole( 'option' );
-		expect( button.disabled ).toBe( true );
+		// Keeping it false to avoid focus loss and disable it using aria-disabled.
+		expect( button.disabled ).toBe( false );
 		expect( button.getAttribute( 'aria-disabled' ) ).toBe( 'true' );
 	} );
 


### PR DESCRIPTION
Extracted from #32765

## What?

For some reason, in the React 18 upgrade PR #32765, `useFocusOutside` works better than trunk (I don't know why yet). Which means there were some failing e2e tests that actually show real bugs we have on trunk, more precisely "focus loss" bugs. 

One of them is in the inserter when installing blocks from the directory: On trunk, on chrome, you can try installing a block from there, you'll notice that when you click a block, the button becomes disabled and the focus is lost (but for some reason the inserter remains open).

This PR solves the focus loss.

## Why?

Focus loss is an a11y issue even if the inserter is kept open right now.

## How?

We already have a solution for buttons that switch from enabled to disabled to avoid focus loss. We rely on `aria-disabled` instead of really disabling the buttons which keeps the button focusable even if it's disabled temporarily. The button component has a dedicated `__experimentalIsFocusable` for these use-cases. We may consider making this API stable separately.

## Testing Instructions

1- Open the inserter
2- Search for a block in the directory (like masonry)
3- Click the button
4- The focus should stay in the button during and after the installation completes and the inserter stays open.

(We already have an e2e test that covers this but it's passing in trunk because of the mystery bug in useFocusOutside, it will start failing in the React 18 upgrade if we do nothing :) ) 

