### PR TITLE
Patterns: Fix core 'Featured' pattern category registration

### DIFF
--- a/lib/compat/wordpress-5.9/block-patterns.php
+++ b/lib/compat/wordpress-5.9/block-patterns.php
@@ -25,9 +25,6 @@ if ( ! function_exists( '_load_remote_featured_patterns' ) ) {
 			return;
 		}
 
-		if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'featured' ) ) {
-			register_block_pattern_category( 'featured', array( 'label' => __( 'Featured', 'gutenberg' ) ) );
-		}
 		$request             = new WP_REST_Request( 'GET', '/wp/v2/pattern-directory/patterns' );
 		$request['category'] = 26; // This is the `Featured` category id from pattern directory.
 		$response            = rest_do_request( $request );

--- a/lib/compat/wordpress-6.0/block-patterns-update.php
+++ b/lib/compat/wordpress-6.0/block-patterns-update.php
@@ -9,9 +9,15 @@
  * Register Gutenberg bundled patterns.
  */
 function gutenberg_register_gutenberg_patterns() {
+	$pattern_category_registry = WP_Block_Pattern_Categories_Registry::get_instance();
+
 	// Register categories used for block patterns.
-	if ( ! WP_Block_Pattern_Categories_Registry::get_instance()->is_registered( 'query' ) ) {
+	if ( ! $pattern_category_registry->is_registered( 'query' ) ) {
 		register_block_pattern_category( 'query', array( 'label' => __( 'Query', 'gutenberg' ) ) );
+	}
+
+	if ( ! $pattern_category_registry->is_registered( 'featured' ) ) {
+		register_block_pattern_category( 'featured', array( 'label' => __( 'Featured', 'gutenberg' ) ) );
 	}
 
 	$patterns = array(


### PR DESCRIPTION
## What?
Resolves #40443.

PR fixes issue with missing core "Featured" patterns category.

## Why?
Regression after Gutenberg started loading patterns via REST API (#39185), the `_load_remote_featured_patterns` method isn't called during WP initialization.

## How?
Updates method that registered the category.

P.S. This will be handled via `_register_core_block_patterns_and_categories` when backported into WP Core.

## Testing Instructions
1. Activate the 2016 theme or any theme that doesn't register Featured pattern categories.
2. Open a Post or Page.
3. Open Block inserter -> Patterns Tab
4. Confirm that the "Featured" patterns category is registered.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-04-27 at 15 56 09](https://user-images.githubusercontent.com/240569/165513048-cc5766f9-5b58-4686-b76f-0b73405021af.png)

