### PR TITLE
[RNMobile] Add haptic feedback to drag & drop feature

### DIFF
--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -13,6 +13,7 @@ import Animated, {
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { generateHapticFeedback } from '@wordpress/react-native-bridge';
 
 /**
  * Internal dependencies
@@ -103,13 +104,16 @@ export default function DroppingInsertionPoint( {
 			opacity.value = 0;
 			blockYPosition.value = nextPosition;
 			opacity.value = withTiming( 1 );
+			generateHapticFeedback();
 		}
 	}
 
 	useAnimatedReaction(
 		() => targetBlockIndex.value,
-		( value ) => {
-			runOnJS( setIndicatorPosition )( value );
+		( value, previous ) => {
+			if ( value !== previous ) {
+				runOnJS( setIndicatorPosition )( value );
+			}
 		}
 	);
 

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -21,6 +21,7 @@ import { Draggable, DraggableTrigger } from '@wordpress/components';
 import { select, useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef, useState, Platform } from '@wordpress/element';
 import { getBlockType } from '@wordpress/blocks';
+import { generateHapticFeedback } from '@wordpress/react-native-bridge';
 
 /**
  * Internal dependencies
@@ -124,6 +125,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 			startDraggingBlocks( [ clientId ] );
 			setDraggedBlockIconByClientId( clientId );
 			runOnUI( startScrolling )( position.y );
+			generateHapticFeedback();
 		} else {
 			// We stop dragging if no block is found.
 			runOnUI( stopDragging )();

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/AndroidManifest.xml
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         </intent>
     </queries>
 
+    <!-- Vibrate permission required for haptic feedback -->
+    <uses-permission android:name="android.permission.VIBRATE" />
+
     <application>
         <activity
             android:name=".GutenbergWebViewActivity"

--- a/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
+++ b/packages/react-native-bridge/android/react-native-bridge/src/main/java/org/wordpress/mobile/ReactNativeGutenbergBridge/RNReactNativeGutenbergBridgeModule.java
@@ -1,6 +1,11 @@
 package org.wordpress.mobile.ReactNativeGutenbergBridge;
 
+import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.VibrationEffect;
+import android.os.Vibrator;
+import android.provider.Settings;
 
 import androidx.annotation.Nullable;
 
@@ -465,5 +470,20 @@ public class RNReactNativeGutenbergBridgeModule extends ReactContextBaseJavaModu
     @ReactMethod
     public void sendEventToHost(final String eventName, final ReadableMap properties) {
         mGutenbergBridgeJS2Parent.sendEventToHost(eventName, properties);
+    }
+
+    @ReactMethod
+    public void generateHapticFeedback() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            int hapticFeedbackEnabled = Settings.System.getInt(mReactContext.getContentResolver(), Settings.System.HAPTIC_FEEDBACK_ENABLED, 0);
+            if (hapticFeedbackEnabled == 0) {
+                return;
+            }
+            VibrationEffect tickEffect = VibrationEffect.createPredefined(VibrationEffect.EFFECT_TICK);
+            Vibrator vibrator = (Vibrator) mReactContext.getSystemService(Context.VIBRATOR_SERVICE);
+            if (vibrator != null) {
+                vibrator.vibrate(tickEffect);
+            }
+        }
     }
 }

--- a/packages/react-native-bridge/index.js
+++ b/packages/react-native-bridge/index.js
@@ -436,4 +436,11 @@ export function sendEventToHost( eventName, properties ) {
 	);
 }
 
+/**
+ * Generate haptic feedback.
+ */
+export function generateHapticFeedback() {
+	RNReactNativeGutenbergBridge.generateHapticFeedback();
+}
+
 export default RNReactNativeGutenbergBridge;

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.m
@@ -38,5 +38,6 @@ RCT_EXTERN_METHOD(setBlockTypeImpressions:(NSDictionary *)impressions)
 RCT_EXTERN_METHOD(requestContactCustomerSupport)
 RCT_EXTERN_METHOD(requestGotoCustomerSupportOptions)
 RCT_EXTERN_METHOD(sendEventToHost:(NSString)eventName properties:(NSDictionary *)properties)
+RCT_EXTERN_METHOD(generateHapticFeedback)
 
 @end

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -392,6 +392,11 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
     func sendEventToHost(_ eventName: String, properties: [AnyHashable: Any]) {
         self.delegate?.gutenbergDidRequestSendEventToHost(eventName, properties: properties)
     }
+
+    @objc
+    func generateHapticFeedback() {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+    }
 }
 
 // MARK: - RCTBridgeModule delegate

--- a/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
+++ b/packages/react-native-bridge/ios/RNReactNativeGutenbergBridge.swift
@@ -395,7 +395,7 @@ public class RNReactNativeGutenbergBridge: RCTEventEmitter {
 
     @objc
     func generateHapticFeedback() {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        UISelectionFeedbackGenerator().selectionChanged()
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4769.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add haptic feedback for the following actions:
- When dragging mode is activated.
- Each time the insertion point changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is an enhancement of the drag & drop feature and was requested as part of design feedback ([reference](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4691#issuecomment-1088038628)).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The function `generateHapticFeedback` has been added to the RN bridge to generate the haptic feedback. On each platform, this function is implemented following a similar approach as it's provided by the [`react-native-haptic-feedback` library](https://github.com/junina-de/react-native-haptic-feedback). I decided not to include that library as the implementation was relatively easy and to prevent adding an extra dependency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
**Preparation:**
Since this PR includes native changes, it's required to build the demo app locally before testing.

1. Open a post/page in the app.
2. Add several blocks, including text blocks like the Paragraph block.
3. Long-press on a block to activate the dragging mode.
4. Observe that the previous action generated haptic feedback (i.e. the device vibrated softly).
5. Drag the block along the block list.
6. Observe that every time the inserter point (i.e. the dropping target position) is displayed, it generates haptic feedback.

## Screenshots or screencast <!-- if applicable -->
N/A