### PR TITLE
Site Editor: Avoid previous content flash when a new template is created

### DIFF
--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -109,7 +109,7 @@ export default function NewTemplate( { postType } ) {
 			);
 
 			// Set template before navigating away to avoid initial stale value.
-			setTemplate( template.id );
+			setTemplate( template.id, template.slug );
 
 			// Navigate to the created template editor.
 			history.push( {

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -37,6 +37,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { useHistory } from '../routes';
+import { store as editSiteStore } from '../../store';
 
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
@@ -86,6 +87,7 @@ export default function NewTemplate( { postType } ) {
 	);
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
+	const { setTemplate } = useDispatch( editSiteStore );
 
 	async function createTemplate( { slug } ) {
 		try {
@@ -105,6 +107,9 @@ export default function NewTemplate( { postType } ) {
 				},
 				{ throwOnError: true }
 			);
+
+			// Set template before navigating away to avoid initial stale value.
+			setTemplate( template.id );
 
 			// Navigate to the created template editor.
 			history.push( {


### PR DESCRIPTION
## What?
Resolves #40286.

PR fixes previous template content flash when creating a new template from the Template list view.

## Why?
The site editor store retains the edited template even after navigating to the Template list view. This template is visible for a second before `URLQueryController` updates the store with the new one.

P.S. In the future, we might want to reset the currently edited template state when the Template list view is rendered. But for now, I decided to keep the fix simple if it's cherry-picked for WP 6.0 RC.

## How?
I update the template creation handler to dispatch `setTemplate` before updating the history and navigating to the editor.

## Testing Instructions

1. Open the Site Editor.
2. Go to the Template List.
3. Click "Add" and select one of the new template types (date, taxonomy, author).
4. Confirm the previous template isn't visible before rendering a new one.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://user-images.githubusercontent.com/240569/166891960-16370978-c51a-49f9-b417-9cb2c091fa6e.mp4

**After**

https://user-images.githubusercontent.com/240569/166891948-e62ef746-5ae5-401d-b9ee-ed026537a6af.mp4


