### PR TITLE
Mobile - AztecView - Trigger notifyInputChange on focus/blur

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -262,9 +262,7 @@ const BlockDraggableWrapper = ( { children } ) => {
  */
 const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 	const wasBeingDragged = useRef( false );
-	const [ isEditingText, setIsEditingText ] = useState(
-		RCTAztecView.InputState.isFocused()
-	);
+	const [ isEditingText, setIsEditingText ] = useState( false );
 
 	const draggingAnimation = {
 		opacity: useSharedValue( 1 ),
@@ -327,6 +325,11 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 	}, [] );
 
 	useEffect( () => {
+		const isAnyAztecInputFocused = RCTAztecView.InputState.isFocused();
+		if ( isAnyAztecInputFocused ) {
+			setIsEditingText( isAnyAztecInputFocused );
+		}
+
 		RCTAztecView.InputState.addFocusChangeListener( onFocusChangeAztec );
 		return () => {
 			RCTAztecView.InputState.removeFocusChangeListener(

--- a/packages/react-native-aztec/src/AztecInputState.js
+++ b/packages/react-native-aztec/src/AztecInputState.js
@@ -90,6 +90,7 @@ export const notifyInputChange = () => {
  */
 export const focus = ( element ) => {
 	TextInputState.focusTextInput( element );
+	notifyInputChange();
 };
 
 /**
@@ -99,6 +100,7 @@ export const focus = ( element ) => {
  */
 export const blur = ( element ) => {
 	TextInputState.blurTextInput( element );
+	notifyInputChange();
 };
 
 /**

--- a/packages/react-native-aztec/src/AztecView.js
+++ b/packages/react-native-aztec/src/AztecView.js
@@ -122,8 +122,6 @@ class AztecView extends Component {
 	}
 
 	_onFocus( event ) {
-		AztecInputState.notifyInputChange();
-
 		if ( ! this.props.onFocus ) {
 			return;
 		}
@@ -136,7 +134,6 @@ class AztecView extends Component {
 		this.selectionEndCaretY = null;
 
 		AztecInputState.blur( this.aztecViewRef.current );
-		AztecInputState.notifyInputChange();
 
 		if ( ! this.props.onBlur ) {
 			return;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4807

## What?
Fixes an issue where a block can't be dragged if it's added by replacing a Paragraph block.

## Why?
It affects adding new blocks and being able to drag them if they're not text-based blocks.

## How?
By triggering `notifyInputChange` from the `focus` and `blur` callbacks in `AztecView`. For cases when a RichText component is unmounted or is focused programmatically.

It also adds a `hasListeners` check within `notifyInputChange`, so it doesn't update the `currentFocusedElement` if there are no listeners set yet.

## Testing Instructions

### Adding a block from an empty post and adding a non-text-based block

- Open the editor
- Tap on the default Paragraph block
- Long-press to drag the block
- **Expect not** to be able to drag it
- Open the inserter and add an Image block
- Dismiss the upload options dialog
- Long-press to drag the block
- **Expect** to be able to drag it

### Adding a block from an empty post and adding a text-based block

- Open the editor
- Tap on the default Paragraph block
- Long-press to drag the block
- **Expect not** to be able to drag it
- Open the inserter and add a Heading block
- Long-press to drag the block
- **Expect not** to be able to drag it

### Transforming a block

- Open the editor
- Tap on the default Paragraph block
- Long-press to drag the block
- **Expect not** to be able to drag it
- Type in some text
- Open the block's settings
- Transform the block into a Heading block
- Long-press to drag the block
- **Expect not** to be able to drag it

## Also, follow the next ones taken from this [PR](https://github.com/WordPress/gutenberg/pull/40480):

### Dragging is ENABLED when the block is not selected
1. Check that no block is selected.
1. Long-press on a block.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Drop the block and observe that the block is moved to the specified position and is selected.

### Dragging is ENABLED when the block is selected
1. Select a block.
1. Long-press on a block.
**NOTE:** Only the block's content will be draggable, the block's toolbar won't enable the dragging mode.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Drop the block and observe that it's is moved to the specified position and is still selected.

### Dragging is DISABLED for the selected block when editing text
1. Tap on a text block to edit its content.
**NOTE:** Check that the text input is focused (i.e. the text editing is enabled).
1. Long-press on the content.
1. Observe that the long-press gesture works and that doesn't trigger the dragging mode.
1. Tap on a block that contains `RichText` components (e.g. Cover block or Media Text block).
1. Edit text by tapping on a `RichText` element.
1. Long-press on the content.
1. Observe that the long-press gesture works and that doesn't trigger the dragging mode.

### Dragging is ENABLED for unselected blocks when editing text
1. Tap on a text block to edit its content.
**NOTE:** Check that the text input is focused (i.e. the text editing is enabled).
1. Long-press on an unselected block.
1. Observe that the dragging mode is enabled and that the block can be dragged around the block list.
1. Observe that the text stops being edited (i.e. the text input is unfocused and the keyboard is hidden).
1. Drop the block and observe that it's is moved to the specified position and is still selected.

## Screenshots or screencast <!-- if applicable -->

Inserter iOS | Inserter Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/166700897-a49224af-0293-40fb-af4c-6ba2b23d2884.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/166700913-41fcb965-d7ac-4b17-a0db-7824e6974b80.gif" width="200" /></kbd>

Media block iOS | Media Block Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/166700992-aabc06d0-eeeb-4e10-9fe7-01d6dcd87fa2.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/166701004-1d91a5c2-2881-4614-828e-0f28ac92db20.gif" width="200" /></kbd>

Transform iOS | Transform Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/166701070-9d9d510e-6ea6-406e-a03c-51ec564ab001.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/166701084-5e2380db-1a7a-453b-9503-26bc5b786e12.gif" width="200" /></kbd>