### PR TITLE
Element styles: prevent the WordPress filter callback from being executed

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -125,7 +125,8 @@ function gutenberg_render_elements_support_styles( $pre_render, $block ) {
 	return null;
 }
 
-// Remove WordPress core filter to avoid rendering duplicate elements stylesheet.
+// Remove WordPress core filters to avoid rendering duplicate elements stylesheet & attaching classes twice.
 remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
+remove_filter( 'pre_render_block', 'wp_render_elements_support_styles', 10, 2 );
 add_filter( 'render_block', 'gutenberg_render_elements_support', 10, 2 );
 add_filter( 'pre_render_block', 'gutenberg_render_elements_support_styles', 10, 2 );


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/37728

Stops a filter callback added by WordPress, as Gutenberg will take care of doing the same.

## Why?

We don't want to end up enqueuing styles or attaching classes to blocks twice.

In https://github.com/WordPress/gutenberg/pull/37728 we introduced a new filter callback for elements styles, which is being backported to core in https://github.com/WordPress/wordpress-develop/pull/2624 This follow-up makes sure that the core callback is not executed in the Gutenberg plugin.

## How?

Removes the filter callback added by WordPress.

## Testing Instructions

- Create a group block and set the link color to red.
- Create a paragraph block and set the link color to purple.

The expected result is that both editor and front end show the paragraph link color as purple.
