### PR TITLE
Fix: npm script(dev:package) is not working on Windows

### DIFF
--- a/bin/packages/watch.js
+++ b/bin/packages/watch.js
@@ -59,7 +59,9 @@ function isDirectory( pathname ) {
 function isSourceFile( filename ) {
 	// Only run this regex on the relative path, otherwise we might run
 	// into some false positives when eg. the project directory contains `src`
-	const relativePath = path.relative( process.cwd(), filename );
+	const relativePath = path
+		.relative( process.cwd(), filename )
+		.replace( /\\/g, '/' );
 
 	return (
 		/\/src\/.+\.(js|json|scss|ts|tsx)$/.test( relativePath ) &&
@@ -98,6 +100,7 @@ function isWatchableFile( filename, skip ) {
 	// Recursive file watching is not available on a Linux-based OS. If this is the case,
 	// the watcher library falls back to watching changes in the subdirectories
 	// and passes the directories to this filter callback instead.
+
 	if ( isDirectory( filename ) ) {
 		return true;
 	}
@@ -117,8 +120,9 @@ function isWatchableFile( filename, skip ) {
 function getBuildFile( srcFile ) {
 	// Could just use string.replace, but the user might have the project
 	// checked out and nested under another src folder.
-	const packageDir = srcFile.substr( 0, srcFile.lastIndexOf( '/src/' ) );
-	const filePath = srcFile.substr( srcFile.lastIndexOf( '/src/' ) + 5 );
+	const srcDir = `${ path.sep }src${ path.sep }`;
+	const packageDir = srcFile.substr( 0, srcFile.lastIndexOf( srcDir ) );
+	const filePath = srcFile.substr( srcFile.lastIndexOf( srcDir ) + 5 );
 	return path.resolve( packageDir, 'build', filePath );
 }
 


### PR DESCRIPTION
- Part of #39388
- Related: #38348

## What?
This PR fixes a problem with the npm script ( `dev:packages` ) not working properly on Windows OS.
On Windows OS, changes, new additions, and deletions of files in the `packages` directory are not properly reflected in the build folder.

## Why?
As with #38348, the Windows OS path separator is a **backslash**, which causes some processing to be incorrect.

## How?
I solved this problem in the following way:

- Use `path.sep` instead of `/`
- Replace backslash with forward slash

## Testing Instructions Example

Run `npm run dev:packages` and perform the following operations on the files in `packages` directory.

### Code Update

- Add code to `packages/a11y/src/index.js` (e.g. `console.log('test');`)
- Confirm that `packages/a11y/build/index.js.map` and `packages/a11y/build/index.js` files have been updated.

### Add New File

- Add a new file `packages/a11y/src/test.js`.
- Confirm that `packages/a11y/build/test.js` and `packages/a11y/build/test.js.map` files have been created.

### Rename File

- Rename `packages/a11y/src/test.js` to `packages/a11y/src/test2.js`.
- Confirm that `packages/a11y/build/test.js` files have been deleted.
- Confirm that `packages/a11y/build/test2.js` and `packages/a11y/build/test2.js.map` files have been created.

### Remove File

- Delete `packages/a11y/src/test2.js`.
- Confirm that `packages/a11y/build/test2.js` files have been deleted.

### About Parent Scripts

The following two scripts are dependent on `dev:packages`:

- `dev`
- `storybook:dev`

The above script should also work correctly with this PR.

