### PR TITLE
[List v2]: Fix outdent on empty list item if we press enter

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-enter.js
+++ b/packages/block-library/src/list-item/hooks/use-enter.js
@@ -15,7 +15,7 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import useIndentListItem from './use-indent-list-item';
+import useOutdentListItem from './use-outdent-list-item';
 
 export default function useEnter( props ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
@@ -27,7 +27,7 @@ export default function useEnter( props ) {
 	} = useSelect( blockEditorStore );
 	const propsRef = useRef( props );
 	propsRef.current = props;
-	const [ canIndent, indentListItem ] = useIndentListItem(
+	const [ canOutdent, outdentListItem ] = useOutdentListItem(
 		propsRef.current.clientId
 	);
 	return useRefEffect(
@@ -41,8 +41,8 @@ export default function useEnter( props ) {
 					return;
 				}
 				event.preventDefault();
-				if ( canIndent ) {
-					indentListItem();
+				if ( canOutdent ) {
+					outdentListItem();
 					return;
 				}
 				// Here we are in top level list so we need to split.
@@ -89,6 +89,6 @@ export default function useEnter( props ) {
 				element.removeEventListener( 'keydown', onKeyDown );
 			};
 		},
-		[ canIndent ]
+		[ canOutdent ]
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There must have been a mixup with naming `indent/outdent` when this was implemented and just noticed that it had the opposite behavior from the wanted. This PR fixes that and outdents the list items.

## Testing Instructions
1. Insert a new list block with any nested lists
2. On an empty list item press `Enter`
3. Should split the list and insert a paragraph in the middle
4. If the list item we press Enter is nested it should outdent

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/160637870-3663d9a3-321d-41f7-aced-ab89ee6e0ac6.mov


## Notes

You need to enable the experiment flag for `List block v2`.
