### PR TITLE
Media&Text: Add help to ImageSizeControl

### DIFF
--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -18,7 +18,6 @@ const MyImageSizeControl = () => {
 
 	return (
 		<ImageSizeControl
-			label={ __( 'Image size' ) }
 			onChange={ ( value ) => setSize( value ) }
 			width={ size.width }
 			height={ size.height }
@@ -33,17 +32,9 @@ const MyImageSizeControl = () => {
 
 The component accepts the following props:
 
-### label
+### imageSizeHelp
 
-The label for the control.
-
--   Type: `string`
--   Required: No
--   Default: `Image size`
-
-### help
-
-If this property is added, a help text will be generated using help property as the content.
+If this property is added, a help text will be generated for the image size control, using imageSizeHelp property as the content.
 
 -   Type: `String|WPElement`
 -   Required: No

--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -18,6 +18,7 @@ const MyImageSizeControl = () => {
 
 	return (
 		<ImageSizeControl
+			label={ __( 'Image Size' ) }
 			onChange={ ( value ) => setSize( value ) }
 			width={ size.width }
 			height={ size.height }
@@ -31,6 +32,21 @@ const MyImageSizeControl = () => {
 ## Props
 
 The component accepts the following props:
+
+### label
+
+The label for the control.
+
+-   Type: `string`
+-   Required: No
+-   Default: `Image Size`
+
+### help
+
+If this property is added, a help text will be generated using help property as the content.
+
+-   Type: `String|WPElement`
+-   Required: No
 
 ### slug
 

--- a/packages/block-editor/src/components/image-size-control/README.md
+++ b/packages/block-editor/src/components/image-size-control/README.md
@@ -18,7 +18,7 @@ const MyImageSizeControl = () => {
 
 	return (
 		<ImageSizeControl
-			label={ __( 'Image Size' ) }
+			label={ __( 'Image size' ) }
 			onChange={ ( value ) => setSize( value ) }
 			width={ size.width }
 			height={ size.height }
@@ -39,7 +39,7 @@ The label for the control.
 
 -   Type: `string`
 -   Required: No
--   Default: `Image Size`
+-   Default: `Image size`
 
 ### help
 

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -22,8 +22,7 @@ import useDimensionHandler from './use-dimension-handler';
 const IMAGE_SIZE_PRESETS = [ 25, 50, 75, 100 ];
 
 export default function ImageSizeControl( {
-	label,
-	help,
+	imageSizeHelp,
 	imageWidth,
 	imageHeight,
 	imageSizeOptions = [],
@@ -45,11 +44,11 @@ export default function ImageSizeControl( {
 		<>
 			{ ! isEmpty( imageSizeOptions ) && (
 				<SelectControl
-					label={ label === undefined ? __( 'Image size' ) : label }
+					label={ __( 'Image size' ) }
 					value={ slug }
 					options={ imageSizeOptions }
 					onChange={ onChangeImage }
-					help={ help }
+					help={ imageSizeHelp }
 				/>
 			) }
 			{ isResizable && (

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -22,6 +22,8 @@ import useDimensionHandler from './use-dimension-handler';
 const IMAGE_SIZE_PRESETS = [ 25, 50, 75, 100 ];
 
 export default function ImageSizeControl( {
+	label,
+	help,
 	imageWidth,
 	imageHeight,
 	imageSizeOptions = [],
@@ -43,10 +45,11 @@ export default function ImageSizeControl( {
 		<>
 			{ ! isEmpty( imageSizeOptions ) && (
 				<SelectControl
-					label={ __( 'Image size' ) }
+					label={ label === undefined ? __( 'Image Size' ) : label }
 					value={ slug }
 					options={ imageSizeOptions }
 					onChange={ onChangeImage }
+					help={ help }
 				/>
 			) }
 			{ isResizable && (

--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -45,7 +45,7 @@ export default function ImageSizeControl( {
 		<>
 			{ ! isEmpty( imageSizeOptions ) && (
 				<SelectControl
-					label={ label === undefined ? __( 'Image Size' ) : label }
+					label={ label === undefined ? __( 'Image size' ) : label }
 					value={ slug }
 					options={ imageSizeOptions }
 					onChange={ onChangeImage }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -293,6 +293,7 @@ function MediaTextEdit( { attributes, isSelected, setAttributes } ) {
 					slug={ mediaSizeSlug }
 					imageSizeOptions={ imageSizeOptions }
 					isResizable={ false }
+					imageSizeHelp={ __( 'Select which image size to load.' ) }
 				/>
 			) }
 			{ mediaUrl && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR:

- Adds the help to the ImageSizeControl component.
- Updates the image size help text for the Media & text block

Partial for https://github.com/WordPress/gutenberg/issues/29362#issuecomment-821073896
Also see https://github.com/WordPress/gutenberg/pull/24795#issuecomment-686065552

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is the first step in improving the ImageSizeControl usage in the Media & text block.

The Media & text block has a select list where you can select an image size. But it does not select the size the image will be displayed in: The display size is controlled by the _media width_ option.
Instead, the control decides which image size to _load._ A small image size makes the image blurry if the media width is large, and a large image size is unnecessary if the media width is small.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
-The help is added to the SelectControl in the image size control so that we can add a help text with a description.

## Testing Instructions
1. Add an image block and a media & text block.
2. Confirm that there are no backwards compatibility errors:
- The label for the image block image size control remains the default text, "Image size", and the control has no help text.
- The help text for the media blocks image size control says "Select which image size to load.".
- The option works
- There are no other errors such as console JavaScript errors

## Screenshots or screencast <!-- if applicable -->
