### PR TITLE
Comment Content: Show moderation message

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -144,6 +144,16 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 			'no_found_rows' => false,
 		);
 
+		if ( is_user_logged_in() ) {
+			$comment_args['include_unapproved'] = array( get_current_user_id() );
+		} else {
+			$unapproved_email = wp_get_unapproved_comment_author_email();
+
+			if ( $unapproved_email ) {
+				$comment_args['include_unapproved'] = array( $unapproved_email );
+			}
+		}
+
 		if ( ! empty( $block->context['postId'] ) ) {
 			$comment_args['post_id'] = (int) $block->context['postId'];
 		}

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -33,7 +33,7 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	$comment_text = apply_filters( 'comment_text', $comment_text, $comment, $args );
 
 	$moderation_note = '';
-	if ( '0' == $comment->comment_approved ) {
+	if ( '0' === $comment->comment_approved ) {
 		$commenter = wp_get_current_commenter();
 
 		if ( $commenter['comment_author_email'] ) {

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -18,7 +18,9 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment = get_comment( $block->context['commentId'] );
+	$comment            = get_comment( $block->context['commentId'] );
+	$commenter          = wp_get_current_commenter();
+	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
 	if ( empty( $comment ) ) {
 		return '';
 	}
@@ -42,6 +44,9 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 			$moderation_note = __( 'Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.' );
 		}
 		$moderation_note = '<em class="comment-awaiting-moderation">' . $moderation_note . '</em>';
+		if ( ! $show_pending_links ) {
+			$comment_text = wp_kses( $comment_text, array() );
+		}
 	}
 
 	$classes = '';

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -32,6 +32,18 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	/** This filter is documented in wp-includes/comment-template.php */
 	$comment_text = apply_filters( 'comment_text', $comment_text, $comment, $args );
 
+	$moderation_note = '';
+	if ( '0' == $comment->comment_approved ) {
+		$commenter = wp_get_current_commenter();
+
+		if ( $commenter['comment_author_email'] ) {
+			$moderation_note = __( 'Your comment is awaiting moderation.' );
+		} else {
+			$moderation_note = __( 'Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.' );
+		}
+		$moderation_note = '<em class="comment-awaiting-moderation">' . $moderation_note . '</em>';
+	}
+
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= 'has-text-align-' . $attributes['textAlign'];
@@ -40,8 +52,9 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 
 	return sprintf(
-		'<div %1$s>%2$s</div>',
+		'<div %1$s>%2$s%3$s</div>',
 		$wrapper_attributes,
+		$moderation_note,
 		$comment_text
 	);
 }

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -43,7 +43,7 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 		} else {
 			$moderation_note = __( 'Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.' );
 		}
-		$moderation_note = '<em class="comment-awaiting-moderation">' . $moderation_note . '</em>';
+		$moderation_note = '<p><em class="comment-awaiting-moderation">' . $moderation_note . '</em></p>';
 		if ( ! $show_pending_links ) {
 			$comment_text = wp_kses( $comment_text, array() );
 		}

--- a/packages/block-library/src/comment-content/style.scss
+++ b/packages/block-library/src/comment-content/style.scss
@@ -1,0 +1,5 @@
+.comment-awaiting-moderation {
+	display: block;
+	font-size: 0.875em;
+	line-height: 1.5;
+}

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -138,8 +138,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertSame(
-			str_replace( array( "\n", "\t" ), '', '<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>' ),
-			str_replace( array( "\n", "\t" ), '', gutenberg_render_block_core_comment_template( null, null, $block ) )
+			str_replace( array( "\n", "\t" ), '', '<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>' ),
+			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 	}
 
@@ -192,7 +192,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			array( "\n", "\t" ),
 			'',
 			<<<END
-				<ol >
+				<ol class="wp-block-comment-template">
 					<li id="comment-{$top_level_ids[0]}" class="comment odd alt thread-odd thread-alt depth-1">
 						<div class="wp-block-comment-author-name">
 							<a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >
@@ -242,7 +242,7 @@ END
 		);
 
 		$this->assertSame(
-			str_replace( array( "\n", "\t" ), '', gutenberg_render_block_core_comment_template( null, null, $block ) ),
+			str_replace( array( "\n", "\t" ), '', $block->render() ),
 			$expected
 		);
 	}
@@ -312,8 +312,8 @@ END
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertSame(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
-			gutenberg_render_block_core_comment_template( null, null, $block )
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
+			$block->render()
 		);
 	}
 
