### PR TITLE
Try: Rename Navigation Menus to Navigation.

### DIFF
--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/index.js
@@ -24,6 +24,9 @@ export default function NavigationMenuSidebar() {
 				<Flex>
 					<FlexBlock>
 						<strong>{ __( 'Navigation Menus' ) }</strong>
+						<span className="edit-site-navigation-sidebar__beta">
+							{ __( 'Beta' ) }
+						</span>
 					</FlexBlock>
 				</Flex>
 			}

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/index.js
@@ -16,7 +16,7 @@ export default function NavigationMenuSidebar() {
 		<DefaultSidebar
 			className="edit-site-navigation-menu-sidebar"
 			identifier="edit-site/navigation-menu"
-			title={ __( 'Navigation Menus' ) }
+			title={ __( 'Navigation' ) }
 			icon={ navigation }
 			closeLabel={ __( 'Close navigation menu sidebar' ) }
 			panelClassName="edit-site-navigation-menu-sidebar__panel"

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -74,6 +74,7 @@
 	padding: $grid-unit-20;
 }
 
+.edit-site-navigation-sidebar__beta,
 .edit-site-global-styles-sidebar__beta {
 	display: inline-flex;
 	margin-left: $grid-unit-10;


### PR DESCRIPTION
## What?

Inspired by #40411.

The site editor top toolbar is space challenged when the text labels option is enabled:

<img width="498" alt="Screenshot 2022-04-18 at 14 12 24" src="https://user-images.githubusercontent.com/1204802/163806592-d95e74a3-76a1-40be-bd2c-f161282f88b7.png">

The gap between buttons is already compressed for the same reason, and as such the space between "Navigation" and "Menus" can easily be interpreted as those being two separate buttons, "Navigation" and "Menus". This PR simplifies the label to just "Navigation":
<img width="469" alt="Screenshot 2022-04-18 at 14 11 16" src="https://user-images.githubusercontent.com/1204802/163806766-f81e8504-fdf9-439d-88af-c6ccb53e0e36.png">

The menu itself is unchanged:

<img width="501" alt="Screenshot 2022-04-18 at 14 14 08" src="https://user-images.githubusercontent.com/1204802/163806784-a4bbd1cf-9fee-4325-99e6-d629a1f37275.png">

## Testing Instructions

Test the site editor and the text label option.