### PR TITLE
[Block Library - Query Pagination]: Try rendering hidden element when no next/previous link exists

### DIFF
--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -12,7 +12,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "queryId", "query", "paginationArrow" ],
+	"usesContext": [ "queryId", "query", "paginationArrow", "layout" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -56,6 +56,17 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 		}
 		wp_reset_postdata(); // Restore original Post Data.
 	}
+
+	// If there is no next page to navigate but a layout justification content setting
+	// is `center` or `space-between`, render a hidden element to avoid layout shifts when
+	// visting other pages.
+	if ( empty( $content ) && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
+		return sprintf(
+			'<a %1$s>%2$s</a>',
+			get_block_wrapper_attributes( array( 'style' => 'visibility:hidden;' ) ),
+			$label
+		);
+	}
 	return $content;
 }
 

--- a/packages/block-library/src/query-pagination-next/index.php
+++ b/packages/block-library/src/query-pagination-next/index.php
@@ -60,7 +60,8 @@ function render_block_core_query_pagination_next( $attributes, $content, $block 
 	// If there is no next page to navigate but a layout justification content setting
 	// is `center` or `space-between`, render a hidden element to avoid layout shifts when
 	// visting other pages.
-	if ( empty( $content ) && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
+	$is_horizontal = isset( $block->context['layout']['orientation'] ) && 'horizontal' === $block->context['layout']['orientation'];
+	if ( empty( $content ) && $is_horizontal && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
 		return sprintf(
 			'<a %1$s>%2$s</a>',
 			get_block_wrapper_attributes( array( 'style' => 'visibility:hidden;' ) ),

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -12,7 +12,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "queryId", "query", "paginationArrow" ],
+	"usesContext": [ "queryId", "query", "paginationArrow", "layout" ],
 	"supports": {
 		"reusable": false,
 		"html": false,

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -44,6 +44,21 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 			$label
 		);
 	}
+	// If there is no previous page to navigate but a layout justification content setting
+	// is `center` or `space-between`, render a hidden element to avoid layout shifts when
+	// visting other pages.
+	if ( empty( $content ) && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
+		return sprintf(
+			'<a %1$s>%2$s</a>',
+			get_block_wrapper_attributes(
+				array(
+					'aria-hidden' => 'true',
+					'style'       => 'visibility:hidden;',
+				)
+			),
+			$label
+		);
+	}
 	return $content;
 }
 

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -47,7 +47,8 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 	// If there is no previous page to navigate but a layout justification content setting
 	// is `center` or `space-between`, render a hidden element to avoid layout shifts when
 	// visting other pages.
-	if ( empty( $content ) && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
+	$is_horizontal = isset( $block->context['layout']['orientation'] ) && 'horizontal' === $block->context['layout']['orientation'];
+	if ( empty( $content ) && $is_horizontal && isset( $block->context['layout']['justifyContent'] ) && in_array( $block->context['layout']['justifyContent'], array( 'center', 'space-between' ), true ) ) {
 		return sprintf(
 			'<a %1$s>%2$s</a>',
 			get_block_wrapper_attributes(

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -15,7 +15,8 @@
 	},
 	"usesContext": [ "queryId", "query" ],
 	"providesContext": {
-		"paginationArrow": "paginationArrow"
+		"paginationArrow": "paginationArrow",
+		"layout": "layout"
 	},
 	"supports": {
 		"align": true,

--- a/packages/block-library/src/query-pagination/index.php
+++ b/packages/block-library/src/query-pagination/index.php
@@ -14,7 +14,15 @@
  * @return string Returns the wrapper for the Query pagination.
  */
 function render_block_core_query_pagination( $attributes, $content ) {
-	if ( empty( trim( $content ) ) ) {
+	$content = trim( $content );
+	if ( empty( $content ) ) {
+		return '';
+	}
+	// TODO: This is a rough quick implementation to see if we can use this or something similar for our use case.
+	preg_match_all( '/visibility:hidden;/', $content, $hiddens );
+	preg_match_all( '/wp-block-query-pagination-next/', $content, $nexts );
+	preg_match_all( '/wp-block-query-pagination-previous/', $content, $prevs );
+	if ( count( $hiddens[0] ) === count( $nexts[0] ) + count( $prevs[0] ) ) {
 		return '';
 	}
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Attempt to fix: https://github.com/WordPress/gutenberg/issues/34997
Alternative of:https://github.com/WordPress/gutenberg/pull/40553 and https://github.com/WordPress/gutenberg/pull/36681.

I'm still not sure if we want to render an element for design purposes only and I think that the proper approach would be a new layout or some layout controls, that do not exist right now.. 


We need to weight the pros and cons of such approach and I haven't done all the testing and considered everything yet.  But I acknowledge that this is a very common use case that needs to be handled somehow.

I started exploring a layout `grid` approach, but it needs exploration and if I come up with something good, I'll open a PR for that. 
<!-- In a few words, what is the PR actually doing? -->

## How?

In this PR I render a hidden element only if there was no link for Query Pagination Next/Previous and only if the parent Query Pagination block has justification content `center or space-between`.
