### PR TITLE
Docs: Omit name from settings object in registerPlugin

### DIFF
--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -142,7 +142,7 @@ registerPlugin( 'plugin-name', {
 _Parameters_
 
 -   _name_ `string`: A string identifying the plugin.Must be unique across all registered plugins.
--   _settings_ `WPPlugin`: The settings for this plugin.
+-   _settings_ `Omit<WPPlugin, 'name'>`: The settings for this plugin.
 
 _Returns_
 

--- a/packages/plugins/src/api/index.js
+++ b/packages/plugins/src/api/index.js
@@ -38,9 +38,9 @@ const plugins = {};
 /**
  * Registers a plugin to the editor.
  *
- * @param {string}   name     A string identifying the plugin.Must be
- *                            unique across all registered plugins.
- * @param {WPPlugin} settings The settings for this plugin.
+ * @param {string}                 name     A string identifying the plugin.Must be
+ *                                          unique across all registered plugins.
+ * @param {Omit<WPPlugin, 'name'>} settings The settings for this plugin.
  *
  * @example
  * ```js


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Make sure the JSDocs on the `registerPlugin` function is correct. The second parameter `settings` don't need a `name` since the first parameter name is mapped into the settings object inside the function.

## Why?
So the JSDocs reflects what is actually is required in the settings object.

## How?
Updated the JSDoc to omit the name from `WPPlugin` in the second paramenter
