### PR TITLE
Add placeholder to Post Comments block

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -228,13 +228,14 @@ if ( ! function_exists( 'get_comments_pagination_arrow' ) ) {
 function gutenberg_extend_block_editor_settings_with_discussion_settings( $settings ) {
 
 	$settings['__experimentalDiscussionSettings'] = array(
-		'commentOrder'        => get_option( 'comment_order' ),
-		'commentsPerPage'     => get_option( 'comments_per_page' ),
-		'defaultCommentsPage' => get_option( 'default_comments_page' ),
-		'pageComments'        => get_option( 'page_comments' ),
-		'threadComments'      => get_option( 'thread_comments' ),
-		'threadCommentsDepth' => get_option( 'thread_comments_depth' ),
-		'avatarURL'           => get_avatar_url(
+		'commentOrder'         => get_option( 'comment_order' ),
+		'commentsPerPage'      => get_option( 'comments_per_page' ),
+		'defaultCommentsPage'  => get_option( 'default_comments_page' ),
+		'pageComments'         => get_option( 'page_comments' ),
+		'threadComments'       => get_option( 'thread_comments' ),
+		'threadCommentsDepth'  => get_option( 'thread_comments_depth' ),
+		'defaultCommentStatus' => get_option( 'default_comment_status' ),
+		'avatarURL'            => get_avatar_url(
 			'',
 			array(
 				'size'          => 96,

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -49,6 +49,7 @@
 @import "./query-pagination/editor.scss";
 @import "./query-pagination-numbers/editor.scss";
 @import "./post-featured-image/editor.scss";
+@import "./post-comments/editor.scss";
 
 :root .editor-styles-wrapper {
 	@include background-colors-deprecated();

--- a/packages/block-library/src/post-comments/block.json
+++ b/packages/block-library/src/post-comments/block.json
@@ -40,5 +40,6 @@
 		"wp-block-post-comments",
 		"wp-block-buttons",
 		"wp-block-button"
-	]
+	],
+	"editorStyle": "wp-block-post-comments-editor"
 }

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -11,6 +11,7 @@ import {
 	BlockControls,
 	Warning,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -23,9 +24,17 @@ export default function PostCommentsEdit( {
 } ) {
 	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	postTitle = postTitle || __( 'Post Title' );
+
 	const { name: currentUserName } = useSelect( ( select ) =>
 		select( coreStore ).getCurrentUser()
 	);
+
+	const { avatarURL } = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__experimentalDiscussionSettings
+	);
+
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -69,8 +78,8 @@ export default function PostCommentsEdit( {
 							<footer className="comment-meta">
 								<div className="comment-author vcard">
 									<img
-										alt=""
-										src="http://1.gravatar.com/avatar/d7a973c7dab26985da5f961be7b74480?s=32&d=mm&r=g"
+										alt="Commenter Avatar"
+										src={ avatarURL }
 										className="avatar avatar-32 photo"
 										height="32"
 										width="32"

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import {
 	AlignmentControl,
 	BlockControls,
@@ -14,57 +13,24 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { RawHTML } from '@wordpress/element';
-import { store as coreStore } from '@wordpress/core-data';
-
-function PostCommentsDisplay( { postId } ) {
-	return useSelect(
-		( select ) => {
-			const comments = select( coreStore ).getEntityRecords(
-				'root',
-				'comment',
-				{
-					post: postId,
-				}
-			);
-			// TODO: "No Comments" placeholder should be editable.
-			return comments && comments.length
-				? comments.map( ( comment ) => (
-						<RawHTML
-							className="wp-block-post-comments__comment"
-							key={ comment.id }
-						>
-							{ comment.content.rendered }
-						</RawHTML>
-				  ) )
-				: __( 'No comments.' );
-		},
-		[ postId ]
-	);
-}
+import { useSelect } from '@wordpress/data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 
 export default function PostCommentsEdit( {
-	attributes,
+	attributes: { textAlign },
 	setAttributes,
-	context,
+	context: { postType, postId },
 } ) {
-	const { postType, postId } = context;
-	const { textAlign } = attributes;
+	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
+	postTitle = postTitle || __( 'Post Title' );
+	const { name: currentUserName } = useSelect( ( select ) =>
+		select( coreStore ).getCurrentUser()
+	);
 	const blockProps = useBlockProps( {
 		className: classnames( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 		} ),
 	} );
-
-	if ( ! postType || ! postId ) {
-		return (
-			<div { ...blockProps }>
-				<Warning>
-					{ __( 'Post comments block: no post found.' ) }
-				</Warning>
-			</div>
-		);
-	}
 
 	return (
 		<>
@@ -78,7 +44,138 @@ export default function PostCommentsEdit( {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				<PostCommentsDisplay postId={ postId } />
+				<Warning>
+					{ __(
+						'This is just a placeholder, not a real comment. The final styling may differ because it also depends on the current theme. For better compatibility with the Block Editor, please consider replacing this block with the "Comments Query Loop" block.'
+					) }
+				</Warning>
+
+				<h3>
+					{ __( 'One response to' ) } “{ postTitle }”
+				</h3>
+
+				<div className="navigation">
+					<div className="alignleft">
+						<a href="#top">« { __( 'Older Comments' ) }</a>
+					</div>
+					<div className="alignright">
+						<a href="#top">{ __( 'Newer Comments' ) } »</a>
+					</div>
+				</div>
+
+				<ol className="commentlist">
+					<li className="comment even thread-even depth-1">
+						<article className="comment-body">
+							<footer className="comment-meta">
+								<div className="comment-author vcard">
+									<img
+										alt=""
+										src="http://1.gravatar.com/avatar/d7a973c7dab26985da5f961be7b74480?s=32&d=mm&r=g"
+										className="avatar avatar-32 photo"
+										height="32"
+										width="32"
+										loading="lazy"
+									/>
+									<b className="fn">
+										<a href="#top" className="url">
+											{ __( 'A WordPress Commenter' ) }
+										</a>
+									</b>{ ' ' }
+									<span className="says">
+										{ __( 'says' ) }:
+									</span>
+								</div>
+
+								<div className="comment-metadata">
+									<a href="#top">
+										<time dateTime="2000-01-01T00:00:00+00:00">
+											{ __(
+												'January 1, 2000 at 00:00 am'
+											) }
+										</time>
+									</a>{ ' ' }
+									<span className="edit-link">
+										<a
+											className="comment-edit-link"
+											href="#top"
+										>
+											{ __( 'Edit' ) }
+										</a>
+									</span>
+								</div>
+							</footer>
+
+							<div className="comment-content">
+								<p>
+									{ __( 'Hi, this is a comment.' ) }
+									<br />
+									{ __(
+										'To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.'
+									) }
+									<br />
+									{ __(
+										'Commenter avatars come from'
+									) }{ ' ' }
+									<a href="https://gravatar.com/">Gravatar</a>
+									.
+								</p>
+							</div>
+
+							<div className="reply">
+								<a
+									className="comment-reply-link"
+									href="#top"
+									aria-label="Reply to A WordPress Commenter"
+								>
+									{ __( 'Reply' ) }
+								</a>
+							</div>
+						</article>
+					</li>
+				</ol>
+
+				<div className="navigation">
+					<div className="alignleft">
+						<a href="#top">« { __( 'Older Comments' ) }</a>
+					</div>
+					<div className="alignright">
+						<a href="#top">{ __( 'Newer Comments' ) } »</a>
+					</div>
+				</div>
+
+				<div className="comment-respond">
+					<h3 className="comment-reply-title">
+						{ __( 'Leave a Reply' ) }
+					</h3>
+
+					<form className="comment-form" noValidate={ true }>
+						<p className="logged-in-as">
+							{ __( 'Logged in as' ) } { currentUserName }.{ ' ' }
+							<a href="#top">{ __( 'Log out?' ) }</a>{ ' ' }
+						</p>
+						<p className="comment-form-comment">
+							<label htmlFor="comment">
+								{ __( 'Comment' ) }{ ' ' }
+								<span className="required">*</span>
+							</label>
+							<textarea
+								name="comment"
+								cols="45"
+								rows="8"
+								required={ true }
+							/>
+						</p>
+						<p className="form-submit wp-block-button">
+							<input
+								name="submit"
+								type="submit"
+								disabled={ true }
+								className="submit wp-block-button__link"
+								value={ __( 'Post Comment' ) }
+							/>
+						</p>
+					</form>
+				</div>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -16,6 +16,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
 
 export default function PostCommentsEdit( {
 	attributes: { textAlign },
@@ -82,6 +83,8 @@ export default function PostCommentsEdit( {
 		} ),
 	} );
 
+	const disabledRef = useDisabled();
+
 	return (
 		<>
 			<BlockControls group="block">
@@ -97,7 +100,10 @@ export default function PostCommentsEdit( {
 				<Warning>{ warning }</Warning>
 
 				{ showPlacholder && (
-					<>
+					<div
+						className="wp-block-post-comments__placeholder"
+						ref={ disabledRef }
+					>
 						<h3>
 							{ __( 'One response to' ) } “{ postTitle }”
 						</h3>
@@ -217,15 +223,13 @@ export default function PostCommentsEdit( {
 									<input
 										name="submit"
 										type="submit"
-										disabled
 										className="submit wp-block-button__link"
 										value={ __( 'Post Comment' ) }
-										readOnly
 									/>
 								</p>
 							</form>
 						</div>
-					</>
+					</div>
 				) }
 			</div>
 		</>

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -15,7 +15,7 @@ import {
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useEntityProp, store as coreStore } from '@wordpress/core-data';
+import { useEntityProp } from '@wordpress/core-data';
 
 export default function PostCommentsEdit( {
 	attributes: { textAlign },
@@ -24,10 +24,6 @@ export default function PostCommentsEdit( {
 } ) {
 	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	postTitle = postTitle || __( 'Post Title' );
-
-	const { name: currentUserName } = useSelect( ( select ) =>
-		select( coreStore ).getCurrentUser()
-	);
 
 	const { avatarURL } = useSelect(
 		( select ) =>
@@ -158,10 +154,6 @@ export default function PostCommentsEdit( {
 					</h3>
 
 					<form className="comment-form" noValidate={ true }>
-						<p className="logged-in-as">
-							{ __( 'Logged in as' ) } { currentUserName }.{ ' ' }
-							<a href="#top">{ __( 'Log out?' ) }</a>{ ' ' }
-						</p>
 						<p className="comment-form-comment">
 							<label htmlFor="comment">
 								{ __( 'Comment' ) }{ ' ' }

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -13,9 +13,9 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 
 export default function PostCommentsEdit( {
 	attributes: { textAlign },
@@ -25,11 +25,56 @@ export default function PostCommentsEdit( {
 	let [ postTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	postTitle = postTitle || __( 'Post Title' );
 
-	const { avatarURL } = useSelect(
+	const [ commentStatus ] = useEntityProp(
+		'postType',
+		postType,
+		'comment_status',
+		postId
+	);
+
+	const { avatarURL, defaultCommentStatus } = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings()
 				.__experimentalDiscussionSettings
 	);
+
+	const isSiteEditor = postType === undefined || postId === undefined;
+
+	const postTypeSupportsComments = useSelect( ( select ) =>
+		postType
+			? !! select( coreStore ).getPostType( postType )?.supports.comments
+			: false
+	);
+
+	let warning = __(
+		'Post Comments block: This is just a placeholder, not a real comment. The final styling may differ because it also depends on the current theme. For better compatibility with the Block Editor, please consider replacing this block with the "Comments Query Loop" block.'
+	);
+	let showPlacholder = true;
+
+	if ( ! isSiteEditor && 'open' !== commentStatus ) {
+		if ( 'closed' === commentStatus ) {
+			warning = sprintf(
+				/* translators: 1: Post type (i.e. "post", "page") */
+				__(
+					'Post Comments block: Comments to this %s are not allowed.'
+				),
+				postType
+			);
+			showPlacholder = false;
+		} else if ( ! postTypeSupportsComments ) {
+			warning = sprintf(
+				/* translators: 1: Post type (i.e. "post", "page") */
+				__(
+					'Post Comments block: Comments for this post type (%s) are not enabled.'
+				),
+				postType
+			);
+			showPlacholder = false;
+		} else if ( 'open' !== defaultCommentStatus ) {
+			warning = __( 'Post Comments block: Comments are not enabled.' );
+			showPlacholder = false;
+		}
+	}
 
 	const blockProps = useBlockProps( {
 		className: classnames( {
@@ -49,134 +94,139 @@ export default function PostCommentsEdit( {
 			</BlockControls>
 
 			<div { ...blockProps }>
-				<Warning>
-					{ __(
-						'This is just a placeholder, not a real comment. The final styling may differ because it also depends on the current theme. For better compatibility with the Block Editor, please consider replacing this block with the "Comments Query Loop" block.'
-					) }
-				</Warning>
+				<Warning>{ warning }</Warning>
 
-				<h3>
-					{ __( 'One response to' ) } “{ postTitle }”
-				</h3>
+				{ showPlacholder && (
+					<>
+						<h3>
+							{ __( 'One response to' ) } “{ postTitle }”
+						</h3>
 
-				<div className="navigation">
-					<div className="alignleft">
-						<a href="#top">« { __( 'Older Comments' ) }</a>
-					</div>
-					<div className="alignright">
-						<a href="#top">{ __( 'Newer Comments' ) } »</a>
-					</div>
-				</div>
+						<div className="navigation">
+							<div className="alignleft">
+								<a href="#top">« { __( 'Older Comments' ) }</a>
+							</div>
+							<div className="alignright">
+								<a href="#top">{ __( 'Newer Comments' ) } »</a>
+							</div>
+						</div>
 
-				<ol className="commentlist">
-					<li className="comment even thread-even depth-1">
-						<article className="comment-body">
-							<footer className="comment-meta">
-								<div className="comment-author vcard">
-									<img
-										alt="Commenter Avatar"
-										src={ avatarURL }
-										className="avatar avatar-32 photo"
-										height="32"
-										width="32"
-										loading="lazy"
-									/>
-									<b className="fn">
-										<a href="#top" className="url">
-											{ __( 'A WordPress Commenter' ) }
-										</a>
-									</b>{ ' ' }
-									<span className="says">
-										{ __( 'says' ) }:
-									</span>
-								</div>
+						<ol className="commentlist">
+							<li className="comment even thread-even depth-1">
+								<article className="comment-body">
+									<footer className="comment-meta">
+										<div className="comment-author vcard">
+											<img
+												alt="Commenter Avatar"
+												src={ avatarURL }
+												className="avatar avatar-32 photo"
+												height="32"
+												width="32"
+												loading="lazy"
+											/>
+											<b className="fn">
+												<a href="#top" className="url">
+													{ __(
+														'A WordPress Commenter'
+													) }
+												</a>
+											</b>{ ' ' }
+											<span className="says">
+												{ __( 'says' ) }:
+											</span>
+										</div>
 
-								<div className="comment-metadata">
-									<a href="#top">
-										<time dateTime="2000-01-01T00:00:00+00:00">
+										<div className="comment-metadata">
+											<a href="#top">
+												<time dateTime="2000-01-01T00:00:00+00:00">
+													{ __(
+														'January 1, 2000 at 00:00 am'
+													) }
+												</time>
+											</a>{ ' ' }
+											<span className="edit-link">
+												<a
+													className="comment-edit-link"
+													href="#top"
+												>
+													{ __( 'Edit' ) }
+												</a>
+											</span>
+										</div>
+									</footer>
+
+									<div className="comment-content">
+										<p>
+											{ __( 'Hi, this is a comment.' ) }
+											<br />
 											{ __(
-												'January 1, 2000 at 00:00 am'
+												'To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.'
 											) }
-										</time>
-									</a>{ ' ' }
-									<span className="edit-link">
+											<br />
+											{ __(
+												'Commenter avatars come from'
+											) }{ ' ' }
+											<a href="https://gravatar.com/">
+												Gravatar
+											</a>
+											.
+										</p>
+									</div>
+
+									<div className="reply">
 										<a
-											className="comment-edit-link"
+											className="comment-reply-link"
 											href="#top"
+											aria-label="Reply to A WordPress Commenter"
 										>
-											{ __( 'Edit' ) }
+											{ __( 'Reply' ) }
 										</a>
-									</span>
-								</div>
-							</footer>
+									</div>
+								</article>
+							</li>
+						</ol>
 
-							<div className="comment-content">
-								<p>
-									{ __( 'Hi, this is a comment.' ) }
-									<br />
-									{ __(
-										'To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.'
-									) }
-									<br />
-									{ __(
-										'Commenter avatars come from'
-									) }{ ' ' }
-									<a href="https://gravatar.com/">Gravatar</a>
-									.
+						<div className="navigation">
+							<div className="alignleft">
+								<a href="#top">« { __( 'Older Comments' ) }</a>
+							</div>
+							<div className="alignright">
+								<a href="#top">{ __( 'Newer Comments' ) } »</a>
+							</div>
+						</div>
+
+						<div className="comment-respond">
+							<h3 className="comment-reply-title">
+								{ __( 'Leave a Reply' ) }
+							</h3>
+
+							<form className="comment-form" noValidate>
+								<p className="comment-form-comment">
+									<label htmlFor="comment">
+										{ __( 'Comment' ) }{ ' ' }
+										<span className="required">*</span>
+									</label>
+									<textarea
+										name="comment"
+										cols="45"
+										rows="8"
+										required
+									/>
 								</p>
-							</div>
-
-							<div className="reply">
-								<a
-									className="comment-reply-link"
-									href="#top"
-									aria-label="Reply to A WordPress Commenter"
-								>
-									{ __( 'Reply' ) }
-								</a>
-							</div>
-						</article>
-					</li>
-				</ol>
-
-				<div className="navigation">
-					<div className="alignleft">
-						<a href="#top">« { __( 'Older Comments' ) }</a>
-					</div>
-					<div className="alignright">
-						<a href="#top">{ __( 'Newer Comments' ) } »</a>
-					</div>
-				</div>
-
-				<div className="comment-respond">
-					<h3 className="comment-reply-title">
-						{ __( 'Leave a Reply' ) }
-					</h3>
-
-					<form className="comment-form" noValidate={ true }>
-						<p className="comment-form-comment">
-							<label htmlFor="comment">
-								{ __( 'Comment' ) }{ ' ' }
-								<span className="required">*</span>
-							</label>
-							<textarea
-								name="comment"
-								cols="45"
-								rows="8"
-								required={ true }
-							/>
-						</p>
-						<p className="form-submit wp-block-button">
-							<input
-								name="submit"
-								type="submit"
-								disabled={ true }
-								className="submit wp-block-button__link"
-								value={ __( 'Post Comment' ) }
-							/>
-						</p>
-					</form>
-				</div>
+								<p className="form-submit wp-block-button">
+									<input
+										name="submit"
+										type="submit"
+										disabled
+										className="submit wp-block-button__link"
+										value={ __( 'Post Comment' ) }
+										readOnly
+									/>
+								</p>
+							</form>
+						</div>
+					</>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments/editor.scss
+++ b/packages/block-library/src/post-comments/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-post-comments__placeholder * {
+	pointer-events: none;
+}

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,10 +1,6 @@
 .wp-block-post-comments {
-	// Remove extraneous top padding added to the first heading of the block.
-	> h3:first-of-type {
-		margin-top: 0;
-	}
-
 	.commentlist {
+		clear: both;
 		list-style: none;
 		margin: 0;
 		padding: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

This PR adds a placeholder in the Editor for the Post Comments block. It includes:

- A warning at the top with the text:

  > This is just a placeholder, not a real comment. The final styling may differ because it also depends on the current theme. For better compatibility with the Block Editor, please consider replacing this block with the "Comments Query Loop" block.

- The navigation links
- A comment example, including an avatar, author name, date, content, and reply link.
- The reply form.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Before this, the Post Comments blocked rendered:

- Site Editor: A warning with the text `Post comments block: no post found.`
- Post Editor:
  - Post with comments: A loop of the raw HTML of all the comments, unnested and unstyled.
  - Post without comments: The text `No comments`.

None of those are especially useful, considering the only action users can perform in this block is to configure its style.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I've added the default comments markup. The only dynamic parts are the post title and the user name (to simulate the reply form message).

I've used Gutenberg's `<Warning>` component for the warning. I'm not a big fan of how it looks like in the UI, but I think it's out of the scope of this PR to address that.

I acknowledge that this type of placeholder is far from ideal, but @darerodz and I analyzed the other possibilities, and we concluded that it was the least bad option. The other possibilities we considered were:

- Using `<ServerSideRender>` component.

  Executing `comment_template()` didn't work within a REST API call (`/wp/v2/block-renderer/`) because it doesn't have a post context.

  Even if that could be solved, the result wouldn't faithfully represent the frontend because:

  - The comment-related styles from the theme and plugins would be missing.
  - It would not work in the site editor because we can't inject dummy data to the `comment_template()` function.

- Looping over the real comments in the Editor to reproduce the final HTML as faithfully as possible.

  Replicating the logic of the comments is not trivial (as [we've seen in the Comments Query Loop blocks](https://github.com/WordPress/gutenberg/issues/34994)).

  Also, the result wouldn't faithfully represent the frontend because:

  - The markup modifications of the theme and plugins would be missing.
  - The comment-related styles from the theme and plugins would be missing.

So at the end, and considering that this is a temporary block that should be removed once the [Comments Query Loop](https://github.com/WordPress/gutenberg/issues/34994) and the [Comments Form blocks](https://github.com/WordPress/gutenberg/issues/38107) are mature enough, we decided to add the default comments markup so the user can get a notion of the styles, and a warning to prevent confusion.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Site Editor:

1. Add the Post Comments block to a template.
2. Look that the placeholder looks as expected.
3. Test that the styling options work.

Post Editor:

1. Add the Post Comments block to a post.
2. Look that the placeholder looks as expected.
3. Test that the styling options work.

## Screenshots or screencast <!-- if applicable -->

<a href="https://www.loom.com/share/91b518264de84e75a7c3a64e283ee0c2">
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/91b518264de84e75a7c3a64e283ee0c2-with-play.gif">
  </a>

https://www.loom.com/share/91b518264de84e75a7c3a64e283ee0c2