### PR TITLE
Block list: Add option in editor settings to show open list view as default

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -72,6 +72,7 @@ function Layout( { styles } ) {
 		setIsInserterOpened,
 	} = useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { setIsListViewOpened } = useDispatch( editPostStore );
 	const {
 		mode,
 		isFullscreenActive,
@@ -89,6 +90,7 @@ function Layout( { styles } ) {
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
+		isListViewOpenByDefault,
 	} = useSelect( ( select ) => {
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
 		const editorSettings = getEditorSettings();
@@ -129,6 +131,9 @@ function Layout( { styles } ) {
 			),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
+			isListViewOpenByDefault: select( editPostStore ).isFeatureActive(
+				'listView'
+			),
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
@@ -141,6 +146,12 @@ function Layout( { styles } ) {
 		openGeneralSidebar(
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
 		);
+
+	useEffect( () => {
+		if ( isListViewOpenByDefault ) {
+			setIsListViewOpened( true );
+		}
+	}, [] );
 
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {
@@ -181,6 +192,7 @@ function Layout( { styles } ) {
 		if ( mode === 'visual' && isListViewOpened ) {
 			return <ListViewSidebar />;
 		}
+
 		return null;
 	};
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -147,6 +147,7 @@ function Layout( { styles } ) {
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
 		);
 
+	// Check if the block list view should be open by default.
 	useEffect( () => {
 		if ( isListViewOpenByDefault ) {
 			setIsListViewOpened( true );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -132,7 +132,7 @@ function Layout( { styles } ) {
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
 			isListViewOpenByDefault: select( editPostStore ).isFeatureActive(
-				'listView'
+				'showListViewByDefault'
 			),
 		};
 	}, [] );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -72,7 +72,6 @@ function Layout( { styles } ) {
 		setIsInserterOpened,
 	} = useDispatch( editPostStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
-	const { setIsListViewOpened } = useDispatch( editPostStore );
 	const {
 		mode,
 		isFullscreenActive,
@@ -90,7 +89,6 @@ function Layout( { styles } ) {
 		showBlockBreadcrumbs,
 		isTemplateMode,
 		documentLabel,
-		isListViewOpenByDefault,
 	} = useSelect( ( select ) => {
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
 		const editorSettings = getEditorSettings();
@@ -131,9 +129,6 @@ function Layout( { styles } ) {
 			),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-			isListViewOpenByDefault: select( editPostStore ).isFeatureActive(
-				'showListViewByDefault'
-			),
 		};
 	}, [] );
 	const className = classnames( 'edit-post-layout', 'is-mode-' + mode, {
@@ -146,13 +141,6 @@ function Layout( { styles } ) {
 		openGeneralSidebar(
 			hasBlockSelected ? 'edit-post/block' : 'edit-post/document'
 		);
-
-	// Check if the block list view should be open by default.
-	useEffect( () => {
-		if ( isListViewOpenByDefault ) {
-			setIsListViewOpened( true );
-		}
-	}, [] );
 
 	// Inserter and Sidebars are mutually exclusive
 	useEffect( () => {

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -118,7 +118,7 @@ export default function EditPostPreferencesModal() {
 							<EnableFeature
 								featureName="listView"
 								help={ __(
-									'Opens the block list view sidebar in the editor by default.'
+									'Opens the block list view sidebar by default.'
 								) }
 								label={ __( 'Always open list view' ) }
 							/>

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -116,6 +116,13 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Spotlight mode' ) }
 							/>
 							<EnableFeature
+								featureName="listView"
+								help={ __(
+									'Opens the block list view sidebar in the editor by default.'
+								) }
+								label={ __( 'Always open list view' ) }
+							/>
+							<EnableFeature
 								featureName="showIconLabels"
 								help={ __( 'Shows text instead of icons.' ) }
 								label={ __( 'Display button labels' ) }

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -116,7 +116,7 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Spotlight mode' ) }
 							/>
 							<EnableFeature
-								featureName="listView"
+								featureName="showListViewByDefault"
 								help={ __(
 									'Opens the block list view sidebar by default.'
 								) }

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -33,6 +33,11 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 label="Spotlight mode"
               />
               <WithSelect(WithDispatch(BaseOption))
+                featureName="listView"
+                help="Opens the block list view sidebar by default."
+                label="Always open list view"
+              />
+              <WithSelect(WithDispatch(BaseOption))
                 featureName="showIconLabels"
                 help="Shows text instead of icons."
                 label="Display button labels"
@@ -157,6 +162,11 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 featureName="focusMode"
                 help="Highlights the current block and fades other content."
                 label="Spotlight mode"
+              />
+              <WithSelect(WithDispatch(BaseOption))
+                featureName="listView"
+                help="Opens the block list view sidebar by default."
+                label="Always open list view"
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="showIconLabels"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -33,7 +33,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 label="Spotlight mode"
               />
               <WithSelect(WithDispatch(BaseOption))
-                featureName="listView"
+                featureName="showListViewByDefault"
                 help="Opens the block list view sidebar by default."
                 label="Always open list view"
               />
@@ -164,7 +164,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 label="Spotlight mode"
               />
               <WithSelect(WithDispatch(BaseOption))
-                featureName="listView"
+                featureName="showListViewByDefault"
                 help="Opens the block list view sidebar by default."
                 label="Always open list view"
               />

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -117,6 +117,7 @@ export function initializeEditor(
 		preferredStyleVariations: {},
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
+		showListViewByDefault: false,
 		themeStyles: true,
 		welcomeGuide: true,
 		welcomeGuideTemplate: true,

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -123,6 +123,12 @@ export function initializeEditor(
 	} );
 
 	dispatch( blocksStore ).__experimentalReapplyBlockTypeFilters();
+
+	// Check if the block list view should be open by default.
+	if ( select( editPostStore ).isFeatureActive( 'showListViewByDefault' ) ) {
+		dispatch( editPostStore ).setIsListViewOpened( true );
+	}
+
 	registerCoreBlocks();
 	if ( process.env.IS_GUTENBERG_PLUGIN ) {
 		__experimentalRegisterExperimentalCoreBlocks( {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -66,7 +66,6 @@ function Editor( { onError } ) {
 		nextShortcut,
 		editorMode,
 		showIconLabels,
-		isListViewOpenByDefault,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -115,15 +114,9 @@ function Editor( { onError } ) {
 				'core/edit-site',
 				'showIconLabels'
 			),
-			isListViewOpenByDefault: select( preferencesStore ).get(
-				'core/edit-site',
-				'showListViewByDefault'
-			),
 		};
 	}, [] );
-	const { setPage, setIsInserterOpened, setIsListViewOpened } = useDispatch(
-		editSiteStore
-	);
+	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const [
@@ -158,13 +151,6 @@ function Editor( { onError } ) {
 		} ),
 		[ page?.context ]
 	);
-
-	// Check if the block list view should be open by default.
-	useEffect( () => {
-		if ( isListViewOpenByDefault ) {
-			setIsListViewOpened( true );
-		}
-	}, [] );
 
 	useEffect( () => {
 		if ( isNavigationOpen ) {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -66,6 +66,7 @@ function Editor( { onError } ) {
 		nextShortcut,
 		editorMode,
 		showIconLabels,
+		isListViewOpenByDefault,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -114,9 +115,14 @@ function Editor( { onError } ) {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			isListViewOpenByDefault: select( editSiteStore ).isFeatureActive(
+				'listView'
+			),
 		};
 	}, [] );
-	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
+	const { setPage, setIsInserterOpened, setIsListViewOpened } = useDispatch(
+		editSiteStore
+	);
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
 	const [
@@ -151,6 +157,13 @@ function Editor( { onError } ) {
 		} ),
 		[ page?.context ]
 	);
+
+	// Check if the block list view should be open by default.
+	useEffect( () => {
+		if ( isListViewOpenByDefault ) {
+			setIsListViewOpened( true );
+		}
+	}, [] );
 
 	useEffect( () => {
 		if ( isNavigationOpen ) {

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -115,8 +115,9 @@ function Editor( { onError } ) {
 				'core/edit-site',
 				'showIconLabels'
 			),
-			isListViewOpenByDefault: select( editSiteStore ).isFeatureActive(
-				'listView'
+			isListViewOpenByDefault: select( preferencesStore ).get(
+				'core/edit-site',
+				'showListViewByDefault'
 			),
 		};
 	}, [] );

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -42,7 +42,7 @@ export default function EditSitePreferencesModal( {
 						help={ __( 'Show text instead of icons on buttons' ) }
 					/>
 					<EnableFeature
-						featureName="listView"
+						featureName="showListViewByDefault"
 						help={ __(
 							'Opens the block list view sidebar by default.'
 						) }

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -41,6 +41,13 @@ export default function EditSitePreferencesModal( {
 						label={ __( 'Show button text labels' ) }
 						help={ __( 'Show text instead of icons on buttons' ) }
 					/>
+					<EnableFeature
+						featureName="listView"
+						help={ __(
+							'Opens the block list view sidebar by default.'
+						) }
+						label={ __( 'Always open list view' ) }
+					/>
 				</PreferencesModalSection>
 			),
 		},

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -64,7 +64,18 @@ export function reinitializeEditor( target, settings ) {
 			keepCaretInsideBlock: false,
 			welcomeGuide: true,
 			welcomeGuideStyles: true,
+			shouldListViewOpenByDefault: false,
 		} );
+
+		// Check if the block list view should be open by default.
+		if (
+			select( preferencesStore ).get(
+				'core/edit-site',
+				'showListViewByDefault'
+			)
+		) {
+			dispatch( editSiteStore ).setIsListViewOpened( true );
+		}
 
 		dispatch( editSiteStore ).updateSettings( settings );
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -68,7 +68,7 @@ npm run test-e2e:playwright
 npm run test-e2e:playwright -- --headed
 
 # Run a single test file.
-npm run test-e2e:playwright -- <path_to_test_file>
+npm run test-e2e:playwright -- <path_to_test_file> # E.g., npm run test-e2e:playwright -- site-editor/title.spec.js
 
 # Debugging
 npm run test-e2e:playwright -- --debug

--- a/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
+++ b/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block list view', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'Should open by default', async ( { page, pageUtils } ) => {
+		await pageUtils.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+		} );
+
+		// Should display the Preview button.
+		await expect(
+			page.locator( '.edit-site-editor__list-view-panel' )
+		).not.toBeVisible();
+
+		// Turn on block list view by default.
+		await page.evaluate( () => {
+			window.wp.data
+				.dispatch( 'core/preferences' )
+				.set( 'core/edit-site', 'showListViewByDefault', true );
+		} );
+
+		await page.reload();
+
+		// Should display the Preview button.
+		await expect(
+			page.locator( '.edit-site-editor__list-view-panel' )
+		).toBeVisible();
+	} );
+} );

--- a/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
+++ b/test/e2e/specs/site-editor/block-list-panel-preference.spec.js
@@ -20,7 +20,7 @@ test.describe( 'Block list view', () => {
 
 		// Should display the Preview button.
 		await expect(
-			page.locator( '.edit-site-editor__list-view-panel' )
+			page.locator( 'role=region[name="List View"i]' )
 		).not.toBeVisible();
 
 		// Turn on block list view by default.
@@ -34,7 +34,7 @@ test.describe( 'Block list view', () => {
 
 		// Should display the Preview button.
 		await expect(
-			page.locator( '.edit-site-editor__list-view-panel' )
+			page.locator( 'role=region[name="List View"i]' )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/40565


## What?

A preference to have the block list view open by default. 🪄 

https://user-images.githubusercontent.com/6458278/166365673-57cda91b-26f4-45cf-8c6a-d897dd8a1567.mp4

## Why?

Some folks use the block list view all the time. 

Creating an option to have it opened by default will save these folks approximately a couple of seconds every time the editor loads. Over a year this could save up to forty-two minutes.

## How?

Adding an extra feature option to the post and site editor preferences modals.

**Note**: the post editor preferences modal has not yet been migrated over to the preference store, hence the use of `isFeatureActive` in [packages/edit-post/src/components/layout/index.js](https://github.com/WordPress/gutenberg/pull/40757/files#diff-8933c0b377d83066f7dde9c8b573bab9a7bfe60f73919e4e5e80aff92a88800cR134) 

See site editor migration over at https://github.com/WordPress/gutenberg/pull/39485


## Testing Instructions

1. Open up the post editor. Notice the block list sidebar is not open.
2. Open the preferences modal and turn on  `Always open list view` 
3. Refresh page.
4. Wait a bit.
5. Check that the block list sidebar is open.
6. Think about what you're having for dinner. 
7. Repeat steps again for the site editor.
8. Be well.

Run the e2e playwright test for glory! 

```bash
npm run test-e2e:playwright -- site-editor/block-list-panel-preference.spec.js
```
