### PR TITLE
DOM: Deprecate `isNumberInput` and fix its handling of value=0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17511,6 +17511,7 @@
 			"version": "file:packages/dom",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@wordpress/deprecated": "^3.8.0",
 				"lodash": "^4.17.21"
 			}
 		},

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Breaking Change
+### Deprecation
 
 - Deprecate `isNumberInput`, as it is no longer used internally ([#40896](https://github.com/WordPress/gutenberg/pull/40896)).
 

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Change
+
+- Deprecate `isNumberInput`, as it is no longer used internally.
+
 ## 3.8.0 (2022-05-04)
 
 ## 3.7.0 (2022-04-21)

--- a/packages/dom/CHANGELOG.md
+++ b/packages/dom/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking Change
 
-- Deprecate `isNumberInput`, as it is no longer used internally.
+- Deprecate `isNumberInput`, as it is no longer used internally ([#40896](https://github.com/WordPress/gutenberg/pull/40896)).
 
 ## 3.8.0 (2022-05-04)
 

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -211,8 +211,7 @@ _Returns_
 
 ### isNumberInput
 
-Check whether the given element is an input field of type number
-and has a valueAsNumber
+Check whether the given element is an input field of type number.
 
 _Parameters_
 
@@ -220,7 +219,7 @@ _Parameters_
 
 _Returns_
 
--   `node is HTMLInputElement`: True if the node is input and holds a number.
+-   `node is HTMLInputElement`: True if the node is number input.
 
 ### isPhrasingContent
 

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -29,6 +29,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@wordpress/deprecated": "^3.8.0",
 		"lodash": "^4.17.21"
 	},
 	"publishConfig": {

--- a/packages/dom/src/dom/is-number-input.js
+++ b/packages/dom/src/dom/is-number-input.js
@@ -1,18 +1,30 @@
 /**
+ * WordPress dependencies
+ */
+import deprecated from '@wordpress/deprecated';
+
+/**
  * Internal dependencies
  */
 import isHTMLInputElement from './is-html-input-element';
 
 /* eslint-disable jsdoc/valid-types */
 /**
- * Check whether the given element is an input field of type number
- * and has a valueAsNumber
+ * Check whether the given element is an input field of type number.
  *
  * @param {Node} node The HTML node.
  *
- * @return {node is HTMLInputElement} True if the node is input and holds a number.
+ * @return {node is HTMLInputElement} True if the node is number input.
  */
 export default function isNumberInput( node ) {
+	deprecated( 'wp.dom.isNumberInput', {
+		since: '6.1',
+		version: '6.5',
+	} );
 	/* eslint-enable jsdoc/valid-types */
-	return isHTMLInputElement( node ) && node.type === 'number';
+	return (
+		isHTMLInputElement( node ) &&
+		node.type === 'number' &&
+		! isNaN( node.valueAsNumber )
+	);
 }

--- a/packages/dom/src/dom/is-number-input.js
+++ b/packages/dom/src/dom/is-number-input.js
@@ -14,9 +14,5 @@ import isHTMLInputElement from './is-html-input-element';
  */
 export default function isNumberInput( node ) {
 	/* eslint-enable jsdoc/valid-types */
-	return (
-		isHTMLInputElement( node ) &&
-		node.type === 'number' &&
-		!! node.valueAsNumber
-	);
+	return isHTMLInputElement( node ) && node.type === 'number';
 }

--- a/packages/dom/src/test/dom.js
+++ b/packages/dom/src/test/dom.js
@@ -5,7 +5,6 @@ import {
 	isHorizontalEdge,
 	placeCaretAtHorizontalEdge,
 	isTextField,
-	isNumberInput,
 	removeInvalidHTML,
 	isEmpty,
 } from '../dom';
@@ -158,21 +157,6 @@ describe( 'DOM', () => {
 			expect( isTextField( document.createElement( 'textarea' ) ) ).toBe(
 				true
 			);
-		} );
-
-		it( 'should return false for empty input element of type number', () => {
-			const input = document.createElement( 'input' );
-			input.type = 'number';
-
-			expect( isNumberInput( input ) ).toBe( false );
-		} );
-
-		it( 'should return true for an input element of type number', () => {
-			const input = document.createElement( 'input' );
-			input.type = 'number';
-			input.valueAsNumber = 23;
-
-			expect( isNumberInput( input ) ).toBe( true );
 		} );
 
 		it( 'should return true for a contenteditable element', () => {


### PR DESCRIPTION
## What?
Follow-up on https://github.com/WordPress/gutenberg/pull/40192#issuecomment-1101524988.

* Deprecate `isNumberInput` in `@wordpress/dom`.
* Fix its logic so that it recognises `<input type="number" value="0">` as a correct number input.

## Why?
As of #40192, `isNumberInput` is no longer used in Gutenberg. This PR started out as just a fix to the faulty logic, until I realised we could also deprecate the function.

## How?
- Fix the case where a number input (`<input type="number">`) has a value of `0`, which was incorrectly rejected by `isNumberInput`.
- In order to keep compatibility for third-party uses, replace the above condition with `! isNaN( valueAsNumber )`.
- Deprecate the function using `@wordpress/deprecated`.

## Testing Instructions
- Ensure `isInputNumber` is not used in Gutenberg and that this change has no effects.
- Confirm the deprecation of the function by calling `wp.dom.isInputNumber` in a suitable environment.