### PR TITLE
Interface: Fix deprecation messages

### DIFF
--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -151,9 +151,9 @@ function convertPanelsToOldFormat( inactivePanels, openPanels ) {
  * @return {Object} Preferences Object.
  */
 export const getPreferences = createRegistrySelector( ( select ) => () => {
-	deprecated( `wp.data.select( 'core/edit-post' ).getPreferences`, {
+	deprecated( `select( 'core/edit-post' ).getPreferences`, {
 		since: '6.0',
-		alternative: `wp.data.select( 'core/preferences' ).get`,
+		alternative: `select( 'core/preferences' ).get`,
 	} );
 
 	// These preferences now exist in the preferences store.
@@ -204,9 +204,9 @@ export const getPreferences = createRegistrySelector( ( select ) => () => {
  * @return {*} Preference Value.
  */
 export function getPreference( state, preferenceKey, defaultValue ) {
-	deprecated( `wp.data.select( 'core/edit-post' ).getPreference`, {
+	deprecated( `select( 'core/edit-post' ).getPreference`, {
 		since: '6.0',
-		alternative: `wp.data.select( 'core/preferences' ).get`,
+		alternative: `select( 'core/preferences' ).get`,
 	} );
 
 	// Avoid using the `getPreferences` registry selector where possible.

--- a/packages/interface/src/store/actions.js
+++ b/packages/interface/src/store/actions.js
@@ -91,9 +91,9 @@ export const unpinItem = ( scope, item ) => ( { registry } ) => {
  */
 export function toggleFeature( scope, featureName ) {
 	return function ( { registry } ) {
-		deprecated( `wp.dispatch( 'core/interface' ).toggleFeature`, {
+		deprecated( `dispatch( 'core/interface' ).toggleFeature`, {
 			since: '6.0',
-			alternative: `wp.dispatch( 'core/preferences' ).toggle`,
+			alternative: `dispatch( 'core/preferences' ).toggle`,
 		} );
 
 		registry.dispatch( preferencesStore ).toggle( scope, featureName );
@@ -112,9 +112,9 @@ export function toggleFeature( scope, featureName ) {
  */
 export function setFeatureValue( scope, featureName, value ) {
 	return function ( { registry } ) {
-		deprecated( `wp.dispatch( 'core/interface' ).setFeatureValue`, {
+		deprecated( `dispatch( 'core/interface' ).setFeatureValue`, {
 			since: '6.0',
-			alternative: `wp.dispatch( 'core/preferences' ).set`,
+			alternative: `dispatch( 'core/preferences' ).set`,
 		} );
 
 		registry
@@ -133,9 +133,9 @@ export function setFeatureValue( scope, featureName, value ) {
  */
 export function setFeatureDefaults( scope, defaults ) {
 	return function ( { registry } ) {
-		deprecated( `wp.dispatch( 'core/interface' ).setFeatureDefaults`, {
+		deprecated( `dispatch( 'core/interface' ).setFeatureDefaults`, {
 			since: '6.0',
-			alternative: `wp.dispatch( 'core/preferences' ).setDefaults`,
+			alternative: `dispatch( 'core/preferences' ).setDefaults`,
 		} );
 
 		registry.dispatch( preferencesStore ).setDefaults( scope, defaults );

--- a/packages/interface/src/store/selectors.js
+++ b/packages/interface/src/store/selectors.js
@@ -51,10 +51,10 @@ export const isItemPinned = createRegistrySelector(
 export const isFeatureActive = createRegistrySelector(
 	( select ) => ( state, scope, featureName ) => {
 		deprecated(
-			`wp.select( 'core/interface' ).isFeatureActive( scope, featureName )`,
+			`select( 'core/interface' ).isFeatureActive( scope, featureName )`,
 			{
 				since: '6.0',
-				alternative: `!! wp.select( 'core/preferences' ).isFeatureActive( scope, featureName )`,
+				alternative: `select( 'core/preferences' ).get( scope, featureName )`,
 			}
 		);
 


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/pull/39640#issuecomment-1117625713.

Update deprecation messages to remove `wp` prefixes and fixes alternative suggestion.

## Testing Instructions
Running this code in the DevTool console should result in the correct message.

```
wp.data.select( 'core/interface' ).isFeatureActive( 'core/edit-post', 'testing' );
```
