### PR TITLE
Border Controls: Passthrough popover props instead of class names

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -253,6 +253,23 @@ export function BorderPanel( props ) {
 	};
 
 	const hydratedBorder = getBorderObject( attributes, colors );
+	const popoversProps = {
+		linked: {
+			className: 'block-editor__border-box-control__popover',
+		},
+		top: {
+			className: 'block-editor__border-box-control__popover-top',
+		},
+		right: {
+			className: 'block-editor__border-box-control__popover-right',
+		},
+		bottom: {
+			className: 'block-editor__border-box-control__popover-bottom',
+		},
+		left: {
+			className: 'block-editor__border-box-control__popover-left',
+		},
+	};
 
 	return (
 		<InspectorControls __experimentalGroup="border">
@@ -269,17 +286,7 @@ export function BorderPanel( props ) {
 						colors={ colors }
 						enableAlpha={ true }
 						onChange={ onBorderChange }
-						popoverClassNames={ {
-							linked: 'block-editor__border-box-control__popover',
-							top:
-								'block-editor__border-box-control__popover-top',
-							right:
-								'block-editor__border-box-control__popover-right',
-							bottom:
-								'block-editor__border-box-control__popover-bottom',
-							left:
-								'block-editor__border-box-control__popover-left',
-						} }
+						popoversProps={ popoversProps }
 						showStyle={ isStyleSupported }
 						value={ hydratedBorder }
 						__experimentalHasMultipleOrigins={ true }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## Enhancements
+
+-    Update `BorderControl` and `BorderBoxControl` to passthrough popover props to their dropdowns instead of classnames only. ([#40836](https://github.com/WordPress/gutenberg/pull/40836))
+
 ## 19.10.0 (2022-05-04)
 
 ### Internal

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -25,7 +25,7 @@ const BorderBoxControlSplitControls = (
 		enableAlpha,
 		enableStyle,
 		onChange,
-		popoverClassNames,
+		popoversProps,
 		value,
 		__experimentalHasMultipleOrigins,
 		__experimentalIsRenderedInSidebar,
@@ -50,7 +50,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Top border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
-				popoverProps={ { className: popoverClassNames?.top } }
+				popoverProps={ popoversProps?.top }
 				value={ value?.top }
 				{ ...sharedBorderControlProps }
 			/>
@@ -58,7 +58,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
-				popoverProps={ { className: popoverClassNames?.left } }
+				popoverProps={ popoversProps?.left }
 				value={ value?.left }
 				{ ...sharedBorderControlProps }
 			/>
@@ -66,7 +66,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Right border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
-				popoverProps={ { className: popoverClassNames?.right } }
+				popoverProps={ popoversProps?.right }
 				value={ value?.right }
 				{ ...sharedBorderControlProps }
 			/>
@@ -75,7 +75,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Bottom border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'bottom' ) }
-				popoverProps={ { className: popoverClassNames?.bottom } }
+				popoverProps={ popoversProps?.bottom }
 				value={ value?.bottom }
 				{ ...sharedBorderControlProps }
 			/>

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -50,7 +50,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Top border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'top' ) }
-				popoverContentClassName={ popoverClassNames?.top }
+				popoverProps={ { className: popoverClassNames?.top } }
 				value={ value?.top }
 				{ ...sharedBorderControlProps }
 			/>
@@ -58,7 +58,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Left border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'left' ) }
-				popoverContentClassName={ popoverClassNames?.left }
+				popoverProps={ { className: popoverClassNames?.left } }
 				value={ value?.left }
 				{ ...sharedBorderControlProps }
 			/>
@@ -66,7 +66,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Right border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'right' ) }
-				popoverContentClassName={ popoverClassNames?.right }
+				popoverProps={ { className: popoverClassNames?.right } }
 				value={ value?.right }
 				{ ...sharedBorderControlProps }
 			/>
