### PR TITLE
Design tweaks to Post Visibility popover

### DIFF
--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -8,12 +8,14 @@ import {
 	PostVisibilityLabel,
 	PostVisibilityCheck,
 } from '@wordpress/editor';
+import { useRef } from '@wordpress/element';
 
 export function PostVisibility() {
+	const rowRef = useRef();
 	return (
 		<PostVisibilityCheck
 			render={ ( { canEdit } ) => (
-				<PanelRow className="edit-post-post-visibility">
+				<PanelRow ref={ rowRef } className="edit-post-post-visibility">
 					<span>{ __( 'Visibility' ) }</span>
 					{ ! canEdit && (
 						<span>
@@ -24,6 +26,12 @@ export function PostVisibility() {
 						<Dropdown
 							position="bottom left"
 							contentClassName="edit-post-post-visibility__dialog"
+							popoverProps={ {
+								// Anchor the popover to the middle of the
+								// entire row so that it doesn't move around
+								// when the label changes.
+								anchorRef: rowRef.current,
+							} }
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
 									aria-expanded={ isOpen }

--- a/packages/edit-post/src/components/sidebar/post-visibility/index.js
+++ b/packages/edit-post/src/components/sidebar/post-visibility/index.js
@@ -34,7 +34,9 @@ export function PostVisibility() {
 									<PostVisibilityLabel />
 								</Button>
 							) }
-							renderContent={ () => <PostVisibilityForm /> }
+							renderContent={ ( { onClose } ) => (
+								<PostVisibilityForm onClose={ onClose } />
+							) }
 						/>
 					) }
 				</PanelRow>

--- a/packages/edit-post/src/components/sidebar/post-visibility/style.scss
+++ b/packages/edit-post/src/components/sidebar/post-visibility/style.scss
@@ -9,34 +9,6 @@
 }
 
 .edit-post-post-visibility__dialog .components-popover__content {
-	@include break-medium {
-		// 279px (sidebar width) - 20px (padding) - 2px (horizontal borders)
-		width: 257px;
-	}
-}
-
-.edit-post-post-visibility__dialog-legend {
-	font-weight: 600;
-}
-
-.edit-post-post-visibility__choice {
-	margin: 10px 0;
-}
-
-.edit-post-post-visibility__dialog-radio,
-.edit-post-post-visibility__dialog-label {
-	vertical-align: top;
-}
-
-.edit-post-post-visibility__dialog-password-input {
-	width: calc(100% - 20px);
-	margin-left: 20px;
-}
-
-.edit-post-post-visibility__dialog-info {
-	color: $gray-700;
-	padding-left: 20px;
-	font-style: italic;
-	margin: 4px 0 0;
-	line-height: 1.4;
+	// sidebar width - padding - horizontal borders
+	width: $sidebar-width - $grid-unit-20 - $border-width * 2;
 }

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -81,7 +81,9 @@ export default function PostVisibility( { onClose } ) {
 				<legend className="editor-post-visibility__legend">
 					{ __( 'Visibility' ) }
 				</legend>
-				<p>{ __( 'Control how this post is viewed.' ) }</p>
+				<p className="editor-post-visibility__description">
+					{ __( 'Control how this post is viewed.' ) }
+				</p>
 				<PostVisibilityChoice
 					instanceId={ instanceId }
 					value="public"

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -6,9 +6,11 @@ import { Component } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	__experimentalConfirmDialog as ConfirmDialog,
+	Button,
 } from '@wordpress/components';
 import { withInstanceId, compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
+import { close as closeIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -73,7 +75,7 @@ export class PostVisibility extends Component {
 	}
 
 	render() {
-		const { visibility, password, instanceId } = this.props;
+		const { visibility, password, instanceId, onClose } = this.props;
 
 		const visibilityHandlers = {
 			public: {
@@ -90,74 +92,82 @@ export class PostVisibility extends Component {
 			},
 		};
 
-		return [
-			<fieldset
-				key="visibility-selector"
-				className="editor-post-visibility__fieldset"
-			>
-				<legend className="editor-post-visibility__legend">
-					{ __( 'Visibility' ) }
-				</legend>
-				<p>{ __( 'Control how this post is viewed.' ) }</p>
-				{ visibilityOptions.map( ( { value, label, info } ) => (
-					<div
-						key={ value }
-						className="editor-post-visibility__choice"
-					>
-						<input
-							type="radio"
-							name={ `editor-post-visibility__setting-${ instanceId }` }
-							value={ value }
-							onChange={ visibilityHandlers[ value ].onSelect }
-							checked={ visibilityHandlers[ value ].checked }
-							id={ `editor-post-${ value }-${ instanceId }` }
-							aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-							className="editor-post-visibility__radio"
-						/>
-						<label
-							htmlFor={ `editor-post-${ value }-${ instanceId }` }
-							className="editor-post-visibility__label"
+		return (
+			<>
+				<Button
+					className="editor-post-visibility__close"
+					isSmall
+					icon={ closeIcon }
+					onClick={ onClose }
+				/>
+				<fieldset className="editor-post-visibility__fieldset">
+					<legend className="editor-post-visibility__legend">
+						{ __( 'Visibility' ) }
+					</legend>
+					<p>{ __( 'Control how this post is viewed.' ) }</p>
+					{ visibilityOptions.map( ( { value, label, info } ) => (
+						<div
+							key={ value }
+							className="editor-post-visibility__choice"
 						>
-							{ label }
-						</label>
-						{
-							<p
-								id={ `editor-post-${ value }-${ instanceId }-description` }
-								className="editor-post-visibility__info"
+							<input
+								type="radio"
+								name={ `editor-post-visibility__setting-${ instanceId }` }
+								value={ value }
+								onChange={
+									visibilityHandlers[ value ].onSelect
+								}
+								checked={ visibilityHandlers[ value ].checked }
+								id={ `editor-post-${ value }-${ instanceId }` }
+								aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+								className="editor-post-visibility__radio"
+							/>
+							<label
+								htmlFor={ `editor-post-${ value }-${ instanceId }` }
+								className="editor-post-visibility__label"
 							>
-								{ info }
-							</p>
-						}
-					</div>
-				) ) }
-				{ this.state.hasPassword && (
-					<div className="editor-post-visibility__password">
-						<VisuallyHidden
-							as="label"
-							htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
-						>
-							{ __( 'Create password' ) }
-						</VisuallyHidden>
-						<input
-							className="editor-post-visibility__password-input"
-							id={ `editor-post-visibility__password-input-${ instanceId }` }
-							type="text"
-							onChange={ this.updatePassword }
-							value={ password }
-							placeholder={ __( 'Use a secure password' ) }
-						/>
-					</div>
-				) }
-			</fieldset>,
-			<ConfirmDialog
-				key="private-publish-confirmation"
-				isOpen={ this.state.showPrivateConfirmDialog }
-				onConfirm={ this.confirmPrivate }
-				onCancel={ this.handleDialogCancel }
-			>
-				{ __( 'Would you like to privately publish this post now?' ) }
-			</ConfirmDialog>,
-		];
+								{ label }
+							</label>
+							{
+								<p
+									id={ `editor-post-${ value }-${ instanceId }-description` }
+									className="editor-post-visibility__info"
+								>
+									{ info }
+								</p>
+							}
+						</div>
+					) ) }
+					{ this.state.hasPassword && (
+						<div className="editor-post-visibility__password">
+							<VisuallyHidden
+								as="label"
+								htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
+							>
+								{ __( 'Create password' ) }
+							</VisuallyHidden>
+							<input
+								className="editor-post-visibility__password-input"
+								id={ `editor-post-visibility__password-input-${ instanceId }` }
+								type="text"
+								onChange={ this.updatePassword }
+								value={ password }
+								placeholder={ __( 'Use a secure password' ) }
+							/>
+						</div>
+					) }
+				</fieldset>
+				<ConfirmDialog
+					isOpen={ this.state.showPrivateConfirmDialog }
+					onConfirm={ this.confirmPrivate }
+					onCancel={ this.handleDialogCancel }
+				>
+					{ __(
+						'Would you like to privately publish this post now?'
+					) }
+				</ConfirmDialog>
+			</>
+		);
 	}
 }
 

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -93,9 +93,9 @@ export class PostVisibility extends Component {
 		return [
 			<fieldset
 				key="visibility-selector"
-				className="editor-post-visibility__dialog-fieldset"
+				className="editor-post-visibility__fieldset"
 			>
-				<legend className="editor-post-visibility__dialog-legend">
+				<legend className="editor-post-visibility__legend">
 					{ __( 'Visibility' ) }
 				</legend>
 				<p>{ __( 'Control how this post is viewed.' ) }</p>
@@ -112,18 +112,18 @@ export class PostVisibility extends Component {
 							checked={ visibilityHandlers[ value ].checked }
 							id={ `editor-post-${ value }-${ instanceId }` }
 							aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-							className="editor-post-visibility__dialog-radio"
+							className="editor-post-visibility__radio"
 						/>
 						<label
 							htmlFor={ `editor-post-${ value }-${ instanceId }` }
-							className="editor-post-visibility__dialog-label"
+							className="editor-post-visibility__label"
 						>
 							{ label }
 						</label>
 						{
 							<p
 								id={ `editor-post-${ value }-${ instanceId }-description` }
-								className="editor-post-visibility__dialog-info"
+								className="editor-post-visibility__info"
 							>
 								{ info }
 							</p>
@@ -131,16 +131,16 @@ export class PostVisibility extends Component {
 					</div>
 				) ) }
 				{ this.state.hasPassword && (
-					<div className="editor-post-visibility__dialog-password">
+					<div className="editor-post-visibility__password">
 						<VisuallyHidden
 							as="label"
-							htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+							htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
 						>
 							{ __( 'Create password' ) }
 						</VisuallyHidden>
 						<input
-							className="editor-post-visibility__dialog-password-input"
-							id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+							className="editor-post-visibility__password-input"
+							id={ `editor-post-visibility__password-input-${ instanceId }` }
 							type="text"
 							onChange={ this.updatePassword }
 							value={ password }

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -96,8 +96,9 @@ export class PostVisibility extends Component {
 				className="editor-post-visibility__dialog-fieldset"
 			>
 				<legend className="editor-post-visibility__dialog-legend">
-					{ __( 'Post Visibility' ) }
+					{ __( 'Visibility' ) }
 				</legend>
+				<p>{ __( 'Control how this post is viewed.' ) }</p>
 				{ visibilityOptions.map( ( { value, label, info } ) => (
 					<div
 						key={ value }
@@ -129,28 +130,25 @@ export class PostVisibility extends Component {
 						}
 					</div>
 				) ) }
+				{ this.state.hasPassword && (
+					<div className="editor-post-visibility__dialog-password">
+						<VisuallyHidden
+							as="label"
+							htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+						>
+							{ __( 'Create password' ) }
+						</VisuallyHidden>
+						<input
+							className="editor-post-visibility__dialog-password-input"
+							id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
+							type="text"
+							onChange={ this.updatePassword }
+							value={ password }
+							placeholder={ __( 'Use a secure password' ) }
+						/>
+					</div>
+				) }
 			</fieldset>,
-			this.state.hasPassword && (
-				<div
-					className="editor-post-visibility__dialog-password"
-					key="password-selector"
-				>
-					<VisuallyHidden
-						as="label"
-						htmlFor={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-					>
-						{ __( 'Create password' ) }
-					</VisuallyHidden>
-					<input
-						className="editor-post-visibility__dialog-password-input"
-						id={ `editor-post-visibility__dialog-password-input-${ instanceId }` }
-						type="text"
-						onChange={ this.updatePassword }
-						value={ password }
-						placeholder={ __( 'Use a secure password' ) }
-					/>
-				</div>
-			),
 			<ConfirmDialog
 				key="private-publish-confirmation"
 				isOpen={ this.state.showPrivateConfirmDialog }

--- a/packages/editor/src/components/post-visibility/index.js
+++ b/packages/editor/src/components/post-visibility/index.js
@@ -2,14 +2,14 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import {
 	VisuallyHidden,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Button,
 } from '@wordpress/components';
-import { withInstanceId, compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useInstanceId } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { close as closeIcon } from '@wordpress/icons';
 
 /**
@@ -18,178 +18,148 @@ import { close as closeIcon } from '@wordpress/icons';
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
-export class PostVisibility extends Component {
-	constructor( props ) {
-		super( ...arguments );
+export default function PostVisibility( { onClose } ) {
+	const instanceId = useInstanceId( PostVisibility );
 
-		this.setPublic = this.setPublic.bind( this );
-		this.setPrivate = this.setPrivate.bind( this );
-		this.setPasswordProtected = this.setPasswordProtected.bind( this );
-		this.updatePassword = this.updatePassword.bind( this );
+	const { status, visibility, password } = useSelect( ( select ) => ( {
+		status: select( editorStore ).getEditedPostAttribute( 'status' ),
+		visibility: select( editorStore ).getEditedPostVisibility(),
+		password: select( editorStore ).getEditedPostAttribute( 'password' ),
+	} ) );
 
-		this.state = {
-			hasPassword: !! props.password,
-			showPrivateConfirmDialog: false,
-		};
-	}
+	const { editPost, savePost } = useDispatch( editorStore );
 
-	setPublic() {
-		const { visibility, onUpdateVisibility, status } = this.props;
+	const [ hasPassword, setHasPassword ] = useState( !! password );
+	const [ showPrivateConfirmDialog, setShowPrivateConfirmDialog ] = useState(
+		false
+	);
 
-		onUpdateVisibility( visibility === 'private' ? 'draft' : status );
-		this.setState( { hasPassword: false } );
-	}
-
-	setPrivate() {
-		this.setState( { showPrivateConfirmDialog: true } );
-	}
-
-	confirmPrivate = () => {
-		const { onUpdateVisibility, onSave } = this.props;
-
-		onUpdateVisibility( 'private' );
-		this.setState( {
-			hasPassword: false,
-			showPrivateConfirmDialog: false,
+	const setPublic = () => {
+		editPost( {
+			status: visibility === 'private' ? 'draft' : status,
+			password: '',
 		} );
-		onSave();
+		setHasPassword( false );
 	};
 
-	handleDialogCancel = () => {
-		this.setState( { showPrivateConfirmDialog: false } );
+	const setPrivate = () => {
+		setShowPrivateConfirmDialog( true );
 	};
 
-	setPasswordProtected() {
-		const { visibility, onUpdateVisibility, status, password } = this.props;
+	const confirmPrivate = () => {
+		editPost( { status: 'private', password: '' } );
+		setHasPassword( false );
+		setShowPrivateConfirmDialog( false );
+		savePost();
+	};
 
-		onUpdateVisibility(
-			visibility === 'private' ? 'draft' : status,
-			password || ''
-		);
-		this.setState( { hasPassword: true } );
-	}
+	const handleDialogCancel = () => {
+		setShowPrivateConfirmDialog( false );
+	};
 
-	updatePassword( event ) {
-		const { status, onUpdateVisibility } = this.props;
-		onUpdateVisibility( status, event.target.value );
-	}
+	const setPasswordProtected = () => {
+		editPost( {
+			status: visibility === 'private' ? 'draft' : status,
+			password: password || '',
+		} );
+		setHasPassword( true );
+	};
 
-	render() {
-		const { visibility, password, instanceId, onClose } = this.props;
+	const updatePassword = ( event ) => {
+		editPost( { password: event.target.value } );
+	};
 
-		const visibilityHandlers = {
-			public: {
-				onSelect: this.setPublic,
-				checked: visibility === 'public' && ! this.state.hasPassword,
-			},
-			private: {
-				onSelect: this.setPrivate,
-				checked: visibility === 'private',
-			},
-			password: {
-				onSelect: this.setPasswordProtected,
-				checked: this.state.hasPassword,
-			},
-		};
-
-		return (
-			<>
-				<Button
-					className="editor-post-visibility__close"
-					isSmall
-					icon={ closeIcon }
-					onClick={ onClose }
+	return (
+		<>
+			<Button
+				className="editor-post-visibility__close"
+				isSmall
+				icon={ closeIcon }
+				onClick={ onClose }
+			/>
+			<fieldset className="editor-post-visibility__fieldset">
+				<legend className="editor-post-visibility__legend">
+					{ __( 'Visibility' ) }
+				</legend>
+				<p>{ __( 'Control how this post is viewed.' ) }</p>
+				<PostVisibilityChoice
+					instanceId={ instanceId }
+					value="public"
+					label={ visibilityOptions.public.label }
+					info={ visibilityOptions.public.info }
+					checked={ visibility === 'public' && ! hasPassword }
+					onChange={ setPublic }
 				/>
-				<fieldset className="editor-post-visibility__fieldset">
-					<legend className="editor-post-visibility__legend">
-						{ __( 'Visibility' ) }
-					</legend>
-					<p>{ __( 'Control how this post is viewed.' ) }</p>
-					{ visibilityOptions.map( ( { value, label, info } ) => (
-						<div
-							key={ value }
-							className="editor-post-visibility__choice"
+				<PostVisibilityChoice
+					instanceId={ instanceId }
+					value="private"
+					label={ visibilityOptions.private.label }
+					info={ visibilityOptions.private.info }
+					checked={ visibility === 'private' }
+					onChange={ setPrivate }
+				/>
+				<PostVisibilityChoice
+					instanceId={ instanceId }
+					value="password"
+					label={ visibilityOptions.password.label }
+					info={ visibilityOptions.password.info }
+					checked={ hasPassword }
+					onChange={ setPasswordProtected }
+				/>
+				{ hasPassword && (
+					<div className="editor-post-visibility__password">
+						<VisuallyHidden
+							as="label"
+							htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
 						>
-							<input
-								type="radio"
-								name={ `editor-post-visibility__setting-${ instanceId }` }
-								value={ value }
-								onChange={
-									visibilityHandlers[ value ].onSelect
-								}
-								checked={ visibilityHandlers[ value ].checked }
-								id={ `editor-post-${ value }-${ instanceId }` }
-								aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
-								className="editor-post-visibility__radio"
-							/>
-							<label
-								htmlFor={ `editor-post-${ value }-${ instanceId }` }
-								className="editor-post-visibility__label"
-							>
-								{ label }
-							</label>
-							{
-								<p
-									id={ `editor-post-${ value }-${ instanceId }-description` }
-									className="editor-post-visibility__info"
-								>
-									{ info }
-								</p>
-							}
-						</div>
-					) ) }
-					{ this.state.hasPassword && (
-						<div className="editor-post-visibility__password">
-							<VisuallyHidden
-								as="label"
-								htmlFor={ `editor-post-visibility__password-input-${ instanceId }` }
-							>
-								{ __( 'Create password' ) }
-							</VisuallyHidden>
-							<input
-								className="editor-post-visibility__password-input"
-								id={ `editor-post-visibility__password-input-${ instanceId }` }
-								type="text"
-								onChange={ this.updatePassword }
-								value={ password }
-								placeholder={ __( 'Use a secure password' ) }
-							/>
-						</div>
-					) }
-				</fieldset>
-				<ConfirmDialog
-					isOpen={ this.state.showPrivateConfirmDialog }
-					onConfirm={ this.confirmPrivate }
-					onCancel={ this.handleDialogCancel }
-				>
-					{ __(
-						'Would you like to privately publish this post now?'
-					) }
-				</ConfirmDialog>
-			</>
-		);
-	}
+							{ __( 'Create password' ) }
+						</VisuallyHidden>
+						<input
+							className="editor-post-visibility__password-input"
+							id={ `editor-post-visibility__password-input-${ instanceId }` }
+							type="text"
+							onChange={ updatePassword }
+							value={ password }
+							placeholder={ __( 'Use a secure password' ) }
+						/>
+					</div>
+				) }
+			</fieldset>
+			<ConfirmDialog
+				isOpen={ showPrivateConfirmDialog }
+				onConfirm={ confirmPrivate }
+				onCancel={ handleDialogCancel }
+			>
+				{ __( 'Would you like to privately publish this post now?' ) }
+			</ConfirmDialog>
+		</>
+	);
 }
 
-export default compose( [
-	withSelect( ( select ) => {
-		const { getEditedPostAttribute, getEditedPostVisibility } = select(
-			editorStore
-		);
-		return {
-			status: getEditedPostAttribute( 'status' ),
-			visibility: getEditedPostVisibility(),
-			password: getEditedPostAttribute( 'password' ),
-		};
-	} ),
-	withDispatch( ( dispatch ) => {
-		const { savePost, editPost } = dispatch( editorStore );
-		return {
-			onSave: savePost,
-			onUpdateVisibility( status, password = '' ) {
-				editPost( { status, password } );
-			},
-		};
-	} ),
-	withInstanceId,
-] )( PostVisibility );
+function PostVisibilityChoice( { instanceId, value, label, info, ...props } ) {
+	return (
+		<div className="editor-post-visibility__choice">
+			<input
+				type="radio"
+				name={ `editor-post-visibility__setting-${ instanceId }` }
+				value={ value }
+				id={ `editor-post-${ value }-${ instanceId }` }
+				aria-describedby={ `editor-post-${ value }-${ instanceId }-description` }
+				className="editor-post-visibility__radio"
+				{ ...props }
+			/>
+			<label
+				htmlFor={ `editor-post-${ value }-${ instanceId }` }
+				className="editor-post-visibility__label"
+			>
+				{ label }
+			</label>
+			<p
+				id={ `editor-post-${ value }-${ instanceId }-description` }
+				className="editor-post-visibility__info"
+			>
+				{ info }
+			</p>
+		</div>
+	);
+}

--- a/packages/editor/src/components/post-visibility/label.js
+++ b/packages/editor/src/components/post-visibility/label.js
@@ -1,12 +1,7 @@
 /**
- * External dependencies
- */
-import { find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
-import { withSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,13 +9,9 @@ import { withSelect } from '@wordpress/data';
 import { visibilityOptions } from './utils';
 import { store as editorStore } from '../../store';
 
-function PostVisibilityLabel( { visibility } ) {
-	const getVisibilityLabel = () =>
-		find( visibilityOptions, { value: visibility } ).label;
-
-	return getVisibilityLabel( visibility );
+export default function PostVisibilityLabel() {
+	const visibility = useSelect( ( select ) =>
+		select( editorStore ).getEditedPostVisibility()
+	);
+	return visibilityOptions[ visibility ]?.label;
 }
-
-export default withSelect( ( select ) => ( {
-	visibility: select( editorStore ).getEditedPostVisibility(),
-} ) )( PostVisibilityLabel );

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -5,12 +5,15 @@
 }
 
 .editor-post-visibility__fieldset {
-	padding: $grid-unit-20;
+	padding: $grid-unit-10;
 
 	.editor-post-visibility__legend {
 		font-weight: 600;
-		margin-top: 1em;
-		padding: 0;
+		padding: 1em 0 0 0;
+	}
+
+	.editor-post-visibility__description {
+		margin-top: 0.5em;
 	}
 
 	.editor-post-visibility__radio[type="radio"] {
@@ -18,13 +21,10 @@
 		margin-top: 2px;
 	}
 
-	.editor-post-visibility__label {
-		font-weight: 600;
-	}
-
 	.editor-post-visibility__info {
-		margin-top: 0.5em;
+		color: $gray-700;
 		margin-left: $grid-unit-15 + $radio-input-size-sm;
+		margin-top: 0.5em;
 
 		@include break-small {
 			margin-left: $grid-unit-15 + $radio-input-size;

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,3 +1,7 @@
+.edit-post-post-visibility__dialog .components-popover__content {
+	min-width: 260px;
+}
+
 .edit-post-post-visibility__dialog,
 .editor-post-visibility__dialog-fieldset {
 	padding: $grid-unit-10;
@@ -19,7 +23,11 @@
 
 	.editor-post-visibility__dialog-info {
 		margin-top: 0.5em;
-		margin-left: $grid-unit-40;
+		margin-left: $grid-unit-15 + $radio-input-size-sm;
+
+		@include break-small {
+			margin-left: $grid-unit-15 + $radio-input-size;
+		}
 	}
 
 	// Remove bottom margin on the last label only.

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,12 +1,10 @@
 .edit-post-post-visibility__dialog,
 .editor-post-visibility__dialog-fieldset {
-	padding: $grid-unit-05;
-	padding-top: 0;
+	padding: $grid-unit-10;
 
 	.editor-post-visibility__dialog-legend {
 		font-weight: 600;
-		margin-bottom: 1em;
-		margin-top: 0.5em;
+		margin-top: 1em;
 		padding: 0;
 	}
 
@@ -20,7 +18,7 @@
 	}
 
 	.editor-post-visibility__dialog-info {
-		margin-top: 0;
+		margin-top: 0.5em;
 		margin-left: $grid-unit-40;
 	}
 
@@ -33,7 +31,7 @@
 .editor-post-visibility__dialog-password {
 	.editor-post-visibility__dialog-password-input[type="text"] {
 		@include input-control;
-		margin-left: $grid-unit * 4.5;
-		margin-top: $grid-unit-10;
+		margin-left: $grid-unit * 4;
+		width: calc(100% - #{$grid-unit * 4});
 	}
 }

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,27 +1,22 @@
-.edit-post-post-visibility__dialog .components-popover__content {
-	min-width: 260px;
-}
+.editor-post-visibility__fieldset {
+	padding: $grid-unit-20;
 
-.edit-post-post-visibility__dialog,
-.editor-post-visibility__dialog-fieldset {
-	padding: $grid-unit-10;
-
-	.editor-post-visibility__dialog-legend {
+	.editor-post-visibility__legend {
 		font-weight: 600;
 		margin-top: 1em;
 		padding: 0;
 	}
 
-	.editor-post-visibility__dialog-radio[type="radio"] {
+	.editor-post-visibility__radio[type="radio"] {
 		@include radio-control;
 		margin-top: 2px;
 	}
 
-	.editor-post-visibility__dialog-label {
+	.editor-post-visibility__label {
 		font-weight: 600;
 	}
 
-	.editor-post-visibility__dialog-info {
+	.editor-post-visibility__info {
 		margin-top: 0.5em;
 		margin-left: $grid-unit-15 + $radio-input-size-sm;
 
@@ -31,13 +26,11 @@
 	}
 
 	// Remove bottom margin on the last label only.
-	.editor-post-visibility__choice:last-child .editor-post-visibility__dialog-info {
+	.editor-post-visibility__choice:last-child .editor-post-visibility__info {
 		margin-bottom: 0;
 	}
-}
 
-.editor-post-visibility__dialog-password {
-	.editor-post-visibility__dialog-password-input[type="text"] {
+	.editor-post-visibility__password .editor-post-visibility__password-input[type="text"] {
 		@include input-control;
 		margin-left: $grid-unit * 4;
 		width: calc(100% - #{$grid-unit * 4});

--- a/packages/editor/src/components/post-visibility/style.scss
+++ b/packages/editor/src/components/post-visibility/style.scss
@@ -1,3 +1,9 @@
+.editor-post-visibility__close {
+	position: absolute;
+	right: $grid-unit-20;
+	top: $grid-unit-20;
+}
+
 .editor-post-visibility__fieldset {
 	padding: $grid-unit-20;
 

--- a/packages/editor/src/components/post-visibility/utils.js
+++ b/packages/editor/src/components/post-visibility/utils.js
@@ -3,20 +3,17 @@
  */
 import { __ } from '@wordpress/i18n';
 
-export const visibilityOptions = [
-	{
-		value: 'public',
+export const visibilityOptions = {
+	public: {
 		label: __( 'Public' ),
 		info: __( 'Visible to everyone.' ),
 	},
-	{
-		value: 'private',
+	private: {
 		label: __( 'Private' ),
 		info: __( 'Only visible to site admins and editors.' ),
 	},
-	{
-		value: 'password',
+	password: {
 		label: __( 'Password protected' ),
 		info: __( 'Only those with the password can view this post.' ),
 	},
-];
+};

--- a/packages/editor/src/components/post-visibility/utils.js
+++ b/packages/editor/src/components/post-visibility/utils.js
@@ -16,9 +16,7 @@ export const visibilityOptions = [
 	},
 	{
 		value: 'password',
-		label: __( 'Password Protected' ),
-		info: __(
-			'Protected with a password you choose. Only those with the password can view this post.'
-		),
+		label: __( 'Password protected' ),
+		info: __( 'Only those with the password can view this post.' ),
 	},
 ];


### PR DESCRIPTION
## What?

A few design tweaks to the Post Visibility popover.

| Before | After |
| - | - |
| <img width="279" alt="Screen Shot 2022-04-22 at 13 22 49" src="https://user-images.githubusercontent.com/612155/164590036-73594f6d-9478-4471-903a-98fea90f7c69.png"> | <img width="290" alt="Screen Shot 2022-04-22 at 13 22 57" src="https://user-images.githubusercontent.com/612155/164590041-e9a9723f-09c4-4449-ab17-12e4f2b74319.png"> |

## Why?

Part of https://github.com/WordPress/gutenberg/issues/39082 which is an effort to refresh the entire Status & Visibility panel. I'm tackling it one popover at a time.

## How?

- Adjusted the copy, padding, and margins.
- Fixed the appearance of the popover on mobile. (Previously it was too narrow to be usable.)
- Added a close (X) button.
- Refactored the CSS to be a bit simpler and rewrote `PostVisibility` to use React hooks, because why not.

I explored inlining the modal confirmation step that happens after you select _Private_ which is what @javierarce suggests in [this Figma file](https://www.figma.com/file/8vEDwRwmzWhxvcvhc6yaQk/Status-%26-visibility?node-id=1%3A2). I decided against this though as it's very difficult to get that flow to work nicely with a screen reader. Let's improve this part of the flow separately—see https://github.com/WordPress/gutenberg/issues/9396.

## Testing Instructions

1. Create a post.
2. Open the post settings sidebar.
3. Change the _Visibility_.
4. Try out each of the options. Things should work the same as they do in `trunk`.