### PR TITLE
Comments Title: Make non-editable

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -222,7 +222,7 @@ Displays a title with the number of comments ([Source](https://github.com/WordPr
 -	**Name:** core/comments-title
 -	**Category:** theme
 -	**Supports:** align, color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~anchor~~, ~~html~~
--	**Attributes:** level, multipleCommentsLabel, showCommentsCount, showPostTitle, singleCommentLabel, textAlign
+-	**Attributes:** level, showCommentsCount, showPostTitle, textAlign
 
 ## Cover
 

--- a/packages/block-library/src/comments-title/block.json
+++ b/packages/block-library/src/comments-title/block.json
@@ -12,12 +12,6 @@
 		"textAlign": {
 			"type": "string"
 		},
-		"singleCommentLabel": {
-			"type": "string"
-		},
-		"multipleCommentsLabel": {
-			"type": "string"
-		},
 		"showPostTitle": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/comments-title/deprecated.js
+++ b/packages/block-library/src/comments-title/deprecated.js
@@ -3,7 +3,7 @@
  */
 import metadata from './block.json';
 
-const { attributes } = metadata;
+const { attributes, supports } = metadata;
 
 export default [
 	{
@@ -16,6 +16,7 @@ export default [
 				type: 'string',
 			},
 		},
+		supports,
 		migrate: ( oldAttributes ) => {
 			/* eslint-disable no-unused-vars */
 			const {

--- a/packages/block-library/src/comments-title/deprecated.js
+++ b/packages/block-library/src/comments-title/deprecated.js
@@ -1,0 +1,33 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+const { attributes } = metadata;
+
+export default [
+	{
+		attributes: {
+			...attributes,
+			singleCommentLabel: {
+				type: 'string',
+			},
+			multipleCommentsLabel: {
+				type: 'string',
+			},
+		},
+		migrate: ( oldAttributes ) => {
+			/* eslint-disable no-unused-vars */
+			const {
+				singleCommentLabel,
+				multipleCommentsLabel,
+				...newAttributes
+			} = oldAttributes;
+			/* eslint-enable no-unused-vars */
+			return newAttributes;
+		},
+		isEligible: ( { multipleCommentsLabel, singleCommentLabel } ) =>
+			multipleCommentsLabel || singleCommentLabel,
+		save: () => null,
+	},
+];

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -10,17 +10,11 @@ import {
 	AlignmentControl,
 	BlockControls,
 	useBlockProps,
-	PlainText,
 	InspectorControls,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
-import {
-	PanelBody,
-	ToggleControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
@@ -31,20 +25,12 @@ import { addQueryArgs } from '@wordpress/url';
 import HeadingLevelDropdown from '../heading/heading-level-dropdown';
 
 export default function Edit( {
-	attributes: {
-		textAlign,
-		singleCommentLabel,
-		multipleCommentsLabel,
-		showPostTitle,
-		showCommentsCount,
-		level,
-	},
+	attributes: { textAlign, showPostTitle, showCommentsCount, level },
 	setAttributes,
 	context: { postType, postId },
 } ) {
 	const TagName = 'h' + level;
 	const [ commentsCount, setCommentsCount ] = useState();
-	const [ editingMode, setEditingMode ] = useState( 'plural' );
 	const [ rawTitle ] = useEntityProp( 'postType', postType, 'title', postId );
 	const isSiteEditor = typeof postId === 'undefined';
 	const blockProps = useBlockProps( {
@@ -100,22 +86,6 @@ export default function Edit( {
 	const inspectorControls = (
 		<InspectorControls>
 			<PanelBody title={ __( 'Settings' ) }>
-				{ isSiteEditor && (
-					<ToggleGroupControl
-						label={ __( 'Editing mode' ) }
-						onChange={ setEditingMode }
-						value={ editingMode }
-					>
-						<ToggleGroupControlOption
-							label={ __( 'Singular' ) }
-							value="singular"
-						/>
-						<ToggleGroupControlOption
-							label={ __( 'Plural' ) }
-							value="plural"
-						/>
-					</ToggleGroupControl>
-				) }
 				<ToggleControl
 					label={ __( 'Show post title' ) }
 					checked={ showPostTitle }
@@ -136,78 +106,52 @@ export default function Edit( {
 
 	const postTitle = isSiteEditor ? __( '"Post Title"' ) : `"${ rawTitle }"`;
 
-	const singlePlaceholder = showPostTitle
-		? __( 'One response to ' )
-		: __( 'One response' );
-
-	const singlePlaceholderNoCount = showPostTitle
-		? __( 'Response to ' )
-		: __( 'Response' );
-
-	const multiplePlaceholder = showPostTitle
-		? __( 'responses to ' )
-		: __( 'responses' );
-
-	const multiplePlaceholderNoCount = showPostTitle
-		? __( 'Responses to ' )
-		: __( 'Responses' );
+	let placeholder;
+	if ( showCommentsCount ) {
+		if ( showPostTitle ) {
+			if ( commentsCount === 1 ) {
+				/* translators: %s: Post title. */
+				placeholder = sprintf( __( 'One response to %s' ), postTitle );
+			} else {
+				placeholder = sprintf(
+					/* translators: 1: Number of comments, 2: Post title. */
+					_n(
+						'%1$s response to %2$s',
+						'%1$s responses to %2$s',
+						commentsCount
+					),
+					commentsCount,
+					postTitle
+				);
+			}
+		} else if ( commentsCount === 1 ) {
+			placeholder = __( 'One response' );
+		} else {
+			placeholder = sprintf(
+				/* translators: %s: Number of comments. */
+				_n( '%s responses', '%s responses', commentsCount ),
+				commentsCount
+			);
+		}
+	} else if ( showPostTitle ) {
+		if ( commentsCount === 1 ) {
+			/* translators: %s: Post title. */
+			placeholder = sprintf( __( 'Response to %s' ), postTitle );
+		} else {
+			/* translators: %s: Post title. */
+			placeholder = sprintf( __( 'Responses to %s' ), postTitle );
+		}
+	} else if ( commentsCount === 1 ) {
+		placeholder = __( 'Response' );
+	} else {
+		placeholder = __( 'Responses' );
+	}
 
 	return (
 		<>
 			{ blockControls }
 			{ inspectorControls }
-			<TagName { ...blockProps }>
-				{ editingMode === 'singular' || commentsCount === 1 ? (
-					<>
-						<PlainText
-							__experimentalVersion={ 2 }
-							tagName="span"
-							aria-label={
-								showCommentsCount
-									? singlePlaceholder
-									: singlePlaceholderNoCount
-							}
-							placeholder={
-								showCommentsCount
-									? singlePlaceholder
-									: singlePlaceholderNoCount
-							}
-							value={ singleCommentLabel }
-							onChange={ ( newLabel ) =>
-								setAttributes( {
-									singleCommentLabel: newLabel,
-								} )
-							}
-						/>
-						{ showPostTitle ? postTitle : null }
-					</>
-				) : (
-					<>
-						{ showCommentsCount ? commentsCount : null }
-						<PlainText
-							__experimentalVersion={ 2 }
-							tagName="span"
-							aria-label={
-								showCommentsCount
-									? ` ${ multiplePlaceholder }`
-									: multiplePlaceholderNoCount
-							}
-							placeholder={
-								showCommentsCount
-									? ` ${ multiplePlaceholder }`
-									: multiplePlaceholderNoCount
-							}
-							value={ multipleCommentsLabel }
-							onChange={ ( newLabel ) =>
-								setAttributes( {
-									multipleCommentsLabel: newLabel,
-								} )
-							}
-						/>
-						{ showPostTitle ? postTitle : null }
-					</>
-				) }
-			</TagName>
+			<TagName { ...blockProps }>{ placeholder }</TagName>
 		</>
 	);
 }

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -107,7 +107,7 @@ export default function Edit( {
 	const postTitle = isSiteEditor ? __( '"Post Title"' ) : `"${ rawTitle }"`;
 
 	let placeholder;
-	if ( showCommentsCount ) {
+	if ( showCommentsCount && commentsCount !== undefined ) {
 		if ( showPostTitle ) {
 			if ( commentsCount === 1 ) {
 				/* translators: %s: Post title. */

--- a/packages/block-library/src/comments-title/index.js
+++ b/packages/block-library/src/comments-title/index.js
@@ -8,6 +8,7 @@ import { commentTitle as icon } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import deprecated from './deprecated';
 
 const { name } = metadata;
 export { metadata, name };
@@ -15,4 +16,5 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	deprecated,
 };

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -22,8 +22,8 @@ function render_block_core_comments_title( $attributes ) {
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
-	$post_title          = $show_post_title ? sprintf( '"%1$s"', get_the_title() ) : null;
 	$comments_count      = number_format_i18n( get_comments_number() );
+	$post_title          = '&#8220;' . get_the_title() . '&#8221;';
 	$tag_name            = 'h2';
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 'h' . $attributes['level'];
@@ -33,34 +33,51 @@ function render_block_core_comments_title( $attributes ) {
 		return;
 	}
 
-	$single_default_comment_label = $show_post_title ? __( 'Response to' ) : __( 'Response' );
-	if ( $show_comments_count ) {
-		$single_default_comment_label = $show_post_title ? __( 'One response to' ) : __( 'One response' );
+	if ( $show_comments_count && ! empty( $comments_count ) ) {
+		if ( $show_post_title ) {
+			if ( '1' === $comments_count ) {
+				/* translators: %s: Post title. */
+				$comment_label = sprintf( __( 'One response to %s' ), $post_title );
+			} else {
+				$comment_label = sprintf(
+					/* translators: 1: Number of comments, 2: Post title. */
+					_n(
+						'%1$s response to %2$s',
+						'%1$s responses to %2$s',
+						$comments_count
+					),
+					$comments_count,
+					$post_title
+				);
+			}
+		} elseif ( '1' === $comments_count ) {
+			$comment_label = __( 'One response' );
+		} else {
+			$comment_label = sprintf(
+				/* translators: %s: Number of comments. */
+				_n( '%s responses', '%s responses', $comments_count ),
+				$comments_count
+			);
+		}
+	} elseif ( $show_post_title ) {
+		if ( '1' === $comments_count ) {
+			/* translators: %s: Post title. */
+			$comment_label = sprintf( __( 'Response to %s' ), $post_title );
+		} else {
+			/* translators: %s: Post title. */
+			$comment_label = sprintf( __( 'Responses to %s' ), $post_title );
+		}
+	} elseif ( '1' === $comments_count ) {
+		$comment_label = __( 'Response' );
+	} else {
+		$comment_label = __( 'Responses' );
 	}
-	$single_comment_label = ! empty( $attributes['singleCommentLabel'] ) ? $attributes['singleCommentLabel'] : $single_default_comment_label;
-
-	$multiple_default_comment_label = $show_post_title ? __( 'Responses to' ) : __( 'Responses' );
-	if ( $show_comments_count ) {
-		$multiple_default_comment_label = $show_post_title ? __( 'responses to' ) : __( 'responses' );
-	}
-
-	$multiple_comment_label = ! empty( $attributes['multipleCommentsLabel'] ) ? $attributes['multipleCommentsLabel'] : $multiple_default_comment_label;
-
-	$comments_title = '%1$s %2$s %3$s';
-
-	$comments_title = sprintf(
-		$comments_title,
-		// If there is only one comment, only display the label.
-		'1' !== $comments_count && $show_comments_count ? $comments_count : null,
-		'1' === $comments_count ? $single_comment_label : $multiple_comment_label,
-		$post_title
-	);
 
 	return sprintf(
 		'<%1$s id="comments" %2$s>%3$s</%1$s>',
 		$tag_name,
 		$wrapper_attributes,
-		$comments_title
+		$comment_label
 	);
 }
 

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -33,7 +33,7 @@ function render_block_core_comments_title( $attributes ) {
 		return;
 	}
 
-	if ( $show_comments_count && ! empty( $comments_count ) ) {
+	if ( $show_comments_count ) {
 		if ( $show_post_title ) {
 			if ( '1' === $comments_count ) {
 				/* translators: %s: Post title. */

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -22,7 +22,7 @@ function render_block_core_comments_title( $attributes ) {
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
-	$comments_count      = number_format_i18n( get_comments_number() );
+	$comments_count      = get_comments_number();
 	$post_title          = '&#8220;' . get_the_title() . '&#8221;';
 	$tag_name            = 'h2';
 	if ( isset( $attributes['level'] ) ) {
@@ -46,7 +46,7 @@ function render_block_core_comments_title( $attributes ) {
 						'%1$s responses to %2$s',
 						$comments_count
 					),
-					$comments_count,
+					number_format_i18n( $comments_count ),
 					$post_title
 				);
 			}
@@ -56,7 +56,7 @@ function render_block_core_comments_title( $attributes ) {
 			$comments_title = sprintf(
 				/* translators: %s: Number of comments. */
 				_n( '%s responses', '%s responses', $comments_count ),
-				$comments_count
+				number_format_i18n( $comments_count )
 			);
 		}
 	} elseif ( $show_post_title ) {

--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -37,9 +37,9 @@ function render_block_core_comments_title( $attributes ) {
 		if ( $show_post_title ) {
 			if ( '1' === $comments_count ) {
 				/* translators: %s: Post title. */
-				$comment_label = sprintf( __( 'One response to %s' ), $post_title );
+				$comments_title = sprintf( __( 'One response to %s' ), $post_title );
 			} else {
-				$comment_label = sprintf(
+				$comments_title = sprintf(
 					/* translators: 1: Number of comments, 2: Post title. */
 					_n(
 						'%1$s response to %2$s',
@@ -51,9 +51,9 @@ function render_block_core_comments_title( $attributes ) {
 				);
 			}
 		} elseif ( '1' === $comments_count ) {
-			$comment_label = __( 'One response' );
+			$comments_title = __( 'One response' );
 		} else {
-			$comment_label = sprintf(
+			$comments_title = sprintf(
 				/* translators: %s: Number of comments. */
 				_n( '%s responses', '%s responses', $comments_count ),
 				$comments_count
@@ -62,22 +62,22 @@ function render_block_core_comments_title( $attributes ) {
 	} elseif ( $show_post_title ) {
 		if ( '1' === $comments_count ) {
 			/* translators: %s: Post title. */
-			$comment_label = sprintf( __( 'Response to %s' ), $post_title );
+			$comments_title = sprintf( __( 'Response to %s' ), $post_title );
 		} else {
 			/* translators: %s: Post title. */
-			$comment_label = sprintf( __( 'Responses to %s' ), $post_title );
+			$comments_title = sprintf( __( 'Responses to %s' ), $post_title );
 		}
 	} elseif ( '1' === $comments_count ) {
-		$comment_label = __( 'Response' );
+		$comments_title = __( 'Response' );
 	} else {
-		$comment_label = __( 'Responses' );
+		$comments_title = __( 'Responses' );
 	}
 
 	return sprintf(
 		'<%1$s id="comments" %2$s>%3$s</%1$s>',
 		$tag_name,
 		$wrapper_attributes,
-		$comment_label
+		$comments_title
 	);
 }
 

--- a/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.html
+++ b/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.html
@@ -1,0 +1,1 @@
+<!-- wp:comments-title {"textAlign":"center","singleCommentLabel":"One reply to ","multipleCommentsLabel":" replies to ","level":4} /-->

--- a/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.json
+++ b/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.json
@@ -1,0 +1,13 @@
+[
+	{
+		"name": "core/comments-title",
+		"isValid": true,
+		"attributes": {
+			"textAlign": "center",
+			"showPostTitle": true,
+			"showCommentsCount": true,
+			"level": 4
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.parsed.json
+++ b/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.parsed.json
@@ -1,0 +1,14 @@
+[
+	{
+		"blockName": "core/comments-title",
+		"attrs": {
+			"textAlign": "center",
+			"singleCommentLabel": "One reply to ",
+			"multipleCommentsLabel": " replies to ",
+			"level": 4
+		},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.serialized.html
+++ b/test/integration/fixtures/blocks/core__comments-title__deprecated-v1.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:comments-title {"textAlign":"center","level":4} /-->


### PR DESCRIPTION
## What?
Make the Comments Title text non-editable by the user, i.e. hard-wire it to read "... responses to ...", while only retaining the option to display or hide the comments count and post title, respectively.

## Why?
See [this Slack discussion](https://wordpress.slack.com/archives/C02QB2JS7/p1651595036972769). Basically, using a `<PlainText />` component with a placeholder to allow editing a string between a comment count and a post title breaks i18n.

## How?
In order to be able to use a properly i18n'd string (via `sprintf()` with placeholders, _`()` and `_n()`), we have to say good-bye to allowing the user to edit that string, and instead add a bunch of conditionals to determine which i18n'd string to render, depending on whether or not we're showing the comments count and/or post title 😅 

As a consequence, we need to remove the `singleCommentLabel` and `multipleCommentsLabel` attributes. A deprecation and corresponding test fixture is included in the PR.

## Testing Instructions
- On `trunk`, open the Site Editor. Navigate to the templates list, and select the Single Post template for editing.
- Insert the Comment Query Loop block.
- Select the Comments Title block (which is the first child of the Comments Query Loop block), and edit the placeholder by typing (e.g. ` replies to `).
- In the Block Inspector (sidebar), switch the block's Editing Mode to "Singular", and change edit the placeholder there as well (by changing it e.g. to `One reply to `.
- Save the template.
- Create a new post in the Post Editor, publish it, and view it. Post a comment to it. Verify that the Comments Title uses the text that you entered earlier.
- Now switch to this PR's branch and rebuild Gutenberg.
- Reload the post you were viewing. Verify that the Comments Title now uses the default text (e.g. `One response to` (rather than `reply`).
- Navigate back to the Site Editor for the Single Post Template. Verify that it still loads the block properly. Verify that the Comments Title no longer reflects your earlier change, but is now also showing the default.
- Select the Comments Title block, and change one of its remaining settings (e.g. disable "Show post title"). Save the template.
- Switch to the Code Editor. Verify that the now-deprecated attributes (`singleCommentLabel` and `multipleCommentsLabel`) are gone.
- Navigate to the post you created earlier, and view it. Verify that the change you made in the Site Editor took effect.

## Screenshots or screencast

| Before | After |
|--------|------|
| ![Bildschirmfoto 2022-05-04 um 19 03 40](https://user-images.githubusercontent.com/96308/166741152-33540fb8-05c7-4394-a6f6-7b5d262ca8de.png) | ![Bildschirmfoto 2022-05-04 um 19 04 34](https://user-images.githubusercontent.com/96308/166741267-7e798c14-941b-4eb7-b12b-689909598d02.png) |
