### PR TITLE
Update `react-dates` to 21.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17281,7 +17281,7 @@
 				"moment": "^2.22.1",
 				"re-resizable": "^6.4.0",
 				"react-colorful": "^5.3.1",
-				"react-dates": "^17.1.1",
+				"react-dates": "^21.8.0",
 				"react-resize-aware": "^3.1.0",
 				"reakit": "^1.3.8",
 				"uuid": "^8.3.0"
@@ -17308,6 +17308,49 @@
 					"version": "3.0.10",
 					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
 					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"react-dates": {
+					"version": "21.8.0",
+					"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-21.8.0.tgz",
+					"integrity": "sha512-PPriGqi30CtzZmoHiGdhlA++YPYPYGCZrhydYmXXQ6RAvAsaONcPtYgXRTLozIOrsQ5mSo40+DiA5eOFHnZ6xw==",
+					"requires": {
+						"airbnb-prop-types": "^2.15.0",
+						"consolidated-events": "^1.1.1 || ^2.0.0",
+						"enzyme-shallow-equal": "^1.0.0",
+						"is-touch-device": "^1.0.1",
+						"lodash": "^4.1.1",
+						"object.assign": "^4.1.0",
+						"object.values": "^1.1.0",
+						"prop-types": "^15.7.2",
+						"raf": "^3.4.1",
+						"react-moment-proptypes": "^1.6.0",
+						"react-outside-click-handler": "^1.2.4",
+						"react-portal": "^4.2.0",
+						"react-with-direction": "^1.3.1",
+						"react-with-styles": "^4.1.0",
+						"react-with-styles-interface-css": "^6.0.0"
+					}
+				},
+				"react-with-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-4.2.0.tgz",
+					"integrity": "sha512-tZCTY27KriRNhwHIbg1NkSdTTOSfXDg6Z7s+Q37mtz0Ym7Sc7IOr3PzVt4qJhJMW6Nkvfi3g34FuhtiGAJCBQA==",
+					"requires": {
+						"airbnb-prop-types": "^2.14.0",
+						"hoist-non-react-statics": "^3.2.1",
+						"object.assign": "^4.1.0",
+						"prop-types": "^15.7.2",
+						"react-with-direction": "^1.3.1"
+					}
+				},
+				"react-with-styles-interface-css": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-6.0.0.tgz",
+					"integrity": "sha512-6khSG1Trf4L/uXOge/ZAlBnq2O2PEXlQEqAhCRbvzaQU4sksIkdwpCPEl6d+DtP3+IdhyffTWuHDO9lhe1iYvA==",
+					"requires": {
+						"array.prototype.flat": "^1.2.1",
+						"global-cache": "^1.2.1"
+					}
 				}
 			}
 		},
@@ -32474,7 +32517,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz",
 			"integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
-			"dev": true,
 			"requires": {
 				"has": "^1.0.3",
 				"object-is": "^1.0.2"
@@ -32483,8 +32525,7 @@
 				"object-is": {
 					"version": "1.0.2",
 					"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-					"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-					"dev": true
+					"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
 				}
 			}
 		},
@@ -48223,8 +48264,7 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"phpegjs": {
 			"version": "1.0.0-beta7",
@@ -50103,7 +50143,6 @@
 			"version": "3.4.1",
 			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
 			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-			"dev": true,
 			"requires": {
 				"performance-now": "^2.1.0"
 			}
@@ -50266,14 +50305,6 @@
 				"object-assign": "^4.1.1"
 			}
 		},
-		"react-addons-shallow-compare": {
-			"version": "15.6.3",
-			"resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.3.tgz",
-			"integrity": "sha512-EDJbgKTtGRLhr3wiGDXK/+AEJ59yqGS+tKE6mue0aNXT6ZMR7VJbbzIiT6akotmHg1BLj46ElJSb+NBMp80XBg==",
-			"requires": {
-				"object-assign": "^4.1.0"
-			}
-		},
 		"react-autosize-textarea": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
@@ -50288,26 +50319,6 @@
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.3.1.tgz",
 			"integrity": "sha512-nkP1w1LGe8PzhtOQO10xSDTsMWAYVj/Wm5c7ORk7CBngjCE7hHsknFRtosT5qMYkwWs8wSiU0sBwZ8dyzRbNEQ=="
