### PR TITLE
Packages[core-data]: Change "include" type in getQueryParts

### DIFF
--- a/packages/core-data/src/queried-data/get-query-parts.js
+++ b/packages/core-data/src/queried-data/get-query-parts.js
@@ -80,6 +80,9 @@ export function getQueryParts( query ) {
 
 				// Two requests with different include values cannot have same results.
 				if ( key === 'include' ) {
+					if ( typeof value === 'number' ) {
+						value = value.toString();
+					}
 					parts.include = (
 						getNormalizedCommaSeparable( value ) ?? []
 					).map( Number );

--- a/packages/core-data/src/queried-data/test/get-query-parts.js
+++ b/packages/core-data/src/queried-data/test/get-query-parts.js
@@ -18,8 +18,12 @@ describe( 'getQueryParts', () => {
 	} );
 
 	it( 'parses out `include` ID filtering', () => {
+		const first = getQueryParts( { include: '1' } );
+		const second = getQueryParts( { include: 1 } );
 		const parts = getQueryParts( { include: [ 1 ] } );
 
+		expect( first ).toEqual( second );
+		expect( second ).toEqual( parts );
 		expect( parts ).toEqual( {
 			context: 'default',
 			page: 1,


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Convert the value of the parameter include into a string when it's
a number.
<!-- In a few words, what is the PR actually doing? -->

## Why?
fixes: #27771

This bug is backwards compatibility issue
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Make a clean Wordpress installation
2. Upload an image to the media library and take note of it's post_id (let's say it's 6)
3. Open the page editor and the Javascript console then type in wp.data.select('core').getEntityRecords('postType', 'attachment', { include: 6 })
4. wp.data.select('core').getEntityRecords('postType', 'attachment', { include: '6' })
5. steps 3 and 4 should return the same result : the attachment data

**Head's up:** steps 3 or 4 could return null first, and then the second time the attachment data after the request had resolved.
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
