### PR TITLE
Add toggle to reverse column order on mobile

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -105,7 +105,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 -	**Name:** core/columns
 -	**Category:** design
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), spacing (blockGap, margin, padding), ~~html~~
--	**Attributes:** isStackedOnMobile, verticalAlignment
+-	**Attributes:** isStackedOnMobile, reverseMobileStackingOrder, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -13,7 +13,11 @@
 		"isStackedOnMobile": {
 			"type": "boolean",
 			"default": true
-		}
+		},
+        "reverseMobileStackingOrder": {
+            "type": "boolean",
+            "default": false
+        }
 	},
 	"supports": {
 		"anchor": true,

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -59,7 +59,11 @@ function ColumnsEditContainer( {
 	updateColumns,
 	clientId,
 } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const {
+		isStackedOnMobile,
+		reverseMobileStackingOrder,
+		verticalAlignment,
+	} = attributes;
 
 	const { count } = useSelect(
 		( select ) => {
@@ -73,6 +77,8 @@ function ColumnsEditContainer( {
 	const classes = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `is-reversed-on-mobile` ]:
+			isStackedOnMobile && reverseMobileStackingOrder,
 	} );
 
 	const blockProps = useBlockProps( {
@@ -117,6 +123,20 @@ function ColumnsEditContainer( {
 							} )
 						}
 					/>
+					{ isStackedOnMobile && (
+						<ToggleControl
+							label={ __( 'Reverse mobile stacking order' ) }
+							checked={ reverseMobileStackingOrder }
+							onChange={ () =>
+								setAttributes( {
+									reverseMobileStackingOrder: ! reverseMobileStackingOrder,
+								} )
+							}
+							help={ __(
+								'When selected, columns on mobile will stack right to left instead of left to right.'
+							) }
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,11 +9,17 @@ import classnames from 'classnames';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const {
+		isStackedOnMobile,
+		reverseMobileStackingOrder,
+		verticalAlignment,
+	} = attributes;
 
 	const className = classnames( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `is-reversed-on-mobile` ]:
+			isStackedOnMobile && reverseMobileStackingOrder,
 	} );
 
 	const blockProps = useBlockProps.save( { className } );

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -56,6 +56,14 @@
 		}
 	}
 
+	&.is-reversed-on-mobile {
+		@media (max-width: #{ ($break-medium - 1) }) {
+			// Responsiveness: Reverse the order of columns on mobile, so that
+			// the rightmost column on larger screens is the first column.
+			flex-direction: column-reverse !important;
+		}
+	}
+
 	&.is-not-stacked-on-mobile {
 		flex-wrap: nowrap !important;
 
@@ -78,7 +86,6 @@
 	// Matches paragraph block padding.
 	padding: $block-bg-padding--v $block-bg-padding--h;
 }
-
 
 .wp-block-column {
 	flex-grow: 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds a toggle to reverse the column stacking order on mobile, so that the rightmost column will be listed first instead of the leftmost column.

## Why?
Addresses #40706. The example use case given there is for alternating/zig-zag content on desktop where the stacking order on mobile makes more sense if alternate columns stack in reverse order.

## How?
Adds a new attribute, reverseMobileStackingOrder, a toggle to set that value if stack columns on mobile is also selected, and adds a class, .is-reversed-on-mobile, that applies only if both isStackedOnMobile and reverseMobileStackingOrder are true.

## Testing Instructions
1. Open a Post or Page
2. Add a columns block and some content in the columns.
3. Ensure "Stack columns on mobile is selected"
4. Verify that you can see an additional toggle below it, "Reverse mobile stacking order." Select the toggle.
Expected outcome: in both the editor and the front-end page, on mobile widths when the columns stack, the right column should appear above the left one.


