### PR TITLE
Ensure that post thumbnail is cached in post template block.

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -13,26 +13,19 @@
  * @return bool
  */
 function block_core_post_template_uses_feature_image( $inner_blocks ) {
-	$inner_blocks_array = iterator_to_array( $inner_blocks );
-	$has_thumbnail      = false;
-	foreach ( $inner_blocks_array as $block ) {
+	foreach ( $inner_blocks as $block ) {
 		if ( 'core/post-featured-image' === $block->name ) {
-			$has_thumbnail = true;
-			break;
+			return true;
 		}
 		if ( 'core/cover' === $block->name && $block->attributes && isset( $block->attributes['useFeaturedImage'] ) && $block->attributes['useFeaturedImage'] ) {
-			$has_thumbnail = true;
-			break;
+			return true;
 		}
-		if ( $block->inner_blocks ) {
-			if ( block_core_post_template_uses_feature_image( $block->inner_blocks ) ) {
-				$has_thumbnail = true;
-				break;
-			}
+		if ( $block->inner_blocks && block_core_post_template_uses_feature_image( $block->inner_blocks ) ) {
+			return true;
 		}
 	}
 
-	return $has_thumbnail;
+	return false;
 }
 
 /**

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -39,6 +39,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	if ( ! $query->have_posts() ) {
 		return '';
 	}
+	update_post_thumbnail_cache( $query );
 
 	$classnames = '';
 	if ( isset( $block->context['displayLayout'] ) && isset( $block->context['query'] ) ) {

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -14,6 +14,7 @@
  */
 function block_core_post_template_uses_feature_image( $inner_blocks ) {
 	$inner_blocks_array = iterator_to_array( $inner_blocks );
+	$has_thumbnail      = false;
 	foreach ( $inner_blocks_array as $block ) {
 		if ( 'core/post-featured-image' === $block->name ) {
 			$has_thumbnail = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Ensure that post thumbnails are correctly primed when using the post template block.

Related to https://github.com/WordPress/gutenberg/pull/40571.

## Why?
If this function is not called, it results in one query to post meta table. Calling `update_post_thumbnail_cache` primes all caches in one.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
