### PR TITLE
Comment template: Call `comment_class()` before recursing into child comments

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -38,7 +38,8 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		 * This is because comment_class() uses globals like
 		 * `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
 		 *
-		 * The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
+		 * The `false` parameter at the end means that we do NOT want the function
+		 * to `echo` the output but to return a string.
 		 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
 		 */
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -35,8 +35,8 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		/*
 		 * We need to create the CSS classes BEFORE recursing into the children.
-		 * This is because comment_class() uses globals like
-		 * `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
+		 * This is because comment_class() uses globals like `$comment_alt`
+		 * and `$comment_thread_alt` which are order-sensitive.
 		 *
 		 * The `false` parameter at the end means that we do NOT want the function
 		 * to `echo` the output but to return a string.

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -8,6 +8,8 @@
 /**
  * Function that recursively renders a list of nested comments.
  *
+ * @global int $comment_depth
+ *
  * @param WP_Comment[] $comments        The array of comments.
  * @param WP_Block     $block           Block instance.
  * @return string
@@ -31,6 +33,11 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		$children = $comment->get_children();
 
+		// We need to create the CSS classes BEFORE recursing into the children.
+		// This is because comment_class() uses globals like
+		// `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
+		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
+
 		// If the comment has children, recurse to create the HTML for the nested
 		// comments.
 		if ( ! empty( $children ) ) {
@@ -45,8 +52,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
 		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
-		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
-
 		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 	}
 

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -33,12 +33,14 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		$children = $comment->get_children();
 
-		// We need to create the CSS classes BEFORE recursing into the children.
-		// This is because comment_class() uses globals like
-		// `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
-		//
-		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
-		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+		/*
+		 * We need to create the CSS classes BEFORE recursing into the children.
+		 * This is because comment_class() uses globals like
+		 * `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
+		 *
+		 * The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
+		 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+		 */
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		// If the comment has children, recurse to create the HTML for the nested

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -36,6 +36,9 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 		// We need to create the CSS classes BEFORE recursing into the children.
 		// This is because comment_class() uses globals like
 		// `$comment_alt` and `$comment_thread_alt` which are order-sensitive.
+		//
+		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
+		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
 		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		// If the comment has children, recurse to create the HTML for the nested
@@ -50,8 +53,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$comment_depth -= 1;
 		}
 
-		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
-		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
 		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 	}
 


### PR DESCRIPTION
## What?
The `odd` and `even` CSS classes were not being applied correctly to the comments in the Comment Template.

I've moved the call to `comment_class()` to BEFORE we recurse into the children so that it's in line with how comments are being rendered in the WordPress core.


## Screenshots

I've added this CSS so that you can see the difference:

```css
.even { 
  background-color: aquamarine;
}

.odd {
  background-color: lightblue;
}

```

This is what the **core** comments look like. The colors alternate, regardless of the comment level:

<img width="349" alt="Screenshot 2022-04-19 at 20 11 09" src="https://user-images.githubusercontent.com/5417266/164127162-74e5c361-883c-4578-8d88-880a959d2081.png">


### Before (left) and after (right)

Comments rendered with the Comments Query Loop:

<span>
<img width="345" alt="Screenshot 2022-04-19 at 20 10 59" src="https://user-images.githubusercontent.com/5417266/164127392-89961ae2-0fee-459b-9cec-bf7e1d082008.png">

<img width="357" alt="Screenshot 2022-04-19 at 20 10 05" src="https://user-images.githubusercontent.com/5417266/164127402-71453e21-d4c8-4a93-bdf7-b24c441128bf.png">

</span>
