### PR TITLE
Code Editor: Commit changes upon switching editors to avoid content loss

### DIFF
--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,12 +7,11 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState, useRef } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
-import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -30,6 +29,7 @@ export default function PostTextEditor() {
 	const [ value, setValue ] = useState( postContent );
 	const [ isDirty, setIsDirty ] = useState( false );
 	const instanceId = useInstanceId( PostTextEditor );
+	const valueRef = useRef();
 
 	if ( ! isDirty && value !== postContent ) {
 		setValue( postContent );
@@ -66,8 +66,17 @@ export default function PostTextEditor() {
 		}
 	};
 
-	// Ensure changes aren't lost when switching modes using shortcuts.
-	useShortcut( 'core/edit-post/toggle-mode', stopEditing );
+	useEffect( () => {
+		valueRef.current = value;
+	}, [ value ] );
+
+	// Ensure changes aren't lost when component unmounts.
+	useEffect( () => {
+		return () => {
+			const blocks = parse( valueRef.current );
+			resetEditorBlocks( blocks );
+		};
+	}, [] );
 
 	return (
 		<>

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,7 +7,7 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
@@ -64,6 +64,16 @@ export default function PostTextEditor() {
 			setIsDirty( false );
 		}
 	};
+
+	// Ensure changes aren't lost when the component unmounts
+	useEffect( () => {
+		return () => {
+			if ( isDirty ) {
+				const blocks = parse( value );
+				resetEditorBlocks( blocks );
+			}
+		};
+	}, [ isDirty, value ] );
 
 	return (
 		<>

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -7,11 +7,12 @@ import Textarea from 'react-autosize-textarea';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { parse } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 import { VisuallyHidden } from '@wordpress/components';
+import { useShortcut } from '@wordpress/keyboard-shortcuts';
 
 /**
  * Internal dependencies
@@ -65,15 +66,13 @@ export default function PostTextEditor() {
 		}
 	};
 
-	// Ensure changes aren't lost when the component unmounts
-	useEffect( () => {
-		return () => {
-			if ( isDirty ) {
-				const blocks = parse( value );
-				resetEditorBlocks( blocks );
-			}
-		};
-	}, [ isDirty, value ] );
+	// Ensure changes aren't lost when switching modes using shortcuts.
+	useShortcut( 'core/edit-post/toggle-mode', () => {
+		if ( isDirty ) {
+			const blocks = parse( value );
+			resetEditorBlocks( blocks );
+		}
+	} );
 
 	return (
 		<>

--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -67,12 +67,7 @@ export default function PostTextEditor() {
 	};
 
 	// Ensure changes aren't lost when switching modes using shortcuts.
-	useShortcut( 'core/edit-post/toggle-mode', () => {
-		if ( isDirty ) {
-			const blocks = parse( value );
-			resetEditorBlocks( blocks );
-		}
-	} );
+	useShortcut( 'core/edit-post/toggle-mode', stopEditing );
 
 	return (
 		<>

--- a/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
+++ b/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
@@ -34,9 +34,9 @@ export default function useShortcut( name, callback, { isDisabled } = {} ) {
 			}
 		}
 
-		shortcuts.current.add( _callback );
+		shortcuts?.current?.add( _callback );
 		return () => {
-			shortcuts.current.delete( _callback );
+			shortcuts?.current?.delete( _callback );
 		};
 	}, [ name, isDisabled ] );
 }

--- a/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
+++ b/packages/keyboard-shortcuts/src/hooks/use-shortcut.js
@@ -34,9 +34,9 @@ export default function useShortcut( name, callback, { isDisabled } = {} ) {
 			}
 		}
 
-		shortcuts?.current?.add( _callback );
+		shortcuts.current.add( _callback );
 		return () => {
-			shortcuts?.current?.delete( _callback );
+			shortcuts.current.delete( _callback );
 		};
 	}, [ name, isDisabled ] );
 }


### PR DESCRIPTION
## What?
Fixes #40575.

PR fixes content loss issue when switching between editors mode using keyboard shortcuts.

## How?
Currently, blocks are only updated `onBlur`. I added a new effect to try and update them when the component unmounts. 

## Testing Instructions
1. Create a new post or page.
2. Switch to Code view (on PC, Ctrl + Shift + Alt + M).
3. Start typing in the post content area.
4. Use the keyboard shortcut again to exit the Code view.
5. Confirm that new content is available in Visual Editor.
