### PR TITLE
Comments block e2e test: Remove now-obsolete Post Comments Form block

### DIFF
--- a/packages/e2e-tests/specs/editor/blocks/comments.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/comments.test.js
@@ -33,7 +33,6 @@ describe( 'Comments', () => {
 	it( 'Pagination links are working as expected', async () => {
 		await createNewPost();
 		await insertBlock( 'Comments' );
-		await insertBlock( 'Post Comments Form' );
 		await publishPost();
 		// Visit the post that was just published.
 		await page.click(
@@ -94,7 +93,6 @@ describe( 'Comments', () => {
 		await setOption( 'page_comments', '0' );
 		await createNewPost();
 		await insertBlock( 'Comments' );
-		await insertBlock( 'Post Comments Form' );
 		await publishPost();
 		// Visit the post that was just published.
 		await page.click(


### PR DESCRIPTION
## What?
Remove two lines that inserted Post Comments Form blocks as part of the Comments (The Block Formerly Known as Comments Query Loop) e2e test.

## Why?
These were needed to enable the e2e test to post comments on the frontend. But as of #40256, the Post Comments Form block is part of the Comments block default template, which we're inserting separately anyway. This means that the e2e test can post comments by using that form (and there's no more need for the separate one).

## How?
Say "What?" 😬 

## Testing Instructions
Verify that e2e tests are still green in CI, or run locally.

## Screenshots or screencast

Here's the "Before", showing both the Post Comments Form that's now part of the Comments block, and the separate one that we were inserting below:

![Pagination links are working as expected 2022-05-02T19-20-00](https://user-images.githubusercontent.com/96308/166482360-62425f36-497b-415a-a673-74639bf86918.jpg)

(Found while looking into an issue flagged [here](https://github.com/WordPress/gutenberg/pull/40763#issuecomment-1115352675).)
