### PR TITLE
[RNMobile] Refactor draggable logic and introduce `DraggableTrigger` component

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -34,6 +34,8 @@ const CHIP_OFFSET_TO_TOUCH_POSITION = 32;
 const BLOCK_OPACITY_ANIMATION_CONFIG = { duration: 350 };
 const BLOCK_OPACITY_ANIMATION_DELAY = 250;
 const DEFAULT_LONG_PRESS_MIN_DURATION = 500;
+const DEFAULT_IOS_LONG_PRESS_MIN_DURATION =
+	DEFAULT_LONG_PRESS_MIN_DURATION - 50;
 
 /**
  * Block draggable wrapper component
@@ -310,7 +312,9 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 				// value prevents the long-press gesture from being
 				// triggered in underneath elements. This is required to
 				// prevent enabling text editing when dragging is available.
-				ios: canDragBlock ? 450 : DEFAULT_LONG_PRESS_MIN_DURATION,
+				ios: canDragBlock
+					? DEFAULT_IOS_LONG_PRESS_MIN_DURATION
+					: DEFAULT_LONG_PRESS_MIN_DURATION,
 				android: DEFAULT_LONG_PRESS_MIN_DURATION,
 			} ) }
 		>

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -17,7 +17,7 @@ import TextInputState from 'react-native/Libraries/Components/TextInput/TextInpu
  */
 import { Draggable, DraggableTrigger } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState, Platform } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -33,6 +33,7 @@ import styles from './style.scss';
 const CHIP_OFFSET_TO_TOUCH_POSITION = 32;
 const BLOCK_OPACITY_ANIMATION_CONFIG = { duration: 350 };
 const BLOCK_OPACITY_ANIMATION_DELAY = 250;
