### PR TITLE
Update the block overlay to rely on useDisabled hook

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -724,6 +724,7 @@ _Parameters_
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
 -   _options.\_\_unstableIsHtml_ `boolean`:
+-   _options.isDisabled_ `boolean`: Whether the block should be disabled.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -724,7 +724,7 @@ _Parameters_
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
 -   _options.\_\_unstableIsHtml_ `boolean`:
--   _options.isDisabled_ `boolean`: Whether the block should be disabled.
+-   _options.\_\_unstableIsDisabled_ `boolean`: Whether the block should be disabled.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-content-overlay/index.js
+++ b/packages/block-editor/src/components/block-content-overlay/index.js
@@ -9,18 +9,20 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 
 export default function useBlockOverlayActive( clientId ) {
-	const { isParentSelected, hasChildSelected } = useSelect(
+	return useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock } = select(
-				blockEditorStore
+			const {
+				isBlockSelected,
+				hasSelectedInnerBlock,
+				canEditBlock,
+			} = select( blockEditorStore );
+
+			return (
+				! canEditBlock( clientId ) ||
+				( ! isBlockSelected( clientId ) &&
+					! hasSelectedInnerBlock( clientId, true ) )
 			);
-			return {
-				isParentSelected: isBlockSelected( clientId ),
-				hasChildSelected: hasSelectedInnerBlock( clientId, true ),
-			};
 		},
 		[ clientId ]
 	);
-
-	return ! isParentSelected && ! hasChildSelected;
 }

--- a/packages/block-editor/src/components/block-content-overlay/index.js
+++ b/packages/block-editor/src/components/block-content-overlay/index.js
@@ -2,114 +2,25 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
 
