### PR TITLE
Update negative values for margins

### DIFF
--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -46,7 +46,7 @@ function useUniqueId( idProp ) {
 }
 export default function BoxControl( {
 	id: idProp,
-	inputProps,
+	inputProps = defaultInputProps,
 	onChange = noop,
 	label = __( 'Box Control' ),
 	values: valuesProp,
@@ -57,7 +57,7 @@ export default function BoxControl( {
 	resetValues = DEFAULT_VALUES,
 	allowNegativeValues = false,
 } ) {
-	inputProps = allowNegativeValues ? { min: -Infinity } : defaultInputProps;
+	inputProps.min = allowNegativeValues ? -Infinity : defaultInputProps.min;
 
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,


### PR DESCRIPTION
## What?
Follows up https://github.com/WordPress/gutenberg/pull/40464.

## Why?
The initial PR had an issue where the `inputProps` could be unusable. See https://github.com/WordPress/gutenberg/pull/40464#discussion_r859592523.

## How?
This PR set back `inputProps` to `defaultInputProps` in the `BoxControl()` function, and updates its value to `inputProps.min = allowNegativeValues ? -Infinity : defaultInputProps.min;`.

## Testing Instructions
- Add to a post a group block
- Try to set the block margin to a negative value
- The input should accept the negative value and the margin should apply to the block

