### PR TITLE
getBlockTransformItems: Support single block object

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -428,6 +428,7 @@ Items are returned ordered descendingly by their 'frecency'.
 _Parameters_
 
 -   _state_ `Object`: Editor state.
+-   _blocks_ `Object|Object[]`: Block object or array objects.
 -   _rootClientId_ `?string`: Optional root client ID of block list.
 
 _Returns_

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2050,23 +2050,25 @@ export const getInserterItems = createSelector(
  *
  * Items are returned ordered descendingly by their 'frecency'.
  *
- * @param    {Object}  state        Editor state.
- * @param    {?string} rootClientId Optional root client ID of block list.
+ * @param    {Object}          state        Editor state.
+ * @param    {Object|Object[]} blocks       Block object or array objects.
+ * @param    {?string}         rootClientId Optional root client ID of block list.
  *
  * @return {WPEditorTransformItem[]} Items that appear in inserter.
  *
  * @typedef {Object} WPEditorTransformItem
- * @property {string}  id           Unique identifier for the item.
- * @property {string}  name         The type of block to create.
- * @property {string}  title        Title of the item, as it appears in the inserter.
- * @property {string}  icon         Dashicon for the item, as it appears in the inserter.
- * @property {boolean} isDisabled   Whether or not the user should be prevented from inserting
- *                                  this item.
- * @property {number}  frecency     Heuristic that combines frequency and recency.
+ * @property {string}          id           Unique identifier for the item.
+ * @property {string}          name         The type of block to create.
+ * @property {string}          title        Title of the item, as it appears in the inserter.
+ * @property {string}          icon         Dashicon for the item, as it appears in the inserter.
+ * @property {boolean}         isDisabled   Whether or not the user should be prevented from inserting
+ *                                          this item.
+ * @property {number}          frecency     Heuristic that combines frequency and recency.
  */
 export const getBlockTransformItems = createSelector(
 	( state, blocks, rootClientId = null ) => {
-		const [ sourceBlock ] = blocks;
+		const normalizedBlocks = castArray( blocks );
+		const [ sourceBlock ] = normalizedBlocks;
 		const buildBlockTypeTransformItem = buildBlockTypeItem( state, {
 			buildScope: 'transform',
 		} );
@@ -2088,11 +2090,11 @@ export const getBlockTransformItems = createSelector(
 			isDisabled: false,
 			name: '*',
 			title: __( 'Unwrap' ),
-			icon: itemsByName[ sourceBlock.name ]?.icon,
+			icon: itemsByName[ sourceBlock?.name ]?.icon,
 		};
 
 		const possibleTransforms = getPossibleBlockTransformations(
-			blocks
+			normalizedBlocks
 		).reduce( ( accumulator, block ) => {
 			if ( block === '*' ) {
 				accumulator.push( itemsByName[ '*' ] );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3093,6 +3093,23 @@ describe( 'selectors', () => {
 				] )
 			);
 		} );
+		it( 'should support single block object', () => {
+			const state = {
+				blocks: {
+					byClientId: {},
+					attributes: {},
+					order: {},
+					parents: {},
+					cache: {},
+				},
+				settings: {},
+				preferences: {},
+				blockListSettings: {},
+			};
+			const block = { name: 'core/with-tranforms-a' };
+			const items = getBlockTransformItems( state, block );
+			expect( items ).toHaveLength( 2 );
+		} );
 		it( 'should return only eligible blocks for transformation - `allowedBlocks`', () => {
 			const state = {
 				blocks: {

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -354,7 +354,7 @@ function LinkControlTransforms( { clientId, replace } ) {
 			return {
 				getBlock: _getBlock,
 				blockTransforms: getBlockTransformItems(
-					[ _getBlock( clientId ) ],
+					_getBlock( clientId ),
 					getBlockRootClientId( clientId )
 				),
 			};


### PR DESCRIPTION
## What?
PR updates `getBlockTransformItems` selector `blocks` arguments. Now it allows passing a single object or array of objects. This matches how `getBlocksByClientId` works.

## Why?
When trying to get a transformation for a single block, we often have to pass blocks argument like this - `[ getBlock( clientId ) ]`. If arguments aren't referentially equal, the `createSelector` returns the new value and re-rerenders the component. This can affect performance if left unchecked.

Discovered while working on #40696.

## How?
The blocks argument now is cast into an array inside the selector.

## Testing Instructions
Tests should be passing.
