### PR TITLE
BorderControl: Make reset to default button only display when required

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+- `BorderControl` now only displays the reset button in its popover when selections have already been made. [#40917](https://github.com/WordPress/gutenberg/pull/40917)
+
 ## 19.10.0 (2022-05-04)
 
 ### Internal

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -164,6 +164,7 @@ const BorderControlDropdown = (
 		enableStyle
 	);
 
+	const showResetButton = color || ( style && style !== 'none' );
 	const dropdownPosition = __experimentalIsRenderedInSidebar
 		? 'bottom left'
 		: undefined;
@@ -220,16 +221,18 @@ const BorderControlDropdown = (
 					/>
 				) }
 			</VStack>
-			<Button
-				className={ resetButtonClassName }
-				variant="tertiary"
-				onClick={ () => {
-					onReset();
-					onClose();
-				} }
-			>
-				{ __( 'Reset to default' ) }
-			</Button>
+			{ showResetButton && (
+				<Button
+					className={ resetButtonClassName }
+					variant="tertiary"
+					onClick={ () => {
+						onReset();
+						onClose();
+					} }
+				>
+					{ __( 'Reset to default' ) }
+				</Button>
+			) }
 		</>
 	);
 


### PR DESCRIPTION
Fixes #40895

## What?

Makes the `BorderControl` popover's "reset to default" button only appear when a value has been selected (i.e. when control isn't in default state).

## Why?

This avoids the situation where the reset button is unnecessarily visible and can be clicked appearing to have no effect.

## How?

Checks if the control's border value has a `color`, or `style` that isn't `none`, before displaying the reset button.

## Testing Instructions

1. Start up Storybook and visit the [border control example](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default)
2. Play with the component, selecting various value combinations and ensuring the popover's reset button only displays when you'd expect.

## Screenshots or screencast <!-- if applicable -->


https://user-images.githubusercontent.com/60436221/167318722-46778ed3-7e84-48e7-a6d1-0d0a1cd7352c.mp4


