### PR TITLE
Add optional chaining in case taxonomy visibility is not defined

### DIFF
--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -28,6 +28,8 @@ export function PostTaxonomies( {
 	);
 	const visibleTaxonomies = filter(
 		availableTaxonomies,
+		// In some circumstances .visibility can end up as undefined so optional chaining operator required.
+		// https://github.com/WordPress/gutenberg/issues/40326
 		( taxonomy ) => taxonomy.visibility?.show_ui
 	);
 	return visibleTaxonomies.map( ( taxonomy ) => {

--- a/packages/editor/src/components/post-taxonomies/index.js
+++ b/packages/editor/src/components/post-taxonomies/index.js
@@ -28,7 +28,7 @@ export function PostTaxonomies( {
 	);
 	const visibleTaxonomies = filter(
 		availableTaxonomies,
-		( taxonomy ) => taxonomy.visibility.show_ui
+		( taxonomy ) => taxonomy.visibility?.show_ui
 	);
 	return visibleTaxonomies.map( ( taxonomy ) => {
 		const TaxonomyComponent = taxonomy.hierarchical


### PR DESCRIPTION
## What?
Adds an optional chaining operator to the taxonomy `visibility` property.

## Why?
Fixes: #40326 In some circumstances it seems that the `visibility` property of a taxonomy can be undefined causing the editor to crash.

## How?
Adds a defensive check to make sure `visibility` is not undefined before checking `show_ui` property

## Testing Instructions

- Check that the taxonomy selectors still work as expected in the editor, eg. Category and Tag options display by default
- I couldn't find a way to replicate the bug noted in #40326 other than adding the following above line 29 in `packages/editor/src/components/post-taxonomies/index.js` 
```js
availableTaxonomies[0].visibility = undefined;
```
doing this the editor should still load, but without Category taxonomy showing. Without this patch doing this causes the editor to crash.
