### PR TITLE
Fix dragging in inspector causing block deselection

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -98,6 +98,13 @@ export default function useSelectionObserver() {
 				const endClientId = getBlockClientId(
 					extractSelectionEndNode( selection )
 				);
+
+				// If the selection did not involve a block, return early.
+				if ( clientId === undefined && endClientId === undefined ) {
+					setContentEditableWrapper( node, false );
+					return;
+				}
+
 				const isSingularSelection = clientId === endClientId;
 
 				if ( isSingularSelection ) {

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -9,6 +9,7 @@ import {
 	pressKeyWithModifier,
 	insertBlock,
 	clickBlockToolbarButton,
+	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 
 const getActiveBlockName = async () =>
@@ -701,7 +702,7 @@ describe( 'Writing Flow', () => {
 		).toBe( 'Table' );
 	} );
 
-	it( 'Should unselect all blocks when hitting double escape', async () => {
+	it( 'should unselect all blocks when hitting double escape', async () => {
 		// Add demo content.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.type( 'Random Paragraph' );
@@ -719,5 +720,34 @@ describe( 'Writing Flow', () => {
 		await page.keyboard.press( 'Escape' );
 		activeBlockName = await getActiveBlockName();
 		expect( activeBlockName ).toBe( undefined );
+	} );
+
+	// Checks for regressions of https://github.com/WordPress/gutenberg/issues/40091.
+	it( 'does not deselect the block when selecting text outside the editor canvas', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'Random Paragraph' );
+		await openDocumentSettingsSidebar();
+		const blockDescription = await page.waitForSelector(
+			'.block-editor-block-card__description'
+		);
+		const boundingBox = await blockDescription.boundingBox();
+		const startPosition = {
+			x: boundingBox.x + 10,
+			y: boundingBox.y + 8,
+		};
+		const endPosition = {
+			x: startPosition.x + 50,
+			y: startPosition.y,
+		};
+
+		await page.mouse.move( startPosition.x, startPosition.y );
+		await page.mouse.down();
+		await page.mouse.move( endPosition.x, endPosition.y );
+		await page.mouse.up();
+
+		const selectedParagraph = await page.waitForSelector(
+			'.wp-block-paragraph.is-selected'
+		);
+		expect( selectedParagraph ).toBeDefined();
 	} );
 } );


### PR DESCRIPTION
## What?
Fixes #40091

Fixes an issue where dragging (e.g. to select text) resulted in the block being deselected and the block inspector being hidden.

## Why?
The problem seems to have been accidentally introduced with cross-block text selection. There's a `useSelectionObserver` that picks up selection events from both inside and outside the editor canvas, it wasn't checking to see if that selection involved blocks.

`selectBlock` was being called here with an `undefined` clientId, resulting in a deselection:
https://github.com/WordPress/gutenberg/blob/f705d1c171034ae0c52b9f58d452bc318817830c/packages/block-editor/src/components/writing-flow/use-selection-observer.js#L103-L105

## How?
This fix adds an early return to `useSelectionObserver` when there's no `clientId` (block) involved in the selection, which looking at how other similar hooks work seemed like the most consistent fix.

Added an e2e test.

## Alternatives
It may also be possible to check that the event only occurred within the editor canvas, but I'm not familiar enough with the pitfalls of making such a change.

## Testing Instructions
1. Add a paragraph
2. Open the block inspector
3. Try click dragging to select some text from the block description

Expected: the text should be selected and the block should stay selected.

Also worth testing - cross-block text selections still works

## Screenshots or screencast <!-- if applicable -->
### Before
https://user-images.githubusercontent.com/677833/165232650-88ea682d-d6f4-43d6-bd52-2dc90b9cc627.mp4

### After
https://user-images.githubusercontent.com/677833/165232108-94d89f61-a520-43fc-a732-03a9beba36ba.mp4


