### PR TITLE
Add a built-in exploded mode instead of a separate view

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1492,7 +1492,7 @@ Action that enables or disables the navigation mode.
 
 _Parameters_
 
--   _isNavigationMode_ `string`: Enable/Disable navigation mode.
+-   _isNavigationMode_ `boolean`: Enable/Disable navigation mode.
 
 ### setTemplateValidity
 

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { getDefaultBlockName } from '@wordpress/blocks';
 
 /**
@@ -18,14 +18,38 @@ import { store as blockEditorStore } from '../../store';
 
 function BlockListAppender( {
 	rootClientId,
-	canInsertDefaultBlock,
-	isLocked,
 	renderAppender: CustomAppender,
 	className,
-	selectedBlockClientId,
 	tagName: TagName = 'div',
 } ) {
-	if ( isLocked || CustomAppender === false ) {
+	const {
+		hideInserter,
+		canInsertDefaultBlock,
+		selectedBlockClientId,
+	} = useSelect(
+		( select ) => {
+			const {
+				canInsertBlockType,
+				getTemplateLock,
+				getSelectedBlockClientId,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
+
+			return {
+				hideInserter:
+					!! getTemplateLock( rootClientId ) ||
+					__unstableGetEditorMode() !== 'edit',
+				canInsertDefaultBlock: canInsertBlockType(
+					getDefaultBlockName(),
+					rootClientId
+				),
+				selectedBlockClientId: getSelectedBlockClientId(),
+			};
+		},
+		[ rootClientId ]
+	);
+
+	if ( hideInserter || CustomAppender === false ) {
 		return null;
 	}
 
@@ -92,19 +116,4 @@ function BlockListAppender( {
 	);
 }
 
-export default withSelect( ( select, { rootClientId } ) => {
-	const {
-		canInsertBlockType,
-		getTemplateLock,
-		getSelectedBlockClientId,
-	} = select( blockEditorStore );
-
-	return {
-		isLocked: !! getTemplateLock( rootClientId ),
-		canInsertDefaultBlock: canInsertBlockType(
-			getDefaultBlockName(),
-			rootClientId
-		),
-		selectedBlockClientId: getSelectedBlockClientId(),
-	};
-} )( BlockListAppender );
+export default BlockListAppender;

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -34,16 +34,16 @@ export const IntersectionObserver = createContext();
 function Root( { className, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { isOutlineMode, isFocusMode, isNavigationMode } = useSelect(
+	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
 		( select ) => {
-			const { getSettings, isNavigationMode: _isNavigationMode } = select(
+			const { getSettings, __unstableGetEditorMode } = select(
 				blockEditorStore
 			);
 			const { outlineMode, focusMode } = getSettings();
 			return {
 				isOutlineMode: outlineMode,
 				isFocusMode: focusMode,
-				isNavigationMode: _isNavigationMode(),
+				editorMode: __unstableGetEditorMode(),
 			};
 		},
 		[]
@@ -75,7 +75,8 @@ function Root( { className, ...settings } ) {
 			className: classnames( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,
 				'is-focus-mode': isFocusMode && isLargeViewport,
-				'is-navigate-mode': isNavigationMode,
+				'is-navigate-mode': editorMode === 'navigation',
+				'is-exploded-mode': editorMode === 'exploded',
 			} ),
 		},
 		settings

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -408,3 +408,13 @@
 		margin-bottom: auto;
 	}
 }
+
+/** Exploded mode styles **/
+.is-root-container.is-exploded-mode {
+	margin-top: 100px;
+}
+
+.is-root-container.is-exploded-mode > .wp-block {
+	transform: scale(0.8);
+	transform-origin: top center;
+}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -410,12 +410,7 @@
 }
 
 /** Exploded mode styles **/
-.is-root-container.is-exploded-mode {
-	margin-top: 100px;
-}
-
 .is-root-container.is-exploded-mode > .wp-block {
-	transform: scale(0.8);
 	transform-origin: center center;
 	position: relative;
 	overflow: hidden;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -417,4 +417,30 @@
 .is-root-container.is-exploded-mode > .wp-block {
 	transform: scale(0.8);
 	transform-origin: top center;
+	position: relative;
+	overflow: hidden;
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: z-index(".block-editor-block-content-overlay__overlay");
+		pointer-events: unset !important;
+	}
+
+	&:hover:not(.is-selected)::after {
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+		box-shadow: 0 0 0 0 var(--wp-admin-theme-color) inset;
+	}
+
+	&.overlay-active * {
+		pointer-events: none;
+	}
+
+	&.is-selected {
+		box-shadow: $border-width 0 0 0 var(--wp-admin-theme-color) inset;
+	}
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -444,3 +444,7 @@
 		box-shadow: $border-width 0 0 0 var(--wp-admin-theme-color) inset;
 	}
 }
