### PR TITLE
Prevent comments rendering on password protected posts.

### DIFF
--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -79,6 +79,10 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		return '';
 	}
 
+	if ( post_password_required( $block->context['postId'] ) ) {
+		return;
+	}
+
 	$comment_query = new WP_Comment_Query(
 		build_comment_query_vars_from_block( $block )
 	);

--- a/packages/block-library/src/comments-pagination/index.php
+++ b/packages/block-library/src/comments-pagination/index.php
@@ -18,6 +18,10 @@ function render_block_core_comments_pagination( $attributes, $content ) {
 		return '';
 	}
 
+	if ( post_password_required() ) {
+		return;
+	}
+
 	return sprintf(
 		'<div %1$s>%2$s</div>',
 		get_block_wrapper_attributes(),

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -14,6 +14,10 @@
  */
 function render_block_core_comments_title( $attributes ) {
 
+	if ( post_password_required() ) {
+		return;
+	}
+
 	$align_class_name    = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -18,6 +18,10 @@ function render_block_core_post_comments_form( $attributes, $content, $block ) {
 		return '';
 	}
 
+	if ( post_password_required( $block->context['postId'] ) ) {
+		return;
+	}
+
 	$classes = 'comment-respond'; // See comment further below.
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= 'has-text-align-' . $attributes['textAlign'];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

On password protected posts, prevent the rendering of the following blocks prior to the password being entered:

* comment-template
* post-comments-form
* comments-pagination
* comments-title

See #40747

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This matches the behavior of the comments query loop to that of the comments template. In neither case are comments shown on password protected posts prior to the password been displayed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds early returns to the PHP functions rendering the blocks listed above.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Configure: WP 5.9 with Gutenberg
7. Activate TT2 and configure comments to use the new comment loop
2. Create and publish a post (don't password protect it yet)
3. Visit the post and leave a comment
4. Edit the post and password protect it
5. Visit the post in a private/incognito browser window but do not enter the password
6. observe the comments are not shown


## Screenshots or screencast <!-- if applicable -->

**Without PR applied**

![Screen Shot 2022-05-02 at 3 20 41 pm](https://user-images.githubusercontent.com/519727/166187793-07c7630f-daaf-43c8-b053-3680dcec54b0.png)

**With PR applied**

![Screen Shot 2022-05-02 at 3 19 38 pm](https://user-images.githubusercontent.com/519727/166187724-a51065ee-e42a-4c35-9aa0-d0713728324e.png)

----

I've matched the labels to those on the issue, please let me know if this is incorrect.