### PR TITLE
UnitControl: avoid calling onChange callback twice when unit changes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 -    The `Button` component now displays the label as the tooltip for icon only buttons. ([#40716](https://github.com/WordPress/gutenberg/pull/40716))
 -    Use fake timers and fix usage of async methods from `@testing-library/user-event`. ([#40790](https://github.com/WordPress/gutenberg/pull/40790))
+-    UnitControl: avoid calling onChange callback twice when unit changes. ([#40796](https://github.com/WordPress/gutenberg/pull/40796))
 
 ### Internal
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -178,10 +178,7 @@ function UnforwardedUnitControl(
 				: undefined;
 			const changeProps = { event, data };
 
-			onChangeProp?.(
-				`${ validParsedQuantity ?? '' }${ validParsedUnit }`,
-				changeProps
-			);
+			// The `onChange` callback already gets called, no need to call it explicitely.
 			onUnitChange?.( validParsedUnit, changeProps );
 
 			setUnit( validParsedUnit );

--- a/packages/components/src/unit-control/test/index.tsx
+++ b/packages/components/src/unit-control/test/index.tsx
@@ -310,8 +310,7 @@ describe( 'UnitControl', () => {
 			// Clicking document.body to trigger a blur event on the input.
 			await user.click( document.body );
 
-			// TODO: investigate why `onChange` gets called twice instead of once
-			expect( onChangeSpy ).toHaveBeenCalledTimes( 2 );
+			expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 			expect( onChangeSpy ).toHaveBeenLastCalledWith( '41vh' );
 
 			expect( onUnitChangeSpy ).toHaveBeenCalledTimes( 1 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prior to this PR, the `onChange` callback on `UnitControl` is called twice when the unit changes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Just an error in the component's logic.

This bug was uncovered by the work done in https://github.com/WordPress/gutenberg/pull/40790#discussion_r863844145 while a solution was, at the same time, already being proposed by @stokesman as part of #40568.

This PR extracts the fix from #40568, while also updating the corresponding unit test.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed the call to `onChange` from within the `mayUpdateUnit` function.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Updated unit tests pass
- Pass both the `onChange` and `onUnitChange` callbacks to `UnitControl`. Interact with the component by changing the unit from the dropdown. Make sure that the both callbacks are called, but that `onChange` is called only once.
