### PR TITLE
env: Allow overriding admin user credentials on development environment

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -492,6 +492,22 @@ Additionally, the key `env` is available to override any of the above options on
 }
 ```
 
+The development supports one last field for `admin` which allows the environment to use credentials other than `admin`/`password`:
+
+```json
+{
+  "env": {
+    "development": {
+      "admin": {
+        "user": "foo",
+        "password": "phoFooPh00",
+        "email": "foo@example.com"
+      }
+    }
+  }
+}
+```
+
 On the development instance, `cwd` will be mapped as a plugin, `one-theme` will be mapped as a theme, KEY_1 will be set to true, and KEY_2 will be set to false. Also note that the default port, 8888, will be used as well.
 
 On the tests instance, `cwd` is still mapped as a plugin, but no theme is mapped. Additionally, while KEY_2 is still set to false, KEY_1 is overridden and set to false. 3000 overrides the default port as well.

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -46,6 +46,7 @@ module.exports = function parseConfig( config, options ) {
 		themeSources: config.themes.map( ( sourceString ) =>
 			parseSourceString( sourceString, options )
 		),
+		admin: config.admin,
 		config: config.config,
 		mappings: Object.entries( config.mappings ).reduce(
 			( result, [ wpDir, localDir ] ) => {

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -55,7 +55,12 @@ async function configureWordPress( environment, config, spinner ) {
 		return `${ domain }:${ port }`;
 	} )();
 
-	const installCommand = `wp core install --url="${ url }" --title="${ config.name }" --admin_user=admin --admin_password=password --admin_email=wordpress@example.com --skip-email`;
+	// Allow env to specify default user to avoid browser warnings about insecure password.
+	const adminUser = environment === 'development' && config.env.development?.admin?.user || 'admin';
+	const adminPassword = environment === 'development' && config.env.development?.admin?.password || 'password';
+	const adminEmail = environment === 'development' && config.env.development?.admin?.email || 'wordpress@example.com';
+
+	const installCommand = `wp core install --url="${ url }" --title="${ config.name }" --admin_user=${ adminUser } --admin_password=${ adminPassword } --admin_email=${ adminEmail } --skip-email`;
 
 	// -eo pipefail exits the command as soon as anything fails in bash.
 	const setupCommands = [ 'set -eo pipefail', installCommand ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This allows a project's `.wp-env.json` to override the admin user's credentials for the `development` instance.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When logging in with the `admin` and `password` credentials, Chrome can complain each time with this warning:

> ![Screen Shot 2022-04-29 at 11 40 03](https://user-images.githubusercontent.com/134745/166007655-09a02801-1815-461c-b771-b56db5ef9ae4.png)

When using Chrome's password manager, similarly it persistently flags this saved password as being compromised:

> ![Screen Shot 2022-04-29 at 11 39 47](https://user-images.githubusercontent.com/134745/166007764-c27ea4b5-6a8b-485d-bdee-344153fe4c52.png)

If there is a best practice to get around this issue, then this PR would be unnecessary.

## How?

By adding a new `admin` field to the `env.development` config, this issue can be avoided by supplying project-specific credentials.

I don't know if this is the best way to go about it, but it's what I came up with. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
