### PR TITLE
Gallery block: make full image clickable when link and caption applied

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -53,6 +53,7 @@ figure.wp-block-gallery.has-nested-images {
 			text-align: center;
 			width: 100%;
 			box-sizing: border-box;
+			pointer-events: none;
 
 			img {
 				display: inline;


### PR DESCRIPTION
## What?
Make sure full gallery image is clickable when a link is applied and also a caption

## Why?
Fixes: #14304 Currently if a gallery image has a caption the portion of the image with the caption is not clickable to follow the attached link

## How?
Applies `pointer-events: none` to caption to allow click events to fall through to image anchor

## Testing Instructions

- Add a Gallery block with images and apply a link and a caption to each
- In the frontend make sure the full image is clickable to follow the attached anchor

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/165886461-e088046c-180f-4d6e-8948-2df3eb590cd0.mp4

After:

https://user-images.githubusercontent.com/3629020/165886495-5246ad89-e408-4c1d-a3b8-8e177aa85983.mp4



