### PR TITLE
[RNMobile] Improvements to Getting Started Guides

### DIFF
--- a/docs/contributors/code/react-native/getting-started-react-native.md
+++ b/docs/contributors/code/react-native/getting-started-react-native.md
@@ -72,6 +72,8 @@ To see a list of all of your available iOS devices, use `xcrun simctl list devic
 
 ### Troubleshooting
 
+If the Android emulator doesn't start correctly, or compiling fails with `Could not initialize class org.codehaus.groovy.runtime.InvokerHelper` or similar, it may help to double check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the `ANDROID_HOME` environment variable and ensure that your version of JDK matches the latest requirements.
+
 Some times, and especially when tweaking anything in the `package.json`, Babel configuration (`.babelrc`) or the Jest configuration (`jest.config.js`), your changes might seem to not take effect as expected. On those times, you might need to stop the metro bunder process and restart it with `npm run native start:reset`. Other times, you might want to reinstall the NPM packages from scratch and the `npm run native clean:install` script can be handy.
 
 ## Developing with Visual Studio Code

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -63,7 +63,7 @@ arch -x86_64 pod install
 
 #### Ruby Manager
 
-It may not be necessary to manually install Cocoapods if you're using a Ruby Version manager. Please refer to your chosen manager's documentation for guidance. 
+It may not be necessary to manually install Cocoapods or the `ffi` package if you're using a Ruby Version manager. Please refer to your chosen manager's documentation for guidance. 
 
 [`rbenv`](https://github.com/rbenv/rbenv) is the recommended manager if you're running Gutenberg from within [the WordPress iOS app](https://github.com/wordpress-mobile/WordPress-iOS) (vs. only the demo app). 
 

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -44,7 +44,11 @@ npm ci
 
 ### CocoaPods
 
-[CocoaPods](https://guides.cocoapods.org/using/getting-started.html) is needed to fetch React and third-party dependencies:
+[CocoaPods](https://guides.cocoapods.org/using/getting-started.html) is required to fetch React and third-party dependencies. The steps to install it vary depending on how Ruby is managed on your machine.
+
+#### System Ruby
+
+If you're using the default Ruby available with MacOS, you'll need to use the `sudo` command to install gems like Cocoapods:
 
 ```
 sudo gem install cocoapods
@@ -56,6 +60,12 @@ Note, Mac M1 is not directly compatible with Cocoapods. If you encounter issues,
 sudo arch -x86_64 gem install ffi
 arch -x86_64 pod install
 ```
+
+#### Ruby Manager
+
+It may not be necessary to manually install Cocoapods if you're using a Ruby Version manager. Please refer to your chosen manager's documentation for guidance. 
+
+[`rbenv`](https://github.com/rbenv/rbenv) is the recommended manager if you're running Gutenberg from within [the WordPress iOS app](https://github.com/wordpress-mobile/WordPress-iOS) (vs. only the demo app). 
 
 ### Set up Xcode
 

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -4,20 +4,7 @@ Are you interested in contributing to the native mobile editor? This guide is a 
 
 Note that these instructions are primarily focused on the macOS environment. For other environments, [the React Native quickstart documentation](https://reactnative.dev/docs/environment-setup) has helpful pointers and steps for getting set up.
 
-## Install Xcode
-
-Install [Xcode](https://developer.apple.com/xcode/) via the app store and then open it up:
-
--   Accept the license agreement.
--   Verify that `Xcode > Preferences > Locations > Command Line Tools` points to the current Xcode version.
-
-<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="700px" alt="Screenshot of XCode command line tools settings.">
-
 ## Clone Gutenberg
-
-If Xcode was installed successfully, we'll also have a version of Git available. (It's possible to update this later if we want to use a more recent version).
-
-In a terminal run:
 
 ```sh
 git clone git@github.com:WordPress/gutenberg.git
@@ -27,7 +14,9 @@ git clone git@github.com:WordPress/gutenberg.git
 
 If you’re working in multiple JS projects, a node version manager may make sense. A manager will let you switch between different node and npm versions of your choosing.
 
