### PR TITLE
[Block Locking]: Unlock from list view

### DIFF
--- a/packages/block-editor/src/components/list-view/block-select-button.js
+++ b/packages/block-editor/src/components/list-view/block-select-button.js
@@ -8,7 +8,6 @@ import classnames from 'classnames';
  */
 import { Button } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
-import { Icon, lock } from '@wordpress/icons';
 import { SPACE, ENTER } from '@wordpress/keycodes';
 
 /**
@@ -18,7 +17,6 @@ import BlockIcon from '../block-icon';
 import useBlockDisplayInformation from '../use-block-display-information';
 import BlockTitle from '../block-title';
 import ListViewExpander from './expander';
-import { useBlockLock } from '../block-lock';
 
 function ListViewBlockSelectButton(
 	{
@@ -35,7 +33,6 @@ function ListViewBlockSelectButton(
 	ref
 ) {
 	const blockInformation = useBlockDisplayInformation( clientId );
-	const { isLocked } = useBlockLock( clientId );
 
 	// The `href` attribute triggers the browser's native HTML drag operations.
 	// When the link is dragged, the element's outerHTML is set in DataTransfer object as text/html.
@@ -78,11 +75,6 @@ function ListViewBlockSelectButton(
 				{ blockInformation?.anchor && (
 					<span className="block-editor-list-view-block-select-button__anchor">
 						{ blockInformation.anchor }
-					</span>
-				) }
-				{ isLocked && (
-					<span className="block-editor-list-view-block-select-button__lock">
-						<Icon icon={ lock } />
 					</span>
 				) }
 			</Button>

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -128,7 +128,7 @@
 			content: "";
 			position: absolute;
 			top: 0;
-			right: -(24px + 5px); // Icon size + padding.
+			right: -(60px + 5px); // Icon sizes(lock+block actions) + padding.
 			bottom: 0;
 			left: 0;
 			border-radius: inherit;
@@ -170,9 +170,36 @@
 
 	.block-editor-list-view-block__menu-cell,
 	.block-editor-list-view-block__mover-cell,
+	.block-editor-list-view-block__lock-cell,
 	.block-editor-list-view-block__contents-cell {
 		padding-top: 0;
 		padding-bottom: 0;
+	}
+
+	.block-editor-list-view-block__lock-cell {
+		line-height: 0;
+		width: $button-size;
+		vertical-align: middle;
+		position: relative;
+		z-index: 1;
+
+		// Don't show the focus inherited by the Button component.
+		button:focus:enabled {
+			box-shadow: none;
+			outline: none;
+		}
+
+		// Focus style.
+		button:focus {
+			box-shadow: none;
+			outline: none;
+		}
+
+		.components-button.has-icon {
+			width: 24px;
+			min-width: 24px;
+			padding: 0;
+		}
 	}
 
 	.block-editor-list-view-block__menu-cell,
@@ -310,15 +337,6 @@
 
 	&.is-selected .block-editor-list-view-block-select-button__anchor {
 		background: rgba($black, 0.3);
-	}
-
-	.block-editor-list-view-block-select-button__lock {
-		line-height: 0;
-		width: 24px;
-		min-width: 24px;
-		margin-left: auto;
-		padding: 0;
-		vertical-align: middle;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/40343

This PR will allow unlocking from list view. 



## How?

In general the view is really fragile and not scalable. There are styles for example that need to be updated if we make some changes(examples: [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/list-view/style.scss#L131) and [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/list-view/style.scss#L92)), setting specific [colspan](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/list-view/block.js#L185) for the first cell conditionally, etc..

I'll try to possibly add the lock icon in the same cell(`td`) of block description and have to test for regressions when other cells are visible, like `movers`. 
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
