### PR TITLE
Fix the html data is wrong in clipboard emulation in Playwright

### DIFF
--- a/packages/e2e-test-utils-playwright/src/page/press-key-with-modifier.ts
+++ b/packages/e2e-test-utils-playwright/src/page/press-key-with-modifier.ts
@@ -64,13 +64,9 @@ async function emulateClipboard( page: Page, type: 'copy' | 'cut' | 'paste' ) {
 					const range = selection.getRangeAt( 0 );
 					const fragment = range.cloneContents();
 					html = Array.from( fragment.childNodes )
-						.map( ( node ) =>
-							Object.prototype.hasOwnProperty.call(
-								node,
-								'outerHTML'
-							)
-								? ( node as Element ).outerHTML
-								: node.nodeValue
+						.map(
+							( node ) =>
+								( node as Element ).outerHTML ?? node.nodeValue
 						)
 						.join( '' );
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
`Object.prototype.hasOwnProperty.call(Element, 'outerHTML')` will always returns false since `outerHTML` is not a `ownProperty` of the Element's instance.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix clipboard emulation gets the html data wrong in Playwright utils. A bug introduced back in #39807.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR changes that to doing downcasting and `??` to follow the same logic in the original util.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Fortunately, no tests were affected by this bug. The tests should still pass.
