### PR TITLE
Handle promise rejections from preferences persistence if the user is offline or the REST API errors.

### DIFF
--- a/packages/preferences-persistence/src/create/index.js
+++ b/packages/preferences-persistence/src/create/index.js
@@ -86,6 +86,8 @@ export default function create( {
 		// The user meta endpoint seems susceptible to errors when consecutive
 		// requests are made in quick succession. Ensure there's a gap between
 		// any consecutive requests.
+		//
+		// Catch and do nothing with errors from the REST API.
 		debouncedApiFetch( {
 			path: '/wp/v2/users/me',
 			method: 'PUT',
@@ -100,7 +102,7 @@ export default function create( {
 					persisted_preferences: dataWithTimestamp,
 				},
 			},
-		} );
+		} ).catch( () => {} );
 	}
 
 	return {

--- a/packages/preferences-persistence/src/create/test/debounce-async.js
+++ b/packages/preferences-persistence/src/create/test/debounce-async.js
@@ -77,4 +77,47 @@ describe( 'debounceAsync', () => {
 		jest.runAllTimers();
 		expect( fn ).toHaveBeenCalledTimes( 2 );
 	} );
+
+	it( 'is thenable, returning any data from promise resolution of the debounced function', async () => {
+		expect.assertions( 2 );
+		const fn = async () => 'test';
+		const debounced = debounceAsync( fn, 20 );
+
+		// Test the return value via awaiting.
+		const returnValue = await debounced();
+		expect( returnValue ).toBe( 'test' );
+
+		// Test then-ing.
+		await debounced().then( ( thenValue ) =>
+			expect( thenValue ).toBe( 'test' )
+		);
+	} );
+
+	it( 'is catchable', async () => {
+		expect.assertions( 2 );
+		const expectedError = new Error( 'test' );
+		const fn = async () => {
+			throw expectedError;
+		};
+
+		const debounced = debounceAsync( fn, 20 );
+
+		// Test traditional try/catch.
+		try {
+			await debounced();
+		} catch ( error ) {
+			// Disable reason - the test uses `expect.assertions` to ensure
+			// conditional assertions are called.
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect( error ).toBe( expectedError );
+		}
+
+		// Test chained .catch().
+		await debounced().catch( ( error ) => {
+			// Disable reason - the test uses `expect.assertions` to ensure
+			// conditional assertions are called.
+			// eslint-disable-next-line jest/no-conditional-expect
+			expect( error ).toBe( expectedError );
+		} );
+	} );
 } );


### PR DESCRIPTION
## What?
Addresses this code review comment - https://github.com/WordPress/gutenberg/pull/39795#discussion_r854760887

Handles promise errors when persisting preferences.

## Why?
If the user goes offline, or the REST API throws an uncaught error and the browser will log an 'unhandled promise rejection' error in the console. Similarly the REST API can itself return an error, and the same console message will be shown.

Thankfully it doesn't cause the editor to crash, but it's still good practice to handle promise errors, so this is mostly a code quality change.

## How?
First thing - I don't think there's a need to show any user facing error. If we did, the user may not know what it's about. 

There's a local storage back up that the persistence code uses if the REST API fails. So I think this adds enough resilience that any REST errors can be swallowed, but I'm still open to other thoughts on this.

In terms of code, the `debounceAsync` utility didn't support handling promises from the call site, since it wasn't returning a promise itself. To fix this, I've made the debounced function always return a promise that's:
a) rejected when its wrapped async function throws
and
b) resolved to the value of its wrapped function if it succeeds.

(and yes, maybe a library could be used for `debounceAsync` 😄 )

## Testing Instructions
1. Load the post editor
2. Using the browser dev tools 'network' tab, switch to offline
3. Toggle a setting
4. There should be no 'unhandled promise rejection' errors in the browser console.
