### PR TITLE
Audio: Correctly handle drag and drop upload errors

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -62,13 +62,8 @@ function AudioEdit( {
 			if ( file ) {
 				mediaUpload( {
 					filesList: [ file ],
-					onFileChange: ( [ { id: mediaId, url } ] ) => {
-						setAttributes( { id: mediaId, src: url } );
-					},
-					onError: ( e ) => {
-						setAttributes( { src: undefined, id: undefined } );
-						noticeOperations.createErrorNotice( e );
-					},
+					onFileChange: ( [ media ] ) => onSelectAudio( media ),
+					onError: ( e ) => onUploadError( e ),
 					allowedTypes: ALLOWED_MEDIA_TYPES,
 				} );
 			}


### PR DESCRIPTION
## What?
Similar to #40552.

PR improves error handling when Audio is uploaded by dropping a file on the content area.

## Why?
Before this fix Audio block would stay in the uploading state and doesn't display the error.

## How?
Updated media upload arguments to re-use `onSelectAudio` and `onUploadError` callbacks.

## Testing Instructions
1. Emulate server upload error (snippet below).
2. Open a Post or Page.
3. Drop video on the content area.
4. Confirm that the error message is correctly displayed

```php
add_filter( 'wp_handle_upload_prefilter', function( $file ) {
	$file['error'] = 'Upload error';
	return $file;
} );
```

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/165311877-d57d1973-dc15-4105-9255-d7180a6ac04f.mp4


https://user-images.githubusercontent.com/240569/165311894-ebf6dc12-d063-406c-8fc9-c95e3f7ea797.mp4


