### PR TITLE
[components] Add panel toggle icon overrides

### DIFF
--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -129,17 +129,19 @@ An icon to be shown next to the `PanelBody` title.
 
 ###### iconExpanded
 
-An icon to be shown as the toggle button within the `PanelBody` title when open.
+An icon to be shown as the toggle button within the `PanelBody` title, in its expanded state. See [the `@wordpress/icons` package](https://github.com/WordPress/gutenberg/blob/trunk/packages/icons/README.md) for a list of available icons.
 
--   Type: `String`
+-   Type: `React.ReactNode`
 -   Required: No
+-   Default: `chevronUp` icon from `@wordpress/icons`
 
 ###### iconCollapsed
 
-An icon to be shown as the toggle button within the `PanelBody` title when closed.
+An icon to be shown as the toggle button within the `PanelBody` title, in its collapsed state. See [the `@wordpress/icons` package](https://github.com/WordPress/gutenberg/blob/trunk/packages/icons/README.md) for a list of available icons.
 
--   Type: `String`
+-   Type: `React.ReactNode`
 -   Required: No
+-   Default: `chevronDown` icon from `@wordpress/icons`
 
 ###### onToggle
 

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -127,14 +127,14 @@ An icon to be shown next to the `PanelBody` title.
 -   Type: `String`
 -   Required: No
 
-###### iconOpen
+###### iconExpanded
 
 An icon to be shown as the toggle button within the `PanelBody` title when open.
 
 -   Type: `String`
 -   Required: No
 
-###### iconClosed
+###### iconCollapsed
 
 An icon to be shown as the toggle button within the `PanelBody` title when closed.
 

--- a/packages/components/src/panel/README.md
+++ b/packages/components/src/panel/README.md
@@ -127,6 +127,20 @@ An icon to be shown next to the `PanelBody` title.
 -   Type: `String`
 -   Required: No
 
+###### iconOpen
+
+An icon to be shown as the toggle button within the `PanelBody` title when open.
+
+-   Type: `String`
+-   Required: No
+
+###### iconClosed
+
+An icon to be shown as the toggle button within the `PanelBody` title when closed.
+
+-   Type: `String`
+-   Required: No
+
 ###### onToggle
 
 A function that is called when the user clicks on the `PanelBody` title after the open state is changed.

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -96,7 +96,10 @@ export function PanelBody(
 }
 
 const PanelBodyTitle = forwardRef(
-	( { isOpened, icon, title, iconExpanded, iconCollapsed, ...props }, ref ) => {
+	(
+		{ isOpened, icon, title, iconExpanded, iconCollapsed, ...props },
+		ref
+	) => {
 		if ( ! title ) return null;
 
 		return (

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -24,8 +24,8 @@ export function PanelBody(
 		children,
 		className,
 		icon,
-		iconOpen = chevronUp,
-		iconClosed = chevronDown,
+		iconExpanded = chevronUp,
+		iconCollapsed = chevronDown,
 		initialOpen,
 		onToggle = noop,
 		opened,
@@ -81,8 +81,8 @@ export function PanelBody(
 		<div className={ classes } ref={ useMergeRefs( [ nodeRef, ref ] ) }>
 			<PanelBodyTitle
 				icon={ icon }
-				iconOpen={ iconOpen }
-				iconClosed={ iconClosed }
+				iconExpanded={ iconExpanded }
+				iconCollapsed={ iconCollapsed }
 				isOpened={ isOpened }
 				onClick={ handleOnToggle }
 				title={ title }
@@ -96,7 +96,7 @@ export function PanelBody(
 }
 
 const PanelBodyTitle = forwardRef(
-	( { isOpened, icon, title, iconOpen, iconClosed, ...props }, ref ) => {
+	( { isOpened, icon, title, iconExpanded, iconCollapsed, ...props }, ref ) => {
 		if ( ! title ) return null;
 
 		return (
@@ -114,7 +114,7 @@ const PanelBodyTitle = forwardRef(
 					<span aria-hidden="true">
 						<Icon
 							className="components-panel__arrow"
-							icon={ isOpened ? iconOpen : iconClosed }
+							icon={ isOpened ? iconExpanded : iconCollapsed }
 						/>
 					</span>
 					{ title }

--- a/packages/components/src/panel/body.js
+++ b/packages/components/src/panel/body.js
@@ -24,6 +24,8 @@ export function PanelBody(
 		children,
 		className,
 		icon,
+		iconOpen = chevronUp,
+		iconClosed = chevronDown,
 		initialOpen,
 		onToggle = noop,
 		opened,
@@ -79,6 +81,8 @@ export function PanelBody(
 		<div className={ classes } ref={ useMergeRefs( [ nodeRef, ref ] ) }>
 			<PanelBodyTitle
 				icon={ icon }
+				iconOpen={ iconOpen }
+				iconClosed={ iconClosed }
 				isOpened={ isOpened }
 				onClick={ handleOnToggle }
 				title={ title }
@@ -92,7 +96,7 @@ export function PanelBody(
 }
 
 const PanelBodyTitle = forwardRef(
-	( { isOpened, icon, title, ...props }, ref ) => {
+	( { isOpened, icon, title, iconOpen, iconClosed, ...props }, ref ) => {
 		if ( ! title ) return null;
 
 		return (
@@ -110,7 +114,7 @@ const PanelBodyTitle = forwardRef(
 					<span aria-hidden="true">
 						<Icon
 							className="components-panel__arrow"
-							icon={ isOpened ? chevronUp : chevronDown }
+							icon={ isOpened ? iconOpen : iconClosed }
 						/>
 					</span>
 					{ title }

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -13,7 +13,7 @@ import PanelBody from '../body';
 /**
  * WordPress dependencies
  */
-import { wordpress } from '@wordpress/icons';
+import { wordpress, plus, close } from '@wordpress/icons';
 
 export default {
 	title: 'Components/Panel',
@@ -71,6 +71,20 @@ export const multipleBodies = () => {
 };
 
 export const withIcon = () => {
+	const bodyTitle = text( 'Body Title', 'My Block Settings' );
+	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
+	const icon = boolean( 'Icon', true ) ? wordpress : undefined;
+	const opened = boolean( 'Opened', true );
+	return (
+		<Panel header="My Panel">
+			<PanelBody title={ bodyTitle } opened={ opened } icon={ icon } iconOpen={ close } iconClosed={ plus }>
+				<PanelRow>{ rowText }</PanelRow>
+			</PanelBody>
+		</Panel>
+	);
+};
+
+export const CustomToggleIcons = () => {
 	const bodyTitle = text( 'Body Title', 'My Block Settings' );
 	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
 	const icon = boolean( 'Icon', true ) ? wordpress : undefined;

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -87,16 +87,16 @@ export const withIcon = () => {
 export const CustomToggleIcons = () => {
 	const bodyTitle = text( 'Body Title', 'My Block Settings' );
 	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
-	const iconOpen = boolean( 'Open Icon', true ) ? closeSmall : undefined;
-	const iconClosed = boolean( 'Closed Icon', true ) ? plus : undefined;
+	const iconExpanded = boolean( 'Expanded Icon', true ) ? closeSmall : undefined;
+	const iconCollapsed = boolean( 'Collapsed Icon', true ) ? plus : undefined;
 	const opened = boolean( 'Opened', true );
 	return (
 		<Panel header="My Panel">
 			<PanelBody
 				title={ bodyTitle }
 				opened={ opened }
-				iconOpen={ iconOpen }
-				iconClosed={ iconClosed }
+				iconExpanded={ iconExpanded }
+				iconCollapsed={ iconCollapsed }
 			>
 				<PanelRow>{ rowText }</PanelRow>
 			</PanelBody>

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -87,7 +87,9 @@ export const withIcon = () => {
 export const CustomToggleIcons = () => {
 	const bodyTitle = text( 'Body Title', 'My Block Settings' );
 	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
-	const iconExpanded = boolean( 'Expanded Icon', true ) ? closeSmall : undefined;
+	const iconExpanded = boolean( 'Expanded Icon', true )
+		? closeSmall
+		: undefined;
 	const iconCollapsed = boolean( 'Collapsed Icon', true ) ? plus : undefined;
 	const opened = boolean( 'Opened', true );
 	return (

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -77,7 +77,7 @@ export const withIcon = () => {
 	const opened = boolean( 'Opened', true );
 	return (
 		<Panel header="My Panel">
-			<PanelBody title={ bodyTitle } opened={ opened } icon={ icon } iconOpen={ close } iconClosed={ plus }>
+			<PanelBody title={ bodyTitle } opened={ opened } icon={ icon }>
 				<PanelRow>{ rowText }</PanelRow>
 			</PanelBody>
 		</Panel>
@@ -91,7 +91,7 @@ export const CustomToggleIcons = () => {
 	const opened = boolean( 'Opened', true );
 	return (
 		<Panel header="My Panel">
-			<PanelBody title={ bodyTitle } opened={ opened } icon={ icon }>
+			<PanelBody title={ bodyTitle } opened={ opened } iconOpen={ iconOpen } iconClosed={ iconClosed }>
 				<PanelRow>{ rowText }</PanelRow>
 			</PanelBody>
 		</Panel>

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -13,7 +13,7 @@ import PanelBody from '../body';
 /**
  * WordPress dependencies
  */
-import { wordpress, plus, close } from '@wordpress/icons';
+import { wordpress, plus, closeSmall } from '@wordpress/icons';
 
 export default {
 	title: 'Components/Panel',
@@ -87,12 +87,17 @@ export const withIcon = () => {
 export const CustomToggleIcons = () => {
 	const bodyTitle = text( 'Body Title', 'My Block Settings' );
 	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
-	const iconOpen = boolean( 'Toggle Open Icon', true ) ? closeSmall : undefined;
-	const iconClosed = boolean( 'Toggle Closed Icon', true ) ? plus : undefined;
+	const iconOpen = boolean( 'Open Icon', true ) ? closeSmall : undefined;
+	const iconClosed = boolean( 'Closed Icon', true ) ? plus : undefined;
 	const opened = boolean( 'Opened', true );
 	return (
 		<Panel header="My Panel">
-			<PanelBody title={ bodyTitle } opened={ opened } iconOpen={ iconOpen } iconClosed={ iconClosed }>
+			<PanelBody
+				title={ bodyTitle }
+				opened={ opened }
+				iconOpen={ iconOpen }
+				iconClosed={ iconClosed }
+			>
 				<PanelRow>{ rowText }</PanelRow>
 			</PanelBody>
 		</Panel>

--- a/packages/components/src/panel/stories/index.js
+++ b/packages/components/src/panel/stories/index.js
@@ -87,7 +87,8 @@ export const withIcon = () => {
 export const CustomToggleIcons = () => {
 	const bodyTitle = text( 'Body Title', 'My Block Settings' );
 	const rowText = text( 'Row Text', 'My Panel Inputs and Labels' );
-	const icon = boolean( 'Icon', true ) ? wordpress : undefined;
+	const iconOpen = boolean( 'Toggle Open Icon', true ) ? closeSmall : undefined;
+	const iconClosed = boolean( 'Toggle Closed Icon', true ) ? plus : undefined;
 	const opened = boolean( 'Opened', true );
 	return (
 		<Panel header="My Panel">


### PR DESCRIPTION
## What?
This adds support for customizing the PanelBody toggle icons beyond just `chevronUp` & `chevronDown`.

## Why?
This allows replacing the up & down icons with something else for better context.

Without this a developer is required to duplicate 4+ files to remake the needed components. This is primarily due to usage of internal functions that are not exposed `import { useControlledState, useUpdateEffect } from '../utils';`

## How?
- [x] Adds new `iconOpen` & `iconClosed` props with defaults set to current `chevron*` icons. I had considered `iconUp` & `iconDown` but decided these were more explicit. They could be even more specific by changing them to `toggleIconUp` or similar. Open to suggestion.
- [x] Updated readme to reflect new props.
- [x] Updated stories with new example.

## Testing Instructions
1. Create a `Panel` & `PanelBody`.
2. Add `iconOpen` and/or `iconClosed` props to `PanelBody`.
3. Render/run and view new ability to customize them.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/847818/165879626-b730f54d-6927-4014-90cd-ccc089032711.png)
