### PR TITLE
Finish making `InputControl` et al. more controllable

### DIFF
--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -73,7 +73,8 @@ function InputField(
 			value: valueProp,
 			isPressEnterToChange,
 		},
-		onChange
+		onChange,
+		isFocused
 	);
 
 	const { value, isDragging, isDirty } = state;

--- a/packages/components/src/input-control/input-field.tsx
+++ b/packages/components/src/input-control/input-field.tsx
@@ -73,8 +73,7 @@ function InputField(
 			value: valueProp,
 			isPressEnterToChange,
 		},
-		onChange,
-		isFocused
+		onChange
 	);
 
 	const { value, isDragging, isDirty } = state;

--- a/packages/components/src/input-control/reducer/actions.ts
+++ b/packages/components/src/input-control/reducer/actions.ts
@@ -20,7 +20,7 @@ export const PRESS_UP = 'PRESS_UP';
 export const RESET = 'RESET';
 
 interface EventPayload {
-	event?: SyntheticEvent;
+	event: SyntheticEvent;
 }
 
 interface Action< Type, ExtraPayload = {} > {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -57,10 +57,10 @@ function inputControlStateReducer(
 		// Updates state and returns early when there's no action type. These
 		// are controlled updates and need no exposure to additional reducers.
 		if ( ! ( 'type' in action ) ) {
-			let { value = state.value } = action;
-			value ??= '';
-			if ( value !== '' ) value = `${ value }`;
-			return { ...state, value };
+			return {
+				...state,
+				value: `${ action.value ?? '' }`,
+			};
 		}
 
 		switch ( action.type ) {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -54,6 +54,15 @@ function inputControlStateReducer(
 	return ( state, action ) => {
 		const nextState = { ...state };
 
+		// Updates state and returns early when there's no action type. These
+		// are controlled updates and need no exposure to additional reducers.
+		if ( ! ( 'type' in action ) ) {
+			let { value = state.value } = action;
+			value ??= '';
+			if ( value !== '' ) value = `${ value }`;
+			return { ...state, value };
+		}
+
 		switch ( action.type ) {
 			/**
 			 * Keyboard events
@@ -109,10 +118,6 @@ function inputControlStateReducer(
 				break;
 		}
 
-		if ( action.payload.event ) {
-			nextState._event = action.payload.event;
-		}
-
 		/**
 		 * Send the nextState + action to the composedReducers via
 		 * this "bridge" mechanism. This allows external stateReducers
@@ -160,6 +165,7 @@ export function useInputControlStateReducer(
 			event.persist();
 		}
 
+		refEvent.current = event;
 		dispatch( {
 			type,
 			payload: { value: nextValue, event },
@@ -178,12 +184,14 @@ export function useInputControlStateReducer(
 			event.persist();
 		}
 
+		refEvent.current = event;
 		dispatch( { type, payload: { event } } );
 	};
 
 	const createDragEvent = ( type: actions.DragEventAction[ 'type' ] ) => (
 		payload: actions.DragEventAction[ 'payload' ]
 	) => {
+		refEvent.current = payload.event;
 		dispatch( { type, payload } );
 	};
 
@@ -191,8 +199,10 @@ export function useInputControlStateReducer(
 	 * Actions for the reducer
 	 */
 	const change = createChangeEvent( actions.CHANGE );
-	const invalidate = ( error: unknown, event: SyntheticEvent ) =>
+	const invalidate = ( error: unknown, event: SyntheticEvent ) => {
+		refEvent.current = event;
 		dispatch( { type: actions.INVALIDATE, payload: { error, event } } );
+	};
 	const reset = createChangeEvent( actions.RESET );
 	const commit = createChangeEvent( actions.COMMIT );
 
@@ -206,31 +216,32 @@ export function useInputControlStateReducer(
 
 	const currentState = useRef( state );
 	const currentValueProp = useRef( initialState.value );
+	const refEvent = useRef< SyntheticEvent | null >( null );
 	useLayoutEffect( () => {
 		currentState.current = state;
 		currentValueProp.current = initialState.value;
 	} );
 	useLayoutEffect( () => {
 		if (
+			refEvent.current &&
 			state.value !== currentValueProp.current &&
 			! currentState.current.isDirty
 		) {
 			onChangeHandler( state.value ?? '', {
-				event: currentState.current._event as
+				event: refEvent.current as
 					| ChangeEvent< HTMLInputElement >
 					| PointerEvent< HTMLInputElement >,
 			} );
+			refEvent.current = null;
 		}
 	}, [ state.value ] );
 	useLayoutEffect( () => {
 		if (
+			! refEvent.current &&
 			initialState.value !== currentState.current.value &&
 			! currentState.current.isDirty
 		) {
-			reset(
-				initialState.value,
-				currentState.current._event as SyntheticEvent
-			);
+			dispatch( { value: initialState.value } );
 		}
 	}, [ initialState.value ] );
 

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -156,15 +156,6 @@ export function useInputControlStateReducer(
 		nextValue: actions.ChangeEventAction[ 'payload' ][ 'value' ],
 		event: actions.ChangeEventAction[ 'payload' ][ 'event' ]
 	) => {
-		/**
-		 * Persist allows for the (Synthetic) event to be used outside of
-		 * this function call.
-		 * https://reactjs.org/docs/events.html#event-pooling
-		 */
-		if ( event && event.persist ) {
-			event.persist();
-		}
-
 		refEvent.current = event;
 		dispatch( {
 			type,
@@ -175,15 +166,6 @@ export function useInputControlStateReducer(
 	const createKeyEvent = ( type: actions.KeyEventAction[ 'type' ] ) => (
 		event: actions.KeyEventAction[ 'payload' ][ 'event' ]
 	) => {
-		/**
-		 * Persist allows for the (Synthetic) event to be used outside of
-		 * this function call.
-		 * https://reactjs.org/docs/events.html#event-pooling
-		 */
-		if ( event && event.persist ) {
-			event.persist();
-		}
-
 		refEvent.current = event;
 		dispatch( { type, payload: { event } } );
 	};

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -98,7 +98,10 @@ function inputControlStateReducer(
 			case actions.RESET:
 				nextState.error = null;
 				nextState.isDirty = false;
-				nextState.value = action.payload.value || state.initialValue;
+				nextState.value =
+					action.payload.value === undefined
+						? state.initialValue
+						: action.payload.value ?? '';
 				break;
 
 			/**

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -204,8 +204,9 @@ export function useInputControlStateReducer(
 		currentValueProp.current = initialState.value;
 	} );
 	useLayoutEffect( () => {
+		if ( ! refEvent.current ) return;
+
 		if (
-			refEvent.current &&
 			state.value !== currentValueProp.current &&
 			! currentState.current.isDirty
 		) {
@@ -214,9 +215,9 @@ export function useInputControlStateReducer(
 					| ChangeEvent< HTMLInputElement >
 					| PointerEvent< HTMLInputElement >,
 			} );
-			refEvent.current = null;
 		}
-	}, [ state.value ] );
+		refEvent.current = null;
+	}, [ state.value, state.isDragging ] );
 	useLayoutEffect( () => {
 		if (
 			! refEvent.current &&

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -139,12 +139,14 @@ function inputControlStateReducer(
  * @param  stateReducer    An external state reducer.
  * @param  initialState    The initial state for the reducer.
  * @param  onChangeHandler A handler for the onChange event.
+ * @param  isFocused       Focus state.
  * @return State, dispatch, and a collection of actions.
  */
 export function useInputControlStateReducer(
 	stateReducer: StateReducer = initialStateReducer,
 	initialState: Partial< InputState > = initialInputControlState,
-	onChangeHandler: InputChangeCallback
+	onChangeHandler: InputChangeCallback,
+	isFocused: Boolean
 ) {
 	const [ state, dispatch ] = useReducer< StateReducer >(
 		inputControlStateReducer( stateReducer ),
@@ -216,7 +218,7 @@ export function useInputControlStateReducer(
 			} );
 		}
 		refEvent.current = null;
-	}, [ state.value, state.isDragging ] );
+	}, [ state.value, state.isDragging, isFocused ] );
 	useLayoutEffect( () => {
 		if (
 			! refEvent.current &&

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -98,10 +98,7 @@ function inputControlStateReducer(
 			case actions.RESET:
 				nextState.error = null;
 				nextState.isDirty = false;
-				nextState.value =
-					action.payload.value === undefined
-						? state.initialValue
-						: action.payload.value ?? '';
+				nextState.value = action.payload.value ?? state.initialValue;
 				break;
 
 			/**

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -139,14 +139,12 @@ function inputControlStateReducer(
  * @param  stateReducer    An external state reducer.
  * @param  initialState    The initial state for the reducer.
  * @param  onChangeHandler A handler for the onChange event.
- * @param  isFocused       Focus state.
  * @return State, dispatch, and a collection of actions.
  */
 export function useInputControlStateReducer(
 	stateReducer: StateReducer = initialStateReducer,
 	initialState: Partial< InputState > = initialInputControlState,
-	onChangeHandler: InputChangeCallback,
-	isFocused: Boolean
+	onChangeHandler: InputChangeCallback
 ) {
 	const [ state, dispatch ] = useReducer< StateReducer >(
 		inputControlStateReducer( stateReducer ),
@@ -205,9 +203,8 @@ export function useInputControlStateReducer(
 		currentValueProp.current = initialState.value;
 	} );
 	useLayoutEffect( () => {
-		if ( ! refEvent.current ) return;
-
 		if (
+			refEvent.current &&
 			state.value !== currentValueProp.current &&
 			! currentState.current.isDirty
 		) {
@@ -217,16 +214,15 @@ export function useInputControlStateReducer(
 					| PointerEvent< HTMLInputElement >,
 			} );
 		}
-		refEvent.current = null;
-	}, [ state.value, state.isDragging, isFocused ] );
+	}, [ state.value ] );
 	useLayoutEffect( () => {
 		if (
-			! refEvent.current &&
 			initialState.value !== currentState.current.value &&
 			! currentState.current.isDirty
 		) {
 			dispatch( { value: initialState.value } );
 		}
+		if ( refEvent.current ) refEvent.current = null;
 	}, [ initialState.value ] );
 
 	return {

--- a/packages/components/src/input-control/reducer/reducer.ts
+++ b/packages/components/src/input-control/reducer/reducer.ts
@@ -52,8 +52,6 @@ function inputControlStateReducer(
 	composedStateReducers: StateReducer
 ): StateReducer {
 	return ( state, action ) => {
-		const nextState = { ...state };
-
 		// Updates state and returns early when there's no action type. These
 		// are controlled updates and need no exposure to additional reducers.
 		if ( ! ( 'type' in action ) ) {
@@ -62,6 +60,7 @@ function inputControlStateReducer(
 				value: `${ action.value ?? '' }`,
 			};
 		}
+		const nextState = { ...state };
 
 		switch ( action.type ) {
 			/**

--- a/packages/components/src/input-control/reducer/state.ts
+++ b/packages/components/src/input-control/reducer/state.ts
@@ -9,22 +9,23 @@ import type { Reducer } from 'react';
 import type { InputAction } from './actions';
 
 export interface InputState {
-	_event: Event | {};
 	error: unknown;
-	initialValue?: string;
+	initialValue: string;
 	isDirty: boolean;
 	isDragEnabled: boolean;
 	isDragging: boolean;
 	isPressEnterToChange: boolean;
-	value?: string;
+	value: string;
 }
 
-export type StateReducer = Reducer< InputState, InputAction >;
+export type StateReducer = Reducer<
+	InputState,
+	InputAction | Partial< InputState >
+>;
 
 export const initialStateReducer: StateReducer = ( state: InputState ) => state;
 
 export const initialInputControlState: InputState = {
-	_event: {},
 	error: null,
 	initialValue: '',
 	isDirty: false,

--- a/packages/components/src/input-control/reducer/state.ts
+++ b/packages/components/src/input-control/reducer/state.ts
@@ -22,6 +22,7 @@ export type StateReducer = Reducer<
 	InputState,
 	InputAction | Partial< InputState >
 >;
+export type SecondaryReducer = Reducer< InputState, InputAction >;
 
 export const initialStateReducer: StateReducer = ( state: InputState ) => state;
 

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -72,7 +72,7 @@ function RangeControl(
 ) {
 	const isResetPendent = useRef( false );
 	const [ value, setValue ] = useControlledValue( {
-		defaultValue: initialPosition ?? '',
+		defaultValue: initialPosition ?? null,
 		value: isResetPendent.current ? undefined : valueProp,
 		onChange: ( nextValue ) => {
 			/*

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -19,7 +19,7 @@ import BaseControl from '../base-control';
 import Button from '../button';
 import Icon from '../icon';
 import { COLORS } from '../utils';
-import { floatClamp, useControlledRangeValue } from './utils';
+import { floatClamp } from './utils';
 import InputRange from './input-range';
 import RangeRail from './rail';
 import SimpleTooltip from './tooltip';
@@ -70,12 +70,7 @@ function RangeControl(
 	},
 	ref
 ) {
-	const [ value, setValue ] = useControlledRangeValue( {
-		min,
-		max,
-		value: valueProp,
-		initial: initialPosition,
-	} );
+	const [ value, setValue ] = useState( valueProp ?? initialPosition ?? '' );
 	const isResetPendent = useRef( false );
 
 	if ( step === 'any' ) {

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -70,7 +70,7 @@ function RangeControl(
 	},
 	ref
 ) {
-	const isResetPendent = useRef( false )
+	const isResetPendent = useRef( false );
 	const [ value, setValue ] = useControlledValue( {
 		defaultValue: initialPosition ?? '',
 		value: isResetPendent.current ? undefined : valueProp,

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -111,15 +111,15 @@ function RangeControl(
 	const isThumbFocused = ! disabled && isFocused;
 
 	const isValueReset = value === null;
-	const currentValue = value !== undefined ? value : currentInput;
+	const usedValue = isValueReset
+		? resetFallbackValue ?? initialPosition
+		: value ?? currentInput;
 
-	const inputSliderValue = isValueReset ? '' : currentValue;
-
-	const rangeFillValue = isValueReset ? ( max - min ) / 2 + min : value;
-
-	const calculatedFillValue = ( ( value - min ) / ( max - min ) ) * 100;
-	const fillValue = isValueReset ? 50 : calculatedFillValue;
-	const fillValueOffset = `${ clamp( fillValue, 0, 100 ) }%`;
+	const fillPercent = `${
+		usedValue === null || usedValue === undefined
+			? 50
+			: ( ( clamp( usedValue, min, max ) - min ) / ( max - min ) ) * 100
+	}%`;
 
 	const classes = classnames( 'components-range-control', className );
 
@@ -140,7 +140,7 @@ function RangeControl(
 	const someNumberInputProps = useUnimpededRangedNumberEntry( {
 		max,
 		min,
-		value: inputSliderValue,
+		value: usedValue ?? '',
 		onChange: ( nextValue ) => {
 			if ( ! isNaN( nextValue ) ) {
 				setValue( nextValue );
@@ -184,7 +184,7 @@ function RangeControl(
 	};
 
 	const offsetStyle = {
-		[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
+		[ isRTL() ? 'right' : 'left' ]: fillPercent,
 	};
 
 	return (
@@ -222,7 +222,7 @@ function RangeControl(
 						onMouseLeave={ onMouseLeave }
 						ref={ setRef }
 						step={ step }
-						value={ inputSliderValue }
+						value={ usedValue ?? '' }
 					/>
 					<RangeRail
 						aria-hidden={ true }
@@ -232,13 +232,13 @@ function RangeControl(
 						min={ min }
 						railColor={ railColor }
 						step={ step }
-						value={ rangeFillValue }
+						value={ usedValue }
 					/>
 					<Track
 						aria-hidden={ true }
 						className="components-range-control__track"
 						disabled={ disabled }
-						style={ { width: fillValueOffset } }
+						style={ { width: fillPercent } }
 						trackColor={ trackColor }
 					/>
 					<ThumbWrapper style={ offsetStyle } disabled={ disabled }>

--- a/packages/components/src/range-control/index.js
+++ b/packages/components/src/range-control/index.js
@@ -85,6 +85,14 @@ function RangeControl(
 				}
 				onChange( nextValue );
 				isResetPendent.current = false;
+			} else if ( nextValue === null ) {
+				/*
+				 * handleOnReset has led the execution here due to lack of a
+				 * defined resetFallbackValue. In such conditions the onChange
+				 * callback receives undefined as that was the behavior when the
+				 * component was stablized.
+				 */
+				onChange( undefined );
 			} else if ( allowReset ) {
 				isResetPendent.current = true;
 			}
@@ -155,29 +163,12 @@ function RangeControl(
 
 	const handleOnReset = () => {
 		let resetValue = parseFloat( resetFallbackValue );
-		let onChangeResetValue = resetValue;
 
 		if ( isNaN( resetValue ) ) {
 			resetValue = null;
-			onChangeResetValue = undefined;
 		}
 
 		setValue( resetValue );
-
-		/**
-		 * Previously, this callback would always receive undefined as
-		 * an argument. This behavior is unexpected, specifically
-		 * when resetFallbackValue is defined.
-		 *
-		 * The value of undefined is not ideal. Passing it through
-		 * to internal <input /> elements would change it from a
-		 * controlled component to an uncontrolled component.
-		 *
-		 * For now, to minimize unexpected regressions, we're going to
-		 * preserve the undefined callback argument, except when a
-		 * resetFallbackValue is defined.
-		 */
-		onChange( onChangeResetValue );
 	};
 
 	const handleShowTooltip = () => setShowTooltip( true );

--- a/packages/components/src/range-control/rail.js
+++ b/packages/components/src/range-control/rail.js
@@ -16,7 +16,7 @@ export default function RangeRail( {
 	min = 0,
 	max = 100,
 	step = 1,
-	value = 0,
+	value,
 	...restProps
 } ) {
 	return (
@@ -29,7 +29,7 @@ export default function RangeRail( {
 					min={ min }
 					max={ max }
 					step={ step }
-					value={ value }
+					value={ value ?? ( max - min ) / 2 + min }
 				/>
 			) }
 		</>

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -110,7 +110,7 @@ describe.each( [
 			expect( onChange ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should keep invalid values in number input until loss of focus', () => {
+		it( 'should keep invalid values in number input until loss of focus', async () => {
 			const onChange = jest.fn();
 			const { container } = render(
 				<Component onChange={ onChange } min={ -1 } max={ 1 } />
@@ -122,7 +122,7 @@ describe.each( [
 			numberInput.focus();
 			fireEvent.change( numberInput, { target: { value: '-1.1' } } );
 
-			expect( numberInput.value ).toBe( '-1.1' );
+			await waitFor( () => expect( numberInput.value ).toBe( '-1.1' ) );
 			expect( rangeInput.value ).toBe( '-1' );
 
 			fireEvent.blur( numberInput );

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -29,14 +29,17 @@ function ControlledRangeControl( props ) {
 	return <RangeControl { ...props } onChange={ onChange } value={ value } />;
 }
 
-describe( 'RangeControl', () => {
+describe.each( [
+	[ 'uncontrolled', RangeControl ],
+	[ 'controlled', ControlledRangeControl ],
+] )( 'RangeControl %s', ( ...modeAndComponent ) => {
+	const [ , Component ] = modeAndComponent;
+
 	describe( '#render()', () => {
 		it( 'should trigger change callback with numeric value', () => {
 			const onChange = jest.fn();
 
-			const { container } = render(
-				<RangeControl onChange={ onChange } />
-			);
+			const { container } = render( <Component onChange={ onChange } /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -53,10 +56,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should render with icons', () => {
 			const { container } = render(
-				<RangeControl
-					beforeIcon="format-image"
-					afterIcon="format-video"
-				/>
+				<Component beforeIcon="format-image" afterIcon="format-video" />
 			);
 
 			const beforeIcon = container.querySelector(
@@ -73,7 +73,7 @@ describe( 'RangeControl', () => {
 
 	describe( 'validation', () => {
 		it( 'should not apply if new value is lower than minimum', () => {
-			const { container } = render( <RangeControl min={ 11 } /> );
+			const { container } = render( <Component min={ 11 } /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -85,7 +85,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should not apply if new value is greater than maximum', () => {
-			const { container } = render( <RangeControl max={ 20 } /> );
+			const { container } = render( <Component max={ 20 } /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -99,7 +99,7 @@ describe( 'RangeControl', () => {
 		it( 'should not call onChange if new value is invalid', () => {
 			const onChange = jest.fn();
 			const { container } = render(
-				<RangeControl onChange={ onChange } min={ 10 } max={ 20 } />
+				<Component onChange={ onChange } min={ 10 } max={ 20 } />
 			);
 
 			const numberInput = getNumberInput( container );
@@ -113,7 +113,7 @@ describe( 'RangeControl', () => {
 		it( 'should keep invalid values in number input until loss of focus', () => {
 			const onChange = jest.fn();
 			const { container } = render(
-				<RangeControl onChange={ onChange } min={ -1 } max={ 1 } />
+				<Component onChange={ onChange } min={ -1 } max={ 1 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -132,7 +132,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should validate when provided a max or min of zero', () => {
 			const { container } = render(
-				<RangeControl min={ -100 } max={ 0 } />
+				<Component min={ -100 } max={ 0 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -147,7 +147,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should validate when min and max are negative', () => {
 			const { container } = render(
-				<RangeControl min={ -100 } max={ -50 } />
+				<Component min={ -100 } max={ -50 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -168,11 +168,7 @@ describe( 'RangeControl', () => {
 		it( 'should take into account the step starting from min', () => {
 			const onChange = jest.fn();
 			const { container } = render(
-				<RangeControl
-					onChange={ onChange }
-					min={ 0.1 }
-					step={ 0.125 }
-				/>
+				<Component onChange={ onChange } min={ 0.1 } step={ 0.125 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -193,9 +189,7 @@ describe( 'RangeControl', () => {
 
 	describe( 'initialPosition / value', () => {
 		it( 'should render initial rendered value of 50% of min/max, if no initialPosition or value is defined', () => {
-			const { container } = render(
-				<RangeControl min={ 0 } max={ 10 } />
-			);
+			const { container } = render( <Component min={ 0 } max={ 10 } /> );
 
 			const rangeInput = getRangeInput( container );
 
@@ -204,7 +198,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should render initialPosition if no value is provided', () => {
 			const { container } = render(
-				<RangeControl initialPosition={ 50 } />
+				<Component initialPosition={ 50 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -214,7 +208,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should render value instead of initialPosition is provided', () => {
 			const { container } = render(
-				<RangeControl initialPosition={ 50 } value={ 10 } />
+				<Component initialPosition={ 50 } value={ 10 } />
 			);
 
 			const rangeInput = getRangeInput( container );
@@ -225,7 +219,7 @@ describe( 'RangeControl', () => {
 
 	describe( 'input field', () => {
 		it( 'should render an input field by default', () => {
-			const { container } = render( <RangeControl /> );
+			const { container } = render( <Component /> );
 
 			const numberInput = getNumberInput( container );
 
@@ -234,7 +228,7 @@ describe( 'RangeControl', () => {
 
 		it( 'should not render an input field, if disabled', () => {
 			const { container } = render(
-				<RangeControl withInputField={ false } />
+				<Component withInputField={ false } />
 			);
 
 			const numberInput = getNumberInput( container );
@@ -243,7 +237,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should render a zero value into input range and field', () => {
-			const { container } = render( <RangeControl value={ 0 } /> );
+			const { container } = render( <Component value={ 0 } /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -253,7 +247,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should update both field and range on change', () => {
-			const { container } = render( <RangeControl /> );
+			const { container } = render( <Component /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -272,7 +266,7 @@ describe( 'RangeControl', () => {
 		} );
 
 		it( 'should reset input values if next value is removed', () => {
-			const { container } = render( <RangeControl /> );
+			const { container } = render( <Component /> );
 
 			const rangeInput = getRangeInput( container );
 			const numberInput = getNumberInput( container );
@@ -308,8 +302,7 @@ describe( 'RangeControl', () => {
 			const [ , propsForReset, [ expectedValue, expectedChange ] ] = all;
 			const spy = jest.fn();
 			const { container } = render(
-				<RangeControl
-					initialPosition={ 10 }
+				<Component
 					allowReset={ true }
 					onChange={ spy }
 					{ ...propsForReset }
@@ -327,31 +320,25 @@ describe( 'RangeControl', () => {
 			expect( spy ).toHaveBeenCalledWith( expectedChange );
 		} );
 
-		it.concurrent.each( [ RangeControl, ControlledRangeControl ] )(
-			'should reset to a 50% of min/max value, if no initialPosition or resetFallbackValue is defined',
-			( Component ) => {
-				const value =
-					Component === ControlledRangeControl ? 89 : undefined;
-				const { container } = render(
-					<Component
-						initialPosition={ undefined }
-						min={ 0 }
-						max={ 100 }
-						allowReset={ true }
-						resetFallbackValue={ undefined }
-						value={ value }
-					/>
-				);
+		it( 'should reset to a 50% of min/max value, of no initialPosition or value is defined', () => {
+			const { container } = render(
+				<Component
+					initialPosition={ undefined }
+					min={ 0 }
+					max={ 100 }
+					allowReset={ true }
+					resetFallbackValue={ undefined }
+				/>
+			);
 
-				const resetButton = getResetButton( container );
-				const rangeInput = getRangeInput( container );
-				const numberInput = getNumberInput( container );
+			const resetButton = getResetButton( container );
+			const rangeInput = getRangeInput( container );
+			const numberInput = getNumberInput( container );
 
-				fireEvent.click( resetButton );
+			fireEvent.click( resetButton );
 
-				expect( rangeInput.value ).toBe( '50' );
-				expect( numberInput.value ).toBe( '' );
-			}
-		);
+			expect( rangeInput.value ).toBe( '50' );
+			expect( numberInput.value ).toBe( '' );
+		} );
 	} );
 } );

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -4,6 +4,11 @@
 import { fireEvent, render } from '@testing-library/react';
 
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import RangeControl from '../';
@@ -14,6 +19,15 @@ const getNumberInput = ( container ) =>
 	container.querySelector( 'input[type="number"]' );
 const getResetButton = ( container ) =>
 	container.querySelector( '.components-range-control__reset' );
+
+function ControlledRangeControl( props ) {
+	const [ value, setValue ] = useState( props.value );
+	const onChange = ( v ) => {
+		setValue( v );
+		props.onChange?.( v );
+	};
+	return <RangeControl { ...props } onChange={ onChange } value={ value } />;
+}
 
 describe( 'RangeControl', () => {
 	describe( '#render()', () => {
@@ -296,25 +310,31 @@ describe( 'RangeControl', () => {
 			expect( spy ).toHaveBeenCalledWith( 33 );
 		} );
 
-		it( 'should reset to a 50% of min/max value, of no initialPosition or value is defined', () => {
-			const { container } = render(
-				<RangeControl
-					initialPosition={ undefined }
-					min={ 0 }
-					max={ 100 }
-					allowReset={ true }
-					resetFallbackValue={ undefined }
-				/>
-			);
+		it.concurrent.each( [ RangeControl, ControlledRangeControl ] )(
+			'should reset to a 50% of min/max value, if no initialPosition or resetFallbackValue is defined',
+			( Component ) => {
+				const value =
+					Component === ControlledRangeControl ? 89 : undefined;
+				const { container } = render(
+					<Component
+						initialPosition={ undefined }
+						min={ 0 }
+						max={ 100 }
+						allowReset={ true }
+						resetFallbackValue={ undefined }
+						value={ value }
+					/>
+				);
 
-			const resetButton = getResetButton( container );
-			const rangeInput = getRangeInput( container );
-			const numberInput = getNumberInput( container );
+				const resetButton = getResetButton( container );
+				const rangeInput = getRangeInput( container );
+				const numberInput = getNumberInput( container );
 
-			fireEvent.click( resetButton );
+				fireEvent.click( resetButton );
 
-			expect( rangeInput.value ).toBe( '50' );
-			expect( numberInput.value ).toBe( '' );
-		} );
+				expect( rangeInput.value ).toBe( '50' );
+				expect( numberInput.value ).toBe( '' );
+			}
+		);
 	} );
 } );

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -33,7 +33,7 @@ describe.each( [
 	[ 'uncontrolled', RangeControl ],
 	[ 'controlled', ControlledRangeControl ],
 ] )( 'RangeControl %s', ( ...modeAndComponent ) => {
-	const [ , Component ] = modeAndComponent;
+	const [ mode, Component ] = modeAndComponent;
 
 	describe( '#render()', () => {
 		it( 'should trigger change callback with numeric value', () => {
@@ -306,6 +306,7 @@ describe.each( [
 					allowReset={ true }
 					onChange={ spy }
 					{ ...propsForReset }
+					value={ mode === 'controlled' ? 89 : undefined }
 				/>
 			);
 
@@ -328,6 +329,7 @@ describe.each( [
 					max={ 100 }
 					allowReset={ true }
 					resetFallbackValue={ undefined }
+					value={ mode === 'controlled' ? 89 : undefined }
 				/>
 			);
 

--- a/packages/components/src/range-control/test/index.js
+++ b/packages/components/src/range-control/test/index.js
@@ -288,14 +288,31 @@ describe( 'RangeControl', () => {
 	} );
 
 	describe( 'reset', () => {
-		it( 'should reset to a custom fallback value, defined by a parent component', () => {
+		it.concurrent.each( [
+			[
+				'initialPosition if it is defined',
+				{ initialPosition: 21 },
+				[ '21', undefined ],
+			],
+			[
+				'resetFallbackValue if it is defined',
+				{ resetFallbackValue: 34 },
+				[ '34', 34 ],
+			],
+			[
+				'resetFallbackValue if both it and initialPosition are defined',
+				{ initialPosition: 21, resetFallbackValue: 34 },
+				[ '34', 34 ],
+			],
+		] )( 'should reset to %s', ( ...all ) => {
+			const [ , propsForReset, [ expectedValue, expectedChange ] ] = all;
 			const spy = jest.fn();
 			const { container } = render(
 				<RangeControl
 					initialPosition={ 10 }
 					allowReset={ true }
 					onChange={ spy }
-					resetFallbackValue={ 33 }
+					{ ...propsForReset }
 				/>
 			);
 
@@ -305,9 +322,9 @@ describe( 'RangeControl', () => {
 
 			fireEvent.click( resetButton );
 
-			expect( rangeInput.value ).toBe( '33' );
-			expect( numberInput.value ).toBe( '33' );
-			expect( spy ).toHaveBeenCalledWith( 33 );
+			expect( rangeInput.value ).toBe( expectedValue );
+			expect( numberInput.value ).toBe( expectedValue );
+			expect( spy ).toHaveBeenCalledWith( expectedChange );
 		} );
 
 		it.concurrent.each( [ RangeControl, ControlledRangeControl ] )(

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -27,6 +27,43 @@ export function floatClamp( value, min, max ) {
 }
 
 /**
+ * Enables entry of out-of-range and invalid values that diverge from state.
+ *
+ * @param {Object}                 props          Props
+ * @param {number|null}            props.value    Incoming value.
+ * @param {number}                 props.max      Maximum valid value.
+ * @param {number}                 props.min      Minimum valid value.
+ * @param {(next: number) => void} props.onChange Callback for changes.
+ *
+ * @return {Object} Assorted props for the input.
+ */
+export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
+	const ref = useRef();
+	const isDiverging = useRef( false );
+	/** @type {import('../input-control/types').InputChangeCallback}*/
+	const changeHandler = ( next ) => {
+		next = parseFloat( next );
+		const isOverflow = next < min || next > max;
+		isDiverging.current = isNaN( next ) || isOverflow;
+		if ( isOverflow ) {
+			next = Math.max( min, Math.min( max, next ) );
+		}
+		onChange( next );
+	};
+	useEffect( () => {
+		if ( ref.current && isDiverging.current ) {
+			const input = ref.current;
+			const entry = input.value;
+			const { defaultView } = input.ownerDocument;
+			defaultView.requestAnimationFrame( () => ( input.value = entry ) );
+			isDiverging.current = false;
+		}
+	}, [ value ] );
+
+	return { max, min, ref, value, onChange: changeHandler };
+}
+
+/**
  * Hook to encapsulate the debouncing "hover" to better handle the showing
  * and hiding of the Tooltip.
  *

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -33,6 +33,12 @@ export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
 		}
 		onChange( next );
 	};
+	// When the value entered in the input is out of range then a clamped value
+	// is sent through onChange and that goes on to update the input. In such
+	// circumstances this effect overwrites the input value with the entered
+	// value to avoid interfering with typing. E.g. Without this effect, if
+	// `min` is 20 and the user intends to type 25, as soon as 2 is typed the
+	// input will update to 20 and likely lead to an entry of 205.
 	useEffect( () => {
 		if ( ref.current && isDiverging.current ) {
 			const input = ref.current;

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -2,29 +2,12 @@
 /**
  * External dependencies
  */
-import { clamp, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
-
-/**
- * A float supported clamp function for a specific value.
- *
- * @param {number|null} value The value to clamp.
- * @param {number}      min   The minimum value.
- * @param {number}      max   The maximum value.
- *
- * @return {number} A (float) number
- */
-export function floatClamp( value, min, max ) {
-	if ( typeof value !== 'number' ) {
-		return null;
-	}
-
-	return parseFloat( clamp( value, min, max ) );
-}
 
 /**
  * Enables entry of out-of-range and invalid values that diverge from state.

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -26,9 +26,8 @@ export function useUnimpededRangedNumberEntry( { max, min, onChange, value } ) {
 	/** @type {import('../input-control/types').InputChangeCallback}*/
 	const changeHandler = ( next ) => {
 		next = parseFloat( next );
-		const isOverflow = next < min || next > max;
-		isDiverging.current = isNaN( next ) || isOverflow;
-		if ( isOverflow ) {
+		if ( next < min || next > max ) {
+			isDiverging.current = true;
 			next = Math.max( min, Math.min( max, next ) );
 		}
 		onChange( next );

--- a/packages/components/src/range-control/utils.js
+++ b/packages/components/src/range-control/utils.js
@@ -10,11 +10,6 @@ import { clamp, noop } from 'lodash';
 import { useCallback, useRef, useEffect, useState } from '@wordpress/element';
 
 /**
- * Internal dependencies
- */
-import { useControlledState } from '../utils/hooks';
-
-/**
  * A float supported clamp function for a specific value.
  *
  * @param {number|null} value The value to clamp.
@@ -29,42 +24,6 @@ export function floatClamp( value, min, max ) {
 	}
 
 	return parseFloat( clamp( value, min, max ) );
-}
-
-/**
- * Hook to store a clamped value, derived from props.
- *
- * @param {Object} settings         Hook settings.
- * @param {number} settings.min     The minimum value.
- * @param {number} settings.max     The maximum value.
- * @param {number} settings.value   The current value.
- * @param {any}    settings.initial The initial value.
- *
- * @return {[*, Function]} The controlled value and the value setter.
- */
-export function useControlledRangeValue( {
-	min,
-	max,
-	value: valueProp,
-	initial,
-} ) {
-	const [ state, setInternalState ] = useControlledState(
-		floatClamp( valueProp, min, max ),
-		{ initial, fallback: null }
-	);
-
-	const setState = useCallback(
-		( nextValue ) => {
-			if ( nextValue === null ) {
-				setInternalState( null );
-			} else {
-				setInternalState( floatClamp( nextValue, min, max ) );
-			}
-		},
-		[ min, max ]
-	);
-
-	return [ state, setState ];
 }
 
 /**

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -34,7 +34,7 @@ import {
 } from './utils';
 import { useControlledState } from '../utils/hooks';
 import type { UnitControlProps, UnitControlOnChangeCallback } from './types';
-import type { StateReducer } from '../input-control/reducer/state';
+import type { SecondaryReducer } from '../input-control/reducer/state';
 
 function UnforwardedUnitControl(
 	unitControlProps: WordPressComponentProps<
@@ -206,7 +206,7 @@ function UnforwardedUnitControl(
 	 * @param  action Action triggering state change
 	 * @return The updated state to apply to InputControl
 	 */
-	const unitControlStateReducer: StateReducer = ( state, action ) => {
+	const unitControlStateReducer: SecondaryReducer = ( state, action ) => {
 		const nextState = { ...state };
 
 		/*
@@ -226,7 +226,7 @@ function UnforwardedUnitControl(
 		return nextState;
 	};
 
-	let stateReducer: StateReducer = unitControlStateReducer;
+	let stateReducer: SecondaryReducer = unitControlStateReducer;
 	if ( stateReducerProp ) {
 		stateReducer = ( state, action ) => {
 			const baseState = unitControlStateReducer( state, action );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -178,6 +178,7 @@ function UnforwardedUnitControl(
 				: undefined;
 			const changeProps = { event, data };
 
+			// The `onChange` callback already gets called, no need to call it explicitely.
 			onUnitChange?.( validParsedUnit, changeProps );
 
 			setUnit( validParsedUnit );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -178,10 +178,6 @@ function UnforwardedUnitControl(
 				: undefined;
 			const changeProps = { event, data };
 
-			onChangeProp?.(
-				`${ validParsedQuantity ?? '' }${ validParsedUnit }`,
-				changeProps
-			);
 			onUnitChange?.( validParsedUnit, changeProps );
 
 			setUnit( validParsedUnit );

--- a/packages/components/src/unit-control/test/index.js
+++ b/packages/components/src/unit-control/test/index.js
@@ -215,7 +215,7 @@ describe( 'UnitControl', () => {
 			expect( input.value ).toBe( '300px' );
 			expect( state ).toBe( 50 );
 
-			user.keyboard( '{Escape}' );
+			await user.keyboard( '{Escape}' );
 
 			expect( input.value ).toBe( '50' );
 			expect( state ).toBe( 50 );


### PR DESCRIPTION
## What?
Builds upon #40518 to add the changes to `RangeControl` ~~and `UnitControl`~~ necessitated by the making `InputControl` controllable regardless of its focused state.

## Why?
`RangeControl` needs changes is because it depends on its `NumberControl` being self-controlled while focused (i.e. ignoring the `value` prop it gets from `RangeControl`) so that when `RangeControl` actively constrains its state value it does not interfere with the entry of the value in the focused input.

~~I've not yet pinpointed why `UnitControl` requires a change but without it, the issue is that it calls `onChange` twice for a single change (from a `blur` event). That probably wouldn't have hurt a thing but it's nice that our unit tests caught this.~~ UPDATE: It turns out this was an existing issue but our test that would catch it, wasn't doing so on trunk. The related changes from this PR have already been extracted/merged with #40796 so they are to be removed from this branch.

## How?
- Logic is added to `RangeControl` to temporarily keep entered values in its number input if they are out-of-range or non-numeric.
- ~~`UnitControl` stops calling `onChange` explicitly from `mayUpdateUnit` because apparently `InputControl` now does so on its own~~

## Testing Instructions
Unit tests pass.
Try finding any differences manually testing `RangeControl` ~~and `UnitControl`~~.