### PR TITLE
Improve function name for finding navigation links that use the featured image

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -6,21 +6,24 @@
  */
 
 /**
- * Loop through recursively to find blocks that use featured images.
+ * Determines whether a block list contains a block that uses the featured image.
  *
  * @param WP_Block_List $inner_blocks Inner block instance.
  *
- * @return bool
+ * @return bool Whether the block list contains a block that uses the featured image.
  */
-function block_core_post_template_uses_feature_image( $inner_blocks ) {
+function block_core_post_template_uses_featured_image( $inner_blocks ) {
 	foreach ( $inner_blocks as $block ) {
 		if ( 'core/post-featured-image' === $block->name ) {
 			return true;
 		}
-		if ( 'core/cover' === $block->name && $block->attributes && isset( $block->attributes['useFeaturedImage'] ) && $block->attributes['useFeaturedImage'] ) {
+		if (
+			'core/cover' === $block->name &&
+			! empty( $block->attributes['useFeaturedImage'] )
+		) {
 			return true;
 		}
-		if ( $block->inner_blocks && block_core_post_template_uses_feature_image( $block->inner_blocks ) ) {
+		if ( $block->inner_blocks && block_core_post_template_uses_featured_image( $block->inner_blocks ) ) {
 			return true;
 		}
 	}
@@ -63,7 +66,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		return '';
 	}
 
-	if ( block_core_post_template_uses_feature_image( $block->inner_blocks ) ) {
+	if ( block_core_post_template_uses_featured_image( $block->inner_blocks ) ) {
 		update_post_thumbnail_cache( $query );
 	}
 


### PR DESCRIPTION
Follow up to #40572

@costdev added this comment after the PR was merged, I think the points all made sense so I made a follow up PR:

https://github.com/WordPress/gutenberg/pull/40572#issuecomment-1120129766
 
Some notes on this:

1. The function is called `block_core_post_template_uses_feature_image()`. 

Shouldn't this be `block_core_post_template_uses_featured_image()`?

This occurs on lines 15, 23 and 66.


2. The docblock description is inaccurate:

`Loop through recursively to find blocks that use featured images.`

This function tries to find one block that uses the featured image, then returns immediately.

Suggest this instead:

`Determines whether a block list contains a block that uses the featured image.`

3. The docblock for this function has no description for the @return value.

Suggest this:

```
@return bool Whether the block list contains a block that uses the featured image.
```

4. This conditional:

```
if ( 'core/cover' === $block->name && $block->attributes && isset( $block->attributes['useFeaturedImage'] ) && $block->attributes['useFeaturedImage'] ) {
```

can be shortened to:

```
if ( 'core/cover' === $block->name && ! empty( $block->attributes['useFeaturedImage'] ) ) {
```