### PR TITLE
[bug] Theme Export: Use a better method to determine the theme name

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
@@ -76,7 +76,10 @@ class Gutenberg_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 			return $filename;
 		}
 
-		$theme_name = wp_get_theme()->get( 'TextDomain' );
+		$stylesheet = get_stylesheet();
+		$stylesheet_directories = explode( '/', $stylesheet );
+		$theme_name = end( $stylesheet_directories );
+
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme_name . '.zip' );
 		header( 'Content-Length: ' . filesize( $filename ) );

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
@@ -76,9 +76,9 @@ class Gutenberg_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 			return $filename;
 		}
 
-		$stylesheet = get_stylesheet();
+		$stylesheet             = get_stylesheet();
 		$stylesheet_directories = explode( '/', $stylesheet );
-		$theme_name = end( $stylesheet_directories );
+		$theme_name             = end( $stylesheet_directories );
 
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme_name . '.zip' );


### PR DESCRIPTION
## What?
When a theme doesn't define a TextDomain, the export fails, and we get this error message:
<img width="348" alt="Screenshot 2022-05-05 at 10 41 01" src="https://user-images.githubusercontent.com/275961/166898475-be1e64aa-312b-45fa-a8fc-a907f1c80da2.png">

This changes the method for getting the theme name so that it just uses the folder name, which is safer.

## Why?
So that themes can still be exported without defining a TextDomain.

## How?
This has to use a bit of string manipulation as we don't store the theme slug anywhere, but I think the logic is sound.

## Testing Instructions
1. Use a theme without a TextDomain defined (for example https://hgg-cloud.de/index.php/s/UOgaldj3BGLYWnR)
2. Export the theme from the Site Editor
3. In trunk you get an error message, in this branch it is successful.

@WordPress/block-themers 
