### PR TITLE
[RNMobile] Fix issues related to editing text and dragging gesture

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -319,28 +319,14 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		wasBeingDragged.current = isBeingDragged;
 	}, [ isBeingDragged ] );
 
-	const onFocusAztec = useCallback( () => {
-		setIsEditingText( true );
+	const onFocusChangeAztec = useCallback( ( { isFocused } ) => {
+		setIsEditingText( isFocused );
 	}, [] );
-
-	const onBlurAztec = useCallback( () => {
-		setIsEditingText( false );
-	}, [] );
-
-	const registerAztecListeners = () => {
-		RCTAztecView.InputState.addFocusListener( onFocusAztec );
-		RCTAztecView.InputState.addBlurListener( onBlurAztec );
-	};
-
-	const unregisterAztecListeners = () => {
-		RCTAztecView.InputState.removeFocusListener( onFocusAztec );
-		RCTAztecView.InputState.removeBlurListener( onBlurAztec );
-	};
 
 	useEffect( () => {
-		registerAztecListeners();
+		RCTAztecView.InputState.addFocusChangeListener( onFocusChangeAztec );
 		return () => {
-			unregisterAztecListeners();
+			RCTAztecView.InputState.removeFocusListener( onFocusChangeAztec );
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -335,6 +335,11 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		};
 	}, [] );
 
+	const onLongPressDraggable = useCallback( () => {
+		// Ensure that no text input is focused when starting the dragging gesture in order to prevent conflicts with text editing.
+		RCTAztecView.InputState.blurCurrentFocusedElement();
+	}, [] );
+
 	const animatedWrapperStyles = useAnimatedStyle( () => {
 		return {
 			opacity: draggingAnimation.opacity.value,
@@ -365,10 +370,7 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 					: DEFAULT_LONG_PRESS_MIN_DURATION,
 				android: DEFAULT_LONG_PRESS_MIN_DURATION,
 			} ) }
-			onLongPress={ () => {
-				// Ensure that no text input is focused when starting the dragging gesture in order to prevent conflicts with text editing.
-				RCTAztecView.InputState.blurCurrentFocusedElement();
-			} }
+			onLongPress={ onLongPressDraggable }
 		>
 			<Animated.View style={ wrapperStyles }>
 				{ children( { isDraggable: true } ) }

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -374,6 +374,10 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 					: DEFAULT_LONG_PRESS_MIN_DURATION,
 				android: DEFAULT_LONG_PRESS_MIN_DURATION,
 			} ) }
