### PR TITLE
Remove sticky posts setting when we inherit the query

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -54,28 +54,29 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			// Unset all the query block query args that cannot be set by the user
 			// when inherit is set to on.
 			$block_provided_query_args = array_keys( $query_args );
-			$user_visible_query_args = [
-				'ignore_sticky_posts', // Ignore sticky posts
-				'post__in', // Only sticky posts
-				'post__not_in' // Exclude sticky posts
-			];
-			foreach( $block_provided_query_args as $i => $query_args_key ) {
-				if( ! in_array( $query_args_key, $user_visible_query_args ) ) {
+			$user_visible_query_args   = array(
+				'ignore_sticky_posts', // Ignore sticky posts.
+				'post__in', // Only sticky posts.
+				'post__not_in', // Exclude sticky posts.
+			);
+			foreach ( $block_provided_query_args as $query_args_key ) {
+				if ( ! in_array( $query_args_key, $user_visible_query_args, true ) ) {
 					unset( $query_args[ $query_args_key ] );
 				}
 			}
-			
 
-			// merge the user settings into the defaults of the query
+			// merge the user settings into the defaults of the query.
 			$query_args = wp_parse_args( $query_args, $wp_query->query_vars );
-			
-			// Unset the `s` query arg because it is automagically filled by
-			// `WP_Query::fill_query_vars` and makes the query believe 
-			// it is a search query when it is not
+
+			/*
+			* Unset the `s` query arg because it is automagically filled by
+			* `WP_Query::fill_query_vars` and makes the query believe
+			* it is a search query when it is not.
+			*/
 			if ( ! is_search() ) {
 				unset( $query_args['s'] );
 			}
-			
+
 			if ( empty( $query_args['post_type'] ) && is_singular() ) {
 				$query_args['post_type'] = get_post_type( get_the_ID() );
 			}

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -51,17 +51,31 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	if ( $use_global_query ) {
 		global $wp_query;
 		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			// Unset `offset` because if is set, $wp_query overrides/ignores the paged parameter and breaks pagination.
-			unset( $query_args['offset'] );
+			// Unset all the query block query args that cannot be set by the user
+			// when inherit is set to on.
+			$block_provided_query_args = array_keys( $query_args );
+			$user_visible_query_args = [
+				'ignore_sticky_posts', // Ignore sticky posts
+				'post__in', // Only sticky posts
+				'post__not_in' // Exclude sticky posts
+			];
+			foreach( $block_provided_query_args as $i => $query_args_key ) {
+				if( ! in_array( $query_args_key, $user_visible_query_args ) ) {
+					unset( $query_args[ $query_args_key ] );
+				}
+			}
+			
 
 			// merge the user settings into the defaults of the query
 			$query_args = wp_parse_args( $query_args, $wp_query->query_vars );
-
-			// Unset the `s` query arg because it is automagically filled by `WP_Query::fill_query_vars` and makes the query believe it is a search query when it is not
+			
+			// Unset the `s` query arg because it is automagically filled by
+			// `WP_Query::fill_query_vars` and makes the query believe 
+			// it is a search query when it is not
 			if ( ! is_search() ) {
 				unset( $query_args['s'] );
 			}
-
+			
 			if ( empty( $query_args['post_type'] ) && is_singular() ) {
 				$query_args['post_type'] = get_post_type( get_the_ID() );
 			}

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -57,6 +57,10 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 			if ( empty( $query_args['post_type'] ) && is_singular() ) {
 				$query_args['post_type'] = get_post_type( get_the_ID() );
 			}
+
+			if ( $block->context['query']['sticky'] === '') {
+				$query['ignore_sticky_posts'] = 0;
+			}
 		}
 	}
 

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -49,7 +49,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	if ( $use_global_query ) {
 		global $wp_query;
 		$query = $wp_query;
-	}  else {
+	} else {
 		$query_args = build_query_vars_from_query_block( $block, $page );
 		$query      = new WP_Query( $query_args );
 	}

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -44,46 +44,15 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
-	$query_args = build_query_vars_from_query_block( $block, $page );
-
-	// Override the custom query with the global query if needed.
+	// Use global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
-		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			// Unset all the query block query args that cannot be set by the user
-			// when inherit is set to on.
-			$block_provided_query_args = array_keys( $query_args );
-			$user_visible_query_args   = array(
-				'ignore_sticky_posts', // Ignore sticky posts.
-				'post__in', // Only sticky posts.
-				'post__not_in', // Exclude sticky posts.
-			);
-			foreach ( $block_provided_query_args as $query_args_key ) {
-				if ( ! in_array( $query_args_key, $user_visible_query_args, true ) ) {
-					unset( $query_args[ $query_args_key ] );
-				}
-			}
-
-			// merge the user settings into the defaults of the query.
-			$query_args = wp_parse_args( $query_args, $wp_query->query_vars );
-
-			/*
-			* Unset the `s` query arg because it is automagically filled by
-			* `WP_Query::fill_query_vars` and makes the query believe
-			* it is a search query when it is not.
-			*/
-			if ( ! is_search() ) {
-				unset( $query_args['s'] );
-			}
-
-			if ( empty( $query_args['post_type'] ) && is_singular() ) {
-				$query_args['post_type'] = get_post_type( get_the_ID() );
-			}
-		}
+		$query = $wp_query;
+	}  else {
+		$query_args = build_query_vars_from_query_block( $block, $page );
+		$query      = new WP_Query( $query_args );
 	}
