### PR TITLE
Register all fonts before enqueing any

### DIFF
--- a/lib/experimental/register-webfonts-from-theme-json.php
+++ b/lib/experimental/register-webfonts-from-theme-json.php
@@ -90,6 +90,8 @@ function gutenberg_register_webfonts_from_theme_json() {
 	}
 	foreach ( $webfonts as $webfont ) {
 		wp_webfonts()->register_webfont( $webfont );
+	}
+	foreach ( $webfonts as $webfont ) {
 		wp_webfonts()->enqueue_webfont( $webfont['font-family'] );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This first registers all of the webfonts before enqueing any of the webfonts.  



## Why?

This is because once a webfont is enqueued it is not enqueued again and if other assets for that font family/slug are later added will not be enqueued.

## How?
Runs the loop twice, first registering and then enqueing (rather than both in the same loop).

## Testing Instructions
Note steps to reproduce in #40487.  When patched all of the resources available will be enqueued.

For an example of a theme attempting this today see [Archeo](https://github.com/Automattic/themes/tree/trunk/archeo).

