### PR TITLE
Separator Block: add border property for dots style to editor stylesheet

### DIFF
--- a/packages/block-library/src/separator/editor.scss
+++ b/packages/block-library/src/separator/editor.scss
@@ -7,5 +7,6 @@
 	// due to the way that color block supports adds additional background color styles.
 	&.wp-block-separator.is-style-dots {
 		background: none !important;
+		border: none;
 	}
 }

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -8,7 +8,7 @@
 		// Override any background themes often set on the hr tag for this style.
 		// also override the color set in the editor since it's intented for normal HR
 		background: none !important;
-		border: none;
+		border: none !important;
 		text-align: center;
 		line-height: 1;
 		height: auto;

--- a/packages/block-library/src/separator/style.scss
+++ b/packages/block-library/src/separator/style.scss
@@ -8,7 +8,7 @@
 		// Override any background themes often set on the hr tag for this style.
 		// also override the color set in the editor since it's intented for normal HR
 		background: none !important;
-		border: none !important;
+		border: none;
 		text-align: center;
 		line-height: 1;
 		height: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds a `border: none` property for the dots style of the separator block to the block's editor.scss file. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the dots style renders a border below the dots in the editor when border settings have been set in the `theme.json` file.

| Before      | After |
| ----------- | ----------- |
| <img width="657" alt="image" src="https://user-images.githubusercontent.com/1645628/166973592-f721a0f3-f730-4750-a8ba-5e8813a4663e.png">      | <img width="689" alt="image" src="https://user-images.githubusercontent.com/1645628/166973929-a6e27e8b-ecee-43b9-a23a-1e13a2fa1c78.png">       |

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This is happening because the theme.json border CSS for the separator appears at a higher precedence than the `.is-style-dots` CSS. The border property in the editor.scss overrides this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Activate Twenty Twenty-Two
2. Add the following separator settings to the `theme.json` file:
```
"core/separator": {
    "border": {
        "color": "#000",
        "style": "solid",
        "width": "0 0 1px 0"
    }
}
```
3. Edit a post or page
4. Insert a separator block
5. Change the style of the separator block to the dots style
6. Without this PR, you should see a solid border below the dots in the editor (it displays correctly on the front end)