### PR TITLE
Send registered patterns in HTML and combine them with REST ones

### DIFF
--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -120,6 +120,8 @@ function gutenberg_edit_site_init( $hook ) {
 		'defaultTemplateTypes'     => $indexed_template_types,
 		'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
 		'__unstableHomeTemplate'   => gutenberg_resolve_home_template(),
+		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
+		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	);
 
 	/**

--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -114,12 +114,12 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	$custom_settings = array(
-		'siteUrl'                  => site_url(),
-		'postsPerPage'             => get_option( 'posts_per_page' ),
-		'styles'                   => gutenberg_get_editor_styles(),
-		'defaultTemplateTypes'     => $indexed_template_types,
-		'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
-		'__unstableHomeTemplate'   => gutenberg_resolve_home_template(),
+		'siteUrl'                              => site_url(),
+		'postsPerPage'                         => get_option( 'posts_per_page' ),
+		'styles'                               => gutenberg_get_editor_styles(),
+		'defaultTemplateTypes'                 => $indexed_template_types,
+		'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
+		'__unstableHomeTemplate'               => gutenberg_resolve_home_template(),
 		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
 		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
 	);

--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -120,8 +120,8 @@ function gutenberg_edit_site_init( $hook ) {
 		'defaultTemplateTypes'                 => $indexed_template_types,
 		'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
 		'__unstableHomeTemplate'               => gutenberg_resolve_home_template(),
-		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered(),
-		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered(),
+		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
+		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
 	);
 
 	/**

--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -122,17 +122,9 @@ function gutenberg_edit_site_init( $hook ) {
 		'__unstableHomeTemplate'   => gutenberg_resolve_home_template(),
 	);
 
-	/**
-	 * Filter to enable adding non-REST block patterns to editor settings.
-	 *
-	 * @since 6.0.0
-	 *
-	 * @param bool $should_add_to_settings
-	 */
-	if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
-		$custom_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
-		$custom_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
-	}
+	// Add additional back-compat patterns registered by `current_screen` et al.
+	$custom_settings['__experimentalAdditionalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+	$custom_settings['__experimentalAdditionalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
 
 	/**
 	 * Make the WP Screen object aware that this is a block editor page.

--- a/lib/compat/wordpress-5.9/edit-site-page.php
+++ b/lib/compat/wordpress-5.9/edit-site-page.php
@@ -114,15 +114,25 @@ function gutenberg_edit_site_init( $hook ) {
 	}
 
 	$custom_settings = array(
-		'siteUrl'                              => site_url(),
-		'postsPerPage'                         => get_option( 'posts_per_page' ),
-		'styles'                               => gutenberg_get_editor_styles(),
-		'defaultTemplateTypes'                 => $indexed_template_types,
-		'defaultTemplatePartAreas'             => get_allowed_block_template_part_areas(),
-		'__unstableHomeTemplate'               => gutenberg_resolve_home_template(),
-		'__experimentalBlockPatterns'          => WP_Block_Patterns_Registry::get_instance()->get_all_registered( true ),
-		'__experimentalBlockPatternCategories' => WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true ),
+		'siteUrl'                  => site_url(),
+		'postsPerPage'             => get_option( 'posts_per_page' ),
+		'styles'                   => gutenberg_get_editor_styles(),
+		'defaultTemplateTypes'     => $indexed_template_types,
+		'defaultTemplatePartAreas' => get_allowed_block_template_part_areas(),
+		'__unstableHomeTemplate'   => gutenberg_resolve_home_template(),
 	);
+
+	/**
+	 * Filter to enable adding non-REST block patterns to editor settings.
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param bool $should_add_to_settings
+	 */
+	if ( apply_filters( 'should_add_block_patterns_to_editor_settings', false ) ) {
+		$custom_settings['__experimentalBlockPatterns']          = WP_Block_Patterns_Registry::get_instance()->get_all_registered( true );
+		$custom_settings['__experimentalBlockPatternCategories'] = WP_Block_Pattern_Categories_Registry::get_instance()->get_all_registered( true );
+	}
 
 	/**
 	 * Make the WP Screen object aware that this is a block editor page.

--- a/lib/compat/wordpress-6.0/block-editor-settings.php
+++ b/lib/compat/wordpress-6.0/block-editor-settings.php
@@ -193,18 +193,3 @@ function gutenberg_get_block_editor_settings( $settings ) {
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', PHP_INT_MAX );
-
-/**
- * Removes the unwanted block patterns fields from block editor settings.
- *
- * @param array $settings Existing block editor settings.
- *
- * @return array New block editor settings.
- */
-function gutenberg_remove_block_patterns_settings( $settings ) {
-	unset( $settings['__experimentalBlockPatterns'] );
-	unset( $settings['__experimentalBlockPatternCategories'] );
-	return $settings;
-}
-
-add_filter( 'block_editor_settings_all', 'gutenberg_remove_block_patterns_settings', PHP_INT_MAX );

--- a/lib/compat/wordpress-6.0/block-editor-settings.php
+++ b/lib/compat/wordpress-6.0/block-editor-settings.php
@@ -193,5 +193,3 @@ function gutenberg_get_block_editor_settings( $settings ) {
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', PHP_INT_MAX );
-
-add_filter( 'should_add_block_patterns_to_editor_settings', '__return_true' );

--- a/lib/compat/wordpress-6.0/block-editor-settings.php
+++ b/lib/compat/wordpress-6.0/block-editor-settings.php
@@ -193,3 +193,5 @@ function gutenberg_get_block_editor_settings( $settings ) {
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', PHP_INT_MAX );
+
+add_filter( 'should_add_block_patterns_to_editor_settings', '__return_true' );

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useCallback, useRef, Fragment } from '@wordpress/element';
+import { useCallback, useMemo, useRef, Fragment } from '@wordpress/element';
 import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
 import {
 	BlockList,
@@ -48,50 +49,62 @@ const LAYOUT = {
 };
 
 export default function BlockEditor( { setIsInserterOpen } ) {
-	const { settings } = useSelect(
+	const { storedSettings, templateType, templateId, page } = useSelect(
 		( select ) => {
-			let storedSettings = select( editSiteStore ).getSettings(
-				setIsInserterOpen
-			);
-
-			if ( ! storedSettings.__experimentalBlockPatterns ) {
-				storedSettings = {
-					...storedSettings,
-					__experimentalBlockPatterns: select(
-						coreStore
-					).getBlockPatterns(),
-				};
-			}
-
-			if ( ! storedSettings.__experimentalBlockPatternCategories ) {
-				storedSettings = {
-					...storedSettings,
-					__experimentalBlockPatternCategories: select(
-						coreStore
-					).getBlockPatternCategories(),
-				};
-			}
+			const {
+				getSettings,
+				getEditedPostType,
+				getEditedPostId,
+				getPage,
+			} = select( editSiteStore );
 
 			return {
-				settings: storedSettings,
-			};
-		},
-		[ setIsInserterOpen ]
-	);
-
-	const { templateType, templateId, page } = useSelect(
-		( select ) => {
-			const { getEditedPostType, getEditedPostId, getPage } = select(
-				editSiteStore
-			);
-
-			return {
+				storedSettings: getSettings( setIsInserterOpen ),
 				templateType: getEditedPostType(),
 				templateId: getEditedPostId(),
 				page: getPage(),
 			};
 		},
 		[ setIsInserterOpen ]
+	);
+
+	const {
+		__experimentalBlockPatterns: settingsBlockPatterns,
+		__experimentalBlockPatternCategories: settingsBlockPatternCategories,
+	} = storedSettings;
+
+	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
+		( select ) => ( {
+			restBlockPatterns: select( coreStore ).getBlockPatterns(),
+			restBlockPatternCategories: select(
+				coreStore
+			).getBlockPatternCategories(),
+		} ),
+		[]
+	);
+
+	const blockPatterns = useMemo(
+		() => unionBy( settingsBlockPatterns, restBlockPatterns, 'name' ),
+		[ settingsBlockPatterns, restBlockPatterns ]
+	);
+
+	const blockPatternCategories = useMemo(
+		() =>
+			unionBy(
+				settingsBlockPatternCategories,
+				restBlockPatternCategories,
+				'name'
+			),
+		[ settingsBlockPatternCategories, restBlockPatternCategories ]
+	);
+
+	const settings = useMemo(
+		() => ( {
+			...storedSettings,
+			__experimentalBlockPatterns: blockPatterns,
+			__experimentalBlockPatternCategories: blockPatternCategories,
+		} ),
+		[ storedSettings, blockPatterns, blockPatternCategories ]
 	);
 
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -68,10 +68,12 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 		[ setIsInserterOpen ]
 	);
 
-	const {
-		__experimentalAdditionalBlockPatterns: settingsBlockPatterns,
-		__experimentalAdditionalBlockPatternCategories: settingsBlockPatternCategories,
-	} = storedSettings;
+	const settingsBlockPatterns =
+		storedSettings.__experimentalAdditionalBlockPatterns ?? // WP 6.0
+		storedSettings.__experimentalBlockPatterns; // WP 5.9
+	const settingsBlockPatternCategories =
+		storedSettings.__experimentalAdditionalBlockPatternCategories ?? // WP 6.0
+		storedSettings.__experimentalBlockPatternCategories; // WP 5.9
 
 	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
 		( select ) => ( {

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { unionBy } from 'lodash';
+import { omit, unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -69,8 +69,8 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	);
 
 	const {
-		__experimentalBlockPatterns: settingsBlockPatterns,
-		__experimentalBlockPatternCategories: settingsBlockPatternCategories,
+		__experimentalAdditionalBlockPatterns: settingsBlockPatterns,
+		__experimentalAdditionalBlockPatternCategories: settingsBlockPatternCategories,
 	} = storedSettings;
 
 	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
@@ -100,7 +100,10 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 
 	const settings = useMemo(
 		() => ( {
-			...storedSettings,
+			...omit( storedSettings, [
+				'__experimentalAdditionalBlockPatterns',
+				'__experimentalAdditionalBlockPatternCategories',
+			] ),
 			__experimentalBlockPatterns: blockPatterns,
 			__experimentalBlockPatternCategories: blockPatternCategories,
 		} ),

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, defaultTo } from 'lodash';
+import { pick, defaultTo, unionBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -66,15 +66,29 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		__experimentalBlockPatternCategories: settingsBlockPatternCategories,
 	} = settings;
 
-	const { blockPatterns, blockPatternCategories } = useSelect(
+	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
 		( select ) => ( {
-			blockPatterns:
-				settingsBlockPatterns ?? select( coreStore ).getBlockPatterns(),
-			blockPatternCategories:
-				settingsBlockPatternCategories ??
-				select( coreStore ).getBlockPatternCategories(),
+			restBlockPatterns: select( coreStore ).getBlockPatterns(),
+			restBlockPatternCategories: select(
+				coreStore
+			).getBlockPatternCategories(),
 		} ),
-		[ settingsBlockPatterns, settingsBlockPatternCategories ]
+		[]
+	);
+
+	const blockPatterns = useMemo(
+		() => unionBy( settingsBlockPatterns, restBlockPatterns, 'name' ),
+		[ settingsBlockPatterns, restBlockPatterns ]
+	);
+
+	const blockPatternCategories = useMemo(
+		() =>
+			unionBy(
+				settingsBlockPatternCategories,
+				restBlockPatternCategories,
+				'name'
+			),
+		[ settingsBlockPatternCategories, restBlockPatternCategories ]
 	);
 
 	const { undo } = useDispatch( editorStore );

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -62,8 +62,8 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 	}, [] );
 
 	const {
-		__experimentalBlockPatterns: settingsBlockPatterns,
-		__experimentalBlockPatternCategories: settingsBlockPatternCategories,
+		__experimentalAdditionalBlockPatterns: settingsBlockPatterns,
+		__experimentalAdditionalBlockPatternCategories: settingsBlockPatternCategories,
 	} = settings;
 
 	const { restBlockPatterns, restBlockPatternCategories } = useSelect(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -61,10 +61,12 @@ function useBlockEditorSettings( settings, hasTemplate ) {
 		};
 	}, [] );
 
-	const {
-		__experimentalAdditionalBlockPatterns: settingsBlockPatterns,
-		__experimentalAdditionalBlockPatternCategories: settingsBlockPatternCategories,
-	} = settings;
+	const settingsBlockPatterns =
+		settings.__experimentalAdditionalBlockPatterns ?? // WP 6.0
+		settings.__experimentalBlockPatterns; // WP 5.9
+	const settingsBlockPatternCategories =
+		settings.__experimentalAdditionalBlockPatternCategories ?? // WP 6.0
+		settings.__experimentalBlockPatternCategories; // WP 5.9
 
 	const { restBlockPatterns, restBlockPatternCategories } = useSelect(
 		( select ) => ( {


### PR DESCRIPTION
Fixes #40736. Allows to register patterns on `current_screen` or `admin_init` again, and these are sent serialized, as a `settings` argument of `initializeEditor`, in the editor page HTML. Patterns from REST (preferred source from now) are added on top of these, instead of replacing them completely.
