### PR TITLE
Fix Comments Form Title text alignment

### DIFF
--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -18,13 +18,11 @@
 	&[style*="letter-spacing"] :where(.comment-reply-title) {
 		letter-spacing: inherit;
 	}
-
-	&[class*="-align-left"] :where(.comment-reply-title) {
+	:not(&[class*="-align-center"]) {
 		justify-content: space-between;
 	}
 	&[class*="-align-right"] :where(.comment-reply-title) {
 		flex-direction: row-reverse;
-		justify-content: space-between;
 	}
 	&[class*="-align-center"] :where(.comment-reply-title) {
 		justify-content: center;

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -19,6 +19,20 @@
 		letter-spacing: inherit;
 	}
 
+	&[class*="-align-left"] :where(.comment-reply-title) {
+		justify-content: space-between;
+	}
+	&[class*="-align-right"] :where(.comment-reply-title) {
+		flex-direction: row-reverse;
+		justify-content: space-between;
+	}
+	&[class*="-align-center"] :where(.comment-reply-title) {
+		justify-content: center;
+		:where(small) {
+			margin-left: 0.5em;
+		}
+	}
+
 	// Styles copied from button block styles.
 	input[type="submit"] {
 		border: none;
@@ -71,9 +85,7 @@
 	.comment-reply-title {
 		align-items: baseline;
 		display: flex;
-		justify-content: space-between;
 		margin-bottom: 0;
-
 		:where(small) {
 			font-size: var(--wp--preset--font-size--medium, smaller);
 		}

--- a/packages/block-library/src/post-comments-form/style.scss
+++ b/packages/block-library/src/post-comments-form/style.scss
@@ -18,18 +18,6 @@
 	&[style*="letter-spacing"] :where(.comment-reply-title) {
 		letter-spacing: inherit;
 	}
-	:not(&[class*="-align-center"]) {
-		justify-content: space-between;
-	}
-	&[class*="-align-right"] :where(.comment-reply-title) {
-		flex-direction: row-reverse;
-	}
-	&[class*="-align-center"] :where(.comment-reply-title) {
-		justify-content: center;
-		:where(small) {
-			margin-left: 0.5em;
-		}
-	}
 
 	// Styles copied from button block styles.
 	input[type="submit"] {
@@ -81,11 +69,10 @@
 	}
 
 	.comment-reply-title {
-		align-items: baseline;
-		display: flex;
 		margin-bottom: 0;
 		:where(small) {
 			font-size: var(--wp--preset--font-size--medium, smaller);
+			margin-left: 0.5em;
 		}
 	}
 }

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -86,6 +86,14 @@
 		}
 	}
 
+	.comment-reply-title {
+		margin-bottom: 0;
+		:where(small) {
+			font-size: var(--wp--preset--font-size--medium, smaller);
+			margin-left: 0.5em;
+		}
+	}
+
 	.reply {
 		font-size: 0.875em;
 		margin-bottom: 1.4em;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix the alignment of the comment reply title. This appears on Comments Form block.
Complements #40613

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Now when you change the alignment of Post Comments Form block, all its content respects that option.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By updating the flex CSS so it respects the classes added at setting the alignment.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1.) Add a posts comment form block in the editor or add a Comment Query Loop, and select the comment form block.
1.) Adjust the alignment from the block tool bar. Duplicate the block and select a different alignment -repeat this for every alignment
Save and view the front.
Confirm if the alignments in the editor and front match the toolbar setting.

## Screenshots or screencast <!-- if applicable -->
[Loom Video](https://www.loom.com/share/e7882b0e91244f5182eebb96930a5361)

