### PR TITLE
Fix opinionated block styles loading in editor.

### DIFF
--- a/lib/compat/wordpress-6.0/client-assets.php
+++ b/lib/compat/wordpress-6.0/client-assets.php
@@ -45,9 +45,12 @@ function gutenberg_resolve_assets() {
 	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',
-		'wp-block-library-theme',
-		'wp-edit-blocks',
+		'wp-edit-blocks'
 	);
+
+	if ( current_theme_supports( 'wp-block-styles' ) ) {
+		$style_handles[] = 'wp-block-styles';
+	}
 
 	if ( 'widgets.php' === $pagenow || 'customize.php' === $pagenow ) {
 		$style_handles[] = 'wp-widgets';

--- a/lib/compat/wordpress-6.0/client-assets.php
+++ b/lib/compat/wordpress-6.0/client-assets.php
@@ -45,7 +45,7 @@ function gutenberg_resolve_assets() {
 	$style_handles  = array(
 		'wp-block-editor',
 		'wp-block-library',
-		'wp-edit-blocks'
+		'wp-edit-blocks',
 	);
 
 	if ( current_theme_supports( 'wp-block-styles' ) ) {

--- a/lib/compat/wordpress-6.0/client-assets.php
+++ b/lib/compat/wordpress-6.0/client-assets.php
@@ -49,7 +49,7 @@ function gutenberg_resolve_assets() {
 	);
 
 	if ( current_theme_supports( 'wp-block-styles' ) ) {
-		$style_handles[] = 'wp-block-styles';
+		$style_handles[] = 'wp-block-library-theme';
 	}
 
 	if ( 'widgets.php' === $pagenow || 'customize.php' === $pagenow ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR checks if the current theme has declared support for `wp-block-styles` before adding the dependency in the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Right now the opinionated styles are being loaded in the editor, regardless if the theme has declared support. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I traced the problem to the 6.0 compat file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Activate `emptytheme`
2. Go to the site editor, verify theme.css is loaded. A quick visual check is adding a separator at the root of the page and seeing that the width is limited to 100px.
3. Comment out / remove the `add_theme_support( 'wp-block-styles' );` line of the theme's functions.php  
4. Refresh the site editor, verify the theme.css is no longer loaded. (The separator's width should not be limited.)

## Screenshots or screencast <!-- if applicable -->

cc @WordPress/block-themers 