### PR TITLE
Post Comments: Add Warning via editor.BlockEdit filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17163,6 +17163,7 @@
 				"@wordpress/date": "file:packages/date",
 				"@wordpress/deprecated": "file:packages/deprecated",
 				"@wordpress/dom": "file:packages/dom",
+				"@wordpress/editor": "file:packages/editor",
 				"@wordpress/element": "file:packages/element",
 				"@wordpress/hooks": "file:packages/hooks",
 				"@wordpress/html-entities": "file:packages/html-entities",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/date": "file:../date",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/editor": "file:../editor",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -227,7 +227,7 @@ export const withPostCommentsBlockDeprecationWarning = createHigherOrderComponen
 					.__experimentalDiscussionSettings
 		);
 
-		const isSiteEditor = postType === undefined || postId === undefined;
+		const isSiteEditor = ! postType || ! postId;
 
 		const postTypeSupportsComments = useSelect( ( select ) =>
 			postType

--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -13,6 +13,7 @@ import {
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
@@ -202,10 +203,16 @@ export default function PostCommentsEdit( {
 }
 
 export const withPostCommentsBlockDeprecationWarning = createHigherOrderComponent(
-	( BlockEdit ) => ( props, context ) => {
+	( BlockEdit ) => ( props ) => {
 		const { name } = props;
 
-		const { postType, postId } = context; // FIXME -- No block context available :(
+		// Unfortunately, the `editor.BlockEdit` filter doesn't give us access to
+		// block context from which we could infer postId and postType, so we
+		// have to gather that information ourselves.
+		const { postId, postType } = useSelect( ( select ) => ( {
+			postId: select( editorStore ).getCurrentPostId(),
+			postType: select( editorStore ).getCurrentPostType(),
+		} ) );
 
 		const [ commentStatus ] = useEntityProp(
 			'postType',


### PR DESCRIPTION
## What?
Purports to fix both #40536 and #40826.

## Why?
To fix those issues 😬 

## How?

As explained in https://github.com/WordPress/gutenberg/issues/40536#issuecomment-1119516263,

> Both this issue and #40826 originate from the fact that the Warning is displayed ["inside"](https://github.com/WordPress/gutenberg/blob/b53edba02f2fa4bf08988b0bdf3db7faad44126d/packages/block-library/src/post-comments/edit.js#L105) of the block.
>
> But there’s precedent for Warnings that are displayed outside (such as Invalid Block markup), and they don’t suffer from those issues. So I'd like to try that; I think there's hook for that.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast

## TODO

- [x] Infer `postId` and `postType` (since block context isn't available to the filter we're using)
