### PR TITLE
Post Comments block: Fix missing label in placeholder

### DIFF
--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -16,7 +16,10 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
+import {
+	__experimentalUseDisabled as useDisabled,
+	useInstanceId,
+} from '@wordpress/compose';
 
 export default function PostCommentsEdit( {
 	attributes: { textAlign },
@@ -84,6 +87,8 @@ export default function PostCommentsEdit( {
 	} );
 
 	const disabledRef = useDisabled();
+
+	const textareaId = useInstanceId( PostCommentsEdit );
 
 	return (
 		<>
@@ -208,13 +213,14 @@ export default function PostCommentsEdit( {
 
 							<form className="comment-form" noValidate>
 								<p className="comment-form-comment">
-									<label htmlFor="comment">
+									<label
+										htmlFor={ `comment-${ textareaId }` }
+									>
 										{ __( 'Comment' ) }{ ' ' }
 										<span className="required">*</span>
 									</label>
 									<textarea
-										// eslint-disable-next-line no-restricted-syntax
-										id="comment"
+										id={ `comment-${ textareaId }` }
 										name="comment"
 										cols="45"
 										rows="8"

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -213,6 +213,8 @@ export default function PostCommentsEdit( {
 										<span className="required">*</span>
 									</label>
 									<textarea
+										// eslint-disable-next-line no-restricted-syntax
+										id="comment"
 										name="comment"
 										cols="45"
 										rows="8"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix missing label for textarea in Post Comments block placeholder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

@ryelle did an a11y [review of the new placeholder](https://github.com/WordPress/gutenberg/pull/40484#issuecomment-1105621065) and discovered that the label of the textarea is missing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The label tag is actually there, but I removed the textarea id because the linter was complaining.

~~I added it back along with an eslint exception.~~

As per @ryelle suggestion (https://github.com/WordPress/gutenberg/pull/40527#discussion_r855601392), I switched to using `useInstanceId` instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Set the `inserter` property of the Post Comments `block.json` to `true` so the block shows up in the inserter, or switch to the Code Editor and paste `<!-- wp:post-comments /-->`.
2. Once you have added the block to a post, test that the label is correct.