### PR TITLE
Mobile - Disable long press event in media blocks

### DIFF
--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -167,7 +167,6 @@ function Controls( {
 							styles.mediaPreview,
 							mediaBackground,
 						] }
-						onLongPress={ openMediaOptions }
 					>
 						<View style={ styles.mediaInner }>
 							{ IMAGE_BACKGROUND_TYPE === backgroundType && (

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -375,7 +375,6 @@ const Cover = ( {
 		<TouchableWithoutFeedback
 			accessible={ ! isParentSelected }
 			onPress={ onMediaPressed }
-			onLongPress={ openMediaOptionsRef.current }
 			disabled={ ! isParentSelected }
 		>
 			<View style={ [ styles.background, backgroundColor ] }>

--- a/packages/block-library/src/file/edit.native.js
+++ b/packages/block-library/src/file/edit.native.js
@@ -452,7 +452,6 @@ export class FileEdit extends Component {
 						<TouchableWithoutFeedback
 							accessible={ ! isSelected }
 							onPress={ this.onFilePressed }
-							onLongPress={ openMediaOptions }
 							disabled={ ! isSelected }
 						>
 							<View

--- a/packages/block-library/src/image/edit.native.js
+++ b/packages/block-library/src/image/edit.native.js
@@ -757,7 +757,6 @@ export class ImageEdit extends Component {
 				<TouchableWithoutFeedback
 					accessible={ ! isSelected }
 					onPress={ this.onImagePressed }
-					onLongPress={ openMediaOptions }
 					disabled={ ! isSelected }
 				>
 					<View style={ styles.content }>

--- a/packages/block-library/src/media-text/edit.native.js
+++ b/packages/block-library/src/media-text/edit.native.js
@@ -275,6 +275,8 @@ class MediaTextEdit extends Component {
 		const widthString = `${ temporaryMediaWidth }%`;
 		const innerBlockWidth = shouldStack ? 100 : 100 - temporaryMediaWidth;
 		const innerBlockWidthString = `${ innerBlockWidth }%`;
+		const hasMedia =
+			mediaType === MEDIA_TYPE_IMAGE || mediaType === MEDIA_TYPE_VIDEO;
 
 		const innerBlockContainerStyle = [
 			{ width: innerBlockWidthString },
@@ -344,7 +346,7 @@ class MediaTextEdit extends Component {
 			<>
 				{ mediaType === MEDIA_TYPE_IMAGE && this.getControls() }
 				<BlockControls>
-					{ ( isMediaSelected || mediaType === MEDIA_TYPE_VIDEO ) && (
+					{ hasMedia && (
 						<ToolbarGroup>
 							<Button
 								label={ __( 'Edit media' ) }

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -191,7 +191,6 @@ class MediaContainer extends Component {
 				<TouchableWithoutFeedback
 					accessible={ ! isSelected }
 					onPress={ this.onMediaPressed }
-					onLongPress={ openMediaOptions }
 					disabled={ ! isSelected }
 				>
 					<View
@@ -222,7 +221,7 @@ class MediaContainer extends Component {
 		);
 	}
 
-	renderVideo( params, openMediaOptions ) {
+	renderVideo( params ) {
 		const {
 			aligmentStyles,
 			mediaUrl,
@@ -251,7 +250,6 @@ class MediaContainer extends Component {
 				<TouchableWithoutFeedback
 					accessible={ ! isSelected }
 					onPress={ this.onMediaPressed }
-					onLongPress={ openMediaOptions }
 					disabled={ ! isSelected }
 				>
 					<View style={ [ styles.videoContainer, aligmentStyles ] }>

--- a/packages/block-library/src/media-text/media-container.native.js
+++ b/packages/block-library/src/media-text/media-container.native.js
@@ -303,7 +303,7 @@ class MediaContainer extends Component {
 				mediaElement = this.renderImage( params, openMediaOptions );
 				break;
 			case MEDIA_TYPE_VIDEO:
-				mediaElement = this.renderVideo( params, openMediaOptions );
+				mediaElement = this.renderVideo( params );
 				break;
 		}
 		return mediaElement;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4784

## What?
With the Drag & Drop blocks feature, long-pressing on blocks replaces the previous functionality we had on media blocks to replace media.

## Why?
We can't have two long-press events on a block so we'll remove the current long-pressing functionality on media blocks.

## How?
Removes the long press event on the following blocks:

- Cover
  - Cover controls
- File
- Image
- Media & Text

**Note**: users will be able to replace media by tapping on the edit media button or the replace button in the toolbar.

## Testing Instructions

### Cover block

- Open the editor
- Add a `Cover` block
- Add an image/video
- Long-press on the image/video
- **Expect** the drag & drop event to be active
- Stop dragging the block
- Tap on the right top edit media button
- Either edit or replace the image/video
- **Expect** this functionality to work as expected

### File block

- Open the editor
- Add a `File` block
- Add a file
- While having the block selected
- Tap on the replace media button on the bottom toolbar 
- **Expect** this functionality to work as expected

### Image block

- Open the editor
- Add an `Image` block
- Add an image
- Long-press on the image
- **Expect** the drag & drop event to be active
- Stop dragging the block
- Tap on the right top edit media button
- Either edit or replace the image
- **Expect** this functionality to work as expected
- Tap on the replace media button on the bottom toolbar 
- **Expect** this functionality to work as expected

### Media & Text block

- Open the editor
- Add a `Media & Text` block
- Add an image
- Long-press on the image
- **Expect** the drag & drop event to be active
- Stop dragging the block
- Select the image if it's not selected
- Tap on the right top edit media button
- Either edit or replace the image
- **Expect** this functionality to work as expected
- Tap on the replace media button on the bottom toolbar 
- **Expect** this functionality to work as expected

## Screenshot

<kbd><img src="https://user-images.githubusercontent.com/4885740/165520576-b2485658-80b9-4507-96b9-b85586f4d477.gif" width="200"/></kbd>