### PR TITLE
Fix alignment issue with comment author name

### DIFF
--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -25,10 +25,7 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= 'has-text-align-' . esc_attr( $attributes['textAlign'] );
-	}
-	if ( isset( $attributes['fontSize'] ) ) {
-		$classes .= 'has-' . esc_attr( $attributes['fontSize'] ) . '-font-size';
+		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -138,7 +138,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
 	}
@@ -194,7 +194,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			<<<END
 				<ol >
 					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
-						<div class="has-small-font-size wp-block-comment-author-name">
+						<div class="wp-block-comment-author-name">
 							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 								Test
 							</a>
@@ -204,7 +204,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 						</div>
 						<ol>
 							<li id="comment-{$first_level_ids[0]}" class="comment even depth-2">
-								<div class="has-small-font-size wp-block-comment-author-name">
+								<div class="wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test
 									</a>
@@ -214,7 +214,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 								</div>
 								<ol>
 									<li id="comment-{$second_level_ids[0]}" class="comment odd alt depth-3">
-										<div class="has-small-font-size wp-block-comment-author-name">
+										<div class="wp-block-comment-author-name">
 											<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 												Test
 											</a>
@@ -226,7 +226,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 								</ol>
 							</li>
 							<li id="comment-{$first_level_ids[1]}" class="comment even depth-2">
-								<div class="has-small-font-size wp-block-comment-author-name">
+								<div class="wp-block-comment-author-name">
 									<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
 										Test
 									</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is the equivalent of https://github.com/WordPress/gutenberg/pull/40582 but for the comment author name.
Closes https://github.com/WordPress/gutenberg/issues/40251

Assures that the comment author name text alignment setting works and that the block displays correctly on the front.
Also removes duplicate escaping.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The block had duplicate font-size classes on the front. This caused the alignment class and the font size class to be output as one word without spacing in between them, and the CSS was not applied. Because of this, the alignment option did not work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By removing the extra output of the font size class, the class name for the text alignment is correct and the CSS applied.

## Testing Instructions
1. Add a comment query loop to a post or page that has comments.
2. Select the inner comment author name block.
3. Test the toolbar option for text alignment.
4. Test the font size and color options in the block settings sidebar.
5. Save and view the front. Confirm that both the text alignment, colors and the font size works.

## Screenshots or screencast <!-- if applicable -->

Editor, with right alignment selected:
![comment author name is aligned to the right](https://user-images.githubusercontent.com/7422055/165269235-ed61fe1f-a118-4ffc-a8fa-da467d3d9ff5.png)

Front, with link color, to show that both color options work:
![comment author name is aligned to the right, the link color matches the editor setting](https://user-images.githubusercontent.com/7422055/165269488-59741586-95dc-4658-a62a-002c0dda7a68.png)

With text color instead of link color:
![comment author name is aligned to the right, the text color matches the editor setting ](https://user-images.githubusercontent.com/7422055/165269786-4aac048d-9704-486d-9c34-f362edb98772.png)

