### PR TITLE
[RNMobile] Fix Android crash when closing the editor while dragging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50913,7 +50913,7 @@
 		},
 		"react-native-reanimated": {
 			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
-			"integrity": "sha512-1IHFrxRxL6Rkc4+OdKjoNq8QI/W+nJqq/dhHy5+e4lQscs93zMczvrdJN/ntd7ZcqCSmWcMQJjuZo58/8tYD0Q==",
+			"integrity": "sha512-8Mu7150ezI5PGBYAatqhQlau0nkeXMVNZIODAU7l1e7qjfEALZiuxKMkvWhFw1xBCqx+qRv24yYns7I5GGiZGQ==",
 			"requires": {
 				"@babel/plugin-transform-object-assign": "^7.10.4",
 				"@types/invariant": "^2.2.35",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18180,7 +18180,7 @@
 				"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 				"react-native-modal": "^11.10.0",
 				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-1/react-native-reanimated-2.4.1-wp-1.tgz",
+				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "3.2.0",
 				"react-native-sass-transformer": "^1.1.1",
@@ -21608,6 +21608,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+					"dev": true
+				},
+				"async": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+					"integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
 					"dev": true
 				},
 				"async-limiter": {
@@ -26488,12 +26494,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
 			"integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
-		},
-		"async": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-			"integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
-			"dev": true
 		},
 		"async-each": {
 			"version": "1.0.3",
@@ -50912,7 +50912,7 @@
 			"integrity": "sha512-9whL4Kc5OU5Q89Dneq8oT8vpQTA/cEz24EIPXEQ2KGo1Dkf4qzer5+98YXJM2F8yitCP8UKHOL8WIiE7zukXBA=="
 		},
 		"react-native-reanimated": {
-			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-1/react-native-reanimated-2.4.1-wp-1.tgz",
+			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
 			"integrity": "sha512-1IHFrxRxL6Rkc4+OdKjoNq8QI/W+nJqq/dhHy5+e4lQscs93zMczvrdJN/ntd7ZcqCSmWcMQJjuZo58/8tYD0Q==",
 			"requires": {
 				"@babel/plugin-transform-object-assign": "^7.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18180,7 +18180,7 @@
 				"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 				"react-native-modal": "^11.10.0",
 				"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
+				"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
 				"react-native-safe-area": "^0.5.0",
 				"react-native-safe-area-context": "3.2.0",
 				"react-native-sass-transformer": "^1.1.1",
@@ -50912,7 +50912,7 @@
 			"integrity": "sha512-9whL4Kc5OU5Q89Dneq8oT8vpQTA/cEz24EIPXEQ2KGo1Dkf4qzer5+98YXJM2F8yitCP8UKHOL8WIiE7zukXBA=="
 		},
 		"react-native-reanimated": {
-			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
+			"version": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
 			"integrity": "sha512-8Mu7150ezI5PGBYAatqhQlau0nkeXMVNZIODAU7l1e7qjfEALZiuxKMkvWhFw1xBCqx+qRv24yYns7I5GGiZGQ==",
 			"requires": {
 				"@babel/plugin-transform-object-assign": "^7.10.4",

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -70,13 +70,18 @@ dependencies {
     implementation "com.github.wordpress-mobile:react-native-slider:${extractPackageVersion(packageJson, '@react-native-community/slider', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-gesture-handler:${extractPackageVersion(packageJson, 'react-native-gesture-handler', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"
+
+    implementation("com.github.wordpress-mobile:react-native-gesture-handler:${extractPackageVersion(packageJson, 'react-native-gesture-handler', 'dependencies')}", {
+        // Remove Reanimated transitive dependency as it's already defined here
+        exclude group: 'com.github.wordpress-mobile', module: 'react-native-reanimated'
+    })
+
     runtimeOnly "org.wordpress-mobile:hermes-release-mirror:$rnVersion"
 
     if (willPublishReactNativeBridgeBinary) {

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation 'com.github.wordpress-mobile:react-native-reanimated:22ef6a0b66bd8b077b037f942b0cbd8f6291a25e'
+    implementation 'com.github.wordpress-mobile:react-native-reanimated:9e63336aa24daeefb9f756bbf8cdddfa2f3d44f5'
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
+    implementation 'com.github.wordpress-mobile:react-native-reanimated:22ef6a0b66bd8b077b037f942b0cbd8f6291a25e'
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-bridge/android/react-native-bridge/build.gradle
+++ b/packages/react-native-bridge/android/react-native-bridge/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation 'com.github.wordpress-mobile:react-native-reanimated:9e63336aa24daeefb9f756bbf8cdddfa2f3d44f5'
+    implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -186,13 +186,17 @@ dependencies {
     implementation "com.github.wordpress-mobile:react-native-slider:${extractPackageVersion(packageJson, '@react-native-community/slider', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-get-random-values:${extractPackageVersion(packageJson, 'react-native-get-random-values', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-gesture-handler:${extractPackageVersion(packageJson, 'react-native-gesture-handler', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"
+    
+    implementation("com.github.wordpress-mobile:react-native-gesture-handler:${extractPackageVersion(packageJson, 'react-native-gesture-handler', 'dependencies')}", {
+        // Remove Reanimated transitive dependency as it's already defined here
+        exclude group: 'com.github.wordpress-mobile', module: 'react-native-reanimated'
+    })
 }
 
 // Run this once to be able to run the application with BUCK

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -188,7 +188,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
+    implementation 'com.github.wordpress-mobile:react-native-reanimated:22ef6a0b66bd8b077b037f942b0cbd8f6291a25e'
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -188,7 +188,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation 'com.github.wordpress-mobile:react-native-reanimated:9e63336aa24daeefb9f756bbf8cdddfa2f3d44f5'
+    implementation "com.github.wordpress-mobile:react-native-reanimated:${extractPackageVersion(packageJson, 'react-native-reanimated', 'dependencies')}"
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-editor/android/app/build.gradle
+++ b/packages/react-native-editor/android/app/build.gradle
@@ -188,7 +188,7 @@ dependencies {
     implementation "org.wordpress-mobile:react-native-masked-view:${extractPackageVersion(packageJson, '@react-native-masked-view/masked-view', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-screens:${extractPackageVersion(packageJson, 'react-native-screens', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-safe-area-context:${extractPackageVersion(packageJson, 'react-native-safe-area-context', 'dependencies')}"
-    implementation 'com.github.wordpress-mobile:react-native-reanimated:22ef6a0b66bd8b077b037f942b0cbd8f6291a25e'
+    implementation 'com.github.wordpress-mobile:react-native-reanimated:9e63336aa24daeefb9f756bbf8cdddfa2f3d44f5'
     implementation "com.github.wordpress-mobile:react-native-prompt-android:${extractPackageVersion(packageJson, 'react-native-prompt-android', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-webview:${extractPackageVersion(packageJson, 'react-native-webview', 'dependencies')}"
     implementation "org.wordpress-mobile:react-native-clipboard:${extractPackageVersion(packageJson, '@react-native-clipboard/clipboard', 'dependencies')}"

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -65,7 +65,7 @@
 		"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 		"react-native-modal": "^11.10.0",
 		"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-1/react-native-reanimated-2.4.1-wp-1.tgz",
+		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
 		"react-native-safe-area": "^0.5.0",
 		"react-native-safe-area-context": "3.2.0",
 		"react-native-sass-transformer": "^1.1.1",

--- a/packages/react-native-editor/package.json
+++ b/packages/react-native-editor/package.json
@@ -65,7 +65,7 @@
 		"react-native-linear-gradient": "https://raw.githubusercontent.com/wordpress-mobile/react-native-linear-gradient/v2.5.6-wp-2/react-native-linear-gradient-2.5.6-wp-2.tgz",
 		"react-native-modal": "^11.10.0",
 		"react-native-prompt-android": "https://raw.githubusercontent.com/wordpress-mobile/react-native-prompt-android/v1.0.0-wp-2/react-native-prompt-android-1.0.0-wp-2.tgz",
-		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/fix-android-layout-reanimation-crash/react-native-reanimated-2.4.1-wp-2.tgz",
+		"react-native-reanimated": "https://raw.githubusercontent.com/wordpress-mobile/react-native-reanimated/2.4.1-wp-2/react-native-reanimated-2.4.1-wp-2.tgz",
 		"react-native-safe-area": "^0.5.0",
 		"react-native-safe-area-context": "3.2.0",
 		"react-native-sass-transformer": "^1.1.1",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Bumps the version of `react-native-reanimated` dependency to include [this fix](https://github.com/wordpress-mobile/react-native-reanimated/pull/15).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses the crash outlined in https://github.com/wordpress-mobile/gutenberg-mobile/issues/4801.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR basically changes the version of `react-native-reanimated` dependency. Additionally, `react-native-reanimated` dependency has been excluded from `react-native-gesture-handler` as it's already included. This way we remove the transitive dependency and prevent conflicts due to using different versions of the same dependency.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Open the app and connect it to the Metro server.
1. Start dragging a block.
1. While moving the block around the screen, tap the back button with another finger to close the editor.
1. Observe that the app doesn't crash.

## Screenshots or screencast <!-- if applicable -->
N/A