### PR TITLE
Global Styles Sidebar: Tweak spacing

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -3,8 +3,8 @@
  */
 import {
 	__experimentalItemGroup as ItemGroup,
-	__experimentalItem as Item,
 	__experimentalHStack as HStack,
+	__experimentalSpacer as Spacer,
 	__experimentalVStack as VStack,
 	FlexItem,
 	CardBody,
@@ -37,7 +37,7 @@ function ScreenRoot() {
 	return (
 		<Card size="small">
 			<CardBody>
-				<VStack spacing={ 2 }>
+				<VStack spacing={ 4 }>
 					<Card>
 						<CardMedia>
 							<StylesPreview />
@@ -55,22 +55,28 @@ function ScreenRoot() {
 							</HStack>
 						</NavigationButton>
 					) }
+					<ContextMenu />
 				</VStack>
-			</CardBody>
-
-			<CardBody>
-				<ContextMenu />
 			</CardBody>
 
 			<CardDivider />
 
 			<CardBody>
+				<Spacer
+					as="p"
+					paddingTop={ 2 }
+					/*
+					 * 13px matches the text inset of the NavigationButton (12px padding, plus the width of the button's border).
+					 * This is an ad hoc override for this particular instance only and should be reconsidered before making into a pattern.
+					 */
+					paddingX="13px"
+					marginBottom={ 4 }
+				>
+					{ __(
+						'Customize the appearance of specific blocks for the whole site.'
+					) }
+				</Spacer>
 				<ItemGroup>
-					<Item>
-						{ __(
-							'Customize the appearance of specific blocks for the whole site.'
-						) }
-					</Item>
 					<NavigationButton path="/blocks">
 						<HStack justify="space-between">
 							<FlexItem>{ __( 'Blocks' ) }</FlexItem>


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/38934

## What?

Cleans up spacing issues with the navigator buttons on the Global Styles Sidebar root screen.

## Why?

To refine the visual consistency of the Global Styles sidebar.

## How?

Tightened the main button spacing overall by optimizing the component tree structure, and then tweaked the explicit spacing values.

✅ Design review was done in #40533

## Testing Instructions

1. `npm run dev`
2. See navigator screens in the Global Styles sidebar.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://user-images.githubusercontent.com/555336/164608972-5aa4cec9-51d6-4a32-a1d9-94269be4569a.png" alt="Root screen before" width="250">|<img src="https://user-images.githubusercontent.com/555336/165084536-851fe300-5877-452f-a797-745be01a6aea.png" alt="Root screen after with tighter spacing" width="250"><img src="https://user-images.githubusercontent.com/555336/165084136-92d6a392-d98b-46ca-9d79-339e28899120.png" alt="Main screen with Browse styles button" width="250">|