### PR TITLE
Enable filter hooks for convertLegacyBlockNameAndAttributes

### DIFF
--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -72,7 +72,7 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		name = 'core/comment-date';
 	}
 
-	return applyFilters( 'editor.convertLegacyBlockNameAndAttributes', [
+	return applyFilters( 'blocks.convertLegacyBlockNameAndAttributes', [
 		name,
 		newAttributes,
 	] );

--- a/packages/blocks/src/api/parser/convert-legacy-block.js
+++ b/packages/blocks/src/api/parser/convert-legacy-block.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { applyFilters } from '@wordpress/hooks';
+
+/**
  * Convert legacy blocks to their canonical form. This function is used
  * both in the parser level for previous content and to convert such blocks
  * used in Custom Post Types templates.
@@ -67,5 +72,8 @@ export function convertLegacyBlockNameAndAttributes( name, attributes ) {
 		name = 'core/comment-date';
 	}
 
-	return [ name, newAttributes ];
+	return applyFilters( 'editor.convertLegacyBlockNameAndAttributes', [
+		name,
+		newAttributes,
+	] );
 }


### PR DESCRIPTION
## What? &  Why?

Enable filter hooks for `convertLegacyBlockNameAndAttributes `.

While `convertLegacyBlocks` only has the core blocks available.

This PR allows plugin creators to change their block names.

For example, the following code would change `my-plugin/example-block` to `my-addon/example-block`.
```
addFilter(
	'editor.convertLegacyBlockNameAndAttributes',
	'my-plugin/filter-convertLegacyBlockNameAndAttributes',
	( blockData ) => {
		const name = blockData[ 0 ];
		const attrs = blockData[ 1 ];

		if ( 'my-plugin/example-block' === name ) {
			return [ 'my-addon/example-block', attrs ];
		}
		return [ name, attrs ];
	}
);
```

This can solve problems such as #17372.