### PR TITLE
Comment Template Unit Test: Cover odd/even classes

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -8,6 +8,8 @@
 /**
  * Function that recursively renders a list of nested comments.
  *
+ * @global int $comment_depth
+ *
  * @param WP_Comment[] $comments        The array of comments.
  * @param WP_Block     $block           Block instance.
  * @return string
@@ -31,6 +33,17 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		$children = $comment->get_children();
 
+		/*
+		 * We need to create the CSS classes BEFORE recursing into the children.
+		 * This is because comment_class() uses globals like `$comment_alt`
+		 * and `$comment_thread_alt` which are order-sensitive.
+		 *
+		 * The `false` parameter at the end means that we do NOT want the function
+		 * to `echo` the output but to return a string.
+		 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+		 */
+		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
+
 		// If the comment has children, recurse to create the HTML for the nested
 		// comments.
 		if ( ! empty( $children ) ) {
@@ -42,10 +55,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 			$comment_depth -= 1;
 		}
-
-		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
-		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
-		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 	}

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -8,8 +8,6 @@
 /**
  * Function that recursively renders a list of nested comments.
  *
- * @global int $comment_depth
- *
  * @param WP_Comment[] $comments        The array of comments.
  * @param WP_Block     $block           Block instance.
  * @return string
@@ -33,17 +31,6 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 
 		$children = $comment->get_children();
 
-		/*
-		 * We need to create the CSS classes BEFORE recursing into the children.
-		 * This is because comment_class() uses globals like `$comment_alt`
-		 * and `$comment_thread_alt` which are order-sensitive.
-		 *
-		 * The `false` parameter at the end means that we do NOT want the function
-		 * to `echo` the output but to return a string.
-		 * See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
-		 */
-		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
-
 		// If the comment has children, recurse to create the HTML for the nested
 		// comments.
 		if ( ! empty( $children ) ) {
@@ -55,6 +42,10 @@ function block_core_comment_template_render_comments( $comments, $block ) {
 			$block_content .= sprintf( '<ol>%1$s</ol>', $inner_content );
 			$comment_depth -= 1;
 		}
+
+		// The `false` parameter at the end means that we do NOT want the function to `echo` the output but to return a string.
+		// See https://developer.wordpress.org/reference/functions/comment_class/#parameters.
+		$comment_classes = comment_class( '', $comment->comment_ID, $comment->comment_post_ID, false );
 
 		$content .= sprintf( '<li id="comment-%1$s" %2$s>%3$s</li>', $comment->comment_ID, $comment_classes, $block_content );
 	}

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -187,7 +187,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		);
 
 		$top_level_ids = self::$comment_ids;
