### PR TITLE
Preferences: Improve initial configuration for the new persistence package

### DIFF
--- a/packages/preferences-persistence/CHANGELOG.md
+++ b/packages/preferences-persistence/CHANGELOG.md
@@ -2,6 +2,4 @@
 
 ## Unreleased
 
-## 1.0.0 (2022-03-11)
-
 -   Initial version of the package.

--- a/packages/preferences-persistence/package.json
+++ b/packages/preferences-persistence/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/preferences-persistence",
-	"version": "1.0.0",
+	"version": "1.0.0-prerelease",
 	"description": "Persistence utilities for `wordpress/preferences`.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -25,7 +25,6 @@
 	"main": "build/index.js",
 	"module": "build-module/index.js",
 	"react-native": "src/index",
-	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up for #39795 that introduced `@wordpress/preferences-persistence`.

Some minor changes to the package before it's initial npm publishing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To ensure that the package is going to be released as `v1.0.0` rather than `v1.1.0` after automatic version bumps get applied.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I followed the documentation at https://github.com/WordPress/gutenberg/tree/trunk/packages#creating-a-new-package.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I executed `npm run build` to validate whether TS types are generated before removing `types` reference.

## Screenshots or screencast <!-- if applicable -->

<img width="330" alt="Screenshot 2022-04-29 at 08 44 10" src="https://user-images.githubusercontent.com/699132/165896402-68fc6078-8088-4710-b182-5f0311f82cdc.png">
