### PR TITLE
Fix vertical alignment of rows in nav panel

### DIFF
--- a/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/style.scss
+++ b/packages/edit-site/src/components/sidebar/navigation-menu-sidebar/style.scss
@@ -14,7 +14,6 @@
 	padding: $grid-unit-20;
 
 	.block-editor-list-view-leaf .block-editor-list-view-block-contents {
-		align-items: flex-start;
 		white-space: normal;
 	}
 


### PR DESCRIPTION
## What?
Updates the vertical alignment of elements inside rows in the Navigation Menus panel to be centrally aligned:

<img width="1243" alt="Screenshot 2022-05-06 at 11 22 37" src="https://user-images.githubusercontent.com/846565/167114180-92736fa2-b915-44f2-8fae-935b90ce01d2.png">


## Why?
Because the current alignment is inconsistent with other implementations. Compare List View with the Navigation Menus panel:

<img width="1243" alt="Screenshot 2022-05-06 at 11 21 54" src="https://user-images.githubusercontent.com/846565/167114056-e576ce94-3908-484e-a501-a5e6acf29455.png">

Notice that the text label is mis-aligned.


## How?
Updates `align-items` on `.edit-site-navigation-inspector .block-editor-list-view-leaf .block-editor-list-view-block-contents`.

## Testing Instructions
1. Open the Site Editor
2. Open the Navigation Panel
3. Select a Menu
4. Ensure the elements in each row are centrally aligned on the X axis.
