### PR TITLE
Patterns: Allow patterns within patterns to render in Block Preview

### DIFF
--- a/packages/block-editor/src/components/block-preview/index.js
+++ b/packages/block-editor/src/components/block-preview/index.js
@@ -37,7 +37,6 @@ export function BlockPreview( {
 	);
 	const settings = useMemo( () => {
 		const _settings = { ...originalSettings };
-		_settings.__experimentalBlockPatterns = [];
 		return _settings;
 	}, [ originalSettings ] );
 	const renderedBlocks = useMemo( () => castArray( blocks ), [ blocks ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Return the correct `settings.__experimentalBlockPatterns` in BlockPreview.

Resolves #39732

## Why?
Patterns is not rendered in BlockPreview.

## How?
In BlockPreview, `settings.__experimentalBlockPatterns` was overwritten with `[]`, so that process was removed.

## Testing Instructions

1. Activate TwentyTwentyTwho
2. Go to "Site Editor"
3. Click header template part.
4. Click "Replace" in toolbar.
