### PR TITLE
Add "How To Get Your Pull Request Reviewed?" to developer handbook

### DIFF
--- a/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
@@ -45,7 +45,7 @@ Post a link to your PR in related issues & PRs.
 
 Ping commenters of related issues, previous committers, and tech leads.
 
-Bring it up on [WP.org slack](https://make.wordpress.org/core/tag/core-editor-agenda/).
+Bring it up on the #core-editor channel of the WordPress.org slack. The easiest way to get feedback is to speak out during the [open floor section](https://make.wordpress.org/core/tag/core-editor-agenda/) of the weekly [Core Editor meeting](/docs/getting-started/README.md).
 
 Assign relevant labels, milestones, and projects (or ask someone).
 

--- a/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
@@ -4,7 +4,7 @@ Sometimes we publish a Pull Request and noone reviews our work. What to do?
 
 Attracting a review largely isn't about the code – it is about making the reviewing easy.
 
-If you published a Pull Request that isn't getting any comments or revies, try one of the strategies used by core contributors:
+If you published a Pull Request that isn't getting any comments or reviews, try one of the strategies used by core contributors:
 
 ## Create the smallest reasonable PRs
 

--- a/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/code/how-to-get-your-pull-request-reviewed.md
@@ -1,6 +1,6 @@
 # How To Get Your Pull Request Reviewed?
 
-Sometimes we publish a Pull Request and no one reviews our work. What to do?
+Sometimes we publish a Pull Request and no one [reviews](/docs/contributors/repository-management.md#code-review) our work. What to do?
 
 Attracting a review largely isn't about the code – it is about making the reviewing easy.
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -14,7 +14,7 @@ Approving a 50-line long PR takes days or hours and feels easy.
 
 Large batches slow you down. Ship your work in small chunks to merge more and learn faster.
 
-## Share ALL the context:
+## Share relevant context:
 
 Say:
 * What problem are you solving?

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -53,7 +53,7 @@ Assign relevant labels, milestones, and projects (or ask someone).
 
 It’s the easiest way to get on others’ radar.
 
-Look up the PRs of folks listed in the previous tweet and review them.
+Look up the PRs of commenters of related issues, previous committers, and tech leads. Then review them.
 
 Is their work unfamiliar? Do:
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -78,6 +78,6 @@ Some PRs naturally get more traction than others.
 
 Double down on these.
 
-It’s like finding a product-market fit as a startup; only you’re after the idea–reviewers fit.
+Some Issues are more topical than others (e.g. those listed in the goals for an upcoming release) and thus will garner more attention. By focusing on these it will be easier to attract reviewers.
 
 How to get there quickly? Help with an active project from the WordPress roadmap

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -61,7 +61,7 @@ Is their work unfamiliar? Do:
 * Propose a pair programming session
 * Skip, go for the next PR
 
-## Grease risk with clarity
+## Reduce risk with clarity
 
 Risk adds friction – an approval can backfire later.
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -4,7 +4,7 @@ Sometimes we publish a Pull Request and no one reviews our work. What to do?
 
 Attracting a review largely isn't about the code – it is about making the reviewing easy.
 
-If you published a Pull Request that isn't getting any comments or revies, try one of the strategies used by core contributors:
+If you published a Pull Request that isn't getting any comments or reviews, try one of the strategies used by core contributors:
 
 ## Create the smallest reasonable PRs
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -35,7 +35,7 @@ All contributions are competing for attention. Make your stand out.
 The easiest way? Say why it matters:
 
 ❌ A new react hook to get data
-✅ useEntityRecord: get data with 10x less boilerplate
+✅ `useEntityRecord`: get data with 10x less boilerplate
 
 Then prove it with code examples, visuals, and screencasts.
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -45,7 +45,7 @@ Post a link to your PR in related issues & PRs.
 
 Ping commenters of related issues, previous committers, and tech leads.
 
-Bring it up on WP.org slack.
+Bring it up on [WP.org slack](https://make.wordpress.org/core/tag/core-editor-agenda/).
 
 Assign relevant labels, milestones, and projects (or ask someone).
 

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -1,0 +1,83 @@
+# How To Get Your Pull Request Reviewed?
+
+Sometimes we publish a Pull Request and noone reviews our work. What to do?
+
+Attracting a review largely isn't about the code – it is about making the reviewing easy.
+
+If you published a Pull Request that isn't getting any comments or revies, try one of the strategies used by core contributors:
+
+## Create the smallest reasonable PRs
+
+Approving a 2000-line-long PR takes months and feels overwhelming.
+
+Approving a 50-line long PR takes days or hours and feels easy.
+
+Large batches slow you down. Ship your work in small chunks to merge more and learn faster.
+
+## Share ALL the context:
+
+Say:
+* What problem are you solving?
+* How does your PR solve it?
+* What feedback do you need?
+* What’s out of scope?
+* What’s unintuitive?
+* How to test?
+
+Summarize any related issues and PRs.
+
+It's easier than asking others to go and figure it out.
+
+## Make your PR exciting
+
+All contributions are competing for attention. Make your stand out.
+
+The easiest way? Say why it matters:
+
+❌ A new react hook to get data
+✅ useEntityRecord: get data with 10x less boilerplate
+
+Then prove it with code examples, visuals, and screencasts.
+
+## Show your work
+
+Post a link to your PR in related issues & PRs.
+
+Ping commenters of related issues, previous committers, and tech leads.
+
+Bring it up on WP.org slack.
+
+Assign relevant labels, milestones, and projects (or ask someone).
+
+## Review the work of others
+
+It’s the easiest way to get on others’ radar.
+
+Look up the PRs of folks listed in the previous tweet and review them.
+
+Is their work unfamiliar? Do:
+
+* Take some time to understand it
+* Propose a pair programming session
+* Skip, go for the next PR
+
+## Grease risk with clarity
+
+Risk adds friction – an approval can backfire later.
+
+Clarity is like grease. Clearly document:
+
+* What risks are involved? Why take them?
+* Why is this PR the best solution?
+* How can the risk be minimized?
+* What else has been tried?
+
+## Follow the attention
+
+Some PRs naturally get more traction than others.
+
+Double down on these.
+
+It’s like finding a product-market fit as a startup; only you’re after the idea–reviewers fit.
+
+How to get there quickly? Help with an active project from the WordPress roadmap

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -16,7 +16,7 @@ Large batches slow you down. Ship your work in small chunks to merge more and le
 
 ## Share relevant context:
 
-Say:
+Clarify:
 * What problem are you solving?
 * How does your PR solve it?
 * What feedback do you need?

--- a/docs/contributors/how-to-get-your-pull-request-reviewed.md
+++ b/docs/contributors/how-to-get-your-pull-request-reviewed.md
@@ -1,6 +1,6 @@
 # How To Get Your Pull Request Reviewed?
 
-Sometimes we publish a Pull Request and noone reviews our work. What to do?
+Sometimes we publish a Pull Request and no one reviews our work. What to do?
 
 Attracting a review largely isn't about the code – it is about making the reviewing easy.
 

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -13,7 +13,7 @@ This document covers:
     -   [Design Review](#design-review)
     -   [Merging Pull Requests](#merging-pull-requests)
     -   [Closing Pull Requests](#closing-pull-requests)
-    -   [How To Get Your Pull Request Reviewed?](/docs/contributors/how-to-get-your-pull-request-reviewed.md)
+    -   [How To Get Your Pull Request Reviewed?](/docs/contributors/code/how-to-get-your-pull-request-reviewed.md)
 -   [Projects](#projects)
 
 ## Issues
@@ -103,6 +103,8 @@ _As a contributor_, your responsibility is to learn from suggestions and iterate
 Code reviews are encouraged by everyone who is willing to attempt one. If you review a pull request and are confident in the changes, approve it. If you don't feel totally confident it is ready for merging, add your review with a comment that says it should have another set of eyes on it before final approval. This can help filter out obvious bugs and simplify reviews for core members. Following the later reviews will also help improve your reviewing confidence in the future.
 
 If you are not yet comfortable leaving a full review, try commenting on a PR. Questions about functionality or the reasoning behind a change are helpful too. You could also comment on changes to parts of the code you understand, without leaving a full review.
+
+If you struggle with getting a review, see: [How To Get Your Pull Request Reviewed?](/docs/contributors/code/how-to-get-your-pull-request-reviewed.md)
 
 ### Design Review
 

--- a/docs/contributors/repository-management.md
+++ b/docs/contributors/repository-management.md
@@ -13,6 +13,7 @@ This document covers:
     -   [Design Review](#design-review)
     -   [Merging Pull Requests](#merging-pull-requests)
     -   [Closing Pull Requests](#closing-pull-requests)
+    -   [How To Get Your Pull Request Reviewed?](/docs/contributors/how-to-get-your-pull-request-reviewed.md)
 -   [Projects](#projects)
 
 ## Issues

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2094,6 +2094,12 @@
 		"parent": "code"
 	},
 	{
+		"title": "How To Get Your Pull Request Reviewed?",
+		"slug": "how-to-get-your-pull-request-reviewed",
+		"markdown_source": "../docs/contributors/code/how-to-get-your-pull-request-reviewed.md",
+		"parent": "code"
+	},
+	{
 		"title": "Design Contributions",
 		"slug": "design",
 		"markdown_source": "../docs/contributors/design/README.md",
@@ -2122,12 +2128,6 @@
 		"slug": "copy-guide",
 		"markdown_source": "../docs/contributors/documentation/copy-guide.md",
 		"parent": "documentation"
-	},
-	{
-		"title": "How To Get Your Pull Request Reviewed?",
-		"slug": "how-to-get-your-pull-request-reviewed",
-		"markdown_source": "../docs/contributors/how-to-get-your-pull-request-reviewed.md",
-		"parent": "contributors"
 	},
 	{
 		"title": "Triage",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2148,6 +2148,12 @@
 		"parent": "contributors"
 	},
 	{
+		"title": "How To Get Your Pull Request Reviewed?",
+		"slug": "how-to-get-your-pull-request-reviewed",
+		"markdown_source": "../docs/contributors/how-to-get-your-pull-request-reviewed.md",
+		"parent": "contributors"
+	},
+	{
 		"title": "Folder Structure",
 		"slug": "folder-structure",
 		"markdown_source": "../docs/contributors/folder-structure.md",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2124,6 +2124,12 @@
 		"parent": "documentation"
 	},
 	{
+		"title": "How To Get Your Pull Request Reviewed?",
+		"slug": "how-to-get-your-pull-request-reviewed",
+		"markdown_source": "../docs/contributors/how-to-get-your-pull-request-reviewed.md",
+		"parent": "contributors"
+	},
+	{
 		"title": "Triage",
 		"slug": "triage",
 		"markdown_source": "../docs/contributors/triage.md",
@@ -2145,12 +2151,6 @@
 		"title": "Repository Management",
 		"slug": "repository-management",
 		"markdown_source": "../docs/contributors/repository-management.md",
-		"parent": "contributors"
-	},
-	{
-		"title": "How To Get Your Pull Request Reviewed?",
-		"slug": "how-to-get-your-pull-request-reviewed",
-		"markdown_source": "../docs/contributors/how-to-get-your-pull-request-reviewed.md",
 		"parent": "contributors"
 	},
 	{

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -317,7 +317,8 @@
 						]
 					},
 					{ "docs/contributors/code/backward-compatibility.md": [] },
-					{ "docs/contributors/code/deprecations.md": [] }
+					{ "docs/contributors/code/deprecations.md": [] },
+					{ "docs/contributors/code/how-to-get-your-pull-request-reviewed.md": [] }
 				]
 			},
 			{
@@ -330,10 +331,7 @@
 				"docs/contributors/documentation/README.md": [
 					{ "docs/contributors/documentation/copy-guide.md": [] }
 				]
-			},
-			{
-				"docs/contributors/how-to-get-your-pull-request-reviewed.md": []
-			},
+			},,
 			{ "docs/contributors/triage.md": [] },
 			{ "docs/contributors/localizing.md": [] },
 			{ "docs/contributors/accessibility-testing.md": [] },

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -331,7 +331,7 @@
 				"docs/contributors/documentation/README.md": [
 					{ "docs/contributors/documentation/copy-guide.md": [] }
 				]
-			},,
+			},
 			{ "docs/contributors/triage.md": [] },
 			{ "docs/contributors/localizing.md": [] },
 			{ "docs/contributors/accessibility-testing.md": [] },

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -331,6 +331,9 @@
 					{ "docs/contributors/documentation/copy-guide.md": [] }
 				]
 			},
+			{
+				"docs/contributors/how-to-get-your-pull-request-reviewed.md": []
+			},
 			{ "docs/contributors/triage.md": [] },
 			{ "docs/contributors/localizing.md": [] },
 			{ "docs/contributors/accessibility-testing.md": [] },


### PR DESCRIPTION
## What problem is this PR solving?

I wrote a "tutorial" to solve a common struggle – attracting a code review.

## How does your PR solve it?

By adding a new handbook page. It contains the same tips as my popular [Twitter thread](https://twitter.com/adamzielin/status/1515025299133583360). @carolinan on .org slack [suggested](https://wordpress.slack.com/archives/C02QB2JS7/p1650451347023799) it might be a useful addition to the developer's handbook, so here it is.

## What feedback do you need?

* Is this a good addition?
* Would you phrase anything differently? I literally reused the same writing.

## How to test?

- Confirm the tests work.
- Confirm the URLs are in the handbook format (to work both on wordpress.org and GitHub
- Confirm the manifest.json change is sound

cc @atachibana @carolinan @t-hamano @talldan @gziolo @getdave @ryanwelcher @mkaz 