### PR TITLE
Block Locking: Avoid 'lock' attribute registration warning

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -284,7 +284,7 @@ add_action( 'rest_api_init', 'gutenberg_rest_comment_set_children_as_embeddable'
  */
 function gutenberg_register_lock_attribute( $args ) {
 	// Setup attributes if needed.
-	if ( ! isset( $args['attributes'] ) ) {
+	if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
 		$args['attributes'] = array();
 	}
 


### PR DESCRIPTION
## What?
PR updates condition in `lock` attribute registration to catch cases when the attribute is set but incorrect type.

## Why?
The `array_key_exists` will trigger a warning (fatal error in PHP 8.0) if the second argument isn't an array - https://3v4l.org/jfT9M

## Testing Instructions
Tests are passing.
