### PR TITLE
Expose the exclude post functionality for query loop block

### DIFF
--- a/packages/block-library/src/query/constants.js
+++ b/packages/block-library/src/query/constants.js
@@ -1,7 +1,9 @@
 export const MAX_FETCHED_TERMS = 100;
+export const MAX_SUGGESTED_POSTS = 20;
 export const DEFAULTS_POSTS_PER_PAGE = 3;
 
 export default {
 	MAX_FETCHED_TERMS,
+	MAX_SUGGESTED_POSTS,
 	DEFAULTS_POSTS_PER_PAGE,
 };

--- a/packages/block-library/src/query/edit/inspector-controls/exclude-posts-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/exclude-posts-control.js
@@ -1,0 +1,139 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormTokenField } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDebounce } from '@wordpress/compose';
+import { useState, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getEntitiesInfo } from '../../utils';
+import { MAX_SUGGESTED_POSTS } from '../../constants';
+
+/**
+ * Shared reference to an empty array for cases where it is important to avoid
+ * returning a new array reference on every invocation.
+ *
+ * @type {Array<any>}
+ */
+const EMPTY_ARRAY = [];
+
+const POSTS_QUERY = {
+	per_page: -1,
+	_fields: 'id,title',
+};
+
+function ExcludePostsControl( { value, onChange, query } ) {
+	const [ search, setSearch ] = useState( '' );
+	const debouncedSearch = useDebounce( setSearch, 500 );
+	const searchResults = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const _query = {
+				...POSTS_QUERY,
+				search,
+				per_page: MAX_SUGGESTED_POSTS,
+				order: 'asc',
+				orderby: 'relevance',
+				exclude: value,
+			};
+			return !! search
+				? getEntityRecords( 'postType', query.postType, _query )?.map(
+						( v ) => {
+							return {
+								...v,
+								name: v.title.rendered,
+							};
+						}
+				  )
+				: EMPTY_ARRAY;
+		},
+		[ search ]
+	);
+	const suggestions = useMemo( () => {
+		return ( searchResults ?? [] ).map( ( post ) => post.name );
+	}, [ searchResults ] );
+
+	const excludedPostsList = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( coreStore );
+			const _query = {
+				...POSTS_QUERY,
+				include: value,
+			};
+			const _posts = getEntityRecords(
+				'postType',
+				query.postType,
+				_query
+			);
+			const _searchResults = searchResults ?? [];
+			const _excludedPosts =
+				_posts?.map( ( post ) => {
+					return {
+						...post,
+						name: post.title.rendered,
+					};
+				} ) ?? [];
+			return _excludedPosts.concat( _searchResults );
+		},
+		[ searchResults ]
+	);
+
+	if ( ! excludedPostsList ) {
+		return null;
+	}
+
+	const excludedPostsInfo = getEntitiesInfo( excludedPostsList );
+
+	/**
+	 * We need to normalize the value because the block operates on a
+	 * comma(`,`) separated string value and `FormTokenFiels` needs an
+	 * array.
+	 */
+	const normalizedValue = ! value ? [] : value.toString().split( ',' );
+	// Returns only the existing posts ids. This prevents the component
+	// from crashing in the editor, when non existing ids are provided.
+	const sanitizedValue = normalizedValue.reduce( ( accumulator, postId ) => {
+		const post = excludedPostsInfo.mapById[ postId ];
+		if ( post ) {
+			accumulator.push( {
+				id: postId,
+				value: post.name,
+			} );
+		}
+		return accumulator;
+	}, [] );
+
+	const getIdByValue = ( entitiesMappedByName, postTitle ) => {
+		const id = postTitle?.id || entitiesMappedByName[ postTitle ]?.id;
+		if ( id ) return id;
+	};
+
+	const onExcludedPostsChange = ( newValue ) => {
+		const ids = Array.from(
+			newValue.reduce( ( accumulator, post ) => {
+				// Verify that new values point to existing entities.
+				const id = getIdByValue( excludedPostsInfo.mapByName, post );
+				if ( id ) accumulator.add( id );
+				return accumulator;
+			}, new Set() )
+		);
+		onChange( { exclude: ids.join( ',' ) } );
+	};
+
+	return (
+		<FormTokenField
+			label={ __( 'Exclude Posts' ) }
+			value={ sanitizedValue }
+			suggestions={ suggestions }
+			onInputChange={ debouncedSearch }
+			onChange={ onExcludedPostsChange }
+		/>
+	);
+}
+
+export default ExcludePostsControl;

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -24,6 +24,7 @@ import { useEffect, useState, useCallback } from '@wordpress/element';
 import OrderControl from './order-control';
 import AuthorControl from './author-control';
 import TaxonomyControls from './taxonomy-controls';
+import ExcludePostsControl from './exclude-posts-control';
 import { usePostTypes } from '../../utils';
 
 const stickyOptions = [
@@ -41,6 +42,7 @@ export default function QueryInspectorControls( {
 		order,
 		orderBy,
 		author: authorIds,
+		exclude: postIds,
 		postType,
 		sticky,
 		inherit,
@@ -151,6 +153,11 @@ export default function QueryInspectorControls( {
 				<PanelBody title={ __( 'Filters' ) }>
 					<TaxonomyControls onChange={ setQuery } query={ query } />
 					<AuthorControl value={ authorIds } onChange={ setQuery } />
+					<ExcludePostsControl
+						query={ query }
+						value={ postIds }
+						onChange={ setQuery }
+					/>
 					<TextControl
 						label={ __( 'Keyword' ) }
 						value={ querySearch }


### PR DESCRIPTION
## What?
This PR adds the UI for excluding posts from the query loop block.


## Why?
Currently, the query loop block allows setting an `exclude` list but the functionality is not exposed in the UI.  

## How?


## Testing Instructions
1. Open a Post or Page.
2. Insert a Query Loop block.
3. Under _Filters_ setting a new _Exclude posts_ list should be visible
4. You should be able to add/remove excluded posts via the input

## Screenshots or screencast
<img width="1461" alt="Screenshot 2022-05-03 at 15 06 59" src="https://user-images.githubusercontent.com/266375/166450143-6468ce03-c2d0-4d9a-97fe-1f0eb8551ca0.png">

