### PR TITLE
Enhance doc regarding the doAction / applyFilters

### DIFF
--- a/packages/hooks/README.md
+++ b/packages/hooks/README.md
@@ -52,6 +52,12 @@ One notable difference between the JS and PHP hooks API is that in the JS versio
 -   `filters`
 -   `defaultHooks`
 
+
+#### Parameters
+
+- `hookName` unique name of the hook. It may contains only alphanumeric characters and dashes `[a-zA-z\-\_]`. Slashes are not permitted.
+- `namespace` namespace used by your application. Needed only when adding or removing an action or a filter.
+
 ### Events on action/filter add or remove
 
 Whenever an action or filter is added or removed, a matching `hookAdded` or `hookRemoved` action is triggered.


### PR DESCRIPTION
## What?

Enhance the documentation with missing (IMO important) info on the hook names.
There is no documentation about the hookName, we need to know what kind of names are allowed.
For example, slashes (`/`) are not permitted in the hookName in the JS implementation, which is not a problem when registering PHP actions and filters (any string will do).

## Why?

The main issue is that registering an action/filter with a "wrong" name will not trigger any notice, thus not giving any indication on the source of the error, so improving the doc is a must have.