### PR TITLE
Add eslint warning about use of waitForTimeout to playwright eslint 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -258,6 +258,11 @@ module.exports = {
 						message:
 							'`$$` is discouraged, please use `locator` instead',
 					},
+					{
+						selector:
+							'CallExpression[callee.object.name="page"][callee.property.name="waitForTimeout"]',
+						message: 'Prefer page.waitForSelector instead.',
+					},
 				],
 			},
 		},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -261,7 +261,7 @@ module.exports = {
 					{
 						selector:
 							'CallExpression[callee.object.name="page"][callee.property.name="waitForTimeout"]',
-						message: 'Prefer page.waitForSelector instead.',
+						message: 'Prefer page.locator instead.',
 					},
 				],
 			},


### PR DESCRIPTION
## What?
Adds an eslint warning about the use of waitForTimeout to playwright eslint config

## Why?
Puppeteer has a warning added to prevent people use waitForTimeout and to prompt to use waitForSelector instead as this is best practice.

## How?
Copied the relevant config from the puppeteer config to the playwright config

## Testing Instructions
Try adding `await page.waitForTimeout(1000);` to a playwright test, eg. `test/e2e/specs/editor/plugins/image-size.spec.js`  and check that you get an eslint warning
