### PR TITLE
DocumentSettingPanel: Remove plugin icon fallback

### DIFF
--- a/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
+++ b/packages/edit-post/src/components/sidebar/plugin-document-setting-panel/index.js
@@ -108,7 +108,6 @@ const PluginDocumentSettingPanel = compose(
 			warning( 'PluginDocumentSettingPanel requires a name property.' );
 		}
 		return {
-			icon: ownProps.icon || context.icon,
 			panelName: `${ context.name }/${ ownProps.name }`,
 		};
 	} ),


### PR DESCRIPTION
## What?
PR removes fallback to plugin context icon.

## Why?
Core panels don't display icons next to the labels. So the fallback required explicitly setting plugin icon to falsy value so that default icon wasn't displayed.

I think default behavior should match core document panels but allow developers to specify the icon.

cc @ryanwelcher

## Testing Instructions
1. Open a Post or Page.
2 Register document settings panel using a snippet from docs - https://developer.wordpress.org/block-editor/reference-guides/packages/packages-edit-post/#plugindocumentsettingpanel.
3. Confirm that icon isn't displayed next to the panel label.

## Screenshots or screencast <!-- if applicable -->
| Before | after |
| --- | --- |
|![CleanShot 2022-04-14 at 19 17 01](https://user-images.githubusercontent.com/240569/163422406-2f6d84f1-7c93-4393-9579-8684374254cc.png)|![CleanShot 2022-04-14 at 19 16 25](https://user-images.githubusercontent.com/240569/163422399-eafff063-5588-44c0-b71f-eba6a57745f7.png)|

