### PR TITLE
Fix external styles leaking into Warning component

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -11,145 +11,59 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreHorizontal } from '@wordpress/icons';
 
-export class GutenbergWarningInner extends window.HTMLElement {}
-
-export class GutenbergWarning extends window.HTMLElement {
-	connectedCallback() {
-		const shadowRoot = this.attachShadow( { mode: 'closed' } );
-		shadowRoot.innerHTML = `
-      <style> 
-
-			:host { 
-        display: contents 
-      }
-
-			gutenberg-warning-inner {
-				display: contents;
-			}
-
-			.block-editor-warning {
-				align-items: center;
-				display: flex;
-				flex-wrap: wrap;
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-				padding: 1em;
-				border: 1px solid #1e1e1e;
-				border-radius: 2px;
-				background-color: #fff;
-			}
-
-			.block-editor-warning .block-editor-warning__message {
-				line-height: 1.4;
-				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-				font-size: 13px;
-				color: #1e1e1e;
-				margin: 0;
-			}
-			.block-editor-warning p.block-editor-warning__message.block-editor-warning__message {
-				min-height: auto;
-			}
-			.block-editor-warning .block-editor-warning__contents {
-				display: flex;
-				flex-direction: row;
-				justify-content: space-between;
-				flex-wrap: wrap;
-				align-items: baseline;
-				width: 100%;
-			}
-			.block-editor-warning .block-editor-warning__actions {
-				display: flex;
-				margin-top: 1em;
-			}
-			.block-editor-warning .block-editor-warning__action {
-				margin: 0 8px 0 0;
-			}
-
-			.block-editor-warning__secondary {
-				margin: auto 0 auto 8px;
-			}
-
-			.components-popover.block-editor-warning__dropdown {
-				z-index: 99998;
-			}
-      </style> 
-      `;
-		this.style = 'all: initial;';
-
-		const inner = this.querySelector( 'gutenberg-warning-inner' );
-		const innerClone = inner.cloneNode( true );
-		shadowRoot.appendChild( innerClone );
-	}
-}
-
-window.customElements.define( 'gutenberg-warning', GutenbergWarning );
-window.customElements.define(
-	'gutenberg-warning-inner',
-	GutenbergWarningInner
-);
-
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
-		<gutenberg-warning>
-			<gutenberg-warning-inner>
-				<div
-					className={ classnames(
-						className,
-						'block-editor-warning'
-					) }
-				>
-					<div className="block-editor-warning__contents">
-						<p className="block-editor-warning__message">
-							{ children }
-						</p>
+		<div style={ { display: 'contents', all: 'initial' } }>
+			<div className={ classnames( className, 'block-editor-warning' ) }>
+				<div className="block-editor-warning__contents">
+					<p className="block-editor-warning__message">
+						{ children }
+					</p>
 
-						{ ( Children.count( actions ) > 0 ||
-							secondaryActions ) && (
-							<div className="block-editor-warning__actions">
-								{ Children.count( actions ) > 0 &&
-									Children.map( actions, ( action, i ) => (
-										<span
-											key={ i }
-											className="block-editor-warning__action"
-										>
-											{ action }
-										</span>
-									) ) }
-								{ secondaryActions && (
-									<DropdownMenu
-										className="block-editor-warning__secondary"
-										icon={ moreHorizontal }
-										label={ __( 'More options' ) }
-										popoverProps={ {
-											position: 'bottom left',
-											className:
-												'block-editor-warning__dropdown',
-										} }
-										noIcons
+					{ ( Children.count( actions ) > 0 || secondaryActions ) && (
+						<div className="block-editor-warning__actions">
+							{ Children.count( actions ) > 0 &&
+								Children.map( actions, ( action, i ) => (
+									<span
+										key={ i }
+										className="block-editor-warning__action"
 									>
-										{ () => (
-											<MenuGroup>
-												{ secondaryActions.map(
-													( item, pos ) => (
-														<MenuItem
-															onClick={
-																item.onClick
-															}
-															key={ pos }
-														>
-															{ item.title }
-														</MenuItem>
-													)
-												) }
-											</MenuGroup>
-										) }
-									</DropdownMenu>
-								) }
-							</div>
-						) }
-					</div>
+										{ action }
+									</span>
+								) ) }
+							{ secondaryActions && (
+								<DropdownMenu
+									className="block-editor-warning__secondary"
+									icon={ moreHorizontal }
+									label={ __( 'More options' ) }
+									popoverProps={ {
+										position: 'bottom left',
+										className:
+											'block-editor-warning__dropdown',
+									} }
+									noIcons
+								>
+									{ () => (
+										<MenuGroup>
+											{ secondaryActions.map(
+												( item, pos ) => (
+													<MenuItem
+														onClick={ item.onClick }
+														key={ pos }
+													>
+														{ item.title }
+													</MenuItem>
+												)
+											) }
+										</MenuGroup>
+									) }
+								</DropdownMenu>
+							) }
+						</div>
+					) }
 				</div>
