### PR TITLE
Post Comments Block: Allow placeholders to reorder items in translations

### DIFF
--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -17,6 +17,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
 import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -110,7 +111,10 @@ export default function PostCommentsEdit( {
 						ref={ disabledRef }
 					>
 						<h3>
-							{ __( 'One response to' ) } “{ postTitle }”
+							{
+								/* translators: %s: Post title. */
+								sprintf( __( 'One response to %s' ), postTitle )
+							}
 						</h3>
 
 						<div className="navigation">
@@ -135,16 +139,25 @@ export default function PostCommentsEdit( {
 												width="32"
 												loading="lazy"
 											/>
-											<b className="fn">
-												<a href="#top" className="url">
-													{ __(
-														'A WordPress Commenter'
-													) }
-												</a>
-											</b>{ ' ' }
-											<span className="says">
-												{ __( 'says' ) }:
-											</span>
+											{ createInterpolateElement(
+												__(
+													'<b><a>A WordPress Commenter</a></b> <span>says:</span>'
+												),
+												{
+													span: (
+														<span className="says" />
+													),
+													a: (
+														/* eslint-disable jsx-a11y/anchor-has-content */
+														<a
+															href="#top"
+															className="url"
+														/>
+														/* eslint-enable jsx-a11y/anchor-has-content */
+													),
+													b: <b className="fn" />,
+												}
+											) }
 										</div>
 
 										<div className="comment-metadata">
@@ -174,13 +187,17 @@ export default function PostCommentsEdit( {
 												'To get started with moderating, editing, and deleting comments, please visit the Comments screen in the dashboard.'
 											) }
 											<br />
-											{ __(
-												'Commenter avatars come from'
-											) }{ ' ' }
-											<a href="https://gravatar.com/">
-												Gravatar
-											</a>
-											.
+											{ createInterpolateElement(
+												__(
+													'Commenter avatars come from <a>Gravatar</a>'
+												),
+												{
+													a: (
+														/* eslint-disable-next-line jsx-a11y/anchor-has-content */
+														<a href="https://gravatar.com/" />
+													),
+												}
+											) }
 										</p>
 									</div>
 
@@ -188,7 +205,9 @@ export default function PostCommentsEdit( {
 										<a
 											className="comment-reply-link"
 											href="#top"
-											aria-label="Reply to A WordPress Commenter"
+											aria-label={ __(
+												'Reply to A WordPress Commenter'
+											) }
 										>
 											{ __( 'Reply' ) }
 										</a>

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -140,8 +140,17 @@ export default function PostCommentsEdit( {
 												loading="lazy"
 											/>
 											{ createInterpolateElement(
-												__(
-													'<b><a>A WordPress Commenter</a></b> <span>says:</span>'
+												sprintf(
+													/* translators: %s: Comment author link. */
+													__(
+														'%s <span>says:</span>'
+													),
+													sprintf(
+														'<cite><a>%s</a></cite>',
+														__(
+															'A WordPress Commenter'
+														)
+													)
 												),
 												{
 													span: (
@@ -155,7 +164,9 @@ export default function PostCommentsEdit( {
 														/>
 														/* eslint-enable jsx-a11y/anchor-has-content */
 													),
-													b: <b className="fn" />,
+													cite: (
+														<cite className="fn" />
+													),
 												}
 											) }
 										</div>
@@ -205,8 +216,10 @@ export default function PostCommentsEdit( {
 										<a
 											className="comment-reply-link"
 											href="#top"
-											aria-label={ __(
-												'Reply to A WordPress Commenter'
+											aria-label={ sprintf(
+												/* translators: Comment reply button text. %s: Comment author name. */
+												__( 'Reply to %s' ),
+												__( 'A WordPress Commenter' )
 											) }
 										>
 											{ __( 'Reply' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
With the Comments Placeholder task, we created some translatable fields. These previous ones had the phrase order hardcoded, so the translators could not select in what order the phrases are constructed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because we love the fact that WordPress is in almost all languages ❤️ 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using provided functions. I'm afraid that new strings will appear for the translations.

Before: `{ __( 'One response to' ) } “{ postTitle }”` -> Translator can only change the first sentence, being mandatory to show the post title at the end.

After: `sprintf( __( 'One response to %s' ), postTitle )` -> Translator can move %s wherever they need to.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1.) Translate the new strings and check that you can use the order you need.

## Screenshots or screencast <!-- if applicable -->
