### PR TITLE
Preferences persistence - mark modified property as not readonly in schema

### DIFF
--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -31,7 +31,6 @@ function gutenberg_register_persisted_preferences_meta() {
 							'description' => __( 'The date and time the preferences were updated.', 'default' ),
 							'type'        => 'string',
 							'format'      => 'date-time',
-							'context'     => array( 'edit' ),
 							'readonly'    => false,
 						),
 					),

--- a/lib/compat/wordpress-6.1/persisted-preferences.php
+++ b/lib/compat/wordpress-6.1/persisted-preferences.php
@@ -32,7 +32,7 @@ function gutenberg_register_persisted_preferences_meta() {
 							'type'        => 'string',
 							'format'      => 'date-time',
 							'context'     => array( 'edit' ),
-							'readonly'    => true,
+							'readonly'    => false,
 						),
 					),
 					'additionalProperties' => true,


### PR DESCRIPTION
## What?
Changes a user meta `_modified` schema property (used for persisting preferences) to not be readonly.

## Why?
As mentioned here, it shouldn't be readonly - https://github.com/WordPress/gutenberg/pull/39795#discussion_r859362666

The property is updated in a `PUT` request, so that means it shouldn't be read only.

This doesn't seem to change anything in terms of the actual user experience. Possibly this schema is only used for docs and the `readonly` aspect has to be implemented separately.

## Testing Instructions
Test that persisted preferences still work:
1. Login to WordPress using the same user in two different browsers (e.g. chrome and firefox)
2. Edit a post in each browser
3. Change a preference in one browser (e.g. enable Top Toolbar)
4. Reload the page on the other browser

Expected - the preference change should be reflected (e.g. top toolbar should be enabled)
