### PR TITLE
Remove require editor hooks line from full-content test setup

### DIFF
--- a/test/integration/full-content/full-content.test.js
+++ b/test/integration/full-content/full-content.test.js
@@ -64,8 +64,6 @@ describe( 'full post content fixture', () => {
 			} )
 		);
 		unstable__bootstrapServerSideBlockDefinitions( blockDefinitions );
-		// Load all hooks that modify blocks.
-		require( '../../../packages/editor/src/hooks' );
 		registerCoreBlocks();
 		if ( process.env.IS_GUTENBERG_PLUGIN ) {
 			__experimentalRegisterExperimentalCoreBlocks( {


### PR DESCRIPTION
## What?
Removes a line of code in the `full-content.test.js`.

## Why?
It looks like this line of code was supposed to `require` all the code for blocks supports features (`align`, `color`, `spacing` etc.), which would have been important as that can affect the block `save` output.

The thing is that this code hasn't been in that folder for quite a while now, it was all moved to the block editor package. The tests still pass with this line of code removed, so it doesn't seem to be needed.