### PR TITLE
Styles hook: swap out lodash methods with their JS equivalents

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -1,18 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	first,
-	forEach,
-	get,
-	has,
-	isEmpty,
-	isString,
-	kebabCase,
-	map,
-	omit,
-	startsWith,
-} from 'lodash';
+import { get, has, isEmpty, kebabCase, omit } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -58,7 +47,10 @@ const VARIABLE_REFERENCE_PREFIX = 'var:';
 const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
 const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
 function compileStyleValue( uncompiledValue ) {
-	if ( startsWith( uncompiledValue, VARIABLE_REFERENCE_PREFIX ) ) {
+	if (
+		typeof uncompiledValue === 'string' &&
+		uncompiledValue.startsWith( VARIABLE_REFERENCE_PREFIX )
+	) {
 		const variable = uncompiledValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
@@ -82,13 +74,13 @@ export function getInlineStyles( styles = {} ) {
 		const path = STYLE_PROPERTY[ propKey ].value;
 		const subPaths = STYLE_PROPERTY[ propKey ].properties;
 		// Ignore styles on elements because they are handled on the server.
-		if ( has( styles, path ) && 'elements' !== first( path ) ) {
+		if ( has( styles, path ) && 'elements' !== path[ 0 ] ) {
 			// Checking if style value is a string allows for shorthand css
 			// option and backwards compatibility for border radius support.
 			const styleValue = get( styles, path );
 
 			if ( ! STYLE_PROPERTY[ propKey ].useEngine ) {
-				if ( !! subPaths && ! isString( styleValue ) ) {
+				if ( !! subPaths && typeof styleValue !== 'string' ) {
 					Object.entries( subPaths ).forEach( ( entry ) => {
 						const [ name, subPath ] = entry;
 						const value = get( styleValue, [ subPath ] );
@@ -120,24 +112,27 @@ export function getInlineStyles( styles = {} ) {
 }
 
 function compileElementsStyles( selector, elements = {} ) {
-	return map( elements, ( styles, element ) => {
-		const elementStyles = getInlineStyles( styles );
-		if ( ! isEmpty( elementStyles ) ) {
-			// The .editor-styles-wrapper selector is required on elements styles. As it is
-			// added to all other editor styles, not providing it causes reset and global
-			// styles to override element styles because of higher specificity.
-			return [
-				`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ element ] }{`,
-				...map(
-					elementStyles,
-					( value, property ) =>
-						`\t${ kebabCase( property ) }: ${ value };`
-				),
-				'}',
-			].join( '\n' );
-		}
-		return '';
-	} ).join( '\n' );
+	return Object.keys( elements )
+		.map( ( key ) => {
+			const elementStyles = getInlineStyles( elements[ key ] );
+			if ( ! isEmpty( elementStyles ) ) {
+				// The .editor-styles-wrapper selector is required on elements styles. As it is
+				// added to all other editor styles, not providing it causes reset and global
+				// styles to override element styles because of higher specificity.
+				return [
+					`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ key ] }{`,
+					...Object.keys( elementStyles ).map(
+						( cssProperty ) =>
+							`\t${ kebabCase( cssProperty ) }: ${
+								elementStyles[ cssProperty ]
+							};`
+					),
+					'}',
+				].join( '\n' );
+			}
+			return '';
+		} )
+		.join( '\n' );
 }
 
 /**
@@ -236,17 +231,19 @@ export function addSaveProps(
 
 	let { style } = attributes;
 
-	forEach( skipPaths, ( path, indicator ) => {
+	Object.keys( skipPaths ).forEach( ( indicator ) => {
 		const skipSerialization = getBlockSupport( blockType, indicator );
 
 		if ( skipSerialization === true ) {
-			style = omit( style, path );
+			style = omit( style, skipPaths[ indicator ] );
 		}
 
 		if ( Array.isArray( skipSerialization ) ) {
 			skipSerialization.forEach( ( featureName ) => {
 				const feature = renamedFeatures[ featureName ] || featureName;
-				style = omit( style, [ [ ...path, feature ] ] );
+				style = omit( style, [
+					[ ...skipPaths[ indicator ], feature ],
+				] );
 			} );
 		}
 	} );

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -119,7 +119,7 @@ function compileElementsStyles( selector, elements = {} ) {
 				return [
 					`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ key ] }{`,
 					...Object.entries( elementStyles ).map(
-						( cssProperty, value ) =>
+						( [ cssProperty, value ] ) =>
 							`\t${ kebabCase( cssProperty ) }: ${ value };`
 					),
 					'}',

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -110,14 +110,14 @@ export function getInlineStyles( styles = {} ) {
 
 function compileElementsStyles( selector, elements = {} ) {
 	return Object.entries( elements )
-		.map( ( [ key, styles ] ) => {
+		.map( ( [ element, styles ] ) => {
 			const elementStyles = getInlineStyles( styles );
 			if ( ! isEmpty( elementStyles ) ) {
 				// The .editor-styles-wrapper selector is required on elements styles. As it is
 				// added to all other editor styles, not providing it causes reset and global
 				// styles to override element styles because of higher specificity.
 				return [
-					`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ key ] }{`,
+					`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ element ] }{`,
 					...Object.entries( elementStyles ).map(
 						( [ cssProperty, value ] ) =>
 							`\t${ kebabCase( cssProperty ) }: ${ value };`

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -47,10 +47,7 @@ const VARIABLE_REFERENCE_PREFIX = 'var:';
 const VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE = '|';
 const VARIABLE_PATH_SEPARATOR_TOKEN_STYLE = '--';
 function compileStyleValue( uncompiledValue ) {
-	if (
-		typeof uncompiledValue === 'string' &&
-		uncompiledValue.startsWith( VARIABLE_REFERENCE_PREFIX )
-	) {
+	if ( uncompiledValue?.startsWith?.( VARIABLE_REFERENCE_PREFIX ) ) {
 		const variable = uncompiledValue
 			.slice( VARIABLE_REFERENCE_PREFIX.length )
 			.split( VARIABLE_PATH_SEPARATOR_TOKEN_ATTRIBUTE )
@@ -74,7 +71,7 @@ export function getInlineStyles( styles = {} ) {
 		const path = STYLE_PROPERTY[ propKey ].value;
 		const subPaths = STYLE_PROPERTY[ propKey ].properties;
 		// Ignore styles on elements because they are handled on the server.
-		if ( has( styles, path ) && 'elements' !== path[ 0 ] ) {
+		if ( has( styles, path ) && 'elements' !== path?.[ 0 ] ) {
 			// Checking if style value is a string allows for shorthand css
 			// option and backwards compatibility for border radius support.
 			const styleValue = get( styles, path );
@@ -112,20 +109,18 @@ export function getInlineStyles( styles = {} ) {
 }
 
 function compileElementsStyles( selector, elements = {} ) {
-	return Object.keys( elements )
-		.map( ( key ) => {
-			const elementStyles = getInlineStyles( elements[ key ] );
+	return Object.entries( elements )
+		.map( ( [ key, styles ] ) => {
+			const elementStyles = getInlineStyles( styles );
 			if ( ! isEmpty( elementStyles ) ) {
 				// The .editor-styles-wrapper selector is required on elements styles. As it is
 				// added to all other editor styles, not providing it causes reset and global
 				// styles to override element styles because of higher specificity.
 				return [
 					`.editor-styles-wrapper .${ selector } ${ ELEMENTS[ key ] }{`,
-					...Object.keys( elementStyles ).map(
-						( cssProperty ) =>
-							`\t${ kebabCase( cssProperty ) }: ${
-								elementStyles[ cssProperty ]
-							};`
+					...Object.entries( elementStyles ).map(
+						( cssProperty, value ) =>
+							`\t${ kebabCase( cssProperty ) }: ${ value };`
 					),
 					'}',
 				].join( '\n' );
@@ -230,20 +225,17 @@ export function addSaveProps(
 	}
 
 	let { style } = attributes;
-
-	Object.keys( skipPaths ).forEach( ( indicator ) => {
+	Object.entries( skipPaths ).forEach( ( [ indicator, path ] ) => {
 		const skipSerialization = getBlockSupport( blockType, indicator );
 
 		if ( skipSerialization === true ) {
-			style = omit( style, skipPaths[ indicator ] );
+			style = omit( style, path );
 		}
 
 		if ( Array.isArray( skipSerialization ) ) {
 			skipSerialization.forEach( ( featureName ) => {
 				const feature = renamedFeatures[ featureName ] || featureName;
-				style = omit( style, [
-					[ ...skipPaths[ indicator ], feature ],
-				] );
+				style = omit( style, [ [ ...path, feature ] ] );
 			} );
 		}
 	} );


### PR DESCRIPTION
## What?
Just removing a couple of lodash methods that we arguably don't require.

## Why?

Just coz.

## How?

Replacing:

- `_.map( Object, fn() )` with `Object.entries( object ).map( fn() )`
- `_.startsWith( String, arg )` with `'somestring'.startsWith( arg )`
- `_.forEach( Object, fn() )` with `Object.keys( Object ).forEach( fn() )`
- `_.first( Array )` with `array[ 0 ]`

## Testing Instructions

Ensure that blocks styles work on the post/site editors.

Here is some test block code:

<details>

<summary>Test HTML</summary>

```html
<!-- wp:group {"style":{"color":{"background":"#cd4444"},"elements":{"link":{"color":{"text":"var:preset|color|custom-custom-color-2"}}},"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":5.6,"letterSpacing":"-10px","textTransform":"lowercase"},"border":{"top":{"width":"84px","color":"var:preset|color|custom-custom-color-2"},"right":{"width":"49rem","color":"var:preset|color|custom-custom-color-2"},"bottom":{"width":"49px","color":"var:preset|color|custom-custom-color-2"},"left":{"width":"49px","color":"var:preset|color|custom-custom-color-2"},"radius":"79px"},"spacing":{"blockGap":"68px","padding":{"top":"44px","right":"44px","bottom":"44px","left":"44px"},"margin":{"bottom":"43px","top":"75px"}}},"textColor":"vivid-cyan-blue","fontSize":"large"} -->
<div class="wp-block-group has-vivid-cyan-blue-color has-text-color has-background has-link-color has-large-font-size" style="background-color:#cd4444;border-radius:79px;border-top-color:var(--wp--preset--color--custom-custom-color-2);border-top-width:84px;border-right-color:var(--wp--preset--color--custom-custom-color-2);border-right-width:49rem;border-bottom-color:var(--wp--preset--color--custom-custom-color-2);border-bottom-width:49px;border-left-color:var(--wp--preset--color--custom-custom-color-2);border-left-width:49px;font-style:normal;font-weight:600;line-height:5.6;text-transform:lowercase;letter-spacing:-10px;margin-top:75px;margin-bottom:43px;padding-top:44px;padding-right:44px;padding-bottom:44px;padding-left:44px"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-cyan-blue"}}}},"backgroundColor":"vivid-cyan-blue","textColor":"luminous-vivid-orange"} -->
<p class="has-luminous-vivid-orange-color has-vivid-cyan-blue-background-color has-text-color has-background has-link-color"><a href="https://test.com">Test</a> some text</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|pale-cyan-blue"}}}},"backgroundColor":"vivid-cyan-blue","textColor":"luminous-vivid-orange"} -->
<p class="has-luminous-vivid-orange-color has-vivid-cyan-blue-background-color has-text-color has-background has-link-color"><a href="https://test.com">Test</a> some text</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:paragraph -->
<p></p>
<!-- /wp:paragraph -->

```

</details>

Run `npm run test-unit packages/block-editor/src/hooks/test/style.js`