-We recommend [nvm](https://github.com/nvm-sh/nvm). After installing nvm, run the following from the top-level directory of the cloned project:
+We recommend [nvm](https://github.com/nvm-sh/nvm). 
+
+After installing nvm, run the following from the top-level directory of the cloned project:
 
 ```sh
 nvm install 'lts/*'
@@ -41,7 +30,7 @@ Then install dependencies:
 npm ci
 ```
 
-#### Do you have an older existing Gutenberg checkout?
+### Do you have an older existing Gutenberg checkout?
 
 If you have an existing Gutenberg checkout be sure to fully clean `node_modules` and re-install dependencies.
 This may help avoid errors in the future.
@@ -51,17 +40,20 @@ npm run distclean
 npm ci
 ```
 
-## Unit Tests
-
-Unit tests should work at this point.
-
-```sh
-npm run native test
-```
-
 ## iOS
 
-[react-native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor) can be used to identify anything that's missing from your development environment. From your checkout, or relative to `/packages/react-native-editor folder`, run:
+### Set up Xcode
+
+Install [Xcode](https://developer.apple.com/xcode/) via the app store and then open it up:
+
+-   Accept the license agreement.
+-   Verify that `Xcode > Preferences > Locations > Command Line Tools` points to the current Xcode version.
+
+<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="700px" alt="Screenshot of XCode command line tools settings.">
+
+### react-native doctor
+
+[react-native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor) can be used to identify anything that's missing from your development environment. From your Gutenberg checkout, or relative to `/packages/react-native-editor folder`, run:
 
 ```sh
 npx @react-native-community/cli doctor
@@ -70,6 +62,8 @@ npx @react-native-community/cli doctor
 <img src="https://developer.wordpress.org/files/2021/10/react-native-doctor.png" width="700px" alt="Screenshot of react-native-community/cli doctor tool running in the terminal.">
 
 See if `doctor` can fix both "common" and "iOS" issues. (Don't worry if "Android" still has ❌s at this stage, we'll get to those later!)
+
+### Run the demo app
 
 Once all common and iOS issues are resolved, try:
 
@@ -89,11 +83,15 @@ After waiting for everything to build, the demo app should be running from the i
 
 ## Android
 
+### Set up Android Studio
+
 We'll use Android Studio for all JDK and SDK package management. 
 
 The first step is [downloading Android Studio](https://developer.android.com/studio).
 
-Next, open an existing project and select the Gutenberg folder you cloned. From here, click on the cube icon that's highlighted in the following screenshot to access the SDK Manager. Another way to the SDK Manager is to navigate to `Tools > SDK Manager`:
+Next, open an existing project and select the Gutenberg folder you cloned. 
+
+From here, click on the cube icon that's highlighted in the following screenshot to access the SDK Manager. Another way to the SDK Manager is to navigate to `Tools > SDK Manager`:
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" width="700px" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
 
@@ -159,7 +157,7 @@ Pick the target SDK version. This is the targetSdkVersion set in the [build.grad
 
 There are some advanced settings we can toggle, but these are optional. Click finish.
 
-### Putting it all together
+### Run the demo app
 
 Start metro:
 
@@ -176,6 +174,12 @@ npm run native android
 After a bit of a wait, we’ll see something like this:
 
 <img src="https://developer.wordpress.org/files/2021/10/android-simulator.png" width="700px" alt="Screenshot of a the block editor in Android Simulator.">
+
+## Unit Tests
+
+```sh
+npm run native test
+```
 
 ## Integration Tests
 

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -1,20 +1,12 @@
 # Setup guide for React Native development (macOS)
 
-Are you interested in contributing to the native mobile editor? This
-guide is a detailed walk through designed to get you up and running!
+Are you interested in contributing to the native mobile editor? This guide is a detailed walk through designed to get you up and running!
 
-Note that the following instructions here are primarily focused on the
-macOS environment. For other environments, [the React Native quickstart documentation](https://reactnative.dev/docs/environment-setup)
-has helpful pointers and steps for getting set up.
+Note that the following instructions here are primarily focused on the macOS environment. For other environments, [the React Native quickstart documentation](https://reactnative.dev/docs/environment-setup) has helpful pointers and steps for getting set up.
 
 ## Install Xcode
 
-Install [Xcode](https://developer.apple.com/xcode/) via the app store. We'll be using
-the XCode to both compile the iOS app and use the phone simulator app.
-
-Once it has been installed from the App Store, open it by visiting `Applications > Xcode`
-
-After opening the application:
+Install [Xcode](https://developer.apple.com/xcode/) via the app store. After you have finished installing, open the app to do the following:
 
 -   Accept the license agreement.
 -   Verify that `Xcode > Preferences > Locations > Command Line Tools` points at the current Xcode version.
@@ -23,8 +15,7 @@ After opening the application:
 
 ## Clone Gutenberg
 
-If Xcode was installed successfully, we'll also have a version of git available. (It's possible to
-update this later if we want to use a more recent version).
+If Xcode was installed successfully, we'll also have a version of Git available. (It's possible to update this later if we want to use a more recent version).
 
 In a terminal run:
 
@@ -34,8 +25,7 @@ git clone git@github.com:WordPress/gutenberg.git
 
 ### Install node and npm
 
-If you’re working in multiple JS projects, a node version manager may make sense. A manager will let you
-switch between different node and npm versions of your choosing.
+If you’re working in multiple JS projects, a node version manager may make sense. A manager will let you switch between different node and npm versions of your choosing.
 
 Some good options are [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/).
 
@@ -81,9 +71,7 @@ npm run native test
 
 ## iOS
 
-The easiest way to figure out what needs to be installed is using the
-[react native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor). From your checkout, or
-relative to `/packages/react-native-editor folder`, run:
+The easiest way to figure out what needs to be installed is by using the [react-native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor). From your checkout, or relative to `/packages/react-native-editor folder`, run:
 
 ```sh
 npx @react-native-community/cli doctor
@@ -105,31 +93,25 @@ In another terminal type:
 npm run native ios
 ```
 
-After waiting for everything to build we should see:
+After waiting for everything to build we should see the following:
 
 <img src="https://developer.wordpress.org/files/2021/10/iOS-Simulator.png" alt="Screenshot of the block editor in iOS simulator." />
 
 ## Android
 
-To keep things simple, let's use Android Studio for all JDK and SDK package management.
-The first step is [downloading Android Studio](https://developer.android.com/studio).
+We'll use Android Studio for all JDK and SDK package management. The first step is [downloading Android Studio](https://developer.android.com/studio).
 
-Next, open an existing project and select the gutenberg folder you cloned:
-
-Click on the cube with the down arrow:
+Next, open an existing project and select the Gutenberg folder you cloned. From here, click on the cube icon that's highlighted in the following screenshot to access the SDK Manager. Another way to the SDK Manager is to navigate to `Tools > SDK Manager`:
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
 
-We can download SDK platforms, packages and other tools on this screen. Specific versions are
-hidden behind the "Show package details" checkbox, check it, since our build requires specific versions for E2E and
-development:
+We can download SDK platforms, packages and other tools on this screen. Specific versions are hidden behind the "Show package details" checkbox, check it, since our build requires specific versions for E2E and development:
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-show-package-details.png" alt="Screenshot of the package manager in Android Studio, highlighting the Show Package Details checkbox.">
 
-Check all related packages from [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle).
-Then click on "Apply" to download items. There may be other related dependencies from build.gradle files in node_modules.
-If you don’t want to dig through files, stack traces will complain of missing packages, but it does take quite a number
-of tries if you go through this route.
+Check all related packages from [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle). Then click on "Apply" to download items. There may be other related dependencies from build.gradle files in node_modules.
+
+If you don’t want to dig through files, stack traces will complain of missing packages, but it does take quite a number of tries if you go through this route.
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-editor-build-gradle.png" alt="Screenshot of the build.gradle configuration file.">
 
@@ -179,8 +161,7 @@ This brings up the “Android Virtual Device Manager” or (AVD). Click on “Cr
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-android-select-hardware.png" alt="Screenshot of the Virtual Device Configuration setup.">
 
-Pick the target SDK version. This is the targetSdkVersion set in the
-[build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle) file.
+Pick the target SDK version. This is the targetSdkVersion set in the [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle) file.
 
 <img src="https://developer.wordpress.org/files/2021/10/react-native-adv-system-image.png" alt="Screenshot of picking a system image in the Android Device Manager workflow.">
 
@@ -218,8 +199,7 @@ Resolve any required dependencies.
 
 ### iOS Integration Tests
 
-If we know we can run the iOS local environment without issue, E2Es for iOS are straightforward. Stop any running metro processes.
-This was launched previously with `npm run native start:reset`.
+If we know we can run the iOS local environment without issue, E2Es for iOS are straightforward. Stop any running metro processes. This was launched previously with `npm run native start:reset`.
 
 Then in terminal type:
 

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -2,16 +2,16 @@
 
 Are you interested in contributing to the native mobile editor? This guide is a detailed walk through designed to get you up and running!
 
-Note that the following instructions here are primarily focused on the macOS environment. For other environments, [the React Native quickstart documentation](https://reactnative.dev/docs/environment-setup) has helpful pointers and steps for getting set up.
+Note that these instructions are primarily focused on the macOS environment. For other environments, [the React Native quickstart documentation](https://reactnative.dev/docs/environment-setup) has helpful pointers and steps for getting set up.
 
 ## Install Xcode
 
-Install [Xcode](https://developer.apple.com/xcode/) via the app store. After you have finished installing, open the app to do the following:
+Install [Xcode](https://developer.apple.com/xcode/) via the app store and then open it up:
 
 -   Accept the license agreement.
--   Verify that `Xcode > Preferences > Locations > Command Line Tools` points at the current Xcode version.
+-   Verify that `Xcode > Preferences > Locations > Command Line Tools` points to the current Xcode version.
 
-<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="500" alt="Screenshot of XCode command line tools settings.">
+<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="70%" alt="Screenshot of XCode command line tools settings.">
 
 ## Clone Gutenberg
 
@@ -27,11 +27,7 @@ git clone git@github.com:WordPress/gutenberg.git
 
 If you’re working in multiple JS projects, a node version manager may make sense. A manager will let you switch between different node and npm versions of your choosing.
 
-Some good options are [nvm](https://github.com/nvm-sh/nvm) or [volta](https://volta.sh/).
-
-Pick one and follow the install instructions noted on their website.
-
-Then run:
+We recommend [nvm](https://github.com/nvm-sh/nvm). After installing nvm, run the following from the top-level directory of the cloned project:
 
 ```sh
 nvm install 'lts/*'
@@ -39,13 +35,7 @@ nvm alias default 'lts/*' # sets this as the default when opening a new terminal
 nvm use # switches to the project settings
 ```
 
-Or
-
-```sh
-volta install node #defaults to installing lts
-```
-
-Then install dependencies from your Gutenberg checkout folder:
+Then install dependencies:
 
 ```
 npm ci
@@ -71,13 +61,13 @@ npm run native test
 
 ## iOS
 
-The easiest way to figure out what needs to be installed is by using the [react-native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor). From your checkout, or relative to `/packages/react-native-editor folder`, run:
+[react-native doctor](https://reactnative.dev/blog/2019/11/18/react-native-doctor) can be used to identify anything that's missing from your development environment. From your checkout, or relative to `/packages/react-native-editor folder`, run:
 
 ```sh
 npx @react-native-community/cli doctor
 ```
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-doctor.png" width="500px" alt="Screenshot of react-native-community/cli doctor tool running in the terminal.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-doctor.png" width="70%" alt="Screenshot of react-native-community/cli doctor tool running in the terminal.">
 
 See if `doctor` can fix both "common" and "iOS" issues. (Don't worry if "Android" still has ❌s at this stage, we'll get to those later!)
 
@@ -93,31 +83,33 @@ In another terminal type:
 npm run native ios
 ```
 
-After waiting for everything to build we should see the following:
+After waiting for everything to build, the demo app should be running from the iOS simulator:
 
-<img src="https://developer.wordpress.org/files/2021/10/iOS-Simulator.png" alt="Screenshot of the block editor in iOS simulator." />
+<img src="https://developer.wordpress.org/files/2021/10/iOS-Simulator.png" width="70%" alt="Screenshot of the block editor in iOS simulator." />
 
 ## Android
 
-We'll use Android Studio for all JDK and SDK package management. The first step is [downloading Android Studio](https://developer.android.com/studio).
+We'll use Android Studio for all JDK and SDK package management. 
+
+The first step is [downloading Android Studio](https://developer.android.com/studio).
 
 Next, open an existing project and select the Gutenberg folder you cloned. From here, click on the cube icon that's highlighted in the following screenshot to access the SDK Manager. Another way to the SDK Manager is to navigate to `Tools > SDK Manager`:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" width="70%" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
 
 We can download SDK platforms, packages and other tools on this screen. Specific versions are hidden behind the "Show package details" checkbox, check it, since our build requires specific versions for E2E and development:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-show-package-details.png" alt="Screenshot of the package manager in Android Studio, highlighting the Show Package Details checkbox.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-show-package-details.png" width="70%" alt="Screenshot of the package manager in Android Studio, highlighting the Show Package Details checkbox.">
 
 Check all related packages from [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle). Then click on "Apply" to download items. There may be other related dependencies from build.gradle files in node_modules.
 
 If you don’t want to dig through files, stack traces will complain of missing packages, but it does take quite a number of tries if you go through this route.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-editor-build-gradle.png" alt="Screenshot of the build.gradle configuration file.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-editor-build-gradle.png" width="70%" alt="Screenshot of the build.gradle configuration file.">
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk.png" width="500" alt="Screenshot of the package manager displaying SDK Platforms.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk.png" width="70%" alt="Screenshot of the package manager displaying SDK Platforms.">
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk-tools.png" width="500" alt="Screenshot of the package manager displaying SDK Tools.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk-tools.png" width="70%" alt="Screenshot of the package manager displaying SDK Tools.">
 
 ### Update Paths
 
@@ -149,21 +141,21 @@ source ~/.bash_profile
 
 If the SDK path can't be found, you can verify its location by visiting Android Studio > Preferences > System Settings > Android SDK
 
-<img src="https://developer.wordpress.org/files/2021/10/sdk-path.png" alt="Screenshot of where the SDK Path may be found in Android Studio.">
+<img src="https://developer.wordpress.org/files/2021/10/sdk-path.png" width="70%" alt="Screenshot of where the SDK Path may be found in Android Studio.">
 
 ### Create a new device image
 
 Next, let’s create a virtual device image. Click on the phone icon with an android to the bottom-right.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-android-device-manager-button.png" alt="Screenshot of where to find the android device manager button.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-android-device-manager-button.png" width="70%" alt="Screenshot of where to find the android device manager button.">
 
 This brings up the “Android Virtual Device Manager” or (AVD). Click on “Create Virtual Device”. Pick a phone type of your choice:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-android-select-hardware.png" alt="Screenshot of the Virtual Device Configuration setup.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-android-select-hardware.png" width="70%" alt="Screenshot of the Virtual Device Configuration setup.">
 
 Pick the target SDK version. This is the targetSdkVersion set in the [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle) file.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-adv-system-image.png" alt="Screenshot of picking a system image in the Android Device Manager workflow.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-adv-system-image.png" width="70%" alt="Screenshot of picking a system image in the Android Device Manager workflow.">
 
 There are some advanced settings we can toggle, but these are optional. Click finish.
 
@@ -183,7 +175,7 @@ npm run native android
 
 After a bit of a wait, we’ll see something like this:
 
-<img src="https://developer.wordpress.org/files/2021/10/android-simulator.png" alt="Screenshot of a the block editor in Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/android-simulator.png" width="70%" alt="Screenshot of a the block editor in Android Simulator.">
 
 ## Integration Tests
 
@@ -193,7 +185,7 @@ After a bit of a wait, we’ll see something like this:
 npx appium-doctor
 ```
 
-<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.20.16.png" width="500px" alt="Screenshot of the appium-doctor tool running in the terminal.">
+<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.20.16.png" width="70%" alt="Screenshot of the appium-doctor tool running in the terminal.">
 
 Resolve any required dependencies.
 
@@ -223,7 +215,7 @@ If all things go well, it should look like:
 
 Start the virtual device first. Go back to the AVD by clicking on the phone icon, then click the green play button.
 
-<img src="https://developer.wordpress.org/files/2021/10/adv-integration.png" alt="A screenshot of how to start the Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/adv-integration.png" width="70%" alt="A screenshot of how to start the Android Simulator.">
 
 Make sure no metro processes are running. This was launched previously with `npm run native start:reset`.
 
@@ -241,4 +233,4 @@ npm run native test:e2e:android:local gutenberg-editor-paragraph.test.js
 
 After a bit of a wait we should see:
 
-<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.28.22.png" alt="A screenshot of block editor integration tests in Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.28.22.png" width="70%" alt="A screenshot of block editor integration tests in Android Simulator.">

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -83,11 +83,20 @@ After waiting for everything to build, the demo app should be running from the i
 
 ## Android
 
+### Java Development Kit (JDK)
+
+The JDK recommended in [the React Native documentation](https://reactnative.dev/docs/environment-setup) is called Azul Zulu. It can be installed [Homebrew](https://brew.sh/). To install it, run the following commands in a terminal after installing Homebrew:
+
+```
+brew tap homebrew/cask-versions
+brew install --cask zulu11
+```
+
+If you already have a JDK installed on your system, it should be JDK 11 or newer.
+
 ### Set up Android Studio
 
-We'll use Android Studio for all JDK and SDK package management. 
-
-The first step is [downloading Android Studio](https://developer.android.com/studio).
+To compile the Android app, [download Android Studio](https://developer.android.com/studio). 
 
 Next, open an existing project and select the Gutenberg folder you cloned. 
 

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -11,7 +11,7 @@ Install [Xcode](https://developer.apple.com/xcode/) via the app store and then o
 -   Accept the license agreement.
 -   Verify that `Xcode > Preferences > Locations > Command Line Tools` points to the current Xcode version.
 
-<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="70%" alt="Screenshot of XCode command line tools settings.">
+<img src="https://developer.wordpress.org/files/2021/10/xcode-command-line-tools.png" width="700px" alt="Screenshot of XCode command line tools settings.">
 
 ## Clone Gutenberg
 
@@ -67,7 +67,7 @@ npm run native test
 npx @react-native-community/cli doctor
 ```
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-doctor.png" width="70%" alt="Screenshot of react-native-community/cli doctor tool running in the terminal.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-doctor.png" width="700px" alt="Screenshot of react-native-community/cli doctor tool running in the terminal.">
 
 See if `doctor` can fix both "common" and "iOS" issues. (Don't worry if "Android" still has ❌s at this stage, we'll get to those later!)
 
@@ -85,7 +85,7 @@ npm run native ios
 
 After waiting for everything to build, the demo app should be running from the iOS simulator:
 
-<img src="https://developer.wordpress.org/files/2021/10/iOS-Simulator.png" width="70%" alt="Screenshot of the block editor in iOS simulator." />
+<img src="https://developer.wordpress.org/files/2021/10/iOS-Simulator.png" width="700px" alt="Screenshot of the block editor in iOS simulator." />
 
 ## Android
 
@@ -95,21 +95,21 @@ The first step is [downloading Android Studio](https://developer.android.com/stu
 
 Next, open an existing project and select the Gutenberg folder you cloned. From here, click on the cube icon that's highlighted in the following screenshot to access the SDK Manager. Another way to the SDK Manager is to navigate to `Tools > SDK Manager`:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" width="70%" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-package-manager.png" width="700px" alt="Screenshot highlighting where the package manager button is located in Android Studio.">
 
 We can download SDK platforms, packages and other tools on this screen. Specific versions are hidden behind the "Show package details" checkbox, check it, since our build requires specific versions for E2E and development:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-show-package-details.png" width="70%" alt="Screenshot of the package manager in Android Studio, highlighting the Show Package Details checkbox.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-show-package-details.png" width="700px" alt="Screenshot of the package manager in Android Studio, highlighting the Show Package Details checkbox.">
 
 Check all related packages from [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle). Then click on "Apply" to download items. There may be other related dependencies from build.gradle files in node_modules.
 
 If you don’t want to dig through files, stack traces will complain of missing packages, but it does take quite a number of tries if you go through this route.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-editor-build-gradle.png" width="70%" alt="Screenshot of the build.gradle configuration file.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-editor-build-gradle.png" width="700px" alt="Screenshot of the build.gradle configuration file.">
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk.png" width="70%" alt="Screenshot of the package manager displaying SDK Platforms.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk.png" width="700px" alt="Screenshot of the package manager displaying SDK Platforms.">
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk-tools.png" width="70%" alt="Screenshot of the package manager displaying SDK Tools.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-sdk-tools.png" width="700px" alt="Screenshot of the package manager displaying SDK Tools.">
 
 ### Update Paths
 
@@ -141,21 +141,21 @@ source ~/.bash_profile
 
 If the SDK path can't be found, you can verify its location by visiting Android Studio > Preferences > System Settings > Android SDK
 
-<img src="https://developer.wordpress.org/files/2021/10/sdk-path.png" width="70%" alt="Screenshot of where the SDK Path may be found in Android Studio.">
+<img src="https://developer.wordpress.org/files/2021/10/sdk-path.png" width="700px" alt="Screenshot of where the SDK Path may be found in Android Studio.">
 
 ### Create a new device image
 
 Next, let’s create a virtual device image. Click on the phone icon with an android to the bottom-right.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-android-device-manager-button.png" width="70%" alt="Screenshot of where to find the android device manager button.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-android-device-manager-button.png" width="700px" alt="Screenshot of where to find the android device manager button.">
 
 This brings up the “Android Virtual Device Manager” or (AVD). Click on “Create Virtual Device”. Pick a phone type of your choice:
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-android-select-hardware.png" width="70%" alt="Screenshot of the Virtual Device Configuration setup.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-android-select-hardware.png" width="700px" alt="Screenshot of the Virtual Device Configuration setup.">
 
 Pick the target SDK version. This is the targetSdkVersion set in the [build.gradle](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/android/build.gradle) file.
 
-<img src="https://developer.wordpress.org/files/2021/10/react-native-adv-system-image.png" width="70%" alt="Screenshot of picking a system image in the Android Device Manager workflow.">
+<img src="https://developer.wordpress.org/files/2021/10/react-native-adv-system-image.png" width="700px" alt="Screenshot of picking a system image in the Android Device Manager workflow.">
 
 There are some advanced settings we can toggle, but these are optional. Click finish.
 
@@ -175,7 +175,7 @@ npm run native android
 
 After a bit of a wait, we’ll see something like this:
 
-<img src="https://developer.wordpress.org/files/2021/10/android-simulator.png" width="70%" alt="Screenshot of a the block editor in Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/android-simulator.png" width="700px" alt="Screenshot of a the block editor in Android Simulator.">
 
 ## Integration Tests
 
@@ -185,7 +185,7 @@ After a bit of a wait, we’ll see something like this:
 npx appium-doctor
 ```
 
-<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.20.16.png" width="70%" alt="Screenshot of the appium-doctor tool running in the terminal.">
+<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.20.16.png" width="700px" alt="Screenshot of the appium-doctor tool running in the terminal.">
 
 Resolve any required dependencies.
 
@@ -215,7 +215,7 @@ If all things go well, it should look like:
 
 Start the virtual device first. Go back to the AVD by clicking on the phone icon, then click the green play button.
 
-<img src="https://developer.wordpress.org/files/2021/10/adv-integration.png" width="70%" alt="A screenshot of how to start the Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/adv-integration.png" width="700px" alt="A screenshot of how to start the Android Simulator.">
 
 Make sure no metro processes are running. This was launched previously with `npm run native start:reset`.
 
@@ -233,4 +233,4 @@ npm run native test:e2e:android:local gutenberg-editor-paragraph.test.js
 
 After a bit of a wait we should see:
 
-<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.28.22.png" width="70%" alt="A screenshot of block editor integration tests in Android Simulator.">
+<img src="https://developer.wordpress.org/files/2021/10/CleanShot-2021-10-27-at-15.28.22.png" width="700px" alt="A screenshot of block editor integration tests in Android Simulator.">

--- a/docs/contributors/code/react-native/osx-setup-guide.md
+++ b/docs/contributors/code/react-native/osx-setup-guide.md
@@ -42,6 +42,21 @@ npm ci
 
 ## iOS
 
+### CocoaPods
+
+[CocoaPods](https://guides.cocoapods.org/using/getting-started.html) is needed to fetch React and third-party dependencies:
+
+```
+sudo gem install cocoapods
+```
+
+Note, Mac M1 is not directly compatible with Cocoapods. If you encounter issues, try running these commands to install the ffi package, which will enable pods to be installed with the proper architecture:
+
+```
+sudo arch -x86_64 gem install ffi
+arch -x86_64 pod install
+```
+
 ### Set up Xcode
 
 Install [Xcode](https://developer.apple.com/xcode/) via the app store and then open it up:
@@ -85,7 +100,7 @@ After waiting for everything to build, the demo app should be running from the i
 
 ### Java Development Kit (JDK)
 
-The JDK recommended in [the React Native documentation](https://reactnative.dev/docs/environment-setup) is called Azul Zulu. It can be installed [Homebrew](https://brew.sh/). To install it, run the following commands in a terminal after installing Homebrew:
+The JDK recommended in [the React Native documentation](https://reactnative.dev/docs/environment-setup) is called Azul Zulu. It can be installed using [Homebrew](https://brew.sh/). To install it, run the following commands in a terminal after installing Homebrew:
 
 ```
 brew tap homebrew/cask-versions


### PR DESCRIPTION
## What?

With this PR, some updates are made to the Getting Started guides for the React Native demo app. 

## Why?

These updates were prompted by some recent recommendations for M1 machines (including a JDK recommendation). By updating the MacOS set up guide and linking to React Native's doc in the general guide, it is hoped the docs will make the set up process smoother for newcomers.    

## How?

### Getting Started - General Guide

The following paragraph has been added to the [general guide](https://github.com/WordPress/gutenberg/blob/44ed96f337400f90c2a193981810bd6bf0bc7f3f/docs/contributors/code/react-native/getting-started-react-native.md):

```
If the Android emulator doesn't start correctly, or compiling fails with `Could not initialize class org.codehaus.groovy.runtime.InvokerHelper` or similar, it may help to double check the set up of your development environment against the latest requirements in [React Native's documentation](https://reactnative.dev/docs/environment-setup). With Android Studio, for example, you will need to configure the `ANDROID_HOME` environment variable and ensure that your version of JDK matches the latest requirements.
```
This is taken from the guide in [the Gutenberg Mobile repository](https://github.com/wordpress-mobile/gutenberg-mobile/blob/3f2cc98b29159d66917dc2cf13e1416d487f987f/README.md) and brings the Gutenberg guide in alignment. An aim behind linking directly to React Native's official documentation is to guide anyone who may be struggling with issues related to their JDK version or similar, as we can trust the official documentation to have the most recent recommendations.

### Getting Started - In-Depth MacOS Guide

The following is an overview of the main changes that have been made to the [more in-depth MacOS guide](https://github.com/WordPress/gutenberg/blob/44ed96f337400f90c2a193981810bd6bf0bc7f3f/docs/contributors/code/react-native/osx-setup-guide.md):

* The sections have been rearranged in order to improve the overall flow of the guide. There are now five main sections, arranged as follows: 1. Clone Gutenberg. 2. iOS. 3. Android. 4. Unit Tests. 5. Integration Tests. 
* A [Cocoapods sub-section](https://github.com/WordPress/gutenberg/blob/44ed96f337400f90c2a193981810bd6bf0bc7f3f/docs/contributors/code/react-native/osx-setup-guide.md?plain=1#L45-L58) has been added under the iOS section.
* A [Java Development Kit (JDK) sub-section](https://github.com/WordPress/gutenberg/blob/44ed96f337400f90c2a193981810bd6bf0bc7f3f/docs/contributors/code/react-native/osx-setup-guide.md?plain=1#L101-L110) has been added under the Android section. 
* The images have been set to the same width in order to tidy up the overall look of the document. 
* Several tweaks to the copy have been made, with an aim to keep the tone concise and inline with [the copy guidelines](https://github.com/WordPress/gutenberg/blob/089acde6d86bf4c792427932578bb8a5554dcdca/docs/contributors/documentation/copy-guide.md).

## Testing Instructions

* Visit the guides directly (vs. looking at the "files changed", as the formatting is hard to read). 
* Review for overall accuracy, clarity, and completeness.