### PR TITLE
BorderControl: Make border color consistent with other controls

### DIFF
--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -27,7 +27,7 @@ export const borderControl = css`
 `;
 
 export const innerWrapper = () => css`
-	border: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] };
+	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 	border-radius: 2px;
 	flex: 1 0 40%;
 
@@ -60,11 +60,11 @@ export const borderControlDropdown = () => css`
 	${ rtl(
 		{
 			borderRadius: `1px 0 0 1px`,
-			borderRight: `${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] }`,
+			borderRight: `${ CONFIG.borderWidth } solid ${ COLORS.ui.border }`,
 		},
 		{
 			borderRadius: `0 1px 1px 0`,
-			borderLeft: `${ CONFIG.borderWidth } solid ${ COLORS.gray[ 200 ] }`,
+			borderLeft: `${ CONFIG.borderWidth } solid ${ COLORS.ui.border }`,
 		}
 	)() }
 


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/40893

## What?

Makes the `BorderControl` and `BorderBoxControl` border colors consistent with other controls. 

_Only addresses the border color from #40893 in this PR as controlling the height might need discussion. See https://github.com/WordPress/gutenberg/pull/40920/._

## Why?

Consistency is good.

## How?

- Set the `BorderControl` border colors to `COLORS.ui.border`.

## Testing Instructions

1. Edit a post, add a group block, and select it.
2. Under the border settings in the sidebar check that the border control has the same border color as other controls

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="300" alt="Screen Shot 2022-05-09 at 4 30 26 pm" src="https://user-images.githubusercontent.com/60436221/167352861-e730fa05-eb9a-476d-bf83-307423a2869b.png"> | <img width="301" alt="Screen Shot 2022-05-09 at 4 27 29 pm" src="https://user-images.githubusercontent.com/60436221/167352521-c1a6daa6-542e-4827-a2c8-c749cdd021ac.png"> | 
<img width="300" alt="Screen Shot 2022-05-09 at 4 18 58 pm" src="https://user-images.githubusercontent.com/60436221/167352464-033e98ef-6edd-4231-8642-35a4a9a7a434.png"> | <img width="285" alt="Screen Shot 2022-05-09 at 4 27 14 pm" src="https://user-images.githubusercontent.com/60436221/167352507-2a1ea3e1-cc4a-417b-9f0d-64c54fb17a2b.png"> |
