### PR TITLE
Fix: Global Styles: Impossible to open welcome guide if global styles are empty.

### DIFF
--- a/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
+++ b/packages/edit-site/src/components/sidebar/global-styles-sidebar.js
@@ -37,11 +37,11 @@ export default function GlobalStylesSidebar() {
 						<DropdownMenu
 							icon={ moreVertical }
 							label={ __( 'More Global Styles Actions' ) }
-							toggleProps={ { disabled: ! canReset } }
 							controls={ [
 								{
 									title: __( 'Reset to defaults' ),
 									onClick: onReset,
+									isDisabled: ! canReset,
 								},
 								{
 									title: __( 'Welcome Guide' ),


### PR DESCRIPTION
The toggle menu on the global styles sidebar now opens the welcome guide and the option to reset the styles. But it is disabled if it is not possible to reset. This makes it impossible to open the welcome guide if the global styles are empty. This PR fixes the issue.