### PR TITLE
Post Comments: Fix invalid date format in placeholder

### DIFF
--- a/packages/block-library/src/post-comments/edit.js
+++ b/packages/block-library/src/post-comments/edit.js
@@ -173,9 +173,9 @@ export default function PostCommentsEdit( {
 
 										<div className="comment-metadata">
 											<a href="#top">
-												<time dateTime="2000-01-01T00:00:00+00:00">
+												<time dateTime="2000-01-01T12:00:00+00:00">
 													{ __(
-														'January 1, 2000 at 00:00 am'
+														'January 1, 2000 at 12:00 am'
 													) }
 												</time>
 											</a>{ ' ' }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix invalid date format in the Post Comments placeholder.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The date that is shown in the Editor doesn't exist because when am/pm is used, there is no 00 hour, as explained in #40916. Even though it is just a placeholder, we should use a valid date.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change 00:00 to 12:00.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Open a post or page.
2. Open the Code Editor (this block is hidden from the inserter).
3. Add `<!-- wp:post-comments /-->`.
4. Check that the date in the placeholder is now correct.

## Screenshots or screencast <!-- if applicable -->

<img width="500" alt="Screenshot 2022-05-09 at 12 12 48" src="https://user-images.githubusercontent.com/3305402/167389583-2bc674e8-98b2-42d9-9381-efa4eca7243d.png">

