### PR TITLE
Improve the logic for warnings for Post Comments Form placeholder

### DIFF
--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -11,10 +11,11 @@ import {
 	BlockControls,
 	Warning,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useEntityProp } from '@wordpress/core-data';
+import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
-
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -39,7 +40,49 @@ export default function PostCommentsFormEdit( {
 		} ),
 	} );
 
-	const isInSiteEditor = postType === undefined || postId === undefined;
+	const isSiteEditor = postType === undefined || postId === undefined;
+
+	const { defaultCommentStatus } = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings()
+				.__experimentalDiscussionSettings
+	);
+
+	const postTypeSupportsComments = useSelect( ( select ) =>
+		postType
+			? !! select( coreStore ).getPostType( postType )?.supports.comments
+			: false
+	);
+
+	let warning = false;
+	let showPlacholder = true;
+
+	if ( ! isSiteEditor && 'open' !== commentStatus ) {
+		if ( 'closed' === commentStatus ) {
+			warning = sprintf(
+				/* translators: 1: Post type (i.e. "post", "page") */
+				__(
+					'Post Comments Form block: Comments on this %s are not allowed.'
+				),
+				postType
+			);
+			showPlacholder = false;
+		} else if ( ! postTypeSupportsComments ) {
+			warning = sprintf(
+				/* translators: 1: Post type (i.e. "post", "page") */
+				__(
+					'Post Comments Form block: Comments for this post type (%s) are not enabled.'
+				),
+				postType
+			);
+			showPlacholder = false;
+		} else if ( 'open' !== defaultCommentStatus ) {
+			warning = __(
+				'Post Comments Form block: Comments are not enabled.'
+			);
+			showPlacholder = false;
+		}
+	}
 
 	return (
 		<>
@@ -52,29 +95,9 @@ export default function PostCommentsFormEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				{ ! commentStatus && ! isInSiteEditor && (
-					<Warning>
-						{ __(
-							'Post Comments Form block: comments are not enabled for this post type.'
-						) }
-					</Warning>
-				) }
+				{ warning && <Warning>{ warning }</Warning> }
 
-				{ 'open' !== commentStatus && ! isInSiteEditor && (
-					<Warning>
-						{ sprintf(
-							/* translators: 1: Post type (i.e. "post", "page") */
-							__(
-								'Post Comments Form block: comments to this %s are not allowed.'
-							),
-							postType
-						) }
-					</Warning>
-				) }
-
-				{ ( 'open' === commentStatus || isInSiteEditor ) && (
-					<CommentsForm />
-				) }
+				{ showPlacholder ? <CommentsForm /> : null }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments-form/edit.js
+++ b/packages/block-library/src/post-comments-form/edit.js
@@ -55,7 +55,7 @@ export default function PostCommentsFormEdit( {
 	);
 
 	let warning = false;
-	let showPlacholder = true;
+	let showPlaceholder = true;
 
 	if ( ! isSiteEditor && 'open' !== commentStatus ) {
 		if ( 'closed' === commentStatus ) {
@@ -66,7 +66,7 @@ export default function PostCommentsFormEdit( {
 				),
 				postType
 			);
-			showPlacholder = false;
+			showPlaceholder = false;
 		} else if ( ! postTypeSupportsComments ) {
 			warning = sprintf(
 				/* translators: 1: Post type (i.e. "post", "page") */
@@ -75,12 +75,12 @@ export default function PostCommentsFormEdit( {
 				),
 				postType
 			);
-			showPlacholder = false;
+			showPlaceholder = false;
 		} else if ( 'open' !== defaultCommentStatus ) {
 			warning = __(
 				'Post Comments Form block: Comments are not enabled.'
 			);
-			showPlacholder = false;
+			showPlaceholder = false;
 		}
 	}
 
@@ -97,7 +97,7 @@ export default function PostCommentsFormEdit( {
 			<div { ...blockProps }>
 				{ warning && <Warning>{ warning }</Warning> }
 
-				{ showPlacholder ? <CommentsForm /> : null }
+				{ showPlaceholder ? <CommentsForm /> : null }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -55,7 +55,7 @@ export default function PostCommentsEdit( {
 	let warning = __(
 		'Post Comments block: This is just a placeholder, not a real comment. The final styling may differ because it also depends on the current theme. For better compatibility with the Block Editor, please consider replacing this block with the "Comments Query Loop" block.'
 	);
-	let showPlacholder = true;
+	let showPlaceholder = true;
 
 	if ( ! isSiteEditor && 'open' !== commentStatus ) {
 		if ( 'closed' === commentStatus ) {
@@ -66,7 +66,7 @@ export default function PostCommentsEdit( {
 				),
 				postType
 			);
-			showPlacholder = false;
+			showPlaceholder = false;
 		} else if ( ! postTypeSupportsComments ) {
 			warning = sprintf(
 				/* translators: 1: Post type (i.e. "post", "page") */
@@ -75,10 +75,10 @@ export default function PostCommentsEdit( {
 				),
 				postType
 			);
-			showPlacholder = false;
+			showPlaceholder = false;
 		} else if ( 'open' !== defaultCommentStatus ) {
 			warning = __( 'Post Comments block: Comments are not enabled.' );
-			showPlacholder = false;
+			showPlaceholder = false;
 		}
 	}
 
@@ -104,7 +104,7 @@ export default function PostCommentsEdit( {
 			<div { ...blockProps }>
 				<Warning>{ warning }</Warning>
 
-				{ showPlacholder && (
+				{ showPlaceholder && (
 					<div
 						className="wp-block-post-comments__placeholder"
 						ref={ disabledRef }


### PR DESCRIPTION
## What?
Followup to https://github.com/WordPress/gutenberg/pull/40368 

In some cases, we want to show a warning to inform the user that one of the following is the case:
- comments are not enabled on the site
- comments are not enabled for this post
- comments are not enabled for this custom post type

Here, we're improving the logic responsible for showing warnings in the Post Comments Form placeholder according to https://github.com/WordPress/gutenberg/pull/40484#issuecomment-1105045818 

## Why?
Previous implementation was not specific enough.

## How?
Mostly re-using the logic for showing the comments that was implemented for the Post Comments in https://github.com/WordPress/gutenberg/pull/40484

## Testing Instructions
Site Editor:

- Add the Post Comments Form block to a template.
- Check that **no warning is shown** regardless of the status of Discussion settings.

Post Editor:

- Comments are not enabled on the site:
  - Add the Post Comments Form block to a post.
  - In the Post settings, deselect "Allow Comments".
  - The **`Post Comments Form block: Comments on this post are not allowed.`** warning should appear.

- Comments are not enabled for this post
  - Go to the Discussion settings.
  - Disable the "Allow people to submit comments on new posts" setting.
  - Create a brand new post.
  - Go to the editor and add a Post Comments block.
  - The **`Post Comments Form block: Comments are not enabled.`** warning should appear.

- Comments are not enabled for this custom post type
  - Make sure that the comments are enabled globally and enable the "Allow people to submit comments on new posts" setting.
  - Create a new custom post type and disable the comments on that post type.
  - Create a new post with that new custom post type.
  - Go to the editor and add a Post Comments block.
  - The **`Post Comments Form block: Comments for this post type <post type name> are not enabled`** warning should be visible.

