### PR TITLE
InputControl: remove default value argument from Storybook

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## 19.8.0 (2022-04-08)
 
+### Bug Fix
+
+-   `InputControl`: allow user to input a value interactively in Storybook, by removing default value argument ([#40410](https://github.com/WordPress/gutenberg/pull/40410)).
+
 ### Enhancements
 
 -   Update `BorderControl` and `BorderBoxControl` to allow the passing of custom class names to popovers ([#39753](https://github.com/WordPress/gutenberg/pull/39753)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,12 +6,11 @@
 
 -   Remove individual color object exports from the `utils/colors-values.js` file. Colors should now be used from the main `COLORS` export([#40387](https://github.com/WordPress/gutenberg/pull/40387)).
 
-
-## 19.8.0 (2022-04-08)
-
 ### Bug Fix
 
 -   `InputControl`: allow user to input a value interactively in Storybook, by removing default value argument ([#40410](https://github.com/WordPress/gutenberg/pull/40410)).
+
+## 19.8.0 (2022-04-08)
 
 ### Enhancements
 

--- a/packages/components/src/input-control/README.md
+++ b/packages/components/src/input-control/README.md
@@ -18,7 +18,7 @@ const Example = () => {
 	return (
 		<InputControl
 			value={ value }
-			onChange={ ( nextValue ) => setValue( nextValue ) }
+			onChange={ ( nextValue ) => setValue( nextValue ?? '' ) }
 		/>
 	);
 };

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -92,7 +92,7 @@ export function UnforwardedInputControl(
  * InputControl components let users enter and edit text. This is an experimental component
  * intended to (in time) merge with or replace `TextControl`.
  *
- * ```jsx
+ * @example
  * import { __experimentalInputControl as InputControl } from '@wordpress/components';
  * import { useState } from '@wordpress/compose';
  *
@@ -106,7 +106,6 @@ export function UnforwardedInputControl(
  *  	/>
  *   );
  * };
- * ```
  */
 export const InputControl = forwardRef( UnforwardedInputControl );
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -92,7 +92,7 @@ export function UnforwardedInputControl(
  * InputControl components let users enter and edit text. This is an experimental component
  * intended to (in time) merge with or replace `TextControl`.
  *
- * @example
+ * ```jsx
  * import { __experimentalInputControl as InputControl } from '@wordpress/components';
  * import { useState } from '@wordpress/compose';
  *
@@ -106,6 +106,7 @@ export function UnforwardedInputControl(
  *  	/>
  *   );
  * };
+ * ```
  */
 export const InputControl = forwardRef( UnforwardedInputControl );
 

--- a/packages/components/src/input-control/index.tsx
+++ b/packages/components/src/input-control/index.tsx
@@ -102,7 +102,7 @@ export function UnforwardedInputControl(
  *   return (
  *  	<InputControl
  *  		value={ value }
- *  		onChange={ ( nextValue ) => setValue( nextValue ) }
+ *  		onChange={ ( nextValue ) => setValue( nextValue ?? '' ) }
  *  	/>
  *   );
  * };

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -4,6 +4,11 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import InputControl from '..';
@@ -18,6 +23,7 @@ const meta: ComponentMeta< typeof InputControl > = {
 		prefix: { control: { type: null } },
 		suffix: { control: { type: null } },
 		type: { control: { type: 'text' } },
+		value: { control: { disable: true } },
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -26,9 +32,17 @@ const meta: ComponentMeta< typeof InputControl > = {
 };
 export default meta;
 
-const Template: ComponentStory< typeof InputControl > = ( args ) => (
-	<InputControl { ...args } />
-);
+const Template: ComponentStory< typeof InputControl > = ( args ) => {
+	const [ value, setValue ] = useState( '' );
+
+	return (
+		<InputControl
+			{ ...args }
+			value={ value }
+			onChange={ ( nextValue ) => setValue( nextValue ?? '' ) }
+		/>
+	);
+};
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -34,7 +34,6 @@ export const Default = Template.bind( {} );
 Default.args = {
 	label: 'Value',
 	placeholder: 'Placeholder',
-	value: '',
 };
 
 export const WithPrefix = Template.bind( {} );

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -23,6 +23,7 @@ const meta: ComponentMeta< typeof InputControl > = {
 		prefix: { control: { type: null } },
 		suffix: { control: { type: null } },
 		type: { control: { type: 'text' } },
+		value: { control: { disable: true } },
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -31,11 +32,7 @@ const meta: ComponentMeta< typeof InputControl > = {
 };
 export default meta;
 
-const UncontrolledTemplate: ComponentStory< typeof InputControl > = (
-	args
-) => <InputControl { ...args } />;
-
-const ControlledTemplate: ComponentStory< typeof InputControl > = ( args ) => {
+const Template: ComponentStory< typeof InputControl > = ( args ) => {
 	const [ value, setValue ] = useState( '' );
 
 	return (
@@ -47,41 +44,33 @@ const ControlledTemplate: ComponentStory< typeof InputControl > = ( args ) => {
 	);
 };
 
-export const Default = UncontrolledTemplate.bind( {} );
+export const Default = Template.bind( {} );
 Default.args = {
 	label: 'Value',
 	placeholder: 'Placeholder',
 };
 
-export const WithPrefix = UncontrolledTemplate.bind( {} );
+export const WithPrefix = Template.bind( {} );
 WithPrefix.args = {
 	...Default.args,
 	prefix: <span style={ { paddingLeft: 8 } }>@</span>,
 };
 
-export const WithSuffix = UncontrolledTemplate.bind( {} );
+export const WithSuffix = Template.bind( {} );
 WithSuffix.args = {
 	...Default.args,
 	suffix: <button style={ { marginRight: 4 } }>Send</button>,
 };
 
-export const WithSideLabel = UncontrolledTemplate.bind( {} );
+export const WithSideLabel = Template.bind( {} );
 WithSideLabel.args = {
 	...Default.args,
 	labelPosition: 'side',
 };
 
-export const WithEdgeLabel = UncontrolledTemplate.bind( {} );
+export const WithEdgeLabel = Template.bind( {} );
 WithEdgeLabel.args = {
 	...Default.args,
 	__unstableInputWidth: '20em',
 	labelPosition: 'edge',
-};
-
-export const Controlled = ControlledTemplate.bind( {} );
-Controlled.args = {
-	...Default.args,
-};
-Controlled.argTypes = {
-	value: { control: { disable: true } },
 };

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -4,11 +4,6 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import InputControl from '..';
@@ -32,17 +27,9 @@ const meta: ComponentMeta< typeof InputControl > = {
 };
 export default meta;
 
-const Template: ComponentStory< typeof InputControl > = ( args ) => {
-	const [ value, setValue ] = useState( '' );
-
-	return (
-		<InputControl
-			{ ...args }
-			value={ value }
-			onChange={ ( nextValue ) => setValue( nextValue ?? '' ) }
-		/>
-	);
-};
+const Template: ComponentStory< typeof InputControl > = ( args ) => (
+	<InputControl { ...args } />
+);
 
 export const Default = Template.bind( {} );
 Default.args = {

--- a/packages/components/src/input-control/stories/index.tsx
+++ b/packages/components/src/input-control/stories/index.tsx
@@ -23,7 +23,6 @@ const meta: ComponentMeta< typeof InputControl > = {
 		prefix: { control: { type: null } },
 		suffix: { control: { type: null } },
 		type: { control: { type: 'text' } },
-		value: { control: { disable: true } },
 	},
 	parameters: {
 		controls: { expanded: true },
@@ -32,7 +31,11 @@ const meta: ComponentMeta< typeof InputControl > = {
 };
 export default meta;
 
-const Template: ComponentStory< typeof InputControl > = ( args ) => {
+const UncontrolledTemplate: ComponentStory< typeof InputControl > = (
+	args
+) => <InputControl { ...args } />;
+
+const ControlledTemplate: ComponentStory< typeof InputControl > = ( args ) => {
 	const [ value, setValue ] = useState( '' );
 
 	return (
@@ -44,33 +47,41 @@ const Template: ComponentStory< typeof InputControl > = ( args ) => {
 	);
 };
 
-export const Default = Template.bind( {} );
+export const Default = UncontrolledTemplate.bind( {} );
 Default.args = {
 	label: 'Value',
 	placeholder: 'Placeholder',
 };
 
-export const WithPrefix = Template.bind( {} );
+export const WithPrefix = UncontrolledTemplate.bind( {} );
 WithPrefix.args = {
 	...Default.args,
 	prefix: <span style={ { paddingLeft: 8 } }>@</span>,
 };
 
-export const WithSuffix = Template.bind( {} );
+export const WithSuffix = UncontrolledTemplate.bind( {} );
 WithSuffix.args = {
 	...Default.args,
 	suffix: <button style={ { marginRight: 4 } }>Send</button>,
 };
 
-export const WithSideLabel = Template.bind( {} );
+export const WithSideLabel = UncontrolledTemplate.bind( {} );
 WithSideLabel.args = {
 	...Default.args,
 	labelPosition: 'side',
 };
 
-export const WithEdgeLabel = Template.bind( {} );
+export const WithEdgeLabel = UncontrolledTemplate.bind( {} );
 WithEdgeLabel.args = {
 	...Default.args,
 	__unstableInputWidth: '20em',
 	labelPosition: 'edge',
+};
+
+export const Controlled = ControlledTemplate.bind( {} );
+Controlled.args = {
+	...Default.args,
+};
+Controlled.argTypes = {
+	value: { control: { disable: true } },
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug in `InputControl`'s Storybook example, where currently it's not possible to interact with the component and enter a custom value

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is probably an unwanted side-effect introduced in #40119

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR removes `value: ''` from the list of default arguments for each Storybook example.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Open Storybook, make sure that it's possible to enter a custom value in the `InputControl` component and that the value is persisted after the input loses focus.

Make sure that any text manually set as the `value` via Storybook controls overrides every other text entered by the user.

## Screenshots or screencast <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/1083581/163805177-f0369fd4-ab82-45b4-b339-5ec108fbb2e6.mp4



After:


https://user-images.githubusercontent.com/1083581/163805199-b006a387-97d3-48fd-9c4e-a189da377d93.mp4


