### PR TITLE
Create single template via site editor if not existing

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -40,7 +40,7 @@ import { useHistory } from '../routes';
 
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
-	'single-post',
+	'single',
 	'page',
 	'index',
 	'archive',
@@ -55,7 +55,7 @@ const DEFAULT_TEMPLATE_SLUGS = [
 
 const TEMPLATE_ICONS = {
 	'front-page': home,
-	'single-post': post,
+	single: post,
 	page,
 	archive,
 	search,

--- a/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
+++ b/packages/edit-site/src/components/navigation-sidebar/navigation-panel/constants.js
@@ -31,7 +31,7 @@ export const TEMPLATES_SECONDARY = [
 	'date',
 	'tag',
 	'attachment',
-	'single-post',
+	'single',
 	'front-page',
 ];
 
@@ -45,7 +45,7 @@ export const TEMPLATES_GENERAL = [ 'page-home' ];
 export const TEMPLATES_POSTS_PREFIXES = [
 	'post-',
 	'author-',
-	'single-post-',
+	'single-',
 	'tag-',
 ];
 

--- a/packages/editor/src/components/post-slug/test/index.js
+++ b/packages/editor/src/components/post-slug/test/index.js
@@ -15,11 +15,11 @@ describe( 'PostSlug', () => {
 
 			wrapper.find( 'input' ).simulate( 'change', {
 				target: {
-					value: 'single-post',
+					value: 'single',
 				},
 			} );
 
-			expect( wrapper.state().editedSlug ).toEqual( 'single-post' );
+			expect( wrapper.state().editedSlug ).toEqual( 'single' );
 		} );
 
 		it( 'should update slug', () => {
@@ -30,11 +30,11 @@ describe( 'PostSlug', () => {
 
 			wrapper.find( 'input' ).simulate( 'blur', {
 				target: {
-					value: 'single-post',
+					value: 'single',
 				},
 			} );
 
-			expect( onUpdateSlug ).toHaveBeenCalledWith( 'single-post' );
+			expect( onUpdateSlug ).toHaveBeenCalledWith( 'single' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR changes the slug of the single template from `single-post` to `single`, which is the default slug for the single (post) template.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR fixes the issue #40814, where it was discovered that the template for `single` is not createable from the site editor when this template is not yet existing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Previously the single template was addressed as `single-post`, but this is not existing in the template hierarchy as default single template. The `post` suffix has been removed from all occurences.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Have an environment with WP 6.0 RC 1 available.
2. Activate a block theme with no single template available, for example [Miniblock OOAK](https://wordpress.org/themes/miniblock-ooak/).
3. Go to the site editor.
4. Open the templates overview.
5. Click on the "Add" button and see the single template in the list of available default templates.

## Screenshots or screencast <!-- if applicable -->
