### PR TITLE
[RNMobile] Allow dragging from block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -253,14 +253,20 @@ const BlockDraggableWrapper = ( { children } ) => {
  * This component serves for animating the block when it is being dragged.
  * Hence, it should be wrapped around the rendering of a block.
  *
- * @param {Object}      props           Component props.
- * @param {JSX.Element} props.children  Children to be rendered.
- * @param {string[]}    props.clientId  Client id of the block.
- * @param {boolean}     [props.enabled] Enables the draggable trigger.
+ * @param {Object}      props                    Component props.
+ * @param {JSX.Element} props.children           Children to be rendered.
+ * @param {string}      props.clientId           Client id of the block.
+ * @param {string}      [props.draggingClientId] Client id to use for dragging. If not defined, the value from `clientId` will be used.
+ * @param {boolean}     [props.enabled]          Enables the draggable trigger.
  *
  * @return {Function} Render function which includes the parameter `isDraggable` to determine if the block can be dragged.
  */
-const BlockDraggable = ( { clientId, children, enabled = true } ) => {
+const BlockDraggable = ( {
+	clientId,
+	children,
+	draggingClientId,
+	enabled = true,
+} ) => {
 	const wasBeingDragged = useRef( false );
 	const [ isEditingText, setIsEditingText ] = useState( false );
 
@@ -289,7 +295,6 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 				getTemplateLock,
 				isBlockBeingDragged,
 				getSelectedBlockClientId,
-				hasSelectedInnerBlock,
 			} = _select( blockEditorStore );
 			const rootClientId = getBlockRootClientId( clientId );
 			const templateLock = rootClientId
@@ -301,9 +306,7 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 				isBeingDragged: isBlockBeingDragged( clientId ),
 				isDraggable: 'all' !== templateLock,
 				isBlockSelected:
-					selectedBlockClientId &&
-					( selectedBlockClientId === clientId ||
-						hasSelectedInnerBlock( clientId, true ) ),
+					selectedBlockClientId && selectedBlockClientId === clientId,
 			};
 		},
 		[ clientId ]
