### PR TITLE
BorderControl: Make height consistent with other controls

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Enhancements
 
-- `BorderControl` now only displays the reset button in its popover when selections have already been made. [#40917](https://github.com/WordPress/gutenberg/pull/40917)
+-   `BorderControl` now only displays the reset button in its popover when selections have already been made. [#40917](https://github.com/WordPress/gutenberg/pull/40917)
+-   `BorderControl` & `BorderBoxControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40920](https://github.com/WordPress/gutenberg/pull/40920)).
 
 ### Internal
 

--- a/packages/components/src/border-box-control/border-box-control-linked-button/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control-linked-button/hook.ts
@@ -15,16 +15,20 @@ import type { LinkedButtonProps } from '../types';
 export function useBorderBoxControlLinkedButton(
 	props: WordPressComponentProps< LinkedButtonProps, 'div' >
 ) {
-	const { className, ...otherProps } = useContextSystem(
-		props,
-		'BorderBoxControlLinkedButton'
-	);
+	const {
+		className,
+		__next36pxDefaultSize = false,
+		...otherProps
+	} = useContextSystem( props, 'BorderBoxControlLinkedButton' );
 
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.BorderBoxControlLinkedButton, className );
-	}, [ className ] );
+		return cx(
+			styles.BorderBoxControlLinkedButton( __next36pxDefaultSize ),
+			className
+		);
+	}, [ className, cx, __next36pxDefaultSize ] );
 
 	return { ...otherProps, className: classes };
 }

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -29,6 +29,7 @@ const BorderBoxControlSplitControls = (
 		value,
 		__experimentalHasMultipleOrigins,
 		__experimentalIsRenderedInSidebar,
+		__next36pxDefaultSize,
 		...otherProps
 	} = useBorderBoxControlSplitControls( props );
 
@@ -40,11 +41,15 @@ const BorderBoxControlSplitControls = (
 		isCompact: true,
 		__experimentalHasMultipleOrigins,
 		__experimentalIsRenderedInSidebar,
+		__next36pxDefaultSize,
 	};
 
 	return (
 		<Grid { ...otherProps } ref={ forwardedRef } gap={ 4 }>
-			<BorderBoxControlVisualizer value={ value } />
+			<BorderBoxControlVisualizer
+				value={ value }
+				__next36pxDefaultSize={ __next36pxDefaultSize }
+			/>
 			<BorderControl
 				className={ centeredClassName }
 				hideLabelFromVision={ true }

--- a/packages/components/src/border-box-control/border-box-control-visualizer/hook.ts
+++ b/packages/components/src/border-box-control/border-box-control-visualizer/hook.ts
@@ -15,16 +15,21 @@ import type { VisualizerProps } from '../types';
 export function useBorderBoxControlVisualizer(
 	props: WordPressComponentProps< VisualizerProps, 'div' >
 ) {
-	const { className, value, ...otherProps } = useContextSystem(
-		props,
-		'BorderBoxControlVisualizer'
-	);
+	const {
+		className,
+		value,
+		__next36pxDefaultSize = false,
+		...otherProps
+	} = useContextSystem( props, 'BorderBoxControlVisualizer' );
 
 	// Generate class names.
 	const cx = useCx();
 	const classes = useMemo( () => {
-		return cx( styles.BorderBoxControlVisualizer( value ), className );
-	}, [ className, value, rtl.watch() ] );
+		return cx(
+			styles.BorderBoxControlVisualizer( value, __next36pxDefaultSize ),
+			className
+		);
+	}, [ className, value, __next36pxDefaultSize, rtl.watch() ] );
 
 	return { ...otherProps, className: classes, value };
 }

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -56,6 +56,7 @@ const BorderBoxControl = (
 		toggleLinked,
 		__experimentalHasMultipleOrigins,
 		__experimentalIsRenderedInSidebar,
+		__next36pxDefaultSize = false,
 		...otherProps
 	} = useBorderBoxControl( props );
 
@@ -88,6 +89,7 @@ const BorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
+						__next36pxDefaultSize={ __next36pxDefaultSize }
 					/>
 				) : (
 					<BorderBoxControlSplitControls
@@ -104,11 +106,13 @@ const BorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
+						__next36pxDefaultSize={ __next36pxDefaultSize }
 					/>
 				) }
 				<BorderBoxControlLinkedButton
 					onClick={ toggleLinked }
 					isLinked={ isLinked }
+					__next36pxDefaultSize={ __next36pxDefaultSize }
 				/>
 			</HStack>
 		</View>

--- a/packages/components/src/border-box-control/stories/index.js
+++ b/packages/components/src/border-box-control/stories/index.js
@@ -84,6 +84,7 @@ Default.args = {
 		style: 'dashed',
 		width: '1px',
 	},
+	__next36pxDefaultSize: false,
 };
 
 const WrapperView = styled.div`

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -18,11 +18,15 @@ export const LinkedBorderControl = css`
 	flex: 1;
 `;
 
-export const BorderBoxControlLinkedButton = css`
-	flex: 0;
-	flex-basis: 36px;
-	margin-top: 3px;
-`;
+export const BorderBoxControlLinkedButton = (
+	__next36pxDefaultSize?: boolean
+) => {
+	return css`
+		flex: 0;
+		flex-basis: 36px;
+		margin-top: ${ __next36pxDefaultSize ? '6px' : '3px' };
+	`;
+};
 
 const BorderBoxStyleWithFallback = ( border?: Border ) => {
 	const {
@@ -39,12 +43,15 @@ const BorderBoxStyleWithFallback = ( border?: Border ) => {
 	return `${ color } ${ borderStyle } ${ clampedWidth }`;
 };
 
-export const BorderBoxControlVisualizer = ( borders?: Borders ) => {
+export const BorderBoxControlVisualizer = (
+	borders?: Borders,
+	__next36pxDefaultSize?: boolean
+) => {
 	return css`
 		position: absolute;
-		top: 15px;
+		top: ${ __next36pxDefaultSize ? '18px' : '15px' };
 		right: 30px;
-		bottom: 15px;
+		bottom: ${ __next36pxDefaultSize ? '18px' : '15px' };
 		left: 30px;
 		border-top: ${ BorderBoxStyleWithFallback( borders?.top ) };
 		border-bottom: ${ BorderBoxStyleWithFallback( borders?.bottom ) };

--- a/packages/components/src/border-box-control/styles.ts
+++ b/packages/components/src/border-box-control/styles.ts
@@ -21,7 +21,7 @@ export const LinkedBorderControl = css`
 export const BorderBoxControlLinkedButton = css`
 	flex: 0;
 	flex-basis: 36px;
-	margin-top: 7px;
+	margin-top: 3px;
 `;
 
 const BorderBoxStyleWithFallback = ( border?: Border ) => {
@@ -42,9 +42,9 @@ const BorderBoxStyleWithFallback = ( border?: Border ) => {
 export const BorderBoxControlVisualizer = ( borders?: Borders ) => {
 	return css`
 		position: absolute;
-		top: 20px;
+		top: 15px;
 		right: 30px;
-		bottom: 20px;
+		bottom: 15px;
 		left: 30px;
 		border-top: ${ BorderBoxStyleWithFallback( borders?.top ) };
 		border-bottom: ${ BorderBoxStyleWithFallback( borders?.bottom ) };

--- a/packages/components/src/border-box-control/types.ts
+++ b/packages/components/src/border-box-control/types.ts
@@ -47,6 +47,13 @@ export type BorderBoxControlProps = ColorProps &
 		 * properties but for each side; `top`, `right`, `bottom`, and `left`.
 		 */
 		value: AnyBorder;
+		/**
+		 * Start opting into the larger default height that will become the
+		 * default size in a future version.
+		 *
+		 * @default false
+		 */
+		__next36pxDefaultSize?: boolean;
 	};
 
 export type LinkedButtonProps = {
@@ -62,6 +69,13 @@ export type LinkedButtonProps = {
 	 * `BorderBoxControl`.
 	 */
 	onClick: () => void;
+	/**
+	 * Start opting into the larger default height that will become the
+	 * default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next36pxDefaultSize?: boolean;
 };
 
 export type VisualizerProps = {
@@ -71,6 +85,13 @@ export type VisualizerProps = {
 	 * color, style, and width.
 	 */
 	value?: Borders;
+	/**
+	 * Start opting into the larger default height that will become the
+	 * default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next36pxDefaultSize?: boolean;
 };
 
 export type SplitControlsProps = ColorProps & {
@@ -95,4 +116,11 @@ export type SplitControlsProps = ColorProps & {
 	 * color, style, and width.
 	 */
 	value?: Borders;
+	/**
+	 * Start opting into the larger default height that will become the
+	 * default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next36pxDefaultSize?: boolean;
 };

--- a/packages/components/src/border-control/border-control-dropdown/hook.ts
+++ b/packages/components/src/border-control/border-control-dropdown/hook.ts
@@ -23,6 +23,7 @@ export function useBorderControlDropdown(
 		contentClassName,
 		onChange,
 		previousStyleSelection,
+		__next36pxDefaultSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderControlDropdown' );
 
@@ -61,8 +62,10 @@ export function useBorderControlDropdown(
 	}, [ cx ] );
 
 	const indicatorWrapperClassName = useMemo( () => {
-		return cx( styles.colorIndicatorWrapper( border ) );
-	}, [ border, cx ] );
+		return cx(
+			styles.colorIndicatorWrapper( border, __next36pxDefaultSize )
+		);
+	}, [ border, cx, __next36pxDefaultSize ] );
 
 	const popoverClassName = useMemo( () => {
 		return cx( styles.borderControlPopover, contentClassName );

--- a/packages/components/src/border-control/border-control/component.tsx
+++ b/packages/components/src/border-control/border-control/component.tsx
@@ -54,6 +54,7 @@ const BorderControl = (
 		withSlider,
 		__experimentalHasMultipleOrigins,
 		__experimentalIsRenderedInSidebar,
+		__next36pxDefaultSize,
 		...otherProps
 	} = useBorderControl( props );
 
@@ -81,6 +82,7 @@ const BorderControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
+						__next36pxDefaultSize={ __next36pxDefaultSize }
 					/>
 					<UnitControl
 						className={ widthControlClassName }

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -35,6 +35,7 @@ export function useBorderControl(
 		shouldSanitizeBorder = true,
 		value: border,
 		width,
+		__next36pxDefaultSize = false,
 		...otherProps
 	} = useContextSystem( props, 'BorderControl' );
 
@@ -116,9 +117,10 @@ export function useBorderControl(
 		const wrapperWidth = isCompact ? '90px' : width;
 		const widthStyle =
 			!! wrapperWidth && styles.wrapperWidth( wrapperWidth );
+		const heightStyle = styles.wrapperHeight( __next36pxDefaultSize );
 
-		return cx( styles.innerWrapper(), widthStyle );
-	}, [ isCompact, width, cx ] );
+		return cx( styles.innerWrapper(), widthStyle, heightStyle );
+	}, [ isCompact, width, cx, __next36pxDefaultSize ] );
 
 	const widthControlClassName = useMemo( () => {
 		return cx( styles.borderWidthControl() );
@@ -141,5 +143,6 @@ export function useBorderControl(
 		widthControlClassName,
 		widthUnit,
 		widthValue,
+		__next36pxDefaultSize,
 	};
 }

--- a/packages/components/src/border-control/stories/index.js
+++ b/packages/components/src/border-control/stories/index.js
@@ -111,6 +111,7 @@ Default.args = {
 	withSlider: true,
 	__experimentalIsRenderedInSidebar: false,
 	__experimentalHasMultipleOrigins: false,
+	__next36pxDefaultSize: false,
 };
 
 const WrapperView = styled.div`

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -14,7 +14,10 @@ import {
 	StyledLabel,
 } from '../base-control/styles/base-control-styles';
 import { BackdropUI } from '../input-control/styles/input-control-styles';
-import { Root as UnitControlWrapper } from '../unit-control/styles/unit-control-styles';
+import {
+	Root as UnitControlWrapper,
+	UnitSelect,
+} from '../unit-control/styles/unit-control-styles';
 
 import type { Border } from './types';
 
@@ -50,6 +53,12 @@ export const innerWrapper = () => css`
 	${ UnitControlWrapper } {
 		flex: 1;
 		${ rtl( { marginLeft: 0 } )() }
+	}
+
+	&& ${ UnitSelect } {
+		/* Prevent default styles forcing heights larger than BorderControl */
+		min-height: 0;
+		${ rtl( { marginRight: 0 } )() }
 	}
 `;
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -33,11 +33,6 @@ export const innerWrapper = () => css`
 	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	border-radius: 2px;
 	flex: 1 0 40%;
-	/*
-	 * When default control height is 36px the following height should be
-	 * removed. See: InputControl and __next36pxDefaultSize.
-	 */
-	height: 30px;
 
 	/*
 	 * Needs more thought. Aim is to prevent the border for BorderBoxControl
@@ -69,6 +64,16 @@ export const wrapperWidth = ( width: CSSProperties[ 'width' ] ) => {
 	`;
 };
 
+/*
+ * When default control height is 36px the following should be removed.
+ * See: InputControl and __next36pxDefaultSize.
+ */
+export const wrapperHeight = ( __next36pxDefaultSize?: boolean ) => {
+	return css`
+		height: ${ __next36pxDefaultSize ? '36px' : '30px' };
+	`;
+};
+
 export const borderControlDropdown = () => css`
 	background: #fff;
 	${ rtl(
@@ -87,7 +92,7 @@ export const borderControlDropdown = () => css`
 		 * Override button component height and padding to fit within
 		 * BorderControl
 		 */
-		height: 28px;
+		height: 100%;
 		padding: ${ space( 0.75 ) };
 		border-radius: inherit;
 	}
@@ -105,17 +110,19 @@ export const colorIndicatorBorder = ( border?: Border ) => {
 	`;
 };
 
-export const colorIndicatorWrapper = ( border?: Border ) => {
+export const colorIndicatorWrapper = (
+	border?: Border,
+	__next36pxDefaultSize?: boolean
+) => {
 	const { style } = border || {};
 
 	return css`
 		border-radius: 9999px;
 		border: 2px solid transparent;
 		${ style ? colorIndicatorBorder( border ) : undefined }
-		/* Dimensions adjusted to fit in 30px control height. */
-		width: 22px;
-		height: 22px;
-		padding: 1px;
+		width: ${ __next36pxDefaultSize ? '28px' : '22px' };
+		height: ${ __next36pxDefaultSize ? '28px' : '22px' };
+		padding: ${ __next36pxDefaultSize ? '2px' : '1px' };
 
 		/*
 		 * ColorIndicator
@@ -124,9 +131,13 @@ export const colorIndicatorWrapper = ( border?: Border ) => {
 		 * over the active state of the border control dropdown's toggle button.
 		 */
 		& > span {
-			/* Dimensions adjusted to fit in 30px overall control height. */
-			height: 16px;
-			width: 16px;
+			${ ! __next36pxDefaultSize
+				? css`
+						/* Dimensions fit in 30px overall control height. */
+						height: 16px;
+						width: 16px;
+				  `
+				: '' }
 			background: linear-gradient(
 				-45deg,
 				transparent 48%,

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -88,7 +88,7 @@ export const borderControlDropdown = () => css`
 		 * BorderControl
 		 */
 		height: 28px;
-		padding: 0 ${ space( 0.5 ) };
+		padding: ${ space( 0.75 ) };
 		border-radius: inherit;
 	}
 `;
@@ -113,9 +113,9 @@ export const colorIndicatorWrapper = ( border?: Border ) => {
 		border: 2px solid transparent;
 		${ style ? colorIndicatorBorder( border ) : undefined }
 		/* Dimensions adjusted to fit in 30px control height. */
-		width: 24px;
-		height: 24px;
-		padding: 2px;
+		width: 22px;
+		height: 22px;
+		padding: 1px;
 
 		/*
 		 * ColorIndicator

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -30,6 +30,11 @@ export const innerWrapper = () => css`
 	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	border-radius: 2px;
 	flex: 1 0 40%;
+	/*
+	 * When default control height is 36px the following height should be
+	 * removed. See: InputControl and __next36pxDefaultSize.
+	 */
+	height: 30px;
 
 	/*
 	 * Needs more thought. Aim is to prevent the border for BorderBoxControl
@@ -69,7 +74,12 @@ export const borderControlDropdown = () => css`
 	)() }
 
 	&& > button {
-		padding: ${ space( 1 ) };
+		/*
+		 * Override button component height and padding to fit within
+		 * BorderControl
+		 */
+		height: 28px;
+		padding: 0 ${ space( 0.5 ) };
 		border-radius: inherit;
 	}
 `;
@@ -93,8 +103,9 @@ export const colorIndicatorWrapper = ( border?: Border ) => {
 		border-radius: 9999px;
 		border: 2px solid transparent;
 		${ style ? colorIndicatorBorder( border ) : undefined }
-		width: 28px;
-		height: 28px;
+		/* Dimensions adjusted to fit in 30px control height. */
+		width: 24px;
+		height: 24px;
 		padding: 2px;
 
 		/*
@@ -104,6 +115,9 @@ export const colorIndicatorWrapper = ( border?: Border ) => {
 		 * over the active state of the border control dropdown's toggle button.
 		 */
 		& > span {
+			/* Dimensions adjusted to fit in 30px overall control height. */
+			height: 16px;
+			width: 16px;
 			background: linear-gradient(
 				-45deg,
 				transparent 48%,

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -114,6 +114,13 @@ export type BorderControlProps = ColorProps &
 		 * `RangeControl` for additional control over a border's width.
 		 */
 		withSlider?: boolean;
+		/**
+		 * Start opting into the larger default height that will become the
+		 * default size in a future version.
+		 *
+		 * @default false
+		 */
+		__next36pxDefaultSize?: boolean;
 	};
 
 export type DropdownProps = ColorProps & {
@@ -150,6 +157,13 @@ export type DropdownProps = ColorProps & {
 	 * close button.
 	 */
 	showDropdownHeader?: boolean;
+	/**
+	 * Start opting into the larger default height that will become the
+	 * default size in a future version.
+	 *
+	 * @default false
+	 */
+	__next36pxDefaultSize?: boolean;
 };
 
 export type StylePickerProps = LabelProps & {


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/issues/40893

## What?

Makes `BorderControl` height consistent with other controls by default i.e. `30px`. Also, updates `BorderBoxControl` to match. 

A new prop (`__next36pxDefaultSize`)  is introduced to allow opting into the future default of `36px`. 

## Why?

Border controls within the editor are currently inconsistent.

## How?

- Sets `BorderControl` height based on new `__next36pxDefaultSize` prop
- Adjusts inner component styles based on above prop
- Updates Storybook examples to include new prop for toggling default height
- Plumbs `__next36pxDefaultSize` prop through border control components as required

## Testing Instructions

1. Edit a post, add a group block, and select it.
2. In the Inspector Controls sidebar, compare the border and border radius controls. They should both be `30px` tall.
    _(Border color & focus styles will be addressed separately)_
3. Expand the `BorderBoxControl` and confirm the split border view still looks ok
4. Start up the Storybook and visit the [`BorderControl`](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default) and [`BorderBoxControl`](http://localhost:50240/?path=/story/components-experimental-borderboxcontrol--default) component pages
    - `npm run storybook:dev`
    - Toggle the `__next36pxDefaultSize` control and check component renders ok 


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="288" alt="Screen Shot 2022-05-09 at 4 00 04 pm" src="https://user-images.githubusercontent.com/60436221/167349294-bfd30cd5-5e02-45b2-83ca-7d242fa11553.png"> | <img width="293" alt="Screen Shot 2022-05-09 at 3 59 15 pm" src="https://user-images.githubusercontent.com/60436221/167349308-192122b4-95d7-43ae-b646-13caffa8db07.png"> |


