### PR TITLE
Add Core CSS to styles compat hook for editor iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -45,7 +45,6 @@ function useStylesCompatibility() {
 			} catch ( e ) {
 				return;
 			}
-
 			const { ownerNode, cssRules } = styleSheet;
 
 			if ( ! cssRules ) {
@@ -65,6 +64,14 @@ function useStylesCompatibility() {
 				return;
 			}
 
+			let isFilenameMatch = false;
+			if ( styleSheet.href ) {
+				const url = new URL( styleSheet.href );
+				if ( url.pathname === '/wp-admin/css/common.css' ) {
+					isFilenameMatch = true;
+				}
+			}
+
 			const isMatch = Array.from( cssRules ).find(
 				( { selectorText } ) =>
 					selectorText &&
@@ -73,7 +80,7 @@ function useStylesCompatibility() {
 			);
 
 			if (
-				isMatch &&
+				( isMatch || isFilenameMatch ) &&
 				! node.ownerDocument.getElementById( ownerNode.id )
 			) {
 				// Display warning once we have a way to add style dependencies to the editor.


### PR DESCRIPTION
## What?
Follow-up to #40842. Fixes #40827.

Make sure the `common.css` stylesheet is carried over to the Site Editor's iframe.

## Why?
See #40827. _tl;dr_: 

Users that still have the now-deprecated Post Comments block in one of their templates will find that the "Older Comments" and "Newer Comments" links aren't left- and right-aligned like they should be, but stacked on top of each other.

Comparing to the Post Editor, it seems like the "Older Comments" and "Newer Comments" links have the `alignleft` and `alignright` classes assigned, respectively:

![image](https://user-images.githubusercontent.com/96308/166922138-2f77e28d-8c5a-4913-8fa0-7992cf31d7af.png)

These classes are coming from Core's `common.css`: https://github.com/WordPress/wordpress-develop/blob/b27069117eb22c39d5230ceb39439f2dab82dc08/src/wp-admin/css/common.css#L92-L99

I checked the Site Editor's page source, and the `common.css` _is_ enqueued there. However, it is not carried over to the Site Editor's iframe.

## How?
By checking if the stylesheet is coming from Core's `common.css`, and if so, adding its styles to the iframe.

## Testing Instructions

Verify that #40827 is fixed.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/96308/166929850-3e7b37e6-52af-46e3-a446-26d173537de7.png) | ![image](https://user-images.githubusercontent.com/96308/166929745-26c6237d-3524-442f-9e6d-5eab3afb7522.png) | 

Looks like we might have to update some Post Comments block styling accordingly 😬 