### PR TITLE
Cover: Avoid unnecessary wrapping when transformed from Group

### DIFF
--- a/packages/block-library/src/cover/transforms.js
+++ b/packages/block-library/src/cover/transforms.js
@@ -73,6 +73,19 @@ const transforms = {
 					style,
 				} = attributes;
 
+				// If the Group block being transformed has a Cover block as its
+				// only child return that Cover block.
+				if (
+					innerBlocks?.length === 1 &&
+					innerBlocks[ 0 ]?.name === 'core/cover'
+				) {
+					return createBlock(
+						'core/cover',
+						innerBlocks[ 0 ].attributes,
+						innerBlocks[ 0 ].innerBlocks
+					);
+				}
+
 				// If no background or gradient color is provided, default to 50% opacity.
 				// This matches the styling of a Cover block with a background image,
 				// in the state where a background image has been removed.


### PR DESCRIPTION
Related: 
- https://github.com/WordPress/gutenberg/pull/40212
- https://github.com/WordPress/gutenberg/pull/40293
- https://github.com/WordPress/gutenberg/pull/40497

## What?

Prevents unnecessary wrapping of a Group block when it only possesses a single Cover block in its inner blocks. 

## Why?

This will avoid repetitively and unnecessarily nesting Group/Cover blocks.

## How?

Checks if the Group block being transformed from contains only a single Cover block in its inner blocks. If so, it returns a clone of that Cover block instead of wrapping a copy of the Group block within a new Cover block.

## Testing Instructions

1. Create a new post and add a Cover block with a background image.
2. Transform the Cover block to a Group block (this will wrap the Cover block in a Group block)
3. Transform the Group block to a Cover block
4. Confirm that the inner Cover block has been restored rather than the Group block being nested again within a new Cover block.

## Screenshots or screencast <!-- if applicable -->

<details>
<summary><strong> Before </strong></summary>

https://user-images.githubusercontent.com/60436221/165206422-f453916b-912c-4d15-aaf7-70ae7d8f1166.mp4
</details>


<details>
<summary><strong> After </strong></summary>

https://user-images.githubusercontent.com/60436221/165206468-bbbeab82-d867-4449-a67a-0a1fcfc0f862.mp4
</details>




 