### PR TITLE
useSelect: cancel render queue in a more straightforward way

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -123,7 +123,6 @@ export default function useSelect( mapSelect, deps ) {
 	const latestIsAsync = useRef( isAsync );
 	const latestMapOutput = useRef();
 	const latestMapOutputError = useRef();
-	const isMountedAndNotUnsubscribing = useRef();
 
 	// Keep track of the stores being selected in the _mapSelect function,
 	// and only subscribe to those stores later.
@@ -181,7 +180,6 @@ export default function useSelect( mapSelect, deps ) {
 		latestMapSelect.current = _mapSelect;
 		latestMapOutput.current = mapOutput;
 		latestMapOutputError.current = undefined;
-		isMountedAndNotUnsubscribing.current = true;
 
 		// This has to run after the other ref updates
 		// to avoid using stale values in the flushed
@@ -199,21 +197,17 @@ export default function useSelect( mapSelect, deps ) {
 		}
 
 		const onStoreChange = () => {
-			if ( isMountedAndNotUnsubscribing.current ) {
-				try {
-					const newMapOutput = wrapSelect( latestMapSelect.current );
+			try {
+				const newMapOutput = wrapSelect( latestMapSelect.current );
 
-					if (
-						isShallowEqual( latestMapOutput.current, newMapOutput )
-					) {
-						return;
-					}
-					latestMapOutput.current = newMapOutput;
-				} catch ( error ) {
-					latestMapOutputError.current = error;
+				if ( isShallowEqual( latestMapOutput.current, newMapOutput ) ) {
+					return;
 				}
-				forceRender();
+				latestMapOutput.current = newMapOutput;
+			} catch ( error ) {
+				latestMapOutputError.current = error;
 			}
+			forceRender();
 		};
 
 		const onChange = () => {
@@ -233,10 +227,9 @@ export default function useSelect( mapSelect, deps ) {
 		);
 
 		return () => {
-			isMountedAndNotUnsubscribing.current = false;
 			// The return value of the subscribe function could be undefined if the store is a custom generic store.
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
-			renderQueue.flush( queueContext );
+			renderQueue.cancel( queueContext );
 		};
 		// If you're tempted to eliminate the spread dependencies below don't do it!
 		// We're passing these in from the calling function and want to make sure we're

--- a/packages/priority-queue/CHANGELOG.md
+++ b/packages/priority-queue/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+-  Add a new `cancel` method that removes scheduled callbacks without executing them.
+
 ## 2.6.0 (2022-04-08)
 
 ## 2.5.0 (2022-03-23)

--- a/packages/priority-queue/src/index.js
+++ b/packages/priority-queue/src/index.js
@@ -38,9 +38,10 @@ import requestIdleCallback from './request-idle-callback';
  *
  * @typedef {Object} WPPriorityQueue
  *
- * @property {WPPriorityQueueAdd}   add   Add callback to queue for context.
- * @property {WPPriorityQueueFlush} flush Flush queue for context.
- * @property {WPPriorityQueueReset} reset Reset queue.
+ * @property {WPPriorityQueueAdd}   add    Add callback to queue for context.
+ * @property {WPPriorityQueueFlush} flush  Flush queue for context.
+ * @property {WPPriorityQueueFlush} cancel Clear queue for context.
+ * @property {WPPriorityQueueReset} reset  Reset queue.
  */
 
 /**
@@ -152,6 +153,29 @@ export const createQueue = () => {
 	};
 
 	/**
+	 * Clears the queue for a given context, cancelling the callbacks without
+	 * executing them. Returns `true` if there were scheduled callbacks to cancel,
+	 * or `false` if there was is no queue for the given context.
+	 *
+	 * @type {WPPriorityQueueFlush}
+	 *
+	 * @param {WPPriorityQueueContext} element Context object.
+	 *
+	 * @return {boolean} Whether any callbacks got cancelled.
+	 */
+	const cancel = ( element ) => {
+		if ( ! elementsMap.has( element ) ) {
+			return false;
+		}
+
+		const index = waitingList.indexOf( element );
+		waitingList.splice( index, 1 );
+		elementsMap.delete( element );
+
+		return true;
+	};
+
+	/**
 	 * Reset the queue without running the pending callbacks.
 	 *
 	 * @type {WPPriorityQueueReset}
@@ -165,6 +189,7 @@ export const createQueue = () => {
 	return {
 		add,
 		flush,
+		cancel,
 		reset,
 	};
 };

--- a/packages/priority-queue/src/test/index.js
+++ b/packages/priority-queue/src/test/index.js
@@ -128,4 +128,31 @@ describe( 'createQueue', () => {
 			expect( callbackElementB ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
+
+	describe( 'cancel', () => {
+		it( 'removes all callbacks associated with element without executing', () => {
+			const elementA = {};
+			const elementB = {};
+			const callbackElementA = jest.fn();
+			const callbackElementB = jest.fn();
+			queue.add( elementA, callbackElementA );
+			queue.add( elementB, callbackElementB );
+
+			expect( callbackElementA ).not.toHaveBeenCalled();
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			expect( queue.cancel( elementA ) ).toBe( true );
+
+			// No callbacks should have been called.
+			expect( callbackElementA ).not.toHaveBeenCalled();
+			expect( callbackElementB ).not.toHaveBeenCalled();
+
+			// A subsequent `flush` has nothing to remove.
+			expect( queue.flush( elementA ) ).toBe( false );
+
+			// The queue for `elementA` remained intact and can be successfully flushed.
+			expect( queue.flush( elementB ) ).toBe( true );
+			expect( callbackElementB ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
 } );


### PR DESCRIPTION
When the `useSelect` hook runs in async mode, it defers the store update callbacks using `@wordpress/priority-queue`. On certain occasions, it needs to cancel the already scheduled callbacks. Until now, the cancelling was done by setting a `isMountedAndNotUnsubscribing` bool flag to `false`, and then _flushing_ the queue, i.e., executing the scheduled callbacks, while checking the `isMountedAndNotUnsubscribing` flag inside the callbacks, making them into noops.

This patch introduces a new `cancel` method to `@wordpress/priority-queue`, and calls it in `useSelect` when the intent is "cancel". That's more straightforward and easier to understand.

The `flush()` and `cancel()` methods are analogous to how Lodash names methods to flush and cancel functions returned from `debounce` or `throttle`:
```js
let debounced = _.debounce( fn );
debounced.cancel(); // cancel execution
debounced.flush(); // execute immediately and synchronously
```

**How to test:**
Verify that the unit test suite for `useSelect` still passes. Since #40321 the test suite should be sufficiently thorough to verify that a change like this one is OK.