### PR TITLE
Fix alignment issue with the comment edit link

### DIFF
--- a/packages/block-library/src/comment-edit-link/index.php
+++ b/packages/block-library/src/comment-edit-link/index.php
@@ -29,10 +29,7 @@ function render_block_core_comment_edit_link( $attributes, $content, $block ) {
 
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
-	}
-	if ( isset( $attributes['fontSize'] ) ) {
-		$classes .= 'has-' . esc_attr( $attributes['fontSize'] ) . '-font-size';
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is the equivalent of https://github.com/WordPress/gutenberg/pull/40582 but for the comment edit link.

Assures that the comment edit link text alignment setting works and that the block displays correctly on the front.
Also removes duplicate escaping.

Partial for https://github.com/WordPress/gutenberg/issues/40269

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block had duplicate font-size classes on the front. This caused the alignment class and the font size class to be output as one word without spacing in between them, and the CSS was not applied. Because of this, the alignment option did not work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By removing the extra output of the font size class, the class name for the text alignment is correct and the CSS applied.

## Testing Instructions

1. Add a comment query loop to a post or page that has comments.
2. Select the inner comment edit link block.
3. Test the toolbar option for text alignment.
4. Test the font size option in the block settings sidebar.
5. Save and view the front. Confirm that both the text alignment and the font size works.

## Screenshots or screencast <!-- if applicable -->
After:
![the comment edit link is aligned to the right](https://user-images.githubusercontent.com/7422055/165073508-0af7bf3a-ced1-4fea-97ea-1b77df50597f.png)

