### PR TITLE
Improve button spacing in the top right corner of the editor

### DIFF
--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -44,6 +44,10 @@
 	}
 }
 
+/**
+ * Buttons on the right side
+ */
+
 .edit-post-header__settings {
 	display: inline-flex;
 	align-items: center;
@@ -53,10 +57,6 @@
 	@include break-small () {
 		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
 	}
-
-	/**
-	 * Buttons in the Toolbar
- 	 */
 
 	gap: $grid-unit-05;
 
@@ -89,6 +89,10 @@
 		padding-bottom: 0;
 	}
 }
+
+/**
+ * Show icon labels.
+ */
 
 .show-icon-labels.interface-pinned-items,
 .show-icon-labels .edit-post-header,
@@ -143,17 +147,7 @@
 			padding-right: $grid-unit-15;
 		}
 	}
-	.components-dropdown-menu__toggle {
-		margin-left: $grid-unit;
-		padding-left: $grid-unit;
-		padding-right: $grid-unit;
 
-		@include break-small {
-			margin-left: $grid-unit-15;
-			padding-left: $grid-unit-15;
-			padding-right: $grid-unit-15;
-		}
-	}
 	// The inserter has a custom label, different from its aria-label, so we don't want to display both.
 	.edit-post-header-toolbar__inserter-toggle.edit-post-header-toolbar__inserter-toggle {
 		&::after {

--- a/packages/edit-post/src/components/header/style.scss
+++ b/packages/edit-post/src/components/header/style.scss
@@ -51,31 +51,17 @@
 	padding-right: $grid-unit-05;
 
 	@include break-small () {
-		padding-right: $grid-unit-20;
+		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
 	}
 
 	/**
 	 * Buttons in the Toolbar
  	 */
 
-	// Adjust button paddings to scale better to mobile.
-	.editor-post-saved-state,
-	.components-button.components-button {
-		margin-right: $grid-unit-05;
+	gap: $grid-unit-05;
 
-		@include break-small() {
-			margin-right: $grid-unit-15;
-		}
-	}
-
-	.editor-post-saved-state,
-	.components-button.is-tertiary {
-		padding: 0 #{ $grid-unit-15 * 0.5 };
-	}
-
-	.interface-more-menu-dropdown .components-button,
-	.interface-pinned-items .components-button {
-		margin-right: 0;
+	@include break-small() {
+		gap: $grid-unit-10;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -113,36 +113,27 @@ body.is-navigation-sidebar-open {
 	align-items: center;
 	padding-right: $grid-unit-05;
 
+	@include break-small () {
+		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
+	}
+
+	/**
+	 * Buttons in the Toolbar
+ 	 */
+
+	gap: $grid-unit-05;
+
+	@include break-small() {
+		gap: $grid-unit-10;
+	}
+
+	// Pinned items.
 	.interface-pinned-items {
 		display: none;
 
 		@include break-medium() {
 			display: inline-flex;
 		}
-	}
-
-	// Adjust button paddings to scale better to mobile.
-	.editor-post-saved-state,
-	.components-button.components-button {
-		margin-right: $grid-unit-05;
-
-		@include break-small() {
-			margin-right: $grid-unit-15;
-		}
-	}
-
-	.editor-post-saved-state,
-	.components-button.is-tertiary {
-		padding: 0 #{$grid-unit-15 * 0.5};
-	}
-
-	.edit-site-more-menu .components-button,
-	.interface-pinned-items .components-button {
-		margin-right: 0;
-	}
-
-	@include break-small() {
-		padding-right: $grid-unit-20;
 	}
 }
 

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -104,8 +104,9 @@ body.is-navigation-sidebar-open {
 	margin: 0 -6px 0;
 }
 
+
 /**
- * Buttons in the Toolbar
+ * Buttons on the right side
  */
 
 .edit-site-header__actions {
@@ -116,10 +117,6 @@ body.is-navigation-sidebar-open {
 	@include break-small () {
 		padding-right: $grid-unit-20 - ($grid-unit-15 * 0.5);
 	}
-
-	/**
-	 * Buttons in the Toolbar
- 	 */
 
 	gap: $grid-unit-05;
 
@@ -183,11 +180,8 @@ body.is-navigation-sidebar-open {
 	.edit-site-save-button__button {
 		padding-left: 6px;
 		padding-right: 6px;
-		margin-right: $grid-unit-05;
 	}
-	.block-editor-post-preview__button-toggle {
-		margin-right: $grid-unit-05;
-	}
+
 	// The inserter and the template details toggle have custom labels, different from their aria-label, so we don't want to display both.
 	.edit-site-header-toolbar__inserter-toggle.edit-site-header-toolbar__inserter-toggle,
 	.edit-site-document-actions__get-info.edit-site-document-actions__get-info.edit-site-document-actions__get-info {

--- a/packages/interface/src/components/pinned-items/style.scss
+++ b/packages/interface/src/components/pinned-items/style.scss
@@ -11,8 +11,14 @@
 		}
 	}
 
+	// Gap between pinned items.
+	gap: $grid-unit-05;
+
+	// Account for larger grid from parent container gap.
+	margin-right: -$grid-unit-05;
+
 	.components-button {
-		margin-left: $grid-unit-05;
+		margin: 0;
 
 		svg {
 			max-width: $icon-size;


### PR DESCRIPTION
## What?

The spacing of buttons and pinned items is a bit awkward in post and site editors, with the random margins and the ellipsis not lining up:
<img width="426" alt="before post editor" src="https://user-images.githubusercontent.com/1204802/163805360-aabc5c4a-d9cf-4f24-b918-ff43e2ba8185.png">


<img width="390" alt="before site editor" src="https://user-images.githubusercontent.com/1204802/163805371-a129daa6-2c7b-4055-8156-c42e974b468a.png">

This PR retires numerous padding/margin values and replaces them with a simpler `gap` based value, so now things line up and the spacing is considered better:

<img width="400" alt="after, post editor" src="https://user-images.githubusercontent.com/1204802/163805444-e1b7303f-f3a2-43c0-9062-f3a917c99cb5.png">

<img width="371" alt="after, post editor 2" src="https://user-images.githubusercontent.com/1204802/163805454-814693bc-6637-4d64-8566-43b7f1b9a82c.png">

<img width="393" alt="site editor after" src="https://user-images.githubusercontent.com/1204802/163805457-0f848041-ee7a-4d44-9986-d2727d5a2258.png">

I've tested the text label option as well:

<img width="438" alt="post editor text labels" src="https://user-images.githubusercontent.com/1204802/163805503-b5be1549-bd22-45a9-8d35-94e8bdbb107a.png">

<img width="469" alt="site editor text labels" src="https://user-images.githubusercontent.com/1204802/163805509-bebbdf6d-f2fb-4ba3-932e-199a73d854f8.png">

## Testing Instructions

Please test the post and site editor with pinned items and observe the buttons in the top toolbar on the right.