### PR TITLE
Fix replacing with undefined in stripAnsi

### DIFF
--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -336,6 +336,7 @@ function stripAnsi( string ) {
 				'(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
 			].join( '|' ),
 			'g'
-		)
+		),
+		''
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix replacing `undefined` in our custom `stripAnsi` function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is causing the error message in flaky test report showing `undefined` between texts.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Just a stupid mistake 😅.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
There's no reliable way to test it locally for now.
