### PR TITLE
Template Editor: Use the label 'Clear customizations' when changes are revertable

### DIFF
--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -48,6 +48,8 @@ export default function DeleteTemplate() {
 		templateTitle = template.title;
 	}
 
+	const isRevertable = template?.has_theme_file;
+
 	const onDelete = () => {
 		clearSelectedBlock();
 		setIsEditingTemplate( false );
@@ -77,14 +79,15 @@ export default function DeleteTemplate() {
 			<>
 				<MenuItem
 					className="edit-post-template-top-area__delete-template-button"
-					isDestructive
+					isDestructive={ ! isRevertable }
 					variant="secondary"
-					aria-label={ __( 'Delete template' ) }
 					onClick={ () => {
 						setShowConfirmDialog( true );
 					} }
 				>
-					{ __( 'Delete template' ) }
+					{ isRevertable
+						? __( 'Clear customizations' )
+						: __( 'Delete template' ) }
 				</MenuItem>
 				<ConfirmDialog
 					isOpen={ showConfirmDialog }

--- a/packages/edit-post/src/components/header/template-title/delete-template.js
+++ b/packages/edit-post/src/components/header/template-title/delete-template.js
@@ -80,10 +80,14 @@ export default function DeleteTemplate() {
 				<MenuItem
 					className="edit-post-template-top-area__delete-template-button"
 					isDestructive={ ! isRevertable }
-					variant="secondary"
 					onClick={ () => {
 						setShowConfirmDialog( true );
 					} }
+					info={
+						isRevertable
+							? __( 'Restore template to default state' )
+							: undefined
+					}
 				>
 					{ isRevertable
 						? __( 'Clear customizations' )

--- a/packages/edit-post/src/components/header/template-title/edit-template-title.js
+++ b/packages/edit-post/src/components/header/template-title/edit-template-title.js
@@ -42,31 +42,33 @@ export default function EditTemplateTitle() {
 	}
 
 	return (
-		<TextControl
-			label={ __( 'Title' ) }
-			value={ templateTitle }
-			help={ __(
-				'Give the template a title that indicates its purpose, e.g. "Full Width".'
-			) }
-			onChange={ ( newTitle ) => {
-				const settings = getEditorSettings();
-				const newAvailableTemplates = mapValues(
-					settings.availableTemplates,
-					( existingTitle, id ) => {
-						if ( id !== template.slug ) {
-							return existingTitle;
+		<div className="edit-site-template-details__group">
+			<TextControl
+				label={ __( 'Title' ) }
+				value={ templateTitle }
+				help={ __(
+					'Give the template a title that indicates its purpose, e.g. "Full Width".'
+				) }
+				onChange={ ( newTitle ) => {
+					const settings = getEditorSettings();
+					const newAvailableTemplates = mapValues(
+						settings.availableTemplates,
+						( existingTitle, id ) => {
+							if ( id !== template.slug ) {
+								return existingTitle;
+							}
+							return newTitle;
 						}
-						return newTitle;
-					}
-				);
-				updateEditorSettings( {
-					...settings,
-					availableTemplates: newAvailableTemplates,
-				} );
-				editEntityRecord( 'postType', 'wp_template', template.id, {
-					title: newTitle,
-				} );
-			} }
-		/>
+					);
+					updateEditorSettings( {
+						...settings,
+						availableTemplates: newAvailableTemplates,
+					} );
+					editEntityRecord( 'postType', 'wp_template', template.id, {
+						title: newTitle,
+					} );
+				} }
+			/>
+		</div>
 	);
 }

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -48,7 +48,7 @@
 
 .edit-post-template-top-area__popover {
 	.components-popover__content {
-		min-width: 240px;
+		min-width: 280px;
 
 		> div {
 			padding: 0;

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -49,6 +49,18 @@
 .edit-post-template-top-area__popover {
 	.components-popover__content {
 		min-width: 240px;
+
+		> div {
+			padding: 0;
+		}
+	}
+
+	.edit-site-template-details__group {
+		padding: $grid-unit-20;
+
+		.components-base-control__help {
+			margin-bottom: 0;
+		}
 	}
 
 	.edit-post-template-details__description {
@@ -57,18 +69,29 @@
 }
 
 .edit-post-template-top-area__second-menu-group {
-	margin-left: -$grid-unit-10;
-	margin-right: -$grid-unit-10;
-	padding: $grid-unit-20 $grid-unit-10 $grid-unit-05;
 	border-top: $border-width solid $gray-300;
+	padding: $grid-unit-20 $grid-unit-10;
 
 	.edit-post-template-top-area__delete-template-button {
 		display: flex;
 		justify-content: center;
+		padding: $grid-unit-05 $grid-unit;
+
+		&.is-destructive {
+			padding: inherit;
+			margin-left: $grid-unit-10;
+			margin-right: $grid-unit-10;
+			width: calc(100% - #{($grid-unit * 2)});
+
+			.components-menu-item__item {
+				width: auto;
+			}
+		}
 
 		.components-menu-item__item {
 			margin-right: 0;
 			min-width: 0;
+			width: 100%;
 		}
 	}
 }

--- a/packages/edit-post/src/components/header/template-title/style.scss
+++ b/packages/edit-post/src/components/header/template-title/style.scss
@@ -48,8 +48,7 @@
 
 .edit-post-template-top-area__popover {
 	.components-popover__content {
-		min-width: 280px;
-		padding: $grid-unit-10;
+		min-width: 240px;
 	}
 
 	.edit-post-template-details__description {
@@ -58,10 +57,9 @@
 }
 
 .edit-post-template-top-area__second-menu-group {
-	margin-left: -$grid-unit-20;
-	margin-right: -$grid-unit-20;
-	padding: $grid-unit-20;
-	padding-bottom: 0;
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+	padding: $grid-unit-20 $grid-unit-10 $grid-unit-05;
 	border-top: $border-width solid $gray-300;
 
 	.edit-post-template-top-area__delete-template-button {

--- a/packages/edit-post/src/components/header/template-title/template-description.js
+++ b/packages/edit-post/src/components/header/template-title/template-description.js
@@ -32,7 +32,7 @@ export default function TemplateDescription() {
 				className="edit-post-template-details__description"
 				size="body"
 				as="p"
-				style={ { marginTop: '12px' } }
+				style={ { marginTop: '12px', marginBottom: '12px' } }
 			>
 				{ description }
 			</Text>

--- a/packages/edit-post/src/components/header/template-title/template-description.js
+++ b/packages/edit-post/src/components/header/template-title/template-description.js
@@ -23,21 +23,20 @@ export default function TemplateDescription() {
 	if ( ! description ) {
 		return null;
 	}
+
 	return (
-		<>
-			<div className="edit-site-template-details__group">
-				<Heading level={ 4 } weight={ 600 }>
-					{ title }
-				</Heading>
-				<Text
-					className="edit-post-template-details__description"
-					size="body"
-					as="p"
-					style={ { marginTop: '12px' } }
-				>
-					{ description }
-				</Text>
-			</div>
-		</>
+		<div className="edit-site-template-details__group">
+			<Heading level={ 4 } weight={ 600 }>
+				{ title }
+			</Heading>
+			<Text
+				className="edit-post-template-details__description"
+				size="body"
+				as="p"
+				style={ { marginTop: '12px' } }
+			>
+				{ description }
+			</Text>
+		</div>
 	);
 }

--- a/packages/edit-post/src/components/header/template-title/template-description.js
+++ b/packages/edit-post/src/components/header/template-title/template-description.js
@@ -25,17 +25,19 @@ export default function TemplateDescription() {
 	}
 	return (
 		<>
-			<Heading level={ 4 } weight={ 600 }>
-				{ title }
-			</Heading>
-			<Text
-				className="edit-post-template-details__description"
-				size="body"
-				as="p"
-				style={ { marginTop: '12px', marginBottom: '12px' } }
-			>
-				{ description }
-			</Text>
+			<div className="edit-site-template-details__group">
+				<Heading level={ 4 } weight={ 600 }>
+					{ title }
+				</Heading>
+				<Text
+					className="edit-post-template-details__description"
+					size="body"
+					as="p"
+					style={ { marginTop: '12px' } }
+				>
+					{ description }
+				</Text>
+			</div>
 		</>
 	);
 }


### PR DESCRIPTION
## What?
Resolves #40885.

PR updates the delete button label to "Clear customizations" when changes to a template are revertable (template has theme file). It also makes the button non-destructive for this case.

## Testing Instructions
Using TT2

1. Open a Post or Page.
2. Modify the default template.
3. Confirm that dropdown displays the new label.
4. Create a new template.
5. Confirm that it displays the "Delete template" label.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-05-09 at 16 54 04](https://user-images.githubusercontent.com/240569/167415287-ca502d87-585f-4793-887e-72d74eb7517b.png)
![CleanShot 2022-05-09 at 16 54 22](https://user-images.githubusercontent.com/240569/167415293-cf19ebc7-6805-4b7c-957a-81d4000aebf5.png)

