### PR TITLE
Use `get_the_post_thumbnail` function in the cover block. 

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -18,47 +18,27 @@ function render_block_core_cover( $attributes, $content ) {
 		return $content;
 	}
 
-	$current_featured_image = get_the_post_thumbnail_url();
-
-	if ( false === $current_featured_image ) {
+	$is_image_background = 'image' === $attributes['backgroundType'];
+	if ( ! $is_image_background ) {
 		return $content;
 	}
 
-	$is_img_element      = ! ( $attributes['hasParallax'] || $attributes['isRepeated'] );
-	$is_image_background = 'image' === $attributes['backgroundType'];
+	$is_img_element = ! ( $attributes['hasParallax'] || $attributes['isRepeated'] );
 
-	if ( $is_image_background && ! $is_img_element ) {
-		$content = preg_replace(
-			'/class=\".*?\"/',
-			'${0} style="background-image:url(' . esc_url( $current_featured_image ) . ')"',
-			$content,
-			1
-		);
-	}
-
-	if ( $is_image_background && $is_img_element ) {
+	if ( $is_img_element ) {
 		$object_position = '';
 		if ( isset( $attributes['focalPoint'] ) ) {
-			$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' .
-			round( $attributes['focalPoint']['y'] * 100 ) . '%';
+			$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
 		}
 
-		$image_template = '<img
-			class="wp-block-cover__image-background"
-			alt="%s"
-			src="%s"
-			style="object-position: %s"
-			data-object-fit="cover"
-			data-object-position="%s"
-		/>';
-
-		$image = sprintf(
-			$image_template,
-			esc_attr( get_the_post_thumbnail_caption() ),
-			esc_url( $current_featured_image ),
-			esc_attr( $object_position ),
-			esc_attr( $object_position )
+		$attr = array(
+			"class"                => "wp-block-cover__image-background",
+			"style"                => "object-position: " . $object_position,
+			"data-object-fit"      => "cover",
+			"data-object-position" => $object_position,
 		);
+
+		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );
 
 		$content = str_replace(
 			'</span><div',
@@ -66,7 +46,19 @@ function render_block_core_cover( $attributes, $content ) {
 			$content
 		);
 
+	} else {
+		if ( in_the_loop() ) {
+			update_post_thumbnail_cache();
+		}
+		$current_featured_image = get_the_post_thumbnail_url();
+		$content                = preg_replace(
+			'/class=\".*?\"/',
+			'${0} style="background-image:url(' . esc_url( $current_featured_image ) . ')"',
+			$content,
+			1
+		);
 	}
+
 
 	return $content;
 }

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -20,14 +20,14 @@ function render_block_core_cover( $attributes, $content ) {
 
 	if ( ! ( $attributes['hasParallax'] || $attributes['isRepeated'] ) ) {
 		$attr = array(
-			"class"           => "wp-block-cover__image-background",
-			"data-object-fit" => "cover",
+			'class'           => 'wp-block-cover__image-background',
+			'data-object-fit' => 'cover',
 		);
 
 		if ( isset( $attributes['focalPoint'] ) ) {
 			$object_position              = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
-			$attr["data-object-position"] = $object_position;
-			$attr["style"]                = "object-position: " . $object_position;
+			$attr['data-object-position'] = $object_position;
+			$attr['style']                = 'object-position: ' . $object_position;
 		}
 
 		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -14,29 +14,21 @@
  * @return string Returns the cover block markup, if useFeaturedImage is true.
  */
 function render_block_core_cover( $attributes, $content ) {
-	if ( false === $attributes['useFeaturedImage'] ) {
+	if ( 'image' !== $attributes['backgroundType'] || false === $attributes['useFeaturedImage'] ) {
 		return $content;
 	}
 
-	$is_image_background = 'image' === $attributes['backgroundType'];
-	if ( ! $is_image_background ) {
-		return $content;
-	}
-
-	$is_img_element = ! ( $attributes['hasParallax'] || $attributes['isRepeated'] );
-
-	if ( $is_img_element ) {
-		$object_position = '';
-		if ( isset( $attributes['focalPoint'] ) ) {
-			$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
-		}
-
+	if ( ! ( $attributes['hasParallax'] || $attributes['isRepeated'] ) ) {
 		$attr = array(
-			"class"                => "wp-block-cover__image-background",
-			"style"                => "object-position: " . $object_position,
-			"data-object-fit"      => "cover",
-			"data-object-position" => $object_position,
+			"class"           => "wp-block-cover__image-background",
+			"data-object-fit" => "cover",
 		);
+
+		if ( isset( $attributes['focalPoint'] ) ) {
+			$object_position              = round( $attributes['focalPoint']['x'] * 100 ) . '%' . ' ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
+			$attr["data-object-position"] = $object_position;
+			$attr["style"]                = "object-position: " . $object_position;
+		}
 
 		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );
 
@@ -58,7 +50,6 @@ function render_block_core_cover( $attributes, $content ) {
 			1
 		);
 	}
-
 
 	return $content;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow on from https://github.com/WordPress/gutenberg/pull/39658. 

## Why?
Improved logic, to that if cover is not an image, then do not both to load feature image. 
Ensure that `get_the_post_thumbnail` function is called, so that filters are run correctly. 
Ensure that `update_post_thumbnail_cache` is called, so that feature image are loaded into memory. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
