### PR TITLE
Post Comments block: Enqueue comment-reply script

### DIFF
--- a/packages/block-library/src/post-comments/index.php
+++ b/packages/block-library/src/post-comments/index.php
@@ -51,6 +51,8 @@ function render_block_core_post_comments( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 	$output             = ob_get_clean();
 
+	wp_enqueue_script( 'comment-reply' );
+
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $output );
 }
 


### PR DESCRIPTION
## What?
On the frontend, inline the Post Comments block's comment submission form in the position of the "Reply" link that the user clicked.

| Before | After|
|-------|------|
| ![post-comments-before](https://user-images.githubusercontent.com/96308/163474343-0d666155-bf8e-4dd7-a963-907562326e72.gif) | ![post-comments-after](https://user-images.githubusercontent.com/96308/163473413-3eb2023b-f19a-48a2-8657-1f515514002c.gif) |

Note how the comment form opens inline (in the position where the comment will show up, i.e. after the last child of the comment we're replying to).

This means that we're changing the behavior of themes that have been using the Post Comments block -- such as Twenty Twenty Two. We should consult with theme authors if this is okay (or if possibly theme authors might even have implicitly relied on the previous behavior, and if there's any potential for breakage).

## Why?

Feature parity with previous WordPress Comments (prior to FSE). FWIW, the same behavior was implemented in #40268 for the Comments Query Loop block (which is kind of a more modular successor to the Post Comments block.)

## How?
By enqueuing WordPress' `comment-reply.js` script.

## What else?

We might want to enqueue only under some conditions: https://github.com/WordPress/gutenberg/pull/40268#issuecomment-1098564564

## Testing Instructions

1. The Post Comments block is currently hidden from the inserter. You need to remove the following line (and rebuild Gutenberg) in order to show it: https://github.com/WordPress/gutenberg/blob/54fd3bfd349fbe24485bb07899dd25d3aee7fa10/packages/block-library/src/post-comments/block.json#L37
3. Go to the Site Editor and edit the Single page template.
4. Insert the block named "Post Comments (deprecated)". (Don't worry about the somewhat ugly placeholder it inserts for now.)
5. Save the template, and go to your site's frontend.
6. Navigate to a single post, and add a comment.
7. Reply to that comment. Note that the comment form shows up inline, and that the page is scrolled to show that comment at the top of your browser window after submitting the comment.
