### PR TITLE
Post terms: Add prefix & suffix

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -591,7 +591,7 @@ Post terms. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages
 -	**Name:** core/post-terms
 -	**Category:** theme
 -	**Supports:** color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** separator, term, textAlign
+-	**Attributes:** prefix, separator, suffix, term, textAlign
 
 ## Post Title
 

--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -16,6 +16,14 @@
 		"separator": {
 			"type": "string",
 			"default": ", "
+		},
+		"prefix": {
+			"type": "string",
+			"default": ""
+		},
+		"suffix": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -13,6 +13,7 @@ import {
 	BlockControls,
 	useBlockProps,
 	useBlockDisplayInformation,
+	RichText,
 } from '@wordpress/block-editor';
 import { Spinner, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -30,7 +31,7 @@ export default function PostTermsEdit( {
 	context,
 	setAttributes,
 } ) {
-	const { term, textAlign, separator } = attributes;
+	const { term, textAlign, separator, prefix, suffix } = attributes;
 	const { postId, postType } = context;
 
 	const selectedTerm = useSelect(
@@ -83,6 +84,19 @@ export default function PostTermsEdit( {
 			</InspectorControls>
 			<div { ...blockProps }>
 				{ isLoading && <Spinner /> }
+				{ ! isLoading && hasPostTerms && (
+					<RichText
+						className="wp-block-post-terms__prefix"
+						multiline={ false }
+						aria-label={ __( 'Prefix' ) }
+						placeholder={ __( 'Prefix' ) + ' ' }
+						value={ prefix }
+						onChange={ ( value ) =>
+							setAttributes( { prefix: value } )
+						}
+						tagName="span"
+					/>
+				) }
 				{ ! isLoading &&
 					hasPostTerms &&
 					postTerms
@@ -108,6 +122,19 @@ export default function PostTermsEdit( {
 					! hasPostTerms &&
 					( selectedTerm?.labels?.no_terms ||
 						__( 'Term items not found.' ) ) }
+				{ ! isLoading && hasPostTerms && (
+					<RichText
+						className="wp-block-post-terms__suffix"
+						multiline={ false }
+						aria-label={ __( 'Suffix' ) }
+						placeholder={ ' ' + __( 'Suffix' ) }
+						value={ suffix }
+						onChange={ ( value ) =>
+							setAttributes( { suffix: value } )
+						}
+						tagName="span"
+					/>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -43,7 +43,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 
 	$suffix = '</div>';
 	if ( isset( $attributes['suffix'] ) && $attributes['suffix'] ) {
-		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . $suffix;
+		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
 	return get_the_term_list(

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -36,12 +36,22 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
+	$prefix = "<div $wrapper_attributes>";
+	if ( isset( $attributes['prefix'] ) && $attributes['prefix'] ) {
+		$prefix .= '<span class="wp-block-post-terms__prefix">' . $attributes['prefix'] . '</span>';
+	}
+
+	$suffix = '</div>';
+	if ( isset( $attributes['suffix'] ) && $attributes['suffix'] ) {
+		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . $suffix;
+	}
+
 	return get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
-		"<div $wrapper_attributes>" . ( isset( $attributes['prefix'] ) ? $attributes['prefix'] : '' ),
+		$prefix,
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		( isset( $attributes['suffix'] ) ? $attributes['suffix'] : '' ) . '</div>'
+		$suffix
 	);
 }
 

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -39,9 +39,9 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	return get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
-		"<div $wrapper_attributes>",
+		"<div $wrapper_attributes>" . ( isset( $attributes['prefix'] ) ? $attributes['prefix'] : '' ),
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		'</div>'
+		( isset( $attributes['suffix'] ) ? $attributes['suffix'] : '' ) . '</div>'
 	);
 }
 

--- a/test/integration/fixtures/blocks/core__post-terms.json
+++ b/test/integration/fixtures/blocks/core__post-terms.json
@@ -3,7 +3,9 @@
 		"name": "core/post-terms",
 		"isValid": true,
 		"attributes": {
-			"separator": ", "
+			"prefix": "",
+			"separator": ", ",
+			"suffix": ""
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Allowing an optional prefix and suffix to be added to the Post Categories and Post Tags

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A common pattern in themes is to display categories and tags prepended with a text. This is the case for all default themes, including TwentyTwentyOne.

![image](https://user-images.githubusercontent.com/93301/164783132-489a3543-4a7f-4d33-8321-80463fd53df1.png)

Fixes #29909

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
 * Add prefix and suffix attributes to the post-terms block. 
 * Allow these attributes to be set inside the block editor via a RichText component

## Testing Instructions
 1. Open a Post or page
 2. Insert a Post Tags or Post Categories block
 3. Click the placeholder and start typing
 8. Press Publish
 9. Look at the site on the frontend

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/93301/164788905-b91eb2fd-df6e-45df-a509-5ab694ebbc38.png)


https://user-images.githubusercontent.com/93301/164788672-b7899105-19d2-4481-ad9b-b5f1153b3e8c.mp4
