### PR TITLE
Template List: Fix word break for the 'Added by' column

### DIFF
--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -95,6 +95,7 @@
 		// Added by.
 		.edit-site-list-table-column:nth-child(2) {
 			width: calc(40% - 18px);
+			word-break: break-all;
 		}
 
 		// Actions.

--- a/packages/edit-site/src/components/list/style.scss
+++ b/packages/edit-site/src/components/list/style.scss
@@ -95,7 +95,7 @@
 		// Added by.
 		.edit-site-list-table-column:nth-child(2) {
 			width: calc(40% - 18px);
-			word-break: break-all;
+			word-break: break-word;
 		}
 
 		// Actions.


### PR DESCRIPTION
## What?
Fixes #40673. The long usernames didn't wrap on small viewports and overflowing actions.

## How?
PR adds `word-break` to the 'Added by' column.

## Testing Instructions
1. Update "Nickname" from Profile to something lengthy.
2. Create a new template from the list view.
3. Go back to the template list view.
4. Confirm that username doesn't overlap actions.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2022-05-10 at 11 37 21](https://user-images.githubusercontent.com/240569/167576473-9f1220d8-f24d-43a6-9f91-37ad0a75697e.png)

