### PR TITLE
[RNMobile] Display 'expanded' inserter when title is selected

### DIFF
--- a/packages/edit-post/src/components/header/header-toolbar/index.native.js
+++ b/packages/edit-post/src/components/header/header-toolbar/index.native.js
@@ -157,11 +157,8 @@ export default compose( [
 			hasInserterItems,
 			hasSelectedBlock,
 		} = select( blockEditorStore );
-		const { getEditorSettings, isPostTitleSelected } = select(
-			editorStore
-		);
+		const { getEditorSettings } = select( editorStore );
 		const isAnyBlockSelected = hasSelectedBlock();
-		const isTitleSelected = isPostTitleSelected();
 		return {
 			hasRedo: select( editorStore ).hasEditorRedo(),
 			hasUndo: select( editorStore ).hasEditorUndo(),
@@ -175,7 +172,7 @@ export default compose( [
 			isTextModeEnabled:
 				select( editPostStore ).getEditorMode() === 'text',
 			isRTL: select( blockEditorStore ).getSettings().isRTL,
-			noContentSelected: ! isAnyBlockSelected && ! isTitleSelected,
+			noContentSelected: ! isAnyBlockSelected,
 		};
 	} ),
 	withDispatch( ( dispatch ) => {


### PR DESCRIPTION
* `gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4757

## What?

An "expanded" style was applied to the block inserter and toolbar in https://github.com/WordPress/gutenberg/pull/39726. This new style was only visible when the block or title was _de-selected_ in the post editor. With this PR, this is updated so that the new style _does_ display when the title is selected.

## Why?

As per the following screencast, you'll see that a flash of the new "expanded" button style was displaying when first opening a post:

https://user-images.githubusercontent.com/2998162/163352545-7cb61156-3811-4e86-bf1b-ea091569c99d.mov

This was happening because there is a delay of a few seconds before the title of a new post becomes selected, which caused the jump in styling. 

As this is a bit off-putting, especially for users who are just creating a post for the first time, we're preventing the flash by always displaying the "expanded" button style when the title is selected in the editor.

In the future, we may change this behaviour so that the new style only displays when first opening the post editor. We're sticking to always displaying the style when a title is selected for now as we wanted to move quickly on a fix.

## How?

All references to `isTitleSelected` have been removed from the logic around displaying the new style.

## Testing Instructions

To verify this fix, follow these steps within the WordPress Android or iOS app:

* Tap the "new post" button.
* Verify that the title is selected by default and that the new "expanded" button style displays. There should be no "flash" between styles.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/163351006-e3bda07c-66f7-46fd-ad00-458d4f757c34.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/163350857-4d084c96-55ab-4994-b0f2-d5371254a876.png" width="100%"> |