### PR TITLE
Inherit author from global query

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -15,10 +15,7 @@
  */
 function render_block_core_post_author( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
-		global $wp_query;
-		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			$author_id = $wp_query->query_vars['author'];
-		}
+		$author_id = get_query_var( 'author' );
 	} else {
 		$author_id = get_post_field( 'post_author', $block->context['postId'] );
 	}

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -17,7 +17,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		global $wp_query;
 		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			$author_id = $wp_query->query_vars[ 'author' ];
+			$author_id = $wp_query->query_vars['author'];
 		}
 	} else {
 		$author_id = get_post_field( 'post_author', $block->context['postId'] );

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -17,9 +17,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
 		global $wp_query;
 		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
-
-			$author_id = $query_args[ 'author' ];
+			$author_id = $wp_query->query_vars[ 'author' ];
 		}
 	} else {
 		$author_id = get_post_field( 'post_author', $block->context['postId'] );

--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -15,10 +15,16 @@
  */
 function render_block_core_post_author( $attributes, $content, $block ) {
 	if ( ! isset( $block->context['postId'] ) ) {
-		return '';
+		global $wp_query;
+		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
+			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
+
+			$author_id = $query_args[ 'author' ];
+		}
+	} else {
+		$author_id = get_post_field( 'post_author', $block->context['postId'] );
 	}
 
-	$author_id = get_post_field( 'post_author', $block->context['postId'] );
 	if ( empty( $author_id ) ) {
 		return '';
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #40431

## Why?
When building author archive templates the author block should still render even if there are no posts.

## How?
If there is no context we default to trying to get the author from the global query.

## Testing Instructions

1. Open Site Editor.
2. Navigate to the Templates List.
3. Click "Add" and add in an author template.
4. Add a Post Author block at the top of the template.
5. Add a Query Loop below it with the option of “Inherit query from template” selected.
6. Publish the template.
7. View an author with posts and see the author name.
8. View an author without posts and notice the author still shows

## Notes

- Is it a better fix to make the default context come from the global wp query? 