### PR TITLE
Cover Block: Fix focal point error when the Featured Image is applied

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -40,7 +40,7 @@ function render_block_core_cover( $attributes, $content ) {
 		$object_position = '';
 		if ( isset( $attributes['focalPoint'] ) ) {
 			$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' .
-			round( $attributes['focalPoint']['x'] * 100 ) . '%';
+			round( $attributes['focalPoint']['y'] * 100 ) . '%';
 		}
 
 		$image_template = '<img


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
There was a bug in the implementation of the Featured Image support. On the frontend, the x value for the focal point was set for both x and y. This PR corrects that. 

## Why?
Focal point would not work otherwise when the Cover Block was set to display the Featured Image.

## How?
Simply replace the incorrect "x" with "y".

## Testing Instructions
1. Insert a Cover block, set to display the Featured Image and ensure the page/post has a featured image
2. Modify the focal point on the image
3. Check the Frontend to make sure it looks like the Editor

## Screenshots or screencast 

**Editor**
![image](https://user-images.githubusercontent.com/4832319/165497036-c06cdf87-45d4-43f6-a06e-3f4b457dc9a2.png)

**Before**
![image](https://user-images.githubusercontent.com/4832319/165497290-318f9cef-657a-45c2-8427-08a7d1cab870.png)

**After**
![image](https://user-images.githubusercontent.com/4832319/165497231-c570b005-2ef0-40d0-bc3f-4fd00dd1f394.png)