-		$expected = str_replace(
+		$expected      = str_replace(
 			array( "\n", "\t" ),
 			'',
 			<<<END
@@ -231,7 +231,9 @@ END
 		);
 
 		$this->assertEquals(
-			gutenberg_render_block_core_comment_template( null, null, $block ), $expected );
+			gutenberg_render_block_core_comment_template( null, null, $block ),
+			$expected
+		);
 	}
 	/**
 	 * Test that both "Older Comments" and "Newer Comments" are displayed in the correct order

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -186,10 +186,52 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertEquals(
-			gutenberg_render_block_core_comment_template( null, null, $block ),
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-odd thread-alt depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li id="comment-' . $first_level_ids[0] . '" class="comment even depth-2"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div><ol><li id="comment-' . $second_level_ids[0] . '" class="comment odd alt depth-3"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol></li></ol></li></ol>'
+		$top_level_ids = self::$comment_ids;
+		$expected = str_replace(
+			array( "\n", "\t" ),
+			'',
+			<<<END
+				<ol >
+					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
+						<div class="has-small-font-size wp-block-comment-author-name">
+							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+								Test
+							</a>
+						</div>
+						<div class="wp-block-comment-content">
+							Hello world
+						</div>
+						<ol>
+							<li id="comment-{$first_level_ids[0]}" class="comment even depth-2">
+								<div class="has-small-font-size wp-block-comment-author-name">
+									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+										Test
+									</a>
+								</div>
+								<div class="wp-block-comment-content">
+									Hello world
+								</div>
+								<ol>
+									<li id="comment-{$second_level_ids[0]}" class="comment odd alt depth-3">
+										<div class="has-small-font-size wp-block-comment-author-name">
+											<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+												Test
+											</a>
+										</div>
+										<div class="wp-block-comment-content">
+											Hello world
+										</div>
+									</li>
+								</ol>
+							</li>
+						</ol>
+					</li>
+				</ol>
+END
 		);
+
+		$this->assertEquals(
+			gutenberg_render_block_core_comment_template( null, null, $block ), $expected );
 	}
 	/**
 	 * Test that both "Older Comments" and "Newer Comments" are displayed in the correct order

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -144,11 +144,12 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering nested comments:
+	 * Test rendering nested comments, and for correct odd/even classes.
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
 	 *       └─ comment 4
+	 *       └─ comment 5
 	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
@@ -166,7 +167,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		$second_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			1,
+			2,
 			array(
 				'comment_parent'       => $first_level_ids[0],
 				'comment_author'       => 'Test',
@@ -223,9 +224,19 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 											Hello world
 										</div>
 									</li>
+									<li id="comment-{$second_level_ids[1]}" class="comment even alt depth-3">
+										<div class="has-small-font-size wp-block-comment-author-name">
+											<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+												Test
+											</a>
+										</div>
+										<div class="wp-block-comment-content">
+											Hello world
+										</div>
+									</li>
 								</ol>
 							</li>
-							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
+							<li id="comment-{$first_level_ids[1]}" class="comment odd depth-2">
 								<div class="has-small-font-size wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -225,6 +225,16 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 									</li>
 								</ol>
 							</li>
+							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
+								<div class="has-small-font-size wp-block-comment-author-name">
+									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+										Test
+									</a>
+								</div>
+								<div class="wp-block-comment-content">
+									Hello world
+								</div>
+							</li>
 						</ol>
 					</li>
 				</ol>

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -148,13 +148,14 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
-	 *       └─ comment 3
 	 *       └─ comment 4
+	 *       └─ comment 5
+	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
 		$first_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			1,
+			2,
 			array(
 				'comment_parent'       => self::$comment_ids[0],
 				'comment_author'       => 'Test',
@@ -234,6 +235,16 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 										</div>
 									</li>
 								</ol>
+							</li>
+							<li id="comment-{$first_level_ids[1]}" class="comment odd depth-2">
+								<div class="has-small-font-size wp-block-comment-author-name">
+									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+										Test
+									</a>
+								</div>
+								<div class="wp-block-comment-content">
+									Hello world
+								</div>
 							</li>
 						</ol>
 					</li>

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -144,12 +144,11 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering nested comments, and for correct odd/even classes.
+	 * Test rendering nested comments:
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
 	 *       └─ comment 4
-	 *       └─ comment 5
 	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
@@ -167,7 +166,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		$second_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			2,
+			1,
 			array(
 				'comment_parent'       => $first_level_ids[0],
 				'comment_author'       => 'Test',
@@ -224,19 +223,9 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 											Hello world
 										</div>
 									</li>
-									<li id="comment-{$second_level_ids[1]}" class="comment even alt depth-3">
-										<div class="has-small-font-size wp-block-comment-author-name">
-											<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
-												Test
-											</a>
-										</div>
-										<div class="wp-block-comment-content">
-											Hello world
-										</div>
-									</li>
 								</ol>
 							</li>
-							<li id="comment-{$first_level_ids[1]}" class="comment odd depth-2">
+							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
 								<div class="has-small-font-size wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -148,14 +148,13 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
+	 *       └─ comment 3
 	 *       └─ comment 4
-	 *       └─ comment 5
-	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
 		$first_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			2,
+			1,
 			array(
 				'comment_parent'       => self::$comment_ids[0],
 				'comment_author'       => 'Test',
@@ -235,16 +234,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 										</div>
 									</li>
 								</ol>
-							</li>
-							<li id="comment-{$first_level_ids[1]}" class="comment odd depth-2">
-								<div class="has-small-font-size wp-block-comment-author-name">
-									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
-										Test
-									</a>
-								</div>
-								<div class="wp-block-comment-content">
-									Hello world
-								</div>
 							</li>
 						</ol>
 					</li>

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -144,16 +144,17 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering 3 nested comments:
+	 * Test rendering nested comments:
 	 *
 	 * └─ comment 1
 	 *    └─ comment 2
-	 *       └─ comment 3
+	 *       └─ comment 4
+	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
 		$first_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			1,
+			2,
 			array(
 				'comment_parent'       => self::$comment_ids[0],
 				'comment_author'       => 'Test',

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -144,17 +144,17 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering nested comments, and for correct odd/even classes.
+	 * Test rendering nested comments:
 	 *
 	 * └─ comment 1
-	 * └─ comment 2
-	 *    └─ comment 3
+	 *    └─ comment 2
 	 *       └─ comment 4
+	 *    └─ comment 3
 	 */
 	function test_rendering_comment_template_nested() {
 		$first_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			1,
+			2,
 			array(
 				'comment_parent'       => self::$comment_ids[0],
 				'comment_author'       => 'Test',
@@ -193,17 +193,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			'',
 			<<<END
 				<ol >
-					<li id="comment-{$top_level_ids[0]}" class="comment even depth-2">
-						<div class="has-small-font-size wp-block-comment-author-name">
-							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
-								Test
-							</a>
-						</div>
-						<div class="wp-block-comment-content">
-							Hello world
-						</div>
-					</li>
-					<li id="comment-{$top_level_ids[1]}" class="comment odd alt thread-odd thread-alt depth-1">
+					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
 						<div class="has-small-font-size wp-block-comment-author-name">
 							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 								Test
@@ -234,6 +224,16 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 										</div>
 									</li>
 								</ol>
+							</li>
+							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
+								<div class="has-small-font-size wp-block-comment-author-name">
+									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+										Test
+									</a>
+								</div>
+								<div class="wp-block-comment-content">
+									Hello world
+								</div>
 							</li>
 						</ol>
 					</li>

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -144,17 +144,17 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test rendering nested comments:
+	 * Test rendering nested comments, and for correct odd/even classes.
 	 *
 	 * └─ comment 1
-	 *    └─ comment 2
-	 *       └─ comment 4
+	 * └─ comment 2
 	 *    └─ comment 3
+	 *       └─ comment 4
 	 */
 	function test_rendering_comment_template_nested() {
 		$first_level_ids = self::factory()->comment->create_post_comments(
 			self::$custom_post->ID,
-			2,
+			1,
 			array(
 				'comment_parent'       => self::$comment_ids[0],
 				'comment_author'       => 'Test',
@@ -193,7 +193,17 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			'',
 			<<<END
 				<ol >
-					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
+					<li id="comment-{$top_level_ids[0]}" class="comment even depth-2">
+						<div class="has-small-font-size wp-block-comment-author-name">
+							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
+								Test
+							</a>
+						</div>
+						<div class="wp-block-comment-content">
+							Hello world
+						</div>
+					</li>
+					<li id="comment-{$top_level_ids[1]}" class="comment odd alt thread-odd thread-alt depth-1">
 						<div class="has-small-font-size wp-block-comment-author-name">
 							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 								Test
@@ -224,16 +234,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 										</div>
 									</li>
 								</ol>
-							</li>
-							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
-								<div class="has-small-font-size wp-block-comment-author-name">
-									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
-										Test
-									</a>
-								</div>
-								<div class="wp-block-comment-content">
-									Hello world
-								</div>
 							</li>
 						</ol>
 					</li>


### PR DESCRIPTION
## What?
Add a unit test to cover the Comment Template block's `even`/`odd` behavior (i.e. add coverage for #40455).

## Why?
Cover against regressions of #40455.

## How?
By changing our nested test comments in a way that allows us to detect if odd/even classes are applied correctly.

## Testing Instructions
- Verify that PHP unit tests are green in CI.
- Locally, with this branch checked out, revert [caf7b7d](https://github.com/WordPress/gutenberg/commit/caf7b7dcfd4b901fad595d69e3a17a18a89db4dd), rebuild GB, and run `npm run test-unit-php`. The test should fail now. Here's [proof](https://github.com/WordPress/gutenberg/runs/6134795908?check_suite_focus=true) from a previous CI run.
