### PR TITLE
Fix focus loss when creating pages from link control search results

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -148,6 +148,10 @@ function LinkControl( {
 
 	const currentInputIsEmpty = ! currentInputValue?.trim()?.length;
 
+	const { createPage, isCreatingPage, errorMessage } = useCreatePage(
+		createSuggestion
+	);
+
 	useEffect( () => {
 		if (
 			forceIsEditingLink !== undefined &&
@@ -185,7 +189,7 @@ function LinkControl( {
 		nextFocusTarget.focus();
 
 		isEndingEditWithFocus.current = false;
-	}, [ isEditingLink ] );
+	}, [ isEditingLink, isCreatingPage ] );
 
 	useEffect( () => {
 		/**
@@ -216,10 +220,6 @@ function LinkControl( {
 
 		setIsEditingLink( false );
 	}
-
-	const { createPage, isCreatingPage, errorMessage } = useCreatePage(
-		createSuggestion
-	);
 
 	const handleSelectSuggestion = ( updatedValue ) => {
 		onChange( {


### PR DESCRIPTION
Extracted from #32765

## What?

For some reason, in the React 18 upgrade PR #32765, `useFocusOutside` works better than trunk (I don't know why yet). Which means there were some failing e2e tests that actually show real bugs we have on trunk, more precisely "focus loss" bugs. 

One of them is in the inserter when creating pages from link control. This PR solves the focus loss there.

## Why?

Focus loss is an a11y issue even if the inserter is kept open right now.

## How?

We already have a dedicated logic in the component to avoid focus loss when switching from "editing link" to "showing link" but there's a third state "loading state while creating a page" that was not covered by the focus loss preventing logic. This PR just triggers the effect when the `isCreatingPage` boolean becomes true.

## Testing Instructions

1- Write a paragraph
2- Click the "add link" button
3- Write something in the input
4- Select "Create page" from the dropdown
5- The LinkControl component should still have focus and be visible.

(We already have an e2e test that covers this but it's passing in trunk because of the mystery bug in useFocusOutside, it will start failing in the React 18 upgrade if we do nothing :) ) 

