### PR TITLE
[wp-env]: Add support to override `core` by the `WP_ENV_CORE` environment variable.

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -534,9 +534,9 @@ This is useful for plugin development.
 }
 ```
 
-#### Latest development WordPress + current directory as a plugin
+### Latest development WordPress + current directory as a plugin
 
-This is useful for plugin development when upstream Core changes need to be tested.
+This is useful for plugin development when upstream Core changes need to be tested. This can also be set via the environment variable `WP_ENV_CORE`.
 
 ```json
 {

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -13,6 +13,7 @@ const detectDirectoryType = require( './detect-directory-type' );
 const { validateConfig, ValidationError } = require( './validate-config' );
 const readRawConfigFile = require( './read-raw-config-file' );
 const parseConfig = require( './parse-config' );
+const { includeTestsPath, parseSourceString } = parseConfig;
 const md5 = require( '../md5' );
 
 /**
@@ -257,9 +258,16 @@ function withOverrides( config ) {
 		config.env.tests.port;
 
 	// Override WordPress core with environment variable.
-	config.env.development.core =
-		process.env.WP_ENV_CORE || config.env.development.core;
-	config.env.tests.core = process.env.WP_ENV_CORE || config.env.tests.core;
+	if ( process.env.WP_ENV_CORE ) {
+		const coreSource = includeTestsPath(
+			parseSourceString( process.env.WP_ENV_CORE, {
+				workDirectoryPath: config.workDirectoryPath,
+			} ),
+			{ workDirectoryPath: config.workDirectoryPath }
+		);
+		config.env.development.coreSource = coreSource;
+		config.env.tests.coreSource = coreSource;
+	}
 
 	// Override PHP version with environment variable.
 	config.env.development.phpVersion =

--- a/packages/env/lib/config/config.js
+++ b/packages/env/lib/config/config.js
@@ -256,6 +256,11 @@ function withOverrides( config ) {
 		getNumberFromEnvVariable( 'WP_ENV_TESTS_PORT' ) ||
 		config.env.tests.port;
 
+	// Override WordPress core with environment variable.
+	config.env.development.core =
+		process.env.WP_ENV_CORE || config.env.development.core;
+	config.env.tests.core = process.env.WP_ENV_CORE || config.env.tests.core;
+
 	// Override PHP version with environment variable.
 	config.env.development.phpVersion =
 		process.env.WP_ENV_PHP_VERSION || config.env.development.phpVersion;

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -136,6 +136,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		`Invalid or unrecognized source: "${ sourceString }".`
 	);
 }
+module.exports.parseSourceString = parseSourceString;
 
 /**
  * Given a source object, returns a new source object with the testsPath
@@ -160,3 +161,4 @@ function includeTestsPath( source, { workDirectoryPath } ) {
 		),
 	};
 }
+module.exports.includeTestsPath = includeTestsPath;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
allow override `core` by the `WP_ENV_CORE` environment variable as like`WP_ENV_PHP_VERSION`.

## Why?
Just as we test multiple versions of PHP, we should be able to test multiple versions of WordPress. This makes it easier to test plugins on CI.

## Testing Instructions

1. run  `$ WP_ENV_CORE=WordPress/WordPress#5.9.1 npm run wp-env start --update`
2. check wordpress version.

