### PR TITLE
Only allow template part to be replaced if its a header or footer

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -155,7 +155,7 @@ export default function TemplatePartEdit( {
 			) }
 			{ isEntityAvailable &&
 				hasReplacements &&
-				( tagName === 'header' || tagName === 'footer' ) && (
+				( area === 'header' || area === 'footer' ) && (
 					<BlockControls>
 						<ToolbarGroup className="wp-block-template-part__block-control-group">
 							<ToolbarButton

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -153,19 +153,21 @@ export default function TemplatePartEdit( {
 					/>
 				</TagName>
 			) }
-			{ isEntityAvailable && hasReplacements && (
-				<BlockControls>
-					<ToolbarGroup className="wp-block-template-part__block-control-group">
-						<ToolbarButton
-							onClick={ () =>
-								setIsTemplatePartSelectionOpen( true )
-							}
-						>
-							{ __( 'Replace' ) }
-						</ToolbarButton>
-					</ToolbarGroup>
-				</BlockControls>
-			) }
+			{ isEntityAvailable &&
+				hasReplacements &&
+				( tagName === 'header' || tagName === 'footer' ) && (
+					<BlockControls>
+						<ToolbarGroup className="wp-block-template-part__block-control-group">
+							<ToolbarButton
+								onClick={ () =>
+									setIsTemplatePartSelectionOpen( true )
+								}
+							>
+								{ __( 'Replace' ) }
+							</ToolbarButton>
+						</ToolbarGroup>
+					</BlockControls>
+				) }
 			{ isEntityAvailable && (
 				<TemplatePartInnerBlocks
 					clientId={ clientId }


### PR DESCRIPTION
Currently the 'Replace' flow is enabled for all template part types. But it's only really useful for semantically related template parts, IE enabling the replacement of one header with another. For general template parts it's much less useful.

This PR updates the logic so that it's only possible for template parts assigned to the `header` or `footer` area to be replaced.

We might consider re-enabling this in the future if the replace modal is searchable.

### Before

https://user-images.githubusercontent.com/846565/166448962-48fc8b6b-c5c4-47f4-ae72-6f0f837cbdb0.mp4

### After


https://user-images.githubusercontent.com/846565/166448971-09a66eba-37d9-498f-8cc4-b407748979ce.mp4

### To test

* Ensure that header / footer template parts can be replaced
* Ensure that non-header / non-footer template parts cannot be replaced