+const DEFAULT_LONG_PRESS_MIN_DURATION = 500;
 
 /**
  * Block draggable wrapper component
@@ -304,7 +305,14 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		<DraggableTrigger
 			id={ clientId }
 			enabled={ enabled && canDragBlock }
-			minDuration={ 450 }
+			minDuration={ Platform.select( {
+				// On iOS, using a lower min duration than the default
+				// value prevents the long-press gesture from being
+				// triggered in underneath elements. This is required to
+				// prevent enabling text editing when dragging is available.
+				ios: canDragBlock ? 450 : DEFAULT_LONG_PRESS_MIN_DURATION,
+				android: DEFAULT_LONG_PRESS_MIN_DURATION,
+			} ) }
 		>
 			<Animated.View style={ wrapperStyles }>
 				{ children( { isDraggable: true } ) }

--- a/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
@@ -12,7 +12,6 @@ import { useEffect, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import { useBlockListContext } from './block-list-context';
-import BlockDraggable from '../block-draggable';
 
 function BlockListItemCell( { children, clientId, rootClientId } ) {
 	const { blocksLayouts, updateBlocksLayouts } = useBlockListContext();
@@ -37,13 +36,7 @@ function BlockListItemCell( { children, clientId, rootClientId } ) {
 		[ clientId, rootClientId, updateBlocksLayouts ]
 	);
 
-	return (
-		<View onLayout={ onLayout }>
-			<BlockDraggable clientId={ clientId }>
-				{ () => children }
-			</BlockDraggable>
-		</View>
-	);
+	return <View onLayout={ onLayout }>{ children }</View>;
 }
 
 export default BlockListItemCell;

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -31,6 +31,7 @@ import BlockEdit from '../block-edit';
 import BlockInvalidWarning from './block-invalid-warning';
 import BlockMobileToolbar from '../block-mobile-toolbar';
 import { store as blockEditorStore } from '../../store';
+import BlockDraggable from '../block-draggable';
 
 const emptyArray = [];
 function BlockForType( {
@@ -189,6 +190,7 @@ class BlockListBlock extends Component {
 			marginHorizontal,
 			isInnerBlockSelected,
 			name,
+			rootClientId,
 		} = this.props;
 
 		if ( ! attributes || ! blockType ) {
@@ -207,6 +209,7 @@ class BlockListBlock extends Component {
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
 		const isFullWidthToolbar = isFullWidth( align ) || isScreenWidthEqual;
+		const hasParent = !! rootClientId;
 
 		return (
 			<TouchableWithoutFeedback
@@ -256,14 +259,21 @@ class BlockListBlock extends Component {
 								] }
 							/>
 						) }
-						{ isValid ? (
-							this.getBlockForType()
-						) : (
-							<BlockInvalidWarning
-								blockTitle={ title }
-								icon={ icon }
-							/>
-						) }
+						<BlockDraggable
+							enabled={ ! hasParent }
+							clientId={ clientId }
+						>
+							{ () =>
+								isValid ? (
+									this.getBlockForType()
+								) : (
+									<BlockInvalidWarning
+										blockTitle={ title }
+										icon={ icon }
+									/>
+								)
+							}
+						</BlockDraggable>
 						<View
 							style={ styles.neutralToolbar }
 							ref={ this.anchorNodeRef }

--- a/packages/block-editor/src/components/block-mover/index.native.js
+++ b/packages/block-editor/src/components/block-mover/index.native.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { Picker, ToolbarButton } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -36,6 +36,7 @@ export const BlockMover = ( {
 	isStackedHorizontally,
 } ) => {
 	const pickerRef = useRef();
+	const [ shouldPresentPicker, setShouldPresentPicker ] = useState( false );
 	const [ blockPageMoverState, setBlockPageMoverState ] = useState(
 		undefined
 	);
@@ -46,8 +47,16 @@ export const BlockMover = ( {
 		}
 
 		setBlockPageMoverState( direction );
-		pickerRef.current.presentPicker();
+		setShouldPresentPicker( true );
 	};
+
+	// Ensure that the picker is only presented after state updates.
+	useEffect( () => {
+		if ( shouldPresentPicker ) {
+			pickerRef.current?.presentPicker();
+			setShouldPresentPicker( false );
+		}
+	}, [ shouldPresentPicker ] );
 
 	const {
 		description: {
@@ -86,6 +95,15 @@ export const BlockMover = ( {
 		if ( option && option.onSelect ) option.onSelect();
 	};
 
+	const onLongPressMoveUp = useCallback(
+		showBlockPageMover( BLOCK_MOVER_DIRECTION_TOP ),
+		[]
+	);
+	const onLongPressMoveDown = useCallback(
+		showBlockPageMover( BLOCK_MOVER_DIRECTION_BOTTOM ),
+		[]
+	);
+
 	if ( ! canMove || ( isFirst && isLast && ! rootClientId ) ) {
 		return null;
 	}
@@ -96,7 +114,7 @@ export const BlockMover = ( {
 				title={ ! isFirst ? backwardButtonTitle : firstBlockTitle }
 				isDisabled={ isFirst }
 				onClick={ onMoveUp }
-				onLongPress={ showBlockPageMover( BLOCK_MOVER_DIRECTION_TOP ) }
+				onLongPress={ onLongPressMoveUp }
 				icon={ backwardButtonIcon }
 				extraProps={ { hint: backwardButtonHint } }
 			/>
@@ -105,9 +123,7 @@ export const BlockMover = ( {
 				title={ ! isLast ? forwardButtonTitle : lastBlockTitle }
 				isDisabled={ isLast }
 				onClick={ onMoveDown }
-				onLongPress={ showBlockPageMover(
-					BLOCK_MOVER_DIRECTION_BOTTOM
-				) }
+				onLongPress={ onLongPressMoveDown }
 				icon={ forwardButtonIcon }
 				extraProps={ {
 					hint: forwardButtonHint,

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -96,6 +96,9 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 				onDragOver( event );
 			}
 		} )
+		.onEnd( () => {
+			isDragging.value = false;
+		} )
 		.withRef( panGestureRef )
 		.shouldCancelWhenOutside( false );
 

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -55,7 +55,7 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 	useAnimatedReaction(
 		() => isDragging.value,
 		( result, previous ) => {
-			if ( result === previous ) {
+			if ( result === previous || previous === null ) {
 				return;
 			}
 

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -16,7 +16,7 @@ import Animated, {
 /**
  * WordPress dependencies
  */
-import { createContext, useContext, useRef } from '@wordpress/element';
+import { createContext, useContext, useRef, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -99,12 +99,14 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 		.withRef( panGestureRef )
 		.shouldCancelWhenOutside( false );
 
+	const providerValue = useMemo( () => {
+		return { panGestureRef, isDragging, draggingId };
+	}, [] );
+
 	return (
 		<GestureDetector gesture={ panGesture }>
 			<Animated.View style={ styles.draggable__container }>
-				<Provider value={ { panGestureRef, isDragging, draggingId } }>
-					{ children }
-				</Provider>
+				<Provider value={ providerValue }>{ children }</Provider>
 			</Animated.View>
 		</GestureDetector>
 	);

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -39,6 +39,7 @@ const { Provider } = Context;
  */
 const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 	const isDragging = useSharedValue( false );
+	const isPanActive = useSharedValue( false );
 	const draggingId = useSharedValue( '' );
 	const panGestureRef = useRef();
 
@@ -84,7 +85,8 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 			initialPosition.y.value = y;
 		} )
 		.onTouchesMove( ( _, state ) => {
-			if ( isDragging.value ) {
+			if ( ! isPanActive.value && isDragging.value ) {
+				isPanActive.value = true;
 				state.activate();
 			}
 		} )
@@ -97,6 +99,7 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 			}
 		} )
 		.onEnd( () => {
+			isPanActive.value = false;
 			isDragging.value = false;
 		} )
 		.withRef( panGestureRef )
