### PR TITLE
[Writing Flow]: Try to fix multi-selection with `shift+click`

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-click-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-click-selection.js
@@ -11,10 +11,9 @@ import { store as blockEditorStore } from '../../store';
 import { getBlockClientId } from '../../utils/dom';
 
 export default function useClickSelection() {
-	const { multiSelect, selectBlock } = useDispatch( blockEditorStore );
+	const { selectBlock } = useDispatch( blockEditorStore );
 	const {
 		isSelectionEnabled,
-		getBlockParents,
 		getBlockSelectionStart,
 		hasMultiSelection,
 	} = useSelect( blockEditorStore );
@@ -54,10 +53,8 @@ export default function useClickSelection() {
 			};
 		},
 		[
-			multiSelect,
 			selectBlock,
 			isSelectionEnabled,
-			getBlockParents,
 			getBlockSelectionStart,
 			hasMultiSelection,
 		]

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -92,6 +92,15 @@ export default function useSelectionObserver() {
 					setContentEditableWrapper( node, false );
 					return;
 				}
+				// If selection is collapsed and we haven't used `shift+click`,
+				// end multi selection and disable the contentEditable wrapper.
+				// We have to check about `shift+click` case because elements
+				// that doesn't support selection might be involved, and we might
+				// update the clientIds to multi-select blocks.
+				if ( selection.isCollapsed && ! event.shiftKey ) {
+					setContentEditableWrapper( node, false );
+					return;
+				}
 
 				let startClientId = getBlockClientId(
 					extractSelectionStartNode( selection )
@@ -117,26 +126,16 @@ export default function useSelectionObserver() {
 					) {
 						endClientId = clickedClientId;
 					}
-					// Handle the case when we have a non-selectable block and
-					// click another one.
+					// Handle the case when we have a non-selectable block
+					// selected and click another one.
 					if ( startClientId !== selectedClientId ) {
 						startClientId = selectedClientId;
 					}
 				}
 
 				const isSingularSelection = startClientId === endClientId;
-				// If selection is collapsed, end multi selection and disable the
-				// contentEditable wrapper.
-				// We also check if we have updated the clientIds when holding `shift`
-				// and elements that doesn't support selection are involved.
-				// There might be the case that the selection is collapsed but we need
-				// to multi-select blocks.
-				if ( selection.isCollapsed && isSingularSelection ) {
-					setContentEditableWrapper( node, false );
-					return;
-				}
 
