### PR TITLE
Patterns API: Add 'inserter' to the schema

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -117,6 +117,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 			'categories'    => 'categories',
 			'keywords'      => 'keywords',
 			'content'       => 'content',
+			'inserter'      => 'inserter',
 		);
 		$data   = array();
 		foreach ( $keys as $item_key => $rest_key ) {
@@ -189,6 +190,12 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 				'content'        => array(
 					'description' => __( 'The pattern content.', 'gutenberg' ),
 					'type'        => 'string',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit', 'embed' ),
+				),
+				'inserter'        => array(
+					'description' => __( 'Determines whether the pattern is visible in inserter.', 'gutenberg' ),
+					'type'        => 'boolean',
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),

--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -193,7 +193,7 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit', 'embed' ),
 				),
-				'inserter'        => array(
+				'inserter'       => array(
 					'description' => __( 'Determines whether the pattern is visible in inserter.', 'gutenberg' ),
 					'type'        => 'boolean',
 					'readonly'    => true,


### PR DESCRIPTION
## What?
Fixes #40414.

PR adds the missing `inserter` field to the Patterns item schema.

## Why?
Currently, this field is omitted from the response, and patterns that should be hidden in the inserter are visible.

## Testing Instructions
1. Activate the TT2 theme.
2. Open a post editor.
3. Open the Pattern Explorer.
4. Confirm that the "Uncategorized" section isn't visible.
