### PR TITLE
Provide translators comment for Font size and Letter Case

### DIFF
--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -130,6 +130,7 @@ export function TypographyPanel( props ) {
 			{ ! isFontSizeDisabled && (
 				<ToolsPanelItem
 					hasValue={ () => hasFontSizeValue( props ) }
+					/* translators: Ensure translation is distinct from "Letter case" */
 					label={ __( 'Font size' ) }
 					onDeselect={ () => resetFontSize( props ) }
 					isShownByDefault={ defaultControls?.fontSize }
@@ -205,6 +206,7 @@ export function TypographyPanel( props ) {
 				<ToolsPanelItem
 					className="single-column"
 					hasValue={ () => hasTextTransformValue( props ) }
+					/* translators: Ensure translation is distinct from "Font size" */
 					label={ __( 'Letter case' ) }
 					onDeselect={ () => resetTextTransform( props ) }
 					isShownByDefault={ defaultControls?.textTransform }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Provide translators' comment for "Font size" and "Letter Case" in the typography panel to make it less likely for these two strings to be translated the same way.

Fixes #38329

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
In some languages - ie. Polish - it's possible to provide similar translations for both strings, this translator's comment will help to prompt translators to ensure uniqueness between the two.

Apart from possibly this making the UI confusing with two settings behind the same name it also caused the UI to not render correctly as we sometimes rely on labels as unique identifiers ie. like with the Tools Panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Update block-editor `TypographyPanel` to provide translators' comments to reduce the chance of this issue reappearing.

