### PR TITLE
RangeControl: Convert component to TypeScript

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -27,6 +27,7 @@
 -   `Autocomplete`: Refactor away from `_.deburr()` ([#42266](https://github.com/WordPress/gutenberg/pull/42266/)).
 -   `MenuItem`: Refactor away from `_.isString()` ([#42268](https://github.com/WordPress/gutenberg/pull/42268/)).
 -   `Shortcut`: Refactor away from `_.isString()` ([#42268](https://github.com/WordPress/gutenberg/pull/42268/)).
+-   `RangeControl`: Convert to TypeScript ([#40535](https://github.com/WordPress/gutenberg/pull/40535)).
 
 ## 19.14.0 (2022-06-29)
 

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -106,7 +106,7 @@ export function useBorderControl(
 	);
 
 	const onSliderChange = useCallback(
-		( value: number ) => {
+		( value?: number ) => {
 			onWidthChange( `${ value }${ widthUnit }` );
 		},
 		[ onWidthChange, widthUnit ]

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -106,7 +106,7 @@ export function useBorderControl(
 	);
 
 	const onSliderChange = useCallback(
-		( value: string ) => {
+		( value: number ) => {
 			onWidthChange( `${ value }${ widthUnit }` );
 		},
 		[ onWidthChange, widthUnit ]

--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -25,8 +25,8 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Hue"
 				abbreviation="H"
 				value={ h }
-				onChange={ ( nextH?: number ) => {
-					onChange( colord( { h: nextH as number, s, l, a } ) );
+				onChange={ ( nextH: number ) => {
+					onChange( colord( { h: nextH, s, l, a } ) );
 				} }
 			/>
 			<InputWithSlider
@@ -35,11 +35,11 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Saturation"
 				abbreviation="S"
 				value={ s }
-				onChange={ ( nextS?: number ) => {
+				onChange={ ( nextS: number ) => {
 					onChange(
 						colord( {
 							h,
-							s: nextS as number,
+							s: nextS,
 							l,
 							a,
 						} )
@@ -52,12 +52,12 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Lightness"
 				abbreviation="L"
 				value={ l }
-				onChange={ ( nextL?: number ) => {
+				onChange={ ( nextL: number ) => {
 					onChange(
 						colord( {
 							h,
 							s,
-							l: nextL as number,
+							l: nextL,
 							a,
 						} )
 					);
@@ -70,13 +70,13 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 					label="Alpha"
 					abbreviation="A"
 					value={ Math.trunc( 100 * a ) }
-					onChange={ ( nextA?: number ) => {
+					onChange={ ( nextA: number ) => {
 						onChange(
 							colord( {
 								h,
 								s,
 								l,
-								a: ( nextA as number ) / 100,
+								a: nextA / 100,
 							} )
 						);
 					} }

--- a/packages/components/src/color-picker/hsl-input.tsx
+++ b/packages/components/src/color-picker/hsl-input.tsx
@@ -25,8 +25,8 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Hue"
 				abbreviation="H"
 				value={ h }
-				onChange={ ( nextH: number ) => {
-					onChange( colord( { h: nextH, s, l, a } ) );
+				onChange={ ( nextH?: number ) => {
+					onChange( colord( { h: nextH as number, s, l, a } ) );
 				} }
 			/>
 			<InputWithSlider
@@ -35,11 +35,11 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Saturation"
 				abbreviation="S"
 				value={ s }
-				onChange={ ( nextS: number ) => {
+				onChange={ ( nextS?: number ) => {
 					onChange(
 						colord( {
 							h,
-							s: nextS,
+							s: nextS as number,
 							l,
 							a,
 						} )
@@ -52,12 +52,12 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 				label="Lightness"
 				abbreviation="L"
 				value={ l }
-				onChange={ ( nextL: number ) => {
+				onChange={ ( nextL?: number ) => {
 					onChange(
 						colord( {
 							h,
 							s,
-							l: nextL,
+							l: nextL as number,
 							a,
 						} )
 					);
@@ -70,13 +70,13 @@ export const HslInput = ( { color, onChange, enableAlpha }: HslInputProps ) => {
 					label="Alpha"
 					abbreviation="A"
 					value={ Math.trunc( 100 * a ) }
-					onChange={ ( nextA: number ) => {
+					onChange={ ( nextA?: number ) => {
 						onChange(
 							colord( {
 								h,
 								s,
 								l,
-								a: nextA / 100,
+								a: ( nextA as number ) / 100,
 							} )
 						);
 					} }

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -14,7 +14,7 @@ interface InputWithSliderProps {
 	value: number;
 	label: string;
 	abbreviation: string;
-	onChange: ( value?: number ) => void;
+	onChange: ( value: number ) => void;
 }
 
 export const InputWithSlider = ( {
@@ -52,6 +52,8 @@ export const InputWithSlider = ( {
 				min={ min }
 				max={ max }
 				value={ value }
+				// @ts-expect-error
+				// See: https://github.com/WordPress/gutenberg/pull/40535#issuecomment-1172418185
 				onChange={ onChange }
 				withInputField={ false }
 			/>

--- a/packages/components/src/color-picker/input-with-slider.tsx
+++ b/packages/components/src/color-picker/input-with-slider.tsx
@@ -14,7 +14,7 @@ interface InputWithSliderProps {
 	value: number;
 	label: string;
 	abbreviation: string;
-	onChange: ( value: number ) => void;
+	onChange: ( value?: number ) => void;
 }
 
 export const InputWithSlider = ( {

--- a/packages/components/src/color-picker/rgb-input.tsx
+++ b/packages/components/src/color-picker/rgb-input.tsx
@@ -25,8 +25,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Red"
 				abbreviation="R"
 				value={ r }
-				onChange={ ( nextR: number ) =>
-					onChange( colord( { r: nextR, g, b, a } ) )
+				onChange={ ( nextR?: number ) =>
+					onChange( colord( { r: nextR as number, g, b, a } ) )
 				}
 			/>
 			<InputWithSlider
@@ -35,8 +35,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Green"
 				abbreviation="G"
 				value={ g }
-				onChange={ ( nextG: number ) =>
-					onChange( colord( { r, g: nextG, b, a } ) )
+				onChange={ ( nextG?: number ) =>
+					onChange( colord( { r, g: nextG as number, b, a } ) )
 				}
 			/>
 			<InputWithSlider
@@ -45,8 +45,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Blue"
 				abbreviation="B"
 				value={ b }
-				onChange={ ( nextB: number ) =>
-					onChange( colord( { r, g, b: nextB, a } ) )
+				onChange={ ( nextB?: number ) =>
+					onChange( colord( { r, g, b: nextB as number, a } ) )
 				}
 			/>
 			{ enableAlpha && (
@@ -56,13 +56,13 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 					label="Alpha"
 					abbreviation="A"
 					value={ Math.trunc( a * 100 ) }
-					onChange={ ( nextA: number ) =>
+					onChange={ ( nextA?: number ) =>
 						onChange(
 							colord( {
 								r,
 								g,
 								b,
-								a: nextA / 100,
+								a: ( nextA as number ) / 100,
 							} )
 						)
 					}

--- a/packages/components/src/color-picker/rgb-input.tsx
+++ b/packages/components/src/color-picker/rgb-input.tsx
@@ -25,8 +25,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Red"
 				abbreviation="R"
 				value={ r }
-				onChange={ ( nextR?: number ) =>
-					onChange( colord( { r: nextR as number, g, b, a } ) )
+				onChange={ ( nextR: number ) =>
+					onChange( colord( { r: nextR, g, b, a } ) )
 				}
 			/>
 			<InputWithSlider
@@ -35,8 +35,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Green"
 				abbreviation="G"
 				value={ g }
-				onChange={ ( nextG?: number ) =>
-					onChange( colord( { r, g: nextG as number, b, a } ) )
+				onChange={ ( nextG: number ) =>
+					onChange( colord( { r, g: nextG, b, a } ) )
 				}
 			/>
 			<InputWithSlider
@@ -45,8 +45,8 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 				label="Blue"
 				abbreviation="B"
 				value={ b }
-				onChange={ ( nextB?: number ) =>
-					onChange( colord( { r, g, b: nextB as number, a } ) )
+				onChange={ ( nextB: number ) =>
+					onChange( colord( { r, g, b: nextB, a } ) )
 				}
 			/>
 			{ enableAlpha && (
@@ -56,13 +56,13 @@ export const RgbInput = ( { color, onChange, enableAlpha }: RgbInputProps ) => {
 					label="Alpha"
 					abbreviation="A"
 					value={ Math.trunc( a * 100 ) }
-					onChange={ ( nextA?: number ) =>
+					onChange={ ( nextA: number ) =>
 						onChange(
 							colord( {
 								r,
 								g,
 								b,
-								a: ( nextA as number ) / 100,
+								a: nextA / 100,
 							} )
 						)
 					}

--- a/packages/components/src/icon/index.tsx
+++ b/packages/components/src/icon/index.tsx
@@ -20,7 +20,7 @@ import { SVG } from '@wordpress/primitives';
 import Dashicon from '../dashicon';
 import type { IconKey as DashiconIconKey } from '../dashicon/types';
 
-type IconType< P > = DashiconIconKey | ComponentType< P > | JSX.Element;
+export type IconType< P > = DashiconIconKey | ComponentType< P > | JSX.Element;
 
 interface BaseProps< P > {
 	/**

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -309,7 +309,7 @@ const MyRangeControl() {
 -   Required: No
 -   Platform: Web
 
-### `resetFallbackValue`: `number` | `string` | `null`
+### `resetFallbackValue`: `number`
 
 The value to revert to if the Reset button is clicked (enabled by `allowReset`)
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -243,7 +243,7 @@ Callback for when `RangeControl` input loses focus.
 -   Required: No
 -   Platform: Web
 
-### `onChange`: `FocusEventHandler< HTMLInputElement >`
+### `onChange`: `( value?: number ) => void`
 
 A function that receives the new value. The value will be less than `max` and more than `min` unless a reset (enabled by `allowReset`) has occurred. In which case the value will be either that of `resetFallbackValue` if it has been specified or otherwise `undefined`.
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -142,7 +142,7 @@ For more information on `IconType` see the [Icon component](/packages/components
 
 ### `color`: `CSSProperties['color']`
 
-If supplied, this property sets the `color` for the `RangeControl` wrapper.
+CSS color string for the `RangeControl` wrapper.
 
 -   Required: No
 -   Platform: Web
@@ -289,7 +289,7 @@ The maximum `value` allowed.
 
 ### `railColor`: `CSSProperties[ 'color' ]`
 
-Customizes the (background) color of the rail element.
+CSS color string to customize the rail element's background.
 
 -   Required: No
 -   Platform: Web
@@ -344,7 +344,7 @@ The minimum amount by which `value` changes. It is also a factor in validation a
 -   Platform: Web
 ### `trackColor`: `CSSProperties[ 'color' ]`
 
-Customizes the (background) color of the track element.
+CSS color string to customize the track element's background.
 
 -   Required: No
 -   Platform: Web

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -118,6 +118,8 @@ Props not included in this set will be applied to the input elements.
 
 If this property is added, a DashIcon component will be rendered after the slider with the icon equal to afterIcon.
 
+For more information on `IconType` see the [Icon component](/packages/components/src/icon/index.tsx#L23).
+
 -   Required: No
 -   Platform: Web
 
@@ -132,6 +134,8 @@ If this property is true, a button to reset the slider is rendered.
 ### `beforeIcon`: `string|Function|WPComponent|null`
 
 If this property is added, a DashIcon component will be rendered before the slider with the icon equal to beforeIcon.
+
+For more information on `IconType` see the [Icon component](/packages/components/src/icon/index.tsx#L23).
 
 -   Required: No
 -   Platform: Web

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -109,75 +109,96 @@ const MyRangeControl = () => {
 };
 ```
 
-### Props
+## Props
 
 The set of props accepted by the component will be specified below.
 Props not included in this set will be applied to the input elements.
 
-#### label
+### `afterIcon`: `string|Function|WPComponent|null`
 
-If this property is added, a label will be generated using label property as the content.
+If this property is added, a DashIcon component will be rendered after the slider with the icon equal to afterIcon.
 
--   Type: `String`
--   Required: No
--   Platform: Web | Mobile
-
-#### help
-
-If this property is added, a help text will be generated using help property as the content.
-
--   Type: `String|WPElement`
 -   Required: No
 -   Platform: Web
 
-#### beforeIcon
-
-If this property is added, a DashIcon component will be rendered before the slider with the icon equal to beforeIcon
-
--   Type: `String`
--   Required: No
--   Platform: Web
-
-#### afterIcon
-
-If this property is added, a DashIcon component will be rendered after the slider with the icon equal to afterIcon
-
--   Type: `String`
--   Required: No
--   Platform: Web
-
-#### allowReset
+### `allowReset`: `boolean`
 
 If this property is true, a button to reset the slider is rendered.
 
--   Type: `Boolean`
 -   Required: No
+-   Default: `false`
 -   Platform: Web | Mobile
 
-#### disabled
+### `beforeIcon`: `string|Function|WPComponent|null`
 
-Disables the `input`, preventing new values from being applied.
+If this property is added, a DashIcon component will be rendered before the slider with the icon equal to beforeIcon.
 
--   Type: `Boolean`
 -   Required: No
 -   Platform: Web
 
-#### initialPosition
+### `color`: `CSSProperties['color']`
+
+If supplied, this property sets the `color` for the `RangeControl` wrapper.
+
+-   Required: No
+-   Platform: Web
+
+### `currentInput`: `number`
+
+The current input to use as a fallback if `value` is currently `undefined`.
+
+-   Required: No
+-   Platform: Web
+
+### `disabled`: `boolean`
+
+Disables the `input`, preventing new values from being applied.
+
+-   Required: No
+-   Platform: Web
+
+
+### `help`: `string|WPElement`
+
+If this property is added, a help text will be generated using help property as the content.
+
+-   Required: No
+-   Platform: Web
+
+### `hideLabelFromVision`: `boolean`
+
+Provides control over whether the label will only be visible to screen readers.
+
+- Required: No
+
+### `icon`: `string`
+
+An icon to be shown above the slider next to it's container title.
+
+-   Required: No
+-   Platform: Mobile
+
+### `initialPosition`: `number`
 
 If no value exists this prop contains the slider starting position.
 
--   Type: `Number`
 -   Required: No
 -   Platform: Web | Mobile
 
-#### isShiftStepEnabled
+### `isShiftStepEnabled`: `boolean`
 
 Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` is true. If true, while the number input has focus, pressing `UP` or `DOWN` along with the `SHIFT` key will change the value by the `shiftStep` value.
 
--   Type: `Boolean`
 -   Required: No
 
-#### marks
+### `label`: `string`
+
+If this property is added, a label will be generated using label property as the content.
+
+-   Required: No
+-   Platform: Web | Mobile
+
+### `marks`: `Array|boolean`
 
 Renders a visual representation of `step` ticks. Custom mark indicators can be provided by an `Array`.
 
@@ -204,49 +225,72 @@ const marks = [
 ];
 
 const MyRangeControl() {
-	return (<RangeControl marks={ marks } min={ 0 } max={ 10 } step={ 1 } />)
+	return ( <RangeControl marks={ marks } min={ 0 } max={ 10 } step={ 1 } /> )
 }
 ```
 
--   Type: `Array|Boolean`
 -   Required: No
 -   Platform: Web
 
-#### onChange
+### `onBlur`: `FocusEventHandler< HTMLInputElement >`
+
+Callback for when `RangeControl` input loses focus.
+
+-   Required: No
+-   Platform: Web
+
+### `onChange`: `FocusEventHandler< HTMLInputElement >`
 
 A function that receives the new value. The value will be less than `max` and more than `min` unless a reset (enabled by `allowReset`) has occurred. In which case the value will be either that of `resetFallbackValue` if it has been specified or otherwise `undefined`.
 
--   Type: `function`
--   Required: Yes
+-   Required: No
 -   Platform: Web | Mobile
 
-#### min
+### `onFocus`: `FocusEventHandler< HTMLInputElement >`
+
+Callback for when `RangeControl` input gains focus.
+
+-   Required: No
+-   Platform: Web
+
+### `onMouseLeave`: `MouseEventHandler< HTMLInputElement >`
+
+Callback for when mouse exits the `RangeControl`.
+
+-   Required: No
+-   Platform: Web
+
+### `onMouseMove`: `MouseEventHandler< HTMLInputElement >`
+
+Callback for when mouse moves within the `RangeControl`.
+
+-   Required: No
+-   Platform: Web
+
+### `min`: `number`
 
 The minimum `value` allowed.
 
--   Type: `Number`
 -   Required: No
 -   Default: 0
 -   Platform: Web | Mobile
 
-#### max
+### `max`: `number`
 
 The maximum `value` allowed.
 
--   Type: `Number`
 -   Required: No
 -   Default: 100
 -   Platform: Web | Mobile
 
-#### railColor
+### `railColor`: `CSSProperties[ 'color' ]`
 
 Customizes the (background) color of the rail element.
 
--   Type: `String`
 -   Required: No
 -   Platform: Web
 
-#### renderTooltipContent
+### `renderTooltipContent`: ( value ) => value
 
 A way to customize the rendered UI of the value. Example:
 
@@ -258,89 +302,69 @@ const MyRangeControl() {
 }
 ```
 
--   Type: `Function`
 -   Required: No
 -   Platform: Web
 
-#### resetFallbackValue
+### `resetFallbackValue`: `number` | `string` | `null`
 
 The value to revert to if the Reset button is clicked (enabled by `allowReset`)
 
--   Type: `Number`
 -   Required: No
 -   Platform: Web
 
-#### showTooltip
-
-Forcing the Tooltip UI to show or hide. This is overriden to `false` when `step` is set to the special string value `any`.
-
--   Type: `Boolean`
--   Required: No
--   Platform: Web
-
-#### step
-
-The minimum amount by which `value` changes. It is also a factor in validation as `value` must be a multiple of `step` (offset by `min`) to be valid. Accepts the special string value `any` that voids the validation constraint and overrides both `withInputField` and `showTooltip` props to `false`.
-
--   Type: `Number | "any"`
--   Required: No
--   Platform: Web
-
-#### shiftStep
-
-Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` and `isShiftStepEnabled` are both true and while the number input has focus. Acts as a multiplier of `step`.
-
--   Type: `Number`
--   Required: No
-
-#### trackColor
-
-Customizes the (background) color of the track element.
-
--   Type: `String`
--   Required: No
--   Platform: Web
-
-#### value
-
-The current value of the range slider.
-
--   Type: `Number`
--   Required: Yes
--   Platform: Web | Mobile
-
-#### withInputField
-
-Determines if the `input` number field will render next to the RangeControl. This is overriden to `false` when `step` is set to the special string value `any`.
-
--   Type: `Boolean`
--   Required: No
--   Platform: Web
-
-#### icon
-
-An icon to be shown above the slider next to it's container title.
-
--   Type: `String`
--   Required: No
--   Platform: Mobile
-
-#### separatorType
+### `separatorType`: `'none' | 'fullWidth' | 'topFullWidth'`
 
 Define if separator line under/above control row should be disabled or full width. By default it is placed below excluding underline the control icon.
 
--   Type: `String Enum`
--   Values: `none` | `fullWidth` | `topFullWidth`
 -   Required: No
 -   Platform: Mobile
 
-#### type
+### `shiftStep`: `number`
+
+Passed as a prop to the `NumberControl` component and is only applicable if `withInputField` and `isShiftStepEnabled` are both true and while the number input has focus. Acts as a multiplier of `step`.
+
+-   Required: No
+
+### `showTooltip`: `boolean`
+
+Forcing the Tooltip UI to show or hide. This is overridden to `false` when `step` is set to the special string value `any`.
+
+-   Required: No
+-   Platform: Web
+
+### `step`: `number | 'any'`
+
+The minimum amount by which `value` changes. It is also a factor in validation as `value` must be a multiple of `step` (offset by `min`) to be valid. Accepts the special string value `any` that voids the validation constraint and overrides both `withInputField` and `showTooltip` props to `false`.
+
+-   Required: No
+-   Platform: Web
+### `trackColor`: `CSSProperties[ 'color' ]`
+
+Customizes the (background) color of the track element.
+
+-   Required: No
+-   Platform: Web
+
+### `type`: `string`
 
 Define if the value selection should present a stepper control or a slider control in the bottom sheet on mobile. To use the stepper set the type value as `stepper`. Defaults to slider if no option is provided.
 
--   Type: `String`
 -   Required: No
 -   Platform: Mobile
+
+### `value`: `number`
+
+The current value of the range slider.
+
+-   Required: No
+-   Platform: Web | Mobile
+
+### `withInputField`: `boolean`
+
+Determines if the `input` number field will render next to the RangeControl. This is overridden to `false` when `step` is set to the special string value `any`.
+
+-   Required: No
+-   Platform: Web
 
 ## Related components
 

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -177,7 +177,7 @@ Provides control over whether the label will only be visible to screen readers.
 
 ### `icon`: `string`
 
-An icon to be shown above the slider next to it's container title.
+An icon to be shown above the slider next to its container title.
 
 -   Required: No
 -   Platform: Mobile

--- a/packages/components/src/range-control/README.md
+++ b/packages/components/src/range-control/README.md
@@ -116,7 +116,7 @@ Props not included in this set will be applied to the input elements.
 
 ### `afterIcon`: `string|Function|WPComponent|null`
 
-If this property is added, a DashIcon component will be rendered after the slider with the icon equal to afterIcon.
+If this property is added, an [Icon component](/packages/components/src/icon/README.md) will be rendered after the slider with the icon equal to `afterIcon`.
 
 For more information on `IconType` see the [Icon component](/packages/components/src/icon/index.tsx#L23).
 
@@ -133,7 +133,7 @@ If this property is true, a button to reset the slider is rendered.
 
 ### `beforeIcon`: `string|Function|WPComponent|null`
 
-If this property is added, a DashIcon component will be rendered before the slider with the icon equal to beforeIcon.
+If this property is added, an [Icon component](/packages/components/src/icon/README.md) will be rendered before the slider with the icon equal to `beforeIcon`.
 
 For more information on `IconType` see the [Icon component](/packages/components/src/icon/index.tsx#L23).
 

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -35,12 +35,17 @@ import {
 	Wrapper,
 } from './styles/range-control-styles';
 
-import type { UnforwardedRangeControlProps } from './types';
+import type { RangeControlProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
 
 const noop = () => {};
 
 function UnforwardedRangeControl< IconProps = unknown >(
-	props: UnforwardedRangeControlProps< IconProps >,
+	props: WordPressComponentProps<
+		RangeControlProps< IconProps >,
+		'div',
+		false
+	>,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const {

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -136,7 +136,7 @@ function UnforwardedRangeControl< IconProps = unknown >(
 		'inspector-range-control'
 	);
 	const describedBy = !! help ? `${ id }__help` : undefined;
-	const enableTooltip = showTooltipProp !== false && Number.isFinite( value );
+	const enableTooltip = hasTooltip !== false && Number.isFinite( value );
 
 	const handleOnRangeChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		const nextValue = parseFloat( event.target.value );

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -1,8 +1,8 @@
-// @ts-nocheck
 /**
  * External dependencies
  */
 import classnames from 'classnames';
+import type { ChangeEvent, FocusEvent, ForwardedRef } from 'react';
 
 /**
  * WordPress dependencies
@@ -35,67 +35,75 @@ import {
 	Wrapper,
 } from './styles/range-control-styles';
 
+import type { WordPressComponentProps } from '../ui/context';
+import type { RangeControlProps } from './types';
+
 const noop = () => {};
 
-function RangeControl(
-	{
+function RangeControl< P >(
+	props: WordPressComponentProps< RangeControlProps< P >, 'div' >,
+	ref: ForwardedRef< HTMLDivElement >
+) {
+	const {
 		afterIcon,
 		allowReset = false,
 		beforeIcon,
 		className,
-		currentInput,
 		color: colorProp = COLORS.ui.theme,
+		currentInput,
 		disabled = false,
 		help,
+		hideLabelFromVision = false,
 		initialPosition,
 		isShiftStepEnabled = true,
 		label,
-		hideLabelFromVision = false,
 		marks = false,
 		max = 100,
 		min = 0,
 		onBlur = noop,
 		onChange = noop,
 		onFocus = noop,
-		onMouseMove = noop,
 		onMouseLeave = noop,
+		onMouseMove = noop,
 		railColor,
-		resetFallbackValue,
 		renderTooltipContent = ( v ) => v,
-		showTooltip: showTooltipProp,
+		resetFallbackValue,
 		shiftStep = 10,
+		showTooltip: showTooltipProp,
 		step = 1,
 		trackColor,
 		value: valueProp,
 		withInputField = true,
-		...props
-	},
-	ref
-) {
+		...otherProps
+	} = props;
+
 	const [ value, setValue ] = useControlledRangeValue( {
 		min,
 		max,
-		value: valueProp,
+		value: valueProp ?? null,
 		initial: initialPosition,
 	} );
 	const isResetPendent = useRef( false );
 
+	let hasTooltip = showTooltipProp;
+	let hasInputField = withInputField;
+
 	if ( step === 'any' ) {
 		// The tooltip and number input field are hidden when the step is "any"
 		// because the decimals get too lengthy to fit well.
-		showTooltipProp = false;
-		withInputField = false;
+		hasTooltip = false;
+		hasInputField = false;
 	}
 
-	const [ showTooltip, setShowTooltip ] = useState( showTooltipProp );
+	const [ showTooltip, setShowTooltip ] = useState( hasTooltip );
 	const [ isFocused, setIsFocused ] = useState( false );
 
-	const inputRef = useRef();
+	const inputRef = useRef< HTMLInputElement >();
 
-	const setRef = ( nodeRef ) => {
+	const setRef = ( nodeRef: HTMLInputElement ) => {
 		inputRef.current = nodeRef;
 
-		if ( ref ) {
+		if ( typeof ref === 'function' ) {
 			ref( nodeRef );
 		}
 	};
@@ -107,10 +115,13 @@ function RangeControl(
 	const currentValue = value !== undefined ? value : currentInput;
 
 	const inputSliderValue = isValueReset ? '' : currentValue;
+	const numericValue = parseFloat( `${ value }` );
+	const rangeFillValue = isValueReset
+		? ( max - min ) / 2 + min
+		: numericValue;
 
-	const rangeFillValue = isValueReset ? ( max - min ) / 2 + min : value;
-
-	const calculatedFillValue = ( ( value - min ) / ( max - min ) ) * 100;
+	const calculatedFillValue =
+		( ( rangeFillValue - min ) / ( max - min ) ) * 100;
 	const fillValue = isValueReset ? 50 : calculatedFillValue;
 	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
 
@@ -125,14 +136,14 @@ function RangeControl(
 	const describedBy = !! help ? `${ id }__help` : undefined;
 	const enableTooltip = showTooltipProp !== false && Number.isFinite( value );
 
-	const handleOnRangeChange = ( event ) => {
+	const handleOnRangeChange = ( event: ChangeEvent< HTMLInputElement > ) => {
 		const nextValue = parseFloat( event.target.value );
 		setValue( nextValue );
 		onChange( nextValue );
 	};
 
-	const handleOnChange = ( nextValue ) => {
-		nextValue = parseFloat( nextValue );
+	const handleOnChange = ( next: string ) => {
+		let nextValue: number | null = parseFloat( next );
 		setValue( nextValue );
 		/*
 		 * Calls onChange only when nextValue is numeric
@@ -157,8 +168,8 @@ function RangeControl(
 	};
 
 	const handleOnReset = () => {
-		let resetValue = parseFloat( resetFallbackValue );
-		let onChangeResetValue = resetValue;
+		let resetValue: number | null = parseFloat( `${ resetFallbackValue }` );
+		let onChangeResetValue: number | undefined = resetValue;
 
 		if ( isNaN( resetValue ) ) {
 			resetValue = null;
@@ -186,13 +197,13 @@ function RangeControl(
 	const handleShowTooltip = () => setShowTooltip( true );
 	const handleHideTooltip = () => setShowTooltip( false );
 
-	const handleOnBlur = ( event ) => {
+	const handleOnBlur = ( event: FocusEvent< HTMLInputElement > ) => {
 		onBlur( event );
 		setIsFocused( false );
 		handleHideTooltip();
 	};
 
-	const handleOnFocus = ( event ) => {
+	const handleOnFocus = ( event: FocusEvent< HTMLInputElement > ) => {
 		onFocus( event );
 		setIsFocused( true );
 		handleShowTooltip();
@@ -207,7 +218,7 @@ function RangeControl(
 			className={ classes }
 			label={ label }
 			hideLabelFromVision={ hideLabelFromVision }
-			id={ id }
+			id={ `${ id }` }
 			help={ help }
 		>
 			<Root className="components-range-control__root">
@@ -222,11 +233,11 @@ function RangeControl(
 					marks={ !! marks }
 				>
 					<InputRange
-						{ ...props }
+						{ ...otherProps }
 						className="components-range-control__slider"
 						describedBy={ describedBy }
 						disabled={ disabled }
-						id={ id }
+						id={ `${ id }` }
 						label={ label }
 						max={ max }
 						min={ min }
@@ -237,7 +248,7 @@ function RangeControl(
 						onMouseLeave={ onMouseLeave }
 						ref={ setRef }
 						step={ step }
-						value={ inputSliderValue }
+						value={ inputSliderValue ?? undefined }
 					/>
 					<RangeRail
 						aria-hidden={ true }
@@ -280,7 +291,7 @@ function RangeControl(
 						<Icon icon={ afterIcon } />
 					</AfterIconWrapper>
 				) }
-				{ withInputField && (
+				{ hasInputField && (
 					<InputNumber
 						aria-label={ label }
 						className="components-range-control__number"
@@ -314,6 +325,28 @@ function RangeControl(
 	);
 }
 
+/**
+ * RangeControls are used to make selections from a range of incremental values.
+ *
+ * ```jsx
+ * import { RangeControl } from '@wordpress/components';
+ * import { useState } from '@wordpress/element';
+ *
+ * const MyRangeControl = () => {
+ *   const [ isChecked, setChecked ] = useState( true );
+ *   return (
+ *     <RangeControl
+ *       help="Please select how transparent you would like this."
+ *       initialPosition={50}
+ *       label="Opacity"
+ *       max={100}
+ *       min={0}
+ *       onChange={() => {}}
+ *     />
+ *   );
+ * };
+ * ```
+ */
 const ForwardedComponent = forwardRef( RangeControl );
 
 export default ForwardedComponent;

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -43,10 +43,10 @@ const noop = () => {};
 function UnforwardedRangeControl< IconProps = unknown >(
 	props: WordPressComponentProps<
 		RangeControlProps< IconProps >,
-		'div',
+		'input',
 		false
 	>,
-	ref: ForwardedRef< HTMLDivElement >
+	ref: ForwardedRef< HTMLInputElement >
 ) {
 	const {
 		afterIcon,

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -35,13 +35,12 @@ import {
 	Wrapper,
 } from './styles/range-control-styles';
 
-import type { WordPressComponentProps } from '../ui/context';
-import type { RangeControlProps } from './types';
+import type { UnforwardedRangeControlProps } from './types';
 
 const noop = () => {};
 
 function UnforwardedRangeControl< IconProps = unknown >(
-	props: WordPressComponentProps< RangeControlProps< IconProps >, 'div' >,
+	props: UnforwardedRangeControlProps< IconProps >,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const {

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -150,16 +150,18 @@ function UnforwardedRangeControl< IconProps = unknown >(
 	};
 
 	const handleOnChange = ( next: string ) => {
-		let nextValue: number | null = parseFloat( next );
+		let nextValue = parseFloat( next );
 		setValue( nextValue );
+
 		/*
 		 * Calls onChange only when nextValue is numeric
 		 * otherwise may queue a reset for the blur event.
 		 */
 		if ( ! isNaN( nextValue ) ) {
 			if ( nextValue < min || nextValue > max ) {
-				nextValue = floatClamp( nextValue, min, max );
+				nextValue = floatClamp( nextValue, min, max ) as number;
 			}
+
 			onChange( nextValue );
 			isResetPendent.current = false;
 		} else if ( allowReset ) {

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -40,8 +40,8 @@ import type { RangeControlProps } from './types';
 
 const noop = () => {};
 
-function UnforwardedRangeControl< P >(
-	props: WordPressComponentProps< RangeControlProps< P >, 'div' >,
+function UnforwardedRangeControl< IconProps = unknown >(
+	props: WordPressComponentProps< RangeControlProps< IconProps >, 'div' >,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
 	const {

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -9,7 +9,7 @@ import type { ChangeEvent, FocusEvent, ForwardedRef } from 'react';
  */
 import { __, isRTL } from '@wordpress/i18n';
 import { useRef, useState, forwardRef } from '@wordpress/element';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -46,7 +46,7 @@ function UnforwardedRangeControl< IconProps = unknown >(
 		'input',
 		false
 	>,
-	ref: ForwardedRef< HTMLInputElement >
+	forwardedRef: ForwardedRef< HTMLInputElement >
 ) {
 	const {
 		afterIcon,
@@ -103,15 +103,6 @@ function UnforwardedRangeControl< IconProps = unknown >(
 	const [ isFocused, setIsFocused ] = useState( false );
 
 	const inputRef = useRef< HTMLInputElement >();
-
-	const setRef = ( nodeRef: HTMLInputElement ) => {
-		inputRef.current = nodeRef;
-
-		if ( typeof ref === 'function' ) {
-			ref( nodeRef );
-		}
-	};
-
 	const isCurrentlyFocused = inputRef.current?.matches( ':focus' );
 	const isThumbFocused = ! disabled && isFocused;
 
@@ -255,7 +246,7 @@ function UnforwardedRangeControl< IconProps = unknown >(
 						onFocus={ handleOnFocus }
 						onMouseMove={ onMouseMove }
 						onMouseLeave={ onMouseLeave }
-						ref={ setRef }
+						ref={ useMergeRefs( [ inputRef, forwardedRef ] ) }
 						step={ step }
 						value={ inputSliderValue ?? undefined }
 					/>

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -347,6 +347,6 @@ function RangeControl< P >(
  * };
  * ```
  */
-const ForwardedComponent = forwardRef( RangeControl );
+export const ForwardedComponent = forwardRef( RangeControl );
 
 export default ForwardedComponent;

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -40,7 +40,7 @@ import type { RangeControlProps } from './types';
 
 const noop = () => {};
 
-function RangeControl< P >(
+function UnforwardedRangeControl< P >(
 	props: WordPressComponentProps< RangeControlProps< P >, 'div' >,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
@@ -132,7 +132,10 @@ function RangeControl< P >(
 		!! marks && 'is-marked'
 	);
 
-	const id = useInstanceId( RangeControl, 'inspector-range-control' );
+	const id = useInstanceId(
+		UnforwardedRangeControl,
+		'inspector-range-control'
+	);
 	const describedBy = !! help ? `${ id }__help` : undefined;
 	const enableTooltip = showTooltipProp !== false && Number.isFinite( value );
 
@@ -347,6 +350,6 @@ function RangeControl< P >(
  * };
  * ```
  */
-export const ForwardedComponent = forwardRef( RangeControl );
+export const RangeControl = forwardRef( UnforwardedRangeControl );
 
-export default ForwardedComponent;
+export default RangeControl;

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -110,14 +110,11 @@ function UnforwardedRangeControl< IconProps = unknown >(
 	const currentValue = value !== undefined ? value : currentInput;
 
 	const inputSliderValue = isValueReset ? '' : currentValue;
-	const numericValue = parseFloat( `${ value }` );
-	const rangeFillValue = isValueReset
-		? ( max - min ) / 2 + min
-		: numericValue;
+	const rangeFillValue = isValueReset ? ( max - min ) / 2 + min : value;
 
-	const calculatedFillValue =
-		( ( rangeFillValue - min ) / ( max - min ) ) * 100;
-	const fillValue = isValueReset ? 50 : calculatedFillValue;
+	const fillValue = isValueReset
+		? 50
+		: ( ( value - min ) / ( max - min ) ) * 100;
 	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
 
 	const classes = classnames( 'components-range-control', className );

--- a/packages/components/src/range-control/input-range.tsx
+++ b/packages/components/src/range-control/input-range.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * WordPress dependencies
  */
@@ -10,10 +9,16 @@ import { forwardRef } from '@wordpress/element';
 import { InputRange as BaseInputRange } from './styles/range-control-styles';
 import { useDebouncedHoverInteraction } from './utils';
 
+import type { InputRangeProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
+
 const noop = () => {};
 
 function InputRange(
-	{
+	props: WordPressComponentProps< InputRangeProps, 'input' >,
+	ref: React.ForwardedRef< HTMLInputElement >
+) {
+	const {
 		describedBy,
 		label,
 		onHideTooltip = noop,
@@ -21,10 +26,9 @@ function InputRange(
 		onMouseMove = noop,
 		onShowTooltip = noop,
 		value,
-		...props
-	},
-	ref
-) {
+		...otherProps
+	} = props;
+
 	const hoverInteractions = useDebouncedHoverInteraction( {
 		onHide: onHideTooltip,
 		onMouseLeave,
@@ -34,7 +38,7 @@ function InputRange(
 
 	return (
 		<BaseInputRange
-			{ ...props }
+			{ ...otherProps }
 			{ ...hoverInteractions }
 			aria-describedby={ describedBy }
 			aria-label={ label }

--- a/packages/components/src/range-control/mark.tsx
+++ b/packages/components/src/range-control/mark.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * External dependencies
  */
@@ -9,13 +8,20 @@ import classnames from 'classnames';
  */
 import { Mark, MarkLabel } from './styles/range-control-styles';
 
-export default function RangeMark( {
-	className,
-	isFilled = false,
-	label,
-	style = {},
-	...props
-} ) {
+import type { RangeMarkProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
+
+export default function RangeMark(
+	props: WordPressComponentProps< RangeMarkProps, 'span' >
+) {
+	const {
+		className,
+		isFilled = false,
+		label,
+		style = {},
+		...otherProps
+	} = props;
+
 	const classes = classnames(
 		'components-range-control__mark',
 		isFilled && 'is-filled',
@@ -29,7 +35,7 @@ export default function RangeMark( {
 	return (
 		<>
 			<Mark
-				{ ...props }
+				{ ...otherProps }
 				aria-hidden="true"
 				className={ classes }
 				isFilled={ isFilled }

--- a/packages/components/src/range-control/rail.tsx
+++ b/packages/components/src/range-control/rail.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * WordPress dependencies
  */
@@ -10,15 +9,27 @@ import { isRTL } from '@wordpress/i18n';
 import RangeMark from './mark';
 import { MarksWrapper, Rail } from './styles/range-control-styles';
 
-export default function RangeRail( {
-	disabled = false,
-	marks = false,
-	min = 0,
-	max = 100,
-	step = 1,
-	value = 0,
-	...restProps
-} ) {
+import type { WordPressComponentProps } from '../ui/context';
+import type {
+	MarksProps,
+	RangeMarkProps,
+	RailProps,
+	useMarksArgs,
+} from './types';
+
+export default function RangeRail(
+	props: WordPressComponentProps< RailProps, 'span' >
+) {
+	const {
+		disabled = false,
+		marks = false,
+		min = 0,
+		max = 100,
+		step = 1,
+		value,
+		...restProps
+	} = props;
+
 	return (
 		<>
 			<Rail disabled={ disabled } { ...restProps } />
@@ -29,24 +40,24 @@ export default function RangeRail( {
 					min={ min }
 					max={ max }
 					step={ step }
-					value={ value }
+					value={ value ?? ( max - min ) / 2 + min }
 				/>
 			) }
 		</>
 	);
 }
 
-function Marks( {
-	disabled = false,
-	marks = false,
-	min = 0,
-	max = 100,
-	step = 1,
-	value = 0,
-} ) {
-	if ( step === 'any' ) {
-		step = 1;
-	}
+function Marks( props: WordPressComponentProps< MarksProps, 'span' > ) {
+	const {
+		disabled = false,
+		marks = false,
+		min = 0,
+		max = 100,
+		step: stepProp = 1,
+		value = 0,
+	} = props;
+
+	const step = stepProp === 'any' ? 1 : stepProp;
 	const marksData = useMarks( { marks, min, max, step, value } );
 
 	return (
@@ -66,7 +77,13 @@ function Marks( {
 	);
 }
 
-function useMarks( { marks, min = 0, max = 100, step = 1, value = 0 } ) {
+function useMarks( {
+	marks,
+	min = 0,
+	max = 100,
+	step = 1,
+	value = 0,
+}: useMarksArgs ) {
 	if ( ! marks ) {
 		return [];
 	}
@@ -78,7 +95,7 @@ function useMarks( { marks, min = 0, max = 100, step = 1, value = 0 } ) {
 		while ( count > marks.push( { value: step * marks.length + min } ) );
 	}
 
-	const placedMarks = [];
+	const placedMarks: RangeMarkProps[] = [];
 	marks.forEach( ( mark, index ) => {
 		if ( mark.value < min || mark.value > max ) {
 			return;

--- a/packages/components/src/range-control/rail.tsx
+++ b/packages/components/src/range-control/rail.tsx
@@ -26,7 +26,7 @@ export default function RangeRail(
 		min = 0,
 		max = 100,
 		step = 1,
-		value,
+		value = 0,
 		...restProps
 	} = props;
 
@@ -40,7 +40,7 @@ export default function RangeRail(
 					min={ min }
 					max={ max }
 					step={ step }
-					value={ value ?? ( max - min ) / 2 + min }
+					value={ value }
 				/>
 			) }
 		</>

--- a/packages/components/src/range-control/rail.tsx
+++ b/packages/components/src/range-control/rail.tsx
@@ -14,7 +14,7 @@ import type {
 	MarksProps,
 	RangeMarkProps,
 	RailProps,
-	useMarksArgs,
+	UseMarksArgs,
 } from './types';
 
 export default function RangeRail(
@@ -83,7 +83,7 @@ function useMarks( {
 	max = 100,
 	step = 1,
 	value = 0,
-}: useMarksArgs ) {
+}: UseMarksArgs ) {
 	if ( ! marks ) {
 		return [];
 	}

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * External dependencies
  */
@@ -11,6 +10,15 @@ import styled from '@emotion/styled';
 import NumberControl from '../../number-control';
 import { COLORS, reduceMotion, rtl } from '../../utils';
 import { space } from '../../ui/utils/space';
+
+import type {
+	RangeMarkProps,
+	RailProps,
+	ThumbProps,
+	TooltipProps,
+	TrackProps,
+	WrapperProps,
+} from '../types';
 
 const rangeHeightValue = 30;
 const railHeight = 4;
@@ -30,13 +38,13 @@ export const Root = styled.div`
 	width: 100%;
 `;
 
-const wrapperColor = ( { color: colorProp = COLORS.ui.borderFocus } ) => {
-	return css( { color: colorProp } );
-};
-const wrapperMargin = ( { marks } ) =>
-	css( { marginBottom: marks ? 16 : null } );
+const wrapperColor = ( { color = COLORS.ui.borderFocus }: WrapperProps ) =>
+	css( { color } );
 
-export const Wrapper = styled.div`
+const wrapperMargin = ( { marks }: WrapperProps ) =>
+	css( { marginBottom: marks ? 16 : undefined } );
+
+export const Wrapper = styled.div< WrapperProps >`
 	box-sizing: border-box;
 	color: ${ COLORS.blue.medium.focus };
 	display: block;
@@ -61,16 +69,14 @@ export const AfterIconWrapper = styled.span`
 	${ rtl( { marginLeft: 6 } ) }
 `;
 
-const railBackgroundColor = ( { disabled, railColor } ) => {
-	let background = railColor || null;
+const railBackgroundColor = ( { disabled, railColor }: RailProps ) => {
+	let background = railColor || '';
 
 	if ( disabled ) {
 		background = COLORS.lightGray[ 400 ];
 	}
 
-	return css( {
-		background,
-	} );
+	return css( { background } );
 };
 
 export const Rail = styled.span`
@@ -89,16 +95,14 @@ export const Rail = styled.span`
 	${ railBackgroundColor };
 `;
 
-const trackBackgroundColor = ( { disabled, trackColor } ) => {
+const trackBackgroundColor = ( { disabled, trackColor }: TrackProps ) => {
 	let background = trackColor || 'currentColor';
 
 	if ( disabled ) {
 		background = COLORS.lightGray[ 800 ];
 	}
 
-	return css( {
-		background,
-	} );
+	return css( { background } );
 };
 
 export const Track = styled.span`
@@ -124,7 +128,7 @@ export const MarksWrapper = styled.span`
 	user-select: none;
 `;
 
-const markFill = ( { disabled, isFilled } ) => {
+const markFill = ( { disabled, isFilled }: RangeMarkProps ) => {
 	let backgroundColor = isFilled ? 'currentColor' : COLORS.lightGray[ 600 ];
 
 	if ( disabled ) {
@@ -147,7 +151,7 @@ export const Mark = styled.span`
 	${ markFill };
 `;
 
-const markLabelFill = ( { isFilled } ) => {
+const markLabelFill = ( { isFilled }: RangeMarkProps ) => {
 	return css( {
 		color: isFilled ? COLORS.darkGray[ 300 ] : COLORS.lightGray[ 600 ],
 	} );
@@ -166,7 +170,7 @@ export const MarkLabel = styled.span`
 	${ markLabelFill };
 `;
 
-const thumbColor = ( { disabled } ) =>
+const thumbColor = ( { disabled }: ThumbProps ) =>
 	disabled
 		? css`
 				background-color: ${ COLORS.lightGray[ 800 ] };
@@ -198,7 +202,7 @@ export const ThumbWrapper = styled.span`
 	) };
 `;
 
-const thumbFocus = ( { isFocused } ) => {
+const thumbFocus = ( { isFocused }: ThumbProps ) => {
 	return isFocused
 		? css`
 				&::before {
@@ -216,7 +220,7 @@ const thumbFocus = ( { isFocused } ) => {
 		: '';
 };
 
-export const Thumb = styled.span`
+export const Thumb = styled.span< ThumbProps >`
 	align-items: center;
 	border-radius: 50%;
 	box-sizing: border-box;
@@ -245,13 +249,13 @@ export const InputRange = styled.input`
 	width: calc( 100% + ${ thumbSize }px );
 `;
 
-const tooltipShow = ( { show } ) => {
+const tooltipShow = ( { show }: TooltipProps ) => {
 	return css( {
 		opacity: show ? 1 : 0,
 	} );
 };
 
-const tooltipPosition = ( { position } ) => {
+const tooltipPosition = ( { position }: TooltipProps ) => {
 	const isBottom = position === 'bottom';
 
 	if ( isBottom ) {
@@ -265,7 +269,7 @@ const tooltipPosition = ( { position } ) => {
 	`;
 };
 
-export const Tooltip = styled.span`
+export const Tooltip = styled.span< TooltipProps >`
 	background: rgba( 0, 0, 0, 0.8 );
 	border-radius: 2px;
 	box-sizing: border-box;

--- a/packages/components/src/range-control/tooltip.tsx
+++ b/packages/components/src/range-control/tooltip.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 /**
  * External dependencies
  */
@@ -14,17 +13,23 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { Tooltip } from './styles/range-control-styles';
 
-export default function SimpleTooltip( {
-	className,
-	inputRef,
-	tooltipPosition,
-	show = false,
-	style = {},
-	value = 0,
-	renderTooltipContent = ( v ) => v,
-	zIndex = 100,
-	...restProps
-} ) {
+import type { TooltipProps } from './types';
+import type { WordPressComponentProps } from '../ui/context';
+
+export default function SimpleTooltip(
+	props: WordPressComponentProps< TooltipProps, 'span' >
+) {
+	const {
+		className,
+		inputRef,
+		tooltipPosition,
+		show = false,
+		style = {},
+		value = 0,
+		renderTooltipContent = ( v ) => v,
+		zIndex = 100,
+		...restProps
+	} = props;
 	const position = useTooltipPosition( { inputRef, tooltipPosition } );
 	const classes = classnames( 'components-simple-tooltip', className );
 	const styles = {
@@ -47,8 +52,8 @@ export default function SimpleTooltip( {
 	);
 }
 
-function useTooltipPosition( { inputRef, tooltipPosition } ) {
-	const [ position, setPosition ] = useState();
+function useTooltipPosition( { inputRef, tooltipPosition }: TooltipProps ) {
+	const [ position, setPosition ] = useState< string >();
 
 	const setTooltipPosition = useCallback( () => {
 		if ( inputRef && inputRef.current ) {

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -234,10 +234,10 @@ export type RailProps = MarksProps & {
 export type InputRangeProps = {
 	describedBy?: string;
 	label?: string;
-	onHideTooltip?: () => undefined;
+	onHideTooltip?: () => void;
 	onMouseLeave?: MouseEventHandler< HTMLInputElement >;
 	onMouseMove?: MouseEventHandler< HTMLInputElement >;
-	onShowTooltip?: () => undefined;
+	onShowTooltip?: () => void;
 	value?: number | '';
 };
 

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -268,17 +268,12 @@ export type TrackProps = {
 	trackColor: CSSProperties[ 'color' ];
 };
 
-export type useControlledRangeValueProps = {
+export type useControlledRangeValueArgs = {
 	initial?: number;
 	max: number;
 	min: number;
 	value: number | null;
 };
-
-export type useControlledRangeValueReturn = [
-	number | '' | null,
-	( nextValue: number | null ) => void
-];
 
 export type useMarksArgs = NumericProps & {
 	marks: RangeMarks;

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -107,8 +107,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		beforeIcon?: IconType< IconProps >;
 		/**
-		 * If supplied, this property sets the `color` for the `RangeControl`
-		 * wrapper.
+		 * CSS color string for the `RangeControl` wrapper.
 		 *
 		 * @default `COLORS.ui.theme`
 		 * @see /packages/components/src/utils/colors-values.js
@@ -176,7 +175,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		onMouseMove?: MouseEventHandler< HTMLInputElement >;
 		/**
-		 * Customizes the (background) color of the rail element.
+		 * CSS color string to customize the rail element's background.
 		 */
 		railColor?: CSSProperties[ 'color' ];
 		/**
@@ -210,7 +209,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		showTooltip?: boolean;
 		/**
-		 * Customizes the (background) color of the track element.
+		 * CSS color string to customize the track element's background.
 		 */
 		trackColor?: CSSProperties[ 'color' ];
 		/**

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -73,7 +73,6 @@ export type RangeMarkProps = {
 };
 
 export type ControlledRangeValue = number | '' | null;
-export type SetControlledRangeValue = ( value?: number | null ) => void;
 
 export type RangeControlProps< IconProps = unknown > = Pick<
 	BaseControlProps,

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -1,0 +1,282 @@
+/**
+ * External dependencies
+ */
+import type {
+	CSSProperties,
+	FocusEventHandler,
+	MouseEventHandler,
+	MutableRefObject,
+} from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type { BaseControlProps } from '../base-control/types';
+import type { IconType } from '../icon';
+
+export type NumericProps = {
+	/**
+	 * The minimum `value` allowed.
+	 *
+	 * @default 0
+	 */
+	min?: number;
+	/**
+	 * The maximum `value` allowed.
+	 *
+	 * @default 100
+	 */
+	max?: number;
+	/**
+	 * The current value of the range slider.
+	 */
+	value?: number;
+};
+
+export type RangeStep = number | 'any';
+export type RangeMark = { value: number; label?: string };
+export type RangeMarks = boolean | RangeMark[];
+
+export type MarksProps = NumericProps & {
+	/**
+	 * Disables the `input`, preventing new values from being applied.
+	 *
+	 * @default false
+	 */
+	disabled?: boolean;
+	/**
+	 * Renders a visual representation of `step` ticks. Custom mark indicators
+	 * can be provided by an `Array`.
+	 *
+	 * @default false
+	 */
+	marks?: RangeMarks;
+	/**
+	 * The minimum amount by which `value` changes. It is also a factor in
+	 * validation as `value` must be a multiple of `step` (offset by `min`) to
+	 * be valid. Accepts the special string value `any` that voids the
+	 * validation constraint and overrides both `withInputField` and
+	 * `showTooltip` props to `false`.
+	 *
+	 * @default 1
+	 */
+	step?: RangeStep;
+};
+
+export type RangeMarkProps = {
+	isFilled?: boolean;
+	label?: string;
+	disabled?: boolean;
+	key?: string;
+	style?: CSSProperties;
+};
+
+export type ControlledRangeValue = number | '' | null;
+export type SetControlledRangeValue = ( value?: number | null ) => void;
+
+type RenderTooltipContentCallback = (
+	value?: ControlledRangeValue
+) => string | number | null | undefined;
+
+export type RangeControlProps< P > = Pick<
+	BaseControlProps,
+	'hideLabelFromVision' | 'help'
+> &
+	MarksProps & {
+		/**
+		 * If this property is added, a DashIcon component will be rendered
+		 * after the slider with the icon equal to afterIcon.
+		 */
+		afterIcon?: IconType< P >;
+		/**
+		 * If this property is true, a button to reset the the slider is
+		 * rendered.
+		 *
+		 * @default false
+		 */
+		allowReset?: boolean;
+		/**
+		 * If this property is added, a DashIcon component will be rendered
+		 * before the slider with the icon equal to beforeIcon.
+		 */
+		beforeIcon?: IconType< P >;
+		/**
+		 * If supplied, this property sets the `color` for the `RangeControl`
+		 * wrapper.
+		 *
+		 * @default `COLORS.ui.theme`
+		 * @see /packages/components/src/utils/colors-values.js
+		 */
+		color?: CSSProperties[ 'color' ];
+		/**
+		 * The current input to use as a fallback if `value` is currently
+		 * `undefined`.
+		 */
+		currentInput?: number;
+		/**
+		 * An icon to be shown above the slider next to it's container title.
+		 */
+		icon?: string;
+		/**
+		 * If no value exists this prop contains the slider starting position.
+		 */
+		initialPosition?: number;
+		/**
+		 * Passed as a prop to the `NumberControl` component and is only
+		 * applicable if `withInputField` is true. If true, while the number
+		 * input has focus, pressing `UP` or `DOWN` along with the `SHIFT` key
+		 * will change the value by the `shiftStep` value.
+		 *
+		 * @default true
+		 */
+		isShiftStepEnabled?: boolean;
+		/**
+		 * If this property is added, a label will be generated using label
+		 * property as the content.
+		 */
+		label?: string;
+		/**
+		 * Callback for when `RangeControl` input loses focus.
+		 *
+		 * @default () => void
+		 */
+		onBlur?: FocusEventHandler< HTMLInputElement >;
+		/**
+		 * A function that receives the new value. The value will be less than
+		 * `max` and more than `min` unless a reset (enabled by `allowReset`)
+		 * has occurred. In which case the value will be either that of
+		 * `resetFallbackValue` if it has been specified or otherwise
+		 * `undefined`.
+		 *
+		 * @default () => void
+		 */
+		onChange?: ( value: number ) => void;
+		/**
+		 * Callback for when `RangeControl` input gains focus.
+		 *
+		 * @default () => void
+		 */
+		onFocus?: FocusEventHandler< HTMLInputElement >;
+		/**
+		 * Callback for when mouse exits the `RangeControl`.
+		 *
+		 * @default () => void
+		 */
+		onMouseLeave?: MouseEventHandler< HTMLInputElement >;
+		/**
+		 * Callback for when mouse moves within the `RangeControl`.
+		 *
+		 * @default () => void
+		 */
+		onMouseMove?: MouseEventHandler< HTMLInputElement >;
+		/**
+		 * Customizes the (background) color of the rail element.
+		 */
+		railColor?: CSSProperties[ 'color' ];
+		/**
+		 * A way to customize the rendered UI of the value.
+		 *
+		 * @default ( value ) => value
+		 */
+		renderTooltipContent?: RenderTooltipContentCallback;
+		/**
+		 * The value to revert to if the Reset button is clicked (enabled by
+		 * `allowReset`)
+		 */
+		resetFallbackValue?: number | string | null;
+		/**
+		 * Define if separator line under/above control row should be disabled
+		 * or full width. By default it is placed below excluding underline the
+		 * control icon.
+		 */
+		separatorType?: 'none' | 'fullWidth' | 'topFullWidth';
+		/**
+		 * Passed as a prop to the `NumberControl` component and is only
+		 * applicable if `withInputField` and `isShiftStepEnabled` are both true
+		 * and while the number input has focus. Acts as a multiplier of `step`.
+		 *
+		 * @default 10
+		 */
+		shiftStep?: number;
+		/**
+		 * Forcing the Tooltip UI to show or hide. This is overridden to `false`
+		 * when `step` is set to the special string value `any`.
+		 */
+		showTooltip?: boolean;
+		/**
+		 * Customizes the (background) color of the track element.
+		 */
+		trackColor?: CSSProperties[ 'color' ];
+		/**
+		 * Define if the value selection should present a stepper control or a
+		 * slider control in the bottom sheet on mobile. To use the stepper set
+		 * the type value as `stepper`. Defaults to slider if no option is
+		 * provided.
+		 */
+		type?: 'stepper';
+		/**
+		 * Determines if the `input` number field will render next to the
+		 * RangeControl. This is overridden to `false` when `step` is set to the
+		 * special string value `any`.
+		 *
+		 * @default true
+		 */
+		withInputField?: boolean;
+	};
+
+export type RailProps = MarksProps & {
+	railColor?: CSSProperties[ 'color' ];
+};
+
+export type InputRangeProps = {
+	describedBy?: string;
+	label?: string;
+	onHideTooltip?: () => undefined;
+	onMouseLeave?: MouseEventHandler< HTMLInputElement >;
+	onMouseMove?: MouseEventHandler< HTMLInputElement >;
+	onShowTooltip?: () => undefined;
+	value?: number | '';
+};
+
+export type WrapperProps = {
+	className?: string;
+	color?: CSSProperties[ 'color' ];
+	marks?: RangeMarks;
+};
+
+export type ThumbProps = {
+	isFocused?: boolean;
+	disabled?: boolean;
+};
+
+export type TooltipProps = {
+	show?: boolean;
+	position?: string;
+	inputRef?: MutableRefObject< HTMLElement | undefined >;
+	tooltipPosition?: string;
+	value?: ControlledRangeValue;
+	renderTooltipContent?: RenderTooltipContentCallback;
+	zIndex?: number;
+};
+
+export type TrackProps = {
+	disabled: boolean;
+	trackColor: CSSProperties[ 'color' ];
+};
+
+export type useControlledRangeValueProps = {
+	initial?: number;
+	max: number;
+	min: number;
+	value: number | null;
+};
+
+export type useControlledRangeValueReturn = [
+	number | '' | null,
+	( nextValue: any ) => void
+];
+
+export type useMarksArgs = NumericProps & {
+	marks: RangeMarks;
+	step: number;
+};

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -78,7 +78,7 @@ type RenderTooltipContentCallback = (
 	value?: ControlledRangeValue
 ) => string | number | null | undefined;
 
-export type RangeControlProps< P > = Pick<
+export type RangeControlProps< IconProps = unknown > = Pick<
 	BaseControlProps,
 	'hideLabelFromVision' | 'help'
 > &
@@ -87,7 +87,7 @@ export type RangeControlProps< P > = Pick<
 		 * If this property is added, a DashIcon component will be rendered
 		 * after the slider with the icon equal to afterIcon.
 		 */
-		afterIcon?: IconType< P >;
+		afterIcon?: IconType< IconProps >;
 		/**
 		 * If this property is true, a button to reset the the slider is
 		 * rendered.
@@ -99,7 +99,7 @@ export type RangeControlProps< P > = Pick<
 		 * If this property is added, a DashIcon component will be rendered
 		 * before the slider with the icon equal to beforeIcon.
 		 */
-		beforeIcon?: IconType< P >;
+		beforeIcon?: IconType< IconProps >;
 		/**
 		 * If supplied, this property sets the `color` for the `RangeControl`
 		 * wrapper.

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -110,7 +110,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		/**
 		 * CSS color string for the `RangeControl` wrapper.
 		 *
-		 * @default `COLORS.ui.theme`
+		 * @default COLORS.ui.theme
 		 * @see /packages/components/src/utils/colors-values.js
 		 */
 		color?: CSSProperties[ 'color' ];

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -243,7 +243,6 @@ export type InputRangeProps = {
 };
 
 export type WrapperProps = {
-	className?: string;
 	color?: CSSProperties[ 'color' ];
 	marks?: RangeMarks;
 };

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -152,7 +152,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 *
 		 * @default () => void
 		 */
-		onChange?: ( value: number ) => void;
+		onChange?: ( value?: number ) => void;
 		/**
 		 * Callback for when `RangeControl` input gains focus.
 		 *
@@ -279,7 +279,7 @@ export type useControlledRangeValueProps = {
 
 export type useControlledRangeValueReturn = [
 	number | '' | null,
-	( nextValue: any ) => void
+	( nextValue: number | null ) => void
 ];
 
 export type useMarksArgs = NumericProps & {

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -81,7 +81,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 > &
 	MarksProps & {
 		/**
-		 * If this property is added, a DashIcon component will be rendered
+		 * If this property is added, an Icon component will be rendered
 		 * after the slider with the icon equal to afterIcon.
 		 *
 		 * For more information on `IconType` see the Icon component:
@@ -96,7 +96,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		allowReset?: boolean;
 		/**
-		 * If this property is added, a DashIcon component will be rendered
+		 * If this property is added, an Icon component will be rendered
 		 * before the slider with the icon equal to beforeIcon.
 		 *
 		 * For more information on `IconType` see the Icon component:

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -13,6 +13,7 @@ import type {
  */
 import type { BaseControlProps } from '../base-control/types';
 import type { IconType } from '../icon';
+import type { WordPressComponentProps } from '../ui/context';
 
 export type NumericProps = {
 	/**
@@ -228,6 +229,11 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		withInputField?: boolean;
 	};
+
+export type UnforwardedRangeControlProps< IconProps = unknown > = Omit<
+	WordPressComponentProps< RangeControlProps< IconProps >, 'div' >,
+	'as'
+>;
 
 export type RailProps = MarksProps & {
 	railColor?: CSSProperties[ 'color' ];

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -34,8 +34,9 @@ export type NumericProps = {
 	value?: number;
 };
 
-export type RangeStep = number | 'any';
 export type RangeMark = { value: number; label?: string };
+// An expanded definition of this type is used in MarkProps to improve Storybook
+// generated docs.
 export type RangeMarks = boolean | RangeMark[];
 
 export type MarksProps = NumericProps & {
@@ -51,7 +52,7 @@ export type MarksProps = NumericProps & {
 	 *
 	 * @default false
 	 */
-	marks?: RangeMarks;
+	marks?: boolean | { value: number; label?: string }[];
 	/**
 	 * The minimum amount by which `value` changes. It is also a factor in
 	 * validation as `value` must be a multiple of `step` (offset by `min`) to
@@ -61,7 +62,7 @@ export type MarksProps = NumericProps & {
 	 *
 	 * @default 1
 	 */
-	step?: RangeStep;
+	step?: number | 'any';
 };
 
 export type RangeMarkProps = {
@@ -74,10 +75,6 @@ export type RangeMarkProps = {
 
 export type ControlledRangeValue = number | '' | null;
 export type SetControlledRangeValue = ( value?: number | null ) => void;
-
-type RenderTooltipContentCallback = (
-	value?: ControlledRangeValue
-) => string | number | null | undefined;
 
 export type RangeControlProps< IconProps = unknown > = Pick<
 	BaseControlProps,
@@ -184,7 +181,9 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 *
 		 * @default ( value ) => value
 		 */
-		renderTooltipContent?: RenderTooltipContentCallback;
+		renderTooltipContent?: (
+			value?: ControlledRangeValue
+		) => string | number | null | undefined;
 		/**
 		 * The value to revert to if the Reset button is clicked (enabled by
 		 * `allowReset`)
@@ -266,7 +265,9 @@ export type TooltipProps = {
 	inputRef?: MutableRefObject< HTMLElement | undefined >;
 	tooltipPosition?: string;
 	value?: ControlledRangeValue;
-	renderTooltipContent?: RenderTooltipContentCallback;
+	renderTooltipContent?: (
+		value?: ControlledRangeValue
+	) => string | number | null | undefined;
 	zIndex?: number;
 };
 

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -13,7 +13,6 @@ import type {
  */
 import type { BaseControlProps } from '../base-control/types';
 import type { IconType } from '../icon';
-import type { WordPressComponentProps } from '../ui/context';
 
 export type NumericProps = {
 	/**
@@ -228,11 +227,6 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		withInputField?: boolean;
 	};
-
-export type UnforwardedRangeControlProps< IconProps = unknown > = Omit<
-	WordPressComponentProps< RangeControlProps< IconProps >, 'div' >,
-	'as'
->;
 
 export type RailProps = MarksProps & {
 	railColor?: CSSProperties[ 'color' ];

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -86,6 +86,9 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		/**
 		 * If this property is added, a DashIcon component will be rendered
 		 * after the slider with the icon equal to afterIcon.
+		 *
+		 * For more information on `IconType` see the Icon component:
+		 * /packages/components/src/icon/index.tsx
 		 */
 		afterIcon?: IconType< IconProps >;
 		/**
@@ -98,6 +101,9 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		/**
 		 * If this property is added, a DashIcon component will be rendered
 		 * before the slider with the icon equal to beforeIcon.
+		 *
+		 * For more information on `IconType` see the Icon component:
+		 * /packages/components/src/icon/index.tsx
 		 */
 		beforeIcon?: IconType< IconProps >;
 		/**

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -187,7 +187,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 * The value to revert to if the Reset button is clicked (enabled by
 		 * `allowReset`)
 		 */
-		resetFallbackValue?: number | string | null;
+		resetFallbackValue?: number;
 		/**
 		 * Define if separator line under/above control row should be disabled
 		 * or full width. By default it is placed below excluding underline the

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -269,10 +269,55 @@ export type TrackProps = {
 };
 
 export type useControlledRangeValueArgs = {
+	/**
+	 * The initial value.
+	 */
 	initial?: number;
+	/**
+	 * The maximum value.
+	 */
 	max: number;
+	/**
+	 * The minimum value.
+	 */
 	min: number;
+	/**
+	 * The current value.
+	 */
 	value: number | null;
+};
+
+export type useDebouncedHoverInteractionArgs = {
+	/**
+	 *  A callback function invoked when the element is hidden.
+	 *
+	 * @default () => {}
+	 */
+	onHide?: () => void;
+	/**
+	 * A callback function invoked when the mouse is moved out of the element.
+	 *
+	 * @default () => {}
+	 */
+	onMouseLeave?: MouseEventHandler< HTMLInputElement >;
+	/**
+	 * A callback function invoked when the mouse is moved.
+	 *
+	 * @default () => {}
+	 */
+	onMouseMove?: MouseEventHandler< HTMLInputElement >;
+	/**
+	 * A callback function invoked when the element is shown.
+	 *
+	 * @default () => {}
+	 */
+	onShow?: () => void;
+	/**
+	 * Timeout before the element is shown or hidden.
+	 *
+	 * @default 300
+	 */
+	timeout?: number;
 };
 
 export type useMarksArgs = NumericProps & {

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -268,7 +268,7 @@ export type TrackProps = {
 	trackColor: CSSProperties[ 'color' ];
 };
 
-export type useControlledRangeValueArgs = {
+export type UseControlledRangeValueArgs = {
 	/**
 	 * The initial value.
 	 */
@@ -287,7 +287,7 @@ export type useControlledRangeValueArgs = {
 	value: number | null;
 };
 
-export type useDebouncedHoverInteractionArgs = {
+export type UseDebouncedHoverInteractionArgs = {
 	/**
 	 *  A callback function invoked when the element is hidden.
 	 *
@@ -320,7 +320,7 @@ export type useDebouncedHoverInteractionArgs = {
 	timeout?: number;
 };
 
-export type useMarksArgs = NumericProps & {
+export type UseMarksArgs = NumericProps & {
 	marks: RangeMarks;
 	step: number;
 };

--- a/packages/components/src/range-control/types.ts
+++ b/packages/components/src/range-control/types.ts
@@ -115,7 +115,7 @@ export type RangeControlProps< IconProps = unknown > = Pick<
 		 */
 		currentInput?: number;
 		/**
-		 * An icon to be shown above the slider next to it's container title.
+		 * An icon to be shown above the slider next to its container title.
 		 */
 		icon?: string;
 		/**

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -1,4 +1,7 @@
-// @ts-nocheck
+/**
+ * External dependencies
+ */
+import type { MouseEventHandler } from 'react';
 
 /**
  * WordPress dependencies
@@ -86,8 +89,8 @@ export function useControlledRangeValue( {
  */
 export function useDebouncedHoverInteraction( {
 	onHide = noop,
-	onMouseLeave = noop,
-	onMouseMove = noop,
+	onMouseLeave = noop as MouseEventHandler,
+	onMouseMove = noop as MouseEventHandler,
 	onShow = noop,
 	timeout = 300,
 } ) {

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -14,10 +14,7 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { useControlledState } from '../utils/hooks';
 import { clamp } from '../utils/math';
 
-import type {
-	useControlledRangeValueProps,
-	useControlledRangeValueReturn,
-} from './types';
+import type { useControlledRangeValueArgs } from './types';
 
 const noop = () => {};
 
@@ -54,14 +51,14 @@ export function useControlledRangeValue( {
 	max,
 	value: valueProp,
 	initial,
-}: useControlledRangeValueProps ): useControlledRangeValueReturn {
+}: useControlledRangeValueArgs ) {
 	const [ state, setInternalState ] = useControlledState(
 		floatClamp( valueProp, min, max ),
 		{ initial, fallback: null }
 	);
 
 	const setState = useCallback(
-		( nextValue ) => {
+		( nextValue: number | null ) => {
 			if ( nextValue === null ) {
 				setInternalState( null );
 			} else {
@@ -71,7 +68,7 @@ export function useControlledRangeValue( {
 		[ min, max ]
 	);
 
-	return [ state, setState ];
+	return [ state, setState ] as const;
 }
 
 /**

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -11,6 +11,11 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { useControlledState } from '../utils/hooks';
 import { clamp } from '../utils/math';
 
+import type {
+	useControlledRangeValueProps,
+	useControlledRangeValueReturn,
+} from './types';
+
 const noop = () => {};
 
 /**
@@ -20,24 +25,24 @@ const noop = () => {};
  * @param {number}      min   The minimum value.
  * @param {number}      max   The maximum value.
  *
- * @return {number} A (float) number
+ * @return {number | null} A (float) number
  */
-export function floatClamp( value, min, max ) {
+export function floatClamp( value: number | null, min: number, max: number ) {
 	if ( typeof value !== 'number' ) {
 		return null;
 	}
 
-	return parseFloat( clamp( value, min, max ) );
+	return parseFloat( `${ clamp( value, min, max ) }` );
 }
 
 /**
  * Hook to store a clamped value, derived from props.
  *
- * @param {Object} settings         Hook settings.
- * @param {number} settings.min     The minimum value.
- * @param {number} settings.max     The maximum value.
- * @param {number} settings.value   The current value.
- * @param {any}    settings.initial The initial value.
+ * @param {Object}        settings         Hook settings.
+ * @param {number}        settings.min     The minimum value.
+ * @param {number}        settings.max     The maximum value.
+ * @param {number | null} settings.value   The current value.
+ * @param {any}           settings.initial The initial value.
  *
  * @return {[*, Function]} The controlled value and the value setter.
  */
@@ -46,7 +51,7 @@ export function useControlledRangeValue( {
 	max,
 	value: valueProp,
 	initial,
-} ) {
+}: useControlledRangeValueProps ): useControlledRangeValueReturn {
 	const [ state, setInternalState ] = useControlledState(
 		floatClamp( valueProp, min, max ),
 		{ initial, fallback: null }
@@ -87,13 +92,13 @@ export function useDebouncedHoverInteraction( {
 	timeout = 300,
 } ) {
 	const [ show, setShow ] = useState( false );
-	const timeoutRef = useRef();
+	const timeoutRef = useRef< number | undefined >();
 
 	const setDebouncedTimeout = useCallback(
 		( callback ) => {
 			window.clearTimeout( timeoutRef.current );
 
-			timeoutRef.current = setTimeout( callback, timeout );
+			timeoutRef.current = window.setTimeout( callback, timeout );
 		},
 		[ timeout ]
 	);

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -24,11 +24,11 @@ const noop = () => {};
 /**
  * A float supported clamp function for a specific value.
  *
- * @param {number|null} value The value to clamp.
- * @param {number}      min   The minimum value.
- * @param {number}      max   The maximum value.
+ * @param  value The value to clamp.
+ * @param  min   The minimum value.
+ * @param  max   The maximum value.
  *
- * @return {number | null} A (float) number
+ * @return A (float) number
  */
 export function floatClamp( value: number | null, min: number, max: number ) {
 	if ( typeof value !== 'number' ) {
@@ -41,13 +41,13 @@ export function floatClamp( value: number | null, min: number, max: number ) {
 /**
  * Hook to store a clamped value, derived from props.
  *
- * @param {Object}        settings         Hook settings.
- * @param {number}        settings.min     The minimum value.
- * @param {number}        settings.max     The maximum value.
- * @param {number | null} settings.value   The current value.
- * @param {any}           settings.initial The initial value.
+ * @param  settings         Hook settings.
+ * @param  settings.min     The minimum value.
+ * @param  settings.max     The maximum value.
+ * @param  settings.value   The current value.
+ * @param  settings.initial The initial value.
  *
- * @return {[*, Function]} The controlled value and the value setter.
+ * @return The controlled value and the value setter.
  */
 export function useControlledRangeValue( {
 	min,
@@ -78,14 +78,14 @@ export function useControlledRangeValue( {
  * Hook to encapsulate the debouncing "hover" to better handle the showing
  * and hiding of the Tooltip.
  *
- * @param {Object}   settings                     Hook settings.
- * @param {Function} [settings.onShow=noop]       A callback function invoked when the element is shown.
- * @param {Function} [settings.onHide=noop]       A callback function invoked when the element is hidden.
- * @param {Function} [settings.onMouseMove=noop]  A callback function invoked when the mouse is moved.
- * @param {Function} [settings.onMouseLeave=noop] A callback function invoked when the mouse is moved out of the element.
- * @param {number}   [settings.timeout=300]       Timeout before the element is shown or hidden.
+ * @param  settings                     Hook settings.
+ * @param  [settings.onShow=noop]       A callback function invoked when the element is shown.
+ * @param  [settings.onHide=noop]       A callback function invoked when the element is hidden.
+ * @param  [settings.onMouseMove=noop]  A callback function invoked when the mouse is moved.
+ * @param  [settings.onMouseLeave=noop] A callback function invoked when the mouse is moved out of the element.
+ * @param  [settings.timeout=300]       Timeout before the element is shown or hidden.
  *
- * @return {Object} Bound properties for use on a React.Node.
+ * @return Bound properties for use on a React.Node.
  */
 export function useDebouncedHoverInteraction( {
 	onHide = noop,

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -68,7 +68,9 @@ export function useControlledRangeValue( {
 		[ min, max ]
 	);
 
-	return [ state, setState ] as const;
+	// `state` can't be an empty string because we specified a fallback value of
+	// `null` in `useControlledState`
+	return [ state as Exclude< typeof state, '' >, setState ] as const;
 }
 
 /**

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -14,7 +14,10 @@ import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 import { useControlledState } from '../utils/hooks';
 import { clamp } from '../utils/math';
 
-import type { useControlledRangeValueArgs } from './types';
+import type {
+	useControlledRangeValueArgs,
+	useDebouncedHoverInteractionArgs,
+} from './types';
 
 const noop = () => {};
 
@@ -38,20 +41,13 @@ export function floatClamp( value: number | null, min: number, max: number ) {
 /**
  * Hook to store a clamped value, derived from props.
  *
- * @param  settings         Hook settings.
- * @param  settings.min     The minimum value.
- * @param  settings.max     The maximum value.
- * @param  settings.value   The current value.
- * @param  settings.initial The initial value.
- *
+ * @param  settings
  * @return The controlled value and the value setter.
  */
-export function useControlledRangeValue( {
-	min,
-	max,
-	value: valueProp,
-	initial,
-}: useControlledRangeValueArgs ) {
+export function useControlledRangeValue(
+	settings: useControlledRangeValueArgs
+) {
+	const { min, max, value: valueProp, initial } = settings;
 	const [ state, setInternalState ] = useControlledState(
 		floatClamp( valueProp, min, max ),
 		{ initial, fallback: null }
@@ -77,22 +73,20 @@ export function useControlledRangeValue( {
  * Hook to encapsulate the debouncing "hover" to better handle the showing
  * and hiding of the Tooltip.
  *
- * @param  settings                     Hook settings.
- * @param  [settings.onShow=noop]       A callback function invoked when the element is shown.
- * @param  [settings.onHide=noop]       A callback function invoked when the element is hidden.
- * @param  [settings.onMouseMove=noop]  A callback function invoked when the mouse is moved.
- * @param  [settings.onMouseLeave=noop] A callback function invoked when the mouse is moved out of the element.
- * @param  [settings.timeout=300]       Timeout before the element is shown or hidden.
- *
+ * @param  settings
  * @return Bound properties for use on a React.Node.
  */
-export function useDebouncedHoverInteraction( {
-	onHide = noop,
-	onMouseLeave = noop as MouseEventHandler,
-	onMouseMove = noop as MouseEventHandler,
-	onShow = noop,
-	timeout = 300,
-} ) {
+export function useDebouncedHoverInteraction(
+	settings: useDebouncedHoverInteractionArgs
+) {
+	const {
+		onHide = noop,
+		onMouseLeave = noop as MouseEventHandler,
+		onMouseMove = noop as MouseEventHandler,
+		onShow = noop,
+		timeout = 300,
+	} = settings;
+
 	const [ show, setShow ] = useState( false );
 	const timeoutRef = useRef< number | undefined >();
 

--- a/packages/components/src/range-control/utils.ts
+++ b/packages/components/src/range-control/utils.ts
@@ -15,8 +15,8 @@ import { useControlledState } from '../utils/hooks';
 import { clamp } from '../utils/math';
 
 import type {
-	useControlledRangeValueArgs,
-	useDebouncedHoverInteractionArgs,
+	UseControlledRangeValueArgs,
+	UseDebouncedHoverInteractionArgs,
 } from './types';
 
 const noop = () => {};
@@ -45,7 +45,7 @@ export function floatClamp( value: number | null, min: number, max: number ) {
  * @return The controlled value and the value setter.
  */
 export function useControlledRangeValue(
-	settings: useControlledRangeValueArgs
+	settings: UseControlledRangeValueArgs
 ) {
 	const { min, max, value: valueProp, initial } = settings;
 	const [ state, setInternalState ] = useControlledState(
@@ -77,7 +77,7 @@ export function useControlledRangeValue(
  * @return Bound properties for use on a React.Node.
  */
 export function useDebouncedHoverInteraction(
-	settings: useDebouncedHoverInteractionArgs
+	settings: UseDebouncedHoverInteractionArgs
 ) {
 	const {
 		onHide = noop,


### PR DESCRIPTION
Depends On:
- https://github.com/WordPress/gutenberg/pull/40518

Related:
- https://github.com/WordPress/gutenberg/issues/40507
- https://github.com/WordPress/gutenberg/pull/41444
- https://github.com/WordPress/gutenberg/pull/41445

## What?
Converts the `RangeControl` component to TypeScript. 

_(Unit tests and story TypeScript conversions are in separate PRs, #41444 & #41445)_

## Why?
While looking to create a new component combining both a `UnitControl` and `RangeControl` (https://github.com/WordPress/gutenberg/pull/40462) it presented an opportunity to improve the slider components we offered in a more composable way. 

The first step in this process was to type the `RangeControl` component.

See https://github.com/WordPress/gutenberg/issues/40507 for more details.

## How?
Refactors the current `RangeControl` to TypeScript.

## Testing Instructions
1. Run `npm run dev:package-types` and ensure no typing errors
2. Run `npm run test-unit packages/components/src/range-control/test/` and check they all pass
3. Fire up the Storybook and confirm the RangeControl continues to function as expected
4. Test the various range controls within the block/site editors in Gutenberg still work
