### PR TITLE
Dependency extraction: improve calculation of contentHash

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-const { createHash } = require( 'crypto' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 // In webpack 5 there is a `webpack.sources` field but for webpack 4 we have to fallback to the `webpack-sources` package.
 const { RawSource } = webpack.sources || require( 'webpack-sources' );
 const json2php = require( 'json2php' );
 const isWebpack4 = webpack.version.startsWith( '4.' );
+const { createHash } = webpack.util;
 
 /**
  * Internal dependencies
@@ -200,14 +200,13 @@ class DependencyExtractionWebpackPlugin {
 
 			// Go through the assets and hash the sources. We can't just use
 			// `entrypointChunk.contentHash` because that's not updated when
-			// assets are minified. Sigh.
-			// @todo Use `asset.info.contenthash` if we can make sure it's reliably set.
-			const hash = createHash( 'sha512' );
+			// assets are minified.
+			const hash = createHash( compilation.outputOptions.hashFunction );
 			for ( const filename of entrypoint.getFiles().sort() ) {
 				const asset = compilation.getAsset( filename );
-				hash.update( `${ filename }: ` );
-				asset.source.updateHash( hash );
+				hash.update( asset.source.buffer() );
 			}
+			const version = hash.digest( compilation.outputOptions.hashDigest );
 
 			const entrypointChunk = isWebpack4
 				? entrypoint.chunks.find( ( c ) => c.name === entrypointName )
@@ -216,7 +215,7 @@ class DependencyExtractionWebpackPlugin {
 			const assetData = {
 				// Get a sorted array so we can produce a stable, stringified representation.
 				dependencies: Array.from( entrypointExternalizedWpDeps ).sort(),
-				version: hash.digest( 'hex' ).substring( 0, 32 ),
+				version,
 			};
 
 			const assetString = this.stringify( assetData );

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -198,18 +198,20 @@ class DependencyExtractionWebpackPlugin {
 				}
 			}
 
+			const { hashFunction, hashDigest } = compilation.outputOptions;
+
 			// Go through the assets and hash the sources. We can't just use
 			// `entrypointChunk.contentHash` because that's not updated when
 			// assets are minified. In practice the hash is updated by
 			// `RealContentHashPlugin` after minification, but it only modifies
 			// already-produced asset filenames and the updated hash is not
 			// available to plugins.
-			const hash = createHash( compilation.outputOptions.hashFunction );
+			const hash = createHash( hashFunction );
 			for ( const filename of entrypoint.getFiles().sort() ) {
 				const asset = compilation.getAsset( filename );
 				hash.update( asset.source.buffer() );
 			}
-			const version = hash.digest( compilation.outputOptions.hashDigest );
+			const version = hash.digest( hashDigest );
 
 			const entrypointChunk = isWebpack4
 				? entrypoint.chunks.find( ( c ) => c.name === entrypointName )
@@ -222,9 +224,9 @@ class DependencyExtractionWebpackPlugin {
 			};
 
 			const assetString = this.stringify( assetData );
-			const contentHash = createHash( 'sha512' )
+			const contentHash = createHash( hashFunction )
 				.update( assetString )
-				.digest( 'hex' );
+				.digest( hashDigest );
 
 			// Determine a filename for the asset file.
 			const [ filename, query ] = entrypointName.split( '?', 2 );

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -200,7 +200,10 @@ class DependencyExtractionWebpackPlugin {
 
 			// Go through the assets and hash the sources. We can't just use
 			// `entrypointChunk.contentHash` because that's not updated when
-			// assets are minified.
+			// assets are minified. In practice the hash is updated by
+			// `RealContentHashPlugin` after minification, but it only modifies
+			// already-produced asset filenames and the updated hash is not
+			// available to plugins.
 			const hash = createHash( compilation.outputOptions.hashFunction );
 			for ( const filename of entrypoint.getFiles().sort() ) {
 				const asset = compilation.getAsset( filename );

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -220,6 +220,9 @@ class DependencyExtractionWebpackPlugin {
 			};
 
 			const assetString = this.stringify( assetData );
+			const contentHash = createHash( 'sha512' )
+				.update( assetString )
+				.digest( 'hex' );
 
 			// Determine a filename for the asset file.
 			const [ filename, query ] = entrypointName.split( '?', 2 );
@@ -230,9 +233,7 @@ class DependencyExtractionWebpackPlugin {
 					filename,
 					query,
 					basename: basename( filename ),
-					contentHash: createHash( 'sha512' )
-						.update( assetString )
-						.digest( 'hex' ),
+					contentHash,
 				}
 			);
 
@@ -249,9 +250,7 @@ class DependencyExtractionWebpackPlugin {
 					filename,
 					query,
 					basename: basename( filename ),
-					contentHash: createHash( 'sha512' )
-						.update( assetString )
-						.digest( 'hex' ),
+					contentHash,
 				} );
 			} else {
 				assetFilename = buildFilename.replace(

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`combine-assets\` should produce expected output: Asset file 'assets.php' should match snapshot 1`] = `
-"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => '3e34cc9f8b5062d43bb05d71a9865ab1'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '59ef1b47eaac81d79d740e4357df7209'));
+"<?php return array('fileA.js' => array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'bf200ecb3dcb6881a1f39d63cd243206'), 'fileB.js' => array('dependencies' => array('wp-token-list'), 'version' => '0af6c51a8e6ac934b85a78835a93cb5c'));
 "
 `;
 
@@ -32,7 +32,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`dynamic-import\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'f210c845cbb975aa12ca53703279950b');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '1166b9d1044bb1eded0a4193fadf87f8');
 "
 `;
 
@@ -55,7 +55,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '978b7e0c7b7f291c4b16b534a7a431a3');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '4c78134607e6ed966df3de5d3d38b15f');
 "
 `;
 
@@ -78,7 +78,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`has-extension-suffix\` should produce expected output: Asset file 'index.min.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'd57351543a76eca838d184863322b856');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'dabeb91f3cb9dd73d48d044af194a158');
 "
 `;
 
@@ -101,21 +101,21 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`no-default\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '6041d7727db98d5f89967189c9ac013f');
+"<?php return array('dependencies' => array(), 'version' => 'bb85a9737103c7054b00770c09034c6e');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`no-default\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`no-deps\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '86ff60df0b0f882f2a05d1a67ff97cf4');
+"<?php return array('dependencies' => array(), 'version' => '091ffcd70d94dd16e773c0ddca465fdc');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`no-deps\` should produce expected output: External modules should match snapshot 1`] = `Array []`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`option-function-output-filename\` should produce expected output: Asset file 'chunk--main--main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '9e10498153cf094d8c25892525d3cd6c');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '4c78134607e6ed966df3de5d3d38b15f');
 "
 `;
 
@@ -138,7 +138,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`option-output-filename\` should produce expected output: Asset file 'main-foo.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '9e10498153cf094d8c25892525d3cd6c');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '4c78134607e6ed966df3de5d3d38b15f');
 "
 `;
 
@@ -160,7 +160,7 @@ Array [
 ]
 `;
 
-exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{\\"dependencies\\":[\\"lodash\\"],\\"version\\":\\"2a8570fd30cadd4123ee368f90128519\\"}"`;
+exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: Asset file 'main.asset.json' should match snapshot 1`] = `"{\\"dependencies\\":[\\"lodash\\"],\\"version\\":\\"a8f35bfc9f46482cc48a78d50e7099da\\"}"`;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`output-format-json\` should produce expected output: External modules should match snapshot 1`] = `
 Array [
@@ -173,7 +173,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`overrides\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '5620bf1846e497728408912a36d99af6');
+"<?php return array('dependencies' => array('wp-blob', 'wp-script-handle-for-rxjs', 'wp-url'), 'version' => '2a29b245fc3d0509b5a8039bb4cde515');
 "
 `;
 
@@ -212,12 +212,12 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => 'e575aabfcecd0c966cba4df4985af039');
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'afb97a54745e17cee9638e4d9d2322f9');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'd86c3101fe7a68a43edb695f5f897b62');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'ed750e4e046b77c317cb852294984ef3');
 "
 `;
 
@@ -240,7 +240,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '9e10498153cf094d8c25892525d3cd6c');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '4c78134607e6ed966df3de5d3d38b15f');
 "
 `;
 
@@ -263,7 +263,7 @@ Array [
 `;
 
 exports[`DependencyExtractionWebpackPlugin Webpack \`wordpress-require\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'ad8b8843fa9f514255fde2cc0c16b48c');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => 'ed2bd4e7df46768bb3c23c8dc0ba5c50');
 "
 `;
 


### PR DESCRIPTION
Follow-up to #34969 that implements suggestions from https://github.com/WordPress/gutenberg/pull/34969/files#r867737688:
- use `createHash` exported by webpack rather than Node's `crypto` module
- use hash algorithm specified in compiler option rather than hardcoding a specific one
- hash only the asset source, not any filenames or `RawSource` prefixes

The resulting hash is identical to what webpack itself would compute for filename like `[name].[contenthash].js`, and it's also identical to simply hashing the file contents with, e.g.,
```
openssl dgst -md4 file.js
```
