### PR TITLE
Enable `onEnter` support for group block

### DIFF
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -18,6 +18,7 @@
 		}
 	},
 	"supports": {
+		"__experimentalOnEnter": true,
 		"__experimentalSettings": true,
 		"align": [ "wide", "full" ],
 		"anchor": true,


### PR DESCRIPTION
## What?

Allows the user to exit the group block when pressing Enter from an empty paragraph at the end of that block or in the middle. Expands the support introduced at https://github.com/WordPress/gutenberg/pull/39911

## Why?

This is a keyboard interaction that helps improves writing flow for people.

## How?

It enables the `__experimentalOnEnter` support.

## Testing Instructions

On enter at end:

https://user-images.githubusercontent.com/583546/165930766-7f127aef-5ec4-4856-a04b-35965fd26744.mp4

On enter in the middle:

https://user-images.githubusercontent.com/583546/165930803-8f2ef9ee-0064-445f-bd1a-45b9755e5ab0.mp4

