### PR TITLE
[List v2]: Outdent list item when pressing `Backspace` at the start

### DIFF
--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -21,7 +21,12 @@ import { useMergeRefs } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { useEnter, useIndentListItem, useOutdentListItem } from './hooks';
+import {
+	useEnter,
+	useBackspace,
+	useIndentListItem,
+	useOutdentListItem,
+} from './hooks';
 
 function IndentUI( { clientId } ) {
 	const [ canIndent, indentListItem ] = useIndentListItem( clientId );
@@ -61,11 +66,12 @@ export default function ListItemEdit( {
 		allowedBlocks: [ 'core/list' ],
 	} );
 	const useEnterRef = useEnter( { content, clientId } );
+	const useBackspaceRef = useBackspace( { clientId } );
 	return (
 		<>
 			<li { ...innerBlocksProps }>
 				<RichText
-					ref={ useMergeRefs( [ useEnterRef ] ) }
+					ref={ useMergeRefs( [ useEnterRef, useBackspaceRef ] ) }
 					identifier="content"
 					tagName="div"
 					onChange={ ( nextContent ) =>

--- a/packages/block-library/src/list-item/hooks/index.js
+++ b/packages/block-library/src/list-item/hooks/index.js
@@ -1,3 +1,4 @@
 export { default as useOutdentListItem } from './use-outdent-list-item';
 export { default as useIndentListItem } from './use-indent-list-item';
 export { default as useEnter } from './use-enter';
+export { default as useBackspace } from './use-backspace';

--- a/packages/block-library/src/list-item/hooks/use-backspace.js
+++ b/packages/block-library/src/list-item/hooks/use-backspace.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+import { useRefEffect } from '@wordpress/compose';
+import { BACKSPACE } from '@wordpress/keycodes';
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import useOutdentListItem from './use-outdent-list-item';
+
+export default function useBackspace( props ) {
+	const { getSelectionStart, getSelectionEnd } = useSelect(
+		blockEditorStore
+	);
+	const propsRef = useRef( props );
+	propsRef.current = props;
+	const [ canOutdent, outdentListItem ] = useOutdentListItem(
+		propsRef.current.clientId
+	);
+	return useRefEffect(
+		( element ) => {
+			function onKeyDown( event ) {
+				if ( event.defaultPrevented || event.keyCode !== BACKSPACE ) {
+					return;
+				}
+				// Handle only if we have a collapsed selection at the
+				// start of a list item and we can outdent.
+				if (
+					! canOutdent ||
+					[
+						getSelectionStart().offset,
+						getSelectionEnd().offset,
+					].some( ( offset ) => offset !== 0 )
+				) {
+					return;
+				}
+				event.preventDefault();
+				outdentListItem();
+			}
+
+			element.addEventListener( 'keydown', onKeyDown );
+			return () => {
+				element.removeEventListener( 'keydown', onKeyDown );
+			};
+		},
+		[ canOutdent ]
+	);
+}

--- a/packages/block-library/src/list-item/hooks/use-enter.js
+++ b/packages/block-library/src/list-item/hooks/use-enter.js
@@ -19,12 +19,9 @@ import useOutdentListItem from './use-outdent-list-item';
 
 export default function useEnter( props ) {
 	const { replaceBlocks } = useDispatch( blockEditorStore );
-	const {
-		getBlock,
-		getBlockRootClientId,
-		getBlockParents,
-		getBlockIndex,
-	} = useSelect( blockEditorStore );
+	const { getBlock, getBlockRootClientId, getBlockIndex } = useSelect(
+		blockEditorStore
+	);
 	const propsRef = useRef( props );
 	propsRef.current = props;
 	const [ canOutdent, outdentListItem ] = useOutdentListItem(
@@ -47,11 +44,7 @@ export default function useEnter( props ) {
 				}
 				// Here we are in top level list so we need to split.
 				const blockRootClientId = getBlockRootClientId( clientId );
-				const blockParents = getBlockParents( clientId );
-				const topParentListBlockClientId = blockParents[ 0 ];
-				const topParentListBlock = getBlock(
-					topParentListBlockClientId
-				);
+				const topParentListBlock = getBlock( blockRootClientId );
 				const blockIndex = getBlockIndex( clientId );
 				const head = cloneBlock( {
 					...topParentListBlock,


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/39877

This PR outdents a list item(if it's possible) by pressing `Backspace` at the start of the list item. It doesn't resolve fully #39877 as it doesn't handle:
1.  extra cases like being the first list item to transform to a paragraph/default block
2. proper merging if is a top level list item while having innerBlocks

Both of these should be looked in combination with the merging/splitting functionality in: https://github.com/WordPress/gutenberg/issues/39519.


## Testing Instructions
1. Insert a new list block with any nested lists
2. At the `start` of a nested list item press `Backspace`
3. Should outdent until is a top level list item

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/167607794-a6ce77cb-9723-4896-aef2-f7b6a3ca8e0f.mov


