### PR TITLE
Table of Contents block: remove editor-only wrapper `<div>`.

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -15,13 +15,13 @@ import {
 } from '@wordpress/block-editor';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import {
-	Disabled,
 	PanelBody,
 	Placeholder,
 	ToggleControl,
 	ToolbarButton,
 	ToolbarGroup,
 } from '@wordpress/components';
+import { __experimentalUseDisabled as useDisabled } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { renderToString, useEffect } from '@wordpress/element';
@@ -55,6 +55,7 @@ export default function TableOfContentsEdit( {
 	setAttributes,
 } ) {
 	const blockProps = useBlockProps();
+	const disabledRef = useDisabled();
 
 	const listBlockExists = useSelect(
 		( select ) => !! select( blocksStore ).getBlockType( 'core/list' ),
@@ -285,13 +286,9 @@ export default function TableOfContentsEdit( {
 	return (
 		<>
 			<nav { ...blockProps }>
-				<Disabled>
-					<ol>
-						<TableOfContentsList
-							nestedHeadingList={ headingTree }
-						/>
-					</ol>
-				</Disabled>
+				<ol ref={ disabledRef }>
+					<TableOfContentsList nestedHeadingList={ headingTree } />
+				</ol>
 			</nav>
 			{ toolbarControls }
 			{ inspectorControls }


### PR DESCRIPTION
## What?
This PR removes the extra `<div>` in the Table of Contents block editor markup between the `<nav>` and `<ol>`.

## Why?
This makes the markup consistent between the editor and front-end, which will be helpful for future PRs. Specifically, I was working on a PR to add color controls to this block, and I didn't want to write editor-only styles to deal with the extra `<div>`.

## How?
By switching to `useDisabled` instead of the `<Disabled>` component, we can disable the `<ol>` of the Table of Contents directly, instead of having to wrap it.

## Testing Instructions
1. Insert several Heading blocks.
2. Insert a Table of Contents block.
3. Ensure that the links in the Table of Contents are non-interactive, just like in `trunk`.