+
+.is-root-container.is-exploded-mode > .block-list-appender {
+	display: none;
+}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -416,7 +416,7 @@
 
 .is-root-container.is-exploded-mode > .wp-block {
 	transform: scale(0.8);
-	transform-origin: top center;
+	transform-origin: center center;
 	position: relative;
 	overflow: hidden;
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -75,6 +75,7 @@ export function useBlockProps(
 		adjustScrolling,
 		enableAnimation,
 		isExplodedMode,
+		isRootBlock,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -88,6 +89,7 @@ export function useBlockProps(
 				isAncestorMultiSelected,
 				isFirstMultiSelectedBlock,
 				__unstableGetEditorMode,
+				getBlockRootClientId,
 			} = select( blockEditorStore );
 			const isSelected = isBlockSelected( clientId );
 			const isPartOfMultiSelection =
@@ -109,6 +111,7 @@ export function useBlockProps(
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
 				isExplodedMode: __unstableGetEditorMode() === 'exploded',
+				isRootBlock: ! getBlockRootClientId( clientId ),
 			};
 		},
 		[ clientId ]
@@ -131,7 +134,7 @@ export function useBlockProps(
 			adjustScrolling,
 			enableAnimation,
 			triggerAnimationOnChange: index,
-			scale: isExplodedMode ? 0.8 : 1,
+			scale: isExplodedMode && isRootBlock ? 0.8 : 1,
 		} ),
 		useDisabled( { isDisabled: ! __unstableIsDisabled } ),
 	] );

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -74,6 +74,7 @@ export function useBlockProps(
 		isPartOfSelection,
 		adjustScrolling,
 		enableAnimation,
+		isExplodedMode,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -86,6 +87,7 @@ export function useBlockProps(
 				isBlockMultiSelected,
 				isAncestorMultiSelected,
 				isFirstMultiSelectedBlock,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 			const isSelected = isBlockSelected( clientId );
 			const isPartOfMultiSelection =
@@ -106,6 +108,7 @@ export function useBlockProps(
 				enableAnimation:
 					! isTyping() &&
 					getGlobalBlockCount() <= BLOCK_ANIMATION_THRESHOLD,
+				isExplodedMode: __unstableGetEditorMode() === 'exploded',
 			};
 		},
 		[ clientId ]
@@ -128,6 +131,7 @@ export function useBlockProps(
 			adjustScrolling,
 			enableAnimation,
 			triggerAnimationOnChange: index,
+			scale: isExplodedMode ? 0.8 : 1,
 		} ),
 		useDisabled( { isDisabled: ! __unstableIsDisabled } ),
 	] );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -36,7 +36,7 @@ function useInitialPosition( clientId ) {
 		( select ) => {
 			const {
 				getSelectedBlocksInitialCaretPosition,
-				isNavigationMode,
+				__unstableGetEditorMode,
 				isBlockSelected,
 			} = select( blockEditorStore );
 
@@ -44,7 +44,7 @@ function useInitialPosition( clientId ) {
 				return;
 			}
 
-			if ( isNavigationMode() ) {
+			if ( __unstableGetEditorMode() !== 'edit' ) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -31,8 +31,8 @@ export function useIsHovered() {
 		);
 		return (
 			__unstableGetEditorMode() === 'navigation' ||
-			__unstableGetEditorMode() === 'exploded' ||
-			getSettings().outlineMode
+			( getSettings().outlineMode &&
+				__unstableGetEditorMode() === 'exploded' )
 		);
 	}, [] );
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -26,8 +26,14 @@ function listener( event ) {
  */
 export function useIsHovered() {
 	const isEnabled = useSelect( ( select ) => {
-		const { isNavigationMode, getSettings } = select( blockEditorStore );
-		return isNavigationMode() || getSettings().outlineMode;
+		const { __unstableGetEditorMode, getSettings } = select(
+			blockEditorStore
+		);
+		return (
+			__unstableGetEditorMode() === 'navigation' ||
+			__unstableGetEditorMode() === 'exploded' ||
+			getSettings().outlineMode
+		);
 	}, [] );
 
 	return useRefEffect(

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -79,9 +79,7 @@ function BlockPopoverInbetween( {
 
 		if ( isVertical ) {
 			return {
-				width: previousElement
-					? previousElement.offsetWidth
-					: nextElement.offsetWidth,
+				width: previousRect ? previousRect.width : nextRect.width,
 				height:
 					nextRect && previousRect
 						? nextRect.top - previousRect.bottom
@@ -98,9 +96,7 @@ function BlockPopoverInbetween( {
 
 		return {
 			width,
-			height: previousElement
-				? previousElement.offsetHeight
-				: nextElement.offsetHeight,
+			height: previousRect ? previousRect.height : nextRect.height,
 		};
 	}, [ previousElement, nextElement, isVertical, positionRecompute ] );
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -7,7 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useCallback, useMemo, createContext } from '@wordpress/element';
+import {
+	useCallback,
+	useMemo,
+	createContext,
+	useState,
+	useEffect,
+} from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 
@@ -28,6 +34,13 @@ function BlockPopoverInbetween( {
 	__unstableContentRef,
 	...props
 } ) {
+	// This is a temporary hack to get the inbetween inserter to recompute properly.
+	const [ positionRecompute, forceRecompute ] = useState( {} );
+	useEffect( () => {
+		const intervalHandle = setInterval( forceRecompute, 500 );
+		return () => clearInterval( intervalHandle );
+	}, [] );
+
 	const { orientation, rootClientId, isVisible } = useSelect(
 		( select ) => {
 			const {
@@ -89,7 +102,7 @@ function BlockPopoverInbetween( {
 				? previousElement.offsetHeight
 				: nextElement.offsetHeight,
 		};
-	}, [ previousElement, nextElement, isVertical ] );
+	}, [ previousElement, nextElement, isVertical, positionRecompute ] );
 
 	const getAnchorRect = useCallback( () => {
 		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
@@ -150,7 +163,7 @@ function BlockPopoverInbetween( {
 			width: 0,
 			ownerDocument,
 		};
-	}, [ previousElement, nextElement ] );
+	}, [ previousElement, nextElement, positionRecompute ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -98,7 +98,13 @@ function BlockPopoverInbetween( {
 			width,
 			height: previousRect ? previousRect.height : nextRect.height,
 		};
-	}, [ previousElement, nextElement, isVertical, positionRecompute ] );
+	}, [
+		previousElement,
+		nextElement,
+		isVertical,
+		positionRecompute,
+		isVisible,
+	] );
 
 	const getAnchorRect = useCallback( () => {
 		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
@@ -159,7 +165,7 @@ function BlockPopoverInbetween( {
 			width: 0,
 			ownerDocument,
 		};
-	}, [ previousElement, nextElement, positionRecompute ] );
+	}, [ previousElement, nextElement, positionRecompute, isVisible ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -119,8 +119,8 @@ function BlockPopoverInbetween( {
 				return {
 					top: previousRect ? previousRect.bottom : nextRect.top,
 					left: previousRect ? previousRect.right : nextRect.right,
-					right: previousRect ? previousRect.left : nextRect.left,
-					bottom: nextRect ? nextRect.top : previousRect.bottom,
+					right: previousRect ? previousRect.right : nextRect.right,
+					bottom: previousRect ? previousRect.bottom : nextRect.top,
 					height: 0,
 					width: 0,
 					ownerDocument,
@@ -130,8 +130,8 @@ function BlockPopoverInbetween( {
 			return {
 				top: previousRect ? previousRect.bottom : nextRect.top,
 				left: previousRect ? previousRect.left : nextRect.left,
-				right: previousRect ? previousRect.right : nextRect.right,
-				bottom: nextRect ? nextRect.top : previousRect.bottom,
+				right: previousRect ? previousRect.left : nextRect.left,
+				bottom: previousRect ? previousRect.bottom : nextRect.top,
 				height: 0,
 				width: 0,
 				ownerDocument,
@@ -142,8 +142,8 @@ function BlockPopoverInbetween( {
 			return {
 				top: previousRect ? previousRect.top : nextRect.top,
 				left: previousRect ? previousRect.left : nextRect.right,
-				right: nextRect ? nextRect.right : previousRect.left,
-				bottom: previousRect ? previousRect.bottom : nextRect.bottom,
+				right: previousRect ? previousRect.left : nextRect.right,
+				bottom: previousRect ? previousRect.top : nextRect.top,
 				height: 0,
 				width: 0,
 				ownerDocument,
@@ -153,8 +153,8 @@ function BlockPopoverInbetween( {
 		return {
 			top: previousRect ? previousRect.top : nextRect.top,
 			left: previousRect ? previousRect.right : nextRect.left,
-			right: nextRect ? nextRect.left : previousRect.right,
-			bottom: previousRect ? previousRect.bottom : nextRect.bottom,
+			right: previousRect ? previousRect.right : nextRect.left,
+			bottom: previousRect ? previousRect.left : nextRect.right,
 			height: 0,
 			width: 0,
 			ownerDocument,
@@ -192,6 +192,7 @@ function BlockPopoverInbetween( {
 				props.className
 			) }
 			__unstableForcePosition
+			placement="bottom-start"
 		>
 			<div
 				className="block-editor-block-popover__inbetween-container"

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -197,7 +197,12 @@ function BlockPopoverInbetween( {
 			) }
 			__unstableForcePosition
 		>
-			<div style={ style }>{ children }</div>
+			<div
+				className="block-editor-block-popover__inbetween-container"
+				style={ style }
+			>
+				{ children }
+			</div>
 		</Popover>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -62,6 +62,7 @@ export default function BlockPopover( {
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ selectedElement }
 			__unstableForcePosition
+			__unstableShift
 			{ ...props }
 			className={ classnames(
 				'block-editor-block-popover',

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -6,6 +6,9 @@
 	// like the popover is impacted by the block gap margin.
 	margin: 0 !important;
 
+	// Allow clicking through the toolbar holder.
+	pointer-events: none;
+
 	.components-popover__content {
 		margin: 0 !important;
 		min-width: auto;
@@ -16,8 +19,6 @@
 		box-shadow: none;
 		overflow-y: visible;
 
-		// Allow clicking through the toolbar holder.
-		pointer-events: none;
 		> div > * {
 			pointer-events: all;
 		}

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -18,11 +18,15 @@
 
 		// Allow clicking through the toolbar holder.
 		pointer-events: none;
-
-		// Position the block toolbar.
-		> * {
+		> div > * {
 			pointer-events: all;
 		}
 	}
 }
 
+.block-editor-block-popover__inbetween-container {
+	pointer-events: none !important;
+	> div > * {
+		pointer-events: all;
+	}
+}

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -236,6 +236,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 		'block-editor-block-list__block-selection-button',
 		{
 			'is-block-moving-mode': !! blockMovingMode,
+			'is-exploded-mode': editorMode === 'exploded',
 		}
 	);
 

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -39,6 +39,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockDraggable from '../block-draggable';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
+import BlockMover from '../block-mover';
 
 /**
  * Block selection button component, displaying the label of the block. If the block
@@ -59,6 +60,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				getBlockIndex,
 				hasBlockMovingClientId,
 				getBlockListSettings,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 			const index = getBlockIndex( clientId );
 			const { name, attributes } = getBlock( clientId );
@@ -69,11 +71,19 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				attributes,
 				blockMovingMode,
 				orientation: getBlockListSettings( rootClientId )?.orientation,
+				editorMode: __unstableGetEditorMode(),
 			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const { index, name, attributes, blockMovingMode, orientation } = selected;
+	const {
+		index,
+		name,
+		attributes,
+		blockMovingMode,
+		orientation,
+		editorMode,
+	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
@@ -241,20 +251,25 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					<BlockIcon icon={ blockInformation?.icon } showColors />
 				</FlexItem>
 				<FlexItem>
-					<BlockDraggable clientIds={ [ clientId ] }>
-						{ ( draggableProps ) => (
-							<Button
-								icon={ dragHandle }
-								className="block-selection-button_drag-handle"
-								aria-hidden="true"
-								label={ dragHandleLabel }
-								// Should not be able to tab to drag handle as this
-								// button can only be used with a pointer device.
-								tabIndex="-1"
-								{ ...draggableProps }
-							/>
-						) }
-					</BlockDraggable>
+					{ editorMode === 'exploded' && (
+						<BlockMover clientIds={ [ clientId ] } hideDragHandle />
+					) }
+					{ editorMode === 'navigation' && (
+						<BlockDraggable clientIds={ [ clientId ] }>
+							{ ( draggableProps ) => (
+								<Button
+									icon={ dragHandle }
+									className="block-selection-button_drag-handle"
+									aria-hidden="true"
+									label={ dragHandleLabel }
+									// Should not be able to tab to drag handle as this
+									// button can only be used with a pointer device.
+									tabIndex="-1"
+									{ ...draggableProps }
+								/>
+							) }
+						</BlockDraggable>
+					) }
 				</FlexItem>
 				<FlexItem>
 					<Button

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -279,6 +279,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						onKeyDown={ onKeyDown }
 						label={ label }
 						className="block-selection-button_select-button"
+						showTooltip={ false }
 					>
 						<BlockTitle
 							clientId={ clientId }

--- a/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
@@ -1,7 +1,13 @@
 /**
+ * External dependencies
+ */
+import { throttle } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -9,11 +15,55 @@ import { useSelect } from '@wordpress/data';
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
+import { __unstableUseBlockElement } from '../block-list/use-block-props/use-block-refs';
+
+function useIsScrolling() {
+	const [ isScrolling, setIsScrolling ] = useState( false );
+
+	const clientId = useSelect( ( select ) => {
+		return select( blockEditorStore ).getBlockOrder()?.[ 0 ];
+	}, [] );
+	const element = __unstableUseBlockElement( clientId );
+
+	useEffect( () => {
+		let timeout;
+		setIsScrolling( false );
+		if ( ! element ) {
+			return;
+		}
+		const onScroll = throttle( () => {
+			setIsScrolling( true );
+			clearTimeout( timeout );
+			timeout = setTimeout( () => {
+				setIsScrolling( false );
+			}, 100 );
+		}, 100 );
+
+		element.ownerDocument.defaultView.addEventListener(
+			'scroll',
+			onScroll
+		);
+		return () => {
+			clearTimeout( timeout );
+			element.ownerDocument.defaultView.removeEventListener(
+				'scroll',
+				onScroll
+			);
+		};
+	}, [ element ] );
+
+	return isScrolling;
+}
 
 function ExplodedModeInserters( { __unstableContentRef } ) {
+	const isScrolling = useIsScrolling();
 	const blockOrder = useSelect( ( select ) => {
 		return select( blockEditorStore ).getBlockOrder();
 	}, [] );
+
+	if ( isScrolling ) {
+		return null;
+	}
 
 	return blockOrder.map( ( clientId, index ) => {
 		if ( index === blockOrder.length - 1 ) {

--- a/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import BlockPopoverInbetween from '../block-popover/inbetween';
+import { store as blockEditorStore } from '../../store';
+import Inserter from '../inserter';
+
+function ExplodedModeInserters( { __unstableContentRef } ) {
+	const blockOrder = useSelect( ( select ) => {
+		return select( blockEditorStore ).getBlockOrder();
+	}, [] );
+
+	return blockOrder.map( ( clientId, index ) => {
+		if ( index === blockOrder.length - 1 ) {
+			return null;
+		}
+		return (
+			<BlockPopoverInbetween
+				key={ clientId }
+				previousClientId={ clientId }
+				nextClientId={ blockOrder[ index + 1 ] }
+				__unstableContentRef={ __unstableContentRef }
+			>
+				<div className="block-editor-block-list__insertion-point-inserter">
+					<Inserter
+						position="bottom center"
+						clientId={ blockOrder[ index + 1 ] }
+						__experimentalIsQuick
+					/>
+				</div>
+			</BlockPopoverInbetween>
+		);
+	} );
+}
+
+export default ExplodedModeInserters;

--- a/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
@@ -1,13 +1,7 @@
 /**
- * External dependencies
- */
-import { throttle } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,55 +9,11 @@ import { useState, useEffect } from '@wordpress/element';
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
-import { __unstableUseBlockElement } from '../block-list/use-block-props/use-block-refs';
-
-function useIsScrolling() {
-	const [ isScrolling, setIsScrolling ] = useState( false );
-
-	const clientId = useSelect( ( select ) => {
-		return select( blockEditorStore ).getBlockOrder()?.[ 0 ];
-	}, [] );
-	const element = __unstableUseBlockElement( clientId );
-
-	useEffect( () => {
-		let timeout;
-		setIsScrolling( false );
-		if ( ! element ) {
-			return;
-		}
-		const onScroll = throttle( () => {
-			setIsScrolling( true );
-			clearTimeout( timeout );
-			timeout = setTimeout( () => {
-				setIsScrolling( false );
-			}, 100 );
-		}, 100 );
-
-		element.ownerDocument.defaultView.addEventListener(
-			'scroll',
-			onScroll
-		);
-		return () => {
-			clearTimeout( timeout );
-			element.ownerDocument.defaultView.removeEventListener(
-				'scroll',
-				onScroll
-			);
-		};
-	}, [ element ] );
-
-	return isScrolling;
-}
 
 function ExplodedModeInserters( { __unstableContentRef } ) {
-	const isScrolling = useIsScrolling();
 	const blockOrder = useSelect( ( select ) => {
 		return select( blockEditorStore ).getBlockOrder();
 	}, [] );
-
-	if ( isScrolling ) {
-		return null;
-	}
 
 	return blockOrder.map( ( clientId, index ) => {
 		if ( index === blockOrder.length - 1 ) {

--- a/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/exploded-mode-inserters.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,9 +12,24 @@ import { store as blockEditorStore } from '../../store';
 import Inserter from '../inserter';
 
 function ExplodedModeInserters( { __unstableContentRef } ) {
+	const [ isReady, setIsReady ] = useState( false );
 	const blockOrder = useSelect( ( select ) => {
 		return select( blockEditorStore ).getBlockOrder();
 	}, [] );
+
+	// Deffer the initial rendering to avoid the jumps due to the animation.
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setIsReady( true );
+		}, 500 );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [] );
+
+	if ( ! isReady ) {
+		return null;
+	}
 
 	return blockOrder.map( ( clientId, index ) => {
 		if ( index === blockOrder.length - 1 ) {

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -23,6 +23,7 @@ import SelectedBlockPopover from './selected-block-popover';
 import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
+import ExplodedModeInserters from './exploded-mode-inserters';
 
 /**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
@@ -143,6 +144,11 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
+				{ isExplodedMode && (
+					<ExplodedModeInserters
+						__unstableContentRef={ __unstableContentRef }
+					/>
+				) }
 			</InsertionPointOpenRef.Provider>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -227,15 +227,10 @@ function InsertionPointPopover( {
 	);
 }
 
-export default function InsertionPoint( { children, ...props } ) {
+export default function InsertionPoint( props ) {
 	const isVisible = useSelect( ( select ) => {
 		return select( blockEditorStore ).isBlockInsertionPointVisible();
 	}, [] );
 
-	return (
-		<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-			{ isVisible && <InsertionPointPopover { ...props } /> }
-			{ children }
-		</InsertionPointOpenRef.Provider>
-	);
+	return isVisible && <InsertionPointPopover { ...props } />;
 }

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -79,18 +79,18 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		! isTyping && ! editorMode === 'visual' && isEmptyDefaultBlock;
+		! isTyping && ! editorMode === 'edit' && isEmptyDefaultBlock;
 	const shouldShowBreadcrumb =
 		editorMode === 'navigation' || editorMode === 'exploded';
 	const shouldShowContextualToolbar =
-		editorMode === 'visual' &&
+		editorMode === 'edit' &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! isMultiSelecting &&
 		! showEmptyBlockSideInserter &&
 		! isTyping;
 	const canFocusHiddenToolbar =
-		editorMode === 'visual' &&
+		editorMode === 'edit' &&
 		! shouldShowContextualToolbar &&
 		! hasFixedToolbar &&
 		! isEmptyDefaultBlock;

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -23,7 +23,7 @@ import BlockPopover from '../block-popover';
 
 function selector( select ) {
 	const {
-		isNavigationMode,
+		__unstableGetEditorMode,
 		isMultiSelecting,
 		hasMultiSelection,
 		isTyping,
@@ -31,7 +31,7 @@ function selector( select ) {
 		getLastMultiSelectedBlockClientId,
 	} = select( blockEditorStore );
 	return {
-		isNavigationMode: isNavigationMode(),
+		editorMode: __unstableGetEditorMode(),
 		isMultiSelecting: isMultiSelecting(),
 		isTyping: isTyping(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
@@ -50,7 +50,7 @@ function SelectedBlockPopover( {
 	__unstableContentRef,
 } ) {
 	const {
-		isNavigationMode,
+		editorMode,
 		isMultiSelecting,
 		isTyping,
 		hasFixedToolbar,
@@ -79,17 +79,18 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		! isTyping && ! isNavigationMode && isEmptyDefaultBlock;
-	const shouldShowBreadcrumb = isNavigationMode;
+		! isTyping && ! editorMode === 'visual' && isEmptyDefaultBlock;
+	const shouldShowBreadcrumb =
+		editorMode === 'navigation' || editorMode === 'exploded';
 	const shouldShowContextualToolbar =
-		! isNavigationMode &&
+		editorMode === 'visual' &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! isMultiSelecting &&
 		! showEmptyBlockSideInserter &&
 		! isTyping;
 	const canFocusHiddenToolbar =
-		! isNavigationMode &&
+		editorMode === 'visual' &&
 		! shouldShowContextualToolbar &&
 		! hasFixedToolbar &&
 		! isEmptyDefaultBlock;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -122,6 +122,10 @@
 	font-size: $default-font-size;
 	height: $block-toolbar-height;
 
+	&.is-exploded-mode {
+		background: var(--wp-admin-theme-color);
+	}
+
 	.block-editor-block-list__block-selection-button__content {
 		margin: auto;
 		display: inline-flex;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -171,6 +171,11 @@
 	.block-selection-button_select-button.components-button {
 		padding: 0;
 	}
+
+	.block-editor-block-mover__move-button-container {
+		background: unset;
+		border: none;
+	}
 }
 
 // Hide the popover block editor list while dragging.

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -172,7 +172,7 @@
 		padding: 0;
 	}
 
-	.block-editor-block-mover__move-button-container {
+	.block-editor-block-mover {
 		background: unset;
 		border: none;
 	}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -211,6 +211,11 @@ function useExplodedModeBackgroundStyles( isExplodedMode, deps = [] ) {
 			copiedStylesElement.innerHTML = `:where( .is-root-container.is-exploded-mode > .wp-block ) { ${ newBackgroundStyles } }`;
 			bodyStyleElement.innerHTML =
 				'body { background: gray !important; }';
+
+			return () => {
+				bodyStyleElement.textContent = '';
+				copiedStylesElement.textContent = '';
+			};
 		},
 		[ ...deps, isExplodedMode ]
 	);

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -196,7 +196,7 @@ function useExplodedModeBackgroundStyles( isExplodedMode, deps = [] ) {
 			copiedStylesElement.textContent = '';
 
 			const styles = window.getComputedStyle( node.ownerDocument.body );
-			const newBackgroundStyles = Object.values( styles )
+			let newBackgroundStyles = Object.values( styles )
 				.filter( ( propertyName ) => {
 					return propertyName.indexOf( 'background' ) === 0;
 				} )
@@ -208,6 +208,14 @@ function useExplodedModeBackgroundStyles( isExplodedMode, deps = [] ) {
 				)
 				.join( '' );
 
+			const backgroundColor = styles.getPropertyValue(
+				'background-color'
+			);
+			const hasTransparentBackground =
+				! backgroundColor || backgroundColor === 'rgba(0, 0, 0, 0)';
+			newBackgroundStyles += hasTransparentBackground
+				? 'background-color: white;'
+				: '';
 			copiedStylesElement.innerHTML = `:where( .is-root-container.is-exploded-mode > .wp-block ) { ${ newBackgroundStyles } }`;
 			bodyStyleElement.innerHTML =
 				'body { background: #2f2f2f !important; }';

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -210,7 +210,7 @@ function useExplodedModeBackgroundStyles( isExplodedMode, deps = [] ) {
 
 			copiedStylesElement.innerHTML = `:where( .is-root-container.is-exploded-mode > .wp-block ) { ${ newBackgroundStyles } }`;
 			bodyStyleElement.innerHTML =
-				'body { background: gray !important; }';
+				'body { background: #2f2f2f !important; }';
 
 			return () => {
 				bodyStyleElement.textContent = '';

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -155,10 +155,11 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockName,
 				isBlockSelected,
 				hasSelectedInnerBlock,
-				isNavigationMode,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 			const blockName = getBlockName( clientId );
-			const enableClickThrough = isNavigationMode() || isSmallScreen;
+			const enableClickThrough =
+				__unstableGetEditorMode() === 'navigation' || isSmallScreen;
 			return {
 				__experimentalCaptureToolbars: select(
 					blocksStore

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -31,15 +31,11 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const isNavigationTool = useSelect(
-		( select ) => select( blockEditorStore ).isNavigationMode(),
+	const mode = useSelect(
+		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { setNavigationMode } = useDispatch( blockEditorStore );
-
-	const onSwitchMode = ( mode ) => {
-		setNavigationMode( mode === 'edit' ? false : true );
-	};
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown
@@ -47,7 +43,7 @@ function ToolSelector( props, ref ) {
 				<Button
 					{ ...props }
 					ref={ ref }
-					icon={ isNavigationTool ? selectIcon : editIcon }
+					icon={ mode === 'navigation' ? selectIcon : editIcon }
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
 					onClick={ onToggle }
@@ -60,8 +56,10 @@ function ToolSelector( props, ref ) {
 				<>
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
-							value={ isNavigationTool ? 'select' : 'edit' }
-							onSelect={ onSwitchMode }
+							value={
+								mode === 'navigation' ? 'navigation' : 'edit'
+							}
+							onSelect={ __unstableSetEditorMode }
 							choices={ [
 								{
 									value: 'edit',
@@ -73,7 +71,7 @@ function ToolSelector( props, ref ) {
 									),
 								},
 								{
-									value: 'select',
+									value: 'navigation',
 									label: (
 										<>
 											{ selectIcon }

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -47,12 +47,14 @@ const getAbsolutePosition = ( element ) => {
  * @param {boolean} $1.adjustScrolling          Adjust the scroll position to the current block.
  * @param {boolean} $1.enableAnimation          Enable/Disable animation.
  * @param {*}       $1.triggerAnimationOnChange Variable used to trigger the animation if it changes.
+ * @param {*}       $1.scale                    Scale of the element
  */
 function useMovingAnimation( {
 	isSelected,
 	adjustScrolling,
 	enableAnimation,
 	triggerAnimationOnChange,
+	scale = 1,
 } ) {
 	const ref = useRef();
 	const prefersReducedMotion = useReducedMotion() || ! enableAnimation;
@@ -126,10 +128,10 @@ function useMovingAnimation( {
 		}
 
 		const isMoving = x === 0 && y === 0;
-		ref.current.style.transformOrigin = isMoving ? '' : 'center';
+		ref.current.style.transformOrigin = 'center';
 		ref.current.style.transform = isMoving
-			? ''
-			: `translate3d(${ x }px,${ y }px,0)`;
+			? `scale(${ scale })`
+			: `translate3d(${ x }px,${ y }px,0) scale(${ scale })`;
 		ref.current.style.zIndex = ! isSelected || isMoving ? '' : '1';
 
 		preserveScrollPosition();

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1427,25 +1427,36 @@ export const __unstableMarkAutomaticChange = () => ( { dispatch } ) => {
 /**
  * Action that enables or disables the navigation mode.
  *
- * @param {string} isNavigationMode Enable/Disable navigation mode.
+ * @param {boolean} isNavigationMode Enable/Disable navigation mode.
  */
 export const setNavigationMode = ( isNavigationMode = true ) => ( {
 	dispatch,
 } ) => {
-	dispatch( { type: 'SET_NAVIGATION_MODE', isNavigationMode } );
+	dispatch.setMode( isNavigationMode ? 'navigation' : 'edit' );
+};
 
-	if ( isNavigationMode ) {
+/**
+ * Action that sets the editor mode
+ *
+ * @param {string} mode Editor mode
+ */
+export const __unstableSetEditorMode = ( mode ) => ( { dispatch } ) => {
+	dispatch( { type: 'SET_EDITOR_MODE', mode } );
+
+	if ( mode === 'navigation' ) {
 		speak(
 			__(
 				'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
 			)
 		);
-	} else {
+	} else if ( mode === 'edit' ) {
 		speak(
 			__(
 				'You are currently in edit mode. To return to the navigation mode, press Escape.'
 			)
 		);
+	} else if ( mode === 'exploded' ) {
+		speak( __( 'You are currently in exploded mode.' ) );
 	}
 };
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1440,7 +1440,17 @@ export const setNavigationMode = ( isNavigationMode = true ) => ( {
  *
  * @param {string} mode Editor mode
  */
-export const __unstableSetEditorMode = ( mode ) => ( { dispatch } ) => {
+export const __unstableSetEditorMode = ( mode ) => ( { dispatch, select } ) => {
+	// When switching to exploded mode, we need to select to parent block
+	if ( mode === 'exploded' ) {
+		const firstSelectedClientId = select.getBlockSelectionStart();
+		if ( firstSelectedClientId ) {
+			dispatch.selectBlock(
+				select.getBlockHierarchyRootClientId( firstSelectedClientId )
+			);
+		}
+	}
+
 	dispatch( { type: 'SET_EDITOR_MODE', mode } );
 
 	if ( mode === 'navigation' ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1593,14 +1593,14 @@ export const blockListSettings = ( state = {}, action ) => {
  *
  * @return {string} Updated state.
  */
-export function isNavigationMode( state = false, action ) {
+export function editorMode( state = 'edit', action ) {
 	// Let inserting block always trigger Edit mode.
-	if ( action.type === 'INSERT_BLOCKS' ) {
-		return false;
+	if ( action.type === 'INSERT_BLOCKS' && state === 'navigation' ) {
+		return 'edit';
 	}
 
-	if ( action.type === 'SET_NAVIGATION_MODE' ) {
-		return action.isNavigationMode;
+	if ( action.type === 'SET_EDITOR_MODE' ) {
+		return action.mode;
 	}
 
 	return state;
@@ -1621,7 +1621,7 @@ export function hasBlockMovingClientId( state = null, action ) {
 		return action.hasBlockMovingClientId;
 	}
 
-	if ( action.type === 'SET_NAVIGATION_MODE' ) {
+	if ( action.type === 'SET_EDITOR_MODE' ) {
 		return null;
 	}
 
@@ -1769,7 +1769,7 @@ export default combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
-	isNavigationMode,
+	editorMode,
 	hasBlockMovingClientId,
 	automaticChangeStatus,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2541,7 +2541,18 @@ function getReusableBlocks( state ) {
  * @return {boolean} Is navigation mode enabled.
  */
 export function isNavigationMode( state ) {
-	return state.isNavigationMode;
+	return state.editorMode === 'navigation';
+}
+
+/**
+ * Returns the current editor mode.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} the editor mode.
+ */
+export function __unstableGetEditorMode( state ) {
+	return state.editorMode;
 }
 
 /**

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -115,6 +115,7 @@ const Popover = (
 		__unstableSlotName = SLOT_NAME,
 		__unstableObserveElement,
 		__unstableForcePosition,
+		__unstableShift = false,
 		...contentProps
 	},
 	ref
@@ -190,11 +191,12 @@ const Popover = (
 						} );
 					},
 			  } ),
-		,
-		shift( {
-			crossAxis: true,
-			limiter: limitShift(),
-		} ),
+		__unstableShift
+			? shift( {
+					crossAxis: true,
+					limiter: limitShift(),
+			  } )
+			: undefined,
 		hasArrow ? arrow( { element: arrowRef } ) : undefined,
 	].filter( ( m ) => !! m );
 	const anchorRefFallback = useRef( null );
@@ -270,13 +272,12 @@ const Popover = (
 			usedRef = {
 				getBoundingClientRect() {
 					const rect = getAnchorRect();
-					return {
-						...rect,
-						x: rect.x ?? rect.left,
-						y: rect.y ?? rect.top,
-						height: rect.height ?? rect.bottom - rect.top,
-						width: rect.width ?? rect.right - rect.left,
-					};
+					return new window.DOMRect(
+						rect.x ?? rect.left,
+						rect.y ?? rect.top,
+						rect.width ?? rect.right - rect.left,
+						rect.height ?? rect.bottom - rect.top
+					);
 				},
 			};
 		} else if ( anchorRefFallback.current ) {

--- a/packages/dom/src/dom/get-scroll-container.js
+++ b/packages/dom/src/dom/get-scroll-container.js
@@ -19,9 +19,14 @@ export default function getScrollContainer( node ) {
 	if ( node.scrollHeight > node.clientHeight ) {
 		// ...except when overflow is defined to be hidden or visible
 		const { overflowY } = getComputedStyle( node );
+
 		if ( /(auto|scroll)/.test( overflowY ) ) {
 			return node;
 		}
+	}
+
+	if ( node.ownerDocument === node.parentNode ) {
+		return node;
 	}
 
 	// Continue traversing.

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -6,11 +6,12 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	ToolSelector,
 	__experimentalPreviewOptions as PreviewOptions,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus } from '@wordpress/icons';
+import { listView, plus, stack } from '@wordpress/icons';
 import { Button, ToolbarItem } from '@wordpress/components';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { store as editorStore } from '@wordpress/editor';
@@ -47,6 +48,7 @@ export default function Header( {
 		listViewShortcut,
 		isLoaded,
 		isVisualMode,
+		blockEditorMode,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -61,6 +63,7 @@ export default function Header( {
 			editorStore
 		);
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { __unstableGetEditorMode } = select( blockEditorStore );
 
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
@@ -79,6 +82,7 @@ export default function Header( {
 				'core/edit-site/toggle-list-view'
 			),
 			isVisualMode: getEditorMode() === 'visual',
+			blockEditorMode: __unstableGetEditorMode(),
 		};
 	}, [] );
 
@@ -87,6 +91,7 @@ export default function Header( {
 		setIsInserterOpened,
 		setIsListViewOpened,
 	} = useDispatch( editSiteStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -144,6 +149,21 @@ export default function Header( {
 								label={ __( 'List View' ) }
 								onClick={ toggleListView }
 								shortcut={ listViewShortcut }
+							/>
+							<Button
+								className="edit-site-header-toolbar__exploded-view-toggle"
+								icon={ stack }
+								isPressed={ blockEditorMode === 'exploded' }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								label={ __( 'Exploded View' ) }
+								onClick={ () => {
+									setIsListViewOpened( false );
+									__unstableSetEditorMode(
+										blockEditorMode === 'exploded'
+											? 'edit'
+											: 'exploded'
+									);
+								} }
 							/>
 						</>
 					) }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -142,7 +142,10 @@ export default function Header( {
 							<RedoButton />
 							<Button
 								className="edit-site-header-toolbar__list-view-toggle"
-								disabled={ ! isVisualMode }
+								disabled={
+									! isVisualMode &&
+									blockEditorMode === 'exploded'
+								}
 								icon={ listView }
 								isPressed={ isListViewOpen }
 								/* translators: button label text should, if possible, be under 16 characters. */


### PR DESCRIPTION
Related #39281 #40319

Alternative to #40314

## What?

We want to explore an "exploded block view" where the blocks (and sections) of the top level are separated and the actions for each block/sections are separate from the regular toolbar.

See https://github.com/WordPress/gutenberg/issues/39281#issuecomment-1084648592

This PR just bootstraps that mode to allow us to iterate on it.

## Why?

I think the reasoning is to make it easy to build templates from scratch by leveraging ready to use patterns.

## How?

 This PR thought differs from the original one in the sense that instead of building this mode into a separate tree view. This PR "just" tries to style the BlockList view. The advantage of this solution is that it's easier to implement the "animation" when entering/existing the mode. The con is that this is basically hacky. We have code to copy the background from the parent (body) to inner blocks dynamically. The other challenge is that it's going to be hard to inject UI: in-between inserter, the proposed right sidebar. As opposed to the other PR I didn't add the "inserter" yet for this reason.

## Notes and questions?

I'm surprised that I managed to get this far with this approach. I'm still not sure if it's better though. In terms of code quality, I also don't like how this is very intrusive in the existing UI code... Some bugs/regressions are not to be excluded every time we add exceptions/cases to existing stuff.

## Testing Instructions

1- Open the site editor
2- Click the "exploded view" button on the header.
