### PR TITLE
Block Styles: Remove unnecessary button role and 'onKeyDown' handler

### DIFF
--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -9,7 +9,6 @@ import classnames from 'classnames';
  */
 import { useState, useLayoutEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { ENTER, SPACE } from '@wordpress/keycodes';
 import {
 	Button,
 	__experimentalText as Text,
@@ -113,17 +112,7 @@ function BlockStyles( {
 							onFocus={ () => styleItemHandler( style ) }
 							onMouseLeave={ () => styleItemHandler( null ) }
 							onBlur={ () => styleItemHandler( null ) }
-							onKeyDown={ ( event ) => {
-								if (
-									ENTER === event.keyCode ||
-									SPACE === event.keyCode
-								) {
-									event.preventDefault();
-									onSelectStylePreview( style );
-								}
-							} }
 							onClick={ () => onSelectStylePreview( style ) }
-							role="button"
 							tabIndex="0"
 						>
 							<Text

--- a/packages/block-editor/src/components/block-styles/index.js
+++ b/packages/block-editor/src/components/block-styles/index.js
@@ -113,7 +113,7 @@ function BlockStyles( {
 							onMouseLeave={ () => styleItemHandler( null ) }
 							onBlur={ () => styleItemHandler( null ) }
 							onClick={ () => onSelectStylePreview( style ) }
-							tabIndex="0"
+							aria-current={ activeStyle.name === style.name }
 						>
 							<Text
 								as="span"


### PR DESCRIPTION
## What?
PR removes unnecessary button role and `onKeyDown` handler from the block styles item element. Both are leftovers from the time using `div` instead of the native button (changed in #34522).

## Why?
The `role="button"` is already set for the native button and they correctly trigger the `onClick` event when using Enter or Space keys.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image Block.
3. Open Style panel.
4. Confirm that the style item element has the correct role, using the a11y feature of the DevTools.
5. Confirm that you can select styles using Enter and Space key.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-04-18 at 23 43 00](https://user-images.githubusercontent.com/240569/163866785-692cb55e-70b3-4fbc-a385-71f68f8f210c.png)

