### PR TITLE
Post Author: Switch byline to use kses so that rich text elements are rendered correctly

### DIFF
--- a/packages/block-library/src/post-author/index.php
+++ b/packages/block-library/src/post-author/index.php
@@ -39,7 +39,7 @@ function render_block_core_post_author( $attributes, $content, $block ) {
 	return sprintf( '<div %1$s>', $wrapper_attributes ) .
 	( ! empty( $attributes['showAvatar'] ) ? '<div class="wp-block-post-author__avatar">' . $avatar . '</div>' : '' ) .
 	'<div class="wp-block-post-author__content">' .
-	( ! empty( $byline ) ? '<p class="wp-block-post-author__byline">' . esc_html( $byline ) . '</p>' : '' ) .
+	( ! empty( $byline ) ? '<p class="wp-block-post-author__byline">' . wp_kses_post( $byline ) . '</p>' : '' ) .
 	'<p class="wp-block-post-author__name">' . get_the_author_meta( 'display_name', $author_id ) . '</p>' .
 	( ! empty( $attributes['showBio'] ) ? '<p class="wp-block-post-author__bio">' . get_the_author_meta( 'user_description', $author_id ) . '</p>' : '' ) .
 	'</div>' .


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/40600

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the Byline field of the Post Author block renders HTML elements added via the rich text controls in the editor as the raw escaped HTML elements on the front end of a site (e.g. `<strong>my byline</strong>`).

For server-rendered blocks that render out rich text stored in an attribute, we need to use `wp_kses_post` instead of `esc_html` so that the rich text elements (e.g. `<strong>`, `<em>`, etc) are rendered correctly, while still ensuring that illegal elements (e.g. `script`) are stripped. This approach follows eariler PRs like: https://github.com/WordPress/gutenberg/pull/38649

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the Post Author block, swap `esc_html` for `wp_kses_post`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In the site editor, go to update the single template, and add a Post Author block and include a byline for the post author.
2. Use the rich text controls to add bold or emphasised text.
3. Prior to this PR, on the front end of the site, the raw characters of the HTML tags are output
4. After this PR, the rich text elements should be rendered correctly

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/166415314-3bebb7a2-35ed-48d0-9e13-ac40a9c1997a.png) | ![image](https://user-images.githubusercontent.com/14988353/166415332-727aa6f7-3a30-4a3f-b869-58908e36a5d0.png) |

