### PR TITLE
Set 0o777 permissions on downloaded sources

### DIFF
--- a/packages/env/lib/download-sources.js
+++ b/packages/env/lib/download-sources.js
@@ -71,7 +71,8 @@ module.exports = function downloadSources( config, spinner ) {
 
 /**
  * Downloads the given source if necessary. The specific action taken depends
- * on the source type. The source is downloaded to source.path.
+ * on the source type. The source is downloaded to source.path and rwx permissions
+ * are applied.
  *
  * @param {WPSource} source             The source to download.
  * @param {Object}   options
@@ -85,6 +86,8 @@ async function downloadSource( source, options ) {
 	} else if ( source.type === 'zip' ) {
 		await downloadZipSource( source, options );
 	}
+
+	await fs.promises.chmod( source.path, 0o777 );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Sets permissions on downloaded sources after downloading them 

## Why?
There is a problem in wp-env where sources (especially downloaded ones, apparently) can have insufficient permissions, which means Wordpress may not start whatsoever.

## How?
Set 777 (rwx) permissions for all users for all downloaded sources.

## Testing Instructions
1. checkout this branch
2. run `packages/env/bin/wp-env start --update` and see if it solves the problem
3. CI (since it uses wp-env as well)

## Screenshots or screencast <!-- if applicable -->
n/a