### PR TITLE
Post Comments Form Block: Mark as stable

### DIFF
--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -221,6 +221,7 @@ export const __experimentalGetCoreBlocks = () => [
 	commentsPaginationPrevious,
 
 	postComments,
+	postCommentsForm,
 	homeLink,
 	logInOut,
 	termDescription,
@@ -281,7 +282,6 @@ export const __experimentalRegisterExperimentalCoreBlocks = process.env
 							navigationArea,
 							postComment,
 							postCommentsCount,
-							postCommentsForm,
 							postCommentsLink,
 					  ]
 					: [] ),


### PR DESCRIPTION
## What?
Moves the Post Comments Form block out of the experimental section, and into the stable one.

## Why?
As we're promoting the Comments Query Loop block over the Post Comments block, we need the Post Comments Form block in order to allow users to continue to add comments when using the Comments Query Loop block. See https://github.com/WordPress/gutenberg/pull/40256#issuecomment-1099967144 for a more detailed explanation.

## How?
Well easy 😎 

## Testing Instructions
I'm not actually sure how to test this, since the Post Comments Form block is already available 🤔 
It seems like there's no corresponding setting at `/wp-admin/admin.php?page=gutenberg-experiments`.
