### PR TITLE
Fix: Global Styles are always resettable.

### DIFF
--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -20,7 +20,7 @@ import {
 import { getValueFromVariable, getPresetVariableFromValue } from './utils';
 import { GlobalStylesContext } from './context';
 
-const EMPTY_CONFIG = { isGlobalStylesUserThemeJSON: true, version: 1 };
+const EMPTY_CONFIG = { settings: {}, styles: {} };
 
 export const useGlobalStylesReset = () => {
 	const { user: config, setUserConfig } = useContext( GlobalStylesContext );


### PR DESCRIPTION
Props to @draganescu for reporting this issue.
isGlobalStylesUserThemeJSON and version are now managed on the server, and the reset hook was not updated to take into account this fact. That caused a bug where even after a reset canReset returned true and the user could "reset" the styles again. This PR fixes the issue and updates the canReset hook.
 


## Testing Instructions
I went to the site editor, reset the styles, and verified it was not possible to reset them again.
