### PR TITLE
useShortCodeTransform: Fetch media data in single request

### DIFF
--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -24,7 +24,8 @@ export default function useGetMedia( innerBlockImages ) {
 
 			const imageIds = innerBlockImages
 				.map( ( imageBlock ) => imageBlock.attributes.id )
-				.filter( ( id ) => id !== undefined );
+				.filter( ( id ) => id !== undefined )
+				.sort();
 
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;

--- a/packages/block-library/src/gallery/use-get-media.js
+++ b/packages/block-library/src/gallery/use-get-media.js
@@ -24,8 +24,7 @@ export default function useGetMedia( innerBlockImages ) {
 
 			const imageIds = innerBlockImages
 				.map( ( imageBlock ) => imageBlock.attributes.id )
-				.filter( ( id ) => id !== undefined )
-				.sort();
+				.filter( ( id ) => id !== undefined );
 
 			if ( imageIds.length === 0 ) {
 				return currentImageMedia;
@@ -34,6 +33,7 @@ export default function useGetMedia( innerBlockImages ) {
 			return select( coreStore ).getMediaItems( {
 				include: imageIds.join( ',' ),
 				per_page: -1,
+				orderby: 'include',
 			} );
 		},
 		[ innerBlockImages ]

--- a/packages/block-library/src/gallery/use-short-code-transform.js
+++ b/packages/block-library/src/gallery/use-short-code-transform.js
@@ -23,21 +23,14 @@ export default function useShortCodeTransform( shortCodeTransforms ) {
 			if ( ! shortCodeTransforms || shortCodeTransforms.length === 0 ) {
 				return;
 			}
-			const getMedia = select( coreStore ).getMedia;
-			return shortCodeTransforms.map( ( image ) => {
-				const imageData = getMedia( image.id );
-				if ( imageData ) {
-					return {
-						id: imageData.id,
-						type: 'image',
-						url: imageData.source_url,
-						mime: imageData.mime_type,
-						alt: imageData.alt_text,
-						link: imageData.link,
-						caption: imageData?.caption?.raw,
-					};
-				}
-				return undefined;
+
+			const imageIds = shortCodeTransforms
+				.map( ( image ) => image.id )
+				.sort();
+
+			return select( coreStore ).getMediaItems( {
+				include: imageIds.join( ',' ),
+				per_page: -1,
 			} );
 		},
 		[ shortCodeTransforms ]
@@ -47,7 +40,17 @@ export default function useShortCodeTransform( shortCodeTransforms ) {
 		return;
 	}
 
-	if ( every( newImageData, ( img ) => img && img.url ) ) {
-		return newImageData;
+	if ( every( newImageData, ( img ) => img && img.source_url ) ) {
+		return newImageData.map( ( imageData ) => {
+			return {
+				id: imageData.id,
+				type: 'image',
+				url: imageData.source_url,
+				mime: imageData.mime_type,
+				alt: imageData.alt_text,
+				link: imageData.link,
+				caption: imageData?.caption?.raw,
+			};
+		} );
 	}
 }

--- a/packages/block-library/src/gallery/use-short-code-transform.js
+++ b/packages/block-library/src/gallery/use-short-code-transform.js
@@ -24,13 +24,12 @@ export default function useShortCodeTransform( shortCodeTransforms ) {
 				return;
 			}
 
-			const imageIds = shortCodeTransforms
-				.map( ( image ) => image.id )
-				.sort();
+			const imageIds = shortCodeTransforms.map( ( image ) => image.id );
 
 			return select( coreStore ).getMediaItems( {
 				include: imageIds.join( ',' ),
 				per_page: -1,
+				orderby: 'include',
 			} );
 		},
 		[ shortCodeTransforms ]


### PR DESCRIPTION
## What?
PR reduces the number of HTTP requests made by `useShortCodeTransform` when fetching media data for transformation.

Similar to #34389.

## How?
Updates hook to use  `getMediaItems`.
 
## Testing Instructions
1. Open a Post or Page.
2. Add a Classic block and add a Gallery to it. Or paste the gallery shortcode in the Code Editor.
3. Convert the Classic block to Blocks using the Convert to blocks button in the toolbar.
4. Confirm that conversion is successful and image order is preserved.

## Screenshots or screencast <!-- if applicable -->
