### PR TITLE
Mobile - DraggingInsertionPoint - Prevent crash when accessing a null element

### DIFF
--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -118,16 +118,17 @@ export default function DroppingInsertionPoint( {
 			? findBlockLayoutByClientId( blocksLayouts.current, nextClientId )
 			: null;
 
+		const previousElementPosition = previousElement
+			? previousElement.y + previousElement.height
+			: 0;
+		const nextElementPosition = nextElement ? nextElement.y : 0;
+
 		const elementsPositions = {
 			top: Math.floor(
-				previousElement
-					? previousElement.y + previousElement.height
-					: nextElement?.y
+				previousElement ? previousElementPosition : nextElementPosition
 			),
 			bottom: Math.floor(
-				nextElement
-					? nextElement.y
-					: previousElement?.y + previousElement?.height
+				nextElement ? nextElementPosition : previousElementPosition
 			),
 		};
 

--- a/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
+++ b/packages/block-editor/src/components/block-draggable/dropping-insertion-point.native.js
@@ -127,7 +127,7 @@ export default function DroppingInsertionPoint( {
 			bottom: Math.floor(
 				nextElement
 					? nextElement.y
-					: previousElement.y + previousElement.height
+					: previousElement?.y + previousElement?.height
 			),
 		};
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4806

## What?
Fixes a crash when there's only one block in the editor and the dragging event starts.

## Why?
Trying to drag & drop a block when there's only one in the editor would crash the app.

## How?
By adding an optional chaining operator when accessing the `previousElement` which is `null` when there's only one block in the editor.

## Testing Instructions

- Open a post/page.
- Add one block (it's important that the content is just one block).
- Long-press on the block to start dragging.
- Drag the block around and observe that the editor crashes.

## Screenshots or screencast <!-- if applicable -->

Before | After
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/165772139-a111a445-42a6-4c36-a25a-5246fdb6981f.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/165772194-3c683a8b-6a52-4bb0-95e4-6c7900d2d4b1.gif" width="200" /></kbd>
