### PR TITLE
[components] Use internal `Icon` component for `ToggleGroupControlOptionIcon`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `InputControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40622](https://github.com/WordPress/gutenberg/pull/40622)).
 -   `UnitControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40627](https://github.com/WordPress/gutenberg/pull/40627)).
+-   `ToggleControlGroup`: Switch to internal `Icon` component for dashicon support ([40717](https://github.com/WordPress/gutenberg/pull/40717)).
 
 ## 19.9.0 (2022-04-21)
 

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-icon/component.tsx
@@ -1,14 +1,10 @@
 /**
- * WordPress dependencies
- */
-import { Icon } from '@wordpress/icons';
-
-/**
  * Internal dependencies
  */
 import type { WordPressComponentProps } from '../../ui/context';
 import type { ToggleGroupControlOptionIconProps } from '../types';
 import { ToggleGroupControlOptionBase } from '../toggle-group-control-option-base';
+import Icon from '../../icon';
 
 export default function ToggleGroupControlOptionIcon(
 	props: WordPressComponentProps<


### PR DESCRIPTION
## What?
Trying to use dashicon style string based icon props for the `<ToggleGroupControlOptionIcon>` component would throw errors expecting a component and getting a string.

This fix corrects that by switching to the more versatile `<Icon>` from `@wordpress/componenets`

## Why?
`<ToggleGroupControlOptionIcon>` was using the **SVG** based `<Icon>` component from `@wordpress/icons` which does not support dashicon based strings.

## How?
Switched from importing Icon from `@wordpress/icons` to importing it as internal from within `@wordpress/components`.

## Testing Instructions
1. Try using the new component with a dashicon.

```js
<ToggleGroupControlOptionIcon
	icon="hidden"
```

3. You can confirm the fix by simply replacing the "string" prop with a JSX Icon

```js
import { Icon } from '@wordpress/components';

<ToggleGroupControlOptionIcon
	icon={ <Icon icon="hidden" /> }
```

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/847818/165903617-8ecb6596-1128-4226-9d42-4e82801af3f6.png)
