### PR TITLE
Retain Playwright e2e test's trace on failure on CI

### DIFF
--- a/test/e2e/playwright.config.ts
+++ b/test/e2e/playwright.config.ts
@@ -40,7 +40,7 @@ const config: PlaywrightTestConfig = {
 		},
 		storageState: STORAGE_STATE_PATH,
 		actionTimeout: 10_000, // 10 seconds.
-		trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
+		trace: 'retain-on-failure',
 		screenshot: 'only-on-failure',
 		video: 'on-first-retry',
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Originally since #38570, traces are only recorded on CI on the first retry. This PR changes it to retain trace on every failure instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The original idea is to avoid slowing down the tests on CI if they're all passing since recording traces adds a little bit of overhead. However, this makes some flaky tests hard to debug when they always pass on the first retry (https://github.com/WordPress/gutenberg/issues/40307) and basically makes the trace useless. Furthermore, the overhead of recording traces seems to be pretty minimal on CI. Hence, I propose to enable recording traces on every test run instead.

Videos are still being recorded only on the first retry, though. Recording videos seems to have a bigger impact on performance and traces are almost always more useful than videos anyway. We can discuss if we want to remove video recording altogether if needed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Change via the global settings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
N/A
