### PR TITLE
Column: Add border radius support and content clipping

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -96,7 +96,7 @@ A single column within a columns block. ([Source](https://github.com/WordPress/g
 -	**Name:** core/column
 -	**Category:** text
 -	**Supports:** anchor, color (background, gradients, link, text), spacing (blockGap, padding), ~~html~~, ~~reusable~~
--	**Attributes:** allowedBlocks, templateLock, verticalAlignment, width
+-	**Attributes:** allowedBlocks, clipContent, templateLock, verticalAlignment, width
 
 ## Columns
 

--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -8,18 +8,21 @@
 	"description": "A single column within a columns block.",
 	"textdomain": "default",
 	"attributes": {
+		"allowedBlocks": {
+			"type": "array"
+		},
+		"clipContent": {
+			"type": "boolean"
+		},
+		"templateLock": {
+			"type": [ "string", "boolean" ],
+			"enum": [ "all", "insert", false ]
+		},
 		"verticalAlignment": {
 			"type": "string"
 		},
 		"width": {
 			"type": "string"
-		},
-		"allowedBlocks": {
-			"type": "array"
-		},
-		"templateLock": {
-			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", false ]
 		}
 	},
 	"supports": {
@@ -43,10 +46,12 @@
 		},
 		"__experimentalBorder": {
 			"color": true,
+			"radius": true,
 			"style": true,
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
+				"radius": true,
 				"style": true,
 				"width": true
 			}

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -17,19 +17,23 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	__experimentalUseCustomUnits as useCustomUnits,
 	PanelBody,
+	ToggleControl,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUnitControl as UnitControl,
+	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
 function ColumnEdit( {
 	attributes: {
+		allowedBlocks,
+		clipContent,
+		templateLock = false,
 		verticalAlignment,
 		width,
-		templateLock = false,
-		allowedBlocks,
+		style,
 	},
 	setAttributes,
 	clientId,
@@ -79,7 +83,10 @@ function ColumnEdit( {
 	const widthWithUnit = Number.isFinite( width ) ? width + '%' : width;
 	const blockProps = useBlockProps( {
 		className: classes,
-		style: widthWithUnit ? { flexBasis: widthWithUnit } : undefined,
+		style: {
+			flexBasis: widthWithUnit,
+			overflow: clipContent ? 'hidden' : undefined,
+		},
 	} );
 
 	const columnsCount = columnsIds.length;
@@ -128,6 +135,31 @@ function ColumnEdit( {
 					/>
 				</PanelBody>
 			</InspectorControls>
+			{ !! style?.border?.radius && (
+				<InspectorControls __experimentalGroup="border">
+					<ToolsPanelItem
+						hasValue={ () => clipContent !== undefined }
+						label={ __( 'Clip content' ) }
+						onDeselect={ () =>
+							setAttributes( { clipContent: undefined } )
+						}
+						resetAllFilter={ () => ( { clipContent: undefined } ) }
+						isShownByDefault={ true }
+						panelId={ clientId }
+					>
+						<ToggleControl
+							label={ __( 'Clip content' ) }
+							checked={ !! clipContent }
+							onChange={ () =>
+								setAttributes( { clipContent: ! clipContent } )
+							}
+							help={ __(
+								"Turning this on prevents content overflowing beyond the column's borders"
+							) }
+						/>
+					</ToolsPanelItem>
+				</InspectorControls>
+			) }
 			<div { ...innerBlocksProps } />
 		</>
 	);

--- a/packages/block-library/src/column/save.js
+++ b/packages/block-library/src/column/save.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { verticalAlignment, width } = attributes;
+	const { clipContent, verticalAlignment, width } = attributes;
 
 	const wrapperClasses = classnames( {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
@@ -30,6 +30,10 @@ export default function save( { attributes } ) {
 				'%';
 		}
 		style = { flexBasis };
+	}
+
+	if ( clipContent ) {
+		style = { ...style, overflow: 'hidden' };
 	}
 
 	const blockProps = useBlockProps.save( {


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/39967

## ⚠️ Disclaimer ⚠️ 

_This is a very quick and rough draft to demonstrate the UX issue around adding border radius support to the Column block._

## What?

Adds border-radius support to Column blocks and provides the option to toggle content clipping on and off for the column.

## Why?

Enabling border radius support for individual columns will allow matching height columns to have rounded corners as per this [design mockup](https://github.com/WordPress/gutenberg/pull/39967#issuecomment-1118944562). It was initially omitted from #39967 due to concerns around content clipping.

## How?

- Opts into border radius support
- Injects a new "Clip content" control into the border block supports panel 
- If "Clip content" is enabled, then `overflow: hidden` is applied via the column's inline styles.

## Known Issues

⚠️☠️   **When clipping column content in the editor, the block inserter within the column will also be hidden.** ☠️ ⚠️

Given the inserter is added within the Column block's markup I haven't found a way around this problem.

| Default | Clipped |
|---|---|
| <img width="195" alt="Screen Shot 2022-05-09 at 6 52 13 pm" src="https://user-images.githubusercontent.com/60436221/167375426-2523f60f-4124-4c33-968b-2c1a78a094e4.png"> | <img width="186" alt="Screen Shot 2022-05-09 at 6 52 03 pm" src="https://user-images.githubusercontent.com/60436221/167375470-be9c1603-5c16-4fce-97a5-537ee215af94.png"> |

## Testing Instructions

1. Edit a post, add a columns block including multiple columns with content
2. Apply a background color on each column
3. Apply a border radius to a column and experiment with toggling on clipping
4. Notice how when clipped, in most situations, the block inserter is also clipped presenting a problem that may block introduction of clipping

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/167376238-598926ff-9a56-46b0-9f97-612f1b21f546.mp4


