### PR TITLE
Tests: restore real timers after using Jest's fake timers

### DIFF
--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
@@ -27,7 +27,14 @@ const TestScreen = ( { fullScreen, name, navigateTo } ) => {
 	);
 };
 
-jest.useFakeTimers( 'legacy' );
+beforeEach( () => {
+	jest.useFakeTimers( 'legacy' );
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.useRealTimers();
+} );
 
 it( 'animates height transitioning from non-full-screen to full-screen', async () => {
 	const screen = render(

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-navigation/test/navigation-container.native.js
@@ -27,11 +27,11 @@ const TestScreen = ( { fullScreen, name, navigateTo } ) => {
 	);
 };
 
-beforeEach( () => {
+beforeAll( () => {
 	jest.useFakeTimers( 'legacy' );
 } );
 
-afterEach( () => {
+afterAll( () => {
 	jest.runOnlyPendingTimers();
 	jest.useRealTimers();
 } );

--- a/packages/components/src/mobile/link-settings/test/link-settings-navigation.native.js
+++ b/packages/components/src/mobile/link-settings/test/link-settings-navigation.native.js
@@ -9,7 +9,15 @@ import { render, fireEvent, waitFor } from 'test/helpers';
  */
 import LinkSettingsNavigation from '../link-settings-navigation';
 
-jest.useFakeTimers( 'legacy' );
+beforeEach( () => {
+	jest.useFakeTimers( 'legacy' );
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.useRealTimers();
+} );
+
 jest.spyOn( Keyboard, 'dismiss' );
 
 const subject = (

--- a/packages/components/src/mobile/link-settings/test/link-settings-navigation.native.js
+++ b/packages/components/src/mobile/link-settings/test/link-settings-navigation.native.js
@@ -9,11 +9,11 @@ import { render, fireEvent, waitFor } from 'test/helpers';
  */
 import LinkSettingsNavigation from '../link-settings-navigation';
 
-beforeEach( () => {
+beforeAll( () => {
 	jest.useFakeTimers( 'legacy' );
 } );
 
-afterEach( () => {
+afterAll( () => {
 	jest.runOnlyPendingTimers();
 	jest.useRealTimers();
 } );

--- a/packages/components/src/tooltip/test/index.js
+++ b/packages/components/src/tooltip/test/index.js
@@ -149,6 +149,9 @@ describe( 'Tooltip', () => {
 			setTimeout( () => {
 				const popoverAfterTimeout = wrapper.find( 'Popover' );
 				expect( popoverAfterTimeout ).toHaveLength( 1 );
+
+				jest.runOnlyPendingTimers();
+				jest.useRealTimers();
 			}, TOOLTIP_DELAY );
 		} );
 
@@ -183,6 +186,9 @@ describe( 'Tooltip', () => {
 			setTimeout( () => {
 				const popoverAfterTimeout = wrapper.find( 'Popover' );
 				expect( popoverAfterTimeout ).toHaveLength( 1 );
+
+				jest.runOnlyPendingTimers();
+				jest.useRealTimers();
 			}, 2000 );
 		} );
 

--- a/packages/core-data/src/hooks/test/use-entity-record.js
+++ b/packages/core-data/src/hooks/test/use-entity-record.js
@@ -19,6 +19,7 @@ import useEntityRecord from '../use-entity-record';
 
 describe( 'useEntityRecord', () => {
 	let registry;
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 

--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -19,6 +19,7 @@ import useEntityRecords from '../use-entity-records';
 
 describe( 'useEntityRecords', () => {
 	let registry;
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -19,6 +19,7 @@ import useQuerySelect from '../use-query-select';
 
 describe( 'useQuerySelect', () => {
 	let registry;
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 

--- a/packages/core-data/src/test/actions.js
+++ b/packages/core-data/src/test/actions.js
@@ -58,6 +58,11 @@ describe( 'deleteEntityRecord', () => {
 		jest.useFakeTimers();
 	} );
 
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
 	it( 'triggers a DELETE request for an existing record', async () => {
 		const deletedRecord = { title: 'new post', id: 10 };
 		const configs = [
@@ -180,6 +185,11 @@ describe( 'saveEditedEntityRecord', () => {
 		jest.useFakeTimers();
 	} );
 
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
 	it( 'Uses "id" as a key when no entity key is provided', async () => {
 		const area = { id: 1, menu: 0 };
 		const configs = [
@@ -264,6 +274,7 @@ describe( 'saveEditedEntityRecord', () => {
 
 describe( 'saveEntityRecord', () => {
 	let dispatch;
+
 	beforeEach( async () => {
 		apiFetch.mockReset();
 		jest.useFakeTimers();
@@ -272,6 +283,11 @@ describe( 'saveEntityRecord', () => {
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 		} );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'triggers a POST request for a new record', async () => {

--- a/packages/core-data/src/test/entities.js
+++ b/packages/core-data/src/test/entities.js
@@ -55,6 +55,11 @@ describe( 'getKindEntities', () => {
 		jest.useFakeTimers();
 	} );
 
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
 	it( 'shouldn’t do anything if the entities have already been resolved', async () => {
 		const dispatch = jest.fn();
 		const select = {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -27,9 +27,15 @@ describe( 'getEntityRecord', () => {
 			baseURLParams: { context: 'edit' },
 		},
 	];
+
 	beforeEach( async () => {
 		triggerFetch.mockReset();
 		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'yields with requested post type', async () => {
@@ -147,6 +153,11 @@ describe( 'getEntityRecords', () => {
 	beforeEach( async () => {
 		triggerFetch.mockReset();
 		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'dispatches the requested post type', async () => {

--- a/packages/data/src/test/registry.js
+++ b/packages/data/src/test/registry.js
@@ -11,7 +11,14 @@ import { createRegistrySelector } from '../factory';
 import createReduxStore from '../redux-store';
 import coreDataStore from '../store';
 
-jest.useFakeTimers( 'legacy' );
+beforeEach( () => {
+	jest.useFakeTimers( 'legacy' );
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.useRealTimers();
+} );
 
 describe( 'createRegistry', () => {
 	let registry;

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -25,7 +25,14 @@ const unsupportedBlock = `
 <!-- /wp:notablock -->
 `;
 
-jest.useFakeTimers( 'legacy' );
+beforeEach( () => {
+	jest.useFakeTimers( 'legacy' );
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.useRealTimers();
+} );
 
 describe( 'Editor', () => {
 	beforeAll( () => {

--- a/packages/edit-post/src/test/editor.native.js
+++ b/packages/edit-post/src/test/editor.native.js
@@ -25,11 +25,11 @@ const unsupportedBlock = `
 <!-- /wp:notablock -->
 `;
 
-beforeEach( () => {
+beforeAll( () => {
 	jest.useFakeTimers( 'legacy' );
 } );
 
-afterEach( () => {
+afterAll( () => {
 	jest.runOnlyPendingTimers();
 	jest.useRealTimers();
 } );

--- a/packages/editor/src/components/autosave-monitor/test/index.js
+++ b/packages/editor/src/components/autosave-monitor/test/index.js
@@ -23,6 +23,9 @@ describe( 'AutosaveMonitor', () => {
 	} );
 
 	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+
 		setAutosaveTimerSpy.mockClear();
 	} );
 

--- a/packages/format-library/src/link/test/index.native.js
+++ b/packages/format-library/src/link/test/index.native.js
@@ -26,11 +26,11 @@ const LinkEditSlot = ( props ) => (
 
 jest.spyOn( Keyboard, 'dismiss' );
 
-beforeEach( () => {
+beforeAll( () => {
 	jest.useFakeTimers( 'legacy' );
 } );
 
-afterEach( () => {
+afterAll( () => {
 	jest.runOnlyPendingTimers();
 	jest.useRealTimers();
 } );

--- a/packages/format-library/src/link/test/index.native.js
+++ b/packages/format-library/src/link/test/index.native.js
@@ -24,8 +24,16 @@ const LinkEditSlot = ( props ) => (
 	</SlotFillProvider>
 );
 
-jest.useFakeTimers( 'legacy' );
 jest.spyOn( Keyboard, 'dismiss' );
+
+beforeEach( () => {
+	jest.useFakeTimers( 'legacy' );
+} );
+
+afterEach( () => {
+	jest.runOnlyPendingTimers();
+	jest.useRealTimers();
+} );
 
 describe( 'Android', () => {
 	it( 'improves back animation performance by dismissing keyboard beforehand', async () => {

--- a/packages/preferences-persistence/src/create/test/debounce-async.js
+++ b/packages/preferences-persistence/src/create/test/debounce-async.js
@@ -43,6 +43,9 @@ describe( 'debounceAsync', () => {
 		expect( fn ).toHaveBeenCalledTimes( 2 );
 		expect( fn ).toHaveBeenCalledWith( 'A' );
 		expect( fn ).toHaveBeenCalledWith( 'D' );
+
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'ensures the delay has elapsed between calls', async () => {
@@ -76,6 +79,9 @@ describe( 'debounceAsync', () => {
 		await flushPromises();
 		jest.runAllTimers();
 		expect( fn ).toHaveBeenCalledTimes( 2 );
+
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
 	} );
 
 	it( 'is thenable, returning any data from promise resolution of the debounced function', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following [`testing-library`'s advice](https://testing-library.com/docs/using-fake-timers/), we should restore real timers after using Jest's fake timers

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I came across the need for this fix while investigating the issue described in [this comment](https://github.com/testing-library/user-event/issues/565#issuecomment-1064579531). Not restoring fake timers could lead to unexpected behavior

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make sure that every call to `jest.useFakeTimers();` has a matching

```js
jest.runOnlyPendingTimers();
jest.useRealTimers();
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Make sure all tests pass.