### PR TITLE
Global Styles Sidebar: Fix nav header styles and semantics

### DIFF
--- a/packages/edit-site/src/components/global-styles/header.js
+++ b/packages/edit-site/src/components/global-styles/header.js
@@ -7,30 +7,33 @@ import {
 	__experimentalSpacer as Spacer,
 	__experimentalHeading as Heading,
 	__experimentalView as View,
+	__experimentalNavigatorBackButton as NavigatorBackButton,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
 import { chevronRight, chevronLeft } from '@wordpress/icons';
 
-/**
- * Internal dependencies
- */
-import { NavigationBackButtonAsItem } from './navigation-button';
-
 function ScreenHeader( { title, description } ) {
 	return (
-		<VStack spacing={ 2 }>
-			<HStack spacing={ 2 }>
-				<View role="list">
-					<NavigationBackButtonAsItem
-						icon={ isRTL() ? chevronRight : chevronLeft }
-						size="small"
-						aria-label={ __( 'Navigate to the previous view' ) }
-					/>
-				</View>
-				<Spacer>
-					<Heading level={ 5 }>{ title }</Heading>
+		<VStack spacing={ 0 }>
+			<View>
+				<Spacer marginBottom={ 0 } paddingX={ 4 } paddingY={ 3 }>
+					<HStack spacing={ 2 }>
+						<NavigatorBackButton
+							style={
+								// TODO: This style override is also used in ToolsPanelHeader.
+								// It should be supported out-of-the-box by Button.
+								{ minWidth: 24, padding: 0 }
+							}
+							icon={ isRTL() ? chevronRight : chevronLeft }
+							isSmall
+							aria-label={ __( 'Navigate to the previous view' ) }
+						/>
+						<Spacer>
+							<Heading level={ 5 }>{ title }</Heading>
+						</Spacer>
+					</HStack>
 				</Spacer>
-			</HStack>
+			</View>
 			{ description && (
 				<p className="edit-site-global-styles-header__description">
 					{ description }


### PR DESCRIPTION
Part of #38934
Based on #40590

## What?

Fixes visual and semantic issues with the navigation header in the Global Styles sidebar.

## Why?

- The Back button was semantically incorrect, in that the underlying HTML had `listitem` semantics even though this isn't functionally a list. (Addressed in #40590)
- The focus outline was also visually inconsistent with the rest of the component system.

## How?

- Removed the list semantics.
- Replaced the Back button with a canonical `NavigatorBackButton`.
- Adjusted the whitespace so it's closer to the Figma mockup and more congruent with the rest of the component system.

✅ Design review was done in #40533

## Testing Instructions

1. `npm run dev`
2. See navigator screens in the Global Styles sidebar.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="250" alt="Header with incongruous back button outline" src="https://user-images.githubusercontent.com/555336/164608139-71d1c579-dc94-41e5-9eca-2671688cf4c9.png">|<img width="250" alt="Header with harmonious back button" src="https://user-images.githubusercontent.com/555336/164608143-1bf85087-6113-4131-a703-e90fa448d4dc.png">|

### More after shots

<img width="250" alt="Header with description paragraph" src="https://user-images.githubusercontent.com/555336/164608146-c5030d2a-13bc-41a5-a272-50a1a1a25692.png">