### PR TITLE
Templates: Only allow renaming user-created and non-default templates

### DIFF
--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -29,7 +29,8 @@ export default function EditTemplateTitle() {
 	const { getEditorSettings } = useSelect( editorStore );
 	const { updateEditorSettings } = useDispatch( editorStore );
 
-	if ( template.has_theme_file ) {
+	// Only user-created and non-default templates can change the name.
+	if ( ! template.is_custom || template.has_theme_file ) {
 		return null;
 	}
 

--- a/packages/edit-site/src/components/template-details/index.js
+++ b/packages/edit-site/src/components/template-details/index.js
@@ -50,6 +50,9 @@ export default function TemplateDetails( { template, onClose } ) {
 		postId: undefined,
 	} );
 
+	// Only user-created and non-default templates can change the name.
+	const canEditTitle = template.is_custom && ! template.has_theme_file;
+
 	if ( ! template ) {
 		return null;
 	}
@@ -62,7 +65,7 @@ export default function TemplateDetails( { template, onClose } ) {
 	return (
 		<div className="edit-site-template-details">
 			<div className="edit-site-template-details__group">
-				{ template.is_custom ? (
+				{ canEditTitle ? (
 					<EditTemplateTitle template={ template } />
 				) : (
 					<Heading


### PR DESCRIPTION
## What?
Resolves #40876.

PR disabled the title editing field for WP default templates and custom templates defined by the theme.

## Why?
Renaming these templates will break pages/views assigned to them.

## How?
Updates check to use both `is_custom` and `has_theme_file` properties.

* The `is_custom` property is true when the template isn't in the list of default WP templates.
* The `has_theme_file` is set for templates that have corresponding theme files.

## Testing Instructions

Instructions for the issue.

> - Activate a block theme that does not have a template for pages. For example [https://wordpress.org/themes/miniblock-ooak/](https://wordpress.org/themes/miniblock-ooak/)
> - Open the Site Editor, template list, and select "Add new" and then "page".
> - Create a new page in the block editor.
> - Confirm that the default template is the page template you just created and not "index"
> - Select the Edit link in the Template section to open the template editor
> - Click on the template name at the top center above the content area to open the template options modal.
> - Change the template name in the input, and select Update (save).

Additional testing:
* Confirm that you can change custom template names.
* Switch to TT2.
* Go to Site Editor > Templates
* Pick "Blank" template.
* Confirm that the name edit field isn't displayed in the header dropdown.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-05-06 at 13 27 36](https://user-images.githubusercontent.com/240569/167105478-99d8d5ce-b0c5-41e9-8a63-0dfb5a844349.png)