+			onLongPress={ () => {
+				// Ensure that no text input is focused when starting the dragging gesture in order to prevent conflicts with text editing.
+				RCTAztecView.InputState.blurCurrentFocusedElement();
+			} }
 		>
 			<Animated.View style={ wrapperStyles }>
 				{ children( { isDraggable: true } ) }

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -326,7 +326,9 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 	useEffect( () => {
 		RCTAztecView.InputState.addFocusChangeListener( onFocusChangeAztec );
 		return () => {
-			RCTAztecView.InputState.removeFocusListener( onFocusChangeAztec );
+			RCTAztecView.InputState.removeFocusChangeListener(
+				onFocusChangeAztec
+			);
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -12,16 +12,22 @@ import Animated, {
 	ZoomInEasyDown,
 	ZoomOutEasyDown,
 } from 'react-native-reanimated';
-import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
 /**
  * WordPress dependencies
  */
 import { Draggable, DraggableTrigger } from '@wordpress/components';
 import { select, useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef, useState, Platform } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	Platform,
+} from '@wordpress/element';
 import { getBlockType } from '@wordpress/blocks';
 import { generateHapticFeedback } from '@wordpress/react-native-bridge';
+import RCTAztecView from '@wordpress/react-native-aztec';
 
 /**
  * Internal dependencies
@@ -256,6 +262,9 @@ const BlockDraggableWrapper = ( { children } ) => {
  */
 const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 	const wasBeingDragged = useRef( false );
+	const [ isEditingText, setIsEditingText ] = useState(
+		RCTAztecView.InputState.isFocused()
+	);
 
 	const draggingAnimation = {
 		opacity: useSharedValue( 1 ),
@@ -275,27 +284,25 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		);
 	};
 
-	const { isDraggable, isBeingDragged, canDragBlock } = useSelect(
+	const { isDraggable, isBeingDragged, isBlockSelected } = useSelect(
 		( _select ) => {
 			const {
 				getBlockRootClientId,
 				getTemplateLock,
 				isBlockBeingDragged,
-				hasSelectedBlock,
+				getSelectedBlockClientId,
 			} = _select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 			const templateLock = rootClientId
 				? getTemplateLock( rootClientId )
 				: null;
-			const isAnyTextInputFocused =
-				TextInputState.currentlyFocusedInput() !== null;
+			const selectedBlockClientId = getSelectedBlockClientId();
 
 			return {
 				isBeingDragged: isBlockBeingDragged( clientId ),
 				isDraggable: 'all' !== templateLock,
-				canDragBlock: hasSelectedBlock()
-					? ! isAnyTextInputFocused
-					: true,
+				isBlockSelected:
+					selectedBlockClientId && selectedBlockClientId === clientId,
 			};
 		},
 		[ clientId ]
@@ -312,6 +319,31 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		wasBeingDragged.current = isBeingDragged;
 	}, [ isBeingDragged ] );
 
+	const onFocusAztec = useCallback( () => {
+		setIsEditingText( true );
+	}, [] );
+
+	const onBlurAztec = useCallback( () => {
+		setIsEditingText( false );
+	}, [] );
+
+	const registerAztecListeners = () => {
+		RCTAztecView.InputState.addFocusListener( onFocusAztec );
+		RCTAztecView.InputState.addBlurListener( onBlurAztec );
+	};
+
+	const unregisterAztecListeners = () => {
+		RCTAztecView.InputState.removeFocusListener( onFocusAztec );
+		RCTAztecView.InputState.removeBlurListener( onBlurAztec );
+	};
+
+	useEffect( () => {
+		registerAztecListeners();
+		return () => {
+			unregisterAztecListeners();
+		};
+	}, [] );
+
 	const animatedWrapperStyles = useAnimatedStyle( () => {
 		return {
 			opacity: draggingAnimation.opacity.value,
@@ -321,6 +353,8 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 		animatedWrapperStyles,
 		styles[ 'draggable-wrapper__container' ],
 	];
+
+	const canDragBlock = enabled && ( ! isBlockSelected || ! isEditingText );
 
 	if ( ! isDraggable ) {
 		return children( { isDraggable: false } );

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -291,6 +291,7 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 				getTemplateLock,
 				isBlockBeingDragged,
 				getSelectedBlockClientId,
+				hasSelectedInnerBlock,
 			} = _select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 			const templateLock = rootClientId
@@ -302,7 +303,9 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 				isBeingDragged: isBlockBeingDragged( clientId ),
 				isDraggable: 'all' !== templateLock,
 				isBlockSelected:
-					selectedBlockClientId && selectedBlockClientId === clientId,
+					selectedBlockClientId &&
+					( selectedBlockClientId === clientId ||
+						hasSelectedInnerBlock( clientId, true ) ),
 			};
 		},
 		[ clientId ]

--- a/packages/react-native-aztec/CHANGELOG.md
+++ b/packages/react-native-aztec/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 -   [*] Bump Aztec-Android version to v1.5.1 [#36861]
+-   [*] Add text input state to Aztec view [#40480]
 
 ## 1.50.0
 -   [*] Block split/merge fix for a (never shipped) regression (Android only) [#29683]

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
+
+const focusListeners = [];
+const blurListeners = [];
+
+let currentFocusedElement = null;
+
+export const addFocusListener = ( listener ) => {
+	focusListeners.push( listener );
+};
+
+export const addBlurListener = ( listener ) => {
+	blurListeners.push( listener );
+};
+
+export const removeFocusListener = ( listener ) => {
+	const itemIndex = focusListeners.indexOf( listener );
+	if ( itemIndex !== -1 ) {
+		focusListeners.splice( itemIndex, 1 );
+	}
+};
+
+export const removeBlurListener = ( listener ) => {
+	const itemIndex = blurListeners.indexOf( listener );
+	if ( itemIndex !== -1 ) {
+		blurListeners.splice( itemIndex, 1 );
+	}
+};
+
+export const isFocused = () => {
+	return currentFocusedElement !== null;
+};
+
+export const getCurrentFocusedElement = () => {
+	return currentFocusedElement;
+};
+
+export const notifyFocus = ( element ) => {
+	currentFocusedElement = element;
+
+	focusListeners.forEach( ( listener ) => {
+		listener( element );
+	} );
+};
+
+export const notifyBlur = ( element ) => {
+	currentFocusedElement = null;
+
+	blurListeners.forEach( ( listener ) => {
+		listener( element );
+	} );
+};
+
+export const focus = ( element ) => {
+	TextInputState.focusTextInput( element );
+};
+
+export const blur = ( element ) => {
+	TextInputState.blurTextInput( element );
+};
+
+export const blurCurrentFocusedElement = () => {
+	if ( isFocused() ) {
+		blur( getCurrentFocusedElement() );
+	}
+};

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -3,19 +3,36 @@
  */
 import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
+/** @typedef {import('@wordpress/element').RefObject} RefObject */
+
 const focusListeners = [];
 const blurListeners = [];
 
 let currentFocusedElement = null;
 
+/**
+ * Adds a listener that will be called when any Aztec view is focused.
+ *
+ * @param {Function} listener
+ */
 export const addFocusListener = ( listener ) => {
 	focusListeners.push( listener );
 };
 
+/**
+ * Adds a listener that will be called when any Aztec view is unfocused.
+ *
+ * @param {Function} listener
+ */
 export const addBlurListener = ( listener ) => {
 	blurListeners.push( listener );
 };
 
+/**
+ * Removes a listener from the focus listeners list.
+ *
+ * @param {Function} listener
+ */
 export const removeFocusListener = ( listener ) => {
 	const itemIndex = focusListeners.indexOf( listener );
 	if ( itemIndex !== -1 ) {
@@ -23,6 +40,11 @@ export const removeFocusListener = ( listener ) => {
 	}
 };
 
+/**
+ * Removes a listener from the blur listeners list.
+ *
+ * @param {Function} listener
+ */
 export const removeBlurListener = ( listener ) => {
 	const itemIndex = blurListeners.indexOf( listener );
 	if ( itemIndex !== -1 ) {
@@ -30,14 +52,29 @@ export const removeBlurListener = ( listener ) => {
 	}
 };
 
+/**
+ * Determines if any Aztec view is focused.
+ *
+ * @return {boolean} True if focused.
+ */
 export const isFocused = () => {
 	return currentFocusedElement !== null;
 };
 
+/**
+ * Returns the current focused element.
+ *
+ * @return {RefObject} Ref of the current focused element or `null` otherwise.
+ */
 export const getCurrentFocusedElement = () => {
 	return currentFocusedElement;
 };
 
+/**
+ * Notifies that an Aztec view is being focused.
+ *
+ * @param {RefObject} element Aztec view being focused.
+ */
 export const notifyFocus = ( element ) => {
 	currentFocusedElement = element;
 
@@ -46,6 +83,11 @@ export const notifyFocus = ( element ) => {
 	} );
 };
 
+/**
+ * Notifies that an Aztec view is being unfocused.
+ *
+ * @param {RefObject} element Aztec view being unfocused.
+ */
 export const notifyBlur = ( element ) => {
 	currentFocusedElement = null;
 
@@ -54,14 +96,27 @@ export const notifyBlur = ( element ) => {
 	} );
 };
 
+/**
+ * Focuses the specified element.
+ *
+ * @param {RefObject} element Element to be focused.
+ */
 export const focus = ( element ) => {
 	TextInputState.focusTextInput( element );
 };
 
+/**
+ * Unfocuses the specified element.
+ *
+ * @param {RefObject} element Element to be unfocused.
+ */
 export const blur = ( element ) => {
 	TextInputState.blurTextInput( element );
 };
 
+/**
+ * Unfocuses the current focused element.
+ */
 export const blurCurrentFocusedElement = () => {
 	if ( isFocused() ) {
 		blur( getCurrentFocusedElement() );

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -65,12 +65,15 @@ export const getCurrentFocusedElement = () => {
 export const notifyInputChange = () => {
 	const focusedInput = TextInputState.currentlyFocusedInput();
 	const hasAnyFocusedInput = focusedInput !== null;
-	if ( hasAnyFocusedInput && ! currentFocusedElement ) {
-		notifyListeners( { isFocused: true } );
+
+	if ( hasAnyFocusedInput ) {
+		if ( ! currentFocusedElement ) {
+			notifyListeners( { isFocused: true } );
+		}
 		currentFocusedElement = focusedInput;
-	} else if ( ! hasAnyFocusedInput && currentFocusedElement ) {
-		currentFocusedElement = null;
+	} else if ( currentFocusedElement ) {
 		notifyListeners( { isFocused: false } );
+		currentFocusedElement = null;
 	}
 };
 

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -35,6 +35,12 @@ export const removeFocusChangeListener = ( listener ) => {
 	}
 };
 
+/**
+ *	Notifies listeners about changes in focus.
+ *
+ * @param {Object}  event           Event data to be notified to listeners.
+ * @param {boolean} event.isFocused True if any Aztec view is currently focused.
+ */
 const notifyListeners = ( { isFocused } ) => {
 	focusChangeListeners.forEach( ( listener ) => {
 		listener( { isFocused } );

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -7,12 +7,17 @@ import {
 	TouchableWithoutFeedback,
 	Platform,
 } from 'react-native';
-import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
+
 /**
  * WordPress dependencies
  */
 import { Component, createRef } from '@wordpress/element';
 import { ENTER, BACKSPACE } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import * as AztecInputState from './AztecInputState';
 
 const AztecManager = UIManager.getViewManagerConfig( 'RCTAztecView' );
 
@@ -117,6 +122,8 @@ class AztecView extends Component {
 	}
 
 	_onFocus( event ) {
+		AztecInputState.notifyFocus( this.aztecViewRef.current );
+
 		if ( ! this.props.onFocus ) {
 			return;
 		}
@@ -127,7 +134,9 @@ class AztecView extends Component {
 
 	_onBlur( event ) {
 		this.selectionEndCaretY = null;
-		TextInputState.blurTextInput( this.aztecViewRef.current );
+
+		AztecInputState.blur( this.aztecViewRef.current );
+		AztecInputState.notifyBlur( this.aztecViewRef.current );
 
 		if ( ! this.props.onBlur ) {
 			return;
@@ -179,16 +188,16 @@ class AztecView extends Component {
 	}
 
 	blur() {
-		TextInputState.blurTextInput( this.aztecViewRef.current );
+		AztecInputState.blur( this.aztecViewRef.current );
 	}
 
 	focus() {
-		TextInputState.focusTextInput( this.aztecViewRef.current );
+		AztecInputState.focus( this.aztecViewRef.current );
 	}
 
 	isFocused() {
-		const focusedField = TextInputState.currentlyFocusedInput();
-		return focusedField && focusedField === this.aztecViewRef.current;
+		const focusedElement = AztecInputState.getCurrentFocusedElement();
+		return focusedElement && focusedElement === this.aztecViewRef.current;
 	}
 
 	_onPress( event ) {
@@ -250,5 +259,7 @@ class AztecView extends Component {
 }
 
 const RCTAztecView = requireNativeComponent( 'RCTAztecView', AztecView );
+
+AztecView.InputState = AztecInputState;
 
 export default AztecView;

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -122,7 +122,7 @@ class AztecView extends Component {
 	}
 
 	_onFocus( event ) {
-		AztecInputState.notifyFocus( this.aztecViewRef.current );
+		AztecInputState.notifyInputChange();
 
 		if ( ! this.props.onFocus ) {
 			return;
@@ -136,7 +136,7 @@ class AztecView extends Component {
 		this.selectionEndCaretY = null;
 
 		AztecInputState.blur( this.aztecViewRef.current );
-		AztecInputState.notifyBlur( this.aztecViewRef.current );
+		AztecInputState.notifyInputChange();
 
 		if ( ! this.props.onBlur ) {
 			return;

--- a/packages/react-native-aztec/src/test/AztecInputState.test.js
+++ b/packages/react-native-aztec/src/test/AztecInputState.test.js
@@ -35,11 +35,16 @@ const updateCurrentFocusedInput = ( value ) => {
 describe( 'Aztec Input State', () => {
 	it( 'listens to focus change event', () => {
 		const listener = jest.fn();
+		const anotherRef = { current: null };
 		addFocusChangeListener( listener );
 
 		updateCurrentFocusedInput( ref );
 
 		expect( listener ).toHaveBeenCalledWith( { isFocused: true } );
+
+		updateCurrentFocusedInput( anotherRef );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
 
 		updateCurrentFocusedInput( null );
 

--- a/packages/react-native-aztec/src/test/AztecInputState.test.js
+++ b/packages/react-native-aztec/src/test/AztecInputState.test.js
@@ -76,8 +76,12 @@ describe( 'Aztec Input State', () => {
 	} );
 
 	it( 'returns current focused element', () => {
+		const anotherRef = { current: null };
 		updateCurrentFocusedInput( ref );
 		expect( getCurrentFocusedElement() ).toBe( ref );
+
+		updateCurrentFocusedInput( anotherRef );
+		expect( getCurrentFocusedElement() ).toBe( anotherRef );
 	} );
 
 	it( 'returns null if focused element is unfocused', () => {

--- a/packages/react-native-aztec/src/test/AztecInputState.test.js
+++ b/packages/react-native-aztec/src/test/AztecInputState.test.js
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
+
+/**
+ * Internal dependencies
+ */
+import {
+	addBlurListener,
+	addFocusListener,
+	getCurrentFocusedElement,
+	isFocused,
+	focus,
+	blur,
+	notifyBlur,
+	notifyFocus,
+	removeFocusListener,
+	removeBlurListener,
+} from '../AztecInputState';
+
+jest.mock(
+	'react-native/Libraries/Components/TextInput/TextInputState',
+	() => ( {
+		focusTextInput: jest.fn(),
+		blurTextInput: jest.fn(),
+	} )
+);
+
+const ref = { current: null };
+
+describe( 'Aztec Input State', () => {
+	it( 'listens to focus event', () => {
+		const listener = jest.fn();
+		addFocusListener( listener );
+		notifyFocus( ref );
+		expect( listener ).toHaveBeenCalledWith( ref );
+	} );
+
+	it( 'listens to blur event', () => {
+		const listener = jest.fn();
+		addBlurListener( listener );
+		notifyBlur( ref );
+		expect( listener ).toHaveBeenCalledWith( ref );
+	} );
+
+	it( 'does not call focus listener if removed', () => {
+		const listener = jest.fn();
+		addFocusListener( listener );
+		removeFocusListener( listener );
+		notifyFocus( ref );
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not call blur listener if removed', () => {
+		const listener = jest.fn();
+		addBlurListener( listener );
+		removeBlurListener( listener );
+		notifyBlur( ref );
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns true if an element is focused', () => {
+		notifyFocus( ref );
+		expect( isFocused() ).toBeTruthy();
+	} );
+
+	it( 'returns false if an element is unfocused', () => {
+		notifyFocus( ref );
+		notifyBlur( ref );
+		expect( isFocused() ).toBeFalsy();
+	} );
+
+	it( 'returns current focused element', () => {
+		notifyFocus( ref );
+		expect( getCurrentFocusedElement() ).toBe( ref );
+	} );
+
+	it( 'returns null if focused element is unfocused', () => {
+		notifyFocus( ref );
+		notifyBlur( ref );
+		expect( getCurrentFocusedElement() ).toBe( null );
+	} );
+
+	it( 'focus an element', () => {
+		focus( ref );
+		expect( TextInputState.focusTextInput ).toHaveBeenCalledWith( ref );
+	} );
+
+	it( 'unfocuses an element', () => {
+		blur( ref );
+		expect( TextInputState.blurTextInput ).toHaveBeenCalledWith( ref );
+	} );
+} );

--- a/test/native/__mocks__/@wordpress/react-native-aztec/index.js
+++ b/test/native/__mocks__/@wordpress/react-native-aztec/index.js
@@ -9,9 +9,15 @@ import { omit } from 'lodash';
  */
 import { forwardRef } from '@wordpress/element';
 
+const reactNativeAztecMock = jest.createMockFromModule(
+	'@wordpress/react-native-aztec'
+);
+// Preserve the mock of AztecInputState to be exported with the AztecView mock.
+const AztecInputState = reactNativeAztecMock.default.InputState;
+
 const UNSUPPORTED_PROPS = [ 'style' ];
 
-const RCTAztecView = ( { accessibilityLabel, text, ...rest }, ref ) => {
+const AztecView = ( { accessibilityLabel, text, ...rest }, ref ) => {
 	return (
 		<TextInput
 			{ ...omit( rest, UNSUPPORTED_PROPS ) }
@@ -24,4 +30,8 @@ const RCTAztecView = ( { accessibilityLabel, text, ...rest }, ref ) => {
 	);
 };
 
-export default forwardRef( RCTAztecView );
+// Replace default mock of AztecView component with custom implementation.
+reactNativeAztecMock.default = forwardRef( AztecView );
+reactNativeAztecMock.default.InputState = AztecInputState;
+
+module.exports = reactNativeAztecMock;


### PR DESCRIPTION
Closes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4775.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix issues related to editing text and the dragging gesture.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR follows up on the bug described in https://github.com/WordPress/gutenberg/pull/40406#pullrequestreview-945878792 and also addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/4775.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Add listener to be notified when editing text

When the user is editing text within a block, the dragging for that block should be disabled. Originally, I thought that it would be enough by checking when a block is selected if any text input has focus, in order to determine the availability of the dragging gesture. However, I realized that focus/blur events can be triggered before and after the block selected action. This led to the issues outlined in https://github.com/WordPress/gutenberg/pull/40406#pullrequestreview-945878792.

For this reason, I finally decided to implement a listener for being notified whenever text is being edited. Similarly to how React Native handles the input state for the `TextInput` component ([reference](https://github.com/facebook/react-native/blob/v0.63.4/Libraries/Components/TextInput/TextInputState.js)), I created a new file `AztecInputState` that is exposed via the `AztecView` component and allows to add/remove listeners for focus changes:

- [AztecInputState.js](https://github.com/WordPress/gutenberg/blob/5d983e1010e1799213d62632010a436722806f1a/packages/react-native-aztec/src/AztecInputState.js)

Note that the focus/blur events are being notified by the `AztecView` component:

https://github.com/WordPress/gutenberg/blob/5d983e1010e1799213d62632010a436722806f1a/packages/react-native-aztec/src/AztecView.js#L124-L125
https://github.com/WordPress/gutenberg/blob/5d983e1010e1799213d62632010a436722806f1a/packages/react-native-aztec/src/AztecView.js#L135-L139

Additionally, I moved the focus/blur functions that use RN's `TextInputState` to that file so it contains all logic related to the input state.

https://github.com/WordPress/gutenberg/blob/5d983e1010e1799213d62632010a436722806f1a/packages/react-native-aztec/src/AztecInputState.js#L80-L96

Keep in mind that I attached the input state logic to the Aztec component, and not the rest of the text inputs (e.g. RN's `TextInput` component), as it's the only component within the post content that actually edits text and that might affect the dragging logic. 

**NOTE:** If in the future, we'd like to expand this logic to any text input, we could do it by patching the RN code.

### Stop editing text when start dragging a block

When editing text within a block, the dragging for that block is disabled. However, the user could still drag other blocks (i.e. the rest of unselected blocks). For this reason, now when start dragging a block, the editor will unfocus any previously focused Aztec text view.

https://github.com/WordPress/gutenberg/blob/5d983e1010e1799213d62632010a436722806f1a/packages/block-editor/src/components/block-draggable/index.native.js#L359-L362

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

**Preparation:**
1. Open a post/page in the app.
1. Add several blocks, including text blocks like the Paragraph block.

### Dragging is ENABLED when the block is not selected
1. Check that no block is selected.
1. Long-press on a block.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Drop the block and observe that the block is moved to the specified position and is selected.

### Dragging is ENABLED when the block is selected
1. Select a block.
1. Long-press on a block.
**NOTE:** Only the block's content will be draggable, the block's toolbar won't enable the dragging mode.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Drop the block and observe that it's is moved to the specified position and is still selected.

### Dragging is DISABLED for the selected block when editing text
1. Tap on a text block to edit its content.
**NOTE:** Check that the text input is focused (i.e. the text editing is enabled).
1. Long-press on the content.
1. Observe that the long-press gesture works and that doesn't trigger the dragging mode.
1. Tap on a block that contains `RichText` components (e.g. Cover block or Media Text block).
1. Edit text by tapping on a `RichText` element.
1. Long-press on the content.
1. Observe that the long-press gesture works and that doesn't trigger the dragging mode.

### Dragging is ENABLED for unselected blocks when editing text
1. Tap on a text block to edit its content.
**NOTE:** Check that the text input is focused (i.e. the text editing is enabled).
1. Long-press on an unselected block.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Observe that the text stops being edited (i.e. the text input is unfocused and the keyboard is hidden).
1. Drop the block and observe that it's is moved to the specified position and is still selected.

### Check that known bugs are addressed
- Try to reproduce the bug described in https://github.com/WordPress/gutenberg/pull/40406#pullrequestreview-945878792 and check that it's addressed with these changes.
- Try to reproduce the bug described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/4775 and check that it's addressed with these changes.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/164511476-4af66139-4557-4179-9a8b-882ee8f3e8b9.mp4


