### PR TITLE
Dependency Extraction Webpack Plugin: Use OpenSSL provider supported in Node 17+

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
+++ b/packages/dependency-extraction-webpack-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Use OpenSSL provider supported in Node 17+ when calling `crypto.createHash` ([#40503](https://github.com/WordPress/gutenberg/pull/40503)).
+
 ## 3.3.0 (2022-01-27)
 
 -   Add the optional `externalizedReportFile` option ([#35106](https://github.com/WordPress/gutenberg/pull/35106)).

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -219,7 +219,7 @@ class DependencyExtractionWebpackPlugin {
 					filename,
 					query,
 					basename: basename( filename ),
-					contentHash: createHash( 'md4' )
+					contentHash: createHash( 'sha512' )
 						.update( assetString )
 						.digest( 'hex' ),
 				}
@@ -238,7 +238,7 @@ class DependencyExtractionWebpackPlugin {
 					filename,
 					query,
 					basename: basename( filename ),
-					contentHash: createHash( 'md4' )
+					contentHash: createHash( 'sha512' )
 						.update( assetString )
 						.digest( 'hex' ),
 				} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/36471.

> Running `wp-scripts build` to build a block results in this error:
> ```
> Error: error:0308010C:digital envelope routines::unsupported
>     at new Hash (node:internal/crypto/hash:67:19)
>     at createHash (node:crypto:130:10)
>     at DependencyExtractionWebpackPlugin.addAssets (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\@wordpress\dependency-extraction-webpack-plugin\lib\index.js:200:19)
>     at C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\@wordpress\dependency-extraction-webpack-plugin\lib\index.js:129:18        
>     at fn (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\webpack\lib\Compilation.js:476:10)
>     at Hook.eval [as callAsync] (eval at create (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\tapable\lib\HookCodeFactory.js:33:10), <anonymous>:38:1)
>     at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\tapable\lib\Hook.js:18:14)       
>     at cont (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\webpack\lib\Compilation.js:3052:34)
>     at C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\webpack\lib\Compilation.js:3100:10
>     at symbolIterator (C:\Users\FramePush\Projects\Website\websitedev\generic-grid-layouts\node_modules\neo-async\async.js:3485:9)
> ```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> The culprit is trying to use md4 hash: https://github.com/WordPress/gutenberg/blob/c695c3bf03b60442a3cc52ee80b927acabc0244d/packages/dependency-extraction-webpack-plugin/lib/index.js#L200
> 
> Node v17 upgrades OpenSSL to 3.0, which moved md4 hash to the legacy provider. i.e. md4 is disabled by default.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

> webpack solved their issue by proving an md4 implementation. See https://github.com/webpack/webpack/issues/14532. But the fix here could be as simple as switching to one of the hashes in the default provider, like md5. See https://wiki.openssl.org/index.php/OpenSSL_3.0#Provider_implemented_digests What is the significance of using md4?

I picked `sha512` as it was listed in Node.js documentation at https://nodejs.org/api/crypto.html#cryptocreatehashalgorithm-options:

> The algorithm is dependent on the available algorithms supported by the version of OpenSSL on the platform. Examples are 'sha256', 'sha512', etc. On recent releases of OpenSSL, openssl list -digest-algorithms will display the available digest algorithms.

I'm more than happy to change that if there is something that is better.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Switch to Node.js 17 or 18. 
2. Run `npx wp-script build` and ensure that it doesn't error.
3. All unit tests should pass.
