### PR TITLE
[Block Library - Latest Posts]: Prevent opening the links in editor

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -158,8 +158,8 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		// and use a unique id to announce the message in screen readers
 		// in every click.
 		removeNotice( noticeId );
-		noticeId = `block-library/core/latest-psts/redirection-prevented/${ uniqueId() }`;
-		createWarningNotice( __( 'Redirection is prevented in the editor.' ), {
+		noticeId = `block-library/core/latest-posts/redirection-prevented/${ uniqueId() }`;
+		createWarningNotice( __( 'Links are disabled in the editor.' ), {
 			id: noticeId,
 			type: 'snackbar',
 		} );

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, invoke, isUndefined, pickBy, uniqueId } from 'lodash';
+import { get, includes, invoke, isUndefined, pickBy } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -32,6 +32,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { pin, list, grid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -67,6 +68,7 @@ function getFeaturedImageDetails( post, size ) {
 }
 
 export default function LatestPostsEdit( { attributes, setAttributes } ) {
+	const instanceId = useInstanceId( LatestPostsEdit );
 	const {
 		postsToShow,
 		order,
@@ -154,11 +156,9 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	let noticeId;
 	const showRedirectionPreventedNotice = ( event ) => {
 		event.preventDefault();
-		// Always remove previous warning if any to show one at a time
-		// and use a unique id to announce the message in screen readers
-		// in every click.
+		// Remove previous warning if any, to show one at a time per block.
 		removeNotice( noticeId );
-		noticeId = `block-library/core/latest-posts/redirection-prevented/${ uniqueId() }`;
+		noticeId = `block-library/core/latest-posts/redirection-prevented/${ instanceId }`;
 		createWarningNotice( __( 'Links are disabled in the editor.' ), {
 			id: noticeId,
 			type: 'snackbar',

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get, includes, invoke, isUndefined, pickBy } from 'lodash';
+import { get, includes, invoke, isUndefined, pickBy, uniqueId } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -28,9 +28,10 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { pin, list, grid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
+import { store as noticeStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
@@ -147,6 +148,22 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 			selectedAuthor,
 		]
 	);
+
+	// If a user clicks to a link prevent redirection and show a warning.
+	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
+	let noticeId;
+	const showRedirectionPreventedNotice = ( event ) => {
+		event.preventDefault();
+		// Always remove previous warning if any to show one at a time
+		// and use a unique id to announce the message in screen readers
+		// in every click.
+		removeNotice( noticeId );
+		noticeId = `block-library/core/latest-psts/redirection-prevented/${ uniqueId() }`;
+		createWarningNotice( __( 'Redirection is prevented in the editor.' ), {
+			id: noticeId,
+			type: 'snackbar',
+		} );
+	};
 
 	const imageSizeOptions = imageSizes
 		.filter( ( { slug } ) => slug !== 'full' )
@@ -466,7 +483,11 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								.join( ' ' ) }
 							{ /* translators: excerpt truncation character, default …  */ }
 							{ __( ' … ' ) }
-							<a href={ post.link } rel="noopener noreferrer">
+							<a
+								href={ post.link }
+								rel="noopener noreferrer"
+								onClick={ showRedirectionPreventedNotice }
+							>
 								{ __( 'Read more' ) }
 							</a>
 						</>
@@ -483,6 +504,9 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 											className="wp-block-latest-posts__post-title"
 											href={ post.link }
 											rel="noreferrer noopener"
+											onClick={
+												showRedirectionPreventedNotice
+											}
 										>
 											{ featuredImage }
 										</a>
@@ -501,6 +525,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 										  }
 										: undefined
 								}
+								onClick={ showRedirectionPreventedNotice }
 							>
 								{ ! titleTrimmed ? __( '(no title)' ) : null }
 							</a>

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -3,6 +3,10 @@
 	&.is-grid {
 		padding-left: 0;
 	}
+	// Make links unclickable in the editor.
+	a {
+		pointer-events: none;
+	}
 }
 
 .wp-block-latest-posts li a > div {

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -3,10 +3,6 @@
 	&.is-grid {
 		padding-left: 0;
 	}
-	// Make links unclickable in the editor.
-	a {
-		pointer-events: none;
-	}
 }
 
 .wp-block-latest-posts li a > div {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40075

This PR just prevents the default behaviour(that is opening the links) when clicking the link in `Latest Posts` block, in editor.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There is no need to open the links in the editor and especially in the site editor where the content is loaded in an iframe, it might cause an inception effect.


## Testing Instructions
1. Add `Latest Posts` block in **editor** and in **site editor** and update the block settings to show the title, featured image with link and post excerpt(`see more` is shown conditionally depending on the post's excerpt and block settings).
2. Click on the links on the editors
3. Observe that nothing happens

