### PR TITLE
Tidy list view props and deprecate `BlockNavigationDropdown`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17636,6 +17636,7 @@
 				"@wordpress/compose": "file:packages/compose",
 				"@wordpress/core-data": "file:packages/core-data",
 				"@wordpress/data": "file:packages/data",
+				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Breaking change
+
+-   `BlockNavigationDropdown` is now deprecated. Use the `Dropdown` component from the `@wordpress/components` package and the `ListView` component from this package ([#40777](https://github.com/WordPress/gutenberg/pull/40777)).
+-   `ListView` no longer accepts the `__experimentalFeatures`, `__experimentalPersistentListViewFeatures`, `__experimentalHideContainerBlockActions`, and `showNestedBlocks` props. Passing additional undocumented props through to `ListView` is also now disallowed. ([#40777](https://github.com/WordPress/gutenberg/pull/40777)).
+
 ## 8.6.0 (2022-04-21)
 
 ## 8.5.0 (2022-04-08)

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -36,10 +36,7 @@ function BlockNavigationDropdownToggle( {
 	);
 }
 
-function BlockNavigationDropdown(
-	{ isDisabled, __experimentalFeatures, ...props },
-	ref
-) {
+function BlockNavigationDropdown( { isDisabled, ...props }, ref ) {
 	const hasBlocks = useSelect(
 		( select ) => !! select( blockEditorStore ).getBlockCount(),
 		[]
@@ -65,10 +62,7 @@ function BlockNavigationDropdown(
 						{ __( 'List view' ) }
 					</p>
 
-					<ListView
-						showNestedBlocks
-						__experimentalFeatures={ __experimentalFeatures }
-					/>
+					<ListView />
 				</div>
 			) }
 		/>

--- a/packages/block-editor/src/components/block-navigation/dropdown.js
+++ b/packages/block-editor/src/components/block-navigation/dropdown.js
@@ -1,6 +1,11 @@
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
+
+/**
+ * WordPress dependencies
+ */
 import { Button, Dropdown } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
@@ -37,6 +42,11 @@ function BlockNavigationDropdownToggle( {
 }
 
 function BlockNavigationDropdown( { isDisabled, ...props }, ref ) {
+	deprecated( 'wp.blockEditor.BlockNavigationDropdown', {
+		since: '6.1',
+		alternative: 'wp.components.Dropdown and wp.blockEditor.ListView',
+	} );
+
 	const hasBlocks = useSelect(
 		( select ) => !! select( blockEditorStore ).getBlockCount(),
 		[]

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { hasBlockSupport } from '@wordpress/blocks';
 import {
 	__experimentalTreeGridCell as TreeGridCell,
 	__experimentalTreeGridItem as TreeGridItem,
@@ -19,7 +20,7 @@ import {
 	useCallback,
 	memo,
 } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
 /**
@@ -66,6 +67,19 @@ function ListViewBlock( {
 	const { toggleBlockHighlight } = useDispatch( blockEditorStore );
 
 	const blockInformation = useBlockDisplayInformation( clientId );
+	const blockName = useSelect(
+		( select ) => select( blockEditorStore ).getBlockName( clientId ),
+		[ clientId ]
+	);
+
+	// When a block hides its toolbar it also hides the block settings menu,
+	// since that menu is part of the toolbar in the editor canvas.
+	// List View respects this by also hiding the block settings menu.
+	const showBlockActions = hasBlockSupport(
+		blockName,
+		'__experimentalToolbar',
+		true
+	);
 	const { isLocked } = useBlockLock( clientId );
 	const instanceId = useInstanceId( ListViewBlock );
 	const descriptionId = `list-view-block-select-button__${ instanceId }`;
@@ -98,12 +112,7 @@ function ListViewBlock( {
 		  )
 		: __( 'Options' );
 
-	const {
-		__experimentalHideContainerBlockActions: hideContainerBlockActions,
-		isTreeGridMounted,
-		expand,
-		collapse,
-	} = useListViewContext();
+	const { isTreeGridMounted, expand, collapse } = useListViewContext();
 
 	const hasSiblings = siblingBlockCount > 0;
 	const hasRenderedMovers = showBlockMovers && hasSiblings;
@@ -163,11 +172,6 @@ function ListViewBlock( {
 		},
 		[ clientId, expand, collapse, isExpanded ]
 	);
-
-	// hide actions for blocks like core/widget-areas
-	const showBlockActions =
-		! hideContainerBlockActions ||
-		( hideContainerBlockActions && level > 1 );
 
 	let colSpan;
 	if ( hasRenderedMovers ) {

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -99,7 +99,6 @@ function ListViewBlock( {
 		: __( 'Options' );
 
 	const {
-		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
 		__experimentalHideContainerBlockActions: hideContainerBlockActions,
 		isTreeGridMounted,
 		expand,
@@ -122,27 +121,19 @@ function ListViewBlock( {
 	// only focus the selected list item on mount; otherwise the list would always
 	// try to steal the focus from the editor canvas.
 	useEffect( () => {
-		if (
-			withExperimentalPersistentListViewFeatures &&
-			! isTreeGridMounted &&
-			isSelected
-		) {
+		if ( ! isTreeGridMounted && isSelected ) {
 			cellRef.current.focus();
 		}
 	}, [] );
 
-	const highlightBlock = withExperimentalPersistentListViewFeatures
-		? toggleBlockHighlight
-		: () => {};
-
 	const onMouseEnter = useCallback( () => {
 		setIsHovered( true );
-		highlightBlock( clientId, true );
-	}, [ clientId, setIsHovered, highlightBlock ] );
+		toggleBlockHighlight( clientId, true );
+	}, [ clientId, setIsHovered, toggleBlockHighlight ] );
 	const onMouseLeave = useCallback( () => {
 		setIsHovered( false );
-		highlightBlock( clientId, false );
-	}, [ clientId, setIsHovered, highlightBlock ] );
+		toggleBlockHighlight( clientId, false );
+	}, [ clientId, setIsHovered, toggleBlockHighlight ] );
 
 	const selectEditorBlock = useCallback(
 		( event ) => {
@@ -189,8 +180,7 @@ function ListViewBlock( {
 		'is-selected': isSelected,
 		'is-first-selected': isFirstSelectedBlock,
 		'is-last-selected': isLastSelectedBlock,
-		'is-branch-selected':
-			withExperimentalPersistentListViewFeatures && isBranchSelected,
+		'is-branch-selected': isBranchSelected,
 		'is-dragging': isDragged,
 		'has-single-cell': ! showBlockActions,
 	} );

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -99,7 +99,6 @@ function ListViewBlock( {
 		: __( 'Options' );
 
 	const {
-		__experimentalFeatures: withExperimentalFeatures,
 		__experimentalPersistentListViewFeatures: withExperimentalPersistentListViewFeatures,
 		__experimentalHideContainerBlockActions: hideContainerBlockActions,
 		isTreeGridMounted,
@@ -174,18 +173,15 @@ function ListViewBlock( {
 		[ clientId, expand, collapse, isExpanded ]
 	);
 
+	// hide actions for blocks like core/widget-areas
 	const showBlockActions =
-		withExperimentalFeatures &&
-		// hide actions for blocks like core/widget-areas
-		( ! hideContainerBlockActions ||
-			( hideContainerBlockActions && level > 1 ) );
-
-	const hideBlockActions = withExperimentalFeatures && ! showBlockActions;
+		! hideContainerBlockActions ||
+		( hideContainerBlockActions && level > 1 );
 
 	let colSpan;
 	if ( hasRenderedMovers ) {
 		colSpan = 2;
-	} else if ( hideBlockActions ) {
+	} else if ( ! showBlockActions ) {
 		colSpan = 3;
 	}
 
@@ -196,7 +192,7 @@ function ListViewBlock( {
 		'is-branch-selected':
 			withExperimentalPersistentListViewFeatures && isBranchSelected,
 		'is-dragging': isDragged,
-		'has-single-cell': hideBlockActions,
+		'has-single-cell': ! showBlockActions,
 	} );
 
 	// Only include all selected blocks if the currently clicked on block

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -95,11 +95,7 @@ function ListViewBranch( props ) {
 		isExpanded,
 	} = props;
 
-	const {
-		expandedState,
-		draggedClientIds,
-		__experimentalPersistentListViewFeatures,
-	} = useListViewContext();
+	const { expandedState, draggedClientIds } = useListViewContext();
 
 	const filteredBlocks = compact( blocks );
 	const blockCount = filteredBlocks.length;
@@ -119,11 +115,8 @@ function ListViewBranch( props ) {
 					);
 				}
 
-				const usesWindowing = __experimentalPersistentListViewFeatures;
-
 				const { itemInView } = fixedListWindow;
-				const blockInView =
-					! usesWindowing || itemInView( nextPosition );
+				const blockInView = itemInView( nextPosition );
 
 				const position = index + 1;
 				const updatedPath =

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -85,7 +85,6 @@ function ListViewBranch( props ) {
 		blocks,
 		selectBlock,
 		showBlockMovers,
-		showNestedBlocks,
 		selectedClientIds,
 		level = 1,
 		path = '',
@@ -123,8 +122,7 @@ function ListViewBranch( props ) {
 					path.length > 0
 						? `${ path }_${ position }`
 						: `${ position }`;
-				const hasNestedBlocks =
-					showNestedBlocks && !! innerBlocks && !! innerBlocks.length;
+				const hasNestedBlocks = !! innerBlocks?.length;
 
 				const shouldExpand = hasNestedBlocks
 					? expandedState[ clientId ] ?? isExpanded
@@ -172,7 +170,6 @@ function ListViewBranch( props ) {
 								blocks={ innerBlocks }
 								selectBlock={ selectBlock }
 								showBlockMovers={ showBlockMovers }
-								showNestedBlocks={ showNestedBlocks }
 								level={ level + 1 }
 								path={ updatedPath }
 								listPosition={ nextPosition + 1 }

--- a/packages/block-editor/src/components/list-view/context.js
+++ b/packages/block-editor/src/components/list-view/context.js
@@ -3,8 +3,6 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 
-export const ListViewContext = createContext( {
-	__experimentalPersistentListViewFeatures: false,
-} );
+export const ListViewContext = createContext( {} );
 
 export const useListViewContext = () => useContext( ListViewContext );

--- a/packages/block-editor/src/components/list-view/context.js
+++ b/packages/block-editor/src/components/list-view/context.js
@@ -4,7 +4,6 @@
 import { createContext, useContext } from '@wordpress/element';
 
 export const ListViewContext = createContext( {
-	__experimentalFeatures: false,
 	__experimentalPersistentListViewFeatures: false,
 } );
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -56,7 +56,6 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * @param {Array}   props.blocks                                   Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {boolean} props.showNestedBlocks                         Flag to enable displaying nested blocks.
  * @param {boolean} props.showBlockMovers                          Flag to enable block movers
- * @param {boolean} props.__experimentalFeatures                   Flag to enable experimental features.
  * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
  * @param {boolean} props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
  * @param {string}  props.id                                       Unique identifier for the root list element (primarily for a11y purposes).
@@ -66,7 +65,6 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
 function ListView(
 	{
 		blocks,
-		__experimentalFeatures,
 		__experimentalPersistentListViewFeatures,
 		__experimentalHideContainerBlockActions,
 		showNestedBlocks,
@@ -181,7 +179,6 @@ function ListView(
 
 	const contextValue = useMemo(
 		() => ( {
-			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			__experimentalHideContainerBlockActions,
 			isTreeGridMounted: isMounted.current,
@@ -191,7 +188,6 @@ function ListView(
 			collapse,
 		} ),
 		[
-			__experimentalFeatures,
 			__experimentalPersistentListViewFeatures,
 			__experimentalHideContainerBlockActions,
 			isMounted.current,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -52,19 +52,17 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * recursive component (it renders itself), so this ensures TreeGrid is only
  * present at the very top of the navigation grid.
  *
- * @param {Object}  props                                         Components props.
- * @param {Array}   props.blocks                                  Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {boolean} props.showNestedBlocks                        Flag to enable displaying nested blocks.
- * @param {boolean} props.showBlockMovers                         Flag to enable block movers
- * @param {boolean} props.__experimentalHideContainerBlockActions Flag to hide actions of top level blocks (like core/widget-area)
- * @param {string}  props.id                                      Unique identifier for the root list element (primarily for a11y purposes).
- * @param {boolean} props.isExpanded                              Flag to determine whether nested levels are expanded by default.
- * @param {Object}  ref                                           Forwarded ref
+ * @param {Object}  props                  Components props.
+ * @param {Array}   props.blocks           Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {boolean} props.showNestedBlocks Flag to enable displaying nested blocks.
+ * @param {boolean} props.showBlockMovers  Flag to enable block movers
+ * @param {string}  props.id               Unique identifier for the root list element (primarily for a11y purposes).
+ * @param {boolean} props.isExpanded       Flag to determine whether nested levels are expanded by default.
+ * @param {Object}  ref                    Forwarded ref
  */
 function ListView(
 	{
 		blocks,
-		__experimentalHideContainerBlockActions,
 		showNestedBlocks,
 		showBlockMovers,
 		id,
@@ -177,21 +175,13 @@ function ListView(
 
 	const contextValue = useMemo(
 		() => ( {
-			__experimentalHideContainerBlockActions,
 			isTreeGridMounted: isMounted.current,
 			draggedClientIds,
 			expandedState,
 			expand,
 			collapse,
 		} ),
-		[
-			__experimentalHideContainerBlockActions,
-			isMounted.current,
-			draggedClientIds,
-			expandedState,
-			expand,
-			collapse,
-		]
+		[ isMounted.current, draggedClientIds, expandedState, expand, collapse ]
 	);
 
 	return (

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -52,20 +52,18 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * recursive component (it renders itself), so this ensures TreeGrid is only
  * present at the very top of the navigation grid.
  *
- * @param {Object}  props                                          Components props.
- * @param {Array}   props.blocks                                   Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {boolean} props.showNestedBlocks                         Flag to enable displaying nested blocks.
- * @param {boolean} props.showBlockMovers                          Flag to enable block movers
- * @param {boolean} props.__experimentalPersistentListViewFeatures Flag to enable features for the Persistent List View experiment.
- * @param {boolean} props.__experimentalHideContainerBlockActions  Flag to hide actions of top level blocks (like core/widget-area)
- * @param {string}  props.id                                       Unique identifier for the root list element (primarily for a11y purposes).
- * @param {boolean} props.isExpanded                               Flag to determine whether nested levels are expanded by default.
- * @param {Object}  ref                                            Forwarded ref
+ * @param {Object}  props                                         Components props.
+ * @param {Array}   props.blocks                                  Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {boolean} props.showNestedBlocks                        Flag to enable displaying nested blocks.
+ * @param {boolean} props.showBlockMovers                         Flag to enable block movers
+ * @param {boolean} props.__experimentalHideContainerBlockActions Flag to hide actions of top level blocks (like core/widget-area)
+ * @param {string}  props.id                                      Unique identifier for the root list element (primarily for a11y purposes).
+ * @param {boolean} props.isExpanded                              Flag to determine whether nested levels are expanded by default.
+ * @param {Object}  ref                                           Forwarded ref
  */
 function ListView(
 	{
 		blocks,
-		__experimentalPersistentListViewFeatures,
 		__experimentalHideContainerBlockActions,
 		showNestedBlocks,
 		showBlockMovers,
@@ -129,7 +127,7 @@ function ListView(
 		BLOCK_LIST_ITEM_HEIGHT,
 		visibleBlockCount,
 		{
-			useWindowing: __experimentalPersistentListViewFeatures,
+			useWindowing: true,
 			windowOverscan: 40,
 		}
 	);
@@ -179,7 +177,6 @@ function ListView(
 
 	const contextValue = useMemo(
 		() => ( {
-			__experimentalPersistentListViewFeatures,
 			__experimentalHideContainerBlockActions,
 			isTreeGridMounted: isMounted.current,
 			draggedClientIds,
@@ -188,7 +185,6 @@ function ListView(
 			collapse,
 		} ),
 		[
-			__experimentalPersistentListViewFeatures,
 			__experimentalHideContainerBlockActions,
 			isMounted.current,
 			draggedClientIds,

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -52,23 +52,15 @@ export const BLOCK_LIST_ITEM_HEIGHT = 36;
  * recursive component (it renders itself), so this ensures TreeGrid is only
  * present at the very top of the navigation grid.
  *
- * @param {Object}  props                  Components props.
- * @param {Array}   props.blocks           Custom subset of block client IDs to be used instead of the default hierarchy.
- * @param {boolean} props.showNestedBlocks Flag to enable displaying nested blocks.
- * @param {boolean} props.showBlockMovers  Flag to enable block movers
- * @param {string}  props.id               Unique identifier for the root list element (primarily for a11y purposes).
- * @param {boolean} props.isExpanded       Flag to determine whether nested levels are expanded by default.
- * @param {Object}  ref                    Forwarded ref
+ * @param {Object}  props                 Components props.
+ * @param {Array}   props.blocks          Custom subset of block client IDs to be used instead of the default hierarchy.
+ * @param {boolean} props.showBlockMovers Flag to enable block movers
+ * @param {string}  props.id              Unique identifier for the root list element (primarily for a11y purposes).
+ * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
+ * @param {Object}  ref                   Forwarded ref
  */
 function ListView(
-	{
-		blocks,
-		showNestedBlocks,
-		showBlockMovers,
-		id,
-		isExpanded = false,
-		...props
-	},
+	{ blocks, showBlockMovers, id, isExpanded = false, ...props },
 	ref
 ) {
 	const {
@@ -203,7 +195,6 @@ function ListView(
 					<ListViewBranch
 						blocks={ clientIdsTree }
 						selectBlock={ selectEditorBlock }
-						showNestedBlocks={ showNestedBlocks }
 						showBlockMovers={ showBlockMovers }
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -48,19 +48,17 @@ const expanded = ( state, action ) => {
 export const BLOCK_LIST_ITEM_HEIGHT = 36;
 
 /**
- * Wrap `ListViewRows` with `TreeGrid`. ListViewRows is a
- * recursive component (it renders itself), so this ensures TreeGrid is only
- * present at the very top of the navigation grid.
+ * Show a hierarchical list of blocks.
  *
  * @param {Object}  props                 Components props.
+ * @param {string}  props.id              An HTML element id for the root element of ListView.
  * @param {Array}   props.blocks          Custom subset of block client IDs to be used instead of the default hierarchy.
  * @param {boolean} props.showBlockMovers Flag to enable block movers
- * @param {string}  props.id              Unique identifier for the root list element (primarily for a11y purposes).
  * @param {boolean} props.isExpanded      Flag to determine whether nested levels are expanded by default.
  * @param {Object}  ref                   Forwarded ref
  */
 function ListView(
-	{ blocks, showBlockMovers, id, isExpanded = false, ...props },
+	{ id, blocks, showBlockMovers = false, isExpanded = false },
 	ref
 ) {
 	const {
@@ -199,7 +197,6 @@ function ListView(
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
 						isExpanded={ isExpanded }
-						{ ...props }
 					/>
 				</ListViewContext.Provider>
 			</TreeGrid>

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -60,7 +60,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView showNestedBlocks />
+				<ListView />
 			</div>
 		</div>
 	);

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -62,7 +62,6 @@ export default function ListViewSidebar() {
 			>
 				<ListView
 					showNestedBlocks
-					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
 				/>
 			</div>

--- a/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-post/src/components/secondary-sidebar/list-view-sidebar.js
@@ -60,10 +60,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView
-					showNestedBlocks
-					__experimentalPersistentListViewFeatures
-				/>
+				<ListView showNestedBlocks />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -61,7 +61,6 @@ export default function ListViewSidebar() {
 			>
 				<ListView
 					showNestedBlocks
-					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
 				/>
 			</div>

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -59,10 +59,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView
-					showNestedBlocks
-					__experimentalPersistentListViewFeatures
-				/>
+				<ListView showNestedBlocks />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-site/src/components/secondary-sidebar/list-view-sidebar.js
@@ -59,7 +59,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView showNestedBlocks />
+				<ListView />
 			</div>
 		</div>
 	);

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -50,11 +50,7 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 	}, [ updateBlockListSettings, innerBlocks ] );
 	return (
 		<>
-			<ListView
-				id={ id }
-				showNestedBlocks
-				__experimentalPersistentListViewFeatures
-			/>
+			<ListView id={ id } showNestedBlocks />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -50,7 +50,7 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 	}, [ updateBlockListSettings, innerBlocks ] );
 	return (
 		<>
-			<ListView id={ id } showNestedBlocks />
+			<ListView id={ id } />
 		</>
 	);
 }

--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/navigation-menu.js
@@ -53,7 +53,6 @@ export default function NavigationMenu( { innerBlocks, id } ) {
 			<ListView
 				id={ id }
 				showNestedBlocks
-				__experimentalFeatures
 				__experimentalPersistentListViewFeatures
 			/>
 		</>

--- a/packages/edit-widgets/package.json
+++ b/packages/edit-widgets/package.json
@@ -35,6 +35,7 @@
 		"@wordpress/compose": "file:../compose",
 		"@wordpress/core-data": "file:../core-data",
 		"@wordpress/data": "file:../data",
+		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -60,7 +60,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView showNestedBlocks />
+				<ListView />
 			</div>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -60,10 +60,7 @@ export default function ListViewSidebar() {
 					focusOnMountRef,
 				] ) }
 			>
-				<ListView
-					showNestedBlocks
-					__experimentalHideContainerBlockActions
-				/>
+				<ListView showNestedBlocks />
 			</div>
 		</div>
 	);

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,7 +63,6 @@ export default function ListViewSidebar() {
 				<ListView
 					showNestedBlocks
 					__experimentalHideContainerBlockActions
-					__experimentalPersistentListViewFeatures
 				/>
 			</div>
 		</div>

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -63,7 +63,6 @@ export default function ListViewSidebar() {
 				<ListView
 					showNestedBlocks
 					__experimentalHideContainerBlockActions
-					__experimentalFeatures
 					__experimentalPersistentListViewFeatures
 				/>
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Improves the `ListView` component's props, which were a bit untidy, particularly the `__experimental` props:
- `__experimentalFeatures` - which was first used to test some experimental features for List View that were being developed in the navigation editor. All of these features have either now been removed or are considered stable. This prop was `true` on every ListView instance in this project, so I think it's fine to remove the prop and consider and consider all the features tied to it as active by default (block settings menu).
- `__experimentalPersistentListViewFeatures` - Similarly, this was used to make List View behave differently when the persistent sidebar was first introduced. The persistent sidebar is now the norm, so it seems fine to remove the prop. It was `true` (almost) everywhere, and with this PR all the features tied to it are active by default (windowing, and better block highlights).
- `__experimentalHideContainerBlockActions` - this was used by the Widget editor to hide the Block Settings menu for widget areas. I don't think the way it works was ideal. Widget Areas already use the `__experimentalToolbar: false` block supports setting to hide the block toolbar and block settings menu in the editor canvas, so I've switched List View to use this as well.
- `showNestedBlocks` - this was always `true` everywhere ListView was used, and I don't think there's any time a list view would be shown without nested blocks now. I think it'd be good to make it `true` by default.
- `...props` - I don't fully understand why this was there, it allowed any props to be set on `ListViewBranch`. I would expect it to be applied to the root element if anything. It was unused.

This also deprecates the old `BlockNavigationDropdown` component.

## Why?
Code quality / DevEx.

List View itself is an experimental component, but I think it's worth improving the public API and looking at making it stable.

## Testing Instructions
Everything should be the same as in `trunk`.
