### PR TITLE
DevicePreview: Remove unnecessary div tag

### DIFF
--- a/packages/edit-post/src/components/device-preview/index.js
+++ b/packages/edit-post/src/components/device-preview/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { Icon, MenuGroup } from '@wordpress/components';
@@ -7,6 +12,7 @@ import { external } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { __experimentalPreviewOptions as PreviewOptions } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -18,18 +24,23 @@ export default function DevicePreview() {
 		hasActiveMetaboxes,
 		isPostSaveable,
 		isSaving,
+		isViewable,
 		deviceType,
-	} = useSelect(
-		( select ) => ( {
+	} = useSelect( ( select ) => {
+		const { getEditedPostAttribute } = select( editorStore );
+		const { getPostType } = select( coreStore );
+		const postType = getPostType( getEditedPostAttribute( 'type' ) );
+
+		return {
 			hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
 			isSaving: select( editPostStore ).isSavingMetaBoxes(),
 			isPostSaveable: select( editorStore ).isEditedPostSaveable(),
+			isViewable: get( postType, [ 'viewable' ], false ),
 			deviceType: select(
 				editPostStore
 			).__experimentalGetPreviewDeviceType(),
-		} ),
-		[]
-	);
+		};
+	}, [] );
 	const {
 		__experimentalSetPreviewDeviceType: setPreviewDeviceType,
 	} = useDispatch( editPostStore );
@@ -41,24 +52,26 @@ export default function DevicePreview() {
 			deviceType={ deviceType }
 			setDeviceType={ setPreviewDeviceType }
 		>
-			<MenuGroup>
-				<div className="edit-post-header-preview__grouping-external">
-					<PostPreviewButton
-						className={
-							'edit-post-header-preview__button-external'
-						}
-						role="menuitem"
-						forceIsAutosaveable={ hasActiveMetaboxes }
-						forcePreviewLink={ isSaving ? null : undefined }
-						textContent={
-							<>
-								{ __( 'Preview in new tab' ) }
-								<Icon icon={ external } />
-							</>
-						}
-					/>
-				</div>
-			</MenuGroup>
+			{ isViewable && (
+				<MenuGroup>
+					<div className="edit-post-header-preview__grouping-external">
+						<PostPreviewButton
+							className={
+								'edit-post-header-preview__button-external'
+							}
+							role="menuitem"
+							forceIsAutosaveable={ hasActiveMetaboxes }
+							forcePreviewLink={ isSaving ? null : undefined }
+							textContent={
+								<>
+									{ __( 'Preview in new tab' ) }
+									<Icon icon={ external } />
+								</>
+							}
+						/>
+					</div>
+				</MenuGroup>
+			) }
 		</PreviewOptions>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR removes unnecessary div tags when the post type is **not "viewable"** in the `DevicePreview` component.

## Why?
In `PostPreviewButton` component inside `DevicePreview` component, it will not render if the viewable status is false.

But in the `PostPreviewButton ` component, there is no check for viewable, so `.edit-post-header-preview__grouping-external` div tag is always rendered and an unnecessary line is displayed in the preview popover.

## How?
Ensure that elements related to external links are rendered only if "viewable" is true.

## Testing Instructions
- Add a post type with a viewable status of **false**
```php
function my_post_type() {
	$args = array(
		'public'             => true,
		'label'              => 'Books',
		'publicly_queryable' => false,
		'show_in_rest'       => true,
	);
	register_post_type( 'book', $args );
}
add_action( 'init', 'my_post_type' );
```

- Confirm that a unnecessary line and div tags do not appear within the preview popover.

## Screenshots or screencast <!-- if applicable -->

### before
![before](https://user-images.githubusercontent.com/54422211/167279848-24fd86b6-3dc9-43e4-8390-49b6fa07ec4c.png)

### after
![after](https://user-images.githubusercontent.com/54422211/167279851-98c0e04b-cf07-4f19-a669-db2b0c912d35.png)

## About document

It might be good to update the following related readme using `isViewable` as well.

https://github.com/WordPress/gutenberg/tree/trunk/packages/block-editor/src/components/preview-options#development-guidelines