### PR TITLE
Increase fade intensity during spotlight mode

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -293,7 +293,7 @@
 
 // Spotlight mode. Fade out blocks unless they contain a selected block.
 .is-focus-mode .block-editor-block-list__block:not(.has-child-selected) {
-	opacity: 0.5;
+	opacity: 0.2;
 	transition: opacity 0.1s linear;
 	@include reduce-motion("transition");
 

--- a/packages/editor/src/components/post-title/style.scss
+++ b/packages/editor/src/components/post-title/style.scss
@@ -2,7 +2,7 @@
 	position: relative;
 
 	&.is-focus-mode {
-		opacity: 0.5;
+		opacity: 0.2;
 		transition: opacity 0.1s linear;
 		@include reduce-motion("transition");
 


### PR DESCRIPTION
Revisiting spotlight with cross-text selection and looking at increasing the intensity of the mode.