### PR TITLE
Add arrows to post navigation link

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -60,7 +60,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, spacing (blockGap, margin)
--	**Attributes:** 
+-	**Attributes:**
 
 ## Calendar
 
@@ -168,7 +168,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Comments
 
@@ -204,7 +204,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
 -	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Previous Page
 
@@ -420,7 +420,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Name:** core/nextpage
 -	**Category:** design
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Page List
 
@@ -519,7 +519,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Post Date
 
@@ -555,7 +555,7 @@ Displays the next or previous post link that is adjacent to the current post. ([
 -	**Name:** core/post-navigation-link
 -	**Category:** theme
 -	**Supports:** color (background, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** label, linkLabel, showTitle, textAlign, type
+-	**Attributes:** arrow, label, linkLabel, showTitle, textAlign, type
 
 ## Post Template
 
@@ -564,7 +564,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Name:** core/post-template
 -	**Category:** theme
 -	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Post Terms
 
@@ -618,7 +618,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Name:** core/query-no-results
 -	**Category:** theme
 -	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Pagination
 
@@ -645,7 +645,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:** 
+-	**Attributes:**
 
 ## Previous Page
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -60,7 +60,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Name:** core/buttons
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, spacing (blockGap, margin)
--	**Attributes:**
+-	**Attributes:** 
 
 ## Calendar
 
@@ -168,7 +168,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Comments
 
@@ -204,7 +204,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
 -	**Supports:** typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Previous Page
 
@@ -420,7 +420,7 @@ Separate your content into a multi-page experience. ([Source](https://github.com
 -	**Name:** core/nextpage
 -	**Category:** design
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Page List
 
@@ -519,7 +519,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 -	**Name:** core/post-content
 -	**Category:** theme
 -	**Supports:** align (full, wide), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Post Date
 
@@ -564,7 +564,7 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Name:** core/post-template
 -	**Category:** theme
 -	**Supports:** align, typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Post Terms
 
@@ -618,7 +618,7 @@ Contains the block elements used to render content when no query results are fou
 -	**Name:** core/query-no-results
 -	**Category:** theme
 -	**Supports:** align, color (background, gradients, link, text), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Pagination
 
@@ -645,7 +645,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
--	**Attributes:**
+-	**Attributes:** 
 
 ## Previous Page
 

--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -24,6 +24,10 @@
 		"linkLabel": {
 			"type": "boolean",
 			"default": false
+		},
+		"arrow": {
+			"type": "string",
+			"default": "none"
 		}
 	},
 	"supports": {
@@ -45,5 +49,6 @@
 				"fontSize": true
 			}
 		}
-	}
+	},
+	"style": "wp-block-post-navigation-link"
 }

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -30,8 +30,8 @@ export default function PostNavigationLinkEdit( {
 
 	const arrowMap = {
 		none: '',
-		arrow: isNext ? '←' : '→',
-		chevron: isNext ? '«' : '»',
+		arrow: isNext ? '→' : '←',
+		chevron: isNext ? '»' : '«',
 	};
 
 	const displayArrow = arrowMap[ arrow ];
@@ -120,9 +120,9 @@ export default function PostNavigationLinkEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
-				{ isNext && displayArrow && (
+				{ ! isNext && displayArrow && (
 					<span
-						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
+						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow }` }
 					>
 						{ displayArrow }
 					</span>
@@ -145,9 +145,9 @@ export default function PostNavigationLinkEdit( {
 						{ __( 'An example title' ) }
 					</a>
 				) }
-				{ ! isNext && displayArrow && (
+				{ isNext && displayArrow && (
 					<span
-						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow }` }
+						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
 					>
 						{ displayArrow }
 					</span>

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -6,7 +6,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { ToggleControl, PanelBody } from '@wordpress/components';
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	ToggleControl,
+	PanelBody,
+} from '@wordpress/components';
 import {
 	InspectorControls,
 	RichText,
@@ -14,14 +19,22 @@ import {
 	AlignmentToolbar,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 export default function PostNavigationLinkEdit( {
-	attributes: { type, label, showTitle, textAlign, linkLabel },
+	attributes: { type, label, showTitle, textAlign, linkLabel, arrow },
 	setAttributes,
 } ) {
 	const isNext = type === 'next';
 	let placeholder = isNext ? __( 'Next' ) : __( 'Previous' );
+
+	const arrowMap = {
+		none: '',
+		arrow: isNext ? '←' : '→',
+		chevron: isNext ? '«' : '»',
+	};
+
+	const displayArrow = arrowMap[ arrow ];
 
 	if ( showTitle ) {
 		/* translators: Label before for next and previous post. There is a space after the colon. */
@@ -63,6 +76,39 @@ export default function PostNavigationLinkEdit( {
 							}
 						/>
 					) }
+					<ToggleGroupControl
+						label={ __( 'Arrow' ) }
+						value={ arrow }
+						onChange={ ( value ) => {
+							setAttributes( { arrow: value } );
+						} }
+						help={ __(
+							'A decorative arrow for the next and previous link.'
+						) }
+						isBlock
+					>
+						<ToggleGroupControlOption
+							value="none"
+							label={ _x(
+								'None',
+								'Arrow option for Next/Previous link'
+							) }
+						/>
+						<ToggleGroupControlOption
+							value="arrow"
+							label={ _x(
+								'Arrow',
+								'Arrow option for Next/Previous link'
+							) }
+						/>
+						<ToggleGroupControlOption
+							value="chevron"
+							label={ _x(
+								'Chevron',
+								'Arrow option for Next/Previous link'
+							) }
+						/>
+					</ToggleGroupControl>
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
@@ -74,6 +120,13 @@ export default function PostNavigationLinkEdit( {
 				/>
 			</BlockControls>
 			<div { ...blockProps }>
+				{ isNext && displayArrow && (
+					<span
+						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
+					>
+						{ displayArrow }
+					</span>
+				) }
 				<RichText
 					tagName="a"
 					aria-label={ ariaLabel }
@@ -91,6 +144,13 @@ export default function PostNavigationLinkEdit( {
 					>
 						{ __( 'An example title' ) }
 					</a>
+				) }
+				{ ! isNext && displayArrow && (
+					<span
+						className={ `wp-block-post-navigation-link__arrow-previous is-arrow-${ arrow }` }
+					>
+						{ displayArrow }
+					</span>
 				) }
 			</div>
 		</>

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -148,6 +148,7 @@ export default function PostNavigationLinkEdit( {
 				{ isNext && displayArrow && (
 					<span
 						className={ `wp-block-post-navigation-link__arrow-next is-arrow-${ arrow }` }
+						aria-hidden={ true }
 					>
 						{ displayArrow }
 					</span>

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -88,9 +88,9 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
 		if ( 'next' === $navigation_type ) {
-			$format = '%link <span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span>';
+			$format = '%link <span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span>';
 		} else {
-			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span> %link';
+			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '" aria-hidden="true">' . $arrow . '</span> %link';
 		}
 	}
 

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -37,12 +37,12 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$arrow_map = array(
 		'none'    => '',
 		'arrow'   => array(
-			'next'     => '←',
-			'previous' => '→',
+			'next'     => '→',
+			'previous' => '←',
 		),
 		'chevron' => array(
-			'next'     => '«',
-			'previous' => '»',
+			'next'     => '»',
+			'previous' => '«',
 		),
 	);
 
@@ -88,9 +88,9 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
 		if ( 'next' === $navigation_type ) {
-			$format = '<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span> %link';
+			$format = '%link <span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span>';
 		} else {
-			$format = '%link <span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span>';
+			$format = '<span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span> %link';
 		}
 	}
 

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -34,6 +34,18 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	$link   = 'next' === $navigation_type ? _x( 'Next', 'label for next post link' ) : _x( 'Previous', 'label for previous post link' );
 	$label  = '';
 
+	$arrow_map = array(
+		'none'    => '',
+		'arrow'   => array(
+			'next'     => '←',
+			'previous' => '→',
+		),
+		'chevron' => array(
+			'next'     => '«',
+			'previous' => '»',
+		),
+	);
+
 	// If a custom label is provided, make this a link.
 	// `$label` is used to prepend the provided label, if we want to show the page title as well.
 	if ( isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ) {
@@ -68,6 +80,17 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 					'%title'
 				);
 			}
+		}
+	}
+
+	// Display arrows.
+	if ( isset( $attributes['arrow'] ) && ! empty( $attributes['arrow'] ) && $attributes['arrow'] !== 'none' ) {
+		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
+
+		if ( 'next' === $navigation_type ) {
+			$format = '<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] .'">' . $arrow . '</span> %link';
+		} else {
+			$format = '%link <span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] .'">' . $arrow . '</span>';
 		}
 	}
 

--- a/packages/block-library/src/post-navigation-link/index.php
+++ b/packages/block-library/src/post-navigation-link/index.php
@@ -84,13 +84,13 @@ function render_block_core_post_navigation_link( $attributes, $content ) {
 	}
 
 	// Display arrows.
-	if ( isset( $attributes['arrow'] ) && ! empty( $attributes['arrow'] ) && $attributes['arrow'] !== 'none' ) {
+	if ( isset( $attributes['arrow'] ) && ! empty( $attributes['arrow'] ) && 'none' !== $attributes['arrow'] ) {
 		$arrow = $arrow_map[ $attributes['arrow'] ][ $navigation_type ];
 
 		if ( 'next' === $navigation_type ) {
-			$format = '<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] .'">' . $arrow . '</span> %link';
+			$format = '<span class="wp-block-post-navigation-link__arrow-next is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span> %link';
 		} else {
-			$format = '%link <span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] .'">' . $arrow . '</span>';
+			$format = '%link <span class="wp-block-post-navigation-link__arrow-previous is-arrow-' . $attributes['arrow'] . '">' . $arrow . '</span>';
 		}
 	}
 

--- a/packages/block-library/src/post-navigation-link/style.scss
+++ b/packages/block-library/src/post-navigation-link/style.scss
@@ -1,0 +1,23 @@
+.wp-block-post-navigation-link {
+
+	.wp-block-post-navigation-link__arrow-previous {
+		display: inline-block;
+		margin-left: 1ch;
+		// chevron(`»`) symbol doesn't need the mirroring by us.
+		&:not(.is-arrow-chevron) {
+			// Flip for RTL.
+			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
+		}
+	}
+
+	.wp-block-post-navigation-link__arrow-next {
+		display: inline-block;
+		margin-right: 1ch;
+		// chevron(`»`) symbol doesn't need the mirroring by us.
+		&:not(.is-arrow-chevron) {
+			// Flip for RTL.
+			transform: scaleX(1) #{"/*rtl:scaleX(-1);*/"}; // This points the arrow right for LTR and left for RTL.
+		}
+	}
+
+}

--- a/packages/block-library/src/post-navigation-link/style.scss
+++ b/packages/block-library/src/post-navigation-link/style.scss
@@ -2,7 +2,7 @@
 
 	.wp-block-post-navigation-link__arrow-previous {
 		display: inline-block;
-		margin-left: 1ch;
+		margin-right: 1ch;
 		// chevron(`»`) symbol doesn't need the mirroring by us.
 		&:not(.is-arrow-chevron) {
 			// Flip for RTL.
@@ -12,7 +12,7 @@
 
 	.wp-block-post-navigation-link__arrow-next {
 		display: inline-block;
-		margin-right: 1ch;
+		margin-left: 1ch;
 		// chevron(`»`) symbol doesn't need the mirroring by us.
 		&:not(.is-arrow-chevron) {
 			// Flip for RTL.

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -30,6 +30,7 @@
 @import "./post-date/style.scss";
 @import "./post-excerpt/style.scss";
 @import "./post-featured-image/style.scss";
+@import "./post-navigation-link/style.scss";
 @import "./post-terms/style.scss";
 @import "./post-title/style.scss";
 @import "./preformatted/style.scss";

--- a/test/integration/fixtures/blocks/core__post-navigation-link.json
+++ b/test/integration/fixtures/blocks/core__post-navigation-link.json
@@ -5,7 +5,8 @@
 		"attributes": {
 			"type": "next",
 			"showTitle": false,
-			"linkLabel": false
+			"linkLabel": false,
+			"arrow": "none"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds an option to add arrows to the post navigation links.
Fixes https://github.com/WordPress/gutenberg/issues/35954

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This is an enhancement that adds a new feature to the post navigation link to help users style their next and previous post links.
It matches the option that already exists for the next and previous links in the query pagination.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a new attribute called `arrow `and a new toggle group option in the block settings sidebar.

## Testing Instructions

1. First make sure that your WordPress installation has a few posts so that you can test both the next and previous links.
2. In the editor, add the next and previous link blocks.
3. Duplicate the blocks enough times to test one each of the different settings.
4. Save and view the front.

5. Switch to a RTL language and repeat the test.

## Screenshots or screencast <!-- if applicable -->
Editor:
![next and previous link in the editor](https://user-images.githubusercontent.com/7422055/165887378-d033e79e-0a57-428d-af78-a1fb615c9163.png)
