### PR TITLE
Try: Add metadata attribute to blocks allowing section naming and future semantic meta information

### DIFF
--- a/docs/reference-guides/block-api/block-supports.md
+++ b/docs/reference-guides/block-api/block-supports.md
@@ -664,3 +664,17 @@ attributes: {
     }
 }
 ```
+
+### __experimentalMetadata
+
+-   Type: `boolean`
+-   Default value: `false`
+
+The block gets the `metadata` attribute added to the block definition when `__experimentalMetadata` is true. The `metadata` attribute has the type `object` without a default value provided. Blocks can manually add this attribute and set their defaults.
+The metadata attribute contains information related to the block.
+
+For now, the following metadata properties are available:
+- `name` - Contains a descriptive name of the block shown on the block switcher and blocklist view. E.g., A group block may be named "404 Section".
+
+This functionality is experimental, and the properties could be added or removed.
+In the future, `__experimentalMetadata` support may not exist, and the `metadata` attribute may be added unconditionally to all the blocks.

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -43,18 +43,19 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 		icon,
 		blockTitle,
 		patterns,
+		hasBlockName,
 	} = useSelect(
 		( select ) => {
 			const {
 				getBlockRootClientId,
 				getBlockTransformItems,
 				__experimentalGetPatternTransformItems,
+				getBlockAttributes,
 			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType } = select( blocksStore );
 			const { canRemoveBlocks } = select( blockEditorStore );
-			const rootClientId = getBlockRootClientId(
-				castArray( clientIds )[ 0 ]
-			);
+			const clientId = castArray( clientIds )[ 0 ];
+			const rootClientId = getBlockRootClientId( clientId );
 			const [ { name: firstBlockName } ] = blocks;
 			const _isSingleBlockSelected = blocks.length === 1;
 			const styles =
@@ -84,6 +85,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					blocks,
 					rootClientId
 				),
+				hasBlockName: !! getBlockAttributes( clientId ).metadata?.name,
 			};
 		},
 		[ clientIds, blocks, blockInformation?.icon ]
@@ -111,7 +113,7 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 					icon={
 						<>
 							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
+							{ ( hasBlockName || isReusable || isTemplate ) && (
 								<span className="block-editor-block-switcher__toggle-text">
 									<BlockTitle
 										clientId={ clientIds }
@@ -168,7 +170,9 @@ export const BlockSwitcherDropdownMenu = ( { clientIds, blocks } ) => {
 									className="block-editor-block-switcher__toggle"
 									showColors
 								/>
-								{ ( isReusable || isTemplate ) && (
+								{ ( isReusable ||
+									isTemplate ||
+									hasBlockName ) && (
 									<span className="block-editor-block-switcher__toggle-text">
 										<BlockTitle
 											clientId={ clientIds }

--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -31,6 +31,8 @@ jest.mock( '@wordpress/blocks', () => {
 
 				case 'name-with-long-label':
 					return { title: 'Block With Long Label' };
+				case 'name-with-section':
+					return { title: 'Block With Section Support' };
 			}
 		},
 		__experimentalGetBlockLabel( { title } ) {
@@ -46,6 +48,11 @@ jest.mock( '@wordpress/blocks', () => {
 
 				default:
 					return title;
+			}
+		},
+		hasBlockSupport( name, support, defaultSupport = false ) {
+			if ( support === '__experimentalMetadata' ) {
+				return name === 'name-with-section' ? true : defaultSupport;
 			}
 		},
 	};
@@ -177,5 +184,20 @@ describe( 'BlockTitle', () => {
 		expect( wrapper.text() ).toBe(
 			'This is a longer label than typical for blocks to have.'
 		);
+	} );
+
+	it( 'should return section title if the block supports it', () => {
+		useSelect.mockImplementation( () => ( {
+			name: 'name-with-section',
+			attributes: {
+				metadata: { name: 'My custom section' },
+			},
+		} ) );
+
+		const wrapper = shallow(
+			<BlockTitle clientId="id-name-with-long-label" />
+		);
+
+		expect( wrapper.text() ).toBe( 'My custom section' );
 	} );
 } );

--- a/packages/block-editor/src/components/block-title/use-block-display-title.js
+++ b/packages/block-editor/src/components/block-title/use-block-display-title.js
@@ -71,7 +71,9 @@ export default function useBlockDisplayTitle( clientId, maximumLength ) {
 		? getBlockLabel( blockType, attributes )
 		: null;
 
-	const label = reusableBlockTitle || blockLabel;
+	const blockName = attributes?.metadata?.name;
+
+	const label = blockName || reusableBlockTitle || blockLabel;
 	// Label will fallback to the title if no label is defined for the current
 	// label context. If the label is defined we prioritize it over a
 	// possible block variation title match.

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -4,6 +4,7 @@
 import './compat';
 import './align';
 import './lock';
+import './metadata';
 import './anchor';
 import './custom-class-name';
 import './generated-class-name';

--- a/packages/block-editor/src/hooks/metadata.js
+++ b/packages/block-editor/src/hooks/metadata.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { has } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+
+/**
+ * Filters registered block settings, extending attributes to include `metadata` in blocks declaring section support.
+ *
+ * @param {Object} blockTypeSettings Original block settings.
+ *
+ * @return {Object} Filtered block settings.
+ */
+export function addAttribute( blockTypeSettings ) {
+	if (
+		hasBlockSupport( blockTypeSettings, '__experimentalMetadata', false )
+	) {
+		// Allow blocks to specify their own metadata attribute definition with default value if needed.
+		if ( ! has( blockTypeSettings.attributes, [ 'metadata' ] ) ) {
+			blockTypeSettings.attributes = {
+				...blockTypeSettings.attributes,
+				metadata: {
+					type: 'object',
+				},
+			};
+		}
+	}
+	return blockTypeSettings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/metadata/addAttribute',
+	addAttribute
+);

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -22,6 +22,7 @@
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false,
+		"__experimentalMetadata": true,
 		"color": {
 			"gradients": true,
 			"link": true,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/40317

This PR adds an experimental support mechanism ~"__experimentalSection"~ `__experimentalMetadata` that any block can use to mark that a block supports being a section.

It enables ~"__experimentalSection"~ `__experimentalMetadata` on the group block.

When a block supports being a section two attributes are automatically added, isSection defaulting to false and sectionName. When isSection attribute is true it means that the given block instance is a section. sectionName contains a description of the section e.g."404 Section" to show on the UI and can also be used to show similar patterns (e.g: patterns containing sections with the same name).

The isSection attribute is a marker to know the sections we have. We should update https://github.com/WordPress/gutenberg/pull/40314 and or https://github.com/WordPress/gutenberg/pull/40376 to use this marker.

By default, we don't have any UI to control these attributes. But a block can have a UI e.g: A text field or select control to select the name of the section. A block may also register variations that are sections etc.

We are also updating the UI to show the section name has the block title as we do for reusable blocks and template parts.

![image](https://user-images.githubusercontent.com/11271197/163614246-0dc660e4-780e-46a6-a295-388e2e4a36c8.png)
![image](https://user-images.githubusercontent.com/11271197/163615476-a111779c-916c-4127-8754-682df67abcc7.png)



## Testing Instructions
I added the following block to the block editor:
```
<!-- wp:group {"style":{"color":{"background":"#ff0000"}},"metadata":{"name":"404 Section"}} -->
<div id="hgjghjghj" class="wp-block-group has-background" style="background-color:#ff0000"><!-- wp:spacer {"height":"80px"} -->
<div style="height:80px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:heading {"textAlign":"center","style":{"typography":{"fontSize":"200px"}},"textColor":"background"} -->
<h2 class="has-text-align-center has-background-color has-text-color" style="font-size:200px">404</h2>
<!-- /wp:heading -->

<!-- wp:spacer {"height":"75px"} -->
<div style="height:75px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"align":"center","textColor":"background"} -->
<p class="has-text-align-center has-background-color has-text-color">This page could not be found :(</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

I verified the UI showed the section name as the screenshots above show.