### PR TITLE
Fix block toolbar text button padding.

### DIFF
--- a/packages/components/src/toolbar-group/style.scss
+++ b/packages/components/src/toolbar-group/style.scss
@@ -18,7 +18,7 @@
 
 	// Size multiple sequential buttons to be optically balanced.
 	// Icons are 36px, as set by a 24px icon and 12px padding.
-	.components-button,
+	.components-button.components-button, // This needs specificity to override padding values inherited from the button component.
 	.components-button.has-icon.has-icon {
 		min-width: $block-toolbar-height - $grid-unit-15;
 		padding-left: $grid-unit-15 * 0.5; // 6px.


### PR DESCRIPTION
## What?

Followup to #40379, this restores a little bit of specificity for text buttons in the block toolbar. The padding rules for text buttons there had too low specificity, and inherited paddings overrode it:

<img width="547" alt="before" src="https://user-images.githubusercontent.com/1204802/163972784-bd58f044-62ae-4eea-a1e1-12251305554d.png">

This PR adds a little specificity back:

<img width="553" alt="after" src="https://user-images.githubusercontent.com/1204802/163972803-77ce7314-59f4-47ee-b30a-be9ab0c8d3b4.png">

## Testing Instructions

Insert an image block and observe the correct 6px padding left and right on the "Replace" button in the block toolbar.