### PR TITLE
Fix ColorPalette component's documentation

### DIFF
--- a/packages/components/src/color-palette/README.md
+++ b/packages/components/src/color-palette/README.md
@@ -41,7 +41,6 @@ classes to be applied to the container.
 
 -   Type: `String`
 -   Required: No
--   Default: `Select or Upload Media`
 
 ### clearable
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

https://developer.wordpress.org/block-editor/reference-guides/components/color-palette/

The `className` property is documented to have default value of `Select or Upload Media` which is not true, so we should remove it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`className` property is not required, and has no default value.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the particular line from the documentation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
