### PR TITLE
Render hidden span when on first/last page

### DIFF
--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -55,7 +55,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 			);
 		} else {
 			$wrapper_attributes .= 'style="visibility:hidden;"';
-			$content = sprintf(
+			$content             = sprintf(
 				'<span %1$s>%2$s</span>',
 				$wrapper_attributes,
 				$label

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -53,6 +53,13 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 				$wrapper_attributes,
 				$label
 			);
+		} else {
+			$wrapper_attributes .= 'style="visibility:hidden;"';
+			$content = sprintf(
+				'<span %1$s>%2$s</span>',
+				$wrapper_attributes,
+				$label
+			);
 		}
 		wp_reset_postdata(); // Restore original Post Data.
 	}

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -55,7 +55,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 			);
 		} else {
 			$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'query-pagination-disabled' ) );
-			$content             = sprintf(
+			$content            = sprintf(
 				'<span %1$s>%2$s</span>',
 				$wrapper_attributes,
 				$label

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -54,7 +54,7 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 				$label
 			);
 		} else {
-			$wrapper_attributes .= 'style="visibility:hidden;"';
+			$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'query-pagination-disabled' ) );
 			$content             = sprintf(
 				'<span %1$s>%2$s</span>',
 				$wrapper_attributes,

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -45,7 +45,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		);
 	} else {
 		$wrapper_attributes .= 'style="visibility:hidden;"';
-		$content = sprintf(
+		$content             = sprintf(
 			'<span %1$s>%2$s</span>',
 			$wrapper_attributes,
 			$label

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -43,6 +43,13 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			$wrapper_attributes,
 			$label
 		);
+	} else {
+		$wrapper_attributes .= 'style="visibility:hidden;"';
+		$content = sprintf(
+			'<span %1$s>%2$s</span>',
+			$wrapper_attributes,
+			$label
+		);
 	}
 	return $content;
 }

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -15,8 +15,8 @@
  * @return string Returns the previous posts link for the query.
  */
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
-	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+	$page_key           = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+	$page               = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$default_label      = __( 'Previous Page' );
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
@@ -44,7 +44,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		);
 	} else {
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'query-pagination-disabled' ) );
-		$content             = sprintf(
+		$content            = sprintf(
 			'<span %1$s>%2$s</span>',
 			$wrapper_attributes,
 			$label

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -17,7 +17,6 @@
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-
 	$wrapper_attributes = get_block_wrapper_attributes();
 	$default_label      = __( 'Previous Page' );
 	$label              = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
@@ -44,7 +43,7 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			$label
 		);
 	} else {
-		$wrapper_attributes .= 'style="visibility:hidden;"';
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'query-pagination-disabled' ) );
 		$content             = sprintf(
 			'<span %1$s>%2$s</span>',
 			$wrapper_attributes,

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -35,4 +35,8 @@ $pagination-margin: 0.5em;
 	&.aligncenter {
 		justify-content: center;
 	}
+
+	.query-pagination-disabled {
+		visibility: hidden;
+	}
 }


### PR DESCRIPTION
## What?
This change causes the query-pagination-next and query-pagination-previous blocks to render an invisible `<span>` when on the first/last page.

This is an alternative to #36681 (which was merged and then removed) and 
fixes #34997

NOTE: This is a much simpler solution than where #36681 landed and doesn't cover all the scenarios mentioned there (spacing around left/right aligned query pagination).  However it fixes the most glaring issues and (I hope) fits well in the "what is the smallest that we can do that's helpful?".  Especially since "space between" and "centered" are the two most likely design layouts to be used (and those don't look good today).

## Why?
Currently the blocks render nothing when on the first/last page which causes issue with layout when on those pages.

## How?
Add an additional `else{}` statement to the rendering logic to render the span with additional `visibility:hidden` style attribute.  The label is included in the span so that the size of the label will be taken into account during rendering (even though it is not visible).

## Screenshots or screencast <!-- if applicable -->
Before:
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/146530/164759420-312d5f9b-9d44-4ebf-b856-45846146e8d4.png">
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/146530/164759458-8b33ba1d-804e-4f18-a069-e47b0a035afe.png">


After:
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/146530/164759011-68df4d00-0e68-45fc-9571-3ec6c64cb017.png">
<img width="1249" alt="image" src="https://user-images.githubusercontent.com/146530/164759049-8c15f280-c228-4f23-9d06-790f59a15adb.png">

```
<!-- wp:query-pagination {"paginationArrow":"arrow","layout":{"type":"flex","justifyContent":"space-between"}} -->
<!-- wp:query-pagination-previous /-->
<!-- wp:query-pagination-numbers /-->
<!-- wp:query-pagination-next /-->
<!-- /wp:query-pagination -->
```

@WordPress/block-themers 