### PR TITLE
Export hydrate in `@wordpress/element`

### DIFF
--- a/packages/element/README.md
+++ b/packages/element/README.md
@@ -225,6 +225,15 @@ _Returns_
 
 A component which renders its children without any wrapping element.
 
+### hydrate
+
+Hydrates a given element into the target DOM node.
+
+_Parameters_
+
+-   _element_ `import('./react').WPElement`: Element to hydrate.
+-   _target_ `HTMLElement`: DOM node into which element should be hydrated.
+
 ### isEmptyElement
 
 Checks if the provided WP element is empty.

--- a/packages/element/src/react-platform.js
+++ b/packages/element/src/react-platform.js
@@ -5,6 +5,7 @@ import {
 	createPortal,
 	findDOMNode,
 	render,
+	hydrate,
 	unmountComponentAtNode,
 } from 'react-dom';
 
@@ -33,6 +34,14 @@ export { findDOMNode };
  * @param {HTMLElement}                 target  DOM node into which element should be rendered.
  */
 export { render };
+
+/**
+ * Hydrates a given element into the target DOM node.
+ *
+ * @param {import('./react').WPElement} element Element to hydrate.
+ * @param {HTMLElement}                 target  DOM node into which element should be hydrated.
+ */
+export { hydrate };
 
 /**
  * Removes any mounted element from the target DOM node.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

<!-- In a few words, what is the PR actually doing? -->

Expose `hydrate` from `react-dom` in `@wordpress/element`.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because blocks that want to use `@wordpress/element` in the frontend now need to import `hydrate` from `react-dom` instead. For example:

```js
import { hydrate } from "react-dom";
import { useState } from "@wordpress/element";

const Counter = ({ attributes }) => {
  const [counter, setCounter] = useState(attributes.initial);
  const increment = () => setCounter(counter + attributes.increment);
  const decrement = () => setCounter(counter - attributes.increment);

  return (
    <>
      <button onClick={increment}>+</button>
      <div>{counter}</div>
      <button onClick={decrement}>-</button>
    </>
  );
};

window.addEventListener("load", () => {
  document
    .querySelectorAll(".wp-block-gutenberg-interactive-counter-react")
    .forEach((block) => {
      const attributes = JSON.parse(block.dataset.gutenbergAttributes);
      hydrate(<Counter attributes={attributes} />, block);
    });
});
```

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Exporting `hydrate` from `react-dom` in the same way that `render` is exported.

_There are more things that need to be addressed to make `@wordpress/element` useful for the frontend, but this is a first step._

---

cc: @WordPress/frontend-dx 
