### PR TITLE
[WIP] UnitRangeControl: Add combined unit and range control component

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1308,6 +1308,12 @@
 		"parent": "components"
 	},
 	{
+		"title": "UnitRangeControl",
+		"slug": "unit-range-control",
+		"markdown_source": "../packages/components/src/unit-range-control/README.md",
+		"parent": "components"
+	},
+	{
 		"title": "VStack",
 		"slug": "v-stack",
 		"markdown_source": "../packages/components/src/v-stack/README.md",

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -173,6 +173,7 @@ export {
 	useCustomUnits as __experimentalUseCustomUnits,
 	parseQuantityAndUnitFromRawValue as __experimentalParseQuantityAndUnitFromRawValue,
 } from './unit-control';
+export { UnitRangeControl as __experimentalUnitRangeControl } from './unit-range-control';
 export { View as __experimentalView } from './view';
 export { VisuallyHidden } from './visually-hidden';
 export { VStack as __experimentalVStack } from './v-stack';

--- a/packages/components/src/unit-range-control/README.md
+++ b/packages/components/src/unit-range-control/README.md
@@ -1,0 +1,34 @@
+#  UnitRangeControl
+
+<div class="callout callout-alert">
+This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
+</div>
+<br />
+This component combines a `UnitControl` and `RangeControl`
+
+## Development guidelines
+
+TBA
+
+## Usage
+
+```jsx
+import { __experimentalUnitRangeControl as UnitRangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const GapControl = () => {
+	const [ gap, setGap ] = useState();
+
+	return (
+		<UnitRangeControl
+			label={ __( 'Gap' ) }
+			onChange={ setGap }
+			value={ gap }
+		/>
+	);
+};
+```
+
+## Props
+
+TBA

--- a/packages/components/src/unit-range-control/component.tsx
+++ b/packages/components/src/unit-range-control/component.tsx
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import UnitControl from '../unit-control';
+import RangeControl from '../range-control';
+import { HStack } from '../h-stack';
+import { StyledLabel } from '../base-control/styles/base-control-styles';
+import { View } from '../view';
+import { VisuallyHidden } from '../visually-hidden';
+import { contextConnect, WordPressComponentProps } from '../ui/context';
+import { useUnitRangeControl } from './hook';
+
+import type { UnitRangeControlProps, LabelProps } from './types';
+
+const UnitRangeLabel = ( props: LabelProps ) => {
+	const { label, hideLabelFromVision } = props;
+
+	if ( ! label ) {
+		return null;
+	}
+
+	return hideLabelFromVision ? (
+		<VisuallyHidden as="label">{ label }</VisuallyHidden>
+	) : (
+		<StyledLabel>{ label }</StyledLabel>
+	);
+};
+
+const UnitRangeControl = (
+	props: WordPressComponentProps< UnitRangeControlProps, 'div' >,
+	forwardedRef: React.ForwardedRef< any >
+) => {
+	const {
+		hideLabelFromVision,
+		label,
+		unitControlProps,
+		rangeControlProps,
+		...otherProps
+	} = useUnitRangeControl( props );
+
+	return (
+		<View { ...otherProps } ref={ forwardedRef }>
+			<UnitRangeLabel
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+			<HStack spacing={ 3 }>
+				<UnitControl { ...unitControlProps } />
+				<RangeControl { ...rangeControlProps } />
+			</HStack>
+		</View>
+	);
+};
+
+const ConnectedUnitRangeControl = contextConnect(
+	UnitRangeControl,
+	'UnitRangeControl'
+);
+
+export default ConnectedUnitRangeControl;

--- a/packages/components/src/unit-range-control/hook.ts
+++ b/packages/components/src/unit-range-control/hook.ts
@@ -1,0 +1,69 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as styles from './styles';
+import { parseQuantityAndUnitFromRawValue } from '../unit-control';
+import { useContextSystem, WordPressComponentProps } from '../ui/context';
+import { useCx } from '../utils/hooks/use-cx';
+
+import type { UnitRangeControlProps } from './types';
+
+export function useUnitRangeControl(
+	props: WordPressComponentProps< UnitRangeControlProps, 'div' >
+) {
+	const {
+		className,
+		onChange,
+		value: valueWithUnit,
+		unitControlProps,
+		rangeControlProps,
+		...otherProps
+	} = useContextSystem( props, 'UnitRangeControl' );
+
+	const [ value, unit ] = parseQuantityAndUnitFromRawValue( valueWithUnit );
+
+	const onSliderChange = useCallback(
+		( newValue: string ) => onChange( `${ newValue }${ unit }` ),
+		[ onChange, unit ]
+	);
+
+	const cx = useCx();
+	const classes = useMemo( () => {
+		return cx( styles.unitRangeControl, className );
+	}, [ className, cx ] );
+
+	const unitControlClasses = useMemo( () => {
+		return cx( styles.unitControl, unitControlProps?.className );
+	}, [ cx, unitControlProps?.className ] );
+
+	const rangeControlClasses = useMemo( () => {
+		return cx( styles.rangeControl, rangeControlProps?.className );
+	}, [ cx, rangeControlProps?.className ] );
+
+	const defaultSliderStep = [ 'px', '%' ].includes( unit ) ? 1 : 0.1;
+
+	return {
+		...otherProps,
+		className: classes,
+		rangeControlProps: {
+			...rangeControlProps,
+			className: rangeControlClasses,
+			onChange: onSliderChange,
+			value,
+			withInputField: false,
+			step: rangeControlProps?.step || defaultSliderStep,
+		},
+		unitControlProps: {
+			...unitControlProps,
+			className: unitControlClasses,
+			onChange,
+			value: valueWithUnit,
+			step: unitControlProps?.step || defaultSliderStep,
+		},
+	};
+}

--- a/packages/components/src/unit-range-control/index.ts
+++ b/packages/components/src/unit-range-control/index.ts
@@ -1,0 +1,2 @@
+export { default as UnitRangeControl } from './component';
+export { useUnitRangeControl } from './hook';

--- a/packages/components/src/unit-range-control/stories/index.js
+++ b/packages/components/src/unit-range-control/stories/index.js
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import styled from '@emotion/styled';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { UnitRangeControl } from '../';
+
+export default {
+	title: 'Components (Experimental)/UnitRangeControl',
+	component: UnitRangeControl,
+};
+
+const _default = ( props ) => {
+	const [ value, setValue ] = useState();
+
+	return (
+		<WrapperView>
+			<UnitRangeControl
+				{ ...props }
+				label="Unit + Range Control"
+				onChange={ setValue }
+				value={ value }
+			/>
+		</WrapperView>
+	);
+};
+
+export const Default = _default.bind( {} );
+Default.args = {
+	unitControlProps: {},
+	rangeControlProps: {},
+};
+
+const WrapperView = styled.div`
+	max-width: 280px;
+`;

--- a/packages/components/src/unit-range-control/styles.ts
+++ b/packages/components/src/unit-range-control/styles.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { css } from '@emotion/react';
+import type { CSSProperties } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { StyledField } from '../base-control/styles/base-control-styles';
+import { Root as UnitControlWrapper } from '../unit-control/styles/unit-control-styles';
+
+export const unitRangeControl = css``;
+export const unitControl = css`
+	${ UnitControlWrapper } {
+		flex: 1;
+	}
+`;
+export const rangeControl = css`
+	flex: 1 1 50%;
+
+	${ StyledField } {
+		margin-bottom: 0;
+		font-size: 0;
+		display: flex;
+	}
+`;

--- a/packages/components/src/unit-range-control/test/index.js
+++ b/packages/components/src/unit-range-control/test/index.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { UnitRangeControl } from '../';
+
+const props = {
+	label: 'Unit + Range Control',
+	value: '10px',
+	onChange: jest.fn().mockImplementation( ( newValue ) => {
+		props.value = newValue;
+	} ),
+};
+
+const renderUnitRangeControl = ( customProps ) => {
+	return render( <UnitRangeControl { ...{ ...props, ...customProps } } /> );
+};
+
+const rerenderUnitRangeControl = ( rerender, customProps ) => {
+	return rerender( <UnitRangeControl { ...{ ...props, ...customProps } } /> );
+};
+
+describe( 'UnitRangeControl', () => {
+	describe( 'basic rendering', () => {
+		it( 'should render both unit and range controls', () => {
+			renderUnitRangeControl();
+
+			const label = screen.getByText( props.label );
+			const unitControl = screen.getByRole( 'spinbutton' );
+			const rangeControl = screen.getByRole( 'slider' );
+
+			expect( label ).toBeInTheDocument();
+			expect( unitControl ).toBeInTheDocument();
+			expect( rangeControl ).toBeInTheDocument();
+		} );
+
+		it( 'should hide label', () => {
+			renderUnitRangeControl( { hideLabelFromVision: true } );
+			const label = screen.getByText( props.label );
+
+			// As visually hidden labels are still included in the document
+			// and do not have `display: none` styling, we can't rely on
+			// `.toBeInTheDocument()` or `.toBeVisible()` assertions.
+			expect( label ).toHaveAttribute(
+				'data-wp-component',
+				'VisuallyHidden'
+			);
+		} );
+	} );
+
+	describe( 'unit control', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should pass through unit control props', () => {
+			renderUnitRangeControl( {
+				unitControlProps: { placeholder: 'Test' },
+			} );
+			const unitControl = screen.getByRole( 'spinbutton' );
+
+			expect( unitControl ).toHaveAttribute( 'placeholder', 'Test' );
+		} );
+
+		it( 'should update value via input and be reflected by slider', async () => {
+			const { rerender } = renderUnitRangeControl();
+			const unitControl = screen.getByRole( 'spinbutton' );
+			unitControl.focus();
+			fireEvent.change( unitControl, { target: { value: '100' } } );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith(
+				1,
+				'100px',
+				expect.anything()
+			);
+
+			// Ensure UnitControl reflects updated value.
+			rerenderUnitRangeControl( rerender );
+			const rangeControl = screen.getByRole( 'slider' );
+
+			expect( rangeControl.value ).toEqual( '100' );
+		} );
+	} );
+
+	describe( 'range control', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should pass through range control props', () => {
+			renderUnitRangeControl( { rangeControlProps: { max: 200 } } );
+			const rangeControl = screen.getByRole( 'slider' );
+
+			expect( rangeControl ).toHaveAttribute( 'max', '200' );
+		} );
+
+		it( 'should update value via slider and be reflected by unit control', async () => {
+			const { rerender } = renderUnitRangeControl();
+			const slider = screen.getByRole( 'slider' );
+			fireEvent.change( slider, { target: { value: '5' } } );
+
+			expect( props.onChange ).toHaveBeenNthCalledWith( 1, '5px' );
+
+			rerenderUnitRangeControl( rerender );
+			const unitControl = screen.getByRole( 'spinbutton' );
+
+			expect( unitControl.value ).toEqual( '5' );
+		} );
+	} );
+} );

