### PR TITLE
Cover: Update background type when using featured image

### DIFF
--- a/packages/block-library/src/cover/edit.js
+++ b/packages/block-library/src/cover/edit.js
@@ -343,8 +343,13 @@ function CoverEdit( {
 
 	const toggleUseFeaturedImage = () => {
 		setAttributes( {
+			id: undefined,
+			url: undefined,
 			useFeaturedImage: ! useFeaturedImage,
 			dimRatio: dimRatio === 100 ? 50 : dimRatio,
+			backgroundType: useFeaturedImage
+				? IMAGE_BACKGROUND_TYPE
+				: undefined,
 		} );
 	};
 


### PR DESCRIPTION
## What?
Resolves #40871.

PR fixes the issue when the cover block displays video on the front end even after selecting the "Use featured image" option.

## Why?
The featured image toggle action didn't update the `backgroundType` attribute, and the `render_callback` only changes the block content for the image background type.

I understand this action is meant to be "non-destructive," but the block generates incompatible markup for the render callback without this change.

Users can use the "undo" functionality to restore the original state of the block.

## How?
Updates `toggleUseFeaturedImage` callback to rest required attributes.

## Testing Instructions
1. Open a Post or Page
2. Insert a Cover Block, and set it to display video.
3. Set the post's featured image.
4. Set the cover block to use the featured image.
5. Save the post.
6. Confirm that the featured image is displayed.
