### PR TITLE
Fix/block meta icon prop errors

### DIFF
--- a/packages/icons/src/library/block-meta.js
+++ b/packages/icons/src/library/block-meta.js
@@ -6,9 +6,9 @@ import { SVG, Path } from '@wordpress/primitives';
 const blockDefault = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
-			fill-rule="evenodd"
+			fillRule="evenodd"
 			d="M8.95 11.25H4v1.5h4.95v4.5H13V18c0 1.1.9 2 2 2h3c1.1 0 2-.9 2-2v-3c0-1.1-.9-2-2-2h-3c-1.1 0-2 .9-2 2v.75h-2.55v-7.5H13V9c0 1.1.9 2 2 2h3c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3c-1.1 0-2 .9-2 2v.75H8.95v4.5ZM14.5 15v3c0 .3.2.5.5.5h3c.3 0 .5-.2.5-.5v-3c0-.3-.2-.5-.5-.5h-3c-.3 0-.5.2-.5.5Zm0-6V6c0-.3.2-.5.5-.5h3c.3 0 .5.2.5.5v3c0 .3-.2.5-.5.5h-3c-.3 0-.5-.2-.5-.5Z"
-			clip-rule="evenodd"
+			clipRule="evenodd"
 		/>
 	</SVG>
 );

--- a/packages/icons/src/library/block-meta.js
+++ b/packages/icons/src/library/block-meta.js
@@ -3,7 +3,7 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const blockDefault = (
+const blockMeta = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
@@ -13,4 +13,4 @@ const blockDefault = (
 	</SVG>
 );
 
-export default blockDefault;
+export default blockMeta;


### PR DESCRIPTION
## What?
[x] Fix console errors due to usage of hyphenated props on JSX elements.
[x] Update icon export name appropriately.

## Why?
There were errors being thrown in the console when using the `blockMeta` svg icon.

```Warning: Invalid DOM property `fill-rule`. Did you mean `fillRule`?```
```Warning: Invalid DOM property `clip-rule`. Did you mean `clipRule`?```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Use the `blockMeta` svg icon and check the console.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/847818/165876288-c7c63a4e-1d73-4f76-a36c-96d05b167de5.png)
