### PR TITLE
Fixes broken links

### DIFF
--- a/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
+++ b/docs/how-to-guides/data-basics/2-building-a-list-of-pages.md
@@ -185,8 +185,8 @@ in [React’s documentation](https://reactjs.org/docs/hooks-state.html).
 
 We can now request only the pages matching the `searchTerm`.
 
-After checking with the [WordPress API documentation]([https://developer.wordpress.org/rest-api/reference/pages/]), we
-see that the [/wp/v2/pages]([https://developer.wordpress.org/rest-api/reference/pages/]) endpoint accepts a `search`
+After checking with the [WordPress API documentation](https://developer.wordpress.org/rest-api/reference/pages/), we
+see that the [/wp/v2/pages](https://developer.wordpress.org/rest-api/reference/pages/) endpoint accepts a `search`
 query parameter and uses it to  _limit results to those matching a string_. But how can we use it? We can pass custom query
 parameters as the third argument to `getEntityRecords` as below:
 


### PR DESCRIPTION
Fixed markdown format for the links
https://developer.wordpress.org/rest-api/reference/pages/
