### PR TITLE
Revert "Prevent spam links of author's name in pending moderation comments"

### DIFF
--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -18,9 +18,7 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$comment            = get_comment( $block->context['commentId'] );
-	$commenter          = wp_get_current_commenter();
-	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
+	$comment = get_comment( $block->context['commentId'] );
 	if ( empty( $comment ) ) {
 		return '';
 	}
@@ -36,9 +34,6 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 
 	if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
 		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
-	}
-	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
-		$comment_author = wp_kses( $comment_author, array() );
 	}
 
 	return sprintf(


### PR DESCRIPTION
Reverts WordPress/gutenberg#40659

This is currently causing [PHP unit tests to fail](https://github.com/WordPress/gutenberg/runs/6215435232?check_suite_focus=true):

![image](https://user-images.githubusercontent.com/96308/165831369-c7bcabaf-d2a4-4fff-850e-42d839f0fe81.png)

Let's sort this out tomorrow.

cc/ @c4rl0sbr4v0 @DAreRodz 