### PR TITLE
Mark Table of Contents block as experimental using `block.json` flag.

### DIFF
--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
+	"__experimental": true,
 	"name": "core/table-of-contents",
 	"title": "Table of Contents",
 	"category": "layout",


### PR DESCRIPTION
## What?
This PR fixes a minor regression, namely that the Table of Contents is no longer marked as experimental after the merge of #40655.

## Why?
The block was marked as experimental using the old means, but now that #40655 was merged, it needs to use the new `block.json` method.

## How?
This PR simply adds the `__experimental` flag to the `block.json`.