### PR TITLE
Add `DatePicker` tests using React Testing Library

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   `UnitControl`: migrate unit tests to TypeScript ([#40697](https://github.com/WordPress/gutenberg/pull/40697)).
+-   `DatePicker`: Add improved unit tests ([#40754](https://github.com/WordPress/gutenberg/pull/40754)).
 
 ### Enhancements
 

--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -71,6 +71,10 @@ export const WithDaysHighlighted = () => {
 	);
 };
 
+/**
+ * You can mark particular dates as invalid using the `isInvalidDate` prop. This
+ * prevents the user from being able to select it.
+ */
 export const WithInvalidDates = () => {
 	const [ currentDate, setCurrentDate ] = useState( now );
 
@@ -79,6 +83,7 @@ export const WithInvalidDates = () => {
 			currentDate={ currentDate }
 			onChange={ setCurrentDate }
 			isInvalidDate={ ( date ) =>
+				// Mark Saturdays and Sundays as invalid.
 				date.getDay() === 0 || date.getDay() === 6
 			}
 		/>

--- a/packages/components/src/date-time/stories/index.js
+++ b/packages/components/src/date-time/stories/index.js
@@ -70,3 +70,17 @@ export const WithDaysHighlighted = () => {
 		/>
 	);
 };
+
+export const WithInvalidDates = () => {
+	const [ currentDate, setCurrentDate ] = useState( now );
+
+	return (
+		<DateTimePicker
+			currentDate={ currentDate }
+			onChange={ setCurrentDate }
+			isInvalidDate={ ( date ) =>
+				date.getDay() === 0 || date.getDay() === 6
+			}
+		/>
+	);
+};

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -1,97 +1,111 @@
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
 import moment from 'moment';
+import { render, screen, fireEvent } from '@testing-library/react';
+import 'react-dates/initialize';
 
 /**
  * Internal dependencies
  */
 import DatePicker from '../date';
 
-const TIMEZONELESS_FORMAT = 'YYYY-MM-DDTHH:mm:ss';
-
 describe( 'DatePicker', () => {
-	it( 'should pass down a moment object for currentDate', () => {
-		const currentDate = '1986-10-18T23:00:00';
-		const wrapper = shallow( <DatePicker currentDate={ currentDate } /> );
-		const date = wrapper.children().props().date;
-		expect( moment.isMoment( date ) ).toBe( true );
-		expect( date.isSame( moment( currentDate ) ) ).toBe( true );
+	it( 'should highlight the current date', () => {
+		render( <DatePicker currentDate="2022-05-02T11:00:00" /> );
+
+		expect(
+			screen.getByLabelText( 'Monday, May 2, 2022' ).classList
+		).toContain( 'CalendarDay__selected' );
+
+		// Expect React deprecation warning due to outdated 'react-dates' package.
+		// TODO: Update 'react-dates'.
+		expect( console ).toHaveWarned();
 	} );
 
-	it( 'should pass down a null date when currentDate is set to null', () => {
-		const wrapper = shallow( <DatePicker currentDate={ null } /> );
-		expect( wrapper.children().props().date ).toBeNull();
+	it( "should highlight today's date when not provided a currentDate", () => {
+		render( <DatePicker /> );
+
+		const todayDescription = moment().format( 'dddd, MMM D, YYYY' );
+		expect( screen.getByLabelText( todayDescription ).classList ).toContain(
+			'CalendarDay__selected'
+		);
 	} );
 
-	it( 'should pass down a moment object for now when currentDate is undefined', () => {
-		const wrapper = shallow( <DatePicker /> );
-		const date = wrapper.children().props().date;
-		expect( moment.isMoment( date ) ).toBe( true );
+	it( 'should call onChange when a day is selected', () => {
+		const onChange = jest.fn();
+
+		render(
+			<DatePicker
+				currentDate="2022-05-02T11:00:00"
+				onChange={ onChange }
+			/>
+		);
+
+		fireEvent.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );
 
-	describe( 'onChangeMoment', () => {
-		it( 'should call onChange with a formated date of the input', () => {
-			const onChangeSpy = jest.fn();
-			const currentDate = '1986-10-18T11:00:00';
-			const wrapper = shallow(
-				<DatePicker
-					currentDate={ currentDate }
-					onChange={ onChangeSpy }
-				/>
-			);
-			const newDate = moment();
+	it( 'should call onMonthPreviewed and onChange when a day in a different month is selected', () => {
+		const onMonthPreviewed = jest.fn();
+		const onChange = jest.fn();
 
-			wrapper.childAt( 0 ).props().onDateChange( newDate );
+		render(
+			<DatePicker
+				currentDate="2022-05-02T11:00:00"
+				onMonthPreviewed={ onMonthPreviewed }
+				onChange={ onChange }
+			/>
+		);
 
-			expect( onChangeSpy ).toHaveBeenCalledWith(
-				newDate.format( TIMEZONELESS_FORMAT )
-			);
-		} );
+		fireEvent.click(
+			screen.getByLabelText( 'Move forward to switch to the next month.' )
+		);
 
-		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is undefined', () => {
-			let onChangeSpyArgument;
-			const onChangeSpy = ( arg ) => ( onChangeSpyArgument = arg );
-			const wrapper = shallow( <DatePicker onChange={ onChangeSpy } /> );
-			const newDate = moment( '1986-10-18T11:00:00' );
-			const current = moment();
-			const newDateWithCurrentTime = newDate.clone().set( {
-				hours: current.hours(),
-				minutes: current.minutes(),
-				seconds: current.seconds(),
-			} );
-			wrapper.childAt( 0 ).props().onDateChange( newDate );
+		expect( onMonthPreviewed ).toHaveBeenCalledWith(
+			expect.stringMatching( /^2022-06/ )
+		);
 
-			expect(
-				moment( onChangeSpyArgument ).isSame(
-					newDateWithCurrentTime,
-					'minute'
-				)
-			).toBe( true );
-		} );
+		fireEvent.click( screen.getByLabelText( 'Monday, June 20, 2022' ) );
 
-		it( 'should call onChange with hours, minutes, seconds of the current time when currentDate is null', () => {
-			let onChangeSpyArgument;
-			const onChangeSpy = ( arg ) => ( onChangeSpyArgument = arg );
-			const wrapper = shallow(
-				<DatePicker currentDate={ null } onChange={ onChangeSpy } />
-			);
-			const newDate = moment( '1986-10-18T11:00:00' );
-			const current = moment();
-			const newDateWithCurrentTime = newDate.clone().set( {
-				hours: current.hours(),
-				minutes: current.minutes(),
-				seconds: current.seconds(),
-			} );
-			wrapper.childAt( 0 ).props().onDateChange( newDate );
+		expect( onChange ).toHaveBeenCalledWith( '2022-06-20T11:00:00' );
+	} );
 
-			expect(
-				moment( onChangeSpyArgument ).isSame(
-					newDateWithCurrentTime,
-					'minute'
-				)
-			).toBe( true );
-		} );
+	it( 'should highlight events on the calendar', () => {
+		render(
+			<DatePicker
+				currentDate="2022-05-02T11:00:00"
+				events={ [
+					{ date: new Date( '2022-05-04T00:00:00' ) },
+					{ date: new Date( '2022-05-19T00:00:00' ) },
+				] }
+			/>
+		);
+
+		expect(
+			screen
+				.getAllByLabelText( 'There is 1 event.', { exact: false } )
+				.map( ( day ) => day.getAttribute( 'aria-label' ) )
+		).toEqual( [
+			'Wednesday, May 4, 2022. There is 1 event.',
+			'Thursday, May 19, 2022. There is 1 event.',
+		] );
+	} );
+
+	it( 'should not allow invalid date to be selected', () => {
+		const onChange = jest.fn();
+
+		render(
+			<DatePicker
+				currentDate="2022-05-02T11:00:00"
+				onChange={ onChange }
+				isInvalidDate={ ( date ) => date.getDate() === 20 }
+			/>
+		);
+
+		fireEvent.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+
+		expect( onChange ).not.toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );
 } );

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import moment from 'moment';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import 'react-dates/initialize';
 
 /**
@@ -32,7 +33,9 @@ describe( 'DatePicker', () => {
 		);
 	} );
 
-	it( 'should call onChange when a day is selected', () => {
+	it( 'should call onChange when a day is selected', async () => {
+		const user = userEvent.setup( { delay: null } );
+
 		const onChange = jest.fn();
 
 		render(
@@ -42,12 +45,14 @@ describe( 'DatePicker', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+		await user.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
 
 		expect( onChange ).toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );
 
-	it( 'should call onMonthPreviewed and onChange when a day in a different month is selected', () => {
+	it( 'should call onMonthPreviewed and onChange when a day in a different month is selected', async () => {
+		const user = userEvent.setup( { delay: null } );
+
 		const onMonthPreviewed = jest.fn();
 		const onChange = jest.fn();
 
@@ -59,7 +64,7 @@ describe( 'DatePicker', () => {
 			/>
 		);
 
-		fireEvent.click(
+		await user.click(
 			screen.getByLabelText( 'Move forward to switch to the next month.' )
 		);
 
@@ -67,7 +72,7 @@ describe( 'DatePicker', () => {
 			expect.stringMatching( /^2022-06/ )
 		);
 
-		fireEvent.click( screen.getByLabelText( 'Monday, June 20, 2022' ) );
+		await user.click( screen.getByLabelText( 'Monday, June 20, 2022' ) );
 
 		expect( onChange ).toHaveBeenCalledWith( '2022-06-20T11:00:00' );
 	} );
@@ -93,7 +98,9 @@ describe( 'DatePicker', () => {
 		] );
 	} );
 
-	it( 'should not allow invalid date to be selected', () => {
+	it( 'should not allow invalid date to be selected', async () => {
+		const user = userEvent.setup( { delay: null } );
+
 		const onChange = jest.fn();
 
 		render(
@@ -104,7 +111,7 @@ describe( 'DatePicker', () => {
 			/>
 		);
 
-		fireEvent.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+		await user.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
 
 		expect( onChange ).not.toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -16,7 +16,8 @@ describe( 'DatePicker', () => {
 		render( <DatePicker currentDate="2022-05-02T11:00:00" /> );
 
 		expect(
-			screen.getByLabelText( 'Monday, May 2, 2022' ).classList
+			screen.getByRole( 'button', { name: 'Monday, May 2, 2022' } )
+				.classList
 		).toContain( 'CalendarDay__selected' );
 
 		// Expect React deprecation warning due to outdated 'react-dates' package.
@@ -28,9 +29,9 @@ describe( 'DatePicker', () => {
 		render( <DatePicker /> );
 
 		const todayDescription = moment().format( 'dddd, MMM D, YYYY' );
-		expect( screen.getByLabelText( todayDescription ).classList ).toContain(
-			'CalendarDay__selected'
-		);
+		expect(
+			screen.getByRole( 'button', { name: todayDescription } ).classList
+		).toContain( 'CalendarDay__selected' );
 	} );
 
 	it( 'should call onChange when a day is selected', async () => {
@@ -45,7 +46,9 @@ describe( 'DatePicker', () => {
 			/>
 		);
 
-		await user.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Friday, May 20, 2022' } )
+		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );
@@ -65,14 +68,18 @@ describe( 'DatePicker', () => {
 		);
 
 		await user.click(
-			screen.getByLabelText( 'Move forward to switch to the next month.' )
+			screen.getByRole( 'button', {
+				name: 'Move forward to switch to the next month.',
+			} )
 		);
 
 		expect( onMonthPreviewed ).toHaveBeenCalledWith(
 			expect.stringMatching( /^2022-06/ )
 		);
 
-		await user.click( screen.getByLabelText( 'Monday, June 20, 2022' ) );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Monday, June 20, 2022' } )
+		);
 
 		expect( onChange ).toHaveBeenCalledWith( '2022-06-20T11:00:00' );
 	} );
@@ -111,7 +118,9 @@ describe( 'DatePicker', () => {
 			/>
 		);
 
-		await user.click( screen.getByLabelText( 'Friday, May 20, 2022' ) );
+		await user.click(
+			screen.getByRole( 'button', { name: 'Friday, May 20, 2022' } )
+		);
 
 		expect( onChange ).not.toHaveBeenCalledWith( '2022-05-20T11:00:00' );
 	} );

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -17,8 +17,7 @@ describe( 'DatePicker', () => {
 
 		expect(
 			screen.getByRole( 'button', { name: 'Monday, May 2, 2022' } )
-				.classList
-		).toContain( 'CalendarDay__selected' );
+		).toHaveClass( 'CalendarDay__selected' );
 
 		// Expect React deprecation warning due to outdated 'react-dates' package.
 		// TODO: Update 'react-dates'.
@@ -30,8 +29,8 @@ describe( 'DatePicker', () => {
 
 		const todayDescription = moment().format( 'dddd, MMM D, YYYY' );
 		expect(
-			screen.getByRole( 'button', { name: todayDescription } ).classList
-		).toContain( 'CalendarDay__selected' );
+			screen.getByRole( 'button', { name: todayDescription } )
+		).toHaveClass( 'CalendarDay__selected' );
 	} );
 
 	it( 'should call onChange when a day is selected', async () => {


### PR DESCRIPTION
## What?

Rewrites the `DatePicker` tests to use React Testing Library and to test the component's basic functionality instead of simply that `react-dates` is called correctly.

## Why?

- Gives us some confidence that the basic functionality of `DatePicker` works. (I'm about to refactor it.)
- Makes the tests align more closely with `DatePicker`'s sister component, `TimePicker`.

## How?

Wrote new tests using React Testing Library. I focused on ensuring coverage for all of the public props.

I didn't touch `TimePicker`'s tests as they already look pretty good.

I also added a new story that demonstrates the `isInvalidDate` prop which was missing.

## Testing Instructions

`npm run test`