### PR TITLE
BorderControl: Fix focus styling

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `BorderControl` now only displays the reset button in its popover when selections have already been made. [#40917](https://github.com/WordPress/gutenberg/pull/40917)
 -   `BorderControl` & `BorderBoxControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40920](https://github.com/WordPress/gutenberg/pull/40920)).
+-   `BorderControl` improved focus and border radius styling for component. [#40951](https://github.com/WordPress/gutenberg/pull/40951)
 
 ### Internal
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -25,13 +25,15 @@ const labelStyles = css`
 	font-weight: 500;
 `;
 
+const focusBoxShadow = css`
+	box-shadow: inset 0 0 0 ${ CONFIG.borderWidth } ${ COLORS.ui.borderFocus };
+`;
+
 export const borderControl = css`
 	position: relative;
 `;
 
 export const innerWrapper = () => css`
-	border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
-	border-radius: 2px;
 	flex: 1 0 40%;
 
 	/*
@@ -47,14 +49,9 @@ export const innerWrapper = () => css`
 	 */
 	${ UnitControlWrapper } {
 		flex: 1;
-		${ rtl( { marginLeft: 0 } )() }
+		${ rtl( { marginLeft: -1 } )() }
 	}
 
-	/*
-	 * Increased specificity is to overcome the border which doubles the "focus"
-	 * outline/border width. The box shadow brings the focus for the UnitSelect
-	 * into line with the input control's backdrop and the dropdown button.
-	 */
 	&& ${ UnitSelect } {
 		/* Prevent default styles forcing heights larger than BorderControl */
 		min-height: 0;
@@ -68,11 +65,12 @@ export const innerWrapper = () => css`
 				marginLeft: 0,
 			}
 		)() }
+		transition: box-shadow 0.1s linear, border 0.1s linear;
 
 		&:focus {
-			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
-				${ COLORS.ui.borderFocus };
-			border: none;
+			z-index: 1;
+			${ focusBoxShadow }
+			border: 1px solid ${ COLORS.ui.borderFocus };
 		}
 	}
 `;
@@ -96,17 +94,6 @@ export const wrapperHeight = ( __next36pxDefaultSize?: boolean ) => {
 
 export const borderControlDropdown = () => css`
 	background: #fff;
-	z-index: 1;
-	${ rtl(
-		{
-			borderRadius: `1px 0 0 1px`,
-			borderRight: `${ CONFIG.borderWidth } solid ${ COLORS.ui.border }`,
-		},
-		{
-			borderRadius: `0 1px 1px 0`,
-			borderLeft: `${ CONFIG.borderWidth } solid ${ COLORS.ui.border }`,
-		}
-	)() }
 
 	&& > button {
 		/*
@@ -115,12 +102,19 @@ export const borderControlDropdown = () => css`
 		 */
 		height: 100%;
 		padding: ${ space( 0.75 ) };
-		border-radius: inherit;
+		${ rtl(
+			{ borderRadius: `1px 0 0 1px` },
+			{ borderRadius: `0 1px 1px 0` }
+		)() }
+		border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
+		position: relative;
 
-		/* Specificity needed to overcome tertiary button styles. */
+		&:focus,
 		&:hover:not( :disabled ) {
-			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
-				${ COLORS.ui.borderFocus };
+			${ focusBoxShadow }
+			border-color: ${ COLORS.ui.borderFocus };
+			z-index: 1;
+			position: relative;
 		}
 	}
 `;
@@ -214,23 +208,17 @@ export const resetButton = css`
 export const borderWidthControl = () => css`
 	/* Target the InputControl's backdrop */
 	&&& ${ BackdropUI } {
-		border: none;
-		${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
+		${ rtl( {
+			borderTopLeftRadius: 0,
+			borderBottomLeftRadius: 0,
+		} )() }
+		transition: box-shadow 0.1s linear;
 	}
 
 	/* Specificity required to overcome UnitControl padding */
 	/* See packages/components/src/unit-control/styles/unit-control-styles.ts */
 	&&& input {
 		${ rtl( { paddingRight: 0 } )() }
-
-		/*
-		 * Allows the input control's backdrop to overlay its box shadow over
-		 * the BorderControl's wrapper border.
-		 */
-		&:focus ~ ${ BackdropUI } {
-			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
-				${ COLORS.ui.borderFocus };
-		}
 	}
 `;
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -116,6 +116,12 @@ export const borderControlDropdown = () => css`
 		height: 100%;
 		padding: ${ space( 0.75 ) };
 		border-radius: inherit;
+
+		/* Specificity needed to overcome tertiary button styles. */
+		&:hover:not( :disabled ) {
+			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
+				${ COLORS.ui.borderFocus };
+		}
 	}
 `;
 

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -103,8 +103,8 @@ export const borderControlDropdown = () => css`
 		height: 100%;
 		padding: ${ space( 0.75 ) };
 		${ rtl(
-			{ borderRadius: `1px 0 0 1px` },
-			{ borderRadius: `0 1px 1px 0` }
+			{ borderRadius: `2px 0 0 2px` },
+			{ borderRadius: `0 2px 2px 0` }
 		)() }
 		border: ${ CONFIG.borderWidth } solid ${ COLORS.ui.border };
 		position: relative;

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -50,10 +50,30 @@ export const innerWrapper = () => css`
 		${ rtl( { marginLeft: 0 } )() }
 	}
 
+	/*
+	 * Increased specificity is to overcome the border which doubles the "focus"
+	 * outline/border width. The box shadow brings the focus for the UnitSelect
+	 * into line with the input control's backdrop and the dropdown button.
+	 */
 	&& ${ UnitSelect } {
 		/* Prevent default styles forcing heights larger than BorderControl */
 		min-height: 0;
-		${ rtl( { marginRight: 0 } )() }
+		${ rtl(
+			{
+				borderRadius: '0 1px 1px 0',
+				marginRight: 0,
+			},
+			{
+				borderRadius: '1px 0 0 1px',
+				marginLeft: 0,
+			}
+		)() }
+
+		&:focus {
+			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
+				${ COLORS.ui.borderFocus };
+			border: none;
+		}
 	}
 `;
 
@@ -76,6 +96,7 @@ export const wrapperHeight = ( __next36pxDefaultSize?: boolean ) => {
 
 export const borderControlDropdown = () => css`
 	background: #fff;
+	z-index: 1;
 	${ rtl(
 		{
 			borderRadius: `1px 0 0 1px`,
@@ -188,12 +209,22 @@ export const borderWidthControl = () => css`
 	/* Target the InputControl's backdrop */
 	&&& ${ BackdropUI } {
 		border: none;
+		${ rtl( { borderTopLeftRadius: 0, borderBottomLeftRadius: 0 } )() }
 	}
 
 	/* Specificity required to overcome UnitControl padding */
 	/* See packages/components/src/unit-control/styles/unit-control-styles.ts */
 	&&& input {
 		${ rtl( { paddingRight: 0 } )() }
+
+		/*
+		 * Allows the input control's backdrop to overlay its box shadow over
+		 * the BorderControl's wrapper border.
+		 */
+		&:focus ~ ${ BackdropUI } {
+			box-shadow: 0 0 0 ${ CONFIG.borderWidthFocus }
+				${ COLORS.ui.borderFocus };
+		}
 	}
 `;
 


### PR DESCRIPTION
Fixes: #40897

- https://github.com/WordPress/gutenberg/issues/40897

## What?

Makes the inner component focus styles and border radii consistent.

## Why?

The small details matter.

## How?

Updated focus styles and border radii including RTL styling.

###### UnitSelect
- Fixed RTL border radii
- Fixed inconsistent focus box-shadow and border

###### BorderControlDropdown
- Fixed z-index causing focus styles to be clipped

###### InputControl's BackdropUI
- Fixed RTL border radii
- Fixed focus box-shadow

## Testing Instructions

1. Start up Storybook & visit [BorderControl page](http://localhost:50240/?path=/story/components-experimental-bordercontrol--default)
    - `npm run storybook:dev`
2. Optional: Zoom the page in as far as possible to more clearly see styling changes.
3. Select the input within the control then tab/shift-tab through the parts of the control, ensuring correct border radii and that the outline looks correct
4. Switch to RTL mode and repeat the process paying close attention to the border radii

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/167525428-6dff79c0-6895-4b17-875a-36e18fe803d2.mp4


