### PR TITLE
Try: Simpler clear button.

### DIFF
--- a/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
+++ b/packages/block-editor/src/components/color-palette/test/__snapshots__/control.js.snap
@@ -231,7 +231,7 @@ exports[`ColorPaletteControl matches the snapshot 1`] = `
             >
               <button
                 aria-describedby={null}
-                className="components-button components-circular-option-picker__clear is-secondary is-small"
+                className="components-button components-circular-option-picker__clear is-tertiary"
                 onClick={[Function]}
                 type="button"
               >

--- a/packages/components/src/circular-option-picker/index.js
+++ b/packages/components/src/circular-option-picker/index.js
@@ -87,8 +87,7 @@ function ButtonAction( { className, children, ...additionalProps } ) {
 				'components-circular-option-picker__clear',
 				className
 			) }
-			isSmall
-			variant="secondary"
+			variant="tertiary"
 			{ ...additionalProps }
 		>
 			{ children }

--- a/packages/components/src/color-palette/test/__snapshots__/index.js.snap
+++ b/packages/components/src/color-palette/test/__snapshots__/index.js.snap
@@ -1186,13 +1186,12 @@ exports[`ColorPalette should render a dynamic toolbar of colors 1`] = `
                 >
                   <ForwardRef(Button)
                     className="components-circular-option-picker__clear"
-                    isSmall={true}
                     onClick={[Function]}
-                    variant="secondary"
+                    variant="tertiary"
                   >
                     <button
                       aria-describedby={null}
-                      className="components-button components-circular-option-picker__clear is-secondary is-small"
+                      className="components-button components-circular-option-picker__clear is-tertiary"
                       onClick={[Function]}
                       type="button"
                     >


### PR DESCRIPTION
## What?

The clear button looks a litte out of place, being small text in context of larger text:

<img width="345" alt="Screenshot 2022-04-19 at 11 10 34" src="https://user-images.githubusercontent.com/1204802/163970793-f4e43899-921a-428a-80f3-2bb50fd70260.png">

This PR changes the default appearance to be larger but have the same general footprint:

<img width="329" alt="Screenshot 2022-04-19 at 11 08 52" src="https://user-images.githubusercontent.com/1204802/163970859-5c0554b1-f5ce-4a8b-899e-b376dab70f72.png">

## Testing Instructions

This likely needs decent testing. The only instance of this specific clear button I was able to find, was inside the Image block duotone filter dropdown. But it's very probably used in more places. 
