### PR TITLE
Fix: Page patterns don't show when only one pattern is available.

### DIFF
--- a/packages/edit-post/src/components/start-page-options/index.js
+++ b/packages/edit-post/src/components/start-page-options/index.js
@@ -30,11 +30,6 @@ function PatternSelection( { onChoosePattern } ) {
 	}, [] );
 	const shownBlockPatterns = useAsyncList( blockPatterns );
 	const { resetEditorBlocks } = useDispatch( editorStore );
-	useEffect( () => {
-		if ( blockPatterns.length <= 1 ) {
-			onChoosePattern();
-		}
-	}, [ blockPatterns.length ] );
 	return (
 		<BlockPatternsList
 			blockPatterns={ blockPatterns }


### PR DESCRIPTION
This PR fixes a bug reported here https://github.com/WordPress/gutenberg/pull/40034#issuecomment-1108723222 by @ryanwelcher where only a post content pattern did not made the modal appear. It removes code that was on longer needed and was merged by mistake.


## Testing Instructions
On file lib/compat/wordpress-6.0/block-patterns-update.php I updated "Image at left" pattern to include post content:
```
...
			'title'      => _x( 'Image at left', 'Block pattern title', 'gutenberg' ),
			'blockTypes' => array( 'core/query', 'core/post-content' ),
...
```
I created a new page and verified the modal still appeared.

I removed all post-content patterns and verified no modal appears.