### PR TITLE
Global Styles: Add a const for the latest schema version of Global Styles

### DIFF
--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -114,12 +114,13 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	$custom_settings = array(
-		'siteUrl'                  => site_url(),
-		'postsPerPage'             => get_option( 'posts_per_page' ),
-		'styles'                   => gutenberg_get_editor_styles(),
-		'defaultTemplateTypes'     => $indexed_template_types,
-		'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
-		'__unstableHomeTemplate'   => gutenberg_resolve_home_template(),
+		'siteUrl'                         => site_url(),
+		'postsPerPage'                    => get_option( 'posts_per_page' ),
+		'styles'                          => gutenberg_get_editor_styles(),
+		'defaultTemplateTypes'            => $indexed_template_types,
+		'defaultTemplatePartAreas'        => get_allowed_block_template_part_areas(),
+		'__unstableHomeTemplate'          => gutenberg_resolve_home_template(),
+		'__unstableThemeJSONLatestSchema' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 	);
 
 	/**

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -13,6 +13,11 @@ import {
 	__EXPERIMENTAL_PATHS_WITH_MERGE as PATHS_WITH_MERGE,
 	__EXPERIMENTAL_STYLE_PROPERTY as STYLE_PROPERTY,
 } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { store as editSiteStore } from '../../store';
 
 /**
  * Internal dependencies
@@ -26,10 +31,19 @@ import { GlobalStylesContext } from './context';
 
 const EMPTY_CONFIG = {
 	isGlobalStylesUserThemeJSON: true,
-	version: LATEST_SCHEMA,
 };
 
 export const useGlobalStylesReset = () => {
+	const { __unstableThemeJSONLatestSchema } = useSelect( ( select ) => {
+		return {
+			__unstableThemeJSONLatestSchema: select(
+				editSiteStore
+			).getSettings()?.__unstableThemeJSONLatestSchema,
+		};
+	}, [] );
+
+	EMPTY_CONFIG.version = __unstableThemeJSONLatestSchema;
+
 	const { user: config, setUserConfig } = useContext( GlobalStylesContext );
 	const canReset = !! config && ! isEqual( config, EMPTY_CONFIG );
 	return [

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -17,10 +17,17 @@ import {
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, getPresetVariableFromValue } from './utils';
+import {
+	getValueFromVariable,
+	getPresetVariableFromValue,
+	LATEST_SCHEMA,
+} from './utils';
 import { GlobalStylesContext } from './context';
 
-const EMPTY_CONFIG = { isGlobalStylesUserThemeJSON: true, version: 1 };
+const EMPTY_CONFIG = {
+	isGlobalStylesUserThemeJSON: true,
+	version: LATEST_SCHEMA,
+};
 
 export const useGlobalStylesReset = () => {
 	const { user: config, setUserConfig } = useContext( GlobalStylesContext );

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -4,6 +4,7 @@
 import { get, find, isString } from 'lodash';
 
 /* Supporting data. */
+export const LATEST_SCHEMA = 2; // Need to be kept in sync with WP_Theme_JSON.
 export const ROOT_BLOCK_NAME = 'root';
 export const ROOT_BLOCK_SELECTOR = 'body';
 export const ROOT_BLOCK_SUPPORTS = [

--- a/packages/edit-site/src/components/global-styles/utils.js
+++ b/packages/edit-site/src/components/global-styles/utils.js
@@ -4,7 +4,6 @@
 import { get, find, isString } from 'lodash';
 
 /* Supporting data. */
-export const LATEST_SCHEMA = 2; // Need to be kept in sync with WP_Theme_JSON.
 export const ROOT_BLOCK_NAME = 'root';
 export const ROOT_BLOCK_SELECTOR = 'body';
 export const ROOT_BLOCK_SUPPORTS = [


### PR DESCRIPTION
## What?
We updated the schema for Global Styles, but we forgot to update the value when we reset.

## Why?
When users reset their Global Styles we set the version, which should be the latest, not an old one!

## How?
This adds a new const for that value in JavaScript so we can try to keep them in sync. It would be even better if there was a way to share these values between PHP and JS.

## Testing Instructions
1. Open the site editor
2. Make some changes to Global Styles
3. Reset your changes