### PR TITLE
Fix the styles compatibility hook for the editor iframes

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -10,7 +10,6 @@ import {
 	useState,
 	createPortal,
 	forwardRef,
-	useEffect,
 	useMemo,
 	useReducer,
 } from '@wordpress/element';
@@ -34,60 +33,65 @@ const BLOCK_PREFIX = 'wp-block';
  *
  * Ideally, this hook should be removed in the future and styles should be added
  * explicitly as editor styles.
- *
- * @param {Document} doc The document to append cloned stylesheets to.
  */
-function styleSheetsCompat( doc ) {
-	// Search the document for stylesheets targetting the editor canvas.
-	Array.from( document.styleSheets ).forEach( ( styleSheet ) => {
-		try {
-			// May fail for external styles.
-			// eslint-disable-next-line no-unused-expressions
-			styleSheet.cssRules;
-		} catch ( e ) {
-			return;
-		}
-
-		const { ownerNode, cssRules } = styleSheet;
-
-		if ( ! cssRules ) {
-			return;
-		}
-
-		// Generally, ignore inline styles. We add inline styles belonging to a
-		// stylesheet later, which may or may not match the selectors.
-		if ( ownerNode.tagName !== 'LINK' ) {
-			return;
-		}
-
-		// Don't try to add the reset styles, which were removed as a dependency
-		// from `edit-blocks` for the iframe since we don't need to reset admin
-		// styles.
-		if ( ownerNode.id === 'wp-reset-editor-styles-css' ) {
-			return;
-		}
-
-		const isMatch = Array.from( cssRules ).find(
-			( { selectorText } ) =>
-				selectorText &&
-				( selectorText.includes( `.${ BODY_CLASS_NAME }` ) ||
-					selectorText.includes( `.${ BLOCK_PREFIX }` ) )
-		);
-
-		if ( isMatch && ! doc.getElementById( ownerNode.id ) ) {
-			// Display warning once we have a way to add style dependencies to the editor.
-			// See: https://github.com/WordPress/gutenberg/pull/37466.
-
-			doc.head.appendChild( ownerNode.cloneNode( true ) );
-
-			// Add inline styles belonging to the stylesheet.
-			const inlineCssId = ownerNode.id.replace( '-css', '-inline-css' );
-			const inlineCssElement = document.getElementById( inlineCssId );
-
-			if ( inlineCssElement ) {
-				doc.head.appendChild( inlineCssElement.cloneNode( true ) );
+function useCompatRef() {
+	return useRefEffect( ( node ) => {
+		// Search the document for stylesheets targetting the editor canvas.
+		Array.from( document.styleSheets ).forEach( ( styleSheet ) => {
+			try {
+				// May fail for external styles.
+				// eslint-disable-next-line no-unused-expressions
+				styleSheet.cssRules;
+			} catch ( e ) {
+				return;
 			}
-		}
+
+			const { ownerNode, cssRules } = styleSheet;
+
+			if ( ! cssRules ) {
+				return;
+			}
+
+			// Generally, ignore inline styles. We add inline styles belonging to a
+			// stylesheet later, which may or may not match the selectors.
+			if ( ownerNode.tagName !== 'LINK' ) {
+				return;
+			}
+
+			// Don't try to add the reset styles, which were removed as a dependency
+			// from `edit-blocks` for the iframe since we don't need to reset admin
+			// styles.
+			if ( ownerNode.id === 'wp-reset-editor-styles-css' ) {
+				return;
+			}
+
+			const isMatch = Array.from( cssRules ).find(
+				( { selectorText } ) =>
+					selectorText &&
+					( selectorText.includes( `.${ BODY_CLASS_NAME }` ) ||
+						selectorText.includes( `.${ BLOCK_PREFIX }` ) )
+			);
+
+			if (
+				isMatch &&
+				! node.ownerDocument.getElementById( ownerNode.id )
+			) {
+				// Display warning once we have a way to add style dependencies to the editor.
+				// See: https://github.com/WordPress/gutenberg/pull/37466.
+				node.appendChild( ownerNode.cloneNode( true ) );
+
+				// Add inline styles belonging to the stylesheet.
+				const inlineCssId = ownerNode.id.replace(
+					'-css',
+					'-inline-css'
+				);
+				const inlineCssElement = document.getElementById( inlineCssId );
+
+				if ( inlineCssElement ) {
+					node.appendChild( inlineCssElement.cloneNode( true ) );
+				}
+			}
+		} );
 	} );
 }
 
@@ -222,12 +226,7 @@ function Iframe(
 			} );
 	}, [] );
 	const bodyRef = useMergeRefs( [ contentRef, clearerRef, writingFlowRef ] );
-
-	useEffect( () => {
-		if ( iframeDocument ) {
-			styleSheetsCompat( iframeDocument );
-		}
-	}, [ iframeDocument ] );
+	const styleCompatibilityRef = useCompatRef();
 
 	head = (
 		<>
@@ -275,6 +274,12 @@ function Iframe(
 									...bodyClasses
 								) }
 							>
+								{ /*
+								 * This is a wrapper for the extra styles and scripts
+								 * rendered imperatively by cloning the parent,
+								 * it's important that this div's content remains uncontrolled.
+								 */ }
+								<div ref={ styleCompatibilityRef } />
 								<StyleProvider document={ iframeDocument }>
 									{ children }
 								</StyleProvider>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -34,7 +34,7 @@ const BLOCK_PREFIX = 'wp-block';
  * Ideally, this hook should be removed in the future and styles should be added
  * explicitly as editor styles.
  */
-function useCompatRef() {
+function useStylesCompatibility() {
 	return useRefEffect( ( node ) => {
 		// Search the document for stylesheets targetting the editor canvas.
 		Array.from( document.styleSheets ).forEach( ( styleSheet ) => {
@@ -226,7 +226,7 @@ function Iframe(
 			} );
 	}, [] );
 	const bodyRef = useMergeRefs( [ contentRef, clearerRef, writingFlowRef ] );
-	const styleCompatibilityRef = useCompatRef();
+	const styleCompatibilityRef = useStylesCompatibility();
 
 	head = (
 		<>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -279,7 +279,10 @@ function Iframe(
 								 * rendered imperatively by cloning the parent,
 								 * it's important that this div's content remains uncontrolled.
 								 */ }
-								<div ref={ styleCompatibilityRef } />
+								<div
+									style={ { display: 'none' } }
+									ref={ styleCompatibilityRef }
+								/>
 								<StyleProvider document={ iframeDocument }>
 									{ children }
 								</StyleProvider>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -92,7 +92,7 @@ function useStylesCompatibility() {
 				}
 			}
 		} );
-	} );
+	}, [] );
 }
 
 /**


### PR DESCRIPTION
closes #40562 
closes #40469

## What?
There was a regression related to the styles loading in the iframes (previews, site editor...) in Gutenberg 13.0. 
I believe the regression happened as a result of this PR #38855 but the reality is that the bug pre-existed and was hidden.

## How?

We had a function that was copying styles from the parent document to the iframe and using `appendChild` to inject the cloned styles, the problem is that the parent element (the head element) was being controlled by React. Meaning its content can get wiped out at any moment due to re-rendering/remounting... (which I think has been triggered by #38855)

This PR refactors how we apply the "cloning of styles" from the parent document by injecting these styles into a "div" at the top of the body and that div is "uncontrolled", meaning React doesn't care about its content. Also, I'm using `useRefEffect` to retrigger the compatibility hook anytime the reference of that div changes. (It doesn't happen now but it's a security for the future).

## Testing Instructions

1- Add some stylesheet at the root of gutenberg call it `test.css` and put the following content `.wp-block-group { background: red !important; }`.
2- Add the following code to the gutenberg.php file

```
add_action('init', function() {
	wp_register_style( 'toto', gutenberg_url( 'test.css' ) );
	wp_enqueue_block_style(
		'core/group',
		array(
			'handle' => 'toto',
		)
	);
} );
```

3- Load the site editor and notice that group blocks have a red background.