-		},
-		"react-dates": {
-			"version": "17.2.0",
-			"resolved": "https://registry.npmjs.org/react-dates/-/react-dates-17.2.0.tgz",
-			"integrity": "sha512-RDlerU8DdRRrlYS0MQ7Z9igPWABGLDwz6+ykBNff67RM3Sset2TDqeuOr+R5o00Ggn5U47GeLsGcSDxlZd9cHw==",
-			"requires": {
-				"airbnb-prop-types": "^2.10.0",
-				"consolidated-events": "^1.1.1 || ^2.0.0",
-				"is-touch-device": "^1.0.1",
-				"lodash": "^4.1.1",
-				"object.assign": "^4.1.0",
-				"object.values": "^1.0.4",
-				"prop-types": "^15.6.1",
-				"react-addons-shallow-compare": "^15.6.2",
-				"react-moment-proptypes": "^1.6.0",
-				"react-outside-click-handler": "^1.2.0",
-				"react-portal": "^4.1.5",
-				"react-with-styles": "^3.2.0",
-				"react-with-styles-interface-css": "^4.0.2"
-			}
 		},
 		"react-dev-utils": {
 			"version": "11.0.4",
@@ -51321,36 +51332,6 @@
 						"react-is": "^16.7.0"
 					}
 				}
-			}
-		},
-		"react-with-styles": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
-			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
-			"requires": {
-				"hoist-non-react-statics": "^3.2.1",
-				"object.assign": "^4.1.0",
-				"prop-types": "^15.6.2",
-				"react-with-direction": "^1.3.0"
-			},
-			"dependencies": {
-				"hoist-non-react-statics": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-					"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-					"requires": {
-						"react-is": "^16.7.0"
-					}
-				}
-			}
-		},
-		"react-with-styles-interface-css": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/react-with-styles-interface-css/-/react-with-styles-interface-css-4.0.3.tgz",
-			"integrity": "sha512-wE43PIyjal2dexxyyx4Lhbcb+E42amoYPnkunRZkb9WTA+Z+9LagbyxwsI352NqMdFmghR0opg29dzDO4/YXbw==",
-			"requires": {
-				"array.prototype.flat": "^1.2.1",
-				"global-cache": "^1.2.1"
 			}
 		},
 		"read": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `UnitControl`: migrate unit tests to TypeScript ([#40697](https://github.com/WordPress/gutenberg/pull/40697)).
 -   `DatePicker`: Add improved unit tests ([#40754](https://github.com/WordPress/gutenberg/pull/40754)).
+-   `DatePicker`: Update `react-dates` to 21.8.0 ([#40801](https://github.com/WordPress/gutenberg/pull/40801)).
 
 ### Enhancements
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -64,7 +64,7 @@
 		"moment": "^2.22.1",
 		"re-resizable": "^6.4.0",
 		"react-colorful": "^5.3.1",
-		"react-dates": "^17.1.1",
+		"react-dates": "^21.8.0",
 		"react-resize-aware": "^3.1.0",
 		"reakit": "^1.3.8",
 		"uuid": "^8.3.0"

--- a/packages/components/src/date-time/test/date.js
+++ b/packages/components/src/date-time/test/date.js
@@ -19,8 +19,9 @@ describe( 'DatePicker', () => {
 			screen.getByRole( 'button', { name: 'Monday, May 2, 2022' } )
 		).toHaveClass( 'CalendarDay__selected' );
 
-		// Expect React deprecation warning due to outdated 'react-dates' package.
-		// TODO: Update 'react-dates'.
+		// Expect React deprecation warning due to 'react-dates' using outdated
+		// React lifecycle methods.
+		// https://github.com/react-dates/react-dates/issues/1748
 		expect( console ).toHaveWarned();
 	} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates the `react-dates` dependency of `@wordpress/components` to 21.8.0.

## Why?
I was hoping that updating `react-dates` would fix the `console.warn()` that is emitted because `DayPicker` uses `componentWillReceiveProps` which is deprecated. Unfortunately it does not.

Still, it's probably worth updating the package anyway so that we have the latest bug fixes and security fixes.

## How?
I bumped the version in `packages/components/package.json` and ran `npm install`.

## Testing Instructions
This PR is based off of https://github.com/WordPress/gutenberg/pull/40754 which includes tests. You can also:

- Play around with the _Publish_ popover in the post sidebar to check that there is nothing off.
- Play around with the `DateTimePicker` story to check that there is nothing off.