### PR TITLE
Post Terms: Add wp_kses_post to prefix/suffix for consistency

### DIFF
--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -15,6 +15,7 @@ import {
 	useBlockDisplayInformation,
 	RichText,
 } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 import { Spinner, TextControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -30,6 +31,7 @@ export default function PostTermsEdit( {
 	clientId,
 	context,
 	setAttributes,
+	insertBlocksAfter,
 } ) {
 	const { term, textAlign, separator, prefix, suffix } = attributes;
 	const { postId, postType } = context;
@@ -86,6 +88,12 @@ export default function PostTermsEdit( {
 				{ isLoading && <Spinner /> }
 				{ ! isLoading && hasPostTerms && (
 					<RichText
+						allowedFormats={ [
+							'core/bold',
+							'core/italic',
+							'core/image',
+							'core/strikethrough',
+						] }
 						className="wp-block-post-terms__prefix"
 						multiline={ false }
 						aria-label={ __( 'Prefix' ) }
@@ -124,6 +132,12 @@ export default function PostTermsEdit( {
 						__( 'Term items not found.' ) ) }
 				{ ! isLoading && hasPostTerms && (
 					<RichText
+						allowedFormats={ [
+							'core/bold',
+							'core/italic',
+							'core/image',
+							'core/strikethrough',
+						] }
 						className="wp-block-post-terms__suffix"
 						multiline={ false }
 						aria-label={ __( 'Suffix' ) }
@@ -133,6 +147,9 @@ export default function PostTermsEdit( {
 							setAttributes( { suffix: value } )
 						}
 						tagName="span"
+						__unstableOnSplitAtEnd={ () =>
+							insertBlocksAfter( createBlock( 'core/paragraph' ) )
+						}
 					/>
 				) }
 			</div>

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -26,6 +26,16 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import usePostTerms from './use-post-terms';
 
+// Allowed formats for the prefix and suffix fields.
+const ALLOWED_FORMATS = [
+	'core/bold',
+	'core/image',
+	'core/italic',
+	'core/link',
+	'core/strikethrough',
+	'core/text-color',
+];
+
 export default function PostTermsEdit( {
 	attributes,
 	clientId,
@@ -88,12 +98,7 @@ export default function PostTermsEdit( {
 				{ isLoading && <Spinner /> }
 				{ ! isLoading && hasPostTerms && (
 					<RichText
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
+						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__prefix"
 						multiline={ false }
 						aria-label={ __( 'Prefix' ) }
@@ -132,12 +137,7 @@ export default function PostTermsEdit( {
 						__( 'Term items not found.' ) ) }
 				{ ! isLoading && hasPostTerms && (
 					<RichText
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
+						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__suffix"
 						multiline={ false }
 						aria-label={ __( 'Suffix' ) }

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -49,9 +49,9 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	return get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
-		$prefix,
+		wp_kses_post( $prefix ),
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
-		$suffix
+		wp_kses_post( $suffix )
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following on from #40776 and #40559, this adds `wp_kses_post` to the Post Terms prefix and suffix fields.

Also:

* Add `allowedFormats` to reduce the allowed formats for consistency with other blocks like Navigation Link (we probably only really need bold, italic, image, strikethrough rather than keyboard / super/subscript options) – I also added in link and text color, as they're probably still useful here.
* Add `__unstableOnSplitAtEnd` to the suffix field so that if someone presses enter at the end of the suffix, it adds a Paragraph block instead of a newline character to the suffix field.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This probably isn't _really_ necessary, but for consistency with the other blocks that have RichText fields and server-render those fields, I thought we could add it in. (Happy to close this out if folks think it doesn't need it).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Wrap the prefix and suffix in `wp_kses_post`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

On a post with tags attached, add a Post Tags block, and enter text in the prefix or suffix fields. Using the RichText controls, set some of the text to bold or italic and ensure it still renders correctly on the frontend.

## Screenshots or screencast <!-- if applicable -->

![image](https://user-images.githubusercontent.com/14988353/166622187-17728918-b4d7-463b-86b1-87567b2b9c7e.png)
