### PR TITLE
Rename list view prop `expandNested` to `isExpanded`

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -92,7 +92,7 @@ function ListViewBranch( props ) {
 		isBranchSelected = false,
 		listPosition = 0,
 		fixedListWindow,
-		expandNested,
+		isExpanded,
 	} = props;
 
 	const {
@@ -115,7 +115,7 @@ function ListViewBranch( props ) {
 						filteredBlocks[ index - 1 ],
 						expandedState,
 						draggedClientIds,
-						expandNested
+						isExpanded
 					);
 				}
 
@@ -134,7 +134,7 @@ function ListViewBranch( props ) {
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 
 				const shouldExpand = hasNestedBlocks
-					? expandedState[ clientId ] ?? expandNested
+					? expandedState[ clientId ] ?? isExpanded
 					: undefined;
 
 				const isDragged = !! draggedClientIds?.includes( clientId );
@@ -186,7 +186,7 @@ function ListViewBranch( props ) {
 								fixedListWindow={ fixedListWindow }
 								isBranchSelected={ isSelectedBranch }
 								selectedClientIds={ selectedClientIds }
-								expandNested={ expandNested }
+								isExpanded={ isExpanded }
 							/>
 						) }
 					</AsyncModeProvider>

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -133,7 +133,7 @@ function ListViewBranch( props ) {
 				const hasNestedBlocks =
 					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
 
-				const isExpanded = hasNestedBlocks
+				const shouldExpand = hasNestedBlocks
 					? expandedState[ clientId ] ?? expandNested
 					: undefined;
 
@@ -164,7 +164,7 @@ function ListViewBranch( props ) {
 								siblingBlockCount={ blockCount }
 								showBlockMovers={ showBlockMovers }
 								path={ updatedPath }
-								isExpanded={ isExpanded }
+								isExpanded={ shouldExpand }
 								listPosition={ nextPosition }
 								selectedClientIds={ selectedClientIds }
 							/>
@@ -174,7 +174,7 @@ function ListViewBranch( props ) {
 								<td className="block-editor-list-view-placeholder" />
 							</tr>
 						) }
-						{ hasNestedBlocks && isExpanded && ! isDragged && (
+						{ hasNestedBlocks && shouldExpand && ! isDragged && (
 							<ListViewBranch
 								blocks={ innerBlocks }
 								selectBlock={ selectBlock }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -60,7 +60,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {boolean} props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
  * @param {string}  props.id                                       Unique identifier for the root list element (primarily for a11y purposes).
- * @param {boolean} props.expandNested                             Flag to determine whether nested levels are expanded by default.
+ * @param {boolean} props.isExpanded                               Flag to determine whether nested levels are expanded by default.
  * @param {Object}  ref                                            Forwarded ref
  */
 function ListView(
@@ -72,7 +72,7 @@ function ListView(
 		showNestedBlocks,
 		showBlockMovers,
 		id,
-		expandNested = false,
+		isExpanded = false,
 		...props
 	},
 	ref
@@ -225,7 +225,7 @@ function ListView(
 						showBlockMovers={ showBlockMovers }
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
-						expandNested={ expandNested }
+						isExpanded={ isExpanded }
 						{ ...props }
 					/>
 				</ListViewContext.Provider>

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -53,7 +53,6 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			<ListView
 				id={ id }
 				showNestedBlocks
-				isExpanded={ false }
 				__experimentalFeatures
 				__experimentalPersistentListViewFeatures
 			/>

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -53,7 +53,7 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			<ListView
 				id={ id }
 				showNestedBlocks
-				expandNested={ false }
+				isExpanded={ false }
 				__experimentalFeatures
 				__experimentalPersistentListViewFeatures
 			/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Renames the `expandNested` prop of `<ListView>` to `isExpanded`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was discussed at length in https://github.com/WordPress/gutenberg/pull/39486#discussion_r837302573 and it was decided to rename the prop.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Do the prop renaming. Rename intermediate vars to take account of the resulting naming clash.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open the various editors/
2. Check that when toggling open List View it is _collapsed_ by default.
3. Now updated this to `true`
https://github.com/WordPress/gutenberg/blob/dd7db32c1a3430046576b9c2da3f306d7cec06d2/packages/block-editor/src/components/list-view/index.js#L75
4. Check List View is now _expanded_ by default.

## Screenshots or screencast <!-- if applicable -->
