### PR TITLE
Fix an alignment issue with the post comments form

### DIFF
--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -20,7 +20,7 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 
 	$classes = 'comment-respond'; // See comment further below.
 	if ( isset( $attributes['textAlign'] ) ) {
-		$classes .= 'has-text-align-' . $attributes['textAlign'];
+		$classes .= ' has-text-align-' . $attributes['textAlign'];
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is the equivalent of https://github.com/WordPress/gutenberg/pull/40582 but for the comments form.
Assures that the alignment setting in the block toolbar works for the form elements.
**Does not solve the alignment of the comment reply title.**

Partial for https://github.com/WordPress/gutenberg/issues/40576

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The block had two CSS class names that were missing a single space between them, which meant that the CSS did not apply. Because of this, the alignment option did not work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding a space between the CSS class names.

## Testing Instructions

1. Add a posts comment form block in the editor
2. Adjust the alignment from the block tool bar. Duplicate the block and select a different alignment -repeat this for every alignment
3. Save and view the front.
4. Confirm if the alignments in the editor and front match the toolbar setting.

## Screenshots or screencast <!-- if applicable -->
For the _before_ shot, please see the issue. 
With the PR applied:

![The form text elements and the submit button are centered, but the "Leave a Reply" heading is not.](https://user-images.githubusercontent.com/7422055/165298352-d6789561-5f81-4228-ad5a-63719200552c.png)

