### PR TITLE
"Multiple use" block validation logic improvement.

### DIFF
--- a/packages/e2e-tests/specs/editor/various/validate-multiple-use.test.js
+++ b/packages/e2e-tests/specs/editor/various/validate-multiple-use.test.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, insertBlock } from '@wordpress/e2e-test-utils';
+
+describe( 'Validate multiple use', () => {
+	beforeEach( async () => {
+		await createNewPost();
+	} );
+
+	// Regression of: https://github.com/WordPress/gutenberg/pull/39813
+	it( 'should display correct amount of warning message', async () => {
+		const OPTIONS_SELECTOR =
+			'//div[contains(@class, "block-editor-block-settings-menu")]//button[contains(@aria-label, "Options")]';
+		const DUPLICATE_BUTTON_SELECTOR =
+			'//button[contains(@class, "components-menu-item__button")][contains(., "Duplicate")]';
+
+		// Insert a block with `multiple` feature enabled, such as `core/more`
+		await insertBlock( 'More' );
+
+		// Block toolbar options dropdown button
+		let optionButton = await page.waitForXPath( OPTIONS_SELECTOR );
+		await optionButton.click();
+
+		const groupButton = await page.waitForXPath(
+			'//button[contains(@class, "components-menu-item__button")][contains(., "Group")]'
+		);
+
+		await groupButton.click();
+
+		// Block toolbar options dropdown button
+		optionButton = await page.waitForXPath( OPTIONS_SELECTOR );
+		await optionButton.click();
+
+		// Duplicate block twice
+		let duplicateButton = await page.waitForXPath(
+			DUPLICATE_BUTTON_SELECTOR
+		);
+		await duplicateButton.click();
+
+		optionButton = await page.waitForXPath( OPTIONS_SELECTOR );
+		await optionButton.click();
+		duplicateButton = await page.waitForXPath( DUPLICATE_BUTTON_SELECTOR );
+		await duplicateButton.click();
+
+		// Check if there are correct amount of warnings.
+		expect(
+			await page.$x(
+				'//p[contains(@class, "block-editor-warning__message")][contains(., "More: This block can only be used once.")]'
+			)
+		).toHaveLength( 2 );
+	} );
+} );

--- a/packages/edit-post/src/hooks/validate-multiple-use/index.js
+++ b/packages/edit-post/src/hooks/validate-multiple-use/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import { find } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -19,6 +14,33 @@ import { Warning, store as blockEditorStore } from '@wordpress/block-editor';
 import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
+
+/**
+ * Recursively find very first block of an specific block type.
+ *
+ * @param {Object[]} blocks List of blocks.
+ * @param {string}   name   Block name to search.
+ *
+ * @return {Object|undefined} Return block object or undefined.
+ */
+function findFirstOfSameType( blocks, name ) {
+	if ( ! Array.isArray( blocks ) || ! blocks.length ) {
+		return;
+	}
+
+	for ( const block of blocks ) {
+		if ( block.name === name ) {
+			return block;
+		}
+
+		// Search inside innerBlocks.
+		const firstBlock = findFirstOfSameType( block.innerBlocks, name );
+
+		if ( firstBlock ) {
+			return firstBlock;
+		}
+	}
+}
 
 const enhance = compose(
 	/**
@@ -44,10 +66,7 @@ const enhance = compose(
 		// Otherwise, only pass `originalBlockClientId` if it refers to a different
 		// block from the current one.
 		const blocks = select( blockEditorStore ).getBlocks();
-		const firstOfSameType = find(
-			blocks,
-			( { name } ) => block.name === name
-		);
+		const firstOfSameType = findFirstOfSameType( blocks, block.name );
 		const isInvalid =
 			firstOfSameType && firstOfSameType.clientId !== block.clientId;
 		return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/38502

## Why? 
Any block that doesn't support the `multiple` feature, doesn't display the **Multiple blocks** validation warning when it's inside group blocks.

## How?
Include `innerBlocks` in the validation process.

## Testing Instructions

1. Open post or page to edit
2. Insert "Group" block
3. Insert the "More (core/more)" block inside the "Group" block
4. Duplicate "Group" block.

The "Read more" should display the validation warning.

## Screenshots or screencast <!-- if applicable -->

Before:

https://user-images.githubusercontent.com/17360543/160422035-1111351a-8e70-45f4-b9c9-571cc0fd3bed.mov

After:

https://user-images.githubusercontent.com/17360543/160421847-bcc4d749-3e38-43e4-955e-35e258fe6534.mov