--- a/packages/components/src/unit-range-control/types.ts
+++ b/packages/components/src/unit-range-control/types.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import type { CSSProperties } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { UnitControlProps } from '../unit-control/types';
+
+export type LabelProps = {
+	/**
+	 * Provides control over whether the label will only be visible to
+	 * screen readers.
+	 */
+	hideLabelFromVision?: boolean;
+	/**
+	 * If provided, a label will be generated using this as the content.
+	 */
+	label?: string;
+};
+
+// Once RangeControl has been converted to TypeScript, the following type
+// could be imported from that component.
+
+export type RangeMark = {
+	value: number;
+	label: string;
+};
+
+export type RangeControlProps = {
+	label?: string;
+	help?: string;
+	beforeIcon?: string;
+	afterIcon?: string;
+	allowReset?: boolean;
+	disabled?: boolean;
+	initialPosition?: number;
+	isShiftStepEnabled?: boolean;
+	marks?: RangeMark[] | boolean;
+	onChange: ( value?: number ) => void;
+	min?: number;
+	max?: number;
+	railColor?: string;
+	renderTooltipContent: ( value?: string ) => string;
+	resetFallbackValue?: number;
+	showTooltip?: boolean;
+	step?: number | 'any';
+	shiftStep?: number;
+	trackColor?: string;
+	value: number;
+	icon?: string;
+	separatorType?: 'none' | 'fullWidth' | 'topFullWidth';
+	type?: string;
+};
+
+export type UnitRangeControlProps = LabelProps & {
+	className?: string;
+	value?: string;
+	onChange: ( value?: string ) => void;
+	unitControlProps?: UnitControlProps & { className?: string; step?: number };
+	rangeControlProps?: RangeControlProps & { className?: string };
+};


### PR DESCRIPTION
## What?
Adds a new component combining and linking both a `UnitControl` and `RangeControl`.

## Why?
We have a number of controls in the editor sidebar that should also have a slider beside them. A standardized component combining these out of the box will help improve consistency and make updating sidebar controls easier.

## How?
Creates a new component that:
- Accepts an optional label that can also be visually hidden
- Wraps a `UnitControl` and `RangeControl` within a `HStack`
- Automatically parses numeric value for slider from supplied value
- Uses parsed unit to pass along `${ value }${ unit }` to `onChange` when slider changes

## Todo

- [ ] Try and find a better name for the component
- [ ] Finalize API - specifically what props we should allow to be passed through to the `UnitControl` or `RangeControl`
- [ ] Complete `README.md`
- [ ] Perhaps flesh out the unit tests more

## Testing Instructions

1. Check out this PR and spin up Storybook: `npm run storybook:dev`
2. Visit http://localhost:50240/?path=/story/components-experimental-unitrangecontrol--default
3. Test that the component works as you'd expect
4. Update the `UnitControl` or `RangeControl` props via the story's controls

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/164179891-261f5efa-c724-4d65-948d-201b9b054806.mp4