-
-	$query = new WP_Query( $query_args );
 
 	if ( ! $query->have_posts() ) {
 		return '';
@@ -130,7 +99,9 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		$content     .= '<li class="' . esc_attr( $post_classes ) . '">' . $block_content . '</li>';
 	}
 
-	wp_reset_postdata();
+	if ( ! $use_global_query ) {
+		wp_reset_postdata();
+	}
 
 	return sprintf(
 		'<ul %1$s>%2$s</ul>',

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -21,22 +21,23 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 
 	$page_key   = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page       = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-	$query_args = build_query_vars_from_query_block( $block, $page );
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {
 		global $wp_query;
-		if ( $wp_query && isset( $wp_query->query_vars ) && is_array( $wp_query->query_vars ) ) {
-			$query_args = wp_parse_args( $wp_query->query_vars, $query_args );
-		}
+		$query = $wp_query;
+	} else {
+		$query_args = build_query_vars_from_query_block( $block, $page );
+		$query      = new WP_Query( $query_args );
 	}
-	$query = new WP_Query( $query_args );
 
-	if ( $query->have_posts() ) {
+	if ( ! $query->have_posts() ) {
 		return '';
 	}
 
-	wp_reset_postdata();
+	if ( ! $use_global_query ) {
+		wp_reset_postdata();
+	}
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -21,6 +21,7 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 
 	$page_key   = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$page       = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );
 	if ( $use_global_query ) {

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -19,8 +19,8 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$page_key   = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-	$page       = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+	$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+	$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 	// Override the custom query with the global query if needed.
 	$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );

--- a/packages/block-library/src/query-no-results/index.php
+++ b/packages/block-library/src/query-no-results/index.php
@@ -31,7 +31,7 @@ function render_block_core_query_no_results( $attributes, $content, $block ) {
 		$query      = new WP_Query( $query_args );
 	}
 
-	if ( ! $query->have_posts() ) {
+	if ( $query->have_posts() ) {
 		return '';
 	}
 

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -147,7 +147,7 @@ export default function QueryInspectorControls( {
 						onChange={ setQuery }
 					/>
 				) }
-				{ showSticky && (
+				{ ! inherit && showSticky && (
 					<StickyControl
 						value={ sticky }
 						onChange={ ( value ) => setQuery( { sticky: value } ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #38979

## Why?
Because the setting not just doesn't work.

## How?
We hide the setting when inherit is true.

## Testing Instructions

1. Switch to a block theme (e.g. TT2)
2. Create a sticky post
3. Look at a template with a query loop in it (e.g. home.html)
4. Confirm that if the block has inherit query you cannot set sticky posts.

## Notes
This PR has explored allowing sticky post behaviour on inherit but the result was consistently unreliable, one or another query var would be overwritten either by WP_Query or by the query block.

Therefore the PR hides the setting and fixes the server rendering of the block to truly inherit, without interfering with the current WP_Query in any way.

Co-authored-by: Jonny Harris <237508+spacedmonkey@users.noreply.github.com>
Co-authored-by: Huub <50170696+huubl@users.noreply.github.com>
