### PR TITLE
Prevent spam links of author's name in pending moderation comments (take two)

### DIFF
--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -18,7 +18,9 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$comment = get_comment( $block->context['commentId'] );
+	$comment            = get_comment( $block->context['commentId'] );
+	$commenter          = wp_get_current_commenter();
+	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
 	if ( empty( $comment ) ) {
 		return '';
 	}
@@ -34,6 +36,9 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 
 	if ( ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
 		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
+	}
+	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
+		$comment_author = wp_kses( $comment_author, array() );
 	}
 
 	return sprintf(

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -394,7 +394,7 @@ END
 		// Here we use the function prefixed with 'gutenberg_*' because it's added
 		// in the build step.
 		$this->assertEquals(
-			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/unapproved/" target="_self" >Visitor</a></div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
+			'<ol class="wp-block-comment-template"><li id="comment-' . self::$comment_ids[0] . '" class="comment even thread-odd thread-alt depth-1"><div class="wp-block-comment-author-name"><a rel="external nofollow ugc" href="http://example.com/author-url/" target="_self" >Test</a></div><div class="wp-block-comment-content"><p>Hello world</p></div></li><li id="comment-' . $unapproved_comment[0] . '" class="comment odd alt thread-even depth-1"><div class="wp-block-comment-author-name">Visitor</div><div class="wp-block-comment-content"><p><em class="comment-awaiting-moderation">Your comment is awaiting moderation.</em></p>Hi there! My comment needs moderation.</div></li></ol>',
 			str_replace( array( "\n", "\t" ), '', $block->render() )
 		);
 


### PR DESCRIPTION
Take Two of https://github.com/WordPress/gutenberg/pull/40659, which was causing [PHP unit tests to fail](https://github.com/WordPress/gutenberg/runs/6215435232?check_suite_focus=true):

![image](https://user-images.githubusercontent.com/96308/165831369-c7bcabaf-d2a4-4fff-850e-42d839f0fe81.png)

cc/ @c4rl0sbr4v0 @DAreRodz

Reverts WordPress/gutenberg#40701