### PR TITLE
useBlockDisplayInformation: Return anchor for block variations

### DIFF
--- a/packages/block-editor/src/components/use-block-display-information/index.js
+++ b/packages/block-editor/src/components/use-block-display-information/index.js
@@ -19,6 +19,7 @@ import { store as blockEditorStore } from '../../store';
  * @property {string} title       Human-readable block type label.
  * @property {WPIcon} icon        Block type icon.
  * @property {string} description A detailed block type description.
+ * @property {string} anchor      HTML anchor.
  */
 
 /**
@@ -63,6 +64,7 @@ export default function useBlockDisplayInformation( clientId ) {
 				title: match.title || blockType.title,
 				icon: match.icon || blockType.icon,
 				description: match.description || blockType.description,
+				anchor: attributes?.anchor,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
## What?
Fixes #40456.

PR updates the `useBlockDisplayInformation` hook to return the block anchor for variations.

## Why?
Returned block information object shape should be the same for block variations.

## Testing Instructions
1. Open a Post or Page.
2. Create a Group block.
3. Set anchor.
4. Confirm it's displayed in the List View.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-04-20 at 09 23 10](https://user-images.githubusercontent.com/240569/164156314-3c206eaa-555f-42b8-9ba3-e78782847dff.png)