-				// If the selection did not involve a block, return early.
+				// If the selection did not involve a block, return.
 				if (
 					startClientId === undefined &&
 					endClientId === undefined

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -97,7 +97,9 @@ export default function useSelectionObserver() {
 				// We have to check about `shift+click` case because elements
 				// that don't support text selection might be involved, and we might
 				// update the clientIds to multi-select blocks.
-				if ( selection.isCollapsed && ! event.shiftKey ) {
+				// For now we check if the event is a `mouse` event.
+				const isClickShift = event.shiftKey && event.type === 'mouseup';
+				if ( selection.isCollapsed && ! isClickShift ) {
 					setContentEditableWrapper( node, false );
 					return;
 				}
@@ -111,7 +113,7 @@ export default function useSelectionObserver() {
 				// If the selection has changed and we had pressed `shift+click`,
 				// we need to check if in an element that doesn't support
 				// text selection has been clicked.
-				if ( event.shiftKey ) {
+				if ( isClickShift ) {
 					const selectedClientId = getBlockSelectionStart();
 					const clickedClientId = getBlockClientId( event.target );
 					// `endClientId` is not defined if we end the selection by clicking a non-selectable block.

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -95,7 +95,7 @@ export default function useSelectionObserver() {
 				// If selection is collapsed and we haven't used `shift+click`,
 				// end multi selection and disable the contentEditable wrapper.
 				// We have to check about `shift+click` case because elements
-				// that doesn't support selection might be involved, and we might
+				// that don't support text selection might be involved, and we might
 				// update the clientIds to multi-select blocks.
 				if ( selection.isCollapsed && ! event.shiftKey ) {
 					setContentEditableWrapper( node, false );
@@ -110,7 +110,7 @@ export default function useSelectionObserver() {
 				);
 				// If the selection has changed and we had pressed `shift+click`,
 				// we need to check if in an element that doesn't support
-				// selection has been clicked.
+				// text selection has been clicked.
 				if ( event.shiftKey ) {
 					const selectedClientId = getBlockSelectionStart();
 					const clickedClientId = getBlockClientId( event.target );
@@ -133,8 +133,6 @@ export default function useSelectionObserver() {
 					}
 				}
 
-				const isSingularSelection = startClientId === endClientId;
-
 				// If the selection did not involve a block, return.
 				if (
 					startClientId === undefined &&
@@ -144,6 +142,7 @@ export default function useSelectionObserver() {
 					return;
 				}
 
+				const isSingularSelection = startClientId === endClientId;
 				if ( isSingularSelection ) {
 					selectBlock( startClientId );
 				} else {

--- a/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
+++ b/packages/e2e-tests/specs/editor/various/multi-block-selection.test.js
@@ -10,6 +10,7 @@ import {
 	clickBlockToolbarButton,
 	clickButton,
 	clickMenuItem,
+	insertBlock,
 	openListView,
 	saveDraft,
 	transformBlockTo,
@@ -974,5 +975,52 @@ describe( 'Multi-block selection', () => {
 
 		// Expect two blocks with "&" in between.
 		expect( await getEditedPostContent() ).toMatchSnapshot();
+	} );
+	describe( 'shift+click multi-selection', () => {
+		it( 'should multi-select block with text selection and a block without text selection', async () => {
+			await page.keyboard.press( 'Enter' );
+			await page.keyboard.type( 'hi' );
+			await page.keyboard.press( 'Enter' );
+			await insertBlock( 'Spacer' );
+			await page.keyboard.press( 'ArrowUp' );
+
+			const spacerBlock = await page.waitForSelector(
+				'.wp-block.wp-block-spacer'
+			);
+			const boundingBox = await spacerBlock.boundingBox();
+			const mousePosition = {
+				x: boundingBox.x + boundingBox.width / 2,
+				y: boundingBox.y + boundingBox.height / 2,
+			};
+			await page.keyboard.down( 'Shift' );
+			await page.mouse.click( mousePosition.x, mousePosition.y );
+			await page.keyboard.up( 'Shift' );
+
+			const selectedBlocks = await page.$$(
+				'.wp-block.is-multi-selected'
+			);
+			expect( selectedBlocks.length ).toBe( 2 );
+		} );
+		it( 'should multi-select blocks without text selection', async () => {
+			await insertBlock( 'Spacer' );
+			// Get the first spacer block element.
+			const spacerBlock = await page.waitForSelector(
+				'.wp-block.wp-block-spacer'
+			);
+			const boundingBox = await spacerBlock.boundingBox();
+			await page.keyboard.press( 'Enter' );
+			await insertBlock( 'Spacer' );
+			const mousePosition = {
+				x: boundingBox.x + boundingBox.width / 2,
+				y: boundingBox.y + boundingBox.height / 2,
+			};
+			await page.keyboard.down( 'Shift' );
+			await page.mouse.click( mousePosition.x, mousePosition.y );
+			await page.keyboard.up( 'Shift' );
+			const selectedBlocks = await page.$$(
+				'.wp-block.is-multi-selected'
+			);
+			expect( selectedBlocks.length ).toBe( 2 );
+		} );
 	} );
 } );

--- a/packages/rich-text/src/component/use-input-and-selection.js
+++ b/packages/rich-text/src/component/use-input-and-selection.js
@@ -238,7 +238,7 @@ export function useInputAndSelection( props ) {
 		function onCompositionStart() {
 			isComposing = true;
 			// Do not update the selection when characters are being composed as
-			// this rerenders the component and might distroy internal browser
+			// this rerenders the component and might destroy internal browser
 			// editing state.
 			ownerDocument.removeEventListener(
 				'selectionchange',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40636

From the issue:
>Previously, you could hold down the shift key and select multiple blocks at once. This still works if you "start" with a paragraph or similar text-based block. However, if you try and select two non-text blocks using the shift key, such as two images, it is no longer possible.

Partial selection across blocks is handled mostly with the help of [getSelection API](https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection). This creates some problems for blocks that have no text selection(ex Spacer) and things get even more complicated when we have blocks that have a Placeholder state, which actually contains text nodes. See @priethor 's [comment](https://github.com/WordPress/gutenberg/issues/40636#issuecomment-1110900870):
>One extra use test case:
>Partially select text in a paragraph -> Shift+click on an Image/Cover block that has an image -> it doesn't work
Partially select text in a paragraph -> Shift+click on an empty Image/Cover block -> it works
<!-- In a few words, what is the PR actually doing? -->


## How?

At first I tried adding some changes in [use-click-selection](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/writing-flow/use-click-selection.js), but couldn't make it work well at all, because selection changes in other events after that, and there are even [more nuances](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/writing-flow/use-selection-observer.js#L149) to that for handling RichText selection first, before `use-selection-observer` kicks in.

I don't think this solution is perfect and handles all cases, and that's why suggestions and feedback is more than welcome.  I have added comments in the code that will be helpful hopefully 😄 

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Add various blocks both text-based like paragraphs, headings, etc.. and others like Image, Cover, Spacer. Also you could group some blocks.
2. Make sure in testing to also have the list view open to see the actual selected blocks from the store
3. Try different selections by holding `shift+click`

#### Before

https://user-images.githubusercontent.com/16275880/165758559-738da5af-0bc1-4ad6-9d0a-57a4b5274ab9.mov



#### After



https://user-images.githubusercontent.com/16275880/165758573-f4592f07-57cb-473c-bb0d-622b87e867bb.mov


