### PR TITLE
[WIP] Account for positioned elements when positioning Block Toolbar

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -32,7 +32,7 @@ export default function BlockPopover( {
 	const rootElement = useBlockElement( rootClientId );
 
 	useLayoutEffect( () => {
-		if ( ! rootElement ) {
+		if ( ! rootElement || ! selectedElement ) {
 			return;
 		}
 
@@ -119,14 +119,6 @@ export default function BlockPopover( {
 		return () => {
 			observer.disconnect();
 		};
-
-		// console.log( {
-		// 	selectedElement,
-		// 	rootElement,
-		// 	elChildren,
-		// 	boundary,
-		// 	candidate,
-		// } );
 	}, [ rootElement, selectedElement ] );
 
 	const lastSelectedElement = useBlockElement( bottomClientId ?? clientId );

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -129,6 +129,7 @@ function SelectedBlockPopover( {
 
 	return (
 		<BlockPopover
+			rootClientId={ rootClientId }
 			clientId={ capturingClientId || clientId }
 			bottomClientId={ lastClientId }
 			className={ classnames( 'block-editor-block-list__block-popover', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR is an experiment which seeks the element which

## Why?

In https://github.com/WordPress/gutenberg/issues/40382 we learnt that some blocks have content with extends beyond the boundary of the block's root element. 

As the block's toolbar is positioned immediately below the bottom boundary of the block, this can, on occasion, obstruct the ability to interact with crucial elements that are underneath the block toolbar.

This is most prominent on the Navigation block, where the toolbar will often be positioned on top of flyout submenus.

Closes https://github.com/WordPress/gutenberg/issues/40382

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR explores one of the possible approaches outlined in https://github.com/WordPress/gutenberg/issues/36977#issuecomment-992513795, namely:

> Keep the conditional bottom positioning, but manage to include any popover/dropdown for children blocks in the calculation of where the bottom position should be so we aren't obscuring anything like this.

Currently the implementation 

- looks for the root block element and gets it's bottom offset from the top of the viewport (using [`Element.getBoundingClientRect().bottom`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
- iterates through all its child elements comparing their bottom offset against the stored root bottom offset
- any elements that extend _beyond_ the bounds of the root element's bottom offset value are considered to be "outside" the boundary of the block. 
- If found, we pick the one which extends the furtherest and use that as the anchor reference for the `<Popover>` component. 
- The toolbar is then affixed to the bottom of the extruding element rather than the bottom of the root block's element. This means the toolbar doesn't obstruct the content.

The implementation also watches for DOM mutations and will retrigger the toolbar positioning in case of changes (for example elements which are shown/hidden based on classnames .etc).


### Caveats/Concerns

My main concern is inefficiency of the algorithm:

- we currently recusively loop through all child elements. I was hoping to only recurse if the parent proved to extend beyond the root boundary but it turns out that won't work as child elements can extend even if their parent's do not.
- We use `MutationObserver` and I have a hunch that this could be computationally expensive.
- `getComputedStyle` is used which [can force layout reflows](https://gist.github.com/paulirish/5d52fb081b3570c81e3a#calling-getcomputedstyle) 
- the conditions for determining whether an element is currently "visable" are arbitrary

I also think this needs much more stress testing. What other 3rd party blocks have instances whether the block's content extends beyond its layout bounds?



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Create Nav block with several levels of nesting using the submenu block.
2. Click about between the root level Nav block and each "level" of the submenus and check that the toolbar positions itself so as not to obstruct the content.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/165325765-d2c13cfd-323e-482f-8d91-3e39e6cfb731.mov


