### PR TITLE
Packages: Add command to publish to npm targeting WP major release

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -20,9 +20,10 @@ const catchException = ( command ) => {
  * Internal dependencies
  */
 const {
-	publishNpmLatestDistTag,
-	publishNpmBugfixLatestDistTag,
-	publishNpmNextDistTag,
+	publishNpmGutenbergPlugin,
+	publishNpmBugfixLatest,
+	publishNpmBugfixWordPressCore,
+	publishNpmNext,
 } = require( './commands/packages' );
 const { getReleaseChangelog } = require( './commands/changelog' );
 const { runPerformanceTests } = require( './commands/performance' );
@@ -41,20 +42,30 @@ program
 	.option( ...ciOption )
 	.option( ...repositoryPathOption )
 	.description(
-		'Publishes packages to npm (latest dist-tag, production version)'
+		'Publishes to npm packages synced from the Gutenberg plugin (latest dist-tag, production version)'
 	)
-	.action( catchException( publishNpmLatestDistTag ) );
+	.action( catchException( publishNpmGutenbergPlugin ) );
 
 program
 	.command( 'publish-npm-packages-bugfix-latest' )
 	.alias( 'npm-bugfix' )
-	.option( ...semverOption )
 	.option( ...ciOption )
 	.option( ...repositoryPathOption )
 	.description(
-		'Publishes bugfixes for packages to npm (latest dist-tag, production version)'
+		'Publishes to npm bugfixes for packages (latest dist-tag, production version)'
 	)
-	.action( catchException( publishNpmBugfixLatestDistTag ) );
+	.action( catchException( publishNpmBugfixLatest ) );
+
+program
+	.command( 'publish-npm-packages-wordpress-core' )
+	.alias( 'npm-wp' )
+	.requiredOption( '--wp-version <wpVersion>', 'WordPress version' )
+	.option( ...ciOption )
+	.option( ...repositoryPathOption )
+	.description(
+		'Publishes to npm bugfixes targeting WordPress core (wp-X.Y dist-tag, production version)'
+	)
+	.action( catchException( publishNpmBugfixWordPressCore ) );
 
 program
 	.command( 'publish-npm-packages-next' )
@@ -63,9 +74,9 @@ program
 	.option( ...ciOption )
 	.option( ...repositoryPathOption )
 	.description(
-		'Publishes packages to npm (next dist-tag, prerelease version)'
+		'Publishes to npm development version of packages (next dist-tag, prerelease version)'
 	)
-	.action( catchException( publishNpmNextDistTag ) );
+	.action( catchException( publishNpmNext ) );
 
 program
 	.command( 'release-plugin-changelog' )

--- a/bin/plugin/commands/packages.js
+++ b/bin/plugin/commands/packages.js
@@ -40,12 +40,14 @@ const { join } = require( 'path' );
  * @property {boolean} [ci]             Disables interactive mode when executed in CI mode.
  * @property {string}  [repositoryPath] Relative path to the git repository.
  * @property {SemVer}  [semver]         The selected semantic versioning. Defaults to `patch`.
+ * @property {string}  [wpVersion]      The major WordPress version number, example: `6.0`.
  */
 
 /**
  * @typedef WPPackagesConfig
  *
  * @property {string}      abortMessage            Abort Message.
+ * @property {string}      distTag                 The dist-tag used for npm publishing.
  * @property {string}      gitWorkingDirectoryPath Git working directory path.
  * @property {boolean}     interactive             Whether to run in interactive mode.
  * @property {SemVer}      minimumVersionBump      The selected minimum version bump.
@@ -141,6 +143,14 @@ async function updatePackages( config ) {
 		minimumVersionBump,
 		releaseType,
 	} = config;
+
+	if ( releaseType === 'wp' ) {
+		log(
+			'>> Skipping CHANGELOG files processing when targeting WordPress core.'
+		);
+		return;
+	}
+
 	const changelogFiles = await glob(
 		path.resolve( gitWorkingDirectoryPath, 'packages/*/CHANGELOG.md' )
 	);
