### PR TITLE
Site Editor: Decode entities in the site title

### DIFF
--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -6,6 +6,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -37,7 +38,7 @@ export default function useTitle( title ) {
 				/* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
 				__( '%1$s ‹ %2$s — WordPress' ),
 				title,
-				siteTitle
+				decodeEntities( siteTitle )
 			);
 
 			document.title = formattedTitle;

--- a/packages/edit-site/src/components/routes/use-title.js
+++ b/packages/edit-site/src/components/routes/use-title.js
@@ -37,7 +37,7 @@ export default function useTitle( title ) {
 			const formattedTitle = sprintf(
 				/* translators: Admin screen title. 1: Admin screen name, 2: Network or site name. */
 				__( '%1$s ‹ %2$s — WordPress' ),
-				title,
+				decodeEntities( title ),
 				decodeEntities( siteTitle )
 			);
 


### PR DESCRIPTION
## What?
PR fixes entity decoding of the document title in the Site Editor.

## Testing Instructions
1. Change the Site Title to contain HTML entities - `Matt's Blog` 
2. Open Site Editor and confirm entities are correctly decoded.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2022-05-10 at 09 54 48](https://user-images.githubusercontent.com/240569/167559486-08aedbcb-3e2f-4e10-aa55-211fa151ec17.png)

**After**
![CleanShot 2022-05-10 at 09 54 14](https://user-images.githubusercontent.com/240569/167559451-e35d9193-8462-4c87-a954-79890c2e10c4.png)

