### PR TITLE
Add a current-menu-ancestor class to navigation items

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -255,6 +255,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$inner_blocks_html .= $inner_block->render();
 		}
 
+		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {
+			$html = str_replace( 'wp-block-navigation-item__content', 'wp-block-navigation-item__content current-menu-ancestor', $html );
+		}
+
 		$html .= sprintf(
 			'<ul class="wp-block-navigation__submenu-container">%s</ul>',
 			$inner_blocks_html

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -255,11 +255,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$inner_blocks_html .= $inner_block->render();
 		}
 
-		$tag_processor = new WP_HTML_Tag_Processor( $inner_blocks_html );
-		while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item__content' ) ) ) {
-			$tag_processor->add_class( 'current-menu-ancestor' );
+		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {
+			$tag_processor = new WP_HTML_Tag_Processor( $html );
+			while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item__content' ) ) ) {
+				$tag_processor->add_class( 'current-menu-ancestor' );
+			}
+			$html = $tag_processor->get_updated_html();
 		}
-		$inner_blocks_html = $tag_processor->get_updated_html();
 
 		$html .= sprintf(
 			'<ul class="wp-block-navigation__submenu-container">%s</ul>',

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -255,9 +255,11 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$inner_blocks_html .= $inner_block->render();
 		}
 
-		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {
-			$html = str_replace( 'wp-block-navigation-item__content', 'wp-block-navigation-item__content current-menu-ancestor', $html );
+		$tag_processor = new WP_HTML_Tag_Processor( $inner_blocks_html );
+		while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item__content' ) ) ) {
+			$tag_processor->add_class( 'current-menu-ancestor' );
 		}
+		$inner_blocks_html = $tag_processor->get_updated_html();
 
 		$html .= sprintf(
 			'<ul class="wp-block-navigation__submenu-container">%s</ul>',


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/39663

When a submenu item is active, this will add a `current-menu-ancestor` to its parent menu-item(s), allowing theme-developers to style these items more efficiently.

## Why?
To make styling easier, and for consistency with the old navigation

## How?
Adds a simple check in the `navigation-submenu` block. If the inner-blocks HTML contains `current-menu-item`, then the parent gets a `current-menu-ancestor` class.

## Testing Instructions
Add a menu with submenus. Visit one of the pages in a submenu, and check that the parent menu-item gets the `current-menu-ancestor` class. Check with nested submenus as well (2 level deep submenus)
