### PR TITLE
Post Comments Form: Add "proper" visual representation in the editor

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -50,6 +50,7 @@
 @import "./query-pagination-numbers/editor.scss";
 @import "./post-featured-image/editor.scss";
 @import "./post-comments/editor.scss";
+@import "./post-comments-form/editor.scss";
 
 :root .editor-styles-wrapper {
 	@include background-colors-deprecated();

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -34,7 +34,7 @@
 			}
 		}
 	},
-	"editorStyle": "wp-block-post-comments-form",
+	"editorStyle": "wp-block-post-comments-form-editor",
 	"style": [
 		"wp-block-post-comments-form",
 		"wp-block-buttons",

--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -34,6 +34,7 @@
 			}
 		}
 	},
+	"editorStyle": "wp-block-post-comments-form",
 	"style": [
 		"wp-block-post-comments-form",
 		"wp-block-buttons",

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -67,8 +67,59 @@ export default function PostCommentsFormEdit( {
 					</Warning>
 				) }
 
-				{ ( 'open' === commentStatus || isInSiteEditor ) &&
-					__( 'Post Comments Form' ) }
+				{ ( 'open' === commentStatus || isInSiteEditor ) && (
+					<div className="wp-block-post-comments">
+						<h3>{ __( 'Leave a Reply' ) }</h3>
+						<form noValidate="" className="comment-form">
+							<p>
+								<a
+									href="#post-comments-pseudo-link"
+									onClick={ ( event ) =>
+										event.preventDefault()
+									}
+								>
+									{ __( 'Logged in as admin' ) }
+								</a>
+								.{ ' ' }
+								<a
+									href="#post-comments-pseudo-link"
+									onClick={ ( event ) =>
+										event.preventDefault()
+									}
+								>
+									{ __( 'Log out?' ) }
+								</a>{ ' ' }
+								<span>
+									{ __( 'Required fields are marked' ) }{ ' ' }
+									<span>*</span>
+								</span>
+							</p>
+							<p>
+								<label htmlFor="comment">
+									{ __( 'Comment' ) }
+									<span>*</span>
+								</label>
+								<textarea
+									/* eslint-disable-next-line no-restricted-syntax */
+									id="comment"
+									name="comment"
+									cols="45"
+									rows="8"
+									maxLength="65525"
+									required=""
+								/>
+							</p>
+							<p>
+								<input
+									name="submit"
+									type="submit"
+									className="submit wp-block-button__link"
+									value={ __( 'Post Comment' ) }
+								/>
+							</p>
+						</form>
+					</div>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -14,7 +14,10 @@ import {
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
+import {
+	__experimentalUseDisabled as useDisabled,
+	useInstanceId,
+} from '@wordpress/compose';
 
 export default function PostCommentsFormEdit( {
 	attributes,
@@ -38,6 +41,8 @@ export default function PostCommentsFormEdit( {
 	const isInSiteEditor = postType === undefined || postId === undefined;
 
 	const disabledFormRef = useDisabled();
+
+	const instanceId = useInstanceId( PostCommentsFormEdit );
 
 	return (
 		<>
@@ -79,12 +84,12 @@ export default function PostCommentsFormEdit( {
 							ref={ disabledFormRef }
 						>
 							<p>
-								<label htmlFor="comment">
+								<label htmlFor={ `comment-${ instanceId }` }>
 									{ __( 'Comment' ) }
 								</label>
 								<textarea
 									/* eslint-disable-next-line no-restricted-syntax */
-									id="comment"
+									id={ `comment-${ instanceId }` }
 									name="comment"
 									cols="45"
 									rows="8"

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -71,7 +71,7 @@ export default function PostCommentsFormEdit( {
 				) }
 
 				{ ( 'open' === commentStatus || isInSiteEditor ) && (
-					<div className="wp-block-post-comments-form">
+					<div>
 						<h3>{ __( 'Leave a Reply' ) }</h3>
 						<form
 							noValidate

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -14,6 +14,7 @@ import {
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
+import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
 
 export default function PostCommentsFormEdit( {
 	attributes,
@@ -35,6 +36,8 @@ export default function PostCommentsFormEdit( {
 	} );
 
 	const isInSiteEditor = postType === undefined || postId === undefined;
+
+	const disabledFormRef = useDisabled();
 
 	return (
 		<>
@@ -70,7 +73,11 @@ export default function PostCommentsFormEdit( {
 				{ ( 'open' === commentStatus || isInSiteEditor ) && (
 					<div className="wp-block-post-comments-form">
 						<h3>{ __( 'Leave a Reply' ) }</h3>
-						<form noValidate className="comment-form">
+						<form
+							noValidate
+							className="comment-form"
+							ref={ disabledFormRef }
+						>
 							<p>
 								<label htmlFor="comment">
 									{ __( 'Comment' ) }
@@ -81,7 +88,6 @@ export default function PostCommentsFormEdit( {
 									name="comment"
 									cols="45"
 									rows="8"
-									disabled
 								/>
 							</p>
 							<p>

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -90,6 +90,7 @@ export default function PostCommentsFormEdit( {
 									className="submit wp-block-button__link"
 									label={ __( 'Post Comment' ) }
 									value={ __( 'Post Comment' ) }
+									readOnly
 								/>
 							</p>
 						</form>

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -68,36 +68,12 @@ export default function PostCommentsFormEdit( {
 				) }
 
 				{ ( 'open' === commentStatus || isInSiteEditor ) && (
-					<div className="wp-block-post-comments">
+					<div className="wp-block-post-comments-form">
 						<h3>{ __( 'Leave a Reply' ) }</h3>
-						<form noValidate="" className="comment-form">
-							<p>
-								<a
-									href="#post-comments-pseudo-link"
-									onClick={ ( event ) =>
-										event.preventDefault()
-									}
-								>
-									{ __( 'Logged in as admin' ) }
-								</a>
-								.{ ' ' }
-								<a
-									href="#post-comments-pseudo-link"
-									onClick={ ( event ) =>
-										event.preventDefault()
-									}
-								>
-									{ __( 'Log out?' ) }
-								</a>{ ' ' }
-								<span>
-									{ __( 'Required fields are marked' ) }{ ' ' }
-									<span>*</span>
-								</span>
-							</p>
+						<form noValidate className="comment-form">
 							<p>
 								<label htmlFor="comment">
 									{ __( 'Comment' ) }
-									<span>*</span>
 								</label>
 								<textarea
 									/* eslint-disable-next-line no-restricted-syntax */
@@ -105,15 +81,14 @@ export default function PostCommentsFormEdit( {
 									name="comment"
 									cols="45"
 									rows="8"
-									maxLength="65525"
-									required=""
+									disabled
 								/>
 							</p>
 							<p>
 								<input
 									name="submit"
-									type="submit"
 									className="submit wp-block-button__link"
+									label={ __( 'Post Comment' ) }
 									value={ __( 'Post Comment' ) }
 								/>
 							</p>

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -88,7 +88,6 @@ export default function PostCommentsFormEdit( {
 									{ __( 'Comment' ) }
 								</label>
 								<textarea
-									/* eslint-disable-next-line no-restricted-syntax */
 									id={ `comment-${ instanceId }` }
 									name="comment"
 									cols="45"

--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -1,0 +1,23 @@
+.wp-block-post-comments-form {
+	textarea {
+		padding: calc(0.667em + 2px);
+	}
+
+	.comment-form {
+		textarea,
+		label {
+			display: block;
+			margin-bottom: 0.25em;
+		}
+	}
+
+	// Styles copied from button block styles.
+	input[type="submit"] {
+		border: none;
+		box-shadow: none;
+		cursor: pointer;
+		display: inline-block;
+		text-align: center;
+		overflow-wrap: break-word;
+	}
+}

--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -1,25 +1,3 @@
-.wp-block-post-comments-form {
-	textarea {
-		padding: calc(0.667em + 2px);
-		border: 1px solid $gray-600;
-		font-size: 1em;
-		font-family: inherit;
-	}
-
-	.comment-form {
-		textarea,
-		label {
-			display: block;
-			margin-bottom: 0.25em;
-		}
-	}
-
-	input[name="submit"] {
-		border: none;
-		box-shadow: none;
-		cursor: pointer;
-		display: inline-block;
-		text-align: center;
-		overflow-wrap: break-word;
-	}
+.wp-block-post-comments-form * {
+	pointer-events: none;
 }

--- a/packages/block-library/src/post-comments-form/editor.scss
+++ b/packages/block-library/src/post-comments-form/editor.scss
@@ -1,6 +1,9 @@
 .wp-block-post-comments-form {
 	textarea {
 		padding: calc(0.667em + 2px);
+		border: 1px solid $gray-600;
+		font-size: 1em;
+		font-family: inherit;
 	}
 
 	.comment-form {
@@ -11,8 +14,7 @@
 		}
 	}
 
-	// Styles copied from button block styles.
-	input[type="submit"] {
+	input[name="submit"] {
 		border: none;
 		box-shadow: none;
 		cursor: pointer;

--- a/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
+++ b/packages/e2e-tests/specs/experiments/blocks/post-comments-form.test.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	insertBlock,
+	activateTheme,
+	setOption,
+	visitSiteEditor,
+	openSiteEditorNavigationPanel,
+	navigateSiteEditorBackToRoot,
+	deleteAllTemplates,
+	canvas,
+} from '@wordpress/e2e-test-utils';
+
+describe( 'Post Comments Form', () => {
+	beforeAll( async () => {
+		await activateTheme( 'emptytheme' );
+		await deleteAllTemplates( 'wp_template' );
+	} );
+
+	describe( 'placeholder', () => {
+		it( 'displays in site editor even when comments are closed by default', async () => {
+			await setOption( 'default_comment_status', 'closed' );
+
+			// Navigate to "Singular" post template
+			await visitSiteEditor();
+			await openSiteEditorNavigationPanel();
+			await navigateSiteEditorBackToRoot();
+			await expect( page ).toClick(
+				'.components-navigation__item-title',
+				{ text: /templates/i }
+			);
+			await expect( page ).toClick( '.components-heading > a', {
+				text: /singular/i,
+			} );
+
+			// Insert post comments form
+			await insertBlock( 'Post Comments Form' );
+
+			// Ensure the placeholder is there
+			await expect( canvas() ).toMatchElement(
+				'.wp-block-post-comments-form .comment-form'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?
Adding UI elements to represent the Post Comments Form in the editor. Fixing https://github.com/WordPress/gutenberg/issues/26999

## Why?
Currently, in the editor, the Post Comments form just renders a placeholder saying "Post Comments Form". This is bad UX and we're planning to add the Post Comments Form to the Comment Template in https://github.com/WordPress/gutenberg/pull/40256 so would need it to have a "proper" visual representation.

## How?
Adding elements that are close to how the Post Comments Form looks in the frontend.

## Testing Instructions
none yet.

## Screenshots or screencast

This is a screenshot from the editor (still work in progress): 
<img width="500" alt="Screenshot 2022-04-14 at 20 12 18" src="https://user-images.githubusercontent.com/5417266/163502219-95d83f53-031b-41e3-849a-f6b4a34a4826.png">

