### PR TITLE
Babel Preset: Add support for decorators

### DIFF
--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -91,6 +91,12 @@ module.exports = ( api ) => {
 				},
 			],
 			maybeGetPluginTransformRuntime(),
+      [
+        require.resolve( '@babel/plugin-proposal-decorators' ),
+        {
+          legacy: true,
+        },
+      ]
 		].filter( Boolean ),
 	};
 };

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -30,6 +30,7 @@
 	"main": "index.js",
 	"dependencies": {
 		"@babel/core": "^7.16.0",
+		"@babel/plugin-proposal-decorators": "^7.17.9",
 		"@babel/plugin-transform-react-jsx": "^7.16.0",
 		"@babel/plugin-transform-runtime": "^7.16.0",
 		"@babel/preset-env": "^7.16.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds support for decorators to babel-preset-default.

## Why?
Addresses https://github.com/WordPress/gutenberg/issues/39435.

## How?
Adds the `@babel/plugin-proposal-decorators` plugin to the index.js file.

## Testing Instructions
Run `npm run start` on a block script that uses decorators.
