### PR TITLE
Refactor: Reuse code of the editor placeholder across Post Comments and Post Comments Form

### DIFF
--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -14,10 +14,11 @@ import {
 } from '@wordpress/block-editor';
 import { useEntityProp } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-import {
-	__experimentalUseDisabled as useDisabled,
-	useInstanceId,
-} from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import CommentsForm from './form';
 
 export default function PostCommentsFormEdit( {
 	attributes,
@@ -39,10 +40,6 @@ export default function PostCommentsFormEdit( {
 	} );
 
 	const isInSiteEditor = postType === undefined || postId === undefined;
-
-	const disabledFormRef = useDisabled();
-
-	const instanceId = useInstanceId( PostCommentsFormEdit );
 
 	return (
 		<>
@@ -76,35 +73,7 @@ export default function PostCommentsFormEdit( {
 				) }
 
 				{ ( 'open' === commentStatus || isInSiteEditor ) && (
-					<div>
-						<h3>{ __( 'Leave a Reply' ) }</h3>
-						<form
-							noValidate
-							className="comment-form"
-							ref={ disabledFormRef }
-						>
-							<p>
-								<label htmlFor={ `comment-${ instanceId }` }>
-									{ __( 'Comment' ) }
-								</label>
-								<textarea
-									id={ `comment-${ instanceId }` }
-									name="comment"
-									cols="45"
-									rows="8"
-								/>
-							</p>
-							<p>
-								<input
-									name="submit"
-									className="submit wp-block-button__link"
-									label={ __( 'Post Comment' ) }
-									value={ __( 'Post Comment' ) }
-									readOnly
-								/>
-							</p>
-						</form>
-					</div>
+					<CommentsForm />
 				) }
 			</div>
 		</>

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -11,31 +11,33 @@ const CommentsForm = () => {
 	const disabledFormRef = useDisabled();
 	const instanceId = useInstanceId( CommentsForm );
 
-	<div className="comment-respond">
-		<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
-		<form noValidate className="comment-form" ref={ disabledFormRef }>
-			<p>
-				<label htmlFor={ `comment-${ instanceId }` }>
-					{ __( 'Comment' ) }
-				</label>
-				<textarea
-					id={ `comment-${ instanceId }` }
-					name="comment"
-					cols="45"
-					rows="8"
-				/>
-			</p>
-			<p className="form-submit wp-block-button">
-				<input
-					name="submit"
-					type="submit"
-					className="submit wp-block-button__link"
-					label={ __( 'Post Comment' ) }
-					value={ __( 'Post Comment' ) }
-				/>
-			</p>
-		</form>
-	</div>;
+	return (
+		<div className="comment-respond">
+			<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
+			<form noValidate className="comment-form" ref={ disabledFormRef }>
+				<p>
+					<label htmlFor={ `comment-${ instanceId }` }>
+						{ __( 'Comment' ) }
+					</label>
+					<textarea
+						id={ `comment-${ instanceId }` }
+						name="comment"
+						cols="45"
+						rows="8"
+					/>
+				</p>
+				<p className="form-submit wp-block-button">
+					<input
+						name="submit"
+						type="submit"
+						className="submit wp-block-button__link"
+						label={ __( 'Post Comment' ) }
+						value={ __( 'Post Comment' ) }
+					/>
+				</p>
+			</form>
+		</div>
+	);
 };
 
 export default CommentsForm;

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalUseDisabled as useDisabled,
+	useInstanceId,
+} from '@wordpress/compose';
+
+const CommentsForm = () => {
+	const disabledFormRef = useDisabled();
+	const instanceId = useInstanceId( CommentsForm );
+
+	<div className="comment-respond">
+		<h3 className="comment-reply-title">{ __( 'Leave a Reply' ) }</h3>
+		<form noValidate className="comment-form" ref={ disabledFormRef }>
+			<p>
+				<label htmlFor={ `comment-${ instanceId }` }>
+					{ __( 'Comment' ) }
+				</label>
+				<textarea
+					id={ `comment-${ instanceId }` }
+					name="comment"
+					cols="45"
+					rows="8"
+				/>
+			</p>
+			<p className="form-submit wp-block-button">
+				<input
+					name="submit"
+					type="submit"
+					className="submit wp-block-button__link"
+					label={ __( 'Post Comment' ) }
+					value={ __( 'Post Comment' ) }
+				/>
+			</p>
+		</form>
+	</div>;
+};
+
+export default CommentsForm;

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -16,10 +16,12 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import {
-	__experimentalUseDisabled as useDisabled,
-	useInstanceId,
-} from '@wordpress/compose';
+import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import CommentsForm from '../post-comments-form/form';
 
 export default function PostCommentsEdit( {
 	attributes: { textAlign },
@@ -87,8 +89,6 @@ export default function PostCommentsEdit( {
 	} );
 
 	const disabledRef = useDisabled();
-
-	const textareaId = useInstanceId( PostCommentsEdit );
 
 	return (
 		<>
@@ -206,37 +206,7 @@ export default function PostCommentsEdit( {
 							</div>
 						</div>
 
-						<div className="comment-respond">
-							<h3 className="comment-reply-title">
-								{ __( 'Leave a Reply' ) }
-							</h3>
-
-							<form className="comment-form" noValidate>
-								<p className="comment-form-comment">
-									<label
-										htmlFor={ `comment-${ textareaId }` }
-									>
-										{ __( 'Comment' ) }{ ' ' }
-										<span className="required">*</span>
-									</label>
-									<textarea
-										id={ `comment-${ textareaId }` }
-										name="comment"
-										cols="45"
-										rows="8"
-										required
-									/>
-								</p>
-								<p className="form-submit wp-block-button">
-									<input
-										name="submit"
-										type="submit"
-										className="submit wp-block-button__link"
-										value={ __( 'Post Comment' ) }
-									/>
-								</p>
-							</form>
-						</div>
+						<CommentsForm />
 					</div>
 				) }
 			</div>


### PR DESCRIPTION
## What?
Create a `CommentsForm` component that is re-used in the editor across both Post Comments and the Post Comments Form blocks. 

This PR has no functional changes, it's a refactoring.

## Why?

This is based on suggestion by @ockham in https://github.com/WordPress/gutenberg/pull/40484#pullrequestreview-948942959

Previously, there was a duplication of code between the Post Comments and the Post Comments Form blocks.


## Testing Instructions
1. Open the post/site editor
2. Insert a Post Comments block 
3. Insert a Post Comments Form block
4. Check that both blocks include the same Form element

