### PR TITLE
Mobile - Draggable - Add onTouchesCancelled callback

### DIFF
--- a/packages/components/src/draggable/index.native.js
+++ b/packages/components/src/draggable/index.native.js
@@ -121,6 +121,9 @@ const Draggable = ( { children, onDragEnd, onDragOver, onDragStart } ) => {
 				}
 			}
 		} )
+		.onTouchesCancelled( ( _event, state ) => {
+			state.end();
+		} )
 		.onEnd( () => {
 			currentFirstTouchId.value = null;
 			isPanActive.value = false;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4802

## What?
Handles an issue reported by testing another PR https://github.com/WordPress/gutenberg/pull/40519 related to the dragging chip on iOS.

## Why?
Fixes an issue where the dragging "chip" would stay visible when the dragging event is active and the app goes to the background or the notifications center is opened.

## How?
Adds the `onTouchesCancelled` callback that is triggered when the dragging event is canceled, for iOS in cases where the app goes to the background or the notifications center is opened.

If this callback is triggered it will manually end the dragging event.

## Testing Instructions
- Start dragging a block.
- While moving the block, make the app go to the background by swiping up the screen with another finger or opening the notifications center.
- Resume the app or dismiss the notifications center popup and **expect to not see** the draggable chip visible and the block should enable the drag & drop event by long-pressing on it.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4885740/165939946-a1060a96-ebf4-4305-941e-c4f5b7688ed5.mov
