### PR TITLE
Post Comments Form: Fix layout quirks

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -67,4 +67,9 @@
 			margin-top: 0.35em;
 		}
 	}
+
+	.comment-reply-title {
+		display: flex;
+		justify-content: space-between;
+	}
 }

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -71,5 +71,10 @@
 	.comment-reply-title {
 		display: flex;
 		justify-content: space-between;
+		align-items: center;
+
+		:where(small) {
+			font-size: var(--wp--preset--font-size--small, smaller);
+		}
 	}
 }

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -75,7 +75,7 @@
 		margin-bottom: 0;
 
 		:where(small) {
-			font-size: var(--wp--preset--font-size--normal, smaller);
+			font-size: var(--wp--preset--font-size--medium, smaller);
 		}
 	}
 }

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -69,12 +69,13 @@
 	}
 
 	.comment-reply-title {
+		align-items: baseline;
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
+		margin-bottom: 0;
 
 		:where(small) {
-			font-size: var(--wp--preset--font-size--small, smaller);
+			font-size: var(--wp--preset--font-size--normal, smaller);
 		}
 	}
 }


### PR DESCRIPTION
## What?
Follow-up to #40268.

## Why?
When using the Comments Query Loop block and Post Comments Form block in a template, the comments form is rendered inline in the position where the user clicked 'Reply' on the frontend. However, there are still some layout quirks, as seen below:

![image](https://user-images.githubusercontent.com/96308/163438658-1846444b-94fe-4d35-83fc-ca6530be3c20.png)

First and foremost, the 'Cancel reply' link is way to close to the 'Reply to admin' text.

Compare this e.g. to the Twenty Twenty One (TT1) theme:

![image](https://user-images.githubusercontent.com/96308/163438843-09ea2068-a539-4738-84a5-7ada09d7133e.png)

(This is achieved by [a simple flexbox-based styling](https://github.com/WordPress/wordpress-develop/blob/2648a5f984b8abf06872151898e3a61d3458a628/src/wp-content/themes/twentytwentyone/assets/sass/06-components/comments.scss#L49-L51) of `comment-reply-title`.)

## How?
This PR attempts to fix them in a way that doesn't preclude any extra styling by themes.

For now, it only adds flexbox styling akin to TT1's to the Post Comments Form's `style.scss`.

## Testing Instructions
1. Create a post with comments.
2. Add Comment Query Loop.
3. Add Post Comments Form.
4. On the frontend, add multiple comments.
5. Reply to a comment and verify that the 'Cancel reply' link is indeed right-aligned.

## Screenshots or screencast

![image](https://user-images.githubusercontent.com/96308/163439722-41c65651-b68a-41d4-9d39-e50423887416.png)

