### PR TITLE
Fix incorrect results in the flaky tests reporter

### DIFF
--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -88,35 +88,37 @@ const metaData = {
 				}
 			}
 
-			let testResultsList = body
-				.slice(
-					body.indexOf( TEST_RESULTS_LIST.open ) +
-						TEST_RESULTS_LIST.open.length,
-					body.indexOf( TEST_RESULTS_LIST.close )
-				)
-				/**
-				 * Split the text from:
-				 * ```
-				 * <!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->
-				 * ...
-				 * <!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->
-				 * <!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->
-				 * ```
-				 *
-				 * into:
-				 * ```
-				 * [
-				 *   '<!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->',
-				 *   '<!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->',
-				 *   '<!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->',
-				 * ]
-				 * ```
-				 */
-				.split(
-					new RegExp(
-						`(?<=${ TEST_RESULT.close })\n+(?:\.\.\.\n+)?(?=${ TEST_RESULT.open })`
-					)
-				);
+			let testResultsList = body.includes( TEST_RESULTS_LIST.open )
+				? body
+						.slice(
+							body.indexOf( TEST_RESULTS_LIST.open ) +
+								TEST_RESULTS_LIST.open.length,
+							body.indexOf( TEST_RESULTS_LIST.close )
+						)
+						/**
+						 * Split the text from:
+						 * ```
+						 * <!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->
+						 * ...
+						 * <!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->
+						 * <!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->
+						 * ```
+						 *
+						 * into:
+						 * ```
+						 * [
+						 *   '<!-- __TEST_RESULT__ --> Test result 1 <!-- /__TEST_RESULT__ -->',
+						 *   '<!-- __TEST_RESULT__ --> Test result 2 <!-- /__TEST_RESULT__ -->',
+						 *   '<!-- __TEST_RESULT__ --> Test result 3 <!-- /__TEST_RESULT__ -->',
+						 * ]
+						 * ```
+						 */
+						.split(
+							new RegExp(
+								`(?<=${ TEST_RESULT.close })\n+(?:\.\.\.\n+)?(?=${ TEST_RESULT.open })`
+							)
+						)
+				: [];
 			// GitHub issues has character limits on issue's body,
 			// so we only preserve the first and the 9 latest results.
 			if ( testResultsList.length > 10 ) {

--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -133,7 +133,7 @@ const metaData = {
 				[
 					TEST_RESULTS_LIST.open,
 					...testResultsList,
-					renderTestErrorMessage( {
+					renderTestResult( {
 						testRunner,
 						testPath,
 						testResults,
@@ -242,7 +242,7 @@ function renderIssueBody( {
 } ) {
 	return (
 		renderIssueDescription( { meta, testTitle, testPath } ) +
-		renderTestResults( { testRunner, testPath, testResults } )
+		renderTestResultsList( { testRunner, testPath, testResults } )
 	);
 }
 
@@ -263,14 +263,14 @@ ${ testTitle }
 `;
 }
 
-function renderTestResults( { testRunner, testPath, testResults } ) {
+function renderTestResultsList( { testRunner, testPath, testResults } ) {
 	return `${ TEST_RESULTS_LIST.open }
-${ renderTestErrorMessage( { testRunner, testPath, testResults } ) }
+${ renderTestResults( { testRunner, testPath, testResults } ) }
 ${ TEST_RESULTS_LIST.close }
 `;
 }
 
-function renderTestResults( { testRunner, testResults, testPath } ) {
+function renderTestErrorMessage( { testRunner, testResults, testPath } ) {
 	switch ( testRunner ) {
 		case '@playwright/test': {
 			// Could do a slightly better formatting than this.
@@ -297,7 +297,7 @@ function renderTestResults( { testRunner, testResults, testPath } ) {
 	}
 }
 
-function renderTestErrorMessage( { testRunner, testPath, testResults } ) {
+function renderTestResults( { testRunner, testPath, testResults } ) {
 	const date = new Date().toISOString();
 	// It will look something like this without formatting:
 	// ▶ [2021-08-31T16:15:19.875Z] Test passed after 2 failed attempts on trunk
@@ -310,7 +310,7 @@ function renderTestErrorMessage( { testRunner, testPath, testResults } ) {
 </summary>
 
 \`\`\`
-${ renderTestResults( { testRunner, testPath, testResults } ) }
+${ renderTestErrorMessage( { testRunner, testPath, testResults } ) }
 \`\`\`
 </details>${ TEST_RESULT.close }`;
 }

--- a/.github/report-flaky-tests/index.js
+++ b/.github/report-flaky-tests/index.js
@@ -114,7 +114,7 @@ const metaData = {
 				 */
 				.split(
 					new RegExp(
-						`(?<=${ TEST_RESULT.close })\n(?:\.\.\.\n)?(?=${ TEST_RESULT.open })`
+						`(?<=${ TEST_RESULT.close })\n+(?:\.\.\.\n+)?(?=${ TEST_RESULT.open })`
 					)
 				);
 			// GitHub issues has character limits on issue's body,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix incorrect results in the flaky tests reporter introduced in #38570.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's causing the flaky test reports to have wrong formatted error messages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By fixing a duplicate function name (`renderTestResults`), which is valid in JavaScript and I totally missed it... 😓

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Unfortunately, it can't be easily tested.
