### PR TITLE
Search Block: remove id attribute from svg

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -14,7 +14,6 @@
  */
 function render_block_core_search( $attributes ) {
 	static $instance_id = 0;
-	static $index       = 0;
 
 	// Older versions of the Search block defaulted the label and buttonText
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
@@ -87,11 +86,11 @@ function render_block_core_search( $attributes ) {
 			$button_classes .= ' has-icon';
 
 			$search_button_markup =
-				'<svg id="search-icon-%s" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
+				'<svg id="%s" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 					<path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
 				</svg>';
 
-			$button_internal_markup = sprintf( $search_button_markup, $index++ );
+			$button_internal_markup = sprintf( $search_button_markup, wp_unique_id( esc_attr( 'search-icon-' ) ) );
 		}
 
 		$button_markup = sprintf(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -14,6 +14,7 @@
  */
 function render_block_core_search( $attributes ) {
 	static $instance_id = 0;
+	static $index       = 0;
 
 	// Older versions of the Search block defaulted the label and buttonText
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
@@ -85,10 +86,12 @@ function render_block_core_search( $attributes ) {
 			$aria_label      = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
 			$button_classes .= ' has-icon';
 
-			$button_internal_markup =
-				'<svg id="search-icon" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
+			$search_button_markup =
+				'<svg id="search-icon-%s" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 					<path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
 				</svg>';
+
+			$button_internal_markup = sprintf( $search_button_markup, $index++ );
 		}
 
 		$button_markup = sprintf(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -85,12 +85,10 @@ function render_block_core_search( $attributes ) {
 			$aria_label      = sprintf( 'aria-label="%s"', esc_attr( wp_strip_all_tags( $attributes['buttonText'] ) ) );
 			$button_classes .= ' has-icon';
 
-			$search_button_markup =
-				'<svg id="%s" class="search-icon" viewBox="0 0 24 24" width="24" height="24">
+			$button_internal_markup =
+				'<svg class="search-icon" viewBox="0 0 24 24" width="24" height="24">
 					<path d="M13.5 6C10.5 6 8 8.5 8 11.5c0 1.1.3 2.1.9 3l-3.4 3 1 1.1 3.4-2.9c1 .9 2.2 1.4 3.6 1.4 3 0 5.5-2.5 5.5-5.5C19 8.5 16.5 6 13.5 6zm0 9.5c-2.2 0-4-1.8-4-4s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"></path>
 				</svg>';
-
-			$button_internal_markup = sprintf( $search_button_markup, wp_unique_id( esc_attr( 'search-icon-' ) ) );
 		}
 
 		$button_markup = sprintf(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: #40823

## What?
<!-- In a few words, what is the PR actually doing? -->
`id` was same for every instance of search block in the given page/post. 
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`id` property should be removed so that it should not be same for every instance of search block which violates standards.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. checkout to this PR.
2. build and run the project.
3. create a page/post.
4. add multiple `search` blocks in that page/post.
5. while adding search block make sure we select _use button with icon_ from search block toolbar
6. publish the page/post.
7. validate if search icon SVG of the each block doesn't have any `id` attribute.

## Screenshots or screencast <!-- if applicable -->