### PR TITLE
Add `settings` hook

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), settings, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName, templateLock
 
 ## Heading

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -275,7 +275,7 @@ Gather blocks in a layout container. ([Source](https://github.com/WordPress/gute
 
 -	**Name:** core/group
 -	**Category:** design
--	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), settings, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** tagName, templateLock
 
 ## Heading

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -762,8 +762,10 @@ _Parameters_
 
 ### useSetting
 
-Hook that retrieves the editor setting.
-It works with nested objects using by finding the value at path.
+Hook that retrieves the given setting for the block instance in use.
+
+It looks up the settings first in the block instance hierarchy.
+If none is found, it'll look it up in the block editor store.
 
 _Usage_
 

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -7,7 +7,10 @@ import { get } from 'lodash';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { __EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE } from '@wordpress/blocks';
+import {
+	__EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE,
+	hasBlockSupport,
+} from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -91,8 +94,10 @@ const removeCustomPrefixes = ( path ) => {
 };
 
 /**
- * Hook that retrieves the editor setting.
- * It works with nested objects using by finding the value at path.
+ * Hook that retrieves the given setting for the block instance in use.
+ *
+ * It looks up the settings first in the block instance hierarchy.
+ * If none is found, it'll look it up in the block editor store.
  *
  * @param {string} path The path to the setting.
  * @return {any} Returns the value defined for the setting.
@@ -113,41 +118,55 @@ export default function useSetting( path ) {
 				);
 				return undefined;
 			}
-			const settings = select( blockEditorStore ).getSettings();
 
-			// 0 - Use settings for this block instance, if there's any.
-			//     Also, look up in the block hierarchy.
-			// todo: only check if the block type has support for settings to minimize the queries we make
-			// todo: how do we provide i18n for the presets defined by block instances? In PHP, they already do i18n.
-			// todo: the presets defined in a block instance are "custom" ones;
-			// remove the need for users to provide the custom key.
-			const blockAtts = select( blockEditorStore ).getBlockAttributes(
-				clientId
-			);
-
-			// 1 - Use __experimental features, if available.
-			// We cascade to the all value if the block one is not available.
+			let result;
 			const normalizedPath = removeCustomPrefixes( path );
-			const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
-			const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
-			const blockInstancePath = `settings.${ normalizedPath }`;
-			const experimentalFeaturesResult =
-				get( blockAtts, blockInstancePath ) ??
-				get( settings, blockPath ) ??
-				get( settings, defaultsPath );
 
-			if ( experimentalFeaturesResult !== undefined ) {
-				if ( PATHS_WITH_MERGE[ normalizedPath ] ) {
-					return (
-						experimentalFeaturesResult.custom ??
-						experimentalFeaturesResult.theme ??
-						experimentalFeaturesResult.default
-					);
+			// 1. Take settings from the block instance or its ancestors.
+			const candidates = [
+				...select( blockEditorStore ).getBlockParents( clientId ),
+				clientId, // The current block is added last, so it overwrites any ancestor.
+			];
+			candidates.forEach( ( candidateClientId ) => {
+				const candidateBlockName = select(
+					blockEditorStore
+				).getBlockName( candidateClientId );
+				if (
+					hasBlockSupport( candidateBlockName, 'settings', false )
+				) {
+					const candidateAtts = select(
+						blockEditorStore
+					).getBlockAttributes( candidateClientId );
+					const candidateResult =
+						get(
+							candidateAtts,
+							`settings.blocks.${ blockName }.${ normalizedPath }`
+						) ??
+						get( candidateAtts, `settings.${ normalizedPath }` );
+					if ( candidateResult !== undefined ) {
+						result = candidateResult;
+					}
 				}
-				return experimentalFeaturesResult;
+			} );
+
+			// 2. Fall back to the settings from the block editor store (__experimentalFeatures).
+			const settings = select( blockEditorStore ).getSettings();
+			if ( result === undefined ) {
+				const defaultsPath = `__experimentalFeatures.${ normalizedPath }`;
+				const blockPath = `__experimentalFeatures.blocks.${ blockName }.${ normalizedPath }`;
+				result =
+					get( settings, blockPath ) ?? get( settings, defaultsPath );
 			}
 
-			// 2 - Use deprecated settings, otherwise.
+			// Return if the setting was found in either the block instance or the store.
+			if ( result !== undefined ) {
+				if ( PATHS_WITH_MERGE[ normalizedPath ] ) {
+					return result.custom ?? result.theme ?? result.default;
+				}
+				return result;
+			}
+
+			// 3. Otherwise, use deprecated settings.
 			const deprecatedSettingsValue = deprecatedFlags[ normalizedPath ]
 				? deprecatedFlags[ normalizedPath ]( settings )
 				: undefined;
@@ -155,13 +174,13 @@ export default function useSetting( path ) {
 				return deprecatedSettingsValue;
 			}
 
-			// 3 - Fall back for typography.dropCap:
+			// 4. Fallback for typography.dropCap:
 			// This is only necessary to support typography.dropCap.
 			// when __experimentalFeatures are not present (core without plugin).
 			// To remove when __experimentalFeatures are ported to core.
 			return normalizedPath === 'typography.dropCap' ? true : undefined;
 		},
-		[ blockName, path ]
+		[ blockName, clientId, path ]
 	);
 
 	return setting;

--- a/packages/block-editor/src/components/use-setting/index.js
+++ b/packages/block-editor/src/components/use-setting/index.js
@@ -132,7 +132,11 @@ export default function useSetting( path ) {
 					blockEditorStore
 				).getBlockName( candidateClientId );
 				if (
-					hasBlockSupport( candidateBlockName, 'settings', false )
+					hasBlockSupport(
+						candidateBlockName,
+						'__experimentalSettings',
+						false
+					)
 				) {
 					const candidateAtts = select(
 						blockEditorStore

--- a/packages/block-editor/src/hooks/index.js
+++ b/packages/block-editor/src/hooks/index.js
@@ -8,6 +8,7 @@ import './anchor';
 import './custom-class-name';
 import './generated-class-name';
 import './style';
+import './settings';
 import './color';
 import './duotone';
 import './font-size';

--- a/packages/block-editor/src/hooks/settings.js
+++ b/packages/block-editor/src/hooks/settings.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { hasBlockSupport } from '@wordpress/blocks';
+
+const hasSettingsSupport = ( blockType ) =>
+	hasBlockSupport( blockType, 'settings', true );
+
+function addAttribute( settings ) {
+	if ( ! hasSettingsSupport( settings ) ) {
+		return settings;
+	}
+
+	// Allow blocks to specify their own attribute definition with default values if needed.
+	if ( ! settings?.attributes?.settings ) {
+		settings.attributes = {
+			...settings.attributes,
+			settings: {
+				type: 'object',
+			},
+		};
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/settings/addAttribute',
+	addAttribute
+);

--- a/packages/block-editor/src/hooks/settings.js
+++ b/packages/block-editor/src/hooks/settings.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 
 const hasSettingsSupport = ( blockType ) =>
-	hasBlockSupport( blockType, 'settings', true );
+	hasBlockSupport( blockType, 'settings', false );
 
 function addAttribute( settings ) {
 	if ( ! hasSettingsSupport( settings ) ) {

--- a/packages/block-editor/src/hooks/settings.js
+++ b/packages/block-editor/src/hooks/settings.js
@@ -5,7 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { hasBlockSupport } from '@wordpress/blocks';
 
 const hasSettingsSupport = ( blockType ) =>
-	hasBlockSupport( blockType, 'settings', false );
+	hasBlockSupport( blockType, '__experimentalSettings', false );
 
 function addAttribute( settings ) {
 	if ( ! hasSettingsSupport( settings ) ) {

--- a/packages/block-editor/src/hooks/test/settings.js
+++ b/packages/block-editor/src/hooks/test/settings.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import '../settings';
+
+describe( 'with settings', () => {
+	const blockSettings = {
+		save: () => <div className="default" />,
+		category: 'text',
+		title: 'block title',
+	};
+
+	describe( 'addAttribute', () => {
+		const addAttribute = applyFilters.bind(
+			null,
+			'blocks.registerBlockType'
+		);
+
+		it( 'does not have settings att if settings block support is not enabled', () => {
+			const settings = addAttribute( {
+				...blockSettings,
+				supports: {
+					settings: false,
+				},
+			} );
+
+			expect( settings.attributes ).toBe( undefined );
+		} );
+
+		it( 'has settings att if settings block supports is enabled', () => {
+			const settings = addAttribute( {
+				...blockSettings,
+				supports: {
+					settings: true,
+				},
+			} );
+
+			expect( settings.attributes ).toStrictEqual( {
+				settings: { type: 'object' },
+			} );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/settings.js
+++ b/packages/block-editor/src/hooks/test/settings.js
@@ -25,7 +25,7 @@ describe( 'with settings', () => {
 			const settings = addAttribute( {
 				...blockSettings,
 				supports: {
-					settings: false,
+					__experimentalSettings: false,
 				},
 			} );
 
@@ -36,7 +36,7 @@ describe( 'with settings', () => {
 			const settings = addAttribute( {
 				...blockSettings,
 				supports: {
-					settings: true,
+					__experimentalSettings: true,
 				},
 			} );
 

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -18,6 +18,7 @@
 		}
 	},
 	"supports": {
+		"settings": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false,

--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -18,7 +18,7 @@
 		}
 	},
 	"supports": {
-		"settings": true,
+		"__experimentalSettings": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,
 		"html": false,


### PR DESCRIPTION
## What?

This PR adds a new hook called `settings` which blocks can opt-in into and that allows them to have a `settings` object like the `theme.json` has.

## Why?

We want to create the concept of a "section" that is able hold settings & styles (like `theme.json` does) but in block instances. See https://github.com/WordPress/gutenberg/issues/40318 and https://github.com/WordPress/gutenberg/issues/39281

## How?

This is only one part of getting settings to work in block instances. The other part is building an UI for them (get something like a global styles sidebar to show in the blocks that opt-into this hook).

- Creates a new `settings` hook.
- Updates the `useSetting` hook to lookup for settings in the block instance or its ancestors before looking into the block editor store.

## Testing Instructions

- Create a new post and open the code editor.
- Paste the following content:

```html
<!-- wp:group {"settings":{"color":{"defaultPalette":false,"palette":{"custom":[{"slug":"my-hotpink","color":"hotpink","name":"Hotpink"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of top-level group block.</p>
<!-- /wp:paragraph -->

<!-- wp:group {"settings":{"color":{"palette":{"custom":[{"slug":"my-aquamarine","color":"aquamarine","name":"Aquamarine"}]}}}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Leaf paragraph of inner group block.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

- Go back to the visual editor and you'll see:

![Captura de ecrã de 2022-04-25 12-54-14](https://user-images.githubusercontent.com/583546/165075540-90f7f0cd-1424-43da-ba58-9e708598be5b.png)

- Navigate to the top-level group block and inspect its the color panel for text, background, and link color. The expected result is that:
  - the "custom" section contains the "hotpink" color
  - the "default" section is hidden
- Verify that the same is true for its child paragraph.

<img src="https://user-images.githubusercontent.com/583546/164740532-3ccf1901-d9a0-4f01-853c-62ea48e98d44.png" width="50%"/>

- Navigate to the inner group block and inspect its color panel. The expected result is that:
  - the "custom" section contains the "aquamarine" color
  - the "default" section is still hidden
- Verify that the same is true for its child paragraph.

<img src="https://user-images.githubusercontent.com/583546/165075810-05120879-a60f-48d9-b47f-a4ade2004b09.png" width="50%"/>

## Questions

- Format for presets https://github.com/WordPress/gutenberg/pull/40547#issuecomment-1112110409
- Algorithm for settings, see https://github.com/WordPress/gutenberg/issues/40318#issuecomment-1106694527 and https://github.com/WordPress/gutenberg/pull/40547#discussion_r857508021

## Follow-ups

See https://github.com/WordPress/gutenberg/issues/40318
