### PR TITLE
Revert "Allow negative values for margin inputs (#40464)"

### DIFF
--- a/packages/block-editor/src/hooks/margin.js
+++ b/packages/block-editor/src/hooks/margin.js
@@ -143,7 +143,6 @@ export function MarginEdit( props ) {
 					units={ units }
 					allowReset={ false }
 					splitOnAxis={ splitOnAxis }
-					allowNegativeValues={ true }
 				/>
 			</>
 		),

--- a/packages/components/src/box-control/index.js
+++ b/packages/components/src/box-control/index.js
@@ -46,7 +46,7 @@ function useUniqueId( idProp ) {
 }
 export default function BoxControl( {
 	id: idProp,
-	inputProps,
+	inputProps = defaultInputProps,
 	onChange = noop,
 	label = __( 'Box Control' ),
 	values: valuesProp,
@@ -55,10 +55,7 @@ export default function BoxControl( {
 	splitOnAxis = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
-	allowNegativeValues = false,
 } ) {
-	inputProps = allowNegativeValues ? { min: -Infinity } : defaultInputProps;
-
 	const [ values, setValues ] = useControlledState( valuesProp, {
 		fallback: DEFAULT_VALUES,
 	} );


### PR DESCRIPTION
This reverts commit a109d31c02042ad3c6e055f7aea61de9c999e57b.

Following the comments in https://github.com/WordPress/gutenberg/pull/40464#issuecomment-1111779685, this PR reverts the commit so that we can have a bigger discussion and an actionable plan before committing to this.

cc @aaronrobertshaw @ndiego @JustinyAhin 
