### PR TITLE
Navigation block "Open on click": Inherit font style and font weight

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -299,6 +299,8 @@ button.wp-block-navigation-item__content {
 	font-size: inherit;
 	font-family: inherit;
 	line-height: inherit;
+	font-style: inherit;
+	font-weight: inherit;
 
 	// Buttons default to center alignment. This becomes visible
 	// when a menu item label is long enough to wrap.

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -301,6 +301,7 @@ button.wp-block-navigation-item__content {
 	line-height: inherit;
 	font-style: inherit;
 	font-weight: inherit;
+	text-transform: inherit;
 
 	// Buttons default to center alignment. This becomes visible
 	// when a menu item label is long enough to wrap.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Closes https://github.com/WordPress/gutenberg/issues/40669

When the navigation block "Open on click" option is enabled, the menu item link is replaced with a button.
This pr assures that the typography _Appearance_  and _Letter case_ settings work when the option is enabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The font appearance of the menu item should be the same no matter if the "Open on click" option is enabled or not.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds `font-style: inherit;	font-weight: inherit; text-transform: inherit;` when the navigation item is a button (`button.wp-block-navigation-item__content`).

## Testing Instructions
Make sure that you have a child page on your WordPress install, to test the page list with child pages.

1. Add a navigation block with a few items. **Use both the page list and custom links.**
2. Add a submenu item with a submenu item to one of the menu links.
3. Change the appearance and letter casing options.
4. Enable the option "Open on click".
5. Confirm that the menu items have the same style.
6. Save and view the front. Confirm that the menu items have the same style.
7. Enable the responsive menu and confirm that the menu items have the same style.

## Screenshots or screencast <!-- if applicable -->
Before:
![the menu item links and the parent menu items do not have the same style](https://user-images.githubusercontent.com/7422055/165687140-ac4cb8b0-af87-44c7-bfef-5c24bddd4514.png)

After:
![the menu item links and the parent menu items have the same style](https://user-images.githubusercontent.com/7422055/165686571-dd933642-aaa7-48a8-ad15-e3517b66eecd.png)
