### PR TITLE
Global Styles Sidebar: tweak separator margin

### DIFF
--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -136,3 +136,10 @@ $split-border-control-offset: 55px;
 		}
 	}
 }
+
+// Override the `hr` styles defined for the complementary area component
+// from the `@wordpress/interface` package.
+.edit-site-global-styles-sidebar hr {
+	margin: 0;
+	border-color: rgba(0, 0, 0, 0.1);
+}

--- a/packages/edit-site/src/components/sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/style.scss
@@ -137,9 +137,8 @@ $split-border-control-offset: 55px;
 	}
 }
 
-// Override the `hr` styles defined for the complementary area component
+// Override the `hr` styles defined in the `ComplementaryArea` component
 // from the `@wordpress/interface` package.
 .edit-site-global-styles-sidebar hr {
 	margin: 0;
-	border-color: rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tweak the styles of the separator used in the root screen of the Global Styles Sidebar, removing its vertical margin and enforcing its expected color.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is part of a series of tweaks aimed at polishing the Global Styles Sidebar — see #38934 for more details.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The changes in this PR mainly override [the margin styles](https://github.com/WordPress/gutenberg/blob/c1ea8d60db9f05ebbfbaced50a88bfe30a7a0270/packages/interface/src/components/complementary-area/style.scss#L53-L57) that the `ComplementaryArea` component applies to all children `hr` . In particular, the margin has been changed to be `0`.

The idea is that any vertical spacing around the separator may be sufficiently provided by the padding of the sibling components.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Open the site editor
- Open global styles sidebar (if not already opened)
- Make sure that the vertical spacing around the separator looks good

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| ![Screenshot 2022-04-21 at 20 11 09](https://user-images.githubusercontent.com/1083581/164525531-2612a8fc-71b0-4b51-b135-5df968516706.png) | ![Screenshot 2022-04-21 at 20 03 42](https://user-images.githubusercontent.com/1083581/164524984-d461fa96-c01b-4c8a-8f78-a195b74f8b01.png) |



