### PR TITLE
[Block] Display paragraph breaks in comment contents block. 

### DIFF
--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -23,10 +23,14 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment_text = get_comment_text( $comment );
+	$args         = array();
+	$comment_text = get_comment_text( $comment, $args );
 	if ( ! $comment_text ) {
 		return '';
 	}
+
+	/** This filter is documented in wp-includes/comment-template.php */
+	$comment_text = apply_filters( 'comment_text', $comment_text, $comment, $args );
 
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -137,9 +137,9 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
-		$this->assertDiscardWhitespace(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
-			gutenberg_render_block_core_comment_template( null, null, $block )
+		$this->assertSame(
+			str_replace( array( "\n", "\t" ), '', '<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>' ),
+			str_replace( array( "\n", "\t" ), '', gutenberg_render_block_core_comment_template( null, null, $block ) )
 		);
 	}
 
@@ -241,8 +241,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 END
 		);
 
-		$this->assertDiscardWhitespace(
-			gutenberg_render_block_core_comment_template( null, null, $block ),
+		$this->assertSame(
+			str_replace( array( "\n", "\t" ), '', gutenberg_render_block_core_comment_template( null, null, $block ) ),
 			$expected
 		);
 	}

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -299,7 +299,7 @@ END
 			'<!-- wp:comment-template --><!-- wp:comment-content /--><!-- /wp:comment-template -->'
 		);
 
-		$block  = new WP_Block(
+		$block = new WP_Block(
 			$parsed_blocks[0],
 			array(
 				'postId'           => self::$custom_post->ID,

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -138,7 +138,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content">Hello world</div></li></ol>',
+			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
 	}
@@ -200,7 +200,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 							</a>
 						</div>
 						<div class="wp-block-comment-content">
-							Hello world
+							<p>Hello world</p>
 						</div>
 						<ol>
 							<li id="comment-{$first_level_ids[0]}" class="comment even depth-2">
@@ -232,7 +232,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 									</a>
 								</div>
 								<div class="wp-block-comment-content">
-									Hello world
+									<p>Hello world</p>
 								</div>
 							</li>
 						</ol>
@@ -307,12 +307,12 @@ END
 			)
 		);
 
-		$expected_content = "<p>Paragraph One</p>\n\n<p>P2L1<br/>\nP2L2</p>\n\n<p>https://example.com/</p>";
+		$expected_content = "<p>Paragraph One</p>\n\n<p>P2L1<br />\nP2L2</p>\n\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>";
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
-		$this->assertEquals(
-			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
+		$this->assertSame(
+			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-content">' . $expected_content . '</div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
 	}

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -210,7 +210,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 									</a>
 								</div>
 								<div class="wp-block-comment-content">
-									Hello world
+									<p>Hello world</p>
 								</div>
 								<ol>
 									<li id="comment-{$second_level_ids[0]}" class="comment odd alt depth-3">
@@ -220,7 +220,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 											</a>
 										</div>
 										<div class="wp-block-comment-content">
-											Hello world
+											<p>Hello world</p>
 										</div>
 									</li>
 								</ol>
@@ -307,7 +307,7 @@ END
 			)
 		);
 
-		$expected_content = "<p>Paragraph One</p>\n\n<p>P2L1<br />\nP2L2</p>\n\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>\n";
+		$expected_content = "<p>Paragraph One</p>\n<p>P2L1<br />\nP2L2</p>\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>\n";
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -137,7 +137,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
-		$this->assertEquals(
+		$this->assertDiscardWhitespace(
 			'<ol ><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li></ol>',
 			gutenberg_render_block_core_comment_template( null, null, $block )
 		);
@@ -241,7 +241,7 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 END
 		);
 
-		$this->assertEquals(
+		$this->assertDiscardWhitespace(
 			gutenberg_render_block_core_comment_template( null, null, $block ),
 			$expected
 		);
@@ -307,7 +307,7 @@ END
 			)
 		);
 
-		$expected_content = "<p>Paragraph One</p>\n\n<p>P2L1<br />\nP2L2</p>\n\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>";
+		$expected_content = "<p>Paragraph One</p>\n\n<p>P2L1<br />\nP2L2</p>\n\n<p><a href=\"https://example.com/\" rel=\"nofollow ugc\">https://example.com/</a></p>\n";
 
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #40248.

Apply `comment_text` filter in comment template to ensure paragraph breaks, smilies, links, etc are displayed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure comments in a block theme are displayed with the original paragraph breaks included during authoring. Presently the content is shown as one blob which can become difficult to read. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Traditional WP themes use `comment_template()` to echo the comment content.

```php
function comment_text( $comment_ID = 0, $args = array() ) {
	$comment = get_comment( $comment_ID );

	$comment_text = get_comment_text( $comment, $args );
	/**
	 * Filters the text of a comment to be displayed.
	 *
	 * @since 1.2.0
	 *
	 * @see Walker_Comment::comment()
	 *
	 * @param string          $comment_text Text of the current comment.
	 * @param WP_Comment|null $comment      The comment object. Null if not found.
	 * @param array           $args         An array of arguments.
	 */
	echo apply_filters( 'comment_text', $comment_text, $comment, $args );
}
```

The final echo statement rules out it's use for rendering the template block but applying the same filter ensures parity in display between the comment loop and comment template.

## Testing Instructions
1. Test using WP 5.9 (`trunk` will use the previously merged functions)
2. Enable 2022 with a block theme using the comment query loop
3. Checkout gutenberg `trunk`
4. Leave a comment with two or more paragraphs
5. View the comment on the front end, observe it's one blob of text.
6. Switch to this branch
7. Reload the front end and your paragraphs will be visible once again.


## Screenshots or screencast <!-- if applicable -->

**Before**
![Screen Shot 2022-04-28 at 12 13 00 pm](https://user-images.githubusercontent.com/519727/165663015-b5762a55-1e19-4bd0-b9ab-76ba6922a83c.png)

**After**
![Screen Shot 2022-04-28 at 12 13 29 pm](https://user-images.githubusercontent.com/519727/165663043-27a43821-cd56-489e-a5ff-c971aea6f37d.png)

