### PR TITLE
Block Editor: Prevent block styles from leaking into an inner `Warning` component

### DIFF
--- a/packages/block-editor/src/components/warning/style.scss
+++ b/packages/block-editor/src/components/warning/style.scss
@@ -3,6 +3,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	font-family: $default-font;
+	font-size: $default-font-size;
 	padding: 1em;
 
 	// Block UI appearance.
@@ -14,6 +15,10 @@
 		line-height: $default-line-height;
 		font-family: $default-font;
 		font-size: $default-font-size;
+		text-transform: none;
+		letter-spacing: normal;
+		font-weight: normal;
+		font-style: normal;
 		color: $gray-900;
 		margin: 0;
 	}


### PR DESCRIPTION
## What?

When a block uses the [`Warning` component](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/warning/README.md), some block styles can leak into that component and change how it looks. This PR prevents that.

## Why?

It is a weird UX. Fixes https://github.com/WordPress/gutenberg/issues/40536

## How?

See comments after this description.

## Testing Instructions
Just follow the same steps as in the video posted in https://github.com/WordPress/gutenberg/issues/40536 description and check that no color or typography option affects the warning message styles.

## Screenshots or screencast

![Screenshot 2022-05-05 at 13 43 29](https://user-images.githubusercontent.com/6917969/166938591-0dd107f1-fbfd-49e9-9bcc-fdec83fca5f9.png)

