### PR TITLE
Remove padding prop from popover

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -73,7 +73,6 @@ export default function BlockPopover( {
 			__unstableBoundaryParent
 			// Observe movement for block animations (especially horizontal).
 			__unstableObserveElement={ selectedElement }
-			shouldAnchorIncludePadding
 			// Used to safeguard sticky position behavior against cases where it would permanently
 			// obscure specific sections of a block.
 			__unstableEditorCanvasWrapper={ __unstableContentRef?.current }

--- a/packages/components/src/popover/index.js
+++ b/packages/components/src/popover/index.js
@@ -47,7 +47,6 @@ function computeAnchorRect(
 	anchorRect,
 	getAnchorRect,
 	anchorRef = false,
-	shouldAnchorIncludePadding,
 	container
 ) {
 	if ( anchorRect ) {
@@ -98,17 +97,14 @@ function computeAnchorRect(
 				container
 			);
 
-			if ( shouldAnchorIncludePadding ) {
-				return rect;
-			}
-
-			return withoutPadding( rect, anchorRef );
+			return rect;
 		}
 
 		const { top, bottom } = anchorRef;
 		const topRect = top.getBoundingClientRect();
 		const bottomRect = bottom.getBoundingClientRect();
-		const rect = offsetIframe(
+
+		return offsetIframe(
 			new window.DOMRect(
 				topRect.left,
 				topRect.top,
@@ -118,12 +114,6 @@ function computeAnchorRect(
 			top.ownerDocument,
 			container
 		);
-
-		if ( shouldAnchorIncludePadding ) {
-			return rect;
-		}
-
-		return withoutPadding( rect, anchorRef );
 	}
 
 	if ( ! anchorRefFallback.current ) {
@@ -131,45 +121,12 @@ function computeAnchorRect(
 	}
 
 	const { parentNode } = anchorRefFallback.current;
-	const rect = offsetIframe(
+
+	return offsetIframe(
 		parentNode.getBoundingClientRect(),
 		parentNode.ownerDocument,
 		container
 	);
-
-	if ( shouldAnchorIncludePadding ) {
-		return rect;
-	}
-
-	return withoutPadding( rect, parentNode );
-}
-
-function getComputedStyle( node ) {
-	return node.ownerDocument.defaultView.getComputedStyle( node );
-}
-
-function withoutPadding( rect, element ) {
-	const {
-		paddingTop,
-		paddingBottom,
-		paddingLeft,
-		paddingRight,
-	} = getComputedStyle( element );
-	const top = paddingTop ? parseInt( paddingTop, 10 ) : 0;
-	const bottom = paddingBottom ? parseInt( paddingBottom, 10 ) : 0;
-	const left = paddingLeft ? parseInt( paddingLeft, 10 ) : 0;
-	const right = paddingRight ? parseInt( paddingRight, 10 ) : 0;
-
-	return {
-		x: rect.left + left,
-		y: rect.top + top,
-		width: rect.width - left - right,
-		height: rect.height - top - bottom,
-		left: rect.left + left,
-		right: rect.right - right,
-		top: rect.top + top,
-		bottom: rect.bottom - bottom,
-	};
 }
 
 /**
@@ -252,7 +209,6 @@ const Popover = (
 		range,
 		focusOnMount = 'firstElement',
 		anchorRef,
-		shouldAnchorIncludePadding,
 		anchorRect,
 		getAnchorRect,
 		expandOnMobile,
@@ -304,7 +260,6 @@ const Popover = (
 				anchorRect,
 				getAnchorRect,
 				anchorRef,
-				shouldAnchorIncludePadding,
 				containerRef.current
 			);
 
@@ -480,7 +435,6 @@ const Popover = (
 		anchorRect,
 		getAnchorRect,
 		anchorRef,
-		shouldAnchorIncludePadding,
 		position,
 		contentSize,
 		__unstableStickyBoundaryElement,

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -50,7 +50,6 @@ export function DotTip( {
 			position={ position }
 			noArrow
 			focusOnMount="container"
-			shouldAnchorIncludePadding
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }
 			onClick={ onClick }

--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -10,7 +10,6 @@ exports[`DotTip should render correctly 1`] = `
   onFocusOutside={[Function]}
   position="middle right"
   role="dialog"
-  shouldAnchorIncludePadding={true}
 >
   <p>
     It looks like you’re writing a letter. Would you like help?


### PR DESCRIPTION
## What?

In https://github.com/WordPress/gutenberg/pull/17867 a `anchorIncludePadding` prop has been introduced. The reasoning for this seems to have been that sometimes we want to exclude the padding from the "anchor" position of a Popover. I'm having a hard time understand in which use-case we'd ever want that personally. So I'm removing it in this PR.

## Why?

My longer term goal is to simplify the popover component, potentially arrive at a stage where we could just use http://floating-ui.com to power its behavior. So removing this prop (which if I'm not wrong doesn't change anything for us) is a small step.

Technically this is a "breaking change" but I expect that it's impact is negligible for everyone.

## Testing Instructions

1- Open the editor
2- Try opening different kinds of popovers: dropdown, modals, tooltips, inserter, / command...
3- All of them should be positioned properly.

