### PR TITLE
Mobile - DroppingInsertionPoint - Hide indicator when it overflows outside the content

### DIFF
--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -57,7 +57,7 @@ export default function DroppingInsertionPoint( {
 	const safeAreaOffset = insets.top + insets.bottom;
 	const maxHeight =
 		height -
-		( safeAreaOffset + styles[ 'dropping-insertion-point' ].height );
+		( safeAreaOffset + styles[ 'dropping-insertion-point' ]?.height );
 
 	const blockYPosition = useSharedValue( 0 );
 	const opacity = useSharedValue( 0 );

--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useWindowDimensions } from 'react-native';
 import Animated, {
 	useSharedValue,
 	useAnimatedStyle,
@@ -9,7 +8,10 @@ import Animated, {
 	useAnimatedReaction,
 	runOnJS,
 } from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+	useSafeAreaInsets,
+	useSafeAreaFrame,
+} from 'react-native-safe-area-context';
 
 /**
  * WordPress dependencies
@@ -52,12 +54,12 @@ export default function DroppingInsertionPoint( {
 	} = useSelect( blockEditorStore );
 
 	const { blocksLayouts, findBlockLayoutByClientId } = useBlockListContext();
-	const insets = useSafeAreaInsets();
-	const { height } = useWindowDimensions();
-	const safeAreaOffset = insets.top + insets.bottom;
+	const { top, bottom } = useSafeAreaInsets();
+	const { height } = useSafeAreaFrame();
+	const safeAreaOffset = top + bottom;
 	const maxHeight =
 		height -
-		( safeAreaOffset + styles[ 'dropping-insertion-point' ]?.height );
+		( safeAreaOffset + styles[ 'dropping-insertion-point' ].height );
 
 	const blockYPosition = useSharedValue( 0 );
 	const opacity = useSharedValue( 0 );

--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useWindowDimensions } from 'react-native';
 import Animated, {
 	useSharedValue,
 	useAnimatedStyle,
@@ -8,6 +9,7 @@ import Animated, {
 	useAnimatedReaction,
 	runOnJS,
 } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 /**
  * WordPress dependencies
@@ -50,6 +52,12 @@ export default function DroppingInsertionPoint( {
 	} = useSelect( blockEditorStore );
 
 	const { blocksLayouts, findBlockLayoutByClientId } = useBlockListContext();
+	const insets = useSafeAreaInsets();
+	const { height } = useWindowDimensions();
+	const safeAreaOffset = insets.top + insets.bottom;
+	const maxHeight =
+		height -
+		( safeAreaOffset + styles[ 'dropping-insertion-point' ].height );
 
 	const blockYPosition = useSharedValue( 0 );
 	const opacity = useSharedValue( 0 );
@@ -144,11 +152,16 @@ export default function DroppingInsertionPoint( {
 	);
 
 	const animatedStyles = useAnimatedStyle( () => {
+		const translationY = blockYPosition.value - scroll.offsetY.value;
+		// Prevents overflowing behind the header/footer
+		const shouldHideIndicator =
+			translationY < 0 || translationY > maxHeight;
+
 		return {
-			opacity: opacity.value,
+			opacity: shouldHideIndicator ? 0 : opacity.value,
 			transform: [
 				{
-					translateY: blockYPosition.value - scroll.offsetY.value,
+					translateY: translationY,
 				},
 			],
 		};

--- a/packages/editor/src/components/provider/index.native.js
+++ b/packages/editor/src/components/provider/index.native.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import memize from 'memize';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 /**
  * WordPress dependencies
@@ -333,7 +334,7 @@ class NativeEditorProvider extends Component {
 					settings={ editorSettings }
 					{ ...props }
 				>
-					{ children }
+					<SafeAreaProvider>{ children }</SafeAreaProvider>
 				</EditorProvider>
 				<EditorHelpTopics
 					isVisible={ this.state.isHelpVisible }

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -159,4 +159,7 @@ module.exports = {
 	'header-toolbar__container': {
 		height: 44,
 	},
+	'dropping-insertion-point': {
+		height: 3,
+	},
 };

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -132,8 +132,10 @@ jest.mock( 'react-native-safe-area', () => {
 	};
 } );
 
+// To be replaced with built in mocks when we upgrade to the latest version
 jest.mock( 'react-native-safe-area-context', () => {
 	const inset = { top: 0, right: 0, bottom: 0, left: 0 };
+	const frame = { x: 0, y: 0, width: 0, height: 0 };
 	return {
 		SafeAreaProvider: jest
 			.fn()
@@ -142,6 +144,7 @@ jest.mock( 'react-native-safe-area-context', () => {
 			.fn()
 			.mockImplementation( ( { children } ) => children( inset ) ),
 		useSafeAreaInsets: jest.fn().mockImplementation( () => inset ),
+		useSafeAreaFrame: jest.fn().mockImplementation( () => frame ),
 	};
 } );
 

--- a/test/native/setup.js
+++ b/test/native/setup.js
@@ -132,6 +132,19 @@ jest.mock( 'react-native-safe-area', () => {
 	};
 } );
 
+jest.mock( 'react-native-safe-area-context', () => {
+	const inset = { top: 0, right: 0, bottom: 0, left: 0 };
+	return {
+		SafeAreaProvider: jest
+			.fn()
+			.mockImplementation( ( { children } ) => children ),
+		SafeAreaConsumer: jest
+			.fn()
+			.mockImplementation( ( { children } ) => children( inset ) ),
+		useSafeAreaInsets: jest.fn().mockImplementation( () => inset ),
+	};
+} );
+
 jest.mock(
 	'@react-native-community/slider',
 	() => {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4722

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes an issue with the dropping insertion indicator where it was showing behind the header and footer of the app.

## Why?
It shouldn't overflow outside the editor area.

## How?
By getting the safe area insets and the height of the screen to calculate the maximum value where the indicator shouldn't go outside from.

If the `translationY` value is a negative value or is higher than the `maxHeight` value it should be hidden.

It also adds the `SafeAreaProvider` to be able to use the `useSafeAreaInsets` hook.

## Testing Instructions
- Open the app with the initial HTML content
- Scroll to the Gallery block, it's easier to test with a block that has a lot of content
- Start dragging the block slowly as it is shown in the GIF below
- **Expect to not** see the indicator overflowing through the header or footer of the app.

## Screenshots or screencast <!-- if applicable -->
<kbd><img src="https://user-images.githubusercontent.com/4885740/165706492-3da05262-4184-4b06-aa56-153c37869033.gif" width=200 /></kbd>