### PR TITLE
Migrate paragraph test to Playwright

### DIFF
--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -1,15 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-describe( 'Paragraph', () => {
-	beforeEach( async () => {
-		await createNewPost();
+test.describe( 'Paragraph', () => {
+	test.beforeEach( async ( { pageUtils } ) => {
+		await pageUtils.createNewPost();
 	} );
 
-	it( 'should output unwrapped editable paragraph', async () => {
-		await insertBlock( 'Paragraph' );
+	test( 'should output unwrapped editable paragraph', async ( {
+		page,
+		pageUtils,
+	} ) => {
+		await pageUtils.insertBlock( {
+			name: 'core/paragraph',
+		} );
 		await page.keyboard.type( '1' );
 
 		const firstBlockTagName = await page.evaluate( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Migrate [paragraph.test.js](https://github.com/WordPress/gutenberg/blob/trunk/packages/e2e-tests/specs/editor/blocks/paragraph.test.js) to its Playwright version.

## Why?
See https://github.com/WordPress/gutenberg/pull/38570 for its background and rationale. 

## How?
See [MIGRATION.md](https://github.com/WordPress/gutenberg/blob/trunk/test/e2e/MIGRATION.md) for migration steps.

## Testing Instructions
Run npm run test-e2e:playwright -- /test/e2e/specs/editor/blocks/paragraph.spec.js.

related #38851 