### PR TITLE
Add constants file to Spacer block

### DIFF
--- a/packages/block-library/src/spacer/constants.js
+++ b/packages/block-library/src/spacer/constants.js
@@ -1,0 +1,1 @@
+export const MIN_SPACER_SIZE = 0;

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -15,7 +15,7 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_SIZE } from './edit';
+import { MIN_SPACER_SIZE } from './constants';
 
 function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	const inputId = useInstanceId( UnitControl, 'block-spacer-height-input' );

--- a/packages/block-library/src/spacer/controls.native.js
+++ b/packages/block-library/src/spacer/controls.native.js
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { MIN_SPACER_SIZE } from './edit.js';
+import { MIN_SPACER_SIZE } from './constants';
 import styles from './style.scss';
 
 const DEFAULT_VALUES = { px: 100, em: 10, rem: 10, vw: 10, vh: 25 };

--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -15,8 +15,7 @@ import { View } from '@wordpress/primitives';
  * Internal dependencies
  */
 import SpacerControls from './controls';
-
-export const MIN_SPACER_SIZE = 0;
+import { MIN_SPACER_SIZE } from './constants';
 
 const ResizableSpacer = ( {
 	orientation,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add a constants file to the Spacer block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR originates as a follow-up of [this comment](https://github.com/WordPress/gutenberg/pull/40053#discussion_r851230469).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Creates a constants file (i.e. `constants.js`) and adds the `MIN_SPACER_SIZE` constant, so it can be accessed from both web and native versions of the Spacer block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
### Web version _(instructions extracted from https://github.com/WordPress/gutenberg/pull/39577)_
- insert a spacer block, play around by resizing it both by dragging the handle and by changing the value in the controls in the sidebar
- both methods of interacting with the spacer should avoid its width to go negative, but there shouldn't be any limit to how big the spacer can grow.

### Native version _(instructions extracted from https://github.com/WordPress/gutenberg/pull/40053)_
1. Open the app.
1. Create a post or page.
1. Add a Spacer block.
1. Open the block's settings.
1. Change the height value using the keyboard.
1. Observe that the height attribute is updated as expected and that no error is thrown.

## Screenshots or screencast <!-- if applicable -->
N/A