### PR TITLE
`UnitControl`: show unit label when `units` prop has only one unit

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,8 @@
 -    The `Button` component now displays the label as the tooltip for icon only buttons. ([#40716](https://github.com/WordPress/gutenberg/pull/40716))
 -    Use fake timers and fix usage of async methods from `@testing-library/user-event`. ([#40790](https://github.com/WordPress/gutenberg/pull/40790))
 -    UnitControl: avoid calling onChange callback twice when unit changes. ([#40796](https://github.com/WordPress/gutenberg/pull/40796))
+-    `UnitControl`: show unit label when units prop has only one unit. ([#40784](https://github.com/WordPress/gutenberg/pull/40784))
+
 
 ### Internal
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -88,7 +88,7 @@ function UnforwardedUnitControl(
 	);
 
 	const [ unit, setUnit ] = useControlledState< string | undefined >(
-		units.length === 1 ? units[ 0 ].label : unitProp,
+		units.length === 1 ? units[ 0 ].value : unitProp,
 		{
 			initial: parsedUnit,
 			fallback: '',

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -88,7 +88,7 @@ function UnforwardedUnitControl(
 	);
 
 	const [ unit, setUnit ] = useControlledState< string | undefined >(
-		unitProp,
+		units.length === 1 ? units[ 0 ].label : unitProp,
 		{
 			initial: parsedUnit,
 			fallback: '',

--- a/packages/components/src/unit-control/stories/index.tsx
+++ b/packages/components/src/unit-control/stories/index.tsx
@@ -109,40 +109,10 @@ TweakingTheNumberInput.args = {
 /**
  * When only one unit is available, the unit selection dropdown becomes static text.
  */
-export const WithSingleUnitControlled: ComponentStory<
+export const WithSingleUnit: ComponentStory<
 	typeof UnitControl
-> = ( { onChange, ...args } ) => {
-	// Starting value is `undefined`
-	const [ value, setValue ] = useState< string | undefined >( undefined );
-
-	return (
-		<div style={ { maxWidth: '100px' } }>
-			<UnitControl
-				{ ...args }
-				value={ value }
-				onChange={ ( v, extra ) => {
-					setValue( v );
-					onChange?.( v, extra );
-				} }
-			/>
-		</div>
-	);
-};
-WithSingleUnitControlled.args = {
-	...Default.args,
-	units: CSS_UNITS.slice( 0, 1 ),
-};
-
-export const WithSingleUnitUncontrolled: ComponentStory<
-	typeof UnitControl
-> = ( args ) => {
-	return (
-		<div style={ { maxWidth: '100px' } }>
-			<UnitControl { ...args } />
-		</div>
-	);
-};
-WithSingleUnitUncontrolled.args = {
+> = DefaultTemplate.bind( {} );
+WithSingleUnit.args = {
 	...Default.args,
 	units: CSS_UNITS.slice( 0, 1 ),
 };

--- a/packages/components/src/unit-control/test/index.tsx
+++ b/packages/components/src/unit-control/test/index.tsx
@@ -135,12 +135,7 @@ describe( 'UnitControl', () => {
 		} );
 
 		it( 'should render label if single units', () => {
-			render(
-				<UnitControl
-					units={ [ { value: '%', label: '%' } ] }
-					value="30%"
-				/>
-			);
+			render( <UnitControl units={ [ { value: '%', label: '%' } ] } /> );
 
 			const select = screen.queryByRole( 'combobox' );
 			const label = screen.getByText( '%' );

--- a/packages/components/src/unit-control/test/index.tsx
+++ b/packages/components/src/unit-control/test/index.tsx
@@ -314,6 +314,36 @@ describe( 'UnitControl', () => {
 				expect.anything()
 			);
 		} );
+
+		it( 'should update value correctly when typed and blurred when a single unit is passed', async () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<>
+					<button>Click me</button>
+					<UnitControl
+						units={ [ { value: '%', label: '%' } ] }
+						onChange={ onChangeSpy }
+					/>
+				</>
+			);
+
+			const input = getInput();
+			await user.type( input, '62' );
+
+			expect( onChangeSpy ).toHaveBeenLastCalledWith(
+				'62%',
+				expect.anything()
+			);
+
+			// Start counting again calls to `onChangeSpy`.
+			onChangeSpy.mockClear();
+
+			// Clicking on the button should cause the `onBlur` callback to fire.
+			const button = screen.getByRole( 'button' );
+			await user.click( button );
+
+			expect( onChangeSpy ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Unit', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix an issue in `UnitControl`, where the unit label was not being shown if the `units` array prop only had one item.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a bug and should be fixed. See https://github.com/WordPress/gutenberg/pull/40697#discussion_r861178483 and https://github.com/WordPress/gutenberg/pull/40697#issuecomment-1115524503 for more context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is to use the label of the single unit passed through the `units` prop as the initial unit value (as suggested in this [comment](https://github.com/WordPress/gutenberg/pull/40697#issuecomment-1115524503) by @stokesman ).

This PR also restores the `should render label if single units` unit test to how it used to be before the changes applied in #40697.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Make sure tests pass

- Visit the[ "Single Unit Controlled"](http://localhost:50240/?path=/story/components-experimental-unitcontrol--with-single-unit-controlled) Storybook example on `trunk`, verify that there's no unit being displayed when the Story initially renders. Check that the unit is only shown after a numeric value is entered in the input field.

- Apply this patch below to restore the same Storybook example on this branch, visit the same "Single Unit Controlled" Storybook example, and verify that the initial unit is being displayed during the Story initial render.

<details>

<summary>Click to show the patch</summary>

```diff
diff --git a/packages/components/src/unit-control/stories/index.tsx b/packages/components/src/unit-control/stories/index.tsx
index 87dfd3a84c..de60479e7b 100644
--- a/packages/components/src/unit-control/stories/index.tsx
+++ b/packages/components/src/unit-control/stories/index.tsx
@@ -117,6 +117,29 @@ WithSingleUnit.args = {
 	units: CSS_UNITS.slice( 0, 1 ),
 };
 
+export const WithSingleUnitControlled: ComponentStory<
+	typeof UnitControl
+> = ( { onChange, ...args } ) => {
+	const [ value, setValue ] = useState< string | undefined >( undefined );
+
+	return (
+		<div style={ { maxWidth: '100px' } }>
+			<UnitControl
+				{ ...args }
+				value={ value }
+				onChange={ ( v, extra ) => {
+					setValue( v );
+					onChange?.( v, extra );
+				} }
+			/>
+		</div>
+	);
+};
+WithSingleUnitControlled.args = {
+	...Default.args,
+	units: CSS_UNITS.slice( 0, 1 ),
+};
+
 /**
  * It is possible to pass a custom list of units. Every time the unit changes,
  * if the `isResetValueOnUnitChange` is set to `true`, the input's quantity is
```
</details>

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/1083581/166507458-919ec3c5-022f-4570-b7ff-5f9807f598a6.mp4

**After**


https://user-images.githubusercontent.com/1083581/166507590-03fa417d-1585-4fc8-b84f-81c4efda539e.mp4