@@ -75,7 +75,7 @@ const BorderBoxControlSplitControls = (
 				hideLabelFromVision={ true }
 				label={ __( 'Bottom border' ) }
 				onChange={ ( newBorder ) => onChange( newBorder, 'bottom' ) }
-				popoverContentClassName={ popoverClassNames?.bottom }
+				popoverProps={ { className: popoverClassNames?.bottom } }
 				value={ value?.bottom }
 				{ ...sharedBorderControlProps }
 			/>

--- a/packages/components/src/border-box-control/border-box-control/README.md
+++ b/packages/components/src/border-box-control/border-box-control/README.md
@@ -122,19 +122,19 @@ _Note: The will be `undefined` if a user clears all borders._
 
 - Required: Yes
 
-### `popoverClassNames`: `Object`
+### `popoversProps`: `Object`
 
-An object defining CSS classnames for all the inner `BorderControl` popover
-content.
+An object defining the `popoverProps` for all the inner `BorderControl`
+dropdowns.
 
 Example:
 ```js
 {
-	linked: 'linked-border-popover-content',
-	top: 'top-border-popover-content',
-	right: 'right-border-popover-content',
-	bottom: 'bottom-border-popover-content',
-	left: 'left-border-popover-content',
+	linked: { className: 'linked-border-popover-content' },
+	top: { className: 'top-border-popover-content' },
+	right: { className: 'right-border-popover-content' },
+	bottom: { className: 'bottom-border-popover-content' },
+	left: { className: 'left-border-popover-content' },
 }
 ```
 

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -51,7 +51,7 @@ const BorderBoxControl = (
 		linkedValue,
 		onLinkedChange,
 		onSplitChange,
-		popoverClassNames,
+		popoversProps,
 		splitValue,
 		toggleLinked,
 		__experimentalHasMultipleOrigins,
@@ -77,9 +77,7 @@ const BorderBoxControl = (
 						placeholder={
 							hasMixedBorders ? __( 'Mixed' ) : undefined
 						}
-						popoverProps={ {
-							className: popoverClassNames?.linked,
-						} }
+						popoverProps={ popoversProps?.linked }
 						shouldSanitizeBorder={ false } // This component will handle that.
 						value={ linkedValue }
 						withSlider={ true }
@@ -98,7 +96,7 @@ const BorderBoxControl = (
 						enableAlpha={ enableAlpha }
 						enableStyle={ enableStyle }
 						onChange={ onSplitChange }
-						popoverClassNames={ popoverClassNames }
+						popoversProps={ popoversProps }
 						value={ splitValue }
 						__experimentalHasMultipleOrigins={
 							__experimentalHasMultipleOrigins

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -77,7 +77,9 @@ const BorderBoxControl = (
 						placeholder={
 							hasMixedBorders ? __( 'Mixed' ) : undefined
 						}
-						popoverContentClassName={ popoverClassNames?.linked }
+						popoverProps={ {
+							className: popoverClassNames?.linked,
+						} }
 						shouldSanitizeBorder={ false } // This component will handle that.
 						value={ linkedValue }
 						withSlider={ true }

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -1,7 +1,12 @@
 /**
  * Internal dependencies
  */
-import type { Border, ColorProps, LabelProps } from '../border-control/types';
+import type {
+	Border,
+	ColorProps,
+	DropdownPopoverProps,
+	LabelProps,
+} from '../border-control/types';
 
 export type Borders = {
 	top?: Border;
@@ -14,12 +19,15 @@ export type AnyBorder = Border | Borders | undefined;
 export type BorderProp = keyof Border;
 export type BorderSide = keyof Borders;
 
-export type PopoverClassNames = {
-	linked?: string;
-	top?: string;
-	right?: string;
-	bottom?: string;
-	left?: string;
+/**
+ * Collection of `popoverProps` for each of the inner border controls.
+ */
+export type PopoversProps = {
+	linked?: DropdownPopoverProps;
+	top?: DropdownPopoverProps;
+	right?: DropdownPopoverProps;
+	bottom?: DropdownPopoverProps;
+	left?: DropdownPopoverProps;
 };
 
 export type BorderBoxControlProps = ColorProps &
@@ -35,10 +43,10 @@ export type BorderBoxControlProps = ColorProps &
 		 */
 		onChange: ( value: AnyBorder ) => void;
 		/**
-		 * An object defining CSS classnames for all the inner `BorderControl`
-		 * popover content.
+		 * An object defining the `popoverProps` for all the inner
+		 * `BorderControl` dropdowns.
 		 */
-		popoverClassNames?: PopoverClassNames;
+		popoversProps?: PopoversProps;
 		/**
 		 * An object representing the current border configuration.
 		 *
@@ -85,10 +93,10 @@ export type SplitControlsProps = ColorProps & {
 	 */
 	onChange: ( value: Border | undefined, side: BorderSide ) => void;
 	/**
-	 * An object defining CSS classnames for the split side `BorderControl`s'
-	 * popover content.
+	 * An object defining the `popoverProps` for the split side
+	 * `BorderControl` dropdowns.
 	 */
-	popoverClassNames?: PopoverClassNames;
+	popoversProps?: PopoversProps;
 	/**
 	 * An object representing the current border configuration. It contains
 	 * properties for each side, with each side an object reflecting the border

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -141,7 +141,7 @@ const BorderControlDropdown = (
 		onReset,
 		onColorChange,
 		onStyleChange,
-		popoverClassName,
+		popoverProps,
 		popoverControlsClassName,
 		resetButtonClassName,
 		showDropdownHeader,
@@ -236,7 +236,7 @@ const BorderControlDropdown = (
 		<Dropdown
 			renderToggle={ renderToggle }
 			renderContent={ renderContent }
-			popoverProps={ { className: popoverClassName } }
+			popoverProps={ popoverProps }
 			{ ...otherProps }
 			ref={ forwardedRef }
 		/>

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -237,7 +237,7 @@ const BorderControlDropdown = (
 		<Dropdown
 			renderToggle={ renderToggle }
 			renderContent={ renderContent }
-			contentClassName={ popoverClassName }
+			popoverProps={ { className: popoverClassName } }
 			{ ...otherProps }
 			ref={ forwardedRef }
 		/>

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -198,7 +198,6 @@ const BorderControlDropdown = (
 					</HStack>
 				) : undefined }
 				<ColorPalette
-					className="" // TypeScript is throwing error if not present.
 					value={ color }
 					onChange={ onColorChange }
 					{ ...{ colors, disableCustomColors } }

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -142,7 +142,6 @@ const BorderControlDropdown = (
 		onColorChange,
 		onStyleChange,
 		popoverClassName,
-		popoverContentClassName,
 		popoverControlsClassName,
 		resetButtonClassName,
 		showDropdownHeader,
@@ -199,7 +198,7 @@ const BorderControlDropdown = (
 					</HStack>
 				) : undefined }
 				<ColorPalette
-					className={ popoverContentClassName }
+					className="" // TypeScript is throwing error if not present.
 					value={ color }
 					onChange={ onColorChange }
 					{ ...{ colors, disableCustomColors } }

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -20,8 +20,8 @@ export function useBorderControlDropdown(
 		border,
 		className,
 		colors,
-		contentClassName,
 		onChange,
+		popoverProps,
 		previousStyleSelection,
 		...otherProps
 	} = useContextSystem( props, 'BorderControlDropdown' );
@@ -65,8 +65,8 @@ export function useBorderControlDropdown(
 	}, [ border, cx ] );
 
 	const popoverClassName = useMemo( () => {
-		return cx( styles.borderControlPopover, contentClassName );
-	}, [ cx, contentClassName ] );
+		return cx( styles.borderControlPopover, popoverProps?.className );
+	}, [ cx, popoverProps?.className ] );
 
 	const popoverControlsClassName = useMemo( () => {
 		return cx( styles.borderControlPopoverControls );
@@ -86,7 +86,7 @@ export function useBorderControlDropdown(
 		onColorChange,
 		onStyleChange,
 		onReset,
-		popoverClassName,
+		popoverProps: { ...popoverProps, className: popoverClassName },
 		popoverControlsClassName,
 		resetButtonClassName,
 	};

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -72,10 +72,6 @@ export function useBorderControlDropdown(
 		return cx( styles.borderControlPopoverControls );
 	}, [ cx ] );
 
-	const popoverContentClassName = useMemo( () => {
-		return cx( styles.borderControlPopoverContent );
-	}, [ cx ] );
-
 	const resetButtonClassName = useMemo( () => {
 		return cx( styles.resetButton );
 	}, [ cx ] );
@@ -91,7 +87,6 @@ export function useBorderControlDropdown(
 		onStyleChange,
 		onReset,
 		popoverClassName,
-		popoverContentClassName,
 		popoverControlsClassName,
 		resetButtonClassName,
 	};

--- a/packages/components/src/border-control/border-control/README.md
+++ b/packages/components/src/border-control/border-control/README.md
@@ -113,10 +113,10 @@ _Note: the value may be `undefined` if a user clears all border properties._
 
 - Required: Yes
 
-### `popoverContentClassName`: `string`
+### `popoverProps`: `Object`
 
-A custom CSS class name to be assigned to the `BorderControl`'s dropdown
-popover content.
+Properties of the `popoverProps` object will be passed as props to the border
+control's dropdown popover.
 
 - Required: No
 

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -68,11 +68,11 @@ const BorderControl = (
 					<BorderControlDropdown
 						border={ border }
 						colors={ colors }
-						contentClassName={ popoverContentClassName }
 						disableCustomColors={ disableCustomColors }
 						enableAlpha={ enableAlpha }
 						enableStyle={ enableStyle }
 						onChange={ onBorderChange }
+						popoverProps={ { className: popoverContentClassName } }
 						previousStyleSelection={ previousStyleSelection }
 						showDropdownHeader={ showDropdownHeader }
 						__experimentalHasMultipleOrigins={

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -43,7 +43,7 @@ const BorderControl = (
 		onSliderChange,
 		onWidthChange,
 		placeholder,
-		popoverContentClassName,
+		popoverProps,
 		previousStyleSelection,
 		showDropdownHeader,
 		sliderClassName,
@@ -72,7 +72,7 @@ const BorderControl = (
 						enableAlpha={ enableAlpha }
 						enableStyle={ enableStyle }
 						onChange={ onBorderChange }
-						popoverProps={ { className: popoverContentClassName } }
+						popoverProps={ popoverProps }
 						previousStyleSelection={ previousStyleSelection }
 						showDropdownHeader={ showDropdownHeader }
 						__experimentalHasMultipleOrigins={

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -136,7 +136,6 @@ export const borderControlPopoverControls = css`
 	}
 `;
 
-export const borderControlPopoverContent = css``;
 export const borderColorIndicator = css``;
 
 export const resetButton = css`

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -26,7 +26,7 @@ export type Colors = ColorOrigin[] | Color[];
  * dropdown's `popoverProps`. This should be replaced once the Dropdown or
  * Popover components are typed.
  */
-type DropdownPopoverProps = {
+export type DropdownPopoverProps = {
 	className?: string;
 	focusOnMount?: boolean;
 	position?: string;

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -21,6 +21,24 @@ export type ColorOrigin = {
 
 export type Colors = ColorOrigin[] | Color[];
 
+/**
+ * Represents the available props that can be passed through the border control
+ * dropdown's `popoverProps`. This should be replaced once the Dropdown or
+ * Popover components are typed.
+ */
+type DropdownPopoverProps = {
+	className?: string;
+	focusOnMount?: boolean;
+	position?: string;
+	onClose?: () => void;
+	onFocusOutside?: () => void;
+	expandOnMobile?: boolean;
+	headerTitle?: string;
+	noArrow?: boolean;
+	anchorRect?: DOMRect;
+	getAnchorRect?: ( ref: HTMLAnchorElement ) => DOMRect;
+};
+
 export type ColorProps = {
 	/**
 	 * An array of color definitions. This may also be a multi-dimensional array
@@ -81,10 +99,10 @@ export type BorderControlProps = ColorProps &
 		 */
 		onChange: ( value?: Border ) => void;
 		/**
-		 * A custom CSS class name to be assigned to the border control's
-		 * dropdown popover content.
+		 * Properties of the `popoverProps` object will be passed as props to
+		 * the border control's dropdown popover.
 		 */
-		popoverContentClassName?: string;
+		popoverProps?: DropdownPopoverProps;
 		/**
 		 * If opted into, sanitizing the border means that if no width or color
 		 * have been selected, the border style is also cleared and `undefined`
@@ -115,24 +133,6 @@ export type BorderControlProps = ColorProps &
 		 */
 		withSlider?: boolean;
 	};
-
-/**
- * Represents the available props that can be passed through the border control
- * dropdown's `popoverProps`. This should be replaced once the Dropdown or
- * Popover components are typed.
- */
-type DropdownPopoverProps = {
-	className?: string;
-	focusOnMount?: boolean;
-	position?: string;
-	onClose?: () => void;
-	onFocusOutside?: () => void;
-	expandOnMobile?: boolean;
-	headerTitle?: string;
-	noArrow?: boolean;
-	anchorRect?: DOMRect;
-	getAnchorRect?: ( ref: HTMLAnchorElement ) => DOMRect;
-};
 
 export type DropdownProps = ColorProps & {
 	/**

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -116,6 +116,24 @@ export type BorderControlProps = ColorProps &
 		withSlider?: boolean;
 	};
 
+/**
+ * Represents the available props that can be passed through the border control
+ * dropdown's `popoverProps`. This should be replaced once the Dropdown or
+ * Popover components are typed.
+ */
+type DropdownPopoverProps = {
+	className?: string;
+	focusOnMount?: boolean;
+	position?: string;
+	onClose?: () => void;
+	onFocusOutside?: () => void;
+	expandOnMobile?: boolean;
+	headerTitle?: string;
+	noArrow?: boolean;
+	anchorRect?: DOMRect;
+	getAnchorRect?: ( ref: HTMLAnchorElement ) => DOMRect;
+};
+
 export type DropdownProps = ColorProps & {
 	/**
 	 * An object representing a border or `undefined`. This component will
@@ -123,11 +141,6 @@ export type DropdownProps = ColorProps & {
 	 * values for its popover controls.
 	 */
 	border?: Border;
-	/**
-	 * A custom CSS class name to be assigned to the border control's
-	 * dropdown popover content.
-	 */
-	contentClassName?: string;
 	/**
 	 * This controls whether to render border style options.
 	 *
@@ -138,6 +151,11 @@ export type DropdownProps = ColorProps & {
 	 * A callback invoked when the border color or style selections change.
 	 */
 	onChange: ( newBorder?: Border ) => void;
+	/**
+	 * Properties of the `popoverProps` object will be passed as props to the
+	 * border control's dropdown popover.
+	 */
+	popoverProps?: DropdownPopoverProps;
 	/**
 	 * Any previous style selection made by the user. This can be used to
 	 * reapply that previous selection when, for example, a zero border width is

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -152,17 +152,19 @@ const extractColorNameFromCurrentValue = (
 	return __( 'Custom' );
 };
 
-export default function ColorPalette( {
-	clearable = true,
-	className = undefined,
-	colors,
-	disableCustomColors = false,
-	enableAlpha,
-	onChange,
-	value,
-	__experimentalHasMultipleOrigins = false,
-	__experimentalIsRenderedInSidebar = false,
-} ) {
+export default function ColorPalette( props ) {
+	const {
+		clearable = true,
+		className,
+		colors,
+		disableCustomColors = false,
+		enableAlpha,
+		onChange,
+		value,
+		__experimentalHasMultipleOrigins = false,
+		__experimentalIsRenderedInSidebar = false,
+	} = props;
+
 	const clearColor = useCallback( () => onChange( undefined ), [ onChange ] );
 	const showMultiplePalettes =
 		__experimentalHasMultipleOrigins && colors?.length;

--- a/packages/components/src/color-palette/index.js
+++ b/packages/components/src/color-palette/index.js
@@ -154,7 +154,7 @@ const extractColorNameFromCurrentValue = (
 
 export default function ColorPalette( {
 	clearable = true,
-	className,
+	className = undefined,
 	colors,
 	disableCustomColors = false,
 	enableAlpha,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/39753
- https://github.com/WordPress/gutenberg/pull/40740

## What?

Updates the `BorderControl` and `BorderBoxControl` components to pass through `popoverProps` via their internal dropdowns instead of CSS classnames. 

## Why?

This change is to provide greater flexibility and unblock [new work refactoring the `Popover` component](https://github.com/WordPress/gutenberg/pull/40740). Given the border control components are still experimental this change in their API should be ok.

## How?

- Removes the explicit popover class name related props from the border controls
- Updates components to use `popoverProps` as a means for plumbing through class names.
- Updates border support to pass the current class names via the `BorderBoxControl`'s new `popoversProps` prop (any ideas on better naming here would be appreciated).

Note: The class names are still relied upon to provide the correct positioning of the border color/style dropdowns in the block editor. This will change in a followup as https://github.com/WordPress/gutenberg/pull/40740 proceeds.

## Testing Instructions

1. Run border control unit tests
    - `npm run test-unit packages/components/src/border-control/test/index.js`
    - `npm run test-unit packages/components/src/border-box-control/test/index.js`
2. Ensure no typing errors: `npm run build:package-types`
3. Load editor, create a post, add a group block, and select it
4. In the Inspector controls sidebar, toggle all the border color and style dropdowns for the border support control including both linked and unlinked views. Make sure the popovers are positioned correctly to the left of the sidebar.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/166857487-366e23f5-170c-4f26-80a0-5c5b7d4b3cbb.mp4

