### PR TITLE
Mobile - DroppingInsertionPoint - Update indicator position for selected blocks

### DIFF
--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -108,17 +108,15 @@ export default function DroppingInsertionPoint( {
 			: null;
 
 		const elementsPositions = {
-			top: parseInt(
+			top: Math.floor(
 				previousElement
 					? previousElement.y + previousElement.height
-					: nextElement?.y,
-				10
+					: nextElement?.y
 			),
-			bottom: parseInt(
+			bottom: Math.floor(
 				nextElement
 					? nextElement.y
-					: previousElement.y + previousElement.height,
-				10
+					: previousElement.y + previousElement.height
 			),
 		};
 

--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -28,6 +28,7 @@ import styles from './dropping-insertion-point.scss';
  *
  * @param {Object}                                        props                  Component props.
  * @param {Object}                                        props.scroll           Scroll offset object.
+ * @param {Object}                                        props.currentYPosition Current Y coordinate position when dragging.
  * @param {import('react-native-reanimated').SharedValue} props.isDragging       Whether or not dragging has started.
  * @param {import('react-native-reanimated').SharedValue} props.targetBlockIndex Current block target index.
  *
@@ -35,6 +36,7 @@ import styles from './dropping-insertion-point.scss';
  */
 export default function DroppingInsertionPoint( {
 	scroll,
+	currentYPosition,
 	isDragging,
 	targetBlockIndex,
 } ) {
@@ -60,6 +62,16 @@ export default function DroppingInsertionPoint( {
 			}
 		}
 	);
+
+	function getSelectedBlockIndicatorPosition( positions ) {
+		const currentYPositionWithScroll =
+			currentYPosition.value + scroll.offsetY.value;
+		const midpoint = ( positions.top + positions.bottom ) / 2;
+
+		return midpoint < currentYPositionWithScroll
+			? positions.bottom
+			: positions.top;
+	}
 
 	function setIndicatorPosition( index ) {
 		const insertionPointIndex = index;
@@ -95,9 +107,25 @@ export default function DroppingInsertionPoint( {
 			? findBlockLayoutByClientId( blocksLayouts.current, nextClientId )
 			: null;
 
-		const nextPosition = previousElement
-			? previousElement.y + previousElement.height
-			: nextElement?.y;
+		const elementsPositions = {
+			top: parseInt(
+				previousElement
+					? previousElement.y + previousElement.height
+					: nextElement?.y,
+				10
+			),
+			bottom: parseInt(
+				nextElement
+					? nextElement.y
+					: previousElement.y + previousElement.height,
+				10
+			),
+		};
+
+		const nextPosition =
+			elementsPositions.top !== elementsPositions.bottom
+				? getSelectedBlockIndicatorPosition( elementsPositions )
+				: elementsPositions.top;
 
 		if ( nextPosition && blockYPosition.value !== nextPosition ) {
 			opacity.value = 0;

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -78,6 +78,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		width: useSharedValue( 0 ),
 		height: useSharedValue( 0 ),
 	};
+	const currentYPosition = useSharedValue( 0 );
 	const isDragging = useSharedValue( false );
 
 	const [
@@ -159,6 +160,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		const dragPosition = { x, y };
 		chip.x.value = dragPosition.x;
 		chip.y.value = dragPosition.y;
+		currentYPosition.value = dragPosition.y;
 
 		isDragging.value = true;
 
@@ -170,6 +172,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		const dragPosition = { x, y };
 		chip.x.value = dragPosition.x;
 		chip.y.value = dragPosition.y;
+		currentYPosition.value = dragPosition.y;
 
 		runOnJS( onBlockDragOver )( { x, y: y + scroll.offsetY.value } );
 
@@ -207,6 +210,7 @@ const BlockDraggableWrapper = ( { children } ) => {
 		<>
 			<DroppingInsertionPoint
 				scroll={ scroll }
+				currentYPosition={ currentYPosition }
 				isDragging={ isDragging }
 				targetBlockIndex={ targetBlockIndex }
 			/>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4721

## What?
The initial issue was related to the indicator line not being vertically aligned for the current block that's being dragged but since the placeholder was removed it is handled differently in this PR. 

## Why?
When you're dragging over the block you're currently dragging, the indicator was showing up at the top of the block only which could be confusing.

## How?
Now it'll show the line indicator in both at the top and the bottom of the block depending on the position you're currently dragging over.

## Testing Instructions

- Open the app
- Add some blocks or use the initial HTML content
- Select a block and start dragging it
- **Expect** to see the line indicator at the top of the block if you drag over at the top of the block, if you move the finger at the bottom of the block, the line indicator should move to the bottom of the block.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4885740/164454499-06cd985d-3fd7-479d-89e4-1c80c9a19939.mov


