### PR TITLE
Nav link block PHP tests replace prefixed function with non-prefixed

### DIFF
--- a/phpunit/class-block-library-navigation-link-test.php
+++ b/phpunit/class-block-library-navigation-link-test.php
@@ -102,7 +102,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				gutenberg_render_block_core_navigation_link(
+				render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -123,7 +123,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$navigation_link_block = new WP_Block( $parsed_blocks[0], array() );
 		$this->assertEquals(
 			'',
-			gutenberg_render_block_core_navigation_link(
+			render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -143,7 +143,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'',
-			gutenberg_render_block_core_navigation_link(
+			render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -163,7 +163,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				gutenberg_render_block_core_navigation_link(
+				render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -183,7 +183,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				gutenberg_render_block_core_navigation_link(
+				render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block
@@ -205,7 +205,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 
 		$this->assertEquals(
 			'',
-			gutenberg_render_block_core_navigation_link(
+			render_block_core_navigation_link(
 				$navigation_link_block->attributes,
 				array(),
 				$navigation_link_block
@@ -225,7 +225,7 @@ class Block_Library_Navigation_Link_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			true,
 			strpos(
-				gutenberg_render_block_core_navigation_link(
+				render_block_core_navigation_link(
 					$navigation_link_block->attributes,
 					array(),
 					$navigation_link_block


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Replaces the usage of  prefixed `gutenberg_render_block_core_navigation_link` with non-prefixed `render_block_core_navigation_link` in [the PHP Unit tests](https://github.com/WordPress/gutenberg/blob/trunk/phpunit/class-block-library-navigation-link-test.php#L105).

Here's an example where they are failing:

https://github.com/WordPress/gutenberg/runs/6195031409?check_suite_focus=true



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like the Nav Link block PHP Unit tests have been relying on the `gutenberg_` prefixed version of the block's render function.

https://github.com/WordPress/gutenberg/blob/b8aa52dc4a1fe3887be27d5f3d1a77b409dc8750/phpunit/class-block-library-navigation-link-test.php#L105

However, this function [does not exist in Gutenberg Core](https://github.com/WordPress/gutenberg/search?q=gutenberg_render_block_core_navigation_link) so I assume it existed in WP Core. It looks like it was recently removed and thus causes a bug in the PHP unit tests.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just renaming.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Run PHP unit tests for `phpunit/class-block-library-navigation-link-test.php`. Check no failures.

## Screenshots or screencast <!-- if applicable -->

Example of failing tests
<img width="881" alt="Screen Shot 2022-04-27 at 16 39 42" src="https://user-images.githubusercontent.com/444434/165557260-b4bed77a-0dbe-466c-a7d5-406495dc1f68.png">

