### PR TITLE
[RNMobile] Update animation of drag & drop chip component

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.native.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.native.js
@@ -7,8 +7,6 @@ import { View } from 'react-native';
  * WordPress dependencies
  */
 import { dragHandle } from '@wordpress/icons';
-import { useSelect } from '@wordpress/data';
-import { getBlockType } from '@wordpress/blocks';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 
 /**
@@ -16,7 +14,6 @@ import { usePreferredColorSchemeStyle } from '@wordpress/compose';
  */
 import BlockIcon from '../block-icon';
 import styles from './style.scss';
-import { store as blockEditorStore } from '../../store';
 
 const shadowStyle = {
 	shadowColor: '#000',
@@ -33,30 +30,20 @@ const shadowStyle = {
 /**
  * Block draggable chip component
  *
+ * @param {Object} props        Component props.
+ * @param {Object} [props.icon] Block icon.
  * @return {JSX.Element} Chip component.
  */
-export default function BlockDraggableChip() {
+export default function BlockDraggableChip( { icon } ) {
 	const containerStyle = usePreferredColorSchemeStyle(
 		styles[ 'draggable-chip__container' ],
 		styles[ 'draggable-chip__container--dark' ]
 	);
 
-	const { blockIcon } = useSelect( ( select ) => {
-		const { getBlockName, getDraggedBlockClientIds } = select(
-			blockEditorStore
-		);
-		const draggedBlockClientIds = getDraggedBlockClientIds();
-		const blockName = getBlockName( draggedBlockClientIds[ 0 ] );
-
-		return {
-			blockIcon: getBlockType( blockName )?.icon,
-		};
-	} );
-
 	return (
 		<View style={ [ containerStyle, shadowStyle ] }>
 			<BlockIcon icon={ dragHandle } />
-			<BlockIcon icon={ blockIcon } />
+			{ icon && <BlockIcon icon={ icon } /> }
 		</View>
 	);
 }

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -150,8 +150,12 @@ const BlockDraggableWrapper = ( { children } ) => {
 	};
 
 	const onChipLayout = ( { nativeEvent: { layout } } ) => {
-		chip.width.value = layout.width;
-		chip.height.value = layout.height;
+		if ( layout.width > 0 ) {
+			chip.width.value = layout.width;
+		}
+		if ( layout.height > 0 ) {
+			chip.height.value = layout.height;
+		}
 	};
 
 	const startDragging = ( { x, y, id } ) => {

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -224,8 +224,8 @@ const BlockDraggableWrapper = ( { children } ) => {
 			>
 				{ draggedBlockIcon && (
 					<Animated.View
-						entering={ ZoomInEasyDown }
-						exiting={ ZoomOutEasyDown }
+						entering={ ZoomInEasyDown.duration( 200 ) }
+						exiting={ ZoomOutEasyDown.duration( 150 ) }
 					>
 						<DraggableChip icon={ draggedBlockIcon } />
 					</Animated.View>

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -9,6 +9,8 @@ import Animated, {
 	useSharedValue,
 	withDelay,
 	withTiming,
+	ZoomInEasyDown,
+	ZoomOutEasyDown,
 } from 'react-native-reanimated';
 import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
@@ -18,6 +20,7 @@ import TextInputState from 'react-native/Libraries/Components/TextInput/TextInpu
 import { Draggable, DraggableTrigger } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState, Platform } from '@wordpress/element';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -62,6 +65,18 @@ const BlockDraggableWrapper = ( { children } ) => {
 		stopDraggingBlocks,
 	} = useDispatch( blockEditorStore );
 
+	const { blockIcon } = useSelect(
+		( select ) => {
+			const { getBlockName } = select( blockEditorStore );
+			const blockName = getBlockName( currentClientId );
+
+			return {
+				blockIcon: getBlockType( blockName )?.icon,
+			};
+		},
+		[ currentClientId ]
+	);
+
 	const { scrollRef } = useBlockListContext();
 	const animatedScrollRef = useAnimatedRef();
 	animatedScrollRef( scrollRef );
@@ -74,7 +89,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 		y: useSharedValue( 0 ),
 		width: useSharedValue( 0 ),
 		height: useSharedValue( 0 ),
-		scale: useSharedValue( 0 ),
 	};
 	const isDragging = useSharedValue( false );
 
@@ -148,7 +162,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 
 		isDragging.value = true;
 
-		chip.scale.value = withTiming( 1 );
 		runOnJS( onStartDragging )( { clientId: id, position: dragPosition } );
 	};
 
@@ -168,7 +181,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 		'worklet';
 		isDragging.value = false;
 
-		chip.scale.value = withTiming( 0 );
 		stopScrolling();
 		runOnJS( onStopDragging )();
 	};
@@ -183,8 +195,6 @@ const BlockDraggableWrapper = ( { children } ) => {
 						chip.height.value -
 						CHIP_OFFSET_TO_TOUCH_POSITION,
 				},
-				{ scaleX: chip.scale.value },
-				{ scaleY: chip.scale.value },
 			],
 		};
 	} );
@@ -212,7 +222,14 @@ const BlockDraggableWrapper = ( { children } ) => {
 				style={ chipStyles }
 				pointerEvents="none"
 			>
-				<DraggableChip />
+				{ blockIcon && (
+					<Animated.View
+						entering={ ZoomInEasyDown }
+						exiting={ ZoomOutEasyDown }
+					>
+						<DraggableChip icon={ blockIcon } />
+					</Animated.View>
+				) }
 			</Animated.View>
 		</>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Update show/hide animations of the drag & drop chip component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This change originated from design feedback referenced in [this comment](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4691#issuecomment-1092007212).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The show/hide animations are now controlled by layout effects provided by the Reanimated library. Additionally, the block icon is now provided to the chip component by a prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open a post/page in the app.
1. Add several blocks, including text blocks like the Paragraph block.
1. Long-press on a block to activate the dragging mode.
1. Observe that the chip component is shown following the behavior described [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4691#issuecomment-1092007212).
1. Drop the block and observe that the chip component is hidden following the behavior described [here](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4691#issuecomment-1092007212).

## Screenshots or screencast <!-- if applicable -->

Android|iOS
--|--
<video src=https://user-images.githubusercontent.com/14905380/163806711-9ede5c0e-4ac2-4ce3-a585-eefa9f0cdf92.mp4>|<video src=https://user-images.githubusercontent.com/14905380/163806736-c19b3a71-8cdd-4b86-a143-ece702dbf755.mp4>