### PR TITLE
Cover Block: Allow linkable cover when use featured image and allow t…

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -231,7 +231,7 @@ Add an image or video with a text overlay — great for headers. ([Source](https
 -	**Name:** core/cover
 -	**Category:** media
 -	**Supports:** align, anchor, color (~~background~~, ~~text~~), spacing (padding), ~~html~~
--	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, isDark, isRepeated, minHeight, minHeightUnit, overlayColor, templateLock, url, useFeaturedImage
+-	**Attributes:** allowedBlocks, alt, backgroundType, contentPosition, customGradient, customOverlayColor, dimRatio, focalPoint, gradient, hasParallax, id, imageSizeSlug, isDark, isLink, isRepeated, minHeight, minHeightUnit, overlayColor, templateLock, url, useFeaturedImage
 
 ## Embed
 

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -7,6 +7,9 @@
 	"description": "Add an image or video with a text overlay — great for headers.",
 	"textdomain": "default",
 	"attributes": {
+		"isLink": {
+			"type": "boolean"
+		},
 		"url": {
 			"type": "string"
 		},
@@ -74,6 +77,9 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", false ]
+		},
+		"imageSizeSlug": {
+			"type": "string"
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -8,10 +8,10 @@
 /**
  * Renders the `core/cover` block on server.
  *
- * @param array $attributes The block attributes.
- * @param array $content    The block rendered content.
- * @param object $block     The block object.
- * @return string Returns the cover block markup, if useFeaturedImage is true.
+ * @param array $attributes  The block attributes.
+ * @param array $content     The block rendered content.
+ * @param object $block      The block object.
+ * @return string Returns    the cover block markup, if useFeaturedImage is true.
  */
 function render_block_core_cover( $attributes, $content, $block ) {
 	if ( false === $attributes['useFeaturedImage'] ) {
@@ -20,7 +20,7 @@ function render_block_core_cover( $attributes, $content, $block ) {
 
 	$current_featured_image = get_the_post_thumbnail_url();
 
-	if ( isset($attributes['imageSizeSlug']) ) {
+	if ( isset( $attributes['imageSizeSlug'] ) && $attributes['imageSizeSlug'] ) {
 		// since it is using a specific image size, there is no need for srcset.
 		remove_filter( 'wp_calculate_image_srcset_meta', '__return_null' );
 		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['imageSizeSlug'] );
@@ -74,13 +74,13 @@ function render_block_core_cover( $attributes, $content, $block ) {
 		);
 
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-			$post_ID = $block->context['postId'];
-			$post_Permalink = get_the_permalink( $post_ID );
-			$inner_content_length = mb_strrpos( $content, '</div' ) -  mb_strpos( $content, '<span' );
-			$inner_content = mb_substr( $content, mb_strpos( $content, '<span'), $inner_content_length);
+			$post_ID                = $block->context['postId'];
+			$post_permalink         = get_the_permalink( $post_ID );
+			$inner_content_length   = mb_strrpos( $content, '</div' ) - mb_strpos( $content, '<span' );
+			$inner_content          = mb_substr( $content, mb_strpos( $content, '<span' ), $inner_content_length );
 			// we used preg_replace here to get ride of any nested links cos nested links is not allowed in HTML.
-			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_Permalink, preg_replace( array( '/<a.*?>/s', '/<\/a.*?>/s' ), '', $inner_content ) );
-			$content = str_replace( $inner_content, $inner_content_linkable, $content );
+			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_permalink, preg_replace( array( '/<a.*?>/s', '/<\/a.*?>/s' ), '', $inner_content ) );
+			$content                = str_replace( $inner_content, $inner_content_linkable, $content );
 		}
 	}
 

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -8,10 +8,10 @@
 /**
  * Renders the `core/cover` block on server.
  *
- * @param array $attributes  The block attributes.
- * @param array $content     The block rendered content.
- * @param object $block      The block object.
- * @return string Returns    the cover block markup, if useFeaturedImage is true.
+ * @param array  $attributes  The block attributes.
+ * @param array  $content     The block rendered content.
+ * @param object $block       The block object.
+ * @return string Returns     the cover block markup, if useFeaturedImage is true.
  */
 function render_block_core_cover( $attributes, $content, $block ) {
 	if ( false === $attributes['useFeaturedImage'] ) {
@@ -74,10 +74,10 @@ function render_block_core_cover( $attributes, $content, $block ) {
 		);
 
 		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
-			$post_ID                = $block->context['postId'];
-			$post_permalink         = get_the_permalink( $post_ID );
-			$inner_content_length   = mb_strrpos( $content, '</div' ) - mb_strpos( $content, '<span' );
-			$inner_content          = mb_substr( $content, mb_strpos( $content, '<span' ), $inner_content_length );
+			$post_ID              = $block->context['postId'];
+			$post_permalink       = get_the_permalink( $post_ID );
+			$inner_content_length = mb_strrpos( $content, '</div' ) - mb_strpos( $content, '<span' );
+			$inner_content        = mb_substr( $content, mb_strpos( $content, '<span' ), $inner_content_length );
 			// we used preg_replace here to get ride of any nested links cos nested links is not allowed in HTML.
 			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_permalink, preg_replace( array( '/<a.*?>/s', '/<\/a.*?>/s' ), '', $inner_content ) );
 			$content                = str_replace( $inner_content, $inner_content_linkable, $content );

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -13,12 +13,20 @@
  *
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */
-function render_block_core_cover( $attributes, $content ) {
+function render_block_core_cover( $attributes, $content, $block ) {
 	if ( false === $attributes['useFeaturedImage'] ) {
 		return $content;
 	}
 
 	$current_featured_image = get_the_post_thumbnail_url();
+
+	if(isset($attributes['imageSizeSlug'])){
+		//since it is using a specific image size, there is no need for srcset
+		remove_filter( 'wp_calculate_image_srcset_meta', '__return_null' ); 
+		$current_featured_image = get_the_post_thumbnail_url(null, $attributes['imageSizeSlug']);
+		add_filter( 'wp_calculate_image_srcset_meta', '__return_null' );
+	}
+
 
 	if ( false === $current_featured_image ) {
 		return $content;
@@ -66,6 +74,16 @@ function render_block_core_cover( $attributes, $content ) {
 			$content
 		);
 
+		if ( isset( $attributes['isLink'] ) && $attributes['isLink'] ) {
+			$post_ID = $block->context['postId'];
+			$post_Permalink = get_the_permalink( $post_ID );
+			$inner_content_length = mb_strrpos( $content, '</div' ) -  mb_strpos( $content, '<span' );
+			$inner_content = mb_substr( $content, mb_strpos( $content, '<span'), $inner_content_length);
+			//we used preg_replace here to get ride of any nested links cos nested links is not allowed in HTML
+			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_Permalink, preg_replace(array( '/<a.*?>/s', '/<\/a.*?>/s' ), "", $inner_content ) );
+			$content = str_replace( $inner_content, $inner_content_linkable, $content );
+			
+		}
 	}
 
 	return $content;
@@ -83,3 +101,9 @@ function register_block_core_cover() {
 	);
 }
 add_action( 'init', 'register_block_core_cover' );
+
+function clearAnchorTags($string){
+	for ($x = 0; $x <= 100; $x+=10) {
+		echo "The number is: $x <br>";
+	  }
+}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -10,7 +10,7 @@
  *
  * @param array $attributes The block attributes.
  * @param array $content    The block rendered content.
- *
+ * @param object $block     The block object.
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */
 function render_block_core_cover( $attributes, $content, $block ) {
@@ -20,13 +20,12 @@ function render_block_core_cover( $attributes, $content, $block ) {
 
 	$current_featured_image = get_the_post_thumbnail_url();
 
-	if(isset($attributes['imageSizeSlug'])){
-		//since it is using a specific image size, there is no need for srcset
-		remove_filter( 'wp_calculate_image_srcset_meta', '__return_null' ); 
-		$current_featured_image = get_the_post_thumbnail_url(null, $attributes['imageSizeSlug']);
+	if ( isset($attributes['imageSizeSlug']) ) {
+		// since it is using a specific image size, there is no need for srcset.
+		remove_filter( 'wp_calculate_image_srcset_meta', '__return_null' );
+		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['imageSizeSlug'] );
 		add_filter( 'wp_calculate_image_srcset_meta', '__return_null' );
 	}
-
 
 	if ( false === $current_featured_image ) {
 		return $content;
@@ -79,10 +78,9 @@ function render_block_core_cover( $attributes, $content, $block ) {
 			$post_Permalink = get_the_permalink( $post_ID );
 			$inner_content_length = mb_strrpos( $content, '</div' ) -  mb_strpos( $content, '<span' );
 			$inner_content = mb_substr( $content, mb_strpos( $content, '<span'), $inner_content_length);
-			//we used preg_replace here to get ride of any nested links cos nested links is not allowed in HTML
-			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_Permalink, preg_replace(array( '/<a.*?>/s', '/<\/a.*?>/s' ), "", $inner_content ) );
+			// we used preg_replace here to get ride of any nested links cos nested links is not allowed in HTML.
+			$inner_content_linkable = sprintf( '<a href="%1s" class="wp-block-cover__inner-wrapper-link">%2s</a>', $post_Permalink, preg_replace( array( '/<a.*?>/s', '/<\/a.*?>/s' ), '', $inner_content ) );
 			$content = str_replace( $inner_content, $inner_content_linkable, $content );
-			
 		}
 	}
 
@@ -101,9 +99,3 @@ function register_block_core_cover() {
 	);
 }
 add_action( 'init', 'register_block_core_cover' );
-
-function clearAnchorTags($string){
-	for ($x = 0; $x <= 100; $x+=10) {
-		echo "The number is: $x <br>";
-	  }
-}

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -218,6 +218,23 @@
 		border: none;
 		box-shadow: none;
 	}
+	//styles for the anchor wrapper of cover content when use linkable featured image
+	//and since it only propose to make cover linkable, it should mirror some properties from parent to make sure
+	//content position change whenever parent's properties change
+	.wp-block-cover__inner-wrapper-link {
+		display: inherit;
+		justify-content: inherit;
+		align-items: inherit;
+		text-decoration: none;
+		min-height: inherit;
+		width: 100%;
+		cursor: pointer;
+
+	}
+	.wp-block-cover__inner-wrapper-link:hover,
+	.wp-block-cover__inner-wrapper-link:active {
+		text-decoration: none;
+	}
 }
 
 .wp-block-cover__video-background {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allow cover block to be linked to post when it is using featured image as background image, and allow to choose image source size (thumbnail, medium, large, etc.) for all image. 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This makes the cover block usable inside query loop block to make thumbnail clickable and allow for inner blocks at the same time, in order to be able to create much more complex thumbnail, like on with text inside or even post title.  example:  
![image](https://user-images.githubusercontent.com/74800166/164285391-abc36710-e47a-4fd2-ab40-218a2ce00923.png)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- to make it linkable we wrapped the inner content with anchor tag only when rendered server side, then to solve the problem of possible nested links (which not allowed in html) we cleared the html from any nested anchors. so even if you used the post-title and made it linkable inside the cover, it will be cleared when rendered. 

-  the ability to choose image source size, is added to dimensions control, and it only appears when media type is an image, when using featured image -and since it using server-side rendering- we made sure that when choosing a specific image size, the `srcset` attribute is unset (in anyways it was not working when featured image is used).  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->

1. Open Post or Page or even the Editor
2. Insert cover block and set background to any color
4. go to block settings and check dimension more settings (the three vertical dots), (you won't see a change)
5. now choose a background image instead and check dimension more settings, you will see "image size", click on it, then select and image size.
6. now use featured image as a background
7. you will see a new setting for make linkable on settings sidebar
8. make it linkable then save and go to front to preview it. 
9. now add inner block while it set to (link to "post Type") and choose a linkable component like post title and make link to post. 
10. go to front to preview the changes, it will be working fine, inspect the html to check that there is no nest anchor tags.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/74800166/164297368-57947229-dd1a-43dc-961f-3561d98d3b2e.mp4


