### PR TITLE
Video: Fix drag and drop upload error state

### DIFF
--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -61,7 +61,8 @@ function VideoEdit( {
 	const { id, caption, controls, poster, src, tracks } = attributes;
 	const isTemporaryVideo = ! id && isBlobURL( src );
 	const mediaUpload = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().mediaUpload
+		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
+		[]
 	);
 
 	useEffect( () => {

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -70,9 +70,7 @@ function VideoEdit( {
 			if ( file ) {
 				mediaUpload( {
 					filesList: [ file ],
-					onFileChange: ( [ { url } ] ) => {
-						setAttributes( { src: url } );
-					},
+					onFileChange: ( [ media ] ) => onSelectVideo( media ),
 					onError: ( message ) => {
 						noticeOperations.createErrorNotice( message );
 					},


### PR DESCRIPTION
## What?
PR fixes how error state for drag and drop video uploads.

## Why?
Video block got stuck in loading state if an error occurred during drag and drop upload.

## How?
Updates `onFileChange` callback to use `onSelectVideo` which correctly resets attributes on upload error.

## Testing Instructions
1. Emulate server upload error (snippet below).
2. Open a Post or Page.
3. Drop video on the content area.
4. Confirm that the error message is correctly displayed

```php
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'Image upload error';
	return $file;
} );
```

## Screenshots or screencast <!-- if applicable -->

Before

https://user-images.githubusercontent.com/240569/164756830-58c4db98-c9a4-4cf6-af34-ca6693ab7c39.mp4

After

https://user-images.githubusercontent.com/240569/164756818-c3e0010e-8b4c-475b-98dd-52578c95249e.mp4


