### PR TITLE
Heading block: Include text alignment when transforming from paragraph to header and back

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -16,10 +16,11 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
-				attributes.map( ( { content, anchor } ) =>
+				attributes.map( ( { content, anchor, align: textAlign } ) =>
 					createBlock( name, {
 						content,
 						anchor,
+						textAlign,
 					} )
 				),
 		},
@@ -84,8 +85,8 @@ const transforms = {
 			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
-				attributes.map( ( { content } ) =>
-					createBlock( 'core/paragraph', { content } )
+				attributes.map( ( { content, textAlign: align } ) =>
+					createBlock( 'core/paragraph', { content, align } )
 				),
 		},
 	],


### PR DESCRIPTION
## What?
Maintains text alignment when transforming from a paragraph to a heading and back again

## Why?
Text alignment is currently lost when doing this transform and it probably makes sense to maintain it
Fixes: #40704
## How?
Adds the `align` and `textAlign` attributes to the transforms in the Heading block

## Testing Instructions

- Add a paragraph block and set text alignment to right
- Transform the block to a heading and make sure alignment is maintained
- Transform back to a heading and make sure alignment is maintained

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/165868503-a339b04b-8460-4e88-b718-746399a85807.mp4

After:

https://user-images.githubusercontent.com/3629020/165868513-52a9f4a1-d0e4-42e9-94ee-0fb86f2a6723.mp4




