### PR TITLE
LatestPost: Fix issue with floated featured images overflowing focus style

### DIFF
--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -3,6 +3,11 @@
 	&.is-grid {
 		padding-left: 0;
 	}
+
+	// Apply overflow for post items, so any floated featured images won't crop the focus style.
+	> li {
+		overflow: hidden;
+	}
 }
 
 .wp-block-latest-posts li a > div {


### PR DESCRIPTION
## What?

A mostly cosmetic companion to #40662. When you use a left-floated featured image in the latest posts block, then the focus style for the selected block is cut off in the editor:

<img width="466" alt="Screenshot 2022-04-27 at 22 03 44" src="https://user-images.githubusercontent.com/1204802/165626169-e47ba4c2-994d-4c23-a643-20e113f472a9.png">

This happens because the float rule takes the image out of the flow. But the block appears broken. This PR adds an overflow rule to make the focus style appear to contain the entire block:

<img width="513" alt="Screenshot 2022-04-27 at 22 29 01" src="https://user-images.githubusercontent.com/1204802/165626651-7a5ce8b2-c0a7-443d-a97d-bc3dc09c3e84.png">

## Testing Instructions

* Create a number of published posts that all have featured images
* Use the Latest Posts block
* Set featured images to be shown, and aligned left
* Select the latest posts block and the focus style should contain the entire block

