### PR TITLE
Remove a typo from the no results block

### DIFF
--- a/packages/block-library/src/query-no-results/edit.js
+++ b/packages/block-library/src/query-no-results/edit.js
@@ -9,7 +9,7 @@ const TEMPLATE = [
 		'core/paragraph',
 		{
 			placeholder: __(
-				'Add a text or blocks that will display when the query returns no results.'
+				'Add text or blocks that will display when the query returns no results.'
 			),
 		},
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes a grammatical error in the placeholder text of the no results block
Partial for https://github.com/WordPress/gutenberg/issues/40240

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because this is a public facing text in the editor and we should remove typos and grammatical errors when we find them.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Changes "Add a text or blocks that will display when the query returns no results."
to "Add text or blocks that will display when the query returns no results."


## Testing Instructions
1.  Apply the PR
2. In either editor, add a query block with a no results block
3. Confirm that the text is updated as described above.