-/**
- * External dependencies
- */
-import classnames from 'classnames';
-
-export default function BlockContentOverlay( {
-	clientId,
-	tagName: TagName = 'div',
-	wrapperProps,
-	className,
-} ) {
-	const baseClassName = 'block-editor-block-content-overlay';
-	const [ isOverlayActive, setIsOverlayActive ] = useState( true );
-	const [ isHovered, setIsHovered ] = useState( false );
-
-	const {
-		canEdit,
-		isParentSelected,
-		hasChildSelected,
-		isDraggingBlocks,
-		isParentHighlighted,
-	} = useSelect(
+export default function useBlockOverlayActive( clientId ) {
+	const { isParentSelected, hasChildSelected } = useSelect(
 		( select ) => {
-			const {
-				isBlockSelected,
-				hasSelectedInnerBlock,
-				isDraggingBlocks: _isDraggingBlocks,
-				isBlockHighlighted,
-				canEditBlock,
-			} = select( blockEditorStore );
+			const { isBlockSelected, hasSelectedInnerBlock } = select(
+				blockEditorStore
+			);
 			return {
-				canEdit: canEditBlock( clientId ),
 				isParentSelected: isBlockSelected( clientId ),
 				hasChildSelected: hasSelectedInnerBlock( clientId, true ),
-				isDraggingBlocks: _isDraggingBlocks(),
-				isParentHighlighted: isBlockHighlighted( clientId ),
 			};
 		},
 		[ clientId ]
 	);
 
-	const classes = classnames(
-		baseClassName,
-		wrapperProps?.className,
-		className,
-		{
-			'overlay-active': isOverlayActive,
-			'parent-highlighted': isParentHighlighted,
-			'is-dragging-blocks': isDraggingBlocks,
-		}
-	);
-
-	useEffect( () => {
-		// The overlay is always active when editing is locked.
-		if ( ! canEdit ) {
-			setIsOverlayActive( true );
-			return;
-		}
-
-		// Reenable when blocks are not in use.
-		if ( ! isParentSelected && ! hasChildSelected && ! isOverlayActive ) {
-			setIsOverlayActive( true );
-		}
-		// Disable if parent selected by another means (such as list view).
-		// We check hover to ensure the overlay click interaction is not taking place.
-		// Trying to click the overlay will select the parent block via its 'focusin'
-		// listener on the wrapper, so if the block is selected while hovered we will
-		// let the mouseup disable the overlay instead.
-		if ( isParentSelected && ! isHovered && isOverlayActive ) {
-			setIsOverlayActive( false );
-		}
-		// Ensure overlay is disabled if a child block is selected.
-		if ( hasChildSelected && isOverlayActive ) {
-			setIsOverlayActive( false );
-		}
-	}, [
-		isParentSelected,
-		hasChildSelected,
-		isOverlayActive,
-		isHovered,
-		canEdit,
-	] );
-
-	// Disabled because the overlay div doesn't actually have a role or functionality
-	// as far as the a11y is concerned. We're just catching the first click so that
-	// the block can be selected without interacting with its contents.
-	/* eslint-disable jsx-a11y/no-static-element-interactions */
-	return (
-		<TagName
-			{ ...wrapperProps }
-			className={ classes }
-			onMouseEnter={ () => setIsHovered( true ) }
-			onMouseLeave={ () => setIsHovered( false ) }
-			onMouseUp={
-				isOverlayActive && canEdit
-					? () => setIsOverlayActive( false )
-					: undefined
-			}
-		>
-			{ wrapperProps?.children }
-		</TagName>
-	);
+	return ! isParentSelected && ! hasChildSelected;
 }
-/* eslint-enable jsx-a11y/no-static-element-interactions */

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,5 +1,5 @@
 .block-editor-block-content-overlay {
-	&.overlay-active::before {
+	&::before {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -12,17 +12,8 @@
 		z-index: z-index(".block-editor-block-content-overlay__overlay");
 	}
 
-	&:hover:not(.is-dragging-blocks).overlay-active::before,
-	&.parent-highlighted.overlay-active::before {
+	&:hover:not(.is-dragging-blocks)::before {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
-	}
-
-	&.overlay-active:not(.is-dragging-blocks) * {
-		pointer-events: none;
-	}
-
-	&.is-dragging-blocks {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -12,7 +12,10 @@ import {
 	__unstableGetBlockProps as getBlockProps,
 	getBlockType,
 } from '@wordpress/blocks';
-import { useMergeRefs } from '@wordpress/compose';
+import {
+	useMergeRefs,
+	__experimentalUseDisabled as useIsDisabled,
+} from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import warning from '@wordpress/warning';
 
@@ -54,10 +57,14 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  *                                           the ref if one is defined.
  * @param {Object}  options                  Options for internal use only.
  * @param {boolean} options.__unstableIsHtml
+ * @param {boolean} options.isDisabled       Whether the block should be disabled.
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
+export function useBlockProps(
+	props = {},
+	{ __unstableIsHtml, isDisabled = false } = {}
+) {
 	const { clientId, className, wrapperProps = {}, isAligned } = useContext(
 		BlockListBlockContext
 	);
@@ -125,6 +132,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			enableAnimation,
 			triggerAnimationOnChange: index,
 		} ),
+		useIsDisabled( { isDisabled: ! isDisabled } ),
 	] );
 
 	const blockEditContext = useBlockEditContext();

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -53,17 +53,17 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  * also pass any other props through this hook, and they will be merged and
  * returned.
  *
- * @param {Object}  props                    Optional. Props to pass to the element. Must contain
- *                                           the ref if one is defined.
- * @param {Object}  options                  Options for internal use only.
+ * @param {Object}  props                        Optional. Props to pass to the element. Must contain
+ *                                               the ref if one is defined.
+ * @param {Object}  options                      Options for internal use only.
  * @param {boolean} options.__unstableIsHtml
- * @param {boolean} options.isDisabled       Whether the block should be disabled.
+ * @param {boolean} options.__unstableIsDisabled Whether the block should be disabled.
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
 export function useBlockProps(
 	props = {},
-	{ __unstableIsHtml, isDisabled = false } = {}
+	{ __unstableIsHtml, __unstableIsDisabled = false } = {}
 ) {
 	const { clientId, className, wrapperProps = {}, isAligned } = useContext(
 		BlockListBlockContext
@@ -132,7 +132,7 @@ export function useBlockProps(
 			enableAnimation,
 			triggerAnimationOnChange: index,
 		} ),
-		useIsDisabled( { isDisabled: ! isDisabled } ),
+		useIsDisabled( { isDisabled: ! __unstableIsDisabled } ),
 	] );
 
 	const blockEditContext = useBlockEditContext();

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -110,7 +110,7 @@ export function useInBetweenInserter() {
 				// Don't show the insertion point if a parent block has an "overlay"
 				// See https://github.com/WordPress/gutenberg/pull/34012#pullrequestreview-727762337
 				const parentOverlay = element.parentElement?.closest(
-					'.block-editor-block-content-overlay.overlay-active'
+					'.block-editor-block-content-overlay'
 				);
 				if ( parentOverlay ) {
 					return;

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -14,7 +14,7 @@ export {
 export { default as __experimentalBlockFullHeightAligmentControl } from './block-full-height-alignment-control';
 export { default as __experimentalBlockAlignmentMatrixControl } from './block-alignment-matrix-control';
 export { default as BlockBreadcrumb } from './block-breadcrumb';
-export { default as __experimentalBlockContentOverlay } from './block-content-overlay';
+export { default as __experimentalUseBlockOverlayActive } from './block-content-overlay';
 export { BlockContextProvider } from './block-context';
 export {
 	default as BlockControls,

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	useInnerBlocksProps,
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
-	__experimentalBlockContentOverlay as BlockContentOverlay,
+	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 	InnerBlocks,
 	BlockControls,
 	InspectorControls,
@@ -62,19 +62,24 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		ref
 	);
 
-	const blockProps = useBlockProps();
-
-	const innerBlocksProps = useInnerBlocksProps(
-		{},
+	const hasBlockOverlay = useBlockOverlayActive( clientId );
+	const blockProps = useBlockProps(
 		{
-			value: blocks,
-			onInput,
-			onChange,
-			renderAppender: blocks?.length
-				? undefined
-				: InnerBlocks.ButtonBlockAppender,
-		}
+			className: hasBlockOverlay
+				? 'block-library-block__reusable-block-container block-editor-block-content-overlay'
+				: 'block-library-block__reusable-block-container',
+		},
+		{ isDisabled: hasBlockOverlay }
 	);
+
+	const innerBlocksProps = useInnerBlocksProps( blockProps, {
+		value: blocks,
+		onInput,
+		onChange,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
+	} );
 
 	if ( hasAlreadyRendered ) {
 		return (
@@ -108,36 +113,28 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 
 	return (
 		<RecursionProvider>
-			<div { ...blockProps }>
-				{ canRemove && (
-					<BlockControls>
-						<ToolbarGroup>
-							<ToolbarButton
-								onClick={ () =>
-									convertBlockToStatic( clientId )
-								}
-								label={ __( 'Convert to regular blocks' ) }
-								icon={ ungroup }
-								showTooltip
-							/>
-						</ToolbarGroup>
-					</BlockControls>
-				) }
-				<InspectorControls>
-					<PanelBody>
-						<TextControl
-							label={ __( 'Name' ) }
-							value={ title }
-							onChange={ setTitle }
+			{ canRemove && (
+				<BlockControls>
+					<ToolbarGroup>
+						<ToolbarButton
+							onClick={ () => convertBlockToStatic( clientId ) }
+							label={ __( 'Convert to regular blocks' ) }
+							icon={ ungroup }
+							showTooltip
 						/>
-					</PanelBody>
-				</InspectorControls>
-				<BlockContentOverlay
-					clientId={ clientId }
-					wrapperProps={ innerBlocksProps }
-					className="block-library-block__reusable-block-container"
-				/>
-			</div>
+					</ToolbarGroup>
+				</BlockControls>
+			) }
+			<InspectorControls>
+				<PanelBody>
+					<TextControl
+						label={ __( 'Name' ) }
+						value={ title }
+						onChange={ setTitle }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...innerBlocksProps } />
 		</RecursionProvider>
 	);
 }

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -69,7 +69,7 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 				? 'block-library-block__reusable-block-container block-editor-block-content-overlay'
 				: 'block-library-block__reusable-block-container',
 		},
-		{ isDisabled: hasBlockOverlay }
+		{ __unstableIsDisabled: hasBlockOverlay }
 	);
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -24,6 +24,7 @@ import {
 	ContrastChecker,
 	getColorClassName,
 	Warning,
+	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 
@@ -320,33 +321,41 @@ function Navigation( {
 
 	const textDecoration = attributes.style?.typography?.textDecoration;
 
-	const blockProps = useBlockProps( {
-		ref: navRef,
-		className: classnames( className, {
-			'items-justified-right': justifyContent === 'right',
-			'items-justified-space-between': justifyContent === 'space-between',
-			'items-justified-left': justifyContent === 'left',
-			'items-justified-center': justifyContent === 'center',
-			'is-vertical': orientation === 'vertical',
-			'no-wrap': flexWrap === 'nowrap',
-			'is-responsive': 'never' !== overlayMenu,
-			'has-text-color': !! textColor.color || !! textColor?.class,
-			[ getColorClassName(
-				'color',
-				textColor?.slug
-			) ]: !! textColor?.slug,
-			'has-background': !! backgroundColor.color || backgroundColor.class,
-			[ getColorClassName(
-				'background-color',
-				backgroundColor?.slug
-			) ]: !! backgroundColor?.slug,
-			[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
-		} ),
-		style: {
-			color: ! textColor?.slug && textColor?.color,
-			backgroundColor: ! backgroundColor?.slug && backgroundColor?.color,
+	const hasBlockOverlay = useBlockOverlayActive( clientId );
+	const blockProps = useBlockProps(
+		{
+			ref: navRef,
+			className: classnames( className, {
+				'items-justified-right': justifyContent === 'right',
+				'items-justified-space-between':
+					justifyContent === 'space-between',
+				'items-justified-left': justifyContent === 'left',
+				'items-justified-center': justifyContent === 'center',
+				'is-vertical': orientation === 'vertical',
+				'no-wrap': flexWrap === 'nowrap',
+				'is-responsive': 'never' !== overlayMenu,
+				'has-text-color': !! textColor.color || !! textColor?.class,
+				[ getColorClassName(
+					'color',
+					textColor?.slug
+				) ]: !! textColor?.slug,
+				'has-background':
+					!! backgroundColor.color || backgroundColor.class,
+				[ getColorClassName(
+					'background-color',
+					backgroundColor?.slug
+				) ]: !! backgroundColor?.slug,
+				[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
+				'block-editor-block-content-overlay': hasBlockOverlay,
+			} ),
+			style: {
+				color: ! textColor?.slug && textColor?.color,
+				backgroundColor:
+					! backgroundColor?.slug && backgroundColor?.color,
+			},
 		},
-	} );
+		{ isDisabled: hasBlockOverlay }
+	);
 
 	const overlayClassnames = classnames( {
 		'has-text-color':

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -354,7 +354,7 @@ function Navigation( {
 					! backgroundColor?.slug && backgroundColor?.color,
 			},
 		},
-		{ isDisabled: hasBlockOverlay }
+		{ __unstableIsDisabled: hasBlockOverlay }
 	);
 
 	const overlayClassnames = classnames( {

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -5,7 +5,6 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
 	InnerBlocks,
-	__experimentalBlockContentOverlay as BlockContentOverlay,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
@@ -140,11 +139,5 @@ export default function NavigationInnerBlocks( {
 		}
 	);
 
-	return (
-		<BlockContentOverlay
-			clientId={ clientId }
-			tagName={ 'div' }
-			wrapperProps={ innerBlocksProps }
-		/>
-	);
+	return <div { ...innerBlocksProps } />;
 }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -13,6 +13,7 @@ import {
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
 	Warning,
 	store as blockEditorStore,
+	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 } from '@wordpress/block-editor';
 import {
 	ToolbarGroup,
@@ -95,7 +96,15 @@ export default function TemplatePartEdit( {
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
 	const hasReplacements = !! templateParts.length || !! blockPatterns.length;
 	const areaObject = useTemplatePartArea( area );
-	const blockProps = useBlockProps();
+	const hasBlockOverlay = useBlockOverlayActive( clientId );
+	const blockProps = useBlockProps(
+		{
+			className: hasBlockOverlay
+				? 'block-editor-block-content-overlay'
+				: undefined,
+		},
+		{ isDisabled: hasBlockOverlay }
+	);
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;
@@ -168,7 +177,6 @@ export default function TemplatePartEdit( {
 			) }
 			{ isEntityAvailable && (
 				<TemplatePartInnerBlocks
-					clientId={ clientId }
 					tagName={ TagName }
 					blockProps={ blockProps }
 					postId={ templatePartId }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -103,7 +103,7 @@ export default function TemplatePartEdit( {
 				? 'block-editor-block-content-overlay'
 				: undefined,
 		},
-		{ isDisabled: hasBlockOverlay }
+		{ __unstableIsDisabled: hasBlockOverlay }
 	);
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -5,7 +5,6 @@ import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	InnerBlocks,
 	useInnerBlocksProps,
-	__experimentalBlockContentOverlay as BlockContentOverlay,
 	useSetting,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
@@ -15,9 +14,8 @@ export default function TemplatePartInnerBlocks( {
 	postId: id,
 	hasInnerBlocks,
 	layout,
-	tagName,
+	tagName: TagName,
 	blockProps,
-	clientId,
 } ) {
 	const themeSupportsLayout = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
@@ -42,11 +40,5 @@ export default function TemplatePartInnerBlocks( {
 		__experimentalLayout: themeSupportsLayout ? usedLayout : undefined,
 	} );
 
-	return (
-		<BlockContentOverlay
-			clientId={ clientId }
-			tagName={ tagName }
-			wrapperProps={ innerBlocksProps }
-		/>
-	);
+	return <TagName { ...innerBlocksProps } />;
 }

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -66,12 +66,9 @@ export default function useDisabled( {
 
 			/** A variable keeping track of the previous updates in order to restore them. */
 			/** @type {Function[]} */
-			let updates = [];
+			const updates = [];
 
 			const disable = () => {
-				// Restore previous updates.
-				updates = [];
-
 				if ( node.style.getPropertyValue( 'user-select' ) !== 'none' ) {
 					const previousValue = node.style.getPropertyValue(
 						'user-select'

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -70,7 +70,6 @@ export default function useDisabled( {
 
 			const disable = () => {
 				// Restore previous updates.
-				updates.forEach( ( update ) => update() );
 				updates = [];
 
 				if ( node.style.getPropertyValue( 'user-select' ) !== 'none' ) {
@@ -80,6 +79,9 @@ export default function useDisabled( {
 					node.style.setProperty( 'user-select', 'none' );
 					node.style.setProperty( '-webkit-user-select', 'none' );
 					updates.push( () => {
+						if ( ! node.isConnected ) {
+							return;
+						}
 						node.style.setProperty( 'user-select', previousValue );
 						node.style.setProperty(
 							'-webkit-user-select',
@@ -99,6 +101,9 @@ export default function useDisabled( {
 					) {
 						focusable.setAttribute( 'disabled', '' );
 						updates.push( () => {
+							if ( ! focusable.isConnected ) {
+								return;
+							}
 							// @ts-ignore
 							focusable.disabled = false;
 						} );
@@ -113,6 +118,9 @@ export default function useDisabled( {
 						);
 						focusable.setAttribute( 'tabindex', '-1' );
 						updates.push( () => {
+							if ( ! focusable.isConnected ) {
+								return;
+							}
 							if ( ! previousValue ) {
 								focusable.removeAttribute( 'tabindex' );
 							} else {
@@ -128,6 +136,9 @@ export default function useDisabled( {
 					if ( tabIndex !== null && tabIndex !== '-1' ) {
 						focusable.removeAttribute( 'tabindex' );
 						updates.push( () => {
+							if ( ! focusable.isConnected ) {
+								return;
+							}
 							focusable.setAttribute( 'tabindex', tabIndex );
 						} );
 					}
@@ -138,6 +149,9 @@ export default function useDisabled( {
 					) {
 						focusable.setAttribute( 'contenteditable', 'false' );
 						updates.push( () => {
+							if ( ! focusable.isConnected ) {
+								return;
+							}
 							focusable.setAttribute( 'contenteditable', 'true' );
 						} );
 					}
@@ -152,6 +166,9 @@ export default function useDisabled( {
 						);
 						focusable.style.setProperty( 'pointer-events', 'none' );
 						updates.push( () => {
+							if ( ! focusable.isConnected ) {
+								return;
+							}
 							focusable.style.setProperty(
 								'pointer-events',
 								previousValue

--- a/packages/compose/src/hooks/use-disabled/index.js
+++ b/packages/compose/src/hooks/use-disabled/index.js
@@ -37,6 +37,8 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
  * (input fields, links, buttons, etc.) need to be disabled. This hook adds the
  * behavior to disable nested DOM elements to the returned ref.
  *
+ * @param {Object}   config            Configuration object.
+ * @param {boolean=} config.isDisabled Whether the element should be disabled.
  * @return {import('react').RefCallback<HTMLElement>} Element Ref.
  *
  * @example
@@ -53,61 +55,135 @@ const DISABLED_ELIGIBLE_NODE_NAMES = [
  * };
  * ```
  */
-export default function useDisabled() {
-	return useRefEffect( ( node ) => {
-		const disable = () => {
-			node.style.setProperty( 'user-select', 'none' );
-			node.style.setProperty( '-webkit-user-select', 'none' );
-			focus.focusable.find( node ).forEach( ( focusable ) => {
-				if (
-					includes( DISABLED_ELIGIBLE_NODE_NAMES, focusable.nodeName )
-				) {
-					focusable.setAttribute( 'disabled', '' );
-				}
-
-				if ( focusable.nodeName === 'A' ) {
-					focusable.setAttribute( 'tabindex', '-1' );
-				}
-
-				const tabIndex = focusable.getAttribute( 'tabindex' );
-				if ( tabIndex !== null && tabIndex !== '-1' ) {
-					focusable.removeAttribute( 'tabindex' );
-				}
-
-				if ( focusable.hasAttribute( 'contenteditable' ) ) {
-					focusable.setAttribute( 'contenteditable', 'false' );
-				}
-
-				if (
-					node.ownerDocument.defaultView?.HTMLElement &&
-					focusable instanceof
-						node.ownerDocument.defaultView.HTMLElement
-				) {
-					focusable.style.setProperty( 'pointer-events', 'none' );
-				}
-			} );
-		};
-
-		// Debounce re-disable since disabling process itself will incur
-		// additional mutations which should be ignored.
-		const debouncedDisable = debounce( disable, undefined, {
-			leading: true,
-		} );
-		disable();
-
-		/** @type {MutationObserver | undefined} */
-		const observer = new window.MutationObserver( debouncedDisable );
-		observer.observe( node, {
-			childList: true,
-			attributes: true,
-			subtree: true,
-		} );
-
-		return () => {
-			if ( observer ) {
-				observer.disconnect();
+export default function useDisabled( {
+	isDisabled: isDisabledProp = false,
+} = {} ) {
+	return useRefEffect(
+		( node ) => {
+			if ( isDisabledProp ) {
+				return;
 			}
-			debouncedDisable.cancel();
-		};
-	}, [] );
+
+			/** A variable keeping track of the previous updates in order to restore them. */
+			/** @type {Function[]} */
+			let updates = [];
+
+			const disable = () => {
+				// Restore previous updates.
+				updates.forEach( ( update ) => update() );
+				updates = [];
+
+				if ( node.style.getPropertyValue( 'user-select' ) !== 'none' ) {
+					const previousValue = node.style.getPropertyValue(
+						'user-select'
+					);
+					node.style.setProperty( 'user-select', 'none' );
+					node.style.setProperty( '-webkit-user-select', 'none' );
+					updates.push( () => {
+						node.style.setProperty( 'user-select', previousValue );
+						node.style.setProperty(
+							'-webkit-user-select',
+							previousValue
+						);
+					} );
+				}
+
+				focus.focusable.find( node ).forEach( ( focusable ) => {
+					if (
+						includes(
+							DISABLED_ELIGIBLE_NODE_NAMES,
+							focusable.nodeName
+						) &&
+						// @ts-ignore
+						! focusable.disabled
+					) {
+						focusable.setAttribute( 'disabled', '' );
+						updates.push( () => {
+							// @ts-ignore
+							focusable.disabled = false;
+						} );
+					}
+
+					if (
+						focusable.nodeName === 'A' &&
+						focusable.getAttribute( 'tabindex' ) !== '-1'
+					) {
+						const previousValue = focusable.getAttribute(
+							'tabindex'
+						);
+						focusable.setAttribute( 'tabindex', '-1' );
+						updates.push( () => {
+							if ( ! previousValue ) {
+								focusable.removeAttribute( 'tabindex' );
+							} else {
+								focusable.setAttribute(
+									'tabindex',
+									previousValue
+								);
+							}
+						} );
+					}
+
+					const tabIndex = focusable.getAttribute( 'tabindex' );
+					if ( tabIndex !== null && tabIndex !== '-1' ) {
+						focusable.removeAttribute( 'tabindex' );
+						updates.push( () => {
+							focusable.setAttribute( 'tabindex', tabIndex );
+						} );
+					}
+
+					if (
+						focusable.hasAttribute( 'contenteditable' ) &&
+						focusable.getAttribute( 'contenteditable' ) !== 'false'
+					) {
+						focusable.setAttribute( 'contenteditable', 'false' );
+						updates.push( () => {
+							focusable.setAttribute( 'contenteditable', 'true' );
+						} );
+					}
+
+					if (
+						node.ownerDocument.defaultView?.HTMLElement &&
+						focusable instanceof
+							node.ownerDocument.defaultView.HTMLElement
+					) {
+						const previousValue = focusable.style.getPropertyValue(
+							'pointer-events'
+						);
+						focusable.style.setProperty( 'pointer-events', 'none' );
+						updates.push( () => {
+							focusable.style.setProperty(
+								'pointer-events',
+								previousValue
+							);
+						} );
+					}
+				} );
+			};
+
+			// Debounce re-disable since disabling process itself will incur
+			// additional mutations which should be ignored.
+			const debouncedDisable = debounce( disable, undefined, {
+				leading: true,
+			} );
+			disable();
+
+			/** @type {MutationObserver | undefined} */
+			const observer = new window.MutationObserver( debouncedDisable );
+			observer.observe( node, {
+				childList: true,
+				attributes: true,
+				subtree: true,
+			} );
+
+			return () => {
+				if ( observer ) {
+					observer.disconnect();
+				}
+				debouncedDisable.cancel();
+				updates.forEach( ( update ) => update() );
+			};
+		},
+		[ isDisabledProp ]
+	);
 }


### PR DESCRIPTION
closes  #40845
Related https://github.com/WordPress/gutenberg/issues/32163#issuecomment-1110859404

## What?

This PR kind of introduces a "disabled" state/config for a block wrapper. when it's disabled it uses the `useDisabled` hook to prevent editing or selecting anything inside it. Right now it's being used to replace the "Block Overlay" feature. (Reusable blocks, navigation blocks, template parts).

## Why?

We plan to expand the "disabling" behavior to a lot more use-cases:

 - exploded mode
 - locked blocks

and this can be seen as the first step towards that.

## How?

This is composed of two changes:

 - Update the useDisabled hook to allow "disabling" it and "enabling" it again based on a config.
 - Embeds useDisabled in useBlockProps and allow passing a isDisabled config to trigger it

## Testing Instructions

1- Try navigation, reusable and template part blocks
2- See how the selection behaves (overlay..)
