### PR TITLE
#40675: Ensure only the main query is modified when resolving template for new posts.

### DIFF
--- a/lib/compat/wordpress-5.9/block-template.php
+++ b/lib/compat/wordpress-5.9/block-template.php
@@ -286,6 +286,9 @@ add_filter( 'render_block_context', 'gutenberg_template_render_without_post_bloc
  * @return void
  */
 function gutenberg_resolve_template_for_new_post( $wp_query ) {
+	if ( ! $wp_query->is_main_query() ) {
+		return;
+	}
 	remove_filter( 'pre_get_posts', 'gutenberg_resolve_template_for_new_post' );
 
 	// Pages.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix 404 response when resolving template for new posts/pages (#40675).

This issue has been reported with WordPress 6.0 beta 3 and can still be reproduced in RC1.

Since the bug only occur with the Gutenberg plugin disable, this PR would need to be backported into WordPress core to fix the original issue.

