### PR TITLE
Heading: Update the order of style nodes for correct css specificity

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -539,8 +539,8 @@ class WP_Theme_JSON_5_9 {
 			// individual block selector.
 			$block_selectors = explode( ',', static::$blocks_metadata[ $block_name ]['selector'] );
 			foreach ( static::ELEMENTS as $el_name => $el_selector ) {
-				// for elements defined under core/heading, selector should be h1 instead of h1 h1
-				if ("core/heading" === $block_name) {
+				// Avoid double selector (h1 h1) for elements inside heading block.
+				if ( 'core/heading' === $block_name && in_array( $el_selector, $block_selectors, true ) ) {
 					static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = $el_selector;
 					continue;
 				}
@@ -1394,18 +1394,18 @@ class WP_Theme_JSON_5_9 {
 				if ( isset( $selectors[ $name ]['selector'] ) ) {
 					$selector = $selectors[ $name ]['selector'];
 				}
-	
+
 				$duotone_selector = null;
 				if ( isset( $selectors[ $name ]['duotone'] ) ) {
 					$duotone_selector = $selectors[ $name ]['duotone'];
 				}
-	
+
 				$nodes[] = array(
 					'path'     => array( 'styles', 'blocks', $name ),
 					'selector' => $selector,
 					'duotone'  => $duotone_selector,
 				);
-	
+
 				if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
 					foreach ( $theme_json['styles']['blocks'][ $name ]['elements'] as $element => $node ) {
 						$nodes[] = array(
@@ -1414,10 +1414,10 @@ class WP_Theme_JSON_5_9 {
 						);
 					}
 				}
-			}	
+			}
 		}
 
-		// Elements
+		// Elements.
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
 				$nodes[] = array(

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -539,6 +539,12 @@ class WP_Theme_JSON_5_9 {
 			// individual block selector.
 			$block_selectors = explode( ',', static::$blocks_metadata[ $block_name ]['selector'] );
 			foreach ( static::ELEMENTS as $el_name => $el_selector ) {
+				// for elements defined under core/heading, selector should be h1 instead of h1 h1
+				if ("core/heading" === $block_name) {
+					static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = $el_selector;
+					continue;
+				}
+
 				$element_selector = array();
 				foreach ( $block_selectors as $selector ) {
 					$element_selector[] = $selector . ' ' . $el_selector;
@@ -1381,44 +1387,43 @@ class WP_Theme_JSON_5_9 {
 			'selector' => static::ROOT_BLOCK_SELECTOR,
 		);
 
+		// Blocks.
+		if ( isset( $theme_json['styles']['blocks'] ) ) {
+			foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
+				$selector = null;
+				if ( isset( $selectors[ $name ]['selector'] ) ) {
+					$selector = $selectors[ $name ]['selector'];
+				}
+	
+				$duotone_selector = null;
+				if ( isset( $selectors[ $name ]['duotone'] ) ) {
+					$duotone_selector = $selectors[ $name ]['duotone'];
+				}
+	
+				$nodes[] = array(
+					'path'     => array( 'styles', 'blocks', $name ),
+					'selector' => $selector,
+					'duotone'  => $duotone_selector,
+				);
+	
+				if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
+					foreach ( $theme_json['styles']['blocks'][ $name ]['elements'] as $element => $node ) {
+						$nodes[] = array(
+							'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
+							'selector' => $selectors[ $name ]['elements'][ $element ],
+						);
+					}
+				}
+			}	
+		}
+
+		// Elements
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( $theme_json['styles']['elements'] as $element => $node ) {
 				$nodes[] = array(
 					'path'     => array( 'styles', 'elements', $element ),
 					'selector' => static::ELEMENTS[ $element ],
 				);
-			}
-		}
-
-		// Blocks.
-		if ( ! isset( $theme_json['styles']['blocks'] ) ) {
-			return $nodes;
-		}
-
-		foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
-			$selector = null;
-			if ( isset( $selectors[ $name ]['selector'] ) ) {
-				$selector = $selectors[ $name ]['selector'];
-			}
-
-			$duotone_selector = null;
-			if ( isset( $selectors[ $name ]['duotone'] ) ) {
-				$duotone_selector = $selectors[ $name ]['duotone'];
-			}
-
-			$nodes[] = array(
-				'path'     => array( 'styles', 'blocks', $name ),
-				'selector' => $selector,
-				'duotone'  => $duotone_selector,
-			);
-
-			if ( isset( $theme_json['styles']['blocks'][ $name ]['elements'] ) ) {
-				foreach ( $theme_json['styles']['blocks'][ $name ]['elements'] as $element => $node ) {
-					$nodes[] = array(
-						'path'     => array( 'styles', 'blocks', $name, 'elements', $element ),
-						'selector' => $selectors[ $name ]['elements'][ $element ],
-					);
-				}
 			}
 		}
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -462,6 +462,12 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 								'background' => '#333',
 							),
 						),
