### PR TITLE
Fix Nav Sidebar Site Editor error

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useRef } from '@wordpress/element';
+import { useCallback, useRef, Fragment } from '@wordpress/element';
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
 	BlockList,
@@ -127,7 +127,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	// Conditionally include NavMenu sidebar in Plugin only.
 	// Optimise for dead code elimination.
 	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
-	let MaybeNavMenuSidebarToggle = 'Fragment';
+	let MaybeNavMenuSidebarToggle = Fragment;
 
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		MaybeNavMenuSidebarToggle = NavMenuSidebarToggle;

--- a/packages/edit-site/src/components/sidebar/index.js
+++ b/packages/edit-site/src/components/sidebar/index.js
@@ -4,7 +4,7 @@
 import { createSlotFill, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { cog } from '@wordpress/icons';
-import { useEffect } from '@wordpress/element';
+import { useEffect, Fragment } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as interfaceStore } from '@wordpress/interface';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -62,7 +62,7 @@ export function SidebarComplementaryAreaFills() {
 	// Conditionally include NavMenu sidebar in Plugin only.
 	// Optimise for dead code elimination.
 	// See https://github.com/WordPress/gutenberg/blob/trunk/docs/how-to-guides/feature-flags.md#dead-code-elimination.
-	let MaybeNavigationMenuSidebar = 'Fragment';
+	let MaybeNavigationMenuSidebar = Fragment;
 
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		MaybeNavigationMenuSidebar = NavigationMenuSidebar;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an error in the Site Editor for WP Beta caused by conditionally enabled Nav Sidebar component.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `Fragment` was provided as a string. This causes an error because that's not a valid React component.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Import `Fragment` component and use that instead of a string.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Load the Site Editor and check for errors. 
- Click on the Nav Block. Check that the Nav Sidebar toggle is displayed in the block's toolbar.
- Now modify the following conditionals in order that they are never truthy (or just temporarily delete the conditional and the code entirely):

https://github.com/WordPress/gutenberg/blob/a7e433ae055308490c36d7bff22728a475a342b9/packages/edit-site/src/components/sidebar/index.js#L67

https://github.com/WordPress/gutenberg/blob/a7e433ae055308490c36d7bff22728a475a342b9/packages/edit-site/src/components/block-editor/index.js#L132

- Load Site Editor and check there a no errors and that the Nav Sidebar toggle icon doesn't display.
- Click on the Nav Block. Check that the Nav Sidebar toggle is _**not**_ displayed in the block's toolbar.

## Screenshots or screencast <!-- if applicable -->
