### PR TITLE
Refactor image-size test to follow Playwright's best practices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -249,12 +249,12 @@ module.exports = {
 				'no-restricted-syntax': [
 					'error',
 					{
-						selector: 'CallExpression[callee.name="$"]',
+						selector: 'CallExpression[callee.property.name="$"]',
 						message:
 							'`$` is discouraged, please use `locator` instead',
 					},
 					{
-						selector: 'CallExpression[callee.name="$$"]',
+						selector: 'CallExpression[callee.property.name="$$"]',
 						message:
 							'`$$` is discouraged, please use `locator` instead',
 					},

--- a/packages/e2e-test-utils-playwright/src/request/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request/index.ts
@@ -12,6 +12,7 @@ import type { APIRequestContext, Cookie } from '@playwright/test';
 import { WP_ADMIN_USER, WP_BASE_URL } from '../config';
 import type { User } from './login';
 import { login } from './login';
+import { listMedia, uploadMedia, deleteMedia, deleteAllMedia } from './media';
 import { setupRest, rest, getMaxBatchSize, batchRest } from './rest';
 import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import { deleteAllTemplates } from './templates';
@@ -122,6 +123,10 @@ class RequestUtils {
 	addWidgetBlock = addWidgetBlock;
 	deleteAllTemplates = deleteAllTemplates;
 	resetPreferences = resetPreferences;
+	listMedia = listMedia;
+	uploadMedia = uploadMedia;
+	deleteMedia = deleteMedia;
+	deleteAllMedia = deleteAllMedia;
 }
 
 export type { StorageState };

--- a/packages/e2e-test-utils-playwright/src/request/media.ts
+++ b/packages/e2e-test-utils-playwright/src/request/media.ts
@@ -1,0 +1,99 @@
+/**
+ * External dependencies
+ */
+import * as fs from 'fs';
+
+/**
+ * Internal dependencies
+ */
+import type { RequestUtils } from './index';
+
+interface Media {
+	id: number;
+	title: {
+		raw: string;
+		rendered: string;
+	};
+	source_url: string;
+	slug: string;
+	alt_text: string;
+	caption: { rendered: string };
+	link: string;
+}
+
+/**
+ * List all media files.
+ *
+ * @param  this
+ */
+async function listMedia( this: RequestUtils ) {
+	const response = await this.rest< Media[] >( {
+		method: 'GET',
+		path: '/wp/v2/media',
+		params: {
+			per_page: 100,
+		},
+	} );
+
+	return response;
+}
+
+/**
+ * Upload a media file.
+ *
+ * @param  this
+ * @param  filePathOrData The path or data of the file being uploaded.
+ */
+async function uploadMedia(
+	this: RequestUtils,
+	filePathOrData: string | fs.ReadStream
+) {
+	const file =
+		typeof filePathOrData === 'string'
+			? fs.createReadStream( filePathOrData )
+			: filePathOrData;
+
+	const response = await this.rest< Media >( {
+		method: 'POST',
+		path: '/wp/v2/media',
+		multipart: {
+			file,
+		},
+	} );
+
+	return response;
+}
+
+/**
+ * delete a media file.
+ *
+ * @param  this
+ * @param  mediaId The ID of the media file.
+ */
+async function deleteMedia( this: RequestUtils, mediaId: number ) {
+	const response = await this.rest( {
+		method: 'DELETE',
+		path: `/wp/v2/media/${ mediaId }`,
+		params: { force: true },
+	} );
+
+	return response;
+}
+
+/**
+ * delete all media files.
+ *
+ * @param  this
+ */
+async function deleteAllMedia( this: RequestUtils ) {
+	const files = await this.listMedia();
+
+	// The media endpoint doesn't support batch request yet.
+	const responses = await Promise.all(
+		files.map( ( media ) => this.deleteMedia( media.id ) )
+	);
+
+	return responses;
+}
+
+export { listMedia, uploadMedia, deleteMedia, deleteAllMedia };

--- a/packages/e2e-test-utils-playwright/src/request/media.ts
+++ b/packages/e2e-test-utils-playwright/src/request/media.ts
@@ -24,6 +24,7 @@ interface Media {
 /**
  * List all media files.
  *
+ * @see https://developer.wordpress.org/rest-api/reference/media/#list-media
  * @param  this
  */
 async function listMedia( this: RequestUtils ) {
@@ -41,6 +42,7 @@ async function listMedia( this: RequestUtils ) {
 /**
  * Upload a media file.
  *
+ * @see https://developer.wordpress.org/rest-api/reference/media/#create-a-media-item
  * @param  this
  * @param  filePathOrData The path or data of the file being uploaded.
  */
@@ -67,6 +69,7 @@ async function uploadMedia(
 /**
  * delete a media file.
  *
+ * @see https://developer.wordpress.org/rest-api/reference/media/#delete-a-media-item
  * @param  this
  * @param  mediaId The ID of the media file.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Continued from #40467. Refactor `image-size.spec.js` to follow the [best practices](https://github.com/WordPress/gutenberg/blob/HEAD/test/e2e/README.md#best-practices).

This PR also fixes an ESLint issue that is discovered when creating this PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
While #40467 did a great job migrating the test to Playwright, there were some missing pieces in the playwright utils preventing it from adopting the latest best practices. This PR tries to fill in the gap and also refactor the test to follow the best practices in the process.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Introduced some `media` request utils and use role selectors to query elements.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
```sh
npm run test-e2e:playwright -- test/e2e/specs/editor/plugins/image-size.spec.js
```

CI should pass.
