### PR TITLE
Backport #2576 to Gutenberg

### DIFF
--- a/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
+++ b/lib/compat/wordpress-6.0/class-wp-rest-block-patterns-controller.php
@@ -17,6 +17,14 @@
 class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 
 	/**
+	 * Defines whether remote patterns should be loaded.
+	 *
+	 * @since 6.0.0
+	 * @var bool
+	 */
+	private $remote_patterns_loaded;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
@@ -83,10 +91,14 @@ class WP_REST_Block_Patterns_Controller extends WP_REST_Controller {
 	 * @return WP_Error|WP_REST_Response Response object on success, or WP_Error object on failure.
 	 */
 	public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		// Load block patterns from w.org.
-		_load_remote_block_patterns(); // Patterns with the `core` keyword.
-		_load_remote_featured_patterns(); // Patterns in the `featured` category.
-		gutenberg_register_remote_theme_patterns(); // Patterns requested by current theme.
+		if ( ! $this->remote_patterns_loaded ) {
+			// Load block patterns from w.org.
+			_load_remote_block_patterns(); // Patterns with the `core` keyword.
+			_load_remote_featured_patterns(); // Patterns in the `featured` category.
+			gutenberg_register_remote_theme_patterns(); // Patterns requested by current theme.
+
+			$this->remote_patterns_loaded = true;
+		}
 
 		$response = array();
 		$patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR aims to backport changes from https://github.com/WordPress/wordpress-develop/pull/2576 to Gutenberg.

Fixes https://github.com/WordPress/gutenberg/issues/40824.


## Why?
This is needed to keep Core and Gutenberg as compatible as possible.

## Testing Instructions
1. Make sure you are using WordPress 5.9.x
2. Enable Gutenberg.
3. Install [this plugin](https://github.com/WP-API/Basic-Auth) to allow basic authorization for REST API requests.
4. Activate the plugin.
5. Send a GET request to your WordPress instance, e.g.:
```
curl --user username:password "http://wordpress.test/wp-json/wp/v2/block-patterns/patterns"
```
Replace 
```
username:user_password
```
with the actual credentials.
Replace 
```
http://your.wordpress.instance
```
with the actual URL of your instance.
6. Note the response. It must contain block patterns.