### PR TITLE
[Dom]: Fix zero handling in `isNumberInput` util

### DIFF
--- a/packages/dom/src/dom/is-number-input.js
+++ b/packages/dom/src/dom/is-number-input.js
@@ -17,6 +17,6 @@ export default function isNumberInput( node ) {
 	return (
 		isHTMLInputElement( node ) &&
 		node.type === 'number' &&
-		!! node.valueAsNumber
+		! Number.isNaN( node.valueAsNumber )
 	);
 }

--- a/packages/dom/src/dom/test/is-number-input.js
+++ b/packages/dom/src/dom/test/is-number-input.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import isNumberInput from '../is-number-input';
+
+describe( 'isNumberInput', () => {
+	it( 'should handle zero value properly', () => {
+		const input = document.createElement( 'input' );
+		input.type = 'number';
+		input.value = 0;
+		expect( isNumberInput( input ) ).toBe( true );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`isNumberInput` returns wrong result if the value is zero due to the `boolean` conversion.

Found by @mcsf in [this PR](https://github.com/WordPress/gutenberg/pull/40192):
>As a side note, there is a fundamental bug in that function due to !! node.valueAsNumber returning false if the value is the number 0.