@@ -323,6 +333,7 @@ async function runPushGitChangesStep( {
  * @return {?string} The optional commit's hash when packages published to npm.
  */
 async function publishPackagesToNpm( {
+	distTag,
 	gitWorkingDirectoryPath,
 	interactive,
 	minimumVersionBump,
@@ -360,16 +371,16 @@ async function publishPackagesToNpm( {
 
 		log( '>> Publishing modified packages to npm.' );
 		await command(
-			`npx lerna publish from-package --dist-tag next ${ yesFlag } ${ noVerifyAccessFlag }`,
+			`npx lerna publish from-package --dist-tag ${ distTag } ${ yesFlag } ${ noVerifyAccessFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
 			}
 		);
-	} else if ( releaseType === 'bugfix' ) {
+	} else if ( [ 'bugfix', 'wp' ].includes( releaseType ) ) {
 		log( '>> Publishing modified packages to npm.' );
 		await command(
-			`npx lerna publish ${ minimumVersionBump } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
+			`npx lerna publish ${ minimumVersionBump } --dist-tag ${ distTag } --no-private ${ yesFlag } ${ noVerifyAccessFlag }`,
 			{
 				cwd: gitWorkingDirectoryPath,
 				stdio: 'inherit',
@@ -528,54 +539,81 @@ async function runPackagesRelease( config, customMessages ) {
  *
  * @return {WPPackagesConfig} The config object.
  */
-function getConfig( releaseType, { ci, repositoryPath, semver } ) {
+function getConfig(
+	releaseType,
+	{ ci, repositoryPath, semver = 'patch', wpVersion }
+) {
+	let distTag = 'latest';
+	let npmReleaseBranch = 'wp/latest';
+	if ( releaseType === 'next' ) {
+		distTag = 'next';
+		npmReleaseBranch = 'wp/next';
+	} else if ( releaseType === 'wp' ) {
+		distTag = `wp-${ wpVersion }`;
+		npmReleaseBranch = `wp/${ wpVersion }`;
+	}
+
 	return {
 		abortMessage: 'Aborting!',
+		distTag,
 		gitWorkingDirectoryPath:
 			repositoryPath && join( process.cwd(), repositoryPath ),
 		interactive: ! ci,
 		minimumVersionBump: semver,
-		npmReleaseBranch: releaseType === 'next' ? 'wp/next' : 'wp/latest',
+		npmReleaseBranch,
 		releaseType,
 	};
 }
 
 /**
- * Publishes a new latest version of WordPress packages.
+ * Publishes to npm packages synced from the Gutenberg plugin (latest dist-tag, production version).
  *
  * @param {WPPackagesCommandOptions} options Command options.
  */
-async function publishNpmLatestDistTag( options ) {
+async function publishNpmGutenbergPlugin( options ) {
 	await runPackagesRelease( getConfig( 'latest', options ), [
-		'Welcome! This tool helps with publishing a new latest version of WordPress packages.\n',
+		'Welcome! This tool helps with npm publishing a new latest version of WordPress packages synced from the Gutenberg plugin.\n',
 	] );
 }
 
 /**
- * Publishes a new latest version of WordPress packages.
+ * Publishes to npm bugfixes for packages (latest dist-tag, production version).
  *
  * @param {WPPackagesCommandOptions} options Command options.
  */
-async function publishNpmBugfixLatestDistTag( options ) {
+async function publishNpmBugfixLatest( options ) {
 	await runPackagesRelease( getConfig( 'bugfix', options ), [
-		'Welcome! This tool is going to help you with publishing a new bugfix version of WordPress packages with the latest dist tag.\n',
-		'Make sure that all required changes have been already cherry-picked to the release branch.\n',
+		'Welcome! This tool helps with npm publishing a new bugfix version of WordPress packages.\n',
+		'Make sure that all required changes have been already cherry-picked to the `wp/latest` release branch.\n',
 	] );
 }
 
 /**
- * Publishes a new next version of WordPress packages.
+ * Publishes to npm bugfixes targeting WordPress core (wp-X.Y dist-tag, production version).
  *
  * @param {WPPackagesCommandOptions} options Command options.
  */
-async function publishNpmNextDistTag( options ) {
+async function publishNpmBugfixWordPressCore( options ) {
+	await runPackagesRelease( getConfig( 'wp', options ), [
+		'Welcome! This tool helps with npm publishing a new bugfix version of WordPress packages targeting WordPress core.\n',
+		'Make sure that all required changes have been already cherry-picked to the `wp/X.Y` release branch.\n',
+	] );
+}
+
+/**
+ * Publishes to npm development version of packages (next dist-tag, prerelease version).
+ *
+ * @param {WPPackagesCommandOptions} options Command options.
+ */
+async function publishNpmNext( options ) {
 	await runPackagesRelease( getConfig( 'next', options ), [
-		'Welcome! This tool helps with publishing a new next version of WordPress packages.\n',
+		'Welcome! This tool helps with npm publishing a development version of WordPress packages.\n',
 	] );
 }
 
 module.exports = {
-	publishNpmLatestDistTag,
-	publishNpmBugfixLatestDistTag,
-	publishNpmNextDistTag,
+	publishNpmGutenbergPlugin,
+	publishNpmBugfixLatest,
+	publishNpmBugfixWordPressCore,
+	publishNpmNext,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17400,7 +17400,7 @@
 				"@wordpress/lazy-import": "file:packages/lazy-import",
 				"chalk": "^4.0.0",
 				"check-node-version": "^4.1.0",
-				"commander": "^4.1.0",
+				"commander": "^9.2.0",
 				"execa": "^4.0.2",
 				"fast-glob": "^3.2.7",
 				"inquirer": "^7.1.0",
@@ -29471,9 +29471,9 @@
 			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w=="
 		},
 		"commander": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-			"integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-9.2.0.tgz",
+			"integrity": "sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==",
 			"dev": true
 		},
 		"comment-parser": {

--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
 		"benchmark": "2.1.4",
 		"browserslist": "4.17.6",
 		"chalk": "4.1.1",
-		"commander": "4.1.0",
+		"commander": "9.2.0",
 		"concurrently": "3.5.0",
 		"copy-webpack-plugin": "10.2.0",
 		"core-js-builder": "3.19.1",

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+### Internal
+
+-   Updated `commander` dependency from requiring `^4.1.0` to `^9.2.0` ([#40927](https://github.com/WordPress/gutenberg/pull/40927)).
+
 ## 3.1.0 (2022-04-08)
 
 ### New Features
--    Add `npmDevDependencies` template variable to allow definition of `devDependencies` as part of a template ([#39723](https://github.com/WordPress/gutenberg/pull/39723)).
+
+-   Add `npmDevDependencies` template variable to allow definition of `devDependencies` as part of a template ([#39723](https://github.com/WordPress/gutenberg/pull/39723)).
 
 ## 3.0.0 (2022-03-03)
 

--- a/packages/create-block/package.json
+++ b/packages/create-block/package.json
@@ -34,7 +34,7 @@
 		"@wordpress/lazy-import": "file:../lazy-import",
 		"chalk": "^4.0.0",
 		"check-node-version": "^4.1.0",
-		"commander": "^4.1.0",
+		"commander": "^9.2.0",
 		"execa": "^4.0.2",
 		"fast-glob": "^3.2.7",
 		"inquirer": "^7.1.0",


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Part of the efforts to automate npm publishing as discussed in https://github.com/WordPress/gutenberg/discussions/37820.

Adds a new command that automates the process of publishing npm packages targeting the given major WordPress release.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

At the moment the process of publishing to npm changes targeting the current major WordPress release is very manual and repeats every week. We want to automate it with GitHub action that runs behind the scenes the following:

```
npm whoami # should print an npm user from WordPress org
git fetch
git checkout wp/6.0
git pull
nvm use
npm i
npx lerna publish patch --no-private --dist-tag wp-6.0
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Introduce a new command `npm-wp` for the `./bin/plugin/cli.js` tool that we have been using for npm publishing for quite some time.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

Ensure that the `--wp-version` option is mandatory:

```
./bin/plugin/cli.js npm-wp
```

Ensure that the command runs correctly when the WP version is provided:

```
./bin/plugin/cli.js npm-wp --wp-version=6.0
```

## Screenshots or screencast <!-- if applicable -->

Test run:

<img width="1368" alt="Screenshot 2022-05-09 at 13 19 22" src="https://user-images.githubusercontent.com/699132/167400017-a7bd68c3-af43-4032-a0e7-82af42fa8c55.png">

I managed to publish npm packages with this action:

<img width="1102" alt="Screenshot 2022-05-09 at 13 35 24" src="https://user-images.githubusercontent.com/699132/167402478-b716ffc8-167a-4a5a-a979-785c7c7aaa71.png">

I verified that the `@wordpress/block-directory@3.4.7` has the correct `dist-tag` applied: `wp-6.0`.

<img width="798" alt="Screenshot 2022-05-09 at 13 34 11" src="https://user-images.githubusercontent.com/699132/167401824-b6658a23-2cab-4c17-85e6-03e2a29eade9.png">
