### PR TITLE
Theme Export: Bug: Add .DS_Store to the list of ignored files

### DIFF
--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -16,7 +16,7 @@
  * @return Bool Whether this file is in an ignored directory.
  */
 function gutenberg_is_theme_directory_ignored( $path ) {
-	$directories_to_ignore = array( '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
+	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 	foreach ( $directories_to_ignore as $directory ) {
 		if ( strpos( $path, $directory ) === 0 ) {
 			return true;

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -15,7 +15,7 @@
  * @param string $path The path of the file in the theme.
  * @return Bool Whether this file is in an ignored directory.
  */
-function gutenberg_is_theme_directory_ignored( $path ) {
+function gutenberg_is_theme_file_ignored( $path ) {
 	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
 	foreach ( $directories_to_ignore as $directory ) {
 		if ( strpos( $path, $directory ) === 0 ) {
@@ -70,7 +70,7 @@ function gutenberg_generate_block_templates_export_file() {
 			$file_path     = wp_normalize_path( $file );
 			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
 
-			if ( ! gutenberg_is_theme_directory_ignored( $relative_path ) ) {
+			if ( ! gutenberg_is_theme_file_ignored( $relative_path ) ) {
 				$zip->addFile( $file_path, $relative_path );
 			}
 		}

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -8,17 +8,17 @@
  */
 
 /**
- * Filters theme directories that should be ignored during export.
+ * Filters theme files and folders that should be ignored during export.
  *
  * @since 6.0.0
  *
  * @param string $path The path of the file in the theme.
- * @return Bool Whether this file is in an ignored directory.
+ * @return Bool Whether this file is ignored.
  */
-function gutenberg_is_theme_file_ignored( $path ) {
-	$directories_to_ignore = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
-	foreach ( $directories_to_ignore as $directory ) {
-		if ( strpos( $path, $directory ) === 0 ) {
+function gutenberg_is_theme_directory_ignored( $path ) {
+	$ignore_list = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );
+	foreach ( $ignore_list as $ignored ) {
+		if ( strpos( $path, $ignored ) === 0 ) {
 			return true;
 		}
 	}
@@ -70,7 +70,7 @@ function gutenberg_generate_block_templates_export_file() {
 			$file_path     = wp_normalize_path( $file );
 			$relative_path = substr( $file_path, strlen( $theme_path ) + 1 );
 
-			if ( ! gutenberg_is_theme_file_ignored( $relative_path ) ) {
+			if ( ! gutenberg_is_theme_directory_ignored( $relative_path ) ) {
 				$zip->addFile( $file_path, $relative_path );
 			}
 		}

--- a/lib/compat/wordpress-6.0/block-template-utils.php
+++ b/lib/compat/wordpress-6.0/block-template-utils.php
@@ -13,7 +13,7 @@
  * @since 6.0.0
  *
  * @param string $path The path of the file in the theme.
- * @return Bool Whether this file is ignored.
+ * @return Bool Whether this file or directory is ignored.
  */
 function gutenberg_is_theme_directory_ignored( $path ) {
 	$ignore_list = array( '.DS_Store', '.svn', '.git', '.hg', '.bzr', 'node_modules', 'vendor' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This fixes a bug in the Theme Export feature, by adding .DS_Store to the list of files to ignore when exporting a theme.

## Why?
This is just a system file, it's not part of the theme. This was an oversight in the original code.

## How?
We already have an array of excluded files so this just adds a new one. I also updated the function name as it was referencing directories rather than file names.

## Testing Instructions
1. Add a .DS_Store file to your theme.
2. Export your theme using the site editor
3. Check that the .DS_Store file is not in the new theme zip

<img width="1247" alt="Screenshot 2022-04-22 at 10 34 36" src="https://user-images.githubusercontent.com/275961/164679399-a9cd921d-ffc5-4bb6-850e-f52fb5ecac58.png">

@WordPress/block-themers 

