### PR TITLE
Fixes the Icon component mobile icon

### DIFF
--- a/packages/icons/src/library/mobile.js
+++ b/packages/icons/src/library/mobile.js
@@ -3,10 +3,10 @@
  */
 import { SVG, Path } from '@wordpress/primitives';
 
-const desktop = (
+const mobile = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M15 4H9c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h6c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm.5 14c0 .3-.2.5-.5.5H9c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h6c.3 0 .5.2.5.5v12zm-4.5-.5h2V16h-2v1.5z" />
 	</SVG>
 );
 
-export default desktop;
+export default mobile;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Changed the Icon exported constant for the mobile icon

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When using the Icon component the mobile icon does not render.

How to replicate
```
import { Icon } from '@wordpress/components';

...
<Icon icon="desktop" />
<Icon icon="tablet" />
<Icon icon="mobile" />
...
```
<img width="70" alt="Screenshot 2022-04-30 at 18 08 04" src="https://user-images.githubusercontent.com/7514504/166111824-6f593403-5655-4dae-97b0-65cbc91ecf91.png">


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
