### PR TITLE
[RNMobile] Prevent unnecessary re-renders of `RichText` component due to color palettes prop

### DIFF
--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -51,6 +51,15 @@ const unescapeSpaces = ( text ) => {
 	return text.replace( /&nbsp;|&#160;/gi, ' ' );
 };
 
+// The flattened color palettes array is memoized to ensure that the same array instance is
+// returned for the colors palettes. This value might be used as a prop, so having the same
+// instance will prevent unnecessary re-renders of the RichText component.
+const flatColorPalettes = memize( ( colorsPalettes ) => [
+	...( colorsPalettes?.theme || [] ),
+	...( colorsPalettes?.custom || [] ),
+	...( colorsPalettes?.default || [] ),
+] );
+
 const gutenbergFormatNamesToAztec = {
 	'core/bold': 'bold',
 	'core/italic': 'italic',
@@ -1263,14 +1272,10 @@ export default compose( [
 
 		const settings = getSettings();
 		const baseGlobalStyles = settings?.__experimentalGlobalStylesBaseStyles;
-		const colorsPalettes = settings?.__experimentalFeatures?.color?.palette;
-		const allColorsPalette = [
-			...( colorsPalettes?.theme || [] ),
-			...( colorsPalettes?.custom || [] ),
-			...( colorsPalettes?.default || [] ),
-		];
-		const colorPalette = colorsPalettes
-			? allColorsPalette
+
+		const colorPalettes = settings?.__experimentalFeatures?.color?.palette;
+		const colorPalette = colorPalettes
+			? flatColorPalettes( colorPalettes )
 			: settings?.colors;
 
 		return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improve performance of `RichText` component by preventing unnecessary re-renders.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR addresses the issue described in https://github.com/WordPress/gutenberg/issues/39955.

The `RichText` component receives the color palettes via the `colorPalette` prop, which is calculated by flattening all the color palettes into a single array. This was made within the `withSelect` block, so it was generating a new array instance every time editor settings were updated, and therefore, re-rendering unnecessarily all `RichText` components withing the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new function `flatColorPalettes` has been added to the `RichText` component that memoizes the flattened color palettes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Check performance
Follow the Step-by-step reproduction instructions from https://github.com/WordPress/gutenberg/issues/39955.

### Check color palettes
**Preparation:**
It's recommended to use the WordPress app to check changes in the color palettes.

1. Open the WordPress app.
2. Open a post/page.
3. Add a Paragraph block and select it.
4. Open the block settings by tapping on the ⚙️ button.
5. Tap on the "Text" color setting.
6. Observe that theme colors are displayed and match the theme of the site.
7. Observe that default colors are displayed and match the ones defined [here](https://github.com/WordPress/gutenberg/blob/56004234692f61dac01f511189f2d9ea3b74a8ea/packages/block-editor/src/store/defaults.js#L41-L98).
8. Change the theme of the site.
10. Repeat steps 2 - 7.

## Screenshots or screencast <!-- if applicable -->

**Performance comparison:**
Before changes|After changes
--|--
<img src=https://user-images.githubusercontent.com/14905380/165296255-2ee7bf26-8570-4dc7-be55-d9b55c73f861.png>|<img src=https://user-images.githubusercontent.com/14905380/165296258-069de796-c156-483e-9898-7edb41b829e3.png>


