### PR TITLE
UnitControl: Add flag for larger default size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `InputControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40622](https://github.com/WordPress/gutenberg/pull/40622)).
+-   `UnitControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40627](https://github.com/WordPress/gutenberg/pull/40627)).
 
 ## 19.9.0 (2022-04-21)
 

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -26,21 +26,11 @@ export const Root = styled.div`
 	position: relative;
 `;
 
-const paddingStyles = ( { disableUnits, size }: InputProps ) => {
-	const paddings = {
-		default: {
-			paddingRight: 8,
-		},
-		small: {
-			paddingRight: 8,
-		},
-		'__unstable-large': {
-			paddingRight: disableUnits ? 16 : 8,
-		},
-	};
+const paddingStyles = ( { disableUnits }: InputProps ) => {
+	if ( disableUnits ) return '';
 
 	return css`
-		${ rtl( paddings[ size ] )() };
+		${ rtl( { paddingRight: 8 } )() };
 	`;
 };
 

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -74,7 +74,10 @@ export type UnitSelectControlProps = {
 
 // TODO: when available, should (partially) extend `NumberControl` props.
 export type UnitControlProps = Omit< UnitSelectControlProps, 'unit' > &
-	Pick< InputControlProps, 'hideLabelFromVision' > & {
+	Pick<
+		InputControlProps,
+		'hideLabelFromVision' | '__next36pxDefaultSize'
+	> & {
 		__unstableStateReducer?: StateReducer;
 		__unstableInputWidth?: CSSProperties[ 'width' ];
 		/**


### PR DESCRIPTION
Part of #39397

## What?

Adds the temporary prop `__next36pxDefaultSize` to opt into the new 36px height default size.

## Why?

As part of the effort to move toward consistent component sizes.

## How?

Details of the migration plan are written in the original issue #39397.

## Testing Instructions

1. `npm run storybook:dev`
2. Go to the story for `UnitControl`. By setting the `__next36pxDefaultSize` control to `true`, the height of the `default` size variant should increase to 36px. All other size variants are unchanged.

## Screenshots or screencast <!-- if applicable -->

### Old default height

<img src="https://user-images.githubusercontent.com/555336/165324584-a6260081-3514-4fc0-8845-64a5b4f92e1b.png" alt="Old default height">

### New default height (opt-in for now)

<img src="https://user-images.githubusercontent.com/555336/165324484-b04f420c-95ce-4cd0-875a-81fdb210cc3f.png" alt="New default height">


