### PR TITLE
Fix the position of the inbetween inserter

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -170,6 +170,7 @@ function BlockPopoverInbetween( {
 				'block-editor-block-popover',
 				props.className
 			) }
+			__unstableForcePosition
 		>
 			<div style={ style }>{ children }</div>
 		</Popover>


### PR DESCRIPTION
closes #40738

## What?

After #40441 there was a subtle change in the in-between inserter popover: the height of the popover content changed from "0" to the actual real height (the available space) (because It was absolute positioned). I think the new behavior is better but it also triggered the automatic direction flipping for the popover if there were no available space. This PR fixes it by forcing the "position" of the popover.

## Testing Instructions

1- Insert some content in a new post
2- Insert a spacer with a vw based height
3- Insert some content after the spacer
4- The in-between inserter should always show in the right position (between blocks and not on top of blocks).
