### PR TITLE
Gallery block: Include image caption when converting a classic block gallery

### DIFF
--- a/packages/block-library/src/gallery/use-short-code-transform.js
+++ b/packages/block-library/src/gallery/use-short-code-transform.js
@@ -34,6 +34,7 @@ export default function useShortCodeTransform( shortCodeTransforms ) {
 						mime: imageData.mime_type,
 						alt: imageData.alt_text,
 						link: imageData.link,
+						caption: imageData?.caption?.raw,
 					};
 				}
 				return undefined;


### PR DESCRIPTION
## What?
Includes image caption if set when transforming a Classic block Gallery/Short code
Fixes: #19921

## Why?
Currently the image captions are lost when converting a Classic block gallery to a Gallery block

## How?
Transfers the caption retrieved from getMedia call to the new Image block attribs

## Testing Instructions

- Add a Classic block and add a Gallery to it, and set the captions for the selected images in the WP media browser before inserting in the gallery
- Convert the Classic block to Blocks using the `Convert to blocks` button in the toolbar
- Check that the captions are still present in the new Gallery block images

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/167066059-814a9e69-f2a8-4300-b08a-22595a8f934c.mp4

After:

https://user-images.githubusercontent.com/3629020/167065922-9a3d05b9-78cd-426f-8e0f-73e741a8c24a.mp4


