### PR TITLE
`WP_REST_Pattern_Directory_Controller::get_items` doesn't support array arguments

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -59,7 +59,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 
 		$transient_key = $this->get_transient_key( $query_args );
 
-		/*
+		/**
 		 * Use network-wide transient to improve performance. The locale is the only site
 		 * configuration that affects the response, and it's included in the transient key.
 		 */
@@ -126,7 +126,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 		return new WP_REST_Response( $response );
 	}
 
-	/*
+	/**
 	 * Include a hash of the query args, so that different requests are stored in
 	 * separate caches.
 	 *

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -136,7 +136,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 	 * @link https://stackoverflow.com/questions/3665247/fastest-hash-for-non-cryptographic-uses
 	 *
 	 * @since 6.0.0
-	 * @todo This should be removed when the minimum required WP version is >= 6.0.
+	 * @todo This should be removed when the minimum required WordPress version is >= 6.0.
 	 *
 	 * @param array $query_args Query arguments to generate a transient key from.
 	 * @return string Transient key.

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -75,10 +75,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 		$raw_patterns = get_site_transient( $transient_key );
 
 		if ( ! $raw_patterns ) {
-			$api_url = add_query_arg(
-				array_map( 'rawurlencode', $query_args ),
-				'http://api.wordpress.org/patterns/1.0/'
-			);
+			$api_url = 'http://api.wordpress.org/patterns/1.0/?' . build_query( $query_args );
 
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -136,6 +136,7 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 	 * @link https://stackoverflow.com/questions/3665247/fastest-hash-for-non-cryptographic-uses
 	 *
 	 * @since 6.0.0
+	 * @todo This should be removed when the minimum required WP version is >= 6.0.
 	 *
 	 * @param array $query_args Query arguments to generate a transient key from.
 	 * @return string Transient key.

--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-pattern-directory-controller.php
@@ -57,18 +57,9 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 			$query_args['slug'] = $slug;
 		}
 
-		/**
-		 * Include a hash of the query args, so that different requests are stored in
-		 * separate caches.
-		 *
-		 * MD5 is chosen for its speed, low-collision rate, universal availability, and to stay
-		 * under the character limit for `_site_transient_timeout_{...}` keys.
-		 *
-		 * @link https://stackoverflow.com/questions/3665247/fastest-hash-for-non-cryptographic-uses
-		 */
-		$transient_key = 'wp_remote_block_patterns_' . md5( implode( '-', $query_args ) );
+		$transient_key = $this->get_transient_key( $query_args );
 
-		/**
+		/*
 		 * Use network-wide transient to improve performance. The locale is the only site
 		 * configuration that affects the response, and it's included in the transient key.
 		 */
@@ -76,7 +67,6 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 
 		if ( ! $raw_patterns ) {
 			$api_url = 'http://api.wordpress.org/patterns/1.0/?' . build_query( $query_args );
-
 			if ( wp_http_supports( array( 'ssl' ) ) ) {
 				$api_url = set_url_scheme( $api_url, 'https' );
 			}
@@ -134,5 +124,40 @@ class Gutenberg_REST_Pattern_Directory_Controller extends WP_REST_Pattern_Direct
 		}
 
 		return new WP_REST_Response( $response );
+	}
+
+	/*
+	 * Include a hash of the query args, so that different requests are stored in
+	 * separate caches.
+	 *
+	 * MD5 is chosen for its speed, low-collision rate, universal availability, and to stay
+	 * under the character limit for `_site_transient_timeout_{...}` keys.
+	 *
+	 * @link https://stackoverflow.com/questions/3665247/fastest-hash-for-non-cryptographic-uses
+	 *
+	 * @since 6.0.0
+	 *
+	 * @param array $query_args Query arguments to generate a transient key from.
+	 * @return string Transient key.
+	 */
+	protected function get_transient_key( $query_args ) {
+		if ( method_exists( get_parent_class( $this ), __FUNCTION__ ) ) {
+			return parent::get_transient_key( $query_args );
+		}
+
+		if ( isset( $query_args['slug'] ) ) {
+			// This is an additional precaution because the "sort" function expects an array.
+			$query_args['slug'] = wp_parse_list( $query_args['slug'] );
+
+			// Empty arrays should not affect the transient key.
+			if ( empty( $query_args['slug'] ) ) {
+				unset( $query_args['slug'] );
+			} else {
+				// Sort the array so that the transient key doesn't depend on the order of slugs.
+				sort( $query_args['slug'] );
+			}
+		}
+
+		return 'wp_remote_block_patterns_' . md5( serialize( $query_args ) );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR aims to backport changes from https://github.com/WordPress/wordpress-develop/pull/2591 and https://github.com/WordPress/wordpress-develop/pull/2625 back to Gutenberg.

Fixes https://github.com/WordPress/gutenberg/issues/40824.


## Why?
This is needed to keep Core and Gutenberg as compatible as possible.

## Testing Instructions
1. Make sure you are using WordPress 5.9.x
2. Enable Gutenberg.
3. Install [this plugin](https://github.com/WP-API/Basic-Auth) to allow basic authorization for REST API requests.
4. Activate the plugin.
5. Send a GET request to your WordPress instance, e.g.:
```
curl --user username:user_password "http://your.wordpress.instance/wp-json/wp/v2/pattern-directory/patterns?slug=visual-navigation-with-rainbow-gradient,three-columns-of-text-with-buttons"
```
Replace 
```
username:user_password
```
with the actual credentials.
Replace 
```
http://your.wordpress.instance
```
with the actual URL of your instance.
5. Note the response. It should contain 2 patterns.
6. Send a GET request again, but this time replace the slug parameter
with some non-existent pattern. E.g.:
```
curl --user username:user_password "http://your.wordpress.instance/wp-json/wp/v2/pattern-directory/patterns?slug=non-existent-pattern"
```
7. The endpoint should return an empty response.
8. Repeat steps 2-7, but this time use WordPress 6.0.x (or the latest Beta/RC version if WordPress 6.0 is not released yet).