### PR TITLE
Separator Block: Add top & bottom margin support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -725,7 +725,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 
 -	**Name:** core/separator
 -	**Category:** design
--	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~text~~)
+-	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~text~~), spacing (margin)
 -	**Attributes:** opacity
 
 ## Shortcode

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -24,6 +24,9 @@
 			"__experimentalDefaultControls": {
 				"background": true
 			}
+		},
+		"spacing": {
+			"margin": [ "top", "bottom" ]
 		}
 	},
 	"styles": [


### PR DESCRIPTION
This adds top & bottom `margin` support to the separator block. There have been other attempts at this in the past, see https://github.com/WordPress/gutenberg/issues/20758 https://github.com/WordPress/gutenberg/pull/30609 https://github.com/WordPress/gutenberg/pull/28451. They've been closed in favor of using the spacer block, but I don't think that's intuitive, especially as there are other blocks with margin controls.

For example, if I want to add a spacer with 50px space on either side, I need to add a group block, set the block gap & margin top to `0px` (to account for added margins), and then add my spacers & separator.

```html
<!-- wp:group {"style":{"spacing":{"blockGap":"0px","margin":{"top":"0px"}}},"layout":{"inherit":true}} -->
<div class="wp-block-group" style="margin-top:0px">
	<!-- wp:spacer {"height":"50px"} -->
	<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
	<!-- /wp:spacer -->

	<!-- wp:separator {"color":"light-grey","className":"is-style-wide"} -->
	<hr class="wp-block-separator has-text-color has-background has-light-grey-background-color has-light-grey-color is-style-wide" />
	<!-- /wp:separator -->

	<!-- wp:spacer {"height":"50px"} -->
	<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
	<!-- /wp:spacer -->
</div>
<!-- /wp:group -->
```

Or, I could just control the margin directly.

```html
<!-- wp:separator {"style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}},"backgroundColor":"black","className":"is-style-wide"} -->
<hr class="wp-block-separator has-text-color has-black-color has-alpha-channel-opacity has-black-background-color has-background is-style-wide" style="margin-top:50px;margin-bottom:50px"/>
<!-- /wp:separator -->
```

## How?

This simply toggles the block support for `spacing.margin`, for top & bottom margin only (the minimum needed change). 

## Testing Instructions

1. Add a separator block
2. Change the margin (might need to enable "margin" in the Dimension panel)
3. It should reflect the new margin in the editor
4. Save & view the post
5. The margin should also be applied on the frontend

## Screenshots

Added Dimension panel & margin control
<img width="288" alt="" src="https://user-images.githubusercontent.com/541093/164756194-d8ef9719-cc9b-4af5-bb3e-9d424b744d31.png">

Spacer with margin
<img width="952" alt="" src="https://user-images.githubusercontent.com/541093/164756192-912ea666-804f-4b94-a1c6-3ce5569d80a4.png">


