### PR TITLE
env :: support ssh protocol for github repos.

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## Unreleased
 
-## 4.2.1 (2022-05-07)
-
 ### Enhancement
--   Added support for ssh protocol.
+-   Added SSH protocol support for git sources
 
 ## 4.2.0 (2022-01-27)
 

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 4.2.1 (2022-05-07)
+
+### Enhancement
+-   Added support for ssh protocol.
+
 ## 4.2.0 (2022-01-27)
 
 ### Enhancement

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -460,12 +460,13 @@ _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PO
 
 Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 
-| Type              | Format                        | Example(s)                                               |
-| ----------------- | ----------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`            | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`   | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`      | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
-| ZIP File          | `http[s]://<host>/<path>.zip` | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
+| Type              | Format                             | Example(s)                                               |
+| ----------------- | ---------------------------------- | -------------------------------------------------------- |
+| Relative path     | `.<path>\|~<path>`                 | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`        | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| GitHub repository | `<owner>/<repo>[#<ref>]`           | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
+| SSH repository    | `user@host/<owner>/<repo>[#<ref>]` | `"git@github.com/WordPress/WordPress.git"`               |
+| ZIP File          | `http[s]://<host>/<path>.zip`      | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -460,13 +460,13 @@ _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PO
 
 Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 
-| Type              | Format                             | Example(s)                                               |
-| ----------------- | ---------------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`                 | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`        | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`           | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
-| SSH repository    | `user@host/<owner>/<repo>[#<ref>]` | `"git@github.com/WordPress/WordPress.git"`               |
-| ZIP File          | `http[s]://<host>/<path>.zip`      | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
+| Type              | Format                                 | Example(s)                                               |
+| ----------------- | -------------------------------------- | -------------------------------------------------------- |
+| Relative path     | `.<path>\|~<path>`                     | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`            | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| GitHub repository | `<owner>/<repo>[#<ref>]`               | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
+| SSH repository    | `user@host/<owner>/<repo>.git[#<ref>]` | `"git@github.com/WordPress/WordPress.git"`               |
+| ZIP File          | `http[s]://<host>/<path>.zip`          | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -460,13 +460,13 @@ _Note: the port number environment variables (`WP_ENV_PORT` and `WP_ENV_TESTS_PO
 
 Several types of strings can be passed into the `core`, `plugins`, `themes`, and `mappings` fields.
 
-| Type              | Format                                 | Example(s)                                               |
-| ----------------- | -------------------------------------- | -------------------------------------------------------- |
-| Relative path     | `.<path>\|~<path>`                     | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
-| Absolute path     | `/<path>\|<letter>:\<path>`            | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`               | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
-| SSH repository    | `user@host/<owner>/<repo>.git[#<ref>]` | `"git@github.com/WordPress/WordPress.git"`               |
-| ZIP File          | `http[s]://<host>/<path>.zip`          | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
+| Type              | Format                                       | Example(s)                                               |
+| ----------------- | -------------------------------------------- | -------------------------------------------------------- |
+| Relative path     | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
+| Absolute path     | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                   |
+| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
+| SSH repository    | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`         |
+| ZIP File          | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
 Remote sources will be downloaded into a temporary directory located in `~/.wp-env`.
 
@@ -474,22 +474,22 @@ Additionally, the key `env` is available to override any of the above options on
 
 ```json
 {
-  "plugins": ["."],
-  "config": {
-    "KEY_1": true,
-    "KEY_2": false
-  },
-  "env": {
-    "development": {
-      "themes": ["./one-theme"]
-    },
-    "tests": {
-      "config": {
-        "KEY_1": false
-      },
-      "port": 3000
-    }
-  }
+	"plugins": [ "." ],
+	"config": {
+		"KEY_1": true,
+		"KEY_2": false
+	},
+	"env": {
+		"development": {
+			"themes": [ "./one-theme" ]
+		},
+		"tests": {
+			"config": {
+				"KEY_1": false
+			},
+			"port": 3000
+		}
+	}
 }
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -474,22 +474,22 @@ Additionally, the key `env` is available to override any of the above options on
 
 ```json
 {
-	"plugins": [ "." ],
-	"config": {
-		"KEY_1": true,
-		"KEY_2": false
-	},
-	"env": {
-		"development": {
-			"themes": [ "./one-theme" ]
-		},
-		"tests": {
-			"config": {
-				"KEY_1": false
-			},
-			"port": 3000
-		}
-	}
+  "plugins": ["."],
+  "config": {
+    "KEY_1": true,
+    "KEY_2": false
+  },
+  "env": {
+    "development": {
+      "themes": ["./one-theme"]
+    },
+    "tests": {
+      "config": {
+        "KEY_1": false
+      },
+      "port": 3000
+    }
+  }
 }
 ```
 

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -114,6 +114,24 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
+	const sshProtocol = sourceString.match(
+		/^(git@github.com[^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?.git$/
+	);
+	if ( sshProtocol ) {
+		return {
+			type: 'git',
+			url: `${ sshProtocol[ 1 ] }/${ sshProtocol[ 2 ] }`,
+			ref: sshProtocol[ 5 ] || 'master',
+			path: path.resolve(
+				workDirectoryPath,
+				sshProtocol[ 2 ],
+				sshProtocol[ 4 ] || '.'
+			),
+			clonePath: path.resolve( workDirectoryPath, sshProtocol[ 2 ] ),
+			basename: sshProtocol[ 4 ] || sshProtocol[ 2 ],
+		};
+	}
+
 	const gitHubFields = sourceString.match(
 		/^([^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?$/
 	);

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -114,21 +114,29 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
-	const sshProtocol = sourceString.match(
-		/^(git@github.com[^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?.git$/
+	const sshRegEx = RegExp( ''
+	+ '('                               // 1. The git url
+	+ /(?:(?:git\+)?ssh:\/\/)?/.source  // ssh protocol (optional)
+	+ /(?:[^@]+)\@/.source              // username
+	+ /(?:[^\/]+)\//.source               // domain
+	+ /(.*)/.source                     // 2. path
+	+ /\/(.*\.git)/.source              // 3. repo
+	+ ')'
+	+ /(?:#(.*))?/.source               // 4. branch
 	);
-	if ( sshProtocol ) {
+	const sshFields = sourceString.match( sshRegEx );
+	if ( sshFields ) {
 		return {
 			type: 'git',
-			url: `${ sshProtocol[ 1 ] }/${ sshProtocol[ 2 ] }`,
-			ref: sshProtocol[ 5 ] || 'master',
+			url: `${ sshFields[ 1 ] }`,
+			ref: sshFields[ 4 ] || 'master',
 			path: path.resolve(
 				workDirectoryPath,
-				sshProtocol[ 2 ],
-				sshProtocol[ 4 ] || '.'
+				sshFields[ 2 ],
+				sshFields[ 3 ]
 			),
-			clonePath: path.resolve( workDirectoryPath, sshProtocol[ 2 ] ),
-			basename: sshProtocol[ 4 ] || sshProtocol[ 2 ],
+			clonePath: path.resolve( workDirectoryPath, sshFields[ 2 ] ),
+			basename: sshFields[ 3 ],
 		};
 	}
 

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -114,12 +114,22 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
+	/**
+	 * '(' +                              // 1. The git url
+	 * /(?:(?:git\+)?ssh:\/\/)?/.source + // ssh protocol (optional)
+	 * /(?:[^@]+)\@/.source +             // username
+	 * /(?:[^\/]+)\//.source +            // domain
+	 * /(.*)/.source +                    // 2. path
+	 * /\/(.*\.git)/.source +             // 3. repo
+	 * ')' +                              // end 1.
+	 * /(?:#(.*))?/.source                // 4. branch
+	 */
 	const sshRegEx = RegExp(
 		'' +
 			'(' + // 1. The git url
-			/(?:(?:git\+)?ssh:\/\/)?/.source + // ssh protocol (optional)
-			/(?:[^@]+)\@/.source + // username
-			/(?:[^\/]+)\//.source + // domain
+			/(?:(?:git\+)?ssh:\/\/)?/.source +
+			/(?:[^@]+)\@/.source +
+			/(?:[^\/]+)\//.source +
 			/(.*)/.source + // 2. path
 			/\/(.*\.git)/.source + // 3. repo
 			')' +

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -114,15 +114,16 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		};
 	}
 
-	const sshRegEx = RegExp( ''
-	+ '('                               // 1. The git url
-	+ /(?:(?:git\+)?ssh:\/\/)?/.source  // ssh protocol (optional)
-	+ /(?:[^@]+)\@/.source              // username
-	+ /(?:[^\/]+)\//.source               // domain
-	+ /(.*)/.source                     // 2. path
-	+ /\/(.*\.git)/.source              // 3. repo
-	+ ')'
-	+ /(?:#(.*))?/.source               // 4. branch
+	const sshRegEx = RegExp(
+		'' +
+			'(' + // 1. The git url
+			/(?:(?:git\+)?ssh:\/\/)?/.source + // ssh protocol (optional)
+			/(?:[^@]+)\@/.source + // username
+			/(?:[^\/]+)\//.source + // domain
+			/(.*)/.source + // 2. path
+			/\/(.*\.git)/.source + // 3. repo
+			')' +
+			/(?:#(.*))?/.source // 4. branch
 	);
 	const sshFields = sourceString.match( sshRegEx );
 	if ( sshFields ) {

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -1,0 +1,63 @@
+/**
+ * Internal dependencies
+ */
+ const { parseSourceString } = require( '../lib/config/parse-config' );
+ const path = require( 'path' );
+
+ const parseSourceStringOptions = { workDirectoryPath: '.' };
+ const currentDirectory = path.resolve( '.' );
+
+describe( 'parse-config', () => {
+    it( 'returns null for null source', () => {
+        const wpSource = parseSourceString( null, {} );
+        expect( wpSource ).toBeNull();
+    } );
+} );
+
+
+const gitTests = [
+    {
+        sourceString: 'git@github.com/owner/repo.git',
+        url: "git@github.com/owner/repo.git",
+        ref: 'master',
+        path: currentDirectory + '/owner/repo.git',
+        clonePath: currentDirectory + '/owner',
+        basename: 'repo.git'
+    },
+    {
+        sourceString: 'ssh://git@github.com/owner/repo.git',
+        url: "ssh://git@github.com/owner/repo.git",
+        ref: 'master',
+        path: currentDirectory + '/owner/repo.git',
+        clonePath: currentDirectory + '/owner',
+        basename: 'repo.git'
+    },
+    {
+        sourceString: 'git+ssh://git@github.com/owner/repo.git#kitchen-sink',
+        url: "git+ssh://git@github.com/owner/repo.git",
+        ref: 'kitchen-sink',
+        path: currentDirectory + '/owner/repo.git',
+        clonePath: currentDirectory + '/owner',
+        basename: 'repo.git'
+    },
+];
+
+describe.each( gitTests )( 'parse-config :: git', ( source ) => {
+	it( `parses ${source.sourceString}`, () => {
+        debugger;
+        const { 
+            type,
+            url,
+            ref,
+            path,
+            clonePath,
+            basename
+        } = parseSourceString( source.sourceString, parseSourceStringOptions );
+        expect( type ).toBe( 'git' );
+        expect( url ).toBe( source.url );
+        expect( ref ).toBe( source.ref );
+        expect( path ).toBe( source.path );
+        expect( clonePath ).toBe( source.clonePath );
+        expect( basename ).toBe( source.basename );
+	} );
+} );

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -11,7 +11,7 @@ const { parseSourceString } = require( '../lib/config/parse-config' );
 const parseSourceStringOptions = { workDirectoryPath: '.' };
 const currentDirectory = _path.resolve( '.' );
 
-describe( 'parse-config', () => {
+describe( 'parseSourceString', () => {
 	it( 'returns null for null source', () => {
 		const wpSource = parseSourceString( null, {} );
 		expect( wpSource ).toBeNull();
@@ -20,32 +20,32 @@ describe( 'parse-config', () => {
 
 const gitTests = [
 	{
-		sourceString: 'git@github.com/owner/repo.git',
-		url: 'git@github.com/owner/repo.git',
+		sourceString: 'ssh://git@github.com/short.git',
+		url: 'ssh://git@github.com/short.git',
 		ref: 'master',
-		path: currentDirectory + '/owner/repo.git',
-		clonePath: currentDirectory + '/owner',
-		basename: 'repo.git',
+		path: currentDirectory + '/short',
+		clonePath: currentDirectory + '/short',
+		basename: 'short',
 	},
 	{
 		sourceString: 'ssh://git@github.com/owner/long/path/repo.git',
 		url: 'ssh://git@github.com/owner/long/path/repo.git',
 		ref: 'master',
-		path: currentDirectory + '/owner/long/path/repo.git',
-		clonePath: currentDirectory + '/owner/long/path',
-		basename: 'repo.git',
+		path: currentDirectory + '/owner/long/path/repo',
+		clonePath: currentDirectory + '/owner/long/path/repo',
+		basename: 'repo',
 	},
 	{
 		sourceString: 'git+ssh://git@github.com/owner/repo.git#kitchen-sink',
 		url: 'git+ssh://git@github.com/owner/repo.git',
 		ref: 'kitchen-sink',
-		path: currentDirectory + '/owner/repo.git',
-		clonePath: currentDirectory + '/owner',
-		basename: 'repo.git',
+		path: currentDirectory + '/owner/repo',
+		clonePath: currentDirectory + '/owner/repo',
+		basename: 'repo',
 	},
 ];
 
-describe.each( gitTests )( 'parse-config :: git', ( source ) => {
+describe.each( gitTests )( 'parseSourceString', ( source ) => {
 	it( `parses ${ source.sourceString }`, () => {
 		const { type, url, ref, path, clonePath, basename } = parseSourceString(
 			source.sourceString,

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -28,11 +28,11 @@ const gitTests = [
 		basename: 'repo.git',
 	},
 	{
-		sourceString: 'ssh://git@github.com/owner/repo.git',
-		url: 'ssh://git@github.com/owner/repo.git',
+		sourceString: 'ssh://git@github.com/owner/long/path/repo.git',
+		url: 'ssh://git@github.com/owner/long/path/repo.git',
 		ref: 'master',
-		path: currentDirectory + '/owner/repo.git',
-		clonePath: currentDirectory + '/owner',
+		path: currentDirectory + '/owner/long/path/repo.git',
+		clonePath: currentDirectory + '/owner/long/path',
 		basename: 'repo.git',
 	},
 	{

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -1,11 +1,15 @@
 /**
+ * External dependencies
+ */
+const _path = require( 'path' );
+
+/**
  * Internal dependencies
  */
 const { parseSourceString } = require( '../lib/config/parse-config' );
-const path = require( 'path' );
 
 const parseSourceStringOptions = { workDirectoryPath: '.' };
-const currentDirectory = path.resolve( '.' );
+const currentDirectory = _path.resolve( '.' );
 
 describe( 'parse-config', () => {
 	it( 'returns null for null source', () => {
@@ -43,7 +47,6 @@ const gitTests = [
 
 describe.each( gitTests )( 'parse-config :: git', ( source ) => {
 	it( `parses ${ source.sourceString }`, () => {
-		debugger;
 		const { type, url, ref, path, clonePath, basename } = parseSourceString(
 			source.sourceString,
 			parseSourceStringOptions

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -1,63 +1,58 @@
 /**
  * Internal dependencies
  */
- const { parseSourceString } = require( '../lib/config/parse-config' );
- const path = require( 'path' );
+const { parseSourceString } = require( '../lib/config/parse-config' );
+const path = require( 'path' );
 
- const parseSourceStringOptions = { workDirectoryPath: '.' };
- const currentDirectory = path.resolve( '.' );
+const parseSourceStringOptions = { workDirectoryPath: '.' };
+const currentDirectory = path.resolve( '.' );
 
 describe( 'parse-config', () => {
-    it( 'returns null for null source', () => {
-        const wpSource = parseSourceString( null, {} );
-        expect( wpSource ).toBeNull();
-    } );
+	it( 'returns null for null source', () => {
+		const wpSource = parseSourceString( null, {} );
+		expect( wpSource ).toBeNull();
+	} );
 } );
 
-
 const gitTests = [
-    {
-        sourceString: 'git@github.com/owner/repo.git',
-        url: "git@github.com/owner/repo.git",
-        ref: 'master',
-        path: currentDirectory + '/owner/repo.git',
-        clonePath: currentDirectory + '/owner',
-        basename: 'repo.git'
-    },
-    {
-        sourceString: 'ssh://git@github.com/owner/repo.git',
-        url: "ssh://git@github.com/owner/repo.git",
-        ref: 'master',
-        path: currentDirectory + '/owner/repo.git',
-        clonePath: currentDirectory + '/owner',
-        basename: 'repo.git'
-    },
-    {
-        sourceString: 'git+ssh://git@github.com/owner/repo.git#kitchen-sink',
-        url: "git+ssh://git@github.com/owner/repo.git",
-        ref: 'kitchen-sink',
-        path: currentDirectory + '/owner/repo.git',
-        clonePath: currentDirectory + '/owner',
-        basename: 'repo.git'
-    },
+	{
+		sourceString: 'git@github.com/owner/repo.git',
+		url: 'git@github.com/owner/repo.git',
+		ref: 'master',
+		path: currentDirectory + '/owner/repo.git',
+		clonePath: currentDirectory + '/owner',
+		basename: 'repo.git',
+	},
+	{
+		sourceString: 'ssh://git@github.com/owner/repo.git',
+		url: 'ssh://git@github.com/owner/repo.git',
+		ref: 'master',
+		path: currentDirectory + '/owner/repo.git',
+		clonePath: currentDirectory + '/owner',
+		basename: 'repo.git',
+	},
+	{
+		sourceString: 'git+ssh://git@github.com/owner/repo.git#kitchen-sink',
+		url: 'git+ssh://git@github.com/owner/repo.git',
+		ref: 'kitchen-sink',
+		path: currentDirectory + '/owner/repo.git',
+		clonePath: currentDirectory + '/owner',
+		basename: 'repo.git',
+	},
 ];
 
 describe.each( gitTests )( 'parse-config :: git', ( source ) => {
-	it( `parses ${source.sourceString}`, () => {
-        debugger;
-        const { 
-            type,
-            url,
-            ref,
-            path,
-            clonePath,
-            basename
-        } = parseSourceString( source.sourceString, parseSourceStringOptions );
-        expect( type ).toBe( 'git' );
-        expect( url ).toBe( source.url );
-        expect( ref ).toBe( source.ref );
-        expect( path ).toBe( source.path );
-        expect( clonePath ).toBe( source.clonePath );
-        expect( basename ).toBe( source.basename );
+	it( `parses ${ source.sourceString }`, () => {
+		debugger;
+		const { type, url, ref, path, clonePath, basename } = parseSourceString(
+			source.sourceString,
+			parseSourceStringOptions
+		);
+		expect( type ).toBe( 'git' );
+		expect( url ).toBe( source.url );
+		expect( ref ).toBe( source.ref );
+		expect( path ).toBe( source.path );
+		expect( clonePath ).toBe( source.clonePath );
+		expect( basename ).toBe( source.basename );
 	} );
 } );


### PR DESCRIPTION
Add support for ssh strings in the @wordpress/env package sources. (A similar issue was discussed in #20325).

## What?
Adds URL parsing for ssh strings in `env` `parse-config` module (which returns a `WP_Source` object).

## Why?
Git parsing only supported HTTP (until this PR), but fails to pull/clone authenticated projects.

## How?
The git library already supports ssh; this change just implements parsing into a supported `WP_Source`.

## Testing Instructions
1. Add a ssh url to your `wp-env` enabled project. (e.g. `ssh://git@github.com/some/plugin.git`)
2. Run `<gutenberg-dir>/packages/env/bin/wp-env start`
3. Verify that your plugin was downloaded and enabled in the project.
