### PR TITLE
[Gradient Tool]: Fix closing of popover when the angle control is clicked

### DIFF
--- a/packages/components/src/angle-picker-control/angle-circle.js
+++ b/packages/components/src/angle-picker-control/angle-circle.js
@@ -28,12 +28,11 @@ function AngleCircle( { value, onChange, ...props } ) {
 
 	const changeAngleToPosition = ( event ) => {
 		const { x: centerX, y: centerY } = angleCircleCenter.current;
-		const { ownerDocument } = angleCircleRef.current;
 		// Prevent (drag) mouse events from selecting and accidentally
 		// triggering actions from other elements.
 		event.preventDefault();
-		// Ensure the input isn't focused as preventDefault would leave it.
-		ownerDocument.activeElement.blur();
+		// Input control needs to lose focus and by preventDefault above, it doesn't.
+		event.target.focus();
 		onChange( getAngle( centerX, centerY, event.clientX, event.clientY ) );
 	};
 
@@ -72,6 +71,7 @@ function AngleCircle( { value, onChange, ...props } ) {
 					value ? { transform: `rotate(${ value }deg)` } : undefined
 				}
 				className="components-angle-picker-control__angle-circle-indicator-wrapper"
+				tabIndex={ -1 }
 			>
 				<CircleIndicator className="components-angle-picker-control__angle-circle-indicator" />
 			</CircleIndicatorWrapper>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40661

From the issue:
>The gradient tool comes with an input field for angle, and a separate angel control. When clicking the angle control in the flyout, the entire flyout closes, as shown here:



<!-- In a few words, what is the PR actually doing? -->


## How?
In [this PR](https://github.com/WordPress/gutenberg/pull/25609) there were changes that affected InputControl and how it updates/syncs values. That PR added a line of code in angle circle control to programmatically `blur` the active element.

I couldn't find the reason for making the popover close and my guess is that there is someone else listening to that event and/or a rerender somewhere is triggered. I'd love to learn why it was happening if anyone knows or debugs a bit 😄 --cc @ciampo @aaronrobertshaw 

What I did here was explicitly focus the current node(angle circle) if clicked, to contain the triggered event with the same effect.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
* Insert a cover block
* Add a background gradient
* Turn the angle control knob

#### Before
![gradient](https://user-images.githubusercontent.com/1204802/165621239-25c1b261-3fd5-4e4b-b526-388d736d7daf.gif)

#### After

https://user-images.githubusercontent.com/16275880/165960755-7a58a8e9-5552-47d8-b77d-35519e3a8296.mov


