### PR TITLE
Fix style comment awaiting moderation indentation

### DIFF
--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -44,12 +44,13 @@
 	.comment-meta {
 		font-size: 0.875em;
 		line-height: 1.5;
-		margin-left: -3.25em;
 		b {
 			font-weight: normal;
 		}
 		.comment-awaiting-moderation {
-			margin-left: 3.25em;
+			margin-top: 1em;
+			margin-bottom: 1em;
+			display: block;
 		}
 	}
 

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -45,9 +45,11 @@
 		font-size: 0.875em;
 		line-height: 1.5;
 		margin-left: -3.25em;
-
 		b {
 			font-weight: normal;
+		}
+		.comment-awaiting-moderation {
+			margin-left: 3.25em;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixed indentation on `Post Comments Block` of the moderation warning message.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1) Create a post. Log out.
2) Add a Comment. Check that the moderation message appears/
3) On trunk, it should have a negative margin left. Screenshot attached.
4) On the branch, it should be aligned with the rest of the comment metadata text. Screenshot attached.

## Screenshots or screencast <!-- if applicable -->


Before:
![Screenshot 2022-04-28 at 13 13 35](https://user-images.githubusercontent.com/37012961/165740423-b61d73ff-8f11-4d71-91ba-ef895b83ecb2.png)

After:
![Screenshot 2022-04-28 at 13 12 21](https://user-images.githubusercontent.com/37012961/165740449-c19175ad-afd7-449b-b379-fbdf74e8d762.png)

