### PR TITLE
Prevent spam links of author's name in pending moderation comments

### DIFF
--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -18,7 +18,9 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$comment = get_comment( $block->context['commentId'] );
+	$comment            = get_comment( $block->context['commentId'] );
+	$commenter          = wp_get_current_commenter();
+	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
 	if ( empty( $comment ) ) {
 		return '';
 	}
@@ -37,6 +39,9 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 
 	if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
 		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
+	}
+	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
+		$comment_author = wp_kses( $comment_author, array() );
 	}
 
 	return sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Do not include the author link regardless of the block settings ([see wp-develop source](https://github.com/WordPress/wordpress-develop/blob/3fdce9eb4b13ab9e9f52c5636b730aaa43740b12/src/wp-includes/class-walker-comment.php#L329-L333)). Issue mentioned in #40601.

⚠️ Needs #40612 to be merged.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
@peterwilsoncc mentioned that he remembered some anti-spam measures WP Core had to put in for visitors using the moderation hash, so he has edited the original ticket (#40601) to note it.

[Link to the comment](https://github.com/WordPress/gutenberg/pull/40612#pullrequestreview-954243418)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By adding a check that requires that:
 - The comment is not approved
 - We have not defined the current commenter, this means there are no cookies on the browser with the user that made the comment. These checks prevent sharing the hashed link in public to get the link working. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
Needs #40612 to be merged before testing. Or at least the function `build_comment_query_vars_from_block` with the unapproved comments fix backported to Core.

1.) Create a post. Add Comments Query Loop.
2.) Logout 
3.) Use the form to add a comment or a reply, fill the `website` field. Do not check the checkbox saying "save my name, email...."
![Screenshot 2022-04-27 at 19 20 16](https://user-images.githubusercontent.com/37012961/165583499-abcc7beb-c779-4b7c-aa64-751874993a2a.png)
4.) After submitting, check that the Comment Author is not linking anywhere.
5.) Repeat 3, but in this case, enable the checkbox.
6.) Check that now the Comment Author is linking to the website provided in the previous website field.
