### PR TITLE
useSelect: prevent nested component update after unmount

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -191,6 +191,8 @@ export default function useSelect( mapSelect, deps ) {
 		}
 	} );
 
+	const isMounted = useRef( false );
+
 	useIsomorphicLayoutEffect( () => {
 		if ( ! hasMappingFunction ) {
 			return;
@@ -211,6 +213,10 @@ export default function useSelect( mapSelect, deps ) {
 		};
 
 		const onChange = () => {
+			if ( ! isMounted.current ) {
+				return;
+			}
+
 			if ( latestIsAsync.current ) {
 				renderQueue.add( queueContext, onStoreChange );
 			} else {
@@ -226,10 +232,13 @@ export default function useSelect( mapSelect, deps ) {
 			registry.__unstableSubscribeStore( storeName, onChange )
 		);
 
+		isMounted.current = true;
+
 		return () => {
 			// The return value of the subscribe function could be undefined if the store is a custom generic store.
 			unsubscribers.forEach( ( unsubscribe ) => unsubscribe?.() );
 			renderQueue.cancel( queueContext );
+			isMounted.current = false;
 		};
 		// If you're tempted to eliminate the spread dependencies below don't do it!
 		// We're passing these in from the calling function and want to make sure we're

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -162,7 +162,7 @@ describe( 'useSelect', () => {
 		// dispatch in a different event loop tick, where the batched updates are no longer active.
 		await act( async () => {
 			await Promise.resolve();
-			registry.dispatch( 'testStore' ).toggle();
+			registry.dispatch( 'toggler' ).toggle();
 		} );
 
 		// Child was rendered and subscribed to the store, as the _second_ subscription.
@@ -172,7 +172,7 @@ describe( 'useSelect', () => {
 
 		await act( async () => {
 			await Promise.resolve();
-			registry.dispatch( 'testStore' ).toggle();
+			registry.dispatch( 'toggler' ).toggle();
 		} );
 
 		// Check that child was unmounted without any extra state update being performed on it.


### PR DESCRIPTION
Fixes a regression reported by @youknowriad: https://github.com/WordPress/gutenberg/pull/40433#issuecomment-1110760689

When there is a parent and a child component that both listen to the same store, and when on a store update the parent unmounts the child, the same store update still triggered a state update on the child, although it was already unmounted.

To trigger the bug, the listeners need to be registered in certain order (parent first, child second), and React batched updates must not be active. It takes some effort to reproduce these conditions in a test.

To fix this, I re-introduced an `isMounted` check to the `onStoreChange` callback. A more correct solution would be "nested subscriptions" that are used by `react-redux`, where the parent component manages the subscriptions of its children.

**How to test:**
1. Select a block. Block toolbar will appear.
2. Click somewhere outside any block, so that the `clearSelectedBlock` action is dispatched and the block toolbar is unmounted.
3. Verify that this action doesn't trigger a "state update on an unmounted component" warning.

There is also a new unit test that fails before this PR, and passes after the patch.