### PR TITLE
Post saved draft button: overwrite default button component margin

### DIFF
--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -34,6 +34,11 @@
 	}
 }
 
+// Overwrite rules from Button component packages/components/src/button/style.scss
 .editor-post-save-draft.has-text.has-icon svg {
 	margin-right: 0;
+}
+
+:root[dir="rtl"] .editor-post-saved-state.has-text.has-icon {
+	justify-content: right;
 }

--- a/packages/editor/src/components/post-saved-state/style.scss
+++ b/packages/editor/src/components/post-saved-state/style.scss
@@ -33,3 +33,7 @@
 		}
 	}
 }
+
+.editor-post-save-draft.has-text.has-icon svg {
+	margin-right: 0;
+}


### PR DESCRIPTION
## What?
A small change to overwrite [default button component margin](https://github.com/WordPress/gutenberg/blob/0acbb5122b7100e6040fdd08107b333e3b1f9b24/packages/components/src/button/style.scss#L321) of `8px` for the post save draft button.

Also, this PR adds an `rtl` rule for content justification, so that the save draft button content looks the same as `ltr`.


## Why?

In smaller viewport widths the cloud icon has extra right margin when the post is in a dirty state.

This causes the button to jump to the left between saving and saved states.

Furthermore, in an RTL language such as Arabic, the default text justification of the save draft button means that the cloud icon is hidden over to the right. It isn't consistent with the LTR UI.

### Before overwriting

| LTR  | RTL |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/6458278/166848037-e7998b7f-9477-479b-b4c6-f4bed353bd49.gif" width="300" />  | <img src="https://user-images.githubusercontent.com/6458278/166849659-93f96a38-8424-4371-80bb-bf53f5213ba1.gif" width="300" />  |


### After overwriting
| LTR  | RTL |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/6458278/166848042-62cc4eba-3c1f-4767-b7dc-d9e8f3b6c086.gif" width="300" />  | <img src="https://user-images.githubusercontent.com/6458278/166849663-b1940e55-dea2-4028-9599-8a33c071232d.gif" width="300" />  |




## Testing Instructions

_To be sung to the tune of Bohemian Rhapsody_

Open a post first
Narrow the browser screen
Enter some content
Click on save draft to save your scene...

Stare at the cloud
Make sure that it stays in plaaaaace...

Now switch your locale! Hebrew or Arabic
Because they're right-to-left - RTL,
Should be appear, fine as well

Take a look in desktop, shouldn't really change much at alllll, at all.

🎹 


