### PR TITLE
Comment Template: With pagination, make sure to request page 1 if there are no comments

### DIFF
--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -186,6 +186,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				}
 			}
 		}
+
 		return $comment_args;
 	}
 }

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -176,8 +176,10 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				} elseif ( 'oldest' === $default_page ) {
 					$comment_args['paged'] = 1;
 				} elseif ( 'newest' === $default_page ) {
-					$max_num_pages         = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
-					$comment_args['paged'] = 0 === $max_num_pages ? 1 : $max_num_pages;
+					$max_num_pages  = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+					if ( 0 !== $max_num_pages ) {
+						$comment_args['paged'] = $max_num_pages;
+					}
 				}
 				// Set the `cpage` query var to ensure the previous and next pagination links are correct
 				// when inheriting the Discussion Settings.

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -176,7 +176,7 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				} elseif ( 'oldest' === $default_page ) {
 					$comment_args['paged'] = 1;
 				} elseif ( 'newest' === $default_page ) {
-					$max_num_pages  = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+					$max_num_pages = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
 					if ( 0 !== $max_num_pages ) {
 						$comment_args['paged'] = $max_num_pages;
 					}

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -176,7 +176,8 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				} elseif ( 'oldest' === $default_page ) {
 					$comment_args['paged'] = 1;
 				} elseif ( 'newest' === $default_page ) {
-					$comment_args['paged'] = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+					$max_num_pages = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+					$comment_args['paged'] = $max_num_pages === 0 ? 1 : $max_num_pages;
 				}
 				// Set the `cpage` query var to ensure the previous and next pagination links are correct
 				// when inheriting the Discussion Settings.
@@ -185,7 +186,6 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				}
 			}
 		}
-
 		return $comment_args;
 	}
 }

--- a/lib/compat/wordpress-6.0/blocks.php
+++ b/lib/compat/wordpress-6.0/blocks.php
@@ -176,8 +176,8 @@ if ( ! function_exists( 'build_comment_query_vars_from_block' ) ) {
 				} elseif ( 'oldest' === $default_page ) {
 					$comment_args['paged'] = 1;
 				} elseif ( 'newest' === $default_page ) {
-					$max_num_pages = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
-					$comment_args['paged'] = $max_num_pages === 0 ? 1 : $max_num_pages;
+					$max_num_pages         = (int) ( new WP_Comment_Query( $comment_args ) )->max_num_pages;
+					$comment_args['paged'] = 0 === $max_num_pages ? 1 : $max_num_pages;
 				}
 				// Set the `cpage` query var to ensure the previous and next pagination links are correct
 				// when inheriting the Discussion Settings.

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -127,8 +127,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	 * Regression: https://github.com/WordPress/gutenberg/issues/40758.
 	 */
 	function test_build_comment_query_vars_from_block_pagination_with_no_comments() {
-		$previous_per_page     = get_option( 'comments_per_page' );
-		$previous_default_page = get_option( 'default_comments_page' );
+		$comments_per_page     = get_option( 'comments_per_page' );
+		$default_comments_page = get_option( 'default_comments_page' );
 
 		update_option( 'comments_per_page', 50 );
 		update_option( 'previous_default_page', 'newest' );
@@ -169,8 +169,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 			)
 		);
 
-		update_option( 'comments_per_page', $previous_comments_per_page );
-		update_option( 'default_comments_page', $previous_previous_default_page );
+		update_option( 'comments_per_page', $comments_per_page );
+		update_option( 'default_comments_page', $default_comments_page );
 	}
 
 	/**

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -162,9 +162,9 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'order'         => 'ASC',
 				'status'        => 'approve',
 				'no_found_rows' => false,
-				'post_id'       => self::$custom_post->ID,
+				'post_id'       => $post_without_comments->ID,
 				'hierarchical'  => 'threaded',
-				'number'        => 1,
+				'number'        => 50,
 				'paged'         => 1,
 			)
 		);

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -166,7 +166,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'post_id'       => $post_without_comments->ID,
 				'hierarchical'  => 'threaded',
 				'number'        => 50,
-				'paged'         => 1,
 			),
 			build_comment_query_vars_from_block( $block )
 		);

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -158,7 +158,6 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			build_comment_query_vars_from_block( $block ),
 			array(
 				'orderby'       => 'comment_date_gmt',
 				'order'         => 'ASC',
@@ -168,7 +167,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 				'hierarchical'  => 'threaded',
 				'number'        => 50,
 				'paged'         => 1,
-			)
+			),
+			build_comment_query_vars_from_block( $block )
 		);
 
 		update_option( 'comments_per_page', $comments_per_page );

--- a/phpunit/class-block-library-comment-template-test.php
+++ b/phpunit/class-block-library-comment-template-test.php
@@ -125,6 +125,8 @@ class Block_Library_Comment_Template_Test extends WP_UnitTestCase {
 	 * the query is set to look for page 1 (rather than page 0, which would cause an error).
 	 *
 	 * Regression: https://github.com/WordPress/gutenberg/issues/40758.
+	 *
+	 * @covers ::build_comment_query_vars_from_block
 	 */
 	function test_build_comment_query_vars_from_block_pagination_with_no_comments() {
 		$comments_per_page     = get_option( 'comments_per_page' );


### PR DESCRIPTION
## What?
Fixes #40758. See there for detail.

## Why?
It's a bug!

## How?
Setting `paged` to `1` (instead of `0`) if there are no comments.
(It seems that `paged` needs to be `>= 1` ([docs](https://developer.wordpress.org/reference/classes/wp_comment_query/__construct/#parameters)).)

## Testing Instructions
See #40758.

For the unit test, try reverting the commit that fixes `lib/compat/wordpress-6.0/blocks.php`, rebuild GB, and run `npm run test-unit-php`. It should fail.