### PR TITLE
[RNMobile] Group grid block properties in BlockListItem component

### DIFF
--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -170,13 +170,13 @@ export class BlockListItem extends Component {
 		}
 
 		if ( isGridItem ) {
-			const { numOfColumns, tileCount, index } = this.props;
+			const { numOfColumns, tileCount, tileIndex } = this.props;
 			return (
 				<Grid
 					maxWidth={ parentWidth }
 					numOfColumns={ numOfColumns }
 					tileCount={ tileCount }
-					index={ index }
+					index={ tileIndex }
 				>
 					{ this.renderContent() }
 				</Grid>

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -163,19 +163,14 @@ export class BlockListItem extends Component {
 	}
 
 	render() {
-		const {
-			clientId,
-			parentWidth,
-			blockWidth,
-			gridBlockProps,
-		} = this.props;
+		const { clientId, parentWidth, blockWidth, gridItemProps } = this.props;
 
 		if ( ! blockWidth ) {
 			return null;
 		}
 
-		if ( gridBlockProps ) {
-			const { props, items } = gridBlockProps;
+		if ( gridItemProps ) {
+			const { props, items } = gridItemProps;
 			return (
 				<Grid
 					numOfColumns={ props.numColumns }

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -163,21 +163,20 @@ export class BlockListItem extends Component {
 	}
 
 	render() {
-		const { clientId, parentWidth, blockWidth, gridItemProps } = this.props;
+		const {
+			parentWidth,
+			blockWidth,
+			isGridItem,
+			gridItemProps,
+		} = this.props;
 
 		if ( ! blockWidth ) {
 			return null;
 		}
 
-		if ( gridItemProps ) {
-			const { props, items } = gridItemProps;
+		if ( isGridItem ) {
 			return (
-				<Grid
-					numOfColumns={ props.numColumns }
-					tileCount={ items.length }
-					index={ items.indexOf( clientId ) }
-					maxWidth={ parentWidth }
-				>
+				<Grid maxWidth={ parentWidth } { ...gridItemProps }>
 					{ this.renderContent() }
 				</Grid>
 			);

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -163,20 +163,21 @@ export class BlockListItem extends Component {
 	}
 
 	render() {
-		const {
-			parentWidth,
-			blockWidth,
-			isGridItem,
-			gridItemProps,
-		} = this.props;
+		const { parentWidth, blockWidth, isGridItem } = this.props;
 
 		if ( ! blockWidth ) {
 			return null;
 		}
 
 		if ( isGridItem ) {
+			const { numOfColumns, tileCount, index } = this.props;
 			return (
-				<Grid maxWidth={ parentWidth } { ...gridItemProps }>
+				<Grid
+					maxWidth={ parentWidth }
+					numOfColumns={ numOfColumns }
+					tileCount={ tileCount }
+					index={ index }
+				>
 					{ this.renderContent() }
 				</Grid>
 			);

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -121,6 +121,7 @@ export class BlockListItem extends Component {
 			blockWidth,
 			...restProps
 		} = this.props;
+
 		const readableContentViewStyle =
 			contentResizeMode === 'stretch' && stretchStyle;
 		const { isContainerRelated } = alignmentHelpers;
@@ -163,21 +164,21 @@ export class BlockListItem extends Component {
 
 	render() {
 		const {
-			gridProperties,
 			clientId,
 			parentWidth,
-			items,
 			blockWidth,
+			gridBlockProps,
 		} = this.props;
 
 		if ( ! blockWidth ) {
 			return null;
 		}
 
-		if ( gridProperties ) {
+		if ( gridBlockProps ) {
+			const { props, items } = gridBlockProps;
 			return (
 				<Grid
-					numOfColumns={ gridProperties.numColumns }
+					numOfColumns={ props.numColumns }
 					tileCount={ items.length }
 					index={ items.indexOf( clientId ) }
 					maxWidth={ parentWidth }

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -324,7 +324,7 @@ export class BlockList extends Component {
 
 		// blockClientIds are only required for Grid blocks in the BlockListItem component.
 		// However passing the blockClientIds as a top level prop results in unneeded re-renders.
-		const gridBlockProps = gridProperties && {
+		const gridItemProps = gridProperties && {
 			props: gridProperties,
 			items: blockClientIds,
 		};
@@ -344,7 +344,7 @@ export class BlockList extends Component {
 					this.shouldShowInnerBlockAppender
 				}
 				blockWidth={ blockWidth }
-				gridBlockProps={ gridBlockProps }
+				gridItemProps={ gridItemProps }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -321,6 +321,10 @@ export class BlockList extends Component {
 			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
+		const gridBlockProps = gridProperties && {
+			props: gridProperties,
+			items: blockClientIds,
+		};
 		return (
 			<BlockListItem
 				isStackedHorizontally={ isStackedHorizontally }
@@ -337,8 +341,7 @@ export class BlockList extends Component {
 					this.shouldShowInnerBlockAppender
 				}
 				blockWidth={ blockWidth }
-				gridProperties={ gridProperties }
-				items={ blockClientIds }
+				gridBlockProps={ gridBlockProps }
 			/>
 		);
 	}

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -321,6 +321,9 @@ export class BlockList extends Component {
 			gridProperties,
 		} = this.props;
 		const { blockWidth } = this.state;
+
+		// blockClientIds are only required for Grid blocks in the BlockListItem component.
+		// However passing the blockClientIds as a top level prop results in unneeded re-renders.
 		const gridBlockProps = gridProperties && {
 			props: gridProperties,
 			items: blockClientIds,

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -322,11 +322,13 @@ export class BlockList extends Component {
 		} = this.props;
 		const { blockWidth } = this.state;
 
-		// blockClientIds are only required for Grid blocks in the BlockListItem component.
-		// However passing the blockClientIds as a top level prop results in unneeded re-renders.
+		// Extracting the grid item properties here to avoid
+		// re-renders in the blockListItem component.
+		const isGridItem = !! gridProperties;
 		const gridItemProps = gridProperties && {
-			props: gridProperties,
-			items: blockClientIds,
+			numOfColumns: gridProperties.numColumns,
+			tileCount: blockClientIds.length,
+			index: blockClientIds.indexOf( clientId ),
 		};
 		return (
 			<BlockListItem
@@ -344,6 +346,7 @@ export class BlockList extends Component {
 					this.shouldShowInnerBlockAppender
 				}
 				blockWidth={ blockWidth }
+				isGridItem={ isGridItem }
 				gridItemProps={ gridItemProps }
 			/>
 		);

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -328,7 +328,7 @@ export class BlockList extends Component {
 		const gridItemProps = gridProperties && {
 			numOfColumns: gridProperties.numColumns,
 			tileCount: blockClientIds.length,
-			index: blockClientIds.indexOf( clientId ),
+			tileIndex: blockClientIds.indexOf( clientId ),
 		};
 		return (
 			<BlockListItem

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -347,7 +347,7 @@ export class BlockList extends Component {
 				}
 				blockWidth={ blockWidth }
 				isGridItem={ isGridItem }
-				gridItemProps={ gridItemProps }
+				{ ...gridItemProps }
 			/>
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/39958
Moves items out from a top level property in the `BlockListItem` props to prevent unneeded re-renders of the `BlockListBlock` components.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a `gridItemProps` prop to the `BlockListItem` to hold both of the  grid required props `gridProperties` and `items`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When inserting a new block to the editor the `BlockList` was passing the `blockClientIds` as a prop to the the `BlockListItem`. The `items` prop however is only used in the `BlockListItem` for `Grid` Blocks. Furthermore, the `BlockListBlock` component was receiving the `items` prop but not using it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removing the `items` prop from being passed to the `BlockListBlock` component prevents unneeded re-renders.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Testing Performance update
1. Set up Flipper and the react DevTools as noted in the [original issue](https://github.com/WordPress/gutenberg/issues/39958)
2. Open the editor and add a few blocks
3. Open the inserter menu and start the DevTools profiler
4. Insert a block and stop the profiler 
5. Find an instance of a `BlockListBlock` in the  profiler Flamegraph tab.
6. Step through the rendering flames and note that the `BlockListBlock` is never re-rendered.

### Testing Grid Item regression
1. Add a few grid base blocks to a post e.g. Gallery or Grid Layout
2. Verify the render properly

## Screenshots or screencast <!-- if applicable -->
