### PR TITLE
Theme Json: Don't output double selectors for elements inside blocks

### DIFF
--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -541,6 +541,11 @@ class WP_Theme_JSON_5_9 {
 			foreach ( static::ELEMENTS as $el_name => $el_selector ) {
 				$element_selector = array();
 				foreach ( $block_selectors as $selector ) {
+					if ( $selector === $el_selector ) {
+						$element_selector = array( $el_selector );
+						break;
+					}
+
 					$element_selector[] = $selector . ' ' . $el_selector;
 				}
 				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
@@ -14,7 +14,7 @@
  *
  * @access private
  */
-class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_5_9 {
+class WP_Theme_JSON_6_0 extends WP_Theme_JSON_5_9 {
 	/**
 	 * Metadata for style properties.
 	 *

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * WP_Theme_JSON_Gutenberg class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Class that encapsulates the processing of structures that adhere to the theme.json spec.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please,
+ * use get_global_settings, get_global_styles, and get_global_stylesheet instead.
+ *
+ * @access private
+ */
+class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
+	/**
+	 * Returns the metadata for each block.
+	 *
+	 * Example:
+	 *
+	 *     {
+	 *       'core/paragraph': {
+	 *         'selector': 'p',
+	 *         'elements': {
+	 *           'link' => 'link selector',
+	 *           'etc'  => 'element selector'
+	 *         }
+	 *       },
+	 *       'core/heading': {
+	 *         'selector': 'h1',
+	 *         'elements': {}
+	 *       },
+	 *       'core/image': {
+	 *         'selector': '.wp-block-image',
+	 *         'duotone': 'img',
+	 *         'elements': {}
+	 *       }
+	 *     }
+	 *
+	 * @return array Block metadata.
+	 */
+	protected static function get_blocks_metadata() {
+		if ( null !== static::$blocks_metadata ) {
+			return static::$blocks_metadata;
+		}
+
+		static::$blocks_metadata = array();
+
+		$registry = WP_Block_Type_Registry::get_instance();
+		$blocks   = $registry->get_all_registered();
+		foreach ( $blocks as $block_name => $block_type ) {
+			if (
+				isset( $block_type->supports['__experimentalSelector'] ) &&
+				is_string( $block_type->supports['__experimentalSelector'] )
+			) {
+				static::$blocks_metadata[ $block_name ]['selector'] = $block_type->supports['__experimentalSelector'];
+			} else {
+				static::$blocks_metadata[ $block_name ]['selector'] = '.wp-block-' . str_replace( '/', '-', str_replace( 'core/', '', $block_name ) );
+			}
+
+			if (
+				isset( $block_type->supports['color']['__experimentalDuotone'] ) &&
+				is_string( $block_type->supports['color']['__experimentalDuotone'] )
+			) {
+				static::$blocks_metadata[ $block_name ]['duotone'] = $block_type->supports['color']['__experimentalDuotone'];
+			}
+
+			// Assign defaults, then overwrite those that the block sets by itself.
+			// If the block selector is compounded, will append the element to each
+			// individual block selector.
+			$block_selectors = explode( ',', static::$blocks_metadata[ $block_name ]['selector'] );
+			foreach ( static::ELEMENTS as $el_name => $el_selector ) {
+				$element_selector = array();
+				foreach ( $block_selectors as $selector ) {
+					if ( $selector === $el_selector ) {
+						$element_selector = array( $el_selector );
+						break;
+					}
+
+					$element_selector[] = $selector . ' ' . $el_selector;
+				}
+				static::$blocks_metadata[ $block_name ]['elements'][ $el_name ] = implode( ',', $element_selector );
+			}
+		}
+
+		return static::$blocks_metadata;
+	}
+}

--- a/lib/experimental/class-wp-theme-json-gutenberg.php
+++ b/lib/experimental/class-wp-theme-json-gutenberg.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * WP_Theme_JSON_Gutenberg class
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Class that encapsulates the processing of structures that adhere to the theme.json spec.
+ *
+ * This class is for internal core usage and is not supposed to be used by extenders (plugins and/or themes).
+ * This is a low-level API that may need to do breaking changes. Please,
+ * use get_global_settings, get_global_styles, and get_global_stylesheet instead.
+ *
+ * @access private
+ */
+class WP_Theme_JSON_Gutenberg extends WP_Theme_JSON_6_1 {
+
+}

--- a/lib/load.php
+++ b/lib/load.php
@@ -112,7 +112,7 @@ require __DIR__ . '/compat/wordpress-6.0/post-lock.php';
 require __DIR__ . '/compat/wordpress-6.0/blocks.php';
 require __DIR__ . '/compat/wordpress-6.0/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.0/functions.php';
-require __DIR__ . '/compat/wordpress-6.0/class-wp-theme-json-gutenberg.php';
+require __DIR__ . '/compat/wordpress-6.0/class-wp-theme-json-6-0.php';
 require __DIR__ . '/compat/wordpress-6.0/class-wp-theme-json-resolver-6-0.php';
 require __DIR__ . '/compat/wordpress-6.0/block-patterns.php';
 require __DIR__ . '/compat/wordpress-6.0/block-template.php';
@@ -123,11 +123,13 @@ require __DIR__ . '/compat/wordpress-6.0/client-assets.php';
 // WordPress 6.1 compat.
 require __DIR__ . '/compat/wordpress-6.1/blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
+require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';
 require __DIR__ . '/experimental/register-webfonts-from-theme-json.php';
+require __DIR__ . '/experimental/class-wp-theme-json-gutenberg.php';
 require __DIR__ . '/experimental/class-wp-theme-json-resolver-gutenberg.php';
 require __DIR__ . '/experimental/class-wp-webfonts.php';
 require __DIR__ . '/experimental/class-wp-webfonts-provider.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When elements are used inside blocks, if the element selector is the same as the block selector (as it is in the case of heading blocks) then the selector becomes doubled (e.g. h1 h1). To ensure we can use element declarations inside block definitions we need to ensure that when the selectors match we don't double them. Fixes https://github.com/WordPress/gutenberg/issues/39698.

## Why?
To make it possible to use element selectors inside heading block rules.

## How?
We detect whether the element selector matches the block selector. If it does, then we should only use one.

## Testing Instructions
1. Add this to your block theme:
```
		"blocks": {
			"core/heading": {
				"color": {
					"text": "blue"
				},
				"elements": {
					"h1": {
						"color": {
							"text": "purple"
						}
					}
				}
			}
		},
```
2. Add a post with multiple heading blocks.
3. Check that the h1 headings are purple, but the others are still blue.

## Screenshots or screencast <!-- if applicable -->
<img width="963" alt="Screenshot 2022-05-06 at 13 35 43" src="https://user-images.githubusercontent.com/275961/167132410-0688b5a7-0a65-4423-a9cc-eddbcff09026.png">

cc @WordPress/block-themers