@@ -144,6 +147,10 @@ const DraggableTrigger = ( {
 
 	const gestureHandler = useAnimatedGestureHandler( {
 		onActive: () => {
+			if ( isDragging.value ) {
+				return;
+			}
+
 			isDragging.value = true;
 			draggingId.value = id;
 			if ( onLongPress ) {

--- a/packages/components/src/draggable/style.native.scss
+++ b/packages/components/src/draggable/style.native.scss
@@ -1,0 +1,3 @@
+.draggable__container {
+	flex: 1;
+}

--- a/packages/components/src/index.native.js
+++ b/packages/components/src/index.native.js
@@ -61,7 +61,7 @@ export {
 	filterUnitsWithSettings as filterUnitsWithSettings,
 } from './unit-control/utils';
 export { default as Disabled } from './disabled';
-export { default as Draggable } from './draggable';
+export { default as Draggable, DraggableTrigger } from './draggable';
 
 // Higher-Order Components.
 export { default as withConstrainedTabbing } from './higher-order/with-constrained-tabbing';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refactors the draggable logic.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The reason for the refactor is mainly to address the following issues spotted during testing:
- Long-press gesture is not working for buttons located within the block's toolbar.
- Long-press gesture is disabled when editing a text on iOS ([reference](https://github.com/WordPress/gutenberg/pull/40101#issuecomment-1091437376)).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The implementation is described in the following sections:

### Trigger long-press gesture from block component

Originally, the long-press gesture was triggered from a wrapper component over the block list. This was preventing other long-press gestures located in other components to not being triggered, like the inserter button or the up/down arrow buttons within the block's toolbar.

In order to address this issue, a new component named `DraggableTrigger` has been added to handle the long-press gesture. In the following commits you can see the related changes:
- [Refactor draggable component and add `DraggableTrigger` component](https://github.com/WordPress/gutenberg/commit/cb561942b33e00d643525d6094cffe41449d5c51)
- [Use DraggableTrigger in BlockDraggable](https://github.com/WordPress/gutenberg/commit/36c778d8c4d290f2a10d3d322c68961eb6e9617e)

With the introduction of this component, we can now send the `clientId` of the dragged block through the dragging events, so this also implied updating and simplifying the logic of the `BlockDraggable` component and its wrapper.

As an additional note, the `BlockDraggable` component is now rendered in the `BlockListBlock` component, so the dragging gesture doesn't interfere with the block's toolbar ([reference](https://github.com/WordPress/gutenberg/commit/382781d6fdc8a8d9ff726e8d72081ec9d5420046)).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Drag an unselected block
1. Open a post/page in the app.
2. Add several blocks, including text blocks like the Paragraph block.
3. Long-press on a block that is not selected to activate the dragging mode.
4. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
5. Drop the block and observe that the block gets automatically selected.

### Drag a selected block
1. Open a post/page in the app.
2. Add several blocks, including text blocks like the Paragraph block.
3. Select a block.
4. Long-press on the selected block to activate the dragging mode.
**NOTE:** Only the block's content will be draggable, the block's toolbar won't enable the dragging mode.
5. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
6. Drop the block and observe that the block is still selected.

### Long-press gesture still works when editing a text
1. Open a post/page in the app.
2. Add several blocks, including text blocks like the Paragraph block.
3. Tap on a text block to edit its content.
**NOTE:** Check that the text input is focused (i.e. the text editing is enabled).
4. Long-press on the content.
7. Observe that the long-press gesture works and that doesn't trigger the dragging mode.

### Long-press gesture on toolbar buttons
1. Open a post/page in the app.
2. Long-press on the inserter button (i.e. ➕ button).
3. Observe that a picker is displayed and presents extra options in relation to the target position when inserting the block.
4. Select a block.
5. Long-press on both up and down arrow buttons.
6. Observe that a picker is displayed and presents the expected options.

## Screenshots or screencast <!-- if applicable -->

Android|iOS
--|--
<video src=https://user-images.githubusercontent.com/14905380/163803948-a983a2fe-4680-4d67-82db-8439543b54b5.mp4>|<video src=https://user-images.githubusercontent.com/14905380/163803976-f1659c5a-c580-4a80-8378-c06fe7a6eb6b.MP4>