-			</gutenberg-warning-inner>
-		</gutenberg-warning>
+			</div>
+		</div>
 	);
 }
 

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -11,54 +11,145 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreHorizontal } from '@wordpress/icons';
 
+export class GutenbergWarningInner extends window.HTMLElement {}
+
+export class GutenbergWarning extends window.HTMLElement {
+	connectedCallback() {
+		const shadowRoot = this.attachShadow( { mode: 'closed' } );
+		shadowRoot.innerHTML = `
+      <style> 
+
+			:host { 
+        display: contents 
+      }
+
+			gutenberg-warning-inner {
+				display: contents;
+			}
+
+			.block-editor-warning {
+				align-items: center;
+				display: flex;
+				flex-wrap: wrap;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				padding: 1em;
+				border: 1px solid #1e1e1e;
+				border-radius: 2px;
+				background-color: #fff;
+			}
+
+			.block-editor-warning .block-editor-warning__message {
+				line-height: 1.4;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				font-size: 13px;
+				color: #1e1e1e;
+				margin: 0;
+			}
+			.block-editor-warning p.block-editor-warning__message.block-editor-warning__message {
+				min-height: auto;
+			}
+			.block-editor-warning .block-editor-warning__contents {
+				display: flex;
+				flex-direction: row;
+				justify-content: space-between;
+				flex-wrap: wrap;
+				align-items: baseline;
+				width: 100%;
+			}
+			.block-editor-warning .block-editor-warning__actions {
+				display: flex;
+				margin-top: 1em;
+			}
+			.block-editor-warning .block-editor-warning__action {
+				margin: 0 8px 0 0;
+			}
+
+			.block-editor-warning__secondary {
+				margin: auto 0 auto 8px;
+			}
+
+			.components-popover.block-editor-warning__dropdown {
+				z-index: 99998;
+			}
+      </style> 
+      `;
+		this.style = 'all: initial;';
+
+		const inner = this.querySelector( 'gutenberg-warning-inner' );
+		const innerClone = inner.cloneNode( true );
+		shadowRoot.appendChild( innerClone );
+	}
+}
+
+window.customElements.define( 'gutenberg-warning', GutenbergWarning );
+window.customElements.define(
+	'gutenberg-warning-inner',
+	GutenbergWarningInner
+);
+
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
-		<div className={ classnames( className, 'block-editor-warning' ) }>
-			<div className="block-editor-warning__contents">
-				<p className="block-editor-warning__message">{ children }</p>
+		<gutenberg-warning>
+			<gutenberg-warning-inner>
+				<div
+					className={ classnames(
+						className,
+						'block-editor-warning'
+					) }
+				>
+					<div className="block-editor-warning__contents">
+						<p className="block-editor-warning__message">
+							{ children }
+						</p>
 
