### PR TITLE
Check that a transform matches at the time of running the transform

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -460,7 +460,7 @@ export function getBlockTransforms( direction, blockTypeOrName ) {
  * @param {Object} transform A transform object.
  * @param {Array}  blocks    Blocks array.
  *
- * @return {boolean} True if given blocks are a match for given tranform.
+ * @return {boolean} True if given blocks are a match for the transform.
  */
 function checkTransformIsMatch( transform, blocks ) {
 	const sourceBlock = first( blocks );

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -222,7 +222,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	// If the transform has a `isMatch` function specified, check that it returns true.
 	if (
 		isFunction( transform.isMatch ) &&
-		! checkTransformIsMatch( transform, blocks, sourceBlock )
+		! checkTransformIsMatch( transform, blocks )
 	) {
 		return false;
 	}
@@ -457,13 +457,13 @@ export function getBlockTransforms( direction, blockTypeOrName ) {
 /**
  * Checks that a given transforms isMatch method passes for given source blocks.
  *
- * @param {Object}       transform   A transform object.
- * @param {Array|Object} blocks      Blocks array.
- * @param {Object}       sourceBlock Source block being transformed.
+ * @param {Object} transform A transform object.
+ * @param {Array}  blocks    Blocks array.
  *
  * @return {boolean} True if given blocks are a match for given tranform.
  */
-function checkTransformIsMatch( transform, blocks, sourceBlock ) {
+function checkTransformIsMatch( transform, blocks ) {
+	const sourceBlock = first( blocks );
 	const attributes = transform.isMultiBlock
 		? blocks.map( ( block ) => block.attributes )
 		: sourceBlock.attributes;
@@ -500,7 +500,7 @@ export function switchToBlockType( blocks, name ) {
 					t.blocks.indexOf( name ) !== -1 ) &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
 				( ! isFunction( t.isMatch ) ||
-					checkTransformIsMatch( t, blocks, firstBlock ) )
+					checkTransformIsMatch( t, blocksArray ) )
 		) ||
 		findTransform(
 			transformationsFrom,
@@ -510,7 +510,7 @@ export function switchToBlockType( blocks, name ) {
 					t.blocks.indexOf( sourceName ) !== -1 ) &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
 				( ! isFunction( t.isMatch ) ||
-					checkTransformIsMatch( t, blocks, firstBlock ) )
+					checkTransformIsMatch( t, blocksArray ) )
 		);
 
 	// Stop if there is no valid transformation.

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -12,7 +12,6 @@ import {
 	flatMap,
 	has,
 	uniq,
-	isFunction,
 	isEmpty,
 	map,
 } from 'lodash';
@@ -220,10 +219,7 @@ const isPossibleTransformForSource = ( transform, direction, blocks ) => {
 	}
 
 	// If the transform has a `isMatch` function specified, check that it returns true.
-	if (
-		isFunction( transform.isMatch ) &&
-		! checkTransformIsMatch( transform, blocks )
-	) {
+	if ( ! maybeCheckTransformIsMatch( transform, blocks ) ) {
 		return false;
 	}
 
@@ -462,7 +458,10 @@ export function getBlockTransforms( direction, blockTypeOrName ) {
  *
  * @return {boolean} True if given blocks are a match for the transform.
  */
-function checkTransformIsMatch( transform, blocks ) {
+function maybeCheckTransformIsMatch( transform, blocks ) {
+	if ( typeof transform.isMatch !== 'function' ) {
+		return true;
+	}
 	const sourceBlock = first( blocks );
 	const attributes = transform.isMultiBlock
 		? blocks.map( ( block ) => block.attributes )
@@ -499,8 +498,7 @@ export function switchToBlockType( blocks, name ) {
 				( isWildcardBlockTransform( t ) ||
 					t.blocks.indexOf( name ) !== -1 ) &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
-				( ! isFunction( t.isMatch ) ||
-					checkTransformIsMatch( t, blocksArray ) )
+				maybeCheckTransformIsMatch( t, blocksArray )
 		) ||
 		findTransform(
 			transformationsFrom,
@@ -509,8 +507,7 @@ export function switchToBlockType( blocks, name ) {
 				( isWildcardBlockTransform( t ) ||
 					t.blocks.indexOf( sourceName ) !== -1 ) &&
 				( ! isMultiBlock || t.isMultiBlock ) &&
-				( ! isFunction( t.isMatch ) ||
-					checkTransformIsMatch( t, blocksArray ) )
+				maybeCheckTransformIsMatch( t, blocksArray )
 		);
 
 	// Stop if there is no valid transformation.

--- a/packages/blocks/src/api/test/factory.js
+++ b/packages/blocks/src/api/test/factory.js
@@ -1288,6 +1288,98 @@ describe( 'block factory', () => {
 			expect( transformedBlocks ).toBeNull();
 		} );
 
+		it( 'should accept transformations that have an isMatch method that returns true', () => {
+			registerBlockType(
+				'core/updated-text-block',
+				defaultBlockSettings
+			);
+			registerBlockType( 'core/text-block', {
+				attributes: {
+					matches: {
+						type: 'boolean',
+						default: true,
+					},
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [
+						{
+							type: 'block',
+							blocks: [ 'core/updated-text-block' ],
+							isMatch: ( { matches } ) => matches === true,
+							transform: ( { value } ) => {
+								return createBlock( 'core/updated-text-block', {
+									value: 'chicken ' + value,
+								} );
+							},
+						},
+					],
+				},
+				save: noop,
+				category: 'text',
+				title: 'text-block',
+			} );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'ribs',
+			} );
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/updated-text-block'
+			);
+
+			expect( transformedBlocks ).toHaveLength( 1 );
+		} );
+
+		it( 'should reject transformations that have an isMatch method that returns false', () => {
+			registerBlockType(
+				'core/updated-text-block',
+				defaultBlockSettings
+			);
+			registerBlockType( 'core/text-block', {
+				attributes: {
+					matches: {
+						type: 'boolean',
+						default: false,
+					},
+					value: {
+						type: 'string',
+					},
+				},
+				transforms: {
+					to: [
+						{
+							type: 'block',
+							blocks: [ 'core/updated-text-block' ],
+							isMatch: ( { matches } ) => matches === true,
+							transform: ( { value } ) => {
+								return createBlock( 'core/updated-text-block', {
+									value: 'chicken ' + value,
+								} );
+							},
+						},
+					],
+				},
+				save: noop,
+				category: 'text',
+				title: 'text-block',
+			} );
+
+			const block = createBlock( 'core/text-block', {
+				value: 'ribs',
+			} );
+
+			const transformedBlocks = switchToBlockType(
+				block,
+				'core/updated-text-block'
+			);
+
+			expect( transformedBlocks ).toBeNull();
+		} );
+
 		it( 'should reject transformations that return an empty array', () => {
 			registerBlockType( 'core/updated-text-block', {
 				attributes: {


### PR DESCRIPTION
## What?
Checks that a transform matches at the time of running the transform as well as when generating list of transforms for the block transform menu

## Why?
If more than one transform matches in given circumstance the wrong one may get picked, eg. in https://github.com/WordPress/gutenberg/pull/40293 a new Group `to` transform was being used in error even though its `isMatch` function returned false, and because `to` transforms are given priority it was used instead of the `from` Group transform that should be used.

## How?
Checks that a transforms `isMatch` method returns true when deciding which transform should run.

## Testing Instructions
Check out this PR in conjunction with #40293, and make sure that a Cover block with a background image is transformed to a Cover block wrapped in a Group when the Group transform is picked, but to a Group block with the Cover block background color copied to it if Cover has no background image.

## Screenshots or screencast 

The following are taken from #40293 with this PR  applied

Before:

https://user-images.githubusercontent.com/3629020/164374811-75c1a346-91f3-4063-91aa-59517571d1e3.mp4

After:

https://user-images.githubusercontent.com/3629020/164374601-cacc893b-772e-49d7-b6bc-d8203faee92c.mp4



