### PR TITLE
Remove the spotlight mode from template parts

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -303,22 +303,6 @@
 	}
 }
 
-// Active entity spotlight.
-// Disable if focus mode is active.
-.is-root-container:not(.is-focus-mode) .block-editor-block-list__block.has-active-entity {
-	opacity: 0.5;
-	transition: opacity 0.1s linear;
-	@include reduce-motion("transition");
-
-	&.is-active-entity,
-	&.has-child-selected,
-	&:not(.has-child-selected) .block-editor-block-list__block,
-	&.is-active-entity .block-editor-block-list__block,
-	.is-active-entity .block-editor-block-list__block {
-		opacity: 1;
-	}
-}
-
 .wp-block[data-align="left"] > *,
 .wp-block[data-align="right"] > *,
 .wp-block.alignleft,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-block-class-names.js
@@ -33,12 +33,8 @@ export function useBlockClassNames( clientId ) {
 				getSettings,
 				hasSelectedInnerBlock,
 				isTyping,
-				__experimentalGetActiveBlockIdByBlockNames: getActiveBlockIdByBlockNames,
 			} = select( blockEditorStore );
-			const {
-				__experimentalSpotlightEntityBlocks: spotlightEntityBlocks,
-				outlineMode,
-			} = getSettings();
+			const { outlineMode } = getSettings();
 			const isDragging = isBlockBeingDragged( clientId );
 			const isSelected = isBlockSelected( clientId );
 			const name = getBlockName( clientId );
@@ -48,9 +44,6 @@ export function useBlockClassNames( clientId ) {
 				clientId,
 				checkDeep
 			);
-			const activeEntityBlockId = getActiveBlockIdByBlockNames(
-				spotlightEntityBlocks
-			);
 			return classnames( {
 				'is-selected': isSelected,
 				'is-highlighted': isBlockHighlighted( clientId ),
@@ -58,9 +51,6 @@ export function useBlockClassNames( clientId ) {
 				'is-reusable': isReusableBlock( getBlockType( name ) ),
 				'is-dragging': isDragging,
 				'has-child-selected': isAncestorOfSelectedBlock,
-				'has-active-entity': activeEntityBlockId,
-				// Determine if there is an active entity area to spotlight.
-				'is-active-entity': activeEntityBlockId === clientId,
 				'remove-outline': isSelected && outlineMode && isTyping(),
 			} );
 		},

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -160,7 +160,6 @@ export const SETTINGS_DEFAULTS = {
 	__mobileEnablePageTemplates: false,
 	__experimentalBlockPatterns: [],
 	__experimentalBlockPatternCategories: [],
-	__experimentalSpotlightEntityBlocks: [],
 	__unstableGalleryWithImageBlocks: false,
 
 	generateAnchors: false,

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -103,7 +103,6 @@ export function initializeEditor( id, settings ) {
 	settings.__experimentalFetchLinkSuggestions = ( search, searchOptions ) =>
 		fetchLinkSuggestions( search, searchOptions, settings );
 	settings.__experimentalFetchRichUrlData = fetchUrlData;
-	settings.__experimentalSpotlightEntityBlocks = [ 'core/template-part' ];
 
 	const target = document.getElementById( id );
 


### PR DESCRIPTION
closes #40646

## What?

This PR removes the "spotlight" mode effect that is applied by default for template parts.

## Why?

The reasoning is detailed in #40464 but the TLDR is:

 - We already have two other ways to differentiate template parts.
 - If folks like the spotlight mode, they can enable it for all blocks in the preferences.

## Testing Instructions

1- Open the site editor
2- Notice that selecting template parts, doesn't fade out the other blocks in the template.