### PR TITLE
Mobile - Draggable - Disable multiple touches

### DIFF
--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -80,22 +80,30 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 	const panGesture = Gesture.Pan()
 		.manualActivation( true )
 		.onTouchesDown( ( event ) => {
-			const { x = 0, y = 0 } = event.allTouches[ 0 ];
+			const firstEvent = event.allTouches.filter( ( item ) => {
+				return item.id === 0;
+			} )[ 0 ];
+			const { x = 0, y = 0 } = firstEvent;
 			initialPosition.x.value = x;
 			initialPosition.y.value = y;
 		} )
-		.onTouchesMove( ( _, state ) => {
+		.onTouchesMove( ( event, state ) => {
 			if ( ! isPanActive.value && isDragging.value ) {
 				isPanActive.value = true;
 				state.activate();
 			}
-		} )
-		.onUpdate( ( event ) => {
-			lastPosition.x.value = event.x;
-			lastPosition.y.value = event.y;
 
-			if ( onDragOver ) {
-				onDragOver( event );
+			if ( isPanActive.value && isDragging.value ) {
+				const firstEvent = event.allTouches.filter( ( item ) => {
+					return item.id === 0;
+				} )[ 0 ];
+
+				lastPosition.x.value = firstEvent.x;
+				lastPosition.y.value = firstEvent.y;
+
+				if ( onDragOver ) {
+					onDragOver( firstEvent );
+				}
 			}
 		} )
 		.onEnd( () => {

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -77,12 +77,20 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 		}
 	);
 
+	function getFirstTouchEvent( event ) {
+		'worklet';
+
+		const sortedEventsById = event.allTouches.sort(
+			( a, b ) => b.id + a.id
+		);
+		return sortedEventsById[ 0 ];
+	}
+
 	const panGesture = Gesture.Pan()
 		.manualActivation( true )
 		.onTouchesDown( ( event ) => {
-			const firstEvent = event.allTouches.filter( ( item ) => {
-				return item.id === 0;
-			} )[ 0 ];
+			const firstEvent = getFirstTouchEvent( event );
+
 			const { x = 0, y = 0 } = firstEvent;
 			initialPosition.x.value = x;
 			initialPosition.y.value = y;
@@ -94,9 +102,7 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 			}
 
 			if ( isPanActive.value && isDragging.value ) {
-				const firstEvent = event.allTouches.filter( ( item ) => {
-					return item.id === 0;
-				} )[ 0 ];
+				const firstEvent = getFirstTouchEvent( event );
 
 				lastPosition.x.value = firstEvent.x;
 				lastPosition.y.value = firstEvent.y;

--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -120,7 +120,7 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 		.shouldCancelWhenOutside( false );
 
 	const providerValue = useMemo( () => {
-		return { panGestureRef, isDragging, draggingId };
+		return { panGestureRef, isDragging, isPanActive, draggingId };
 	}, [] );
 
 	return (
@@ -157,7 +157,9 @@ const DraggableTrigger = ( {
 	onLongPress,
 	onLongPressEnd,
 } ) => {
-	const { panGestureRef, isDragging, draggingId } = useContext( Context );
+	const { panGestureRef, isDragging, isPanActive, draggingId } = useContext(
+		Context
+	);
 
 	const gestureHandler = useAnimatedGestureHandler( {
 		onActive: () => {
@@ -172,7 +174,10 @@ const DraggableTrigger = ( {
 			}
 		},
 		onEnd: () => {
-			isDragging.value = false;
+			if ( ! isPanActive.value ) {
+				isDragging.value = false;
+			}
+
 			if ( onLongPressEnd ) {
 				runOnJS( onLongPressEnd )( id );
 			}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4754

## What?
This PR disables support for multiple touches when dragging a block.

## Why?
During testing, an issue was reported that having multiple touches on the screen while dragging a block gives the wrong position as it takes into account all touches positions.

## How?
A few options were suggested in this [comment](https://github.com/wordpress-mobile/gutenberg-mobile/issues/4754#issuecomment-1102244321), but unfortunately using `maxPointers` doesn't work as expected on Android.

If you set `maxPointers` to `1` on Android, as soon as another touch is detected while dragging, the previous one gets canceled.

On iOS `maxPointers` works correctly but to avoid having different logic per platform, this PR changes the logic to support only one touch.

It removes `onUpdate` to use `onTouchesMove` instead where all touches are passed through `allTouches`. This prevents getting the other coordinates from other touches.

Since we can't rely on the order of the items as it is [mentioned](https://docs.swmansion.com/react-native-gesture-handler/docs/api/gestures/touch-events#numberoftouches) in the documentation, now it'll store the first touch event id to be able to filter it if other touches happen during dragging a block.

## Testing Instructions
- Open the app with the initial HTML content or several blocks at least
- Drag a block
- While dragging the block, place more fingers on the screen
- **Expect** to only the first touch to be recognized

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4885740/164724342-91f184f7-40ba-4e6a-bf26-943253c3efc8.mov
