### PR TITLE
Comments Title: Count toggle working in 'Singular' editing mode (fix)

### DIFF
--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -140,7 +140,15 @@ export default function Edit( {
 		? __( 'One response to ' )
 		: __( 'One response' );
 
+	const singlePlaceholderNoCount = showPostTitle
+		? __( 'Response to ' )
+		: __( 'Response' );
+
 	const multiplePlaceholder = showPostTitle
+		? __( 'responses to ' )
+		: __( 'responses' );
+
+	const multiplePlaceholderNoCount = showPostTitle
 		? __( 'Responses to ' )
 		: __( 'Responses' );
 
@@ -154,8 +162,16 @@ export default function Edit( {
 						<PlainText
 							__experimentalVersion={ 2 }
 							tagName="span"
-							aria-label={ singlePlaceholder }
-							placeholder={ singlePlaceholder }
+							aria-label={
+								showCommentsCount
+									? singlePlaceholder
+									: singlePlaceholderNoCount
+							}
+							placeholder={
+								showCommentsCount
+									? singlePlaceholder
+									: singlePlaceholderNoCount
+							}
 							value={ singleCommentLabel }
 							onChange={ ( newLabel ) =>
 								setAttributes( {
@@ -174,12 +190,12 @@ export default function Edit( {
 							aria-label={
 								showCommentsCount
 									? ` ${ multiplePlaceholder }`
-									: multiplePlaceholder
+									: multiplePlaceholderNoCount
 							}
 							placeholder={
 								showCommentsCount
 									? ` ${ multiplePlaceholder }`
-									: multiplePlaceholder
+									: multiplePlaceholderNoCount
 							}
 							value={ multipleCommentsLabel }
 							onChange={ ( newLabel ) =>

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -29,11 +29,18 @@ function render_block_core_comments_title( $attributes ) {
 		return;
 	}
 
-	$single_default_comment_label = $show_post_title ? __( 'One response to' ) : __( 'One response' );
-	$single_comment_label         = ! empty( $attributes['singleCommentLabel'] ) ? $attributes['singleCommentLabel'] : $single_default_comment_label;
+	$single_default_comment_label = $show_post_title ? __( 'Response to' ) : __( 'Response' );
+	if ( $show_comments_count ) {
+		$single_default_comment_label = $show_post_title ? __( 'One response to' ) : __( 'One response' );
+	}
+	$single_comment_label = ! empty( $attributes['singleCommentLabel'] ) ? $attributes['singleCommentLabel'] : $single_default_comment_label;
 
 	$multiple_default_comment_label = $show_post_title ? __( 'Responses to' ) : __( 'Responses' );
-	$multiple_comment_label         = ! empty( $attributes['multipleCommentsLabel'] ) ? $attributes['multipleCommentsLabel'] : $multiple_default_comment_label;
+	if ( $show_comments_count ) {
+		$multiple_default_comment_label = $show_post_title ? __( 'responses to' ) : __( 'responses' );
+	}
+
+	$multiple_comment_label = ! empty( $attributes['multipleCommentsLabel'] ) ? $attributes['multipleCommentsLabel'] : $multiple_default_comment_label;
 
 	$comments_title = '%1$s %2$s %3$s';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #40541

Also, to keep consistency, we change uppercase or lowercase on R letter of Response depending on we are enabling or disabling the comments count.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We have both singular and plural editing on the comment title. Also, we have an option for showing comments count or not.
In singular, this last option was not taken into account, showing always the same placeholder. 'One response'


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding new strings placeholders.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1.) Go to site editor -> single template. Add Comments Query Loop.
2.) Click on Comments Title block. Play with the different options.
3.) Check that placeholders are being updated depending on Comments Count and Singular/Plural.
4.) Save and check that the frontend is applying those placeholders.

## Screenshots or screencast <!-- if applicable -->
https://www.loom.com/share/43d3e66bde534d7dac86b2040e2a03fe
