### PR TITLE
Fix Height Value Doing Nothing in Image Blocks

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -149,6 +149,5 @@ html :where([style*="border-left-width"]) {
  * Provide baseline responsiveness for images.
  */
 html :where(img[class*="wp-image-"]) {
-	height: auto;
 	max-width: 100%;
 }

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -2,9 +2,12 @@
 	margin: 0 0 1em 0;
 
 	img {
-		height: auto;
 		max-width: 100%;
 		vertical-align: bottom;
+
+		&[width][height] {
+			height: auto;
+		}
 	}
 
 	&:not(.is-style-rounded) {


### PR DESCRIPTION
## What?

Removes the `height: auto` CSS that is currently overriding the height value in the editor. 

## Why?

This issue was originially reported in the WP Calypso repo, but it was determined that the fix needed to be here: https://github.com/Automattic/wp-calypso/issues/61744

## How?
This PR only applies `height: auto` if both width and height are set to preserve the aspect ratio.

## Testing Instructions
1. Create a post or page
2. Add an image and edit both the width and height
3. Verify that the CSS recognizes this and adds `height: auto` to preserve aspect ratio on the frontend
4. Add an image and edit just the height
5. Verify that the image on the frontend is the size set but with a preserved aspect ratio

## Screenshots or screencast

![CleanShot 2022-05-09 at 15 13 53@2x](https://user-images.githubusercontent.com/1326249/167507422-1ce7fa67-ca4d-4718-a4be-1b415c9b7a62.jpg)

