### PR TITLE
Cover: Alternate approach to handling border support in editor

### DIFF
--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -87,8 +87,21 @@
 				"padding": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalSkipSerialization": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
-			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
+			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background, > .block-library-cover__border-wrapper > .wp-block-cover__video-background, > .block-library-cover__border-wrapper > .wp-block-cover__image-background",
 			"text": false,
 			"background": false
 		}

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -19,6 +19,7 @@ import {
 	useSetting,
 	useInnerBlocksProps,
 	__experimentalUseGradient,
+	__experimentalUseBorderProps as useBorderProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
@@ -96,6 +97,8 @@ function CoverEdit( {
 		allowedBlocks,
 		templateLock,
 	} = attributes;
+
+	const borderProps = useBorderProps( attributes );
 
 	const [ featuredImage ] = useEntityProp(
 		'postType',
@@ -326,53 +329,61 @@ function CoverEdit( {
 					showHandle={ isSelected }
 				/>
 
-				<span
-					aria-hidden="true"
+				<div
 					className={ classnames(
-						'wp-block-cover__background',
-						dimRatioToClass( dimRatio ),
-						{
-							[ overlayColor.class ]: overlayColor.class,
-							'has-background-dim': dimRatio !== undefined,
-							// For backwards compatibility. Former versions of the Cover Block applied
-							// `.wp-block-cover__gradient-background` in the presence of
-							// media, a gradient and a dim.
-							'wp-block-cover__gradient-background':
-								url && gradientValue && dimRatio !== 0,
-							'has-background-gradient': gradientValue,
-							[ gradientClass ]: gradientClass,
-						}
+						'block-library-cover__border-wrapper',
+						borderProps.className
 					) }
-					style={ { backgroundImage: gradientValue, ...bgStyle } }
-				/>
+					style={ { ...borderProps.style } }
+				>
+					<span
+						aria-hidden="true"
+						className={ classnames(
+							'wp-block-cover__background',
+							dimRatioToClass( dimRatio ),
+							{
+								[ overlayColor.class ]: overlayColor.class,
+								'has-background-dim': dimRatio !== undefined,
+								// For backwards compatibility. Former versions of the Cover Block applied
+								// `.wp-block-cover__gradient-background` in the presence of
+								// media, a gradient and a dim.
+								'wp-block-cover__gradient-background':
+									url && gradientValue && dimRatio !== 0,
+								'has-background-gradient': gradientValue,
+								[ gradientClass ]: gradientClass,
+							}
+						) }
+						style={ { backgroundImage: gradientValue, ...bgStyle } }
+					/>
 
-				{ url && isImageBackground && isImgElement && (
-					<img
-						ref={ mediaElement }
-						className="wp-block-cover__image-background"
-						alt={ alt }
-						src={ url }
-						style={ mediaStyle }
+					{ url && isImageBackground && isImgElement && (
+						<img
+							ref={ mediaElement }
+							className="wp-block-cover__image-background"
+							alt={ alt }
+							src={ url }
+							style={ mediaStyle }
+						/>
+					) }
+					{ url && isVideoBackground && (
+						<video
+							ref={ mediaElement }
+							className="wp-block-cover__video-background"
+							autoPlay
+							muted
+							loop
+							src={ url }
+							style={ mediaStyle }
+						/>
+					) }
+					{ isUploadingMedia && <Spinner /> }
+					<CoverPlaceholder
+						disableMediaButtons
+						onSelectMedia={ onSelectMedia }
+						onError={ onUploadError }
 					/>
-				) }
-				{ url && isVideoBackground && (
-					<video
-						ref={ mediaElement }
-						className="wp-block-cover__video-background"
-						autoPlay
-						muted
-						loop
-						src={ url }
-						style={ mediaStyle }
-					/>
-				) }
-				{ isUploadingMedia && <Spinner /> }
-				<CoverPlaceholder
-					disableMediaButtons
-					onSelectMedia={ onSelectMedia }
-					onError={ onUploadError }
-				/>
-				<div { ...innerBlocksProps } />
+					<div { ...innerBlocksProps } />
+				</div>
 			</div>
 		</>
 	);

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -2,6 +2,7 @@
 	/* Extra specificity needed because the reset.css applied in the editor context is overriding this rule. */
 	.editor-styles-wrapper & {
 		box-sizing: border-box;
+		overflow: initial;
 	}
 
 	// Override default cover styles
@@ -97,4 +98,62 @@
 // doesn't work with the transforms that are applied to resize the block in that context.
 .block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
 	background-attachment: scroll;
+}
+
+.block-library-cover__border-wrapper {
+	// Absolute positioning is needed to handle padding that might be applied
+	// to the main block wrapper via global styles.
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	// Hide backgrounds so they don't overflow the border.
+	overflow: hidden;
+	// Re-establish layout and handle custom positions.
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	// Inherits padding from main block wrapper.
+	padding: inherit;
+
+	// Position: Top
+	.is-position-top-left & {
+		align-items: flex-start;
+		justify-content: flex-start;
+	}
+	.is-position-top-center & {
+		align-items: flex-start;
+		justify-content: center;
+	}
+	.is-position-top-right & {
+		align-items: flex-start;
+		justify-content: flex-end;
+	}
+	// Position: Center
+	.is-position-center-left & {
+		align-items: center;
+		justify-content: flex-start;
+	}
+	.is-position-center-center & {
+		align-items: center;
+		justify-content: center;
+	}
+	.is-position-center-right & {
+		align-items: center;
+		justify-content: flex-end;
+	}
+	// Position: Bottom
+	.is-position-bottom-left & {
+		align-items: flex-end;
+		justify-content: flex-start;
+	}
+	.is-position-bottom-center & {
+		align-items: flex-end;
+		justify-content: center;
+	}
+	.is-position-bottom-right & {
+		align-items: flex-end;
+		justify-content: flex-end;
+	}
 }

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -11,6 +11,7 @@ import {
 	getColorClassName,
 	__experimentalGetGradientClass,
 	useBlockProps,
+	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 } from '@wordpress/block-editor';
 
 /**
@@ -59,12 +60,14 @@ export default function save( { attributes } ) {
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
 	const isImgElement = ! ( hasParallax || isRepeated );
+	const borderProps = getBorderClassesAndStyles( attributes );
 
 	const style = {
 		...( isImageBackground && ! isImgElement && ! useFeaturedImage
 			? backgroundImageStyles( url )
 			: {} ),
 		minHeight: minHeight || undefined,
+		...borderProps.style,
 	};
 
 	const bgStyle = {
@@ -87,7 +90,8 @@ export default function save( { attributes } ) {
 				contentPosition
 			),
 		},
-		getPositionClassName( contentPosition )
+		getPositionClassName( contentPosition ),
+		borderProps.className
 	);
 
 	const gradientValue = gradient || customGradient;

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -11,6 +11,8 @@
 	padding: 1em;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	// Prevent overflow of background when block has border radius.
+	overflow: hidden;
 
 	&.has-parallax {
 		background-attachment: fixed;


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/31370

The use of ResizableBox within the Cover block wrapper causes problems when the wrapper may have a border applied to it. Additionally, clipping the content via overflow: hidden also cuts off the drag handle. The approach in this commit attempts to avoid these.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds border support to the Cover block via an alternate approach to those explored in #31370.

## Why?

This alternate approach is necessary to improve the behaviour of how the Cover block behaves in the editor when borders are applied. 

Within the editor the Cover block introduces a `ResizableBox` component so that the Cover block can be resized via drag handles. This `ResizableBox` causes the block to not behave well in the editor. If not for this, the block would only need a simple block.json change.

## How?
- Opts into all border support but skips serialization
- In the editor only, introduces another inner element to wrap the background, image, or, video elements
- On the new wrapping element, it applies the border support styles
- Editor only CSS changes were made to re-establish the internal layout within the Cover block and inherit padding from theme.json or border support.
- Adds `overflow: hidden` to the frontend CSS so cover background honors any border radius
- Updates Cover save such that it applies border support as if serialization wasn't skipped

## Drawbacks
- ⚠️  **Theme.json application of borders won't apply cleanly in the editor.** ⚠️ 

There are other blocks where the block support doesn't play well with the theme.json generated styles. I believe buttons and search blocks are examples of this. Given the importance of the Cover block I'm not convinced that we want that here as well.

- See: https://github.com/WordPress/gutenberg/issues/32417

## Testing Instructions
1. Checkout branch, create post and add a cover block
2. Try various configurations of borders
3. Resize the block's min-height via sidebar control and drag handles
4. Ensure duotone filter and content positioning still work
5. Try applying styles via theme.json or global styles (won't work).


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/166408459-06040458-9501-44a6-b80b-93b1712c8b53.mp4


