### PR TITLE
Add helper text to Cover Block's min-height field

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -140,7 +140,13 @@ function CoverHeightInput( {
 	const min = isPx ? COVER_MIN_HEIGHT : 0;
 
 	return (
-		<BaseControl label={ __( 'Minimum height of cover' ) } id={ inputId }>
+		<BaseControl
+			label={ __( 'Minimum height of cover' ) }
+			id={ inputId }
+			help={ __(
+				'The inner content may increase the actual height of the cover block.'
+			) }
+		>
 			<UnitControl
 				id={ inputId }
 				isResetValueOnUnitChange


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added helper text to Cover Block's min-height field. [Issue #38875](https://github.com/WordPress/gutenberg/issues/38875)

## Why?
The addition of this min-height helper text is to avoid confusion regarding the height of the cover block when inner content is larger than the min-height value.

## How?
The text "The inner content may increase the actual height of the cover block." was added to the help property on the min-height BaseControl.

## Testing Instructions
1. Add a New Page
2. Add a Cover block to the page.
3. In the Cover block sidebar settings you should see the helper text, mentioned above, displayed just below the min-height field.

## Screenshots or screencast 
<img width="278" alt="Screen Shot 2022-04-14 at 11 40 38 AM" src="https://user-images.githubusercontent.com/18356347/163449039-9aacd4dd-dd36-4d86-91d7-1195c64694ea.png">


