### PR TITLE
[Mobile] Quote - Use nested blocks

### DIFF
--- a/packages/block-library/src/index.native.js
+++ b/packages/block-library/src/index.native.js
@@ -179,14 +179,6 @@ const devOnly = ( block ) => ( !! __DEV__ ? block : null );
 const iOSOnly = ( block ) =>
 	Platform.OS === 'ios' ? block : devOnly( block );
 
-// To be removed once Quote V2 is released on the web editor.
-function quoteCheck( quoteBlock, blocksFlags ) {
-	if ( blocksFlags?.__experimentalEnableQuoteBlockV2 ) {
-		quoteBlock.settings = quoteBlock?.settingsV2;
-	}
-	return quoteBlock;
-}
-
 // Hide the Classic block and SocialLink block
 addFilter(
 	'blocks.registerBlockType',
@@ -238,10 +230,9 @@ addFilter(
  *
  * registerCoreBlocks();
  * ```
- * @param {Object} [blocksFlags] Experimental flags
  *
  */
-export const registerCoreBlocks = ( blocksFlags ) => {
+export const registerCoreBlocks = () => {
 	// When adding new blocks to this list please also consider updating /src/block-support/supported-blocks.json in the Gutenberg-Mobile repo
 	[
 		paragraph,
@@ -254,7 +245,7 @@ export const registerCoreBlocks = ( blocksFlags ) => {
 		nextpage,
 		separator,
 		list,
-		quoteCheck( quote, blocksFlags ),
+		quote,
 		mediaText,
 		preformatted,
 		gallery,

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -28,9 +28,7 @@ const unsupportedBlock = `
 jest.useFakeTimers( 'legacy' );
 
 describe( 'Editor', () => {
-	beforeAll( () => {
-		registerCoreBlocks();
-	} );
+	beforeAll( registerCoreBlocks );
 
 	it( 'detects unsupported block and sends hasUnsupportedBlocks true to native', () => {
 		RNReactNativeGutenbergBridge.editorDidMount = jest.fn();

--- a/packages/react-native-editor/src/setup.js
+++ b/packages/react-native-editor/src/setup.js
@@ -58,12 +58,9 @@ const gutenbergSetup = () => {
 
 const setupInitHooks = () => {
 	addAction( 'native.pre-render', 'core/react-native-editor', ( props ) => {
-		const capabilities = props.capabilities ?? {};
-		const blocksFlags = {
-			__experimentalEnableQuoteBlockV2: props?.quoteBlockV2,
-		};
+		registerBlocks();
 
-		registerBlocks( blocksFlags );
+		const capabilities = props.capabilities ?? {};
 
 		// Unregister non-supported blocks by capabilities
 		if (
@@ -119,12 +116,12 @@ const setupInitHooks = () => {
 };
 
 let blocksRegistered = false;
-const registerBlocks = ( blocksFlags ) => {
+const registerBlocks = () => {
 	if ( blocksRegistered ) {
 		return;
 	}
 
-	registerCoreBlocks( blocksFlags );
+	registerCoreBlocks();
 
 	blocksRegistered = true;
 };

--- a/packages/react-native-editor/src/test/index.test.js
+++ b/packages/react-native-editor/src/test/index.test.js
@@ -190,7 +190,8 @@ describe( 'Register Gutenberg', () => {
 			{},
 			{ component: EditorComponent }
 		);
-		const blockList = screen.getByTestId( 'block-list-wrapper' );
+		// Inner blocks create BlockLists so let's take into account selecting the main one
+		const blockList = screen.getAllByTestId( 'block-list-wrapper' )[ 0 ];
 
 		expect( blockList ).toBeVisible();
 		expect( console ).toHaveLoggedWith( 'Hermes is: true' );


### PR DESCRIPTION
## What?
This is a follow-up of https://github.com/WordPress/gutenberg/pull/40133 to remove some Quote block checks to support both versions.

## Why?
This PR https://github.com/WordPress/gutenberg/pull/25892 enables Quote V2 by default so these cheks are no longer needed.

## How?
By removing the extra checks.

## Testing Instructions

### Test case 1

- Open the mobile editor
- Add a Quote block
- Add some text
- Press the enter key to create a new Paragraph within the Quote block
- **Expect** to have two Paragraph blocks within the Quote block

### Test case 2

- Open the mobile editor
- Add a Quote block
- Add some text
- Open the block's settings
- Set some text and background colors
- **Expect** to see the block with the selected colors
- 
### Test case 3

- Open the mobile editor
- Add a Quote block
- Add some text
- Set an alignment for the Quote block
- **Expect** the text to be aligned with the selected setting

## Screenshots or screencast <!-- if applicable -->

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161292092-d693e075-3f8a-4b0b-b0a0-846e1550c059.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161292102-413304d1-44da-4755-afa5-7af310f7477c.gif" width="200" /></kbd>

### Quote block with text and background colors.

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161290859-35992203-1db6-470e-830b-57992144997b.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161290871-90f19a11-86b6-4172-a223-9e62107f42ac.png" width="200" /></kbd>

### Quote block with alignment set

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/161291027-59cdc1fb-d7a1-487a-bb2d-5f4f62e16afa.png" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/161291035-168f15ef-807c-443e-a7b9-40275470f29a.png" width="200" /></kbd>
