### PR TITLE
Try: Add a clickable Group setup state

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -56,7 +56,7 @@
 
 // Show an unselected empty group button as a dashed outline instead of the appender button.
 // This effectively adds a selectable-to-delete state.
-.is-layout-default.block-editor-block-list__block:not(.is-selected) {
+.is-layout-flow.block-editor-block-list__block:not(.is-selected) {
 	.block-list-appender:only-child {
 		pointer-events: none;
 

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -53,3 +53,28 @@
 		pointer-events: all;
 	}
 }
+
+// Show an unselected empty group button as a dashed outline instead of the appender button.
+// This effectively adds a selectable-to-delete state.
+.is-layout-default.block-editor-block-list__block:not(.is-selected) {
+	.block-list-appender:only-child {
+		pointer-events: none;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+			border: $border-width dashed currentColor;
+			opacity: 0.4;
+			border-radius: $radius-block-ui;
+			pointer-events: none;
+		}
+
+		.block-editor-inserter {
+			visibility: hidden;
+		}
+	}
+}

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -44,7 +44,7 @@
 		border-radius: $radius-block-ui;
 		flex: 1;
 		pointer-events: none;
-		min-height: $grid-unit-60;
+		min-height: $grid-unit-60 - $border-width - $border-width;
 	}
 
 	// Let the parent be selectable in the placeholder area.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -42,7 +42,7 @@
 		border: $border-width dashed currentColor;
 		opacity: 0.4;
 		border-radius: $radius-block-ui;
-		flex: 1;
+		flex: 1 0 $grid-unit-60;
 		pointer-events: none;
 		min-height: $grid-unit-60 - $border-width - $border-width;
 	}
@@ -57,7 +57,7 @@
 // Show an unselected empty group button as a dashed outline instead of the appender button.
 // This effectively adds a selectable-to-delete state.
 .is-layout-flow.block-editor-block-list__block:not(.is-selected) {
-	.block-list-appender:only-child {
+	> .block-list-appender:only-child {
 		pointer-events: none;
 
 		&::after {


### PR DESCRIPTION
## What?

Fixes #33025. 

This is a pretty experimental PR, I'd love thoughts on whether this is fundamentally a good idea.

If you insert an empty group block, there's a big appender button to add content inside. That's good enough, as your next step is likely going to be filling in the group. The downside is that you can't, in the canvas, select an empty group to delete it, because you always click the inserter button when trying to select the empty group, as shown in this gif:

![group before](https://user-images.githubusercontent.com/1204802/165634450-772715f0-513a-48cf-8319-9dda66c62303.gif)

This PR follows in the footsteps of changes to the Row and Stack variations, and lets the block have a resting state showing a dashed outline — a literal placeholder. On select, the appender button becomes visible. In effect this means you can select and delete the block, or you can select the block and then click again to insert content inside, as shown in this gif:

![group after](https://user-images.githubusercontent.com/1204802/165634593-e03f676c-194e-435d-8e47-6140af94a3af.gif)

## Why?

The ability to select the row and stack blocks without invoking the inserter popout is a nice aspect that I find myself missing on the base Group block.

## Testing Instructions

Insert an empty group block. Deselect it, then select it again. 

Be sure to test drag and drop, uploads, and various other container blocks. These changes should not affect any of those, and should only change the appearance of the empty group.
