### PR TITLE
useSelect: improve transition from async to sync mode

### DIFF
--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -884,10 +884,10 @@ describe( 'useSelect', () => {
 			// Ensure the async update was flushed during the rerender.
 			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 1 );
 
-			// initial render + subscription check + flushed store update
+			// initial render + subscription check + rerender with isAsync=false
 			expect( selectSpy ).toHaveBeenCalledTimes( 3 );
-			// initial render + rerender with isAsync=false + store state update
-			expect( TestComponent ).toHaveBeenCalledTimes( 3 );
+			// initial render + rerender with isAsync=false
+			expect( TestComponent ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		it( 'cancels scheduled updates when mapSelect function changes', async () => {


### PR DESCRIPTION
This PR refactors `useSelect` code that makes sure that when the component is switching from async to sync mode, then the state updates scheduled while still in async mode won't be forgotten.

The old code achieved that by flushing the render queue during the transition, which means synchronously calling `onStoreChange` and reading the new state from stores.

The new code reads the new state from stores, too, but does it by doing a `hasLeftAsyncMode` check and calling `mapSelect` if the check is true. It's an addition to the set of existing checks that trigger call of `mapSelect`: change of registry, change of the `mapSelect` function itself (and its dependencies), and failure on previous call.

Why is this change for the better? Because it removes a `renderQueue.flush` call, and concentrates all `renderQueue` references into the effect that maintains store subscriptions and calls the `onStoreChange` callback. That makes it easier to extract that effect to a separate hook, i.e., finishing the work in #40093.

**How to test:**
Covered by unit tests, namely the "catches updates while switching from async to sync" one. See also #19286 which describes the conditions where doing the async->sync transition incorrectly can lead to UI bugs.