### PR TITLE
Block Editor: Deprecate 'BlockColorsStyleSelector' component

### DIFF
--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
+import deprecated from '@wordpress/deprecated';
 
 const ColorSelectorSVGIcon = () => (
 	<SVG xmlns="https://www.w3.org/2000/svg" viewBox="0 0 20 20">
@@ -78,14 +79,22 @@ const renderToggleComponent = ( { TextColor, BackgroundColor } ) => ( {
 	);
 };
 
-const BlockColorsStyleSelector = ( { children, ...other } ) => (
-	<Dropdown
-		position="bottom right"
-		className="block-library-colors-selector"
-		contentClassName="block-library-colors-selector__popover"
-		renderToggle={ renderToggleComponent( other ) }
-		renderContent={ () => children }
-	/>
-);
+const BlockColorsStyleSelector = ( { children, ...other } ) => {
+	deprecated( `wp.blockEditor.BlockColorsStyleSelector`, {
+		alternative: 'block supports API',
+		since: '6.1',
+		version: '6.3',
+	} );
+
+	return (
+		<Dropdown
+			position="bottom right"
+			className="block-library-colors-selector"
+			contentClassName="block-library-colors-selector__popover"
+			renderToggle={ renderToggleComponent( other ) }
+			renderContent={ () => children }
+		/>
+	);
+};
 
 export default BlockColorsStyleSelector;


### PR DESCRIPTION
## What?
PR deprecates `BlockColorsStyleSelector` component. 

## Why?
It was introduced in #19894 but hasn't been used since #23044. Block developers should prefer using Block Supports API for colors.

WP.org plugin directory search yields a single result - https://wpdirectory.net/search/01G15G70PDWRPHM36Z464NP7PE.

## Testing Instructions
You can use the following code to see deprecation message (please ignore errors):

```js
const registerPlugin = wp.plugins.registerPlugin;
const el = wp.element.createElement;

registerPlugin( 'deperecation-test', {
    render: function () {
        return el(
            wp.blockEditor.BlockColorsStyleSelector,
            {
                TextColor: null,
                BackgroundColor: null,
            },
            "Colors"
        );
    },
} );
```
