### PR TITLE
[Automated Testing]: Fix partial selection copy flaky tests

### DIFF
--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -246,6 +246,11 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'c' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -268,6 +273,11 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'c' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );

--- a/test/e2e/specs/editor/various/copy-cut-paste.spec.js
+++ b/test/e2e/specs/editor/various/copy-cut-paste.spec.js
@@ -299,6 +299,11 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'x' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -321,6 +326,11 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'x' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );
@@ -342,6 +352,11 @@ test.describe( 'Copy/cut/paste', () => {
 		await pageUtils.pressKeyWithModifier( 'shift', 'ArrowUp' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'x' );
 		await pageUtils.pressKeyWithModifier( 'primary', 'ArrowLeft' );
+		// Sometimes the caret has not moved to the correct position before pressing Enter.
+		// @see https://github.com/WordPress/gutenberg/issues/40303#issuecomment-1109434887
+		await page.waitForFunction(
+			() => window.getSelection().type === 'Caret'
+		);
 		// Create a new block at the top of the document to paste there.
 		await page.keyboard.press( 'Enter' );
 		await page.keyboard.press( 'ArrowUp' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40307
Fixes: https://github.com/WordPress/gutenberg/issues/40303

Fixes partial selection flaky tests caused by intermittent proper placement of the caret.