@@ -361,7 +364,7 @@ const BlockDraggable = ( { clientId, children, enabled = true } ) => {
 
 	return (
 		<DraggableTrigger
-			id={ clientId }
+			id={ draggingClientId || clientId }
 			enabled={ enabled && canDragBlock }
 			minDuration={ Platform.select( {
 				// On iOS, using a lower min duration than the default

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -209,7 +209,9 @@ class BlockListBlock extends Component {
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
 		const isFullWidthToolbar = isFullWidth( align ) || isScreenWidthEqual;
-		const hasParent = !! rootClientId;
+
+		const draggingEnabled = ! rootClientId;
+		const draggingClientId = clientId;
 
 		return (
 			<TouchableWithoutFeedback
@@ -260,8 +262,8 @@ class BlockListBlock extends Component {
 							/>
 						) }
 						<BlockDraggable
-							enabled={ ! hasParent }
-							clientId={ clientId }
+							enabled={ draggingEnabled }
+							clientId={ draggingClientId }
 						>
 							{ () =>
 								isValid ? (
@@ -288,6 +290,8 @@ class BlockListBlock extends Component {
 									blockWidth={ blockWidth }
 									anchorNodeRef={ this.anchorNodeRef.current }
 									isFullWidth={ isFullWidthToolbar }
+									draggingEnabled={ draggingEnabled }
+									draggingClientId={ draggingClientId }
 								/>
 							) }
 						</View>

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -190,7 +190,8 @@ class BlockListBlock extends Component {
 			marginHorizontal,
 			isInnerBlockSelected,
 			name,
-			rootClientId,
+			draggingEnabled,
+			draggingClientId,
 		} = this.props;
 
 		if ( ! attributes || ! blockType ) {
@@ -209,9 +210,6 @@ class BlockListBlock extends Component {
 		const isScreenWidthEqual = blockWidth === screenWidth;
 		const isScreenWidthWider = blockWidth < screenWidth;
 		const isFullWidthToolbar = isFullWidth( align ) || isScreenWidthEqual;
-
-		const draggingEnabled = ! rootClientId;
-		const draggingClientId = clientId;
 
 		return (
 			<TouchableWithoutFeedback
@@ -329,6 +327,7 @@ export default compose( [
 			getLowestCommonAncestorWithSelectedBlock,
 			getBlockParents,
 			hasSelectedInnerBlock,
+			getBlockHierarchyRootClientId,
 		} = select( blockEditorStore );
 
 		const order = getBlockIndex( clientId );
@@ -373,6 +372,15 @@ export default compose( [
 		const baseGlobalStyles = getSettings()
 			?.__experimentalGlobalStylesBaseStyles;
 
+		const topRootClientId = getBlockHierarchyRootClientId( clientId );
+		const isRootBlock = clientId === topRootClientId;
+		// For blocks with inner blocks, we only enable the dragging in the nested blocks. This way
+		// we prevent the long-press gesture from being disabled for elements within the block UI.
+		const draggingEnabled = ! isRootBlock || ! isInnerBlockSelected;
+		// Dragging nested blocks is not supported yet. For this reason, the block to be dragged
+		// will be the top in the hierarchy.
+		const draggingClientId = topRootClientId;
+
 		return {
 			icon,
 			name: name || 'core/missing',
@@ -380,6 +388,8 @@ export default compose( [
 			title,
 			attributes,
 			blockType,
+			draggingClientId,
+			draggingEnabled,
 			isSelected,
 			isInnerBlockSelected,
 			isValid,

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -288,7 +288,6 @@ class BlockListBlock extends Component {
 									blockWidth={ blockWidth }
 									anchorNodeRef={ this.anchorNodeRef.current }
 									isFullWidth={ isFullWidthToolbar }
-									draggingEnabled={ draggingEnabled }
 									draggingClientId={ draggingClientId }
 								/>
 							) }

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -260,8 +260,9 @@ class BlockListBlock extends Component {
 							/>
 						) }
 						<BlockDraggable
+							clientId={ clientId }
+							draggingClientId={ draggingClientId }
 							enabled={ draggingEnabled }
-							clientId={ draggingClientId }
 						>
 							{ () =>
 								isValid ? (
@@ -319,6 +320,7 @@ export default compose( [
 	withSelect( ( select, { clientId } ) => {
 		const {
 			getBlockIndex,
+			getBlockCount,
 			getSettings,
 			isBlockSelected,
 			getBlock,
@@ -371,14 +373,17 @@ export default compose( [
 		const baseGlobalStyles = getSettings()
 			?.__experimentalGlobalStylesBaseStyles;
 
-		const topRootClientId = getBlockHierarchyRootClientId( clientId );
-		const isRootBlock = clientId === topRootClientId;
-		// For blocks with inner blocks, we only enable the dragging in the nested blocks. This way
-		// we prevent the long-press gesture from being disabled for elements within the block UI.
-		const draggingEnabled = ! isRootBlock || ! isInnerBlockSelected;
+		const hasInnerBlocks = getBlockCount( clientId ) > 0;
+		// For blocks with inner blocks, we only enable the dragging in the nested
+		// blocks if any of them are selected. This way we prevent the long-press
+		// gesture from being disabled for elements within the block UI.
+		const draggingEnabled =
+			! hasInnerBlocks ||
+			isSelected ||
+			! hasSelectedInnerBlock( clientId, true );
 		// Dragging nested blocks is not supported yet. For this reason, the block to be dragged
 		// will be the top in the hierarchy.
-		const draggingClientId = topRootClientId;
+		const draggingClientId = getBlockHierarchyRootClientId( clientId );
 
 		return {
 			icon,

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -15,6 +15,7 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import styles from './style.scss';
 import BlockMover from '../block-mover';
+import BlockDraggable from '../block-draggable';
 import BlockActionsMenu from './block-actions-menu';
 import { BlockSettingsButton } from '../block-settings';
 import { store as blockEditorStore } from '../../store';
@@ -33,6 +34,8 @@ const BlockMobileToolbar = ( {
 	blockWidth,
 	anchorNodeRef,
 	isFullWidth,
+	draggingEnabled,
+	draggingClientId,
 } ) => {
 	const [ fillsLength, setFillsLength ] = useState( null );
 	const [ appenderWidth, setAppenderWidth ] = useState( 0 );
@@ -73,7 +76,12 @@ const BlockMobileToolbar = ( {
 				/>
 			) }
 
-			<View style={ styles.spacer } />
+			<BlockDraggable
+				enabled={ draggingEnabled }
+				clientId={ draggingClientId }
+			>
+				{ () => <View style={ styles.spacer } /> }
+			</BlockDraggable>
 
 			<BlockSettingsButton.Slot>
 				{ /* Render only one settings icon even if we have more than one fill - need for hooks with controls. */ }

--- a/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
+++ b/packages/block-editor/src/components/block-mobile-toolbar/index.native.js
@@ -34,7 +34,6 @@ const BlockMobileToolbar = ( {
 	blockWidth,
 	anchorNodeRef,
 	isFullWidth,
-	draggingEnabled,
 	draggingClientId,
 } ) => {
 	const [ fillsLength, setFillsLength ] = useState( null );
@@ -77,8 +76,8 @@ const BlockMobileToolbar = ( {
 			) }
 
 			<BlockDraggable
-				enabled={ draggingEnabled }
-				clientId={ draggingClientId }
+				clientId={ clientId }
+				draggingClientId={ draggingClientId }
 			>
 				{ () => <View style={ styles.spacer } /> }
 			</BlockDraggable>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently, the dragging gesture for a selected block is only allowed by long-pressing over the content. This PR adds the option to also initiate the dragging by long-pressing over the empty space within the block toolbar.

<img src=https://user-images.githubusercontent.com/14905380/167117067-b0ff44b2-3fdb-4ca3-8c23-89b8ef52ba82.png width=300>

Additionally, it also addresses an issue related to nested blocks where up/down arrow buttons within the block toolbar can't be used.

https://user-images.githubusercontent.com/14905380/167118366-7f0d99c5-6b11-41f5-90b3-aed814336ce2.mp4

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Addresses https://github.com/wordpress-mobile/gutenberg-mobile/issues/4791.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- The component `BlockDraggable` is being rendered in `BlockMobileToolbar` wrapping the spacer view, and the configuration values for the dragging are passed via props from the parent component `BlockListBlock`.
- For addressing the issue on nested blocks, I updated the logic related to calculating the `enable` prop. The idea is that for blocks that contain nested blocks, only the content (i.e. the nested blocks) triggers the dragging.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Root block
1. Open a post/page.
2. Add an Image block with an image.
3. Select the Image block.
4. Long-press over the up/down buttons located in the block toolbar.
5. Observe that a picker is displayed with expected options.
6. Long-press over the content of the Image block (i.e. over the image).
7. Observe that the drag mode is enabled.
8. Long-press over the empty space in the block toolbar.
9. Observe that the drag mode is enabled. 

### Block with nested blocks
1. Open a post/page.
2. Add a Group block.
3. Select the Group block.
4. Add different blocks into the Group block.
5. Check that the currently selected block is the Group block (i.e. not a nested block).
6. Long-press over the up/down buttons located in the block toolbar.
7. Observe that a picker is displayed with expected options.
10. Long-press over the content of the Group block.
11. Observe that the drag mode is enabled and the block being dragged is the Group block.
12. Long-press over the empty space in the block toolbar.
13. Observe that the drag mode is enabled and the block being dragged is the Group block.

### Nested block
1. Open a post/page.
2. Add a Group block.
3. Select the Group block.
4. Add different blocks into the Group block.
5. Select a nested block.
6. Long-press over the up/down buttons located in the block toolbar.
7. Observe that a picker is displayed with expected options.
8. Long-press over the content of the nested block.
9. Observe that the drag mode is enabled and the block being dragged is the Group block.
10. Long-press over the empty space in the block toolbar.
11. Observe that the drag mode is enabled and the block being dragged is the Group block.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/14905380/167120692-5ba7b406-2ecc-4c81-8460-a73dbf1fac62.mp4


