### PR TITLE
Tests: Fix escaping for error message in create block test

### DIFF
--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -58,7 +58,7 @@ fi
 expected=6
 actual=$( find src -maxdepth 1 -type f | wc -l )
 if [ "$expected" -ne "$actual" ]; then
-	error "Expected $expected files in the `src` directory, but found $actual."
+	error "Expected $expected files in the \`src\` directory, but found $actual."
     exit 1
 fi
 
@@ -72,7 +72,7 @@ status "Verifying build..."
 expected=5
 actual=$( find build -maxdepth 1 -type f | wc -l )
 if [ "$expected" -ne "$actual" ]; then
-	error "Expected $expected files in the `build` directory, but found $actual."
+	error "Expected $expected files in the \`build\` directory, but found $actual."
     exit 1
 fi
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?
<!-- In a few words, what is the PR actually doing? -->

Addresses the issue raised by @mcsf in https://github.com/WordPress/gutenberg/pull/39049#discussion_r839621496:

> In sh and bash, backticks are the old way to represent command substitution. Which means that the line above actually evals as:
> 
> ```sh
> error "Expected $expected files in the $(src) directory ..."
> ```
> 
> which will invoke `src` as a command that it will try to find in `$PATH`, which will either fail or do something that we don't want.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

> The fix should be to escape:
> 
> ```sh
> error "Expected $expected files in the \`src\` directory, but found $actual."
> ```
> 
> The same applies for this other occurrence in the file:
> 
> ```sh
> error "Expected $expected files in the `build` directory, but found $actual."
> ```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

CI should still pass. You can test it locally by changing `bin/test-create-block.sh` in a way that prints the modified error.