### PR TITLE
Site Editor: Use default cursor for non-editable text blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -262,12 +262,17 @@
 			right: $border-width;
 			bottom: $border-width;
 			box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
-			border-radius: $radius-block-ui - $border-width; // Border is outset, so subtract the width to achieve correct radius.
+			// Border is outset, so subtract the width to achieve correct radius.
+			border-radius: $radius-block-ui - $border-width;
 		}
 	}
 
 	&.is-selected {
-		cursor: unset;
+		cursor: default;
+
+		&.rich-text {
+			cursor: unset;
+		}
 
 		&::after {
 			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color); // Selected not focussed.


### PR DESCRIPTION
This PR updates Outline mode (which is the default in the Site Editor) so that non-editable text blocks display the default cursor at all times. 

A current issue is that blocks like Post Title, Post Content, and the Post Meta collection display a text cursor on hover and selection, which can mislead folks as to their purpose and edit-ability.

### Before
https://user-images.githubusercontent.com/846565/166442186-a744eaf7-155e-41d1-9453-1e65ca59eb72.mp4

### After
https://user-images.githubusercontent.com/846565/166442200-294d7e7a-ac6a-4778-8c19-9e3c87bf3e02.mp4

### To test
In the Site Editor;

* Select a non-rich-text block like Post Title and observe `cursor: default` applied at all times.
* Select an editable text block like Site Title and observe the expected `cursor: text`.