### PR TITLE
Plugin: Fix fatal error for older WP/PHP versions

### DIFF
--- a/lib/compat/wordpress-5.9/polyfills.php
+++ b/lib/compat/wordpress-5.9/polyfills.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Polyfills for functions missing from older WP versions.
+ *
+ * This file should be removed when WordPress 5.9.0 becomes the lowest
+ * supported version by this plugin.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'str_contains' ) ) {
+	/**
+	 * Polyfill for `str_contains()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if needle is
+	 * contained in haystack.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the haystack.
+	 * @return bool True if `$needle` is in `$haystack`, otherwise false.
+	 */
+	function str_contains( $haystack, $needle ) {
+		return ( '' === $needle || false !== strpos( $haystack, $needle ) );
+	}
+}
+
+if ( ! function_exists( 'str_starts_with' ) ) {
+	/**
+	 * Polyfill for `str_starts_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack begins with needle.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$haystack` starts with `$needle`, otherwise false.
+	 */
+	function str_starts_with( $haystack, $needle ) {
+		if ( '' === $needle ) {
+			return true;
+		}
+		return 0 === strpos( $haystack, $needle );
+	}
+}
+
+if ( ! function_exists( 'str_ends_with' ) ) {
+	/**
+	 * Polyfill for `str_ends_with()` function added in PHP 8.0.
+	 *
+	 * Performs a case-sensitive check indicating if
+	 * the haystack ends with needle.
+	 *
+	 * @since 5.9.0
+	 *
+	 * @param string $haystack The string to search in.
+	 * @param string $needle   The substring to search for in the `$haystack`.
+	 * @return bool True if `$haystack` ends with `$needle`, otherwise false.
+	 */
+	function str_ends_with( $haystack, $needle ) {
+		if ( '' === $haystack && '' !== $needle ) {
+			return false;
+		}
+		$len = strlen( $needle );
+		return 0 === substr_compare( $haystack, $needle, -$len, $len );
+	}
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -77,6 +77,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 require __DIR__ . '/experimental/editor-settings.php';
 
 // WordPress 5.9 compat.
+require __DIR__ . '/compat/wordpress-5.9/polyfills.php';
 require __DIR__ . '/compat/wordpress-5.9/block-gallery.php';
 require __DIR__ . '/compat/wordpress-5.9/widget-render-api-endpoint/index.php';
 require __DIR__ . '/compat/wordpress-5.9/blocks.php';


### PR DESCRIPTION
## What?
Resolves #40508.

PR fixes a fatal error when running the plugin with WP 5.8 and PHP < 8.0.

## Why?
Plugin started using new string functions, core polyfills them since WP 5.9, but we forgot to add polyfills for older versions. Gutenberg still supports 5.8.

Files using new functions:
* `lib/compat/wordpress-6.0/block-editor-settings.php`
* `lib/experimental/register-webfonts-from-theme-json.php`

## How?
Added polyfills in WordPress 5.9 compat folder.

## Testing Instructions
1. Confirm you're running PHP < 8.0
2. Downgrade WP to 5.8.x - `wp core update --version=5.8.3 --force`
3. Place this function call somewhere in plugin's core for easy testing - `str_contains( 'abc', 'a' );`
4. PHP shouldn't trigger fatal error.