### PR TITLE
Mobile - RichText - Set a default value for selection values

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -1039,6 +1039,8 @@ export class RichText extends Component {
 			accessibilityLabel,
 			disableEditingMenu = false,
 			baseGlobalStyles,
+			selectionStart,
+			selectionEnd,
 		} = this.props;
 		const { currentFontSize } = this.state;
 
@@ -1065,12 +1067,14 @@ export class RichText extends Component {
 			defaultTextDecorationColor
 		);
 
+		const currentSelectionStart = selectionStart ?? 0;
+		const currentSelectionEnd = selectionEnd ?? 0;
 		let selection = null;
 		if ( this.needsSelectionUpdate ) {
 			this.needsSelectionUpdate = false;
 			selection = {
-				start: this.props.selectionStart,
-				end: this.props.selectionEnd,
+				start: currentSelectionStart,
+				end: currentSelectionEnd,
 			};
 
 			// On AztecAndroid, setting the caret to an out-of-bounds position will crash the editor so, let's check for some cases.
@@ -1086,12 +1090,11 @@ export class RichText extends Component {
 						brBeforeParaMatches[ 0 ].match( /br/g ) || []
 					).length;
 					if ( count > 0 ) {
-						let newSelectionStart =
-							this.props.selectionStart - count;
+						let newSelectionStart = currentSelectionStart - count;
 						if ( newSelectionStart < 0 ) {
 							newSelectionStart = 0;
 						}
-						let newSelectionEnd = this.props.selectionEnd - count;
+						let newSelectionEnd = currentSelectionEnd - count;
 						if ( newSelectionEnd < 0 ) {
 							newSelectionEnd = 0;
 						}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/40545

- `Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4790

## What?
This PR fixes an issue on Android where changing the font size/line-height of the Quote block V2 would make the app crash.

## Why?
When the font size or the line-height is changed, it forces a selection update on Aztec to show the new selected values, by setting `this.needsSelectionUpdate` to `true`.

In this case where this selection update happens it expects to have a `selectionStart` and `selectionEnd` value. On Android if these values are `null` or `undefined` it crashes.

Since this is a new case where a block can set the font size/line-height value of its Paragraph inner blocks without being focused it'll crash.

## How?
This PR adds a default value of `0` for cases where the `selectionStart` and `selectionEnd` are `undefined` and a selection update was triggered.

## Testing Instructions

**Precondition for enabling v2:**

- Use a self-hosted site and install the latest Gutenberg plugin version >= 13.0.0. You can install the latest version [here](https://github.com/WordPress/gutenberg/releases).
- Go to your site's admin page > Gutenberg > Experiments.
- Enable Quote block v2.

**Steps**:
- Add a Quote block.
- Tap the `Up (^)` arrow in the floating toolbar to go up one level and select the parent block if the inner block is focused.
- Open the block settings by tapping on the gear icon button.
- Change the font size or line-height.
- **Expect** the value to be updated in the Paragraph inner block without crashing.

## Screenshots or screencast <!-- if applicable -->

iOS | Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/165078209-e551bd9e-afaa-4efd-aee0-d8af1c6b29a1.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/165078182-cec16fa9-e57e-4695-a32d-cf7a6d2e113b.gif" width="200" /></kbd>