@@ -396,16 +396,16 @@ END
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
-			gutenberg_render_block_core_comment_template( null, null, $block )
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
+			$block->render()
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
 
 		// Test it again and ensure the unmoderated comment doesn't leak out.
 		$this->assertEquals(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
-			gutenberg_render_block_core_comment_template( null, null, $block )
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			$block->render()
 		);
 	}
 }

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -361,7 +361,7 @@ END
 	/**
 	 * Test rendering an unapproved comment preview.
 	 */
-	function test_rendering_comment_template_preview() {
+	function test_rendering_comment_template_unmoderated_preview() {
 		$parsed_blocks = parse_blocks(
 			'<!-- wp:comment-template --><!-- wp:comment-author-name /--><!-- wp:comment-content /--><!-- /wp:comment-template -->'
 		);
@@ -401,5 +401,11 @@ END
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
+
+		// Test it again and ensure the unmoderated comment doesn't leak out.
+		$this->assertEquals(
+			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="has-small-font-size wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			gutenberg_render_block_core_comment_template( null, null, $block )
+		);
 	}
 }

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -385,12 +385,6 @@ END
 			)
 		);
 
-		$commenter_filter = function () {
-			return array(
-				'comment_author_email' => 'unapproved@example.org',
-			);
-		};
-
 		add_filter( 'wp_get_current_commenter', $commenter_filter );
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -354,8 +354,6 @@ END
 				'paged'         => 1,
 			)
 		);
-
-		remove_filter( 'wp_get_current_commenter', $commenter_filter );
 	}
 
 	/**

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -394,7 +394,7 @@ END
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -343,15 +343,15 @@ END
 		$this->assertEquals(
 			build_comment_query_vars_from_block( $block ),
 			array(
-				'orderby'       => 'comment_date_gmt',
-				'order'         => 'ASC',
-				'status'        => 'approve',
-				'no_found_rows' => false,
+				'orderby'            => 'comment_date_gmt',
+				'order'              => 'ASC',
+				'status'             => 'approve',
+				'no_found_rows'      => false,
 				'include_unapproved' => array( 'unapproved@example.org' ),
-				'post_id'       => self::$custom_post->ID,
-				'hierarchical'  => 'threaded',
-				'number'        => 5,
-				'paged'         => 1,
+				'post_id'            => self::$custom_post->ID,
+				'hierarchical'       => 'threaded',
+				'number'             => 5,
+				'paged'              => 1,
 			)
 		);
 	}
@@ -395,7 +395,7 @@ END
 		// in the build step.
 		$this->assertEquals(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
-			str_replace( array( "\n", "\t" ), '', $block->render() ),
+			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
@@ -403,7 +403,7 @@ END
 		// Test it again and ensure the unmoderated comment doesn't leak out.
 		$this->assertEquals(
 			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
-			str_replace( array( "\n", "\t" ), '', $block->render() ),
+			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 	}
 }

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -383,21 +383,27 @@ END
 			)
 		);
 
+		$commenter_filter = function () {
+			return array(
+				'comment_author_email' => 'unapproved@example.org',
+			);
+		};
+
 		add_filter( 'wp_get_current_commenter', $commenter_filter );
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
-			$block->render()
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em>Hi there! My comment needs moderation.</div></li></ol>',
+			str_replace( array( "\n", "\t" ), '', $block->render() ),
 		);
 
 		remove_filter( 'wp_get_current_commenter', $commenter_filter );
 
 		// Test it again and ensure the unmoderated comment doesn't leak out.
 		$this->assertEquals(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
-			$block->render()
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
+			str_replace( array( "\n", "\t" ), '', $block->render() ),
 		);
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Show a moderation message in Comment Content right after publishing a comment that needs moderation.

Fixes https://github.com/WordPress/gutenberg/issues/40601

## Why?

Preview comments were not displayed if they needed moderation.


## How?

- Adding `include_unapproved` in `$comment_args` if needed to fetch the corresponding unapproved comment.
- Showing a moderation note in the Comment Content block.

## Testing Instructions
Follow the same steps described in https://github.com/WordPress/gutenberg/issues/40601, but now ensure that the preview actually appears and it's similar to the images below.

## Screenshots

| Anonymous visitor | User logged in |
| --- | --- |
| <img width="683" alt="Screenshot 2022-04-26 at 13 27 23" src="https://user-images.githubusercontent.com/6917969/165290723-05dfb1f7-9497-47d4-9d96-143a47c8ba1f.png"> | <img width="664" alt="Screenshot 2022-04-26 at 13 29 19" src="https://user-images.githubusercontent.com/6917969/165290729-b70c8726-6a6c-4510-afa3-b4cb12a17ebc.png"> |
 