### PR TITLE
Fix `batchRest` not throwing errors in Playwright

### DIFF
--- a/packages/e2e-test-utils-playwright/src/request/rest.ts
+++ b/packages/e2e-test-utils-playwright/src/request/rest.ts
@@ -168,7 +168,10 @@ async function batchRest< BatchResponse >(
 		return chunkResponses.flat();
 	}
 
-	const { responses } = await this.rest< { responses: BatchResponse[] } >( {
+	const batchResponses = await this.rest< {
+		failed?: string;
+		responses: BatchResponse[];
+	} >( {
 		method: 'POST',
 		path: '/batch/v1',
 		data: {
@@ -177,7 +180,11 @@ async function batchRest< BatchResponse >(
 		},
 	} );
 
-	return responses;
+	if ( batchResponses.failed ) {
+		throw batchResponses;
+	}
+
+	return batchResponses.responses;
 }
 
 export { setupRest, rest, getMaxBatchSize, batchRest };

--- a/packages/e2e-test-utils-playwright/src/request/widgets.js
+++ b/packages/e2e-test-utils-playwright/src/request/widgets.js
@@ -16,12 +16,15 @@ export async function deleteAllWidgets() {
 		} ) )
 	);
 
-	await this.batchRest(
-		sidebars.map( ( sidebar ) => ( {
-			method: 'POST',
-			path: `/wp/v2/sidebars/${ sidebar.id }`,
-			body: { id: sidebar.id, widgets: [] },
-		} ) )
+	// The endpoint doesn't support batch requests yet.
+	await Promise.all(
+		sidebars.map( ( sidebar ) =>
+			this.rest( {
+				method: 'POST',
+				path: `/wp/v2/sidebars/${ sidebar.id }`,
+				data: { id: sidebar.id, widgets: [] },
+			} )
+		)
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix `batchRest` incorrectly swallowing errors.

Turns out the batch API will still return 2XX status code even when some of the requests failed. We have to manually check the `failed` field in the response. Not sure if it's a bug or not.

This PR also fixes an existing bug in the widgets util. Surprisingly, it didn't affect any of the tests though, maybe we don't need them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The bug makes it hard to debug why the API doesn't work in some context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check the `failed` field and re-throw the errors.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
CI should pass.
