### PR TITLE
InputControl: Add flag for larger default size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `InputControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40622](https://github.com/WordPress/gutenberg/pull/40622)).
+
 ## 19.9.0 (2022-04-21)
 
 ### Bug Fix

--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -105,6 +105,7 @@ export const Container = styled.div< ContainerProps >`
 `;
 
 type InputProps = {
+	__next36pxDefaultSize?: boolean;
 	disabled?: boolean;
 	inputSize?: Size;
 	isDragging?: boolean;
@@ -140,14 +141,17 @@ const fontSizeStyles = ( { inputSize: size }: InputProps ) => {
 	`;
 };
 
-const sizeStyles = ( { inputSize: size }: InputProps ) => {
+const sizeStyles = ( {
+	inputSize: size,
+	__next36pxDefaultSize,
+}: InputProps ) => {
 	const sizes = {
 		default: {
-			height: 30,
+			height: 36,
 			lineHeight: 1,
-			minHeight: 30,
-			paddingLeft: 8,
-			paddingRight: 8,
+			minHeight: 36,
+			paddingLeft: 16,
+			paddingRight: 16,
 		},
 		small: {
 			height: 24,
@@ -164,6 +168,16 @@ const sizeStyles = ( { inputSize: size }: InputProps ) => {
 			paddingRight: 16,
 		},
 	};
+
+	if ( ! __next36pxDefaultSize ) {
+		sizes.default = {
+			height: 30,
+			lineHeight: 1,
+			minHeight: 30,
+			paddingLeft: 8,
+			paddingRight: 8,
+		};
+	}
 
 	const style = sizes[ size as Size ] || sizes.default;
 

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -27,6 +27,12 @@ export type DragProps = Parameters< Parameters< typeof useDrag >[ 0 ] >[ 0 ];
 export type Size = 'default' | 'small' | '__unstable-large';
 
 interface BaseProps {
+	/**
+	 * Start opting into the larger default height that will become the default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next36pxDefaultSize?: boolean;
 	__unstableInputWidth?: CSSProperties[ 'width' ];
 	/**
 	 * If true, the label will only be visible to screen readers.


### PR DESCRIPTION
Part of #39397

## What?

Adds the temporary prop `__next36pxDefaultSize` to opt into the new 36px height default size.

### Dependent components

This also technically adds `__next36pxDefaultSize` support to any higher-level component that forwards props onto `InputControl`.

- For `NumberControl`, I checked locally that it looks as expected. I don't think it's worth adding the prop to Storybook at the moment — I'd prefer waiting until the TS conversion + Knobs-to-Controls rewrite.
- For `UnitControl`, I'll do a separate PR to adjust paddings and add "official" support for it via TypeScript. (Which will also add it to Storybook) #40627

## Why?

As part of the effort to move toward consistent component sizes.

## How?

Details of the migration plan are written in the original issue #39397.

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the story for `InputControl`. By setting the `__next36pxDefaultSize` control to `true`, the height of the `default` size variant should increase to 36px. All other size variants are unchanged.

## Screenshots or screencast <!-- if applicable -->

### Old default

<img src="https://user-images.githubusercontent.com/555336/165308418-26bbb2f0-6a5e-431c-b3e7-02593479841a.png" alt="Old default height">

### New default (opt-in for now)

<img src="https://user-images.githubusercontent.com/555336/165308366-e214b56f-37be-44f2-92bc-1d93b85d2657.png" alt="New default height">

