### PR TITLE
Return immediately from Avatar block's render_callback if `$comment` is null

### DIFF
--- a/packages/block-library/src/avatar/index.php
+++ b/packages/block-library/src/avatar/index.php
@@ -105,11 +105,11 @@ function render_block_core_avatar( $attributes, $content, $block ) {
 		return sprintf( '<div %1s>%2s</div>', $wrapper_attributes, $avatar_block );
 	}
 	$comment = get_comment( $block->context['commentId'] );
-	/* translators: %s is the Comment Author name */
-	$alt = sprintf( __( '%s Avatar' ), $comment->comment_author );
 	if ( ! $comment ) {
 		return '';
 	}
+	/* translators: %s is the Comment Author name */
+	$alt          = sprintf( __( '%s Avatar' ), $comment->comment_author );
 	$avatar_block = get_avatar(
 		$comment,
 		$size,


### PR DESCRIPTION
## What?
In the Avatar block's `render_callback`, return `''` immediately if `$comment` is `null`.

## Why?
If the comment is `null`, accessing `$comment->$comment_author` will fail.

In theory, the comment should never be `null` if `$block->context['commentId']` is set, but I was able to accidentally get my machine into a state where it did occur.

## Testing Instructions
I don't quite know how to reproduce it anymore. On my local machine, using twenty twentytwo, I got this error on the frontend:

```
Notice: Trying to get property 'comment_author' of non-object in /var/www/html/wp-content/plugins/gutenberg/build/block-library/blocks/avatar.php on line 109
```

However, this error went away after I've restarted my `wp-env` environment.