### PR TITLE
Eslint: add TypeScript tests and stories to development files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,8 +26,8 @@ const majorMinorRegExp =
  */
 const developmentFiles = [
 	'**/benchmark/**/*.js',
-	'**/@(__mocks__|__tests__|test)/**/*.{js,ts,tsx}',
-	'**/@(storybook|stories)/**/*.js',
+	'**/@(__mocks__|__tests__|test)/**/*.[tj]s?(x)',
+	'**/@(storybook|stories)/**/*.[tj]s?(x)',
 	'packages/babel-preset-default/bin/**/*.js',
 ];
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tweak ESLint's config to include TypeScript unit tests and Storybook stories in the list of development files.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is change is needed to support the usage of TypeScript across the repo (especially in certain packages, like `@wordpress/components`)

This PR is a follow-up to #39436 , taking inspiration from @kevin940726 's changes to `.eslintrc` initially proposed in #40253

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the `[tj]s?(x)` glob matching pattern to include the `js`, `jsx`, `ts`, and `tsx` file extensions in the patterns matching tests and stories.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Project builds
- Stories and tests do not show additional ESLint errors, including [this recently added TypeScript test](https://github.com/WordPress/gutenberg/blob/1ef47334d7ab9b282a52c5f7ea80950abc4e6532/packages/components/src/text/test/index.tsx)

