### PR TITLE
Image Editor: Remove HTML from error messages

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -6,6 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 export default function useSaveImage( {
 	crop,
@@ -60,7 +61,7 @@ export default function useSaveImage( {
 					sprintf(
 						/* translators: 1. Error message */
 						__( 'Could not edit image. %s' ),
-						error.message
+						stripHTML( error.message )
 					),
 					{
 						id: 'image-editing-error',


### PR DESCRIPTION
## What?
Fixes #23906.

PR update `useSaveImage` hook to strip HTML from error messages.

## Why?
Some messages returned by WP can contain HTML and Snackbar component doesn't support HTML.

## Testing Instructions
1. Open a Post or Page.
2. Insert an Image block.
3. Upload or select an image.
4. Place this missing method in functions.php - `__missing_callback();`
5. Zoom or crop the selected image.
6. Confirm error message doesn't contain HTML.
7. Remove method from functions.php.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/166656418-86dffc08-9e0f-4a58-b41d-2ef41d975147.mp4


