### PR TITLE
useSelect: add unit tests for usage without deps

### DIFF
--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -1054,6 +1054,8 @@ describe( 'useSelect', () => {
 			const rendered = render( <App multiple={ 1 } /> );
 			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 1 );
 
+			// Check that the most recent value of `multiple` is used to render:
+			// the old callback wasn't memoized and there is no stale closure problem.
 			rendered.rerender( <App multiple={ 2 } /> );
 			expect( rendered.getByRole( 'status' ) ).toHaveTextContent( 2 );
 		} );


### PR DESCRIPTION
Adds unit tests for usage of `useSelect` without a dependency array, only with a `mapSelect` function.

The behavior in this case is weird and unintuitive -- the `mapSelect` function can change between invocations, the most recent version will always be called, but store subscriptions will never get updated -- and that's one more good reason to have it "documented" in the tests.