### PR TITLE
Storybook: Make description-loader more reliable

### DIFF
--- a/storybook/webpack/description-loader.js
+++ b/storybook/webpack/description-loader.js
@@ -21,19 +21,17 @@ function createDescriptionNode( name, description ) {
 			'=',
 			babel.types.memberExpression(
 				babel.types.identifier( name ),
-				babel.types.identifier( 'story' )
+				babel.types.identifier( 'parameters' )
 			),
 			babel.types.objectExpression( [
 				babel.types.objectProperty(
-					babel.types.identifier( 'parameters' ),
+					babel.types.identifier( 'docs' ),
 					babel.types.objectExpression( [
 						babel.types.objectProperty(
-							babel.types.identifier( 'docs' ),
+							babel.types.identifier( 'description' ),
 							babel.types.objectExpression( [
 								babel.types.objectProperty(
-									babel.types.identifier(
-										'storyDescription'
-									),
+									babel.types.identifier( 'story' ),
 									babel.types.stringLiteral( description )
 								),
 							] )

--- a/storybook/webpack/description-loader.js
+++ b/storybook/webpack/description-loader.js
@@ -49,7 +49,7 @@ function annotateDescriptionPlugin() {
 							${ storyId }.parameters ??= {};
 							${ storyId }.parameters.docs ??= {};
 							${ storyId }.parameters.docs.description ??= {};
-							${ storyId }.parameters.docs.description.story = ${ JSON.stringify(
+							${ storyId }.parameters.docs.description.story ??= ${ JSON.stringify(
 						description
 					) };
 					`

--- a/storybook/webpack/description-loader.js
+++ b/storybook/webpack/description-loader.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+const babel = require( '@babel/core' );
+
+/**
  * Allows a story description to be written as a doc comment above the exported story.
  *
  * Based on https://github.com/izhan/storybook-description-loader
@@ -9,51 +14,46 @@
  * export const MyStory = Template.bind({});
  * ```
  */
-
-/**
- * External dependencies
- */
-const babel = require( '@babel/core' );
-
 function annotateDescriptionPlugin() {
 	return {
 		visitor: {
 			ExportNamedDeclaration( path ) {
-				if ( path.node.leadingComments ) {
-					const commentValues = path.node.leadingComments.map(
-						( node ) => {
-							if ( node.type === 'CommentLine' ) {
-								return node.value.trimLeft();
-							}
-							// else, node.type === 'CommentBlock'
-							return node.value
-								.split( '\n' )
-								.map( ( line ) => {
-									// stripping out the whitespace and * from comment blocks
-									return line.replace(
-										/^(\s+)?(\*+)?(\s+)?/,
-										''
-									);
-								} )
-								.join( '\n' )
-								.trim();
-						}
-					);
-					const description = commentValues.join( '\n' );
-					const storyId =
-						path.node.declaration.declarations[ 0 ].id.name;
+				if ( ! path.node.leadingComments ) {
+					return;
+				}
 
-					path.container.push(
-						...babel.template.ast`
+				const commentValues = path.node.leadingComments.map(
+					( node ) => {
+						if ( node.type === 'CommentLine' ) {
+							return node.value.trimLeft();
+						}
+						// else, node.type === 'CommentBlock'
+						return node.value
+							.split( '\n' )
+							.map( ( line ) => {
+								// stripping out the whitespace and * from comment blocks
+								return line.replace(
+									/^(\s+)?(\*+)?(\s+)?/,
+									''
+								);
+							} )
+							.join( '\n' )
+							.trim();
+					}
+				);
+				const description = commentValues.join( '\n' );
+				const storyId = path.node.declaration.declarations[ 0 ].id.name;
+
+				path.container.push(
+					...babel.template.ast`
 							${ storyId }.parameters ??= {};
 							${ storyId }.parameters.docs ??= {};
 							${ storyId }.parameters.docs.description ??= {};
 							${ storyId }.parameters.docs.description.story = ${ JSON.stringify(
-							description
-						) };
+						description
+					) };
 					`
-					);
-				}
+				);
 			},
 		},
 	};


### PR DESCRIPTION
## What?

Two bug fixes:

- Make the description-loader work even when there are `MyStory.parameters = {}` statements in the code.
- Insert story description nodes at the up-to-date, non-deprecated path.

| Deprecated | ✅ Correct |
|--------|-------|
|`MyStory.story.parameters.docs.storyDescription`|`MyStory.parameters.docs.description.story`|

## Why?

The webpack loader code added in #39165 was naive in a few ways:

- It inserted the `MyStory.story.parameters.docs.storyDescription = "foo"` statement right after the named export statement, meaning that any existing statements in the code after that like `MyStory.parameters = { ... }` could erase the story description.
- It completely replaced the root config node instead of just the "leaf" story description node.

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the Docs view of `UnitControl`.
3. In the story file for that component, pick a story with a JSDoc comment description. Add some custom config like:

	```jsx
	PressEnterToChange.parameters = {
		docs: {
			description: {
				story: 'This explicit description takes precedence.',
			},
			source: {
				code: 'foobar',
				language: 'jsx',
				type: 'auto',
			},
		},
	};
	```

    In this case, the explicit story description should be shown in the Docs view.

4. Remove the explicit description from the code. Now, the JSDoc comment description should be shown in the Docs view.

5. The console warnings below shouldn't be thrown anymore.

```
CSF .story annotations deprecated; annotate story functions directly:
- StoryFn.story.name => StoryFn.storyName
- StoryFn.story.(parameters|decorators) => StoryFn.(parameters|decorators)
```

```
Deprecated parameter: docs.storyDescription => docs.description.story
```