### PR TITLE
Prevent navigation on url input suggestion selection via enter key

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -303,6 +303,7 @@ class URLInput extends Component {
 
 				// Submitting while loading should trigger onSubmit.
 				case ENTER: {
+					event.preventDefault();
 					if ( this.props.onSubmit ) {
 						this.props.onSubmit( null, event );
 					}
@@ -350,6 +351,7 @@ class URLInput extends Component {
 				break;
 			}
 			case ENTER: {
+				event.preventDefault();
 				if ( this.state.selectedSuggestion !== null ) {
 					this.selectLink( suggestion );
 


### PR DESCRIPTION

## What?
Fixes #38950
Fixes #40449

## Why?
We don't have to navigate to selected urls.

## How?
For the enter key on the suggestion list for url input there is a select behavior which did not have preventDefault called on the key event.

## Testing Instructions
1. Create a new post
2. Insert an image block
3. Add an image from your media library
4. Copy this URL: `https://live.staticflickr.com/3784/12091853594_b6f2668721_b.jpg`
5. In your image block click on "Replace" in the block's toolbar
6. From the menu click on the pencil icon
7. Select the current media URL in the input that appears (tiny!)
8. Paste the URL you copied from above
9. Press the Enter key on the keyboard
10. The page should not navigate away and the image is changed.

## Other

The changes seem to come from https://github.com/WordPress/gutenberg/pull/32552 but not 100% sure and also there is a comment that says

> // We shouldn't preventDefault to allow block arrow keys navigation.

... but I don't think this is about the ENTER key. In the past (looking through commits the enter key was handled directly in the button's onClick prop. Later it had a stopPropagation, not it has no handling, hence the error.

cc @youknowriad for a trip down memory lane if there is anything from the past refactoring that required the ENTER key to not be handled.