-				{ ( Children.count( actions ) > 0 || secondaryActions ) && (
-					<div className="block-editor-warning__actions">
-						{ Children.count( actions ) > 0 &&
-							Children.map( actions, ( action, i ) => (
-								<span
-									key={ i }
-									className="block-editor-warning__action"
-								>
-									{ action }
-								</span>
-							) ) }
-						{ secondaryActions && (
-							<DropdownMenu
-								className="block-editor-warning__secondary"
-								icon={ moreHorizontal }
-								label={ __( 'More options' ) }
-								popoverProps={ {
-									position: 'bottom left',
-									className: 'block-editor-warning__dropdown',
-								} }
-								noIcons
-							>
-								{ () => (
-									<MenuGroup>
-										{ secondaryActions.map(
-											( item, pos ) => (
-												<MenuItem
-													onClick={ item.onClick }
-													key={ pos }
-												>
-													{ item.title }
-												</MenuItem>
-											)
+						{ ( Children.count( actions ) > 0 ||
+							secondaryActions ) && (
+							<div className="block-editor-warning__actions">
+								{ Children.count( actions ) > 0 &&
+									Children.map( actions, ( action, i ) => (
+										<span
+											key={ i }
+											className="block-editor-warning__action"
+										>
+											{ action }
+										</span>
+									) ) }
+								{ secondaryActions && (
+									<DropdownMenu
+										className="block-editor-warning__secondary"
+										icon={ moreHorizontal }
+										label={ __( 'More options' ) }
+										popoverProps={ {
+											position: 'bottom left',
+											className:
+												'block-editor-warning__dropdown',
+										} }
+										noIcons
+									>
+										{ () => (
+											<MenuGroup>
+												{ secondaryActions.map(
+													( item, pos ) => (
+														<MenuItem
+															onClick={
+																item.onClick
+															}
+															key={ pos }
+														>
+															{ item.title }
+														</MenuItem>
+													)
+												) }
+											</MenuGroup>
 										) }
-									</MenuGroup>
+									</DropdownMenu>
 								) }
-							</DropdownMenu>
+							</div>
 						) }
 					</div>
-				) }
-			</div>
-		</div>
+				</div>
+			</gutenberg-warning-inner>
+		</gutenberg-warning>
 	);
 }
 

--- a/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
@@ -2,16 +2,25 @@
 
 exports[`Warning should match snapshot 1`] = `
 <div
-  className="block-editor-warning"
+  style={
+    Object {
+      "all": "initial",
+      "display": "contents",
+    }
+  }
 >
   <div
-    className="block-editor-warning__contents"
+    className="block-editor-warning"
   >
-    <p
-      className="block-editor-warning__message"
+    <div
+      className="block-editor-warning__contents"
     >
-      error
-    </p>
+      <p
+        className="block-editor-warning__message"
+      >
+        error
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/packages/block-editor/src/components/warning/test/index.js
+++ b/packages/block-editor/src/components/warning/test/index.js
@@ -18,7 +18,7 @@ describe( 'Warning', () => {
 	it( 'should have valid class', () => {
 		const wrapper = shallow( <Warning /> );
 
-		expect( wrapper.hasClass( 'block-editor-warning' ) ).toBe( true );
+		expect( wrapper.find( '.block-editor-warning' ) ).toHaveLength( 1 );
 		expect( wrapper.find( '.block-editor-warning__actions' ) ).toHaveLength(
 			0
 		);


### PR DESCRIPTION
## What?
Fix #40536

## Why?
External styles have been leaking into the `<Warning />` component. 

## How?
Using the the `all: initial` and `display: content`. Some of the previous approaches are summarized in https://github.com/WordPress/gutenberg/issues/40536#issuecomment-1120101021

Initially, I've tried to use the Shadow DOM to fix this as suggested in https://github.com/WordPress/gutenberg/pull/40847#issuecomment-1118689846

I've have since realised that the Shadow DOM prevents the styles **inside** of it from leaking to the **outside** but we needed the opposite - the component NOT to be affected by the outside styles. 

The key to figuring out this problem was realizing that certain CSS properties are inheritable and that they are the ones that are "leaking" _into_ the `<Warning/>` component and messing up the styling. The Shadow DOM [does not](https://open-wc.org/guides/knowledge/styling/styles-piercing-shadow-dom/) prevent those properties from being inherited. In order to prevent this, we need [`all: initial`](https://developer.mozilla.org/en-US/docs/Web/CSS/all) (as also mentioned in the linked article).

I've also considered marking **only** the [inheritable properties](https://gist.github.com/dcneiner/1137601) with `initial` but it's not necessary. This is because the "wrapping" div gets all of its styles reset to `inital` but its descendants are only influenced by the inheritable styles:

```jsx
{/* This is the "wrapping" div that gets all styles reset to `initial`. */}
<div style={{ display: 'contents', all: 'initial' }}>

  { /* This element's styles are only influenced by styles that are inheritable! 
        So it doesn't matter if non-inheritable styles are ALSO reset on the its parent! */}
  <div className={ classnames( className, 'block-editor-warning' ) }> 
    
    <div className="block-editor-warning__contents">
    .... more content
    </div>
  </div>
</div>
```

## Caveats

There are two (related) caveats with this approach that I'm not 100% happy with but I guess we can live with them:

1. Styles in our [reset.css](https://github.com/WordPress/gutenberg/blob/942e40d919d8466a01761b65252df12bfaf33ef8/packages/block-library/src/reset.scss#L1) are NOT going to be applied to the `<Warning/>`.

2. User Agent styles are [NOT going to be applied](https://drafts.csswg.org/css-cascade/#:~:text=Note%2C%20however%2C%20that%20any%20%22default%22%20style%20applied%20to%20that%20element%20(such%20as%2C%20e.g.%20display%3A%20block%20from%20the%20UA%20style%20sheet%20on%20block%20elements%20such%20as%20%3Cdiv%3E)%20will%20also%20be%20blown%20away.) either. 

I have noticed that there is a tiny discrepancy in how the warnings render pre- and post- this PR. I think this is because some padding is defined in `em` and setting `all: initial` resets the `font-size` which is what controls the "unit" of the `em`:


https://user-images.githubusercontent.com/5417266/167521113-f5706f05-030b-4a1c-95ca-550f4cef2614.mp4



## Screenshots or screencast

(This is outdated because it was made when the PR was not finished):

https://www.loom.com/share/2b82de57b1b44ba9a21ebc84150642b1

-----
