### PR TITLE
Try: Add new duotone filter icon.

### DIFF
--- a/packages/block-editor/src/components/duotone-control/index.js
+++ b/packages/block-editor/src/components/duotone-control/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
+import { Icon, filter } from '@wordpress/icons';
 
 function DuotoneControl( {
 	colorPalette,
@@ -41,7 +42,13 @@ function DuotoneControl( {
 						aria-expanded={ isOpen }
 						onKeyDown={ openOnArrowDown }
 						label={ __( 'Apply duotone filter' ) }
-						icon={ <DuotoneSwatch values={ value } /> }
+						icon={
+							value ? (
+								<DuotoneSwatch values={ value } />
+							) : (
+								<Icon icon={ filter } />
+							)
+						}
 					/>
 				);
 			} }

--- a/packages/components/src/custom-gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-bar/index.js
@@ -142,6 +142,7 @@ export default function CustomGradientBar( {
 							disableAlpha={ disableAlpha }
 							insertPosition={ gradientBarState.insertPosition }
 							value={ controlPoints }
+							label="test"
 							onChange={ onChange }
 							onOpenInserter={ () => {
 								gradientBarStateDispatch( {

--- a/packages/components/src/custom-gradient-bar/index.js
+++ b/packages/components/src/custom-gradient-bar/index.js
@@ -142,7 +142,6 @@ export default function CustomGradientBar( {
 							disableAlpha={ disableAlpha }
 							insertPosition={ gradientBarState.insertPosition }
 							value={ controlPoints }
-							label="test"
 							onChange={ onChange }
 							onOpenInserter={ () => {
 								gradientBarStateDispatch( {

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 ### New Features
 
--   Add new `filter` icon.
+-   Add new `filter` icon. ([#40435](https://github.com/WordPress/gutenberg/pull/40435))
 
 ## 8.2.0 (2022-04-08)
 

--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -1,6 +1,9 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+### New Features
+
+-   Add new `filter` icon.
 
 ## 8.2.0 (2022-04-08)
 

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -67,6 +67,7 @@ export { default as download } from './library/download';
 export { default as edit } from './library/edit';
 export { default as external } from './library/external';
 export { default as file } from './library/file';
+export { default as filter } from './library/filter';
 export { default as flipHorizontal } from './library/flip-horizontal';
 export { default as flipVertical } from './library/flip-vertical';
 export { default as formatBold } from './library/format-bold';

--- a/packages/icons/src/library/filter.js
+++ b/packages/icons/src/library/filter.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const filter = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M12 4 4 19h16L12 4zm0 3.2 5.5 10.3H12V7.2z" />
+	</SVG>
+);
+
+export default filter;


### PR DESCRIPTION
## What?

When no duotone filter is applied, an empty swatch icon is shown:

<img width="713" alt="before" src="https://user-images.githubusercontent.com/1204802/163969918-2e67c30c-cf48-48be-a2cb-4cba45413cd7.png">

This isn't immediately legible as related to duotone or filtering. This PR attempts a new icon, a 2 color triangle:
<img width="761" alt="new-icon-big" src="https://user-images.githubusercontent.com/1204802/163969993-317cd2e3-2feb-4a01-9a4e-93ffbe041c70.png">

![new-icon-small](https://user-images.githubusercontent.com/1204802/163970004-64efb800-5320-4d91-af04-bb09d65fe493.png)

<img width="718" alt="Screenshot 2022-04-19 at 10 47 50" src="https://user-images.githubusercontent.com/1204802/163970061-8d7dc539-6631-4c38-98a7-71c1284be887.png">

## Testing Instructions

Insert an image, and observe the new icon in the block toolbar for an unfiltered image.