+						'h1'   => array(
+							'color' => array(
+								'text'       => '#444',
+								'background' => '#999',
+							),
+						),
 					),
 					'blocks'   => array(
 						'core/group'     => array(
@@ -491,6 +497,15 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 									),
 									'typography' => array(
 										'fontSize' => '60px',
+									),
+								),
+								'h1'   => array(
+									'color'      => array(
+										'text'       => '#123',
+										'background' => '#321',
+									),
+									'typography' => array(
+										'fontSize' => '5rem',
 									),
 								),
 							),
@@ -528,7 +543,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$variables = 'body{--wp--preset--color--grey: grey;--wp--preset--font-family--small: 14px;--wp--preset--font-family--big: 41px;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}';
-		$styles    = 'body { margin: 0; }body{color: var(--wp--preset--color--grey);}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }a{background-color: #333;color: #111;}.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}';
+		$styles    = 'body { margin: 0; }body{color: var(--wp--preset--color--grey);}.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }.wp-site-blocks > .alignright { float: right; margin-left: 2em; }.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }.wp-block-group{border-radius: 10px;padding: 24px;}.wp-block-group a{color: #111;}h1,h2,h3,h4,h5,h6{color: #123456;}h1 a,h2 a,h3 a,h4 a,h5 a,h6 a{background-color: #333;color: #111;font-size: 60px;}h1{background-color: #321;color: #123;font-size: 5rem;}.wp-block-post-date{color: #123456;}.wp-block-post-date a{background-color: #777;color: #555;}.wp-block-image{border-top-left-radius: 10px;border-bottom-right-radius: 1em;margin-bottom: 30px;}a{background-color: #333;color: #111;}h1{background-color: #999;color: #444;}';
 		$presets   = '.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-small-font-family{font-family: var(--wp--preset--font-family--small) !important;}.has-big-font-family{font-family: var(--wp--preset--font-family--big) !important;}';
 		$all       = $variables . $styles . $presets;
 		$this->assertEquals( $all, $theme_json->get_stylesheet() );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes following two issues.

1. When values are provided in both `styles.blocks.core/heading` and `styles.elements.h1` the values provided in the "blocks.core/heading" portion are leveraged rather than the "elements.h1" section.

2. Also `styles.blocks.core/heading.elements.h1` produces `h1 h1` selector instead of `h1`, because of this overrides are not working.

Fixes: #39698

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Use case would be user can define generic styles such as fontFamily at `core/heading` which would apply to all headings and can define `elements.h6` with a different fontFamily to override.

Currently this is not working because of CSS specificity issues (order of the style placement is not right)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changed the order of blocks and elements so that result styles are in right overriding order.

Given theme.json definition

```
"blocks": {
  "core/heading": {
    "typography": {
      "fontWeight": "400",
      "fontSize": "20px"
    },
    "elements": {
      "h1": {
        "typography": {
          "fontSize": "30px"
        }
      }
    }
  }
},
"elements": {
  "h1": {
    "typography": {
      "fontSize": "min(max(2.625rem, 5vw), 4.5rem)"
    }
  }
}
```

Following is the result.

<img width="362" alt="image" src="https://user-images.githubusercontent.com/1935113/166674481-e195d42e-8f2b-453b-9a63-fc9ff431895e.png">


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Case 1:

Define styles under `styles.blocks.core/heading` and override them in `styles.elements.h1`.
Later styles should apply in frontend.

Case 2:

Define styles under `styles.blocks.core/heading` and override them in `styles.blocks.core/heading.element.h1`
Later styles should apply in frontend.

## Screenshots or screencast <!-- if applicable -->
