### PR TITLE
[RNMobile] Set "expanded" version of inserter's "add blocks" text to title case

### DIFF
--- a/packages/block-editor/src/components/inserter/index.native.js
+++ b/packages/block-editor/src/components/inserter/index.native.js
@@ -52,7 +52,7 @@ const defaultRenderToggle = ( {
 	};
 	const expandedModeViewText = (
 		<Text style={ styles[ 'inserter-menu__add-block-button-text' ] }>
-			{ __( 'Add Blocks' ) }
+			{ __( 'Add blocks' ) }
 		</Text>
 	);
 

--- a/packages/block-editor/src/components/inserter/style.native.scss
+++ b/packages/block-editor/src/components/inserter/style.native.scss
@@ -27,6 +27,7 @@
 	color: $white;
 	font-weight: 500;
 	align-self: center;
+	text-transform: capitalize;
 }
 
 .inserter-menu__list-wrapper {


### PR DESCRIPTION
## Related PRs

* `gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4787

## What?

With this PR, the `Add blocks` text in the "expanded" version of the editor's inserter button (introduced in https://github.com/WordPress/gutenberg/pull/39726) is set to title case via CSS.

## Why?

Previous to this PR, the `Add Blocks` text in the button was set to title case (to match the button's design) simply by typing it in as title case within the code. This brought up two problems:

1. The text's capitalisation was automatically converted to `Add blocks` within the app.
2. When bundling Gutenberg Mobile, a new string was added to the translation files, for examples A new string was added to the translation files when. This is unnecessary as an `Add blocks` string is already present and its translations can be re-used.

## How?

`Add blocks` has been set to "regular" sentence capitalisation in the code, in order to prevent extra strings from being added to translation files. In order to match the button's designs, `text-transform: capitalize;` has been used to transform the text to title case via CSS.

## Testing Instructions

### Functionality

* Within the iOS or Android app, go through the steps to create a new post.
* By default, you'll see the new expanded `+` inserter in the editor's toolbar when opening a new post. Verify that the text in this expanded button is capitalised as `Add Blocks` rather than `Add blocks`.

### Translation Files

* Verify that there is only one `Add blocks` string in the translation files (with no variations with different capitalisation) in the bundle produced in [the Gutenberg Mobile PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/4787).

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/164748543-9766cc3b-074e-404d-9fa6-43d15baadd72.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/164748277-0c1d08df-8070-4253-98a9-f989feea522b.png" width="100%"> |

