### PR TITLE
Add missing "type" to the search field on the editor

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -217,6 +217,7 @@ export default function SearchEdit( {
 
 		return (
 			<input
+				type="search"
 				className={ textFieldClasses }
 				style={ textFieldStyles }
 				aria-label={ __( 'Optional placeholder text' ) }


### PR DESCRIPTION
## What?
Adds a missing `type="search"` to the search field in the editor.

## Why?
* Improve consistency between frontend and editor. On the frontend `type="search"` gets added, while on the editor it does not exist
* Allow for more consistent styling. It's not uncommon in CSS to target elements using selectors like `[type="search"]`. This change allows using the same CSS both on the front and the editor, thus eliminating the need for a separate editor stylesheet (for example Tailwind uses that selector)

## How?
Adds `type="search"` to the input field in `edit.js`

## Testing Instructions
Add a search block and confirm that it has the type defined.