### PR TITLE
Remove testid and update tests

### DIFF
--- a/packages/block-library/src/comment-template/edit.js
+++ b/packages/block-library/src/comment-template/edit.js
@@ -288,11 +288,7 @@ export default function CommentTemplateEdit( {
 	}
 
 	if ( ! commentTree.length ) {
-		return (
-			<p { ...blockProps } data-testid="noresults">
-				{ __( 'No results found.' ) }
-			</p>
-		);
+		return <p { ...blockProps }>{ __( 'No results found.' ) }</p>;
 	}
 
 	return (

--- a/packages/e2e-tests/specs/editor/blocks/comments-query.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/comments-query.test.js
@@ -28,13 +28,7 @@ describe( 'Comment Query Loop', () => {
 		await trashAllComments();
 		await createNewPost();
 		await insertBlock( 'Comments Query Loop' );
-		await page.waitForSelector( '[data-testid="noresults"]' );
-		expect(
-			await page.evaluate(
-				( el ) => el.innerText,
-				await page.$( '[data-testid="noresults"]' )
-			)
-		).toEqual( 'No results found.' );
+		await page.waitForXPath( '//p[contains(text(), "No results found.")]' );
 	} );
 	it( 'Pagination links are working as expected', async () => {
 		await createNewPost();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Remove testId value for Comments Template in No results found option.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It is better not to polute production code just for testing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Looking for a `p` with the innerText instead of using a data- selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should be the one in charge of this.

## Screenshots or screencast <!-- if applicable -->
