### PR TITLE
Code Editor: Fix save shortcut

### DIFF
--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -8,17 +8,21 @@ import {
 	store as editorStore,
 } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
-import { withDispatch, withSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { displayShortcut } from '@wordpress/keycodes';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import { store as editPostStore } from '../../store';
 
-function TextEditor( { onExit, isRichEditingEnabled } ) {
+export default function TextEditor() {
+	const isRichEditingEnabled = useSelect( ( select ) => {
+		return select( editorStore ).getEditorSettings().richEditingEnabled;
+	}, [] );
+	const { switchEditorMode } = useDispatch( editPostStore );
+
 	return (
 		<div className="edit-post-text-editor">
 			<TextEditorGlobalKeyboardShortcuts />
@@ -27,7 +31,7 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 					<h2>{ __( 'Editing code' ) }</h2>
 					<Button
 						variant="tertiary"
-						onClick={ onExit }
+						onClick={ () => switchEditorMode( 'visual' ) }
 						shortcut={ displayShortcut.secondary( 'm' ) }
 					>
 						{ __( 'Exit code editor' ) }
@@ -41,17 +45,3 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 		</div>
 	);
 }
-
-export default compose(
-	withSelect( ( select ) => ( {
-		isRichEditingEnabled: select( editorStore ).getEditorSettings()
-			.richEditingEnabled,
-	} ) ),
-	withDispatch( ( dispatch ) => {
-		return {
-			onExit() {
-				dispatch( editPostStore ).switchEditorMode( 'visual' );
-			},
-		};
-	} )
-)( TextEditor );

--- a/packages/edit-post/src/components/text-editor/index.js
+++ b/packages/edit-post/src/components/text-editor/index.js
@@ -21,6 +21,7 @@ import { store as editPostStore } from '../../store';
 function TextEditor( { onExit, isRichEditingEnabled } ) {
 	return (
 		<div className="edit-post-text-editor">
+			<TextEditorGlobalKeyboardShortcuts />
 			{ isRichEditingEnabled && (
 				<div className="edit-post-text-editor__toolbar">
 					<h2>{ __( 'Editing code' ) }</h2>
@@ -31,7 +32,6 @@ function TextEditor( { onExit, isRichEditingEnabled } ) {
 					>
 						{ __( 'Exit code editor' ) }
 					</Button>
-					<TextEditorGlobalKeyboardShortcuts />
 				</div>
 			) }
 			<div className="edit-post-text-editor__body">


### PR DESCRIPTION
## What?
PR fixes Code editor save shortcut when visual editing is disabled from the user profile.

P.S. I also couldn't resist and refactored components to use data hooks.

## Why?
The component wasn't rendering `TextEditorGlobalKeyboardShortcuts` if visual editing was disabled.

## How?
I moved the keyboard shortcuts component outside of the check.

## Testing Instructions
1. Open Users -> Profile and disable visual editing.
2. Open a Post or Page.
3. Update content
4. Saving should work using shortcuts.
