### PR TITLE
Post Comments: Fix Older/Newer comments links styling

### DIFF
--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -96,6 +96,10 @@
 		}
 	}
 
+	.comment-respond {
+		clear: both;
+	}
+
 	.comment-reply-title {
 		margin-bottom: 0;
 		:where(small) {

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -9,6 +9,14 @@
 	}
 	/* end utility classes */
 
+	.navigation {
+		&::after {
+			content: "";
+			display: table;
+			clear: both;
+		}
+	}
+
 	.commentlist {
 		clear: both;
 		list-style: none;
@@ -94,10 +102,6 @@
 		#wp-comment-cookies-consent {
 			margin-top: 0.35em;
 		}
-	}
-
-	.comment-respond {
-		clear: both;
 	}
 
 	.comment-reply-title {

--- a/packages/block-library/src/post-comments/style.scss
+++ b/packages/block-library/src/post-comments/style.scss
@@ -1,4 +1,14 @@
 .wp-block-post-comments {
+	/* utility classes */
+	.alignleft {
+		float: left;
+	}
+
+	.alignright {
+		float: right;
+	}
+	/* end utility classes */
+
 	.commentlist {
 		clear: both;
 		list-style: none;


### PR DESCRIPTION
## What?
Fixes #40827. Alternative approach to #40846; based on suggestions from comments on that PR.

## Why?
See #40827. _tl;dr_: 

Users that still have the now-deprecated Post Comments block in one of their templates will find that the "Older Comments" and "Newer Comments" links aren't left- and right-aligned like they should be, but stacked on top of each other.

## How?
Add `.alignleft` and `.alignright` styling to the Post Comments block's `style.css`.
Furthermore, add `clear: both` to the embedded comments form, in order to make sure that the "Leave a Reply" heading isn't accidentally indented.

## Testing Instructions
1. The Post Comments block is currently hidden from the inserter. You need to remove the following line (and rebuild Gutenberg) in order to show it: https://github.com/WordPress/gutenberg/blob/54fd3bfd349fbe24485bb07899dd25d3aee7fa10/packages/block-library/src/post-comments/block.json#L37
3. Go to the Site Editor and edit the Single page template.
4. Insert the block named "Post Comments (deprecated)".
5. Verify that the "Older Comments" and "Newer Comments" links are now left- and right-aligned like as should be.
6. Make sure that pagination is enabled in your site's Discussion settings, and that it's set to a very low page number (e.g. 2 comments per page).
7. Create and publish a new post, and view on the frontend.
8. Post a few comments to that post.
9. Verify that the "Older Comments" and "Newer Comments" links are now left- and right-aligned.

## Screenshots or screencast

| Before | After |
|--------|------|
| ![Bildschirmfoto 2022-05-09 um 21 23 43](https://user-images.githubusercontent.com/96308/167486316-544b2b20-86b2-40cc-8f7d-f0fce91133b3.png) | ![Bildschirmfoto 2022-05-09 um 21 22 12](https://user-images.githubusercontent.com/96308/167486342-999b51a0-3377-4813-8970-0ff605ea5359.png) |

## Notes

I guess it's called _Cascading_ Style Sheets for a reason 😬 
The `float: left` and `float: right` styling originally caused the "Leave a Reply" comments form heading to get wrongly indented. To fix this, I added `clear: both` to the comments form. As a consequence, the spacing between the "Older"/"Newer Comments" links and that heading now seems too small 🙈 

Ideally, we'd probably recreate the styling for Core's `theme-compat/comments.php` fallback; I wasn't able to figure out how the clear-fix is achieved there.

Anyway, this could use some eyes from a designer 😅 