### PR TITLE
Remove Navigation screen from experiments page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -40,17 +40,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg_display_experiment_section',
 		'gutenberg-experiments'
 	);
-	add_settings_field(
-		'gutenberg-navigation',
-		__( 'Navigation', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable Navigation screen', 'gutenberg' ),
-			'id'    => 'gutenberg-navigation',
-		)
-	);
+
 	add_settings_field(
 		'gutenberg-list-v2',
 		__( 'List block v2', 'gutenberg' ),

--- a/lib/init.php
+++ b/lib/init.php
@@ -30,7 +30,9 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	if ( get_option( 'gutenberg-experiments' ) ) {
+	// The navigation editor menu item is temporarily removed by hardcoding `false` here.
+	// See https://github.com/WordPress/gutenberg/pull/40878 for more info.
+	if ( false && get_option( 'gutenberg-experiments' ) ) {
 		if ( array_key_exists( 'gutenberg-navigation', get_option( 'gutenberg-experiments' ) ) ) {
 			add_submenu_page(
 				'gutenberg',

--- a/lib/init.php
+++ b/lib/init.php
@@ -30,20 +30,6 @@ function gutenberg_menu() {
 		'gutenberg'
 	);
 
-	// The navigation editor menu item is temporarily removed by hardcoding `false` here.
-	// See https://github.com/WordPress/gutenberg/pull/40878 for more info.
-	if ( false && get_option( 'gutenberg-experiments' ) ) {
-		if ( array_key_exists( 'gutenberg-navigation', get_option( 'gutenberg-experiments' ) ) ) {
-			add_submenu_page(
-				'gutenberg',
-				__( 'Navigation (beta)', 'gutenberg' ),
-				__( 'Navigation (beta)', 'gutenberg' ),
-				'edit_theme_options',
-				'gutenberg-navigation',
-				'gutenberg_navigation_page'
-			);
-		}
-	}
 	if ( current_user_can( 'edit_posts' ) ) {
 		add_submenu_page(
 			'gutenberg',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

📣 This is not a formal removal or ending of the Navigation Editor project. It is a stop gap whilst we consider the future of the project. See `Why` below.

As suggested in https://github.com/WordPress/gutenberg/issues/40822#issuecomment-1119238535 by @talldan, this PR removes the Navigation screen from the Gutenberg Experiments page. This means it can now only be accessed directly via URL.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Contributors are getting bug reports regarding this screen but it is not currently being actively maintained or worked on. This takes up time.

I decided against completely deleting the feature because there's been no official discussion or decision on that. However, this is a nice simple step that will help stem the flow of Issues being reported for a project which is not maintained.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the screen from the PHP which registers items on the Experiments page.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Goto Experiments page at http://localhost:8888/wp-admin/admin.php?page=gutenberg-experiments
2. Verify that the Navigation Editor experiment no longer appears.

## Screenshots or screencast <!-- if applicable -->
