### PR TITLE
[RichText]: Ignore selection changes on non contentEditable nodes

### DIFF
--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -132,6 +132,13 @@ export function useInputAndSelection( props ) {
 				onSelectionChange,
 			} = propsRef.current;
 
+			// Check if the implementor disabled editing. `contentEditable`
+			// does disable input, but not text selection, so we must ignore
+			// selection changes.
+			if ( element.contentEditable !== 'true' ) {
+				return;
+			}
+
 			// If the selection changes where the active element is a parent of
 			// the rich text instance (writing flow), call `onSelectionChange`
 			// for the rich text instance that contains the start or end of the


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40358

We need to check if the implementor disabled editing because `contentEditable` does disable input, but not text selection, so we must ignore selection changes. This was removed in https://github.com/WordPress/gutenberg/pull/38892, but I think it was an oversight.
<!-- In a few words, what is the PR actually doing? -->




## Testing Instructions
1.  Insert a Query Loop block and add some blocks that use RichText and are editable, even a `paragraph` block
2. Click on these blocks on different posts(previews)
3. Observe that the there are no added toolbar/inspector controls
4. Make sure that partial selection works as before

## Screenshots or screencast <!-- if applicable -->

#### Before

https://user-images.githubusercontent.com/16275880/165281348-706ac0a2-b416-45d8-89c5-bc549016db8c.mov

#### After


https://user-images.githubusercontent.com/16275880/165281671-69673ea0-a029-4482-9a41-866bede59408.mov




## Notes

I'd like a sanity check here, as RichText is quite complex 😄 
