### PR TITLE
Expand the number of taxonomy items the query block query controls fetch

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/taxonomy-controls.js
@@ -38,9 +38,19 @@ function TaxonomyControls( { onChange, query } ) {
 	const taxonomiesInfo = useSelect(
 		( select ) => {
 			const { getEntityRecords } = select( coreStore );
-			const termsQuery = { per_page: MAX_FETCHED_TERMS };
 			const _taxonomiesInfo = taxonomies?.map( ( { slug, name } ) => {
-				const _terms = getEntityRecords( 'taxonomy', slug, termsQuery );
+				let _terms = [];
+				// When _terms is a multiple of MAX_FETCHED_TERMS, a full page has been returned
+				for ( let page = 1; _terms % MAX_FETCHED_TERMS === 0; page++ ) {
+					const termsQuery = { per_page: MAX_FETCHED_TERMS, page };
+					const termsPage = getEntityRecords(
+						'taxonomy',
+						slug,
+						termsQuery
+					);
+					if ( ! termsPage?.length ) break;
+					_terms = [ ..._terms, ...termsPage ];
+				}
 				return {
 					slug,
 					name,


### PR DESCRIPTION
## What?
This PR expands the number of taxonomy items that the query block query controls brings through.

## Why?
Fixes #40474. Previously, only 100 items per taxonomy were being brought through. If, for example, you had more than 100 tags, it was impossible to select the tags that weren't being brought in.

## How?
The select was changed to bring in multiple pages using a loop.

## Testing Instructions
1. Create more than 100 tags.
2. Try to add all of them to a post.
3. Successfully able to see more than 100 tags in the suggestions.
