### PR TITLE
ESLint Plugin: Fix `recommended` preset when `prettier` is not installed

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Fix the `recommended` preset when Prettier is not installed ([#40634](https://github.com/WordPress/gutenberg/pull/40634)).
+
 ## 12.0.0 (2022-04-08)
 
 ### Breaking Changes

--- a/packages/eslint-plugin/configs/recommended.js
+++ b/packages/eslint-plugin/configs/recommended.js
@@ -6,7 +6,6 @@ const { cosmiconfigSync } = require( 'cosmiconfig' );
 /**
  * WordPress dependencies
  */
-const defaultPrettierConfig = require( '@wordpress/prettier-config' );
 
 /**
  * Internal dependencies
@@ -22,6 +21,7 @@ if ( isPackageInstalled( 'prettier' ) ) {
 
 	const { config: localPrettierConfig } =
 		cosmiconfigSync( 'prettier' ).search() || {};
+	const defaultPrettierConfig = require( '@wordpress/prettier-config' );
 	const prettierConfig = { ...defaultPrettierConfig, ...localPrettierConfig };
 	config.rules = {
 		'prettier/prettier': [ 'error', prettierConfig ],


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This change fixes `recommended` ESLint preset when `prettier` is not installed.
<!-- In a few words, what is the PR actually doing? -->

## Why?

The `prettier` package is intended to be an optional peer dependency, but is incorrectly required when using the `@wordpress/eslint-plugin/recommended` preset. Failure to install `prettier` results in an error when using that preset:

```
Oops! Something went wrong! :(

ESLint: 8.14.0

Error: Failed to load plugin '@wordpress/eslint-plugin' declared in '.eslintrc.json': Cannot find module 'prettier/package.json'
Require stack:
- /[...]/eslint-config-wpvip/node_modules/@wordpress/prettier-config/lib/index.js
- /[...]/eslint-config-wpvip/node_modules/@wordpress/eslint-plugin/configs/recommended.js
- /[...]/eslint-config-wpvip/node_modules/requireindex/index.js
- /[...]/eslint-config-wpvip/node_modules/@wordpress/eslint-plugin/configs/index.js
- /[...]/eslint-config-wpvip/node_modules/@wordpress/eslint-plugin/index.js
- /[...]/eslint-config-wpvip/node_modules/@eslint/eslintrc/dist/eslintrc.cjs
```

The prettier rulesets should be added only when the user has installed `prettier`. However, the `@worpress/prettier-config` package eagerly loads `prettier`'s `package.json`, leading to an error when it is not installed.

## How?

This change moves the require of `@worpress/prettier-config` inside the relevant `if` block, so that it is only loaded when `prettier` is confirmed to be installed.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

On any JavaScript project, use the following `.eslintrc.json` without `prettier` installed:

```
{
	"extends": [
		"plugin:@wordpress/eslint-plugin/recommended"
	]
}
```
