### PR TITLE
.gitignore the `artifacts` folder

### DIFF
--- a/test/e2e/.gitignore
+++ b/test/e2e/.gitignore
@@ -1,0 +1,2 @@
+# Artifacts and storage states
+/artifacts


### PR DESCRIPTION
## What?
Add a `.gitignore` file to the e2e tests folder.

## Why?
When running tests, some files are generated in the `artifacts` folder, like trace zip files when there is an error, and some `.json` files to store the cookies that are reused across tests. These files are not to be committed to the repo, so they should be git ignored.

## How?
Adding https://github.com/WordPress/gutenberg/blob/add/gitignore-to-e2e-tests-folder/test/e2e/.gitignore

