### PR TITLE
Update native mobile wrangler in rich-text CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -117,9 +117,9 @@
 /packages/plugins                               @gziolo @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @ellatrix @cameronvoell
-/packages/rich-text                             @ellatrix @cameronvoell
-/packages/block-editor/src/components/rich-text @ellatrix @cameronvoell
+/packages/format-library                        @ellatrix @fluiddot
+/packages/rich-text                             @ellatrix @fluiddot
+/packages/block-editor/src/components/rich-text @ellatrix @fluiddot
 
 # Project Management
 /.github


### PR DESCRIPTION
This PR updates the CODEOWNER entry for the rich-text areas, to change the native mobile wrangler keeping an eye on the relevant packages.