### PR TITLE
Try: Fix regression with featured images in latest posts.

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -63,10 +63,14 @@
 	&.alignleft {
 		/*rtl:ignore*/
 		margin-right: 1em;
+		/*rtl:ignore*/
+		float: left;
 	}
 	&.alignright {
 		/*rtl:ignore*/
 		margin-left: 1em;
+		/*rtl:ignore*/
+		float: right;
 	}
 	&.aligncenter {
 		margin-bottom: 1em;


### PR DESCRIPTION
## What?

The Latest Posts block has an option to float featured images left and right:
<img width="228" alt="Screenshot 2022-04-27 at 22 20 31" src="https://user-images.githubusercontent.com/1204802/165624504-9328b5e4-e22c-4e26-b78b-9dc4e544379e.png">

In the editor, this works:

<img width="377" alt="Screenshot 2022-04-27 at 22 20 20" src="https://user-images.githubusercontent.com/1204802/165624534-0673cb37-2987-414a-b4d2-3cb7c9dad747.png">

On the frontend, as of #38657, it doesnt, because the float rule is missing:

<img width="331" alt="Screenshot 2022-04-27 at 22 20 24" src="https://user-images.githubusercontent.com/1204802/165624557-150bb094-c601-4017-ac22-f244614b65d7.png">

This PR restores the float rule, but just for the latest posts block. 

## Testing Instructions

* Create a number of published posts that all have featured images
* Use the Latest Posts block
* Set featured images to be shown, and aligned left
* Observe that the editor and frontend look the same.