### PR TITLE
Automate the cherry-picking process for WordPress and Gutenberg releases

### DIFF
--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -59,7 +59,7 @@ function cli( command, args, pipe = false ) {
 		stdio: 'pipe',
 		encoding: 'utf-8',
 	};
-	const result = spawnSync( command, args, ...( pipe ? pipeOptions : [] ) );
+	const result = spawnSync( command, args, ...( pipe ? [ pipeOptions ] : [] ) );
 	if ( result.status !== 0 ) {
 		throw new Error( result.stderr?.toString()?.trim() );
 	}
@@ -207,7 +207,7 @@ function GHcommentAndRemoveLabel( pr ) {
 	const { number, cherryPickHash } = pr;
 	const comment = prComment( cherryPickHash );
 	try {
-		cli( 'gh', ['pr', 'comment', number, comment] );
+		cli( 'gh', ['pr', 'comment', number, '--body', comment] );
 		cli( 'gh', ['pr', 'edit', number, '--remove-label', LABEL] );
 		console.log( `✅ ${ number }: ${ comment }` );
 	} catch ( e ) {

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -28,18 +28,20 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
  * * Reports the results
  */
 async function main() {
+	if ( !GITHUB_CLI_AVAILABLE ) {
+		await reportGhUnavailable();
+	}
+
 	console.log( `You are on branch "${BRANCH}".` );
 	console.log( `This script will:` );
 	console.log( `• Cherry-pick the merged PRs labeled as "${LABEL}" to this branch` );
 	console.log( `• Push this branch` );
 	console.log( `• Comment on each PR` );
 	console.log( `• Remove the label from each PR` );
+	console.log( `The last two actions will be performed USING YOUR GITHUB ACCOUNT that` )
+	console.log( `you've linked to your GitHub CLI (gh command)` )
 	console.log( `` );
 	await promptDoYouWantToProceed();
-
-	if ( !GITHUB_CLI_AVAILABLE ) {
-		await reportGhUnavailable();
-	}
 
 	console.log( `$ git pull origin ${ BRANCH } --rebase...` );
 	cli( 'git', ['pull', 'origin', BRANCH, '--rebase'], true );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -132,7 +132,7 @@ async function fetchPRs() {
 }
 
 /**
- * A utility functino for GET requesting GitHub API.
+ * A utility function for GET requesting GitHub API.
  *
  * @param {string} path The API path to request.
  * @return {Promise<Object>} Parsed response JSON.

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -17,11 +17,15 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
 
 /**
  * The main function of this script. It:
- * * Retrieves the list of relevant PRs to cherry-pick
- * * Tries to cherry-pick them
- * * Pushes the changes comments on the successful cherry-picks
+ * * Confirms with the developer the current branch aligns with the expectations
+ * * Gets local branches in sync with the remote ones
+ * * Requests the list of PRs to cherry-pick from GitHub API (closed, label=`Backport to WP Beta/RC`)
+ * * Runs `git cherry-pick {commitHash}` for each PR
+ * * It keeps track of the failed cherry-picks and then retries them
+ * * Retrying keeps going as long as at least one cherry-pick succeeds
+ * * Pushes the local branch to `origin`
+ * * (optional) Uses the [`gh` console utility](https://cli.github.com/) to comment on the remote PRs and remove the labels
  * * Reports the results
- * * Suggests next steps
  */
 async function main() {
 	console.log( `You are on branch "${BRANCH}".` );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -24,6 +24,15 @@ const AUTO_PROPAGATE_RESULTS_TO_GITHUB = GITHUB_CLI_AVAILABLE;
  * * Suggests next steps
  */
 async function main() {
+	console.log( `You are on branch "${BRANCH}".` );
+	console.log( `This script will:` );
+	console.log( `• Cherry-pick the merged PRs labeled as "${LABEL}" to this branch` );
+	console.log( `• Push this branch` );
+	console.log( `• Comment on each PR` );
+	console.log( `• Remove the label from each PR` );
+	console.log( `` );
+	await promptDoYouWantToProceed();
+
 	if ( !GITHUB_CLI_AVAILABLE ) {
 		await reportGhUnavailable();
 	}
@@ -372,7 +381,16 @@ async function reportGhUnavailable() {
 	console.log(
 		'To enable automatic handling, install the `gh` utility from https://cli.github.com/' );
 	console.log( '' );
+	await promptDoYouWantToProceed();
+}
 
+/**
+ * Asks a CLI prompt whether the user wants to proceed.
+ * Exits if not.
+ *
+ * @return {Promise<void>}
+ */
+async function promptDoYouWantToProceed() {
 	const rl = readline.createInterface( {
 		input: process.stdin,
 		output: process.stdout,

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -6,7 +6,7 @@ import readline from 'readline';
 
 import { spawnSync } from 'node:child_process';
 
-const LABEL = "Backport to WP Beta/RC";
+const LABEL = process.argv[2] || "Backport to WP Minor Release";
 const BRANCH = getCurrentBranch();
 const GITHUB_CLI_AVAILABLE = spawnSync( 'gh', ['auth', 'status'] )
 	?.stderr
@@ -35,7 +35,7 @@ async function main() {
 	console.log( `You are on branch "${BRANCH}".` );
 	console.log( `This script will:` );
 	console.log( `• Cherry-pick the merged PRs labeled as "${LABEL}" to this branch` );
-	console.log( `• Push this branch` );
+	console.log( `• Ask whether you want to push this branch` );
 	console.log( `• Comment on each PR` );
 	console.log( `• Remove the label from each PR` );
 	console.log( `The last two actions will be performed USING YOUR GITHUB ACCOUNT that` )
@@ -58,7 +58,8 @@ async function main() {
 
 	if ( successes.length ) {
 		if ( AUTO_PROPAGATE_RESULTS_TO_GITHUB ) {
-			console.log( `Pushing to origin/${ BRANCH }` );
+			console.log( `About to push to origin/${ BRANCH }` );
+			await promptDoYouWantToProceed();
 			cli( 'git', ['push', 'origin', BRANCH] );
 
 			console.log( `Commenting and removing labels...` );

--- a/bin/cherry-pick.mjs
+++ b/bin/cherry-pick.mjs
@@ -279,7 +279,7 @@ function reportSummaryNextSteps( successes, failures ) {
 	if ( successes.length && !AUTO_PROPAGATE_RESULTS_TO_GITHUB ) {
 		nextSteps.push( 'Push this branch' );
 		nextSteps.push( 'Go to each of the cherry-picked Pull Requests' );
-		nextSteps.push( 'Remove the Backport to WP Beta/RC label' );
+		nextSteps.push( `Remove the ${ LABEL } label` );
 		nextSteps.push( 'Request a backport to wordpress-develop if required' );
 		nextSteps.push( 'Comment, say that PR just got cherry-picked' );
 	}

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+import fetch from 'node-fetch';
+
+import { spawnSync } from 'node:child_process';
+
+async function main() {
+	const PRs = await fetchPRs();
+	console.log( 'Trying to cherry-pick one by one...' );
+	const [successes, failures] = cherryPickAll( PRs );
+	report( successes, failures );
+}
+
+async function fetchPRs() {
+	const { items } = await GitHubFetch(
+		'/search/issues?q=is:pr state:closed sort:updated label:"Backport to WP Beta/RC" repo:WordPress/gutenberg',
+	);
+	const PRs = items.map( ( { id, number, title } ) => ( { id, number, title } ) );
+	console.log( 'Found the following PRs to cherry-pick: ' );
+	PRs.forEach( ( { number, title } ) => console.log( indent( `#${ number } – ${ title }` ) ) );
+	console.log( 'Fetching commit IDs...' );
+
+	const PRsWithMergeCommit = [];
+	for ( const PR of PRs ) {
+		const { merge_commit_sha } = await GitHubFetch(
+			'/repos/WordPress/Gutenberg/pulls/' + PR.number,
+		);
+		PRsWithMergeCommit.push( {
+			...PR,
+			mergeCommitHash: merge_commit_sha,
+		} );
+		if ( !merge_commit_sha ) {
+			throw new Error( `Cannot fetch the merge commit sha for ${ prToString( PR ) }` );
+		}
+	}
+
+	console.log( 'Done!' );
+	PRsWithMergeCommit
+		.forEach( ( msg ) => console.log( indent( `${ prToString( msg ) }` ) ) );
+	return PRsWithMergeCommit;
+}
+
+async function GitHubFetch( path ) {
+	const response = await fetch(
+		'https://api.github.com' + path,
+		{
+			headers: {
+				Accept: 'application/vnd.github.v3+json',
+			},
+		},
+	);
+	return await response.json();
+}
+
+function cherryPickAll( PRs ) {
+	let remainingPRs = [...PRs];
+	let i = 1;
+	let allSuccesses = [];
+	while ( remainingPRs.length ) {
+		console.log( `Cherry-picking round ${ i ++ }: ` );
+		const [successes, failures] = cherryPickRound( remainingPRs );
+		allSuccesses = [...allSuccesses, successes];
+		remainingPRs = failures;
+		if ( !successes.length ) {
+			console.log( 'Nothing merged cleanly in the last round, breaking.' );
+			break;
+		}
+	}
+	console.log( allSuccesses );
+	console.log( 'Cherry-picking finished!' );
+	console.log( 'Summary:' );
+	console.log( indent( `✅  ${ allSuccesses.length } PRs got cherry-picked cleanly` ) );
+	console.log( indent( `❌  ${ remainingPRs.length } PRs failed` ) );
+	console.log( '' );
+	return [allSuccesses, remainingPRs];
+}
+
+function cherryPickRound( PRs ) {
+	const stack = [...PRs];
+	const successes = [];
+	const failures = [];
+	while ( stack.length ) {
+		const PR = stack.shift();
+		try {
+			const cherryPickHash = cherryPickOne( PR.mergeCommitHash );
+			successes.push( {
+				...PR,
+				cherryPickHash,
+			} );
+			console.log(
+				indent(
+					`✅  cherry-pick commit: ${ cherryPickHash }  for PR: ${ prToString( PR, false ) }` ) );
+		} catch ( e ) {
+			failures.push( {
+				...PR,
+				error: e.toString(),
+			} );
+			console.log( indent( `❌  ${ prToString( PR ) }` ) );
+		}
+	}
+	return [successes, failures];
+}
+
+const identity = x => x;
+
+function prToString( { number, mergeCommitHash, title }, withMergeCommitHash = true ) {
+	return [
+		`#${ number }`,
+		withMergeCommitHash ? mergeCommitHash?.substr( 0, 20 ) : '',
+		`${ title?.substr( 0, 30 ) }${ title?.length > 30 ? '...' : '' }`,
+	].filter( identity ).join( ' – ' );
+}
+
+function indent( text, width = 3 ) {
+	const indent = ' '.repeat( width );
+	return text.split( "\n" ).map( line => indent + line ).join( "\n" );
+}
+
+function cherryPickOne( commit ) {
+	const result = spawnSync( 'git', ['cherry-pick', commit] );
+	const message = result.stdout.toString().trim();
+	if ( result.status !== 0 || !message.includes( 'Author: ' ) ) {
+		spawnSync( 'git', ['reset', '--hard'] );
+		throw new Error( result.stderr.toString().trim() );
+	}
+	const commitHashOutput = spawnSync( 'git', ['rev-parse', '--short', 'HEAD'] );
+	return commitHashOutput.stdout.toString().trim();
+}
+
+function report( successes, failures ) {
+	const branch = getCurrentBranch();
+	console.log( "Next steps:" );
+	let n = 1;
+	if ( successes.length ) {
+		console.log( indent( `${ n ++ }. Push this branch` ) );
+		console.log( indent( `${ n ++ }. Go to each of the cherry-picked Pull Requests` ) );
+		console.log( indent( `${ n ++ }. Remove the Backport to WP Beta/RC label` ) );
+		console.log( indent( `${ n ++ }. Request a backport to wordpress-develop if required` ) );
+		console.log( indent( `${ n ++ }. Comment, say that PR just got cherry-picked` ) );
+	}
+	if ( failures.length ) {
+		console.log( indent( `${ n ++ }. Manually cherry-pick the PRs that failed` ) );
+	}
+	console.log( '' );
+	if ( successes.length ) {
+		console.log( "Cherry-picked PRs with copy-able comments:" );
+		for ( const { number, title, cherryPickHash } of successes ) {
+			console.log( indent( `https://github.com/WordPress/gutenberg/pulls/${ number } ` ) );
+			console.log( indent( `#${ number } ${ title }` ) );
+			console.log( '' );
+			console.log(
+				indent(
+					`I just cherry-picked this PR to the ${ branch } branch to get it included in the next release: ${ cherryPickHash }` ) );
+			console.log( '' );
+		}
+	}
+	if ( failures.length ) {
+		console.log( "PRs that could not be cherry-picked automatically:" );
+		console.log( '' );
+		for ( const { number, title, mergeCommitHash, error } of failures ) {
+			console.log( indent( `https://github.com/WordPress/gutenberg/pulls/${ number } ` ) );
+			console.log( indent( `#${ number } ${ title }` ) );
+			console.log( indent( `git cherry-pick ${ mergeCommitHash }`, 6 ) );
+			console.log( indent( `failed with:`, 6 ) );
+			console.log( indent( `${ error }`, 6 ) );
+			console.log( '' );
+		}
+	}
+	console.log( `Done!` );
+}
+
+function getCurrentBranch() {
+	return spawnSync( 'git', ['rev-parse', '--abbrev-ref', 'HEAD'] ).stdout.toString();
+}
+
+main();

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -70,7 +70,7 @@ function cherryPickAll( PRs ) {
 	console.log( 'Cherry-picking finished!' );
 	console.log( 'Summary:' );
 	console.log( indent( `✅  ${ allSuccesses.length } PRs got cherry-picked cleanly` ) );
-	console.log( indent( `❌  ${ remainingPRs.length } PRs failed` ) );
+	console.log( indent( `${ remainingPRs.length > 0 ? '✅' : '❌' }  ${ remainingPRs.length } PRs failed` ) );
 	console.log( '' );
 	return [allSuccesses, remainingPRs];
 }

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -60,14 +60,13 @@ function cherryPickAll( PRs ) {
 	while ( remainingPRs.length ) {
 		console.log( `Cherry-picking round ${ i ++ }: ` );
 		const [successes, failures] = cherryPickRound( remainingPRs );
-		allSuccesses = [...allSuccesses, successes];
+		allSuccesses = [...allSuccesses, ...successes];
 		remainingPRs = failures;
 		if ( !successes.length ) {
 			console.log( 'Nothing merged cleanly in the last round, breaking.' );
 			break;
 		}
 	}
-	console.log( allSuccesses );
 	console.log( 'Cherry-picking finished!' );
 	console.log( 'Summary:' );
 	console.log( indent( `✅  ${ allSuccesses.length } PRs got cherry-picked cleanly` ) );

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -32,8 +32,8 @@ async function main() {
 	const PRs = await fetchPRs();
 	console.log( 'Trying to cherry-pick one by one...' );
 	const [successes, failures] = cherryPickAll( PRs );
-
 	console.log( 'Cherry-picking finished!' );
+
 	reportSummaryNextSteps( successes, failures );
 
 	if ( successes.length ) {

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -70,7 +70,7 @@ function cherryPickAll( PRs ) {
 	console.log( 'Cherry-picking finished!' );
 	console.log( 'Summary:' );
 	console.log( indent( `✅  ${ allSuccesses.length } PRs got cherry-picked cleanly` ) );
-	console.log( indent( `${ remainingPRs.length > 0 ? '✅' : '❌' }  ${ remainingPRs.length } PRs failed` ) );
+	console.log( indent( `${ remainingPRs.length > 0 ? '❌' : '✅' }  ${ remainingPRs.length } PRs failed` ) );
 	console.log( '' );
 	return [allSuccesses, remainingPRs];
 }

--- a/cherry-pick.mjs
+++ b/cherry-pick.mjs
@@ -145,7 +145,7 @@ function report( successes, failures ) {
 	if ( successes.length ) {
 		console.log( "Cherry-picked PRs with copy-able comments:" );
 		for ( const { number, title, cherryPickHash } of successes ) {
-			console.log( indent( `https://github.com/WordPress/gutenberg/pulls/${ number } ` ) );
+			console.log( indent( `https://github.com/WordPress/gutenberg/pull/${ number } ` ) );
 			console.log( indent( `#${ number } ${ title }` ) );
 			console.log( '' );
 			console.log(
@@ -153,6 +153,9 @@ function report( successes, failures ) {
 					`I just cherry-picked this PR to the ${ branch } branch to get it included in the next release: ${ cherryPickHash }` ) );
 			console.log( '' );
 		}
+		// gh pr comment:
+		// https://cli.github.com/manual/gh_pr_comment
+		// Also remove the label
 	}
 	if ( failures.length ) {
 		console.log( "PRs that could not be cherry-picked automatically:" );

--- a/package-lock.json
+++ b/package-lock.json
@@ -18861,7 +18861,7 @@
 		"app-root-dir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/app-root-dir/-/app-root-dir-1.0.2.tgz",
-			"integrity": "sha512-jlpIfsOoNoafl92Sz//64uQHGSyMrD2vYG5d8o2a4qGvyNCvXur7bzIsWtAC/6flI2RYAp3kv8rsfBtaLm7w0g==",
+			"integrity": "sha1-OBh+wt6nV3//Az/8sSFyaS/24Rg=",
 			"dev": true
 		},
 		"app-root-path": {
@@ -27040,7 +27040,7 @@
 		"babel-plugin-add-react-displayname": {
 			"version": "0.0.5",
 			"resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
-			"integrity": "sha512-LY3+Y0XVDYcShHHorshrDbt4KFWL4bSeniCtl4SYZbask+Syngk1uMPCeN9+nSiZo6zX5s0RTq/J9Pnaaf/KHw==",
+			"integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
 			"dev": true
 		},
 		"babel-plugin-apply-mdx-type-prop": {
@@ -27463,7 +27463,7 @@
 		"batch-processor": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
-			"integrity": "sha512-xoLQD8gmmR32MeuBHgH0Tzd5PuSZx71ZsbhVxOCRbgktZEPe4SQy7s9Z50uPp0F/f7iw2XmkHN2xkgbMfckMDA==",
+			"integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg=",
 			"dev": true
 		},
 		"bcrypt-pbkdf": {
@@ -30773,7 +30773,7 @@
 		"css.escape": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-			"integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
 			"dev": true
 		},
 		"cssesc": {
@@ -36972,7 +36972,7 @@
 		"has-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-			"integrity": "sha512-D+8A457fBShSEI3tFCj65PAbT++5sKiFtdCdOam0gnfBgw9D277OERk+HM9qYJXmdVLZ/znez10SqHN0BBQ50g==",
+			"integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
 			"dev": true,
 			"requires": {
 				"is-glob": "^3.0.0"
@@ -36981,7 +36981,7 @@
 				"is-glob": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -38782,7 +38782,7 @@
 		"is-window": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
-			"integrity": "sha512-uj00kdXyZb9t9RcAUAwMZAnkBUwdYGhYlt7djMXhfyhUCzwNba50tIiBKR7q0l7tdoBtFVw/3JmLY6fI3rmZmg==",
+			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0=",
 			"dev": true
 		},
 		"is-windows": {
@@ -42159,7 +42159,7 @@
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
-			"integrity": "sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=",
 			"dev": true
 		},
 		"js-tokens": {
@@ -43688,7 +43688,7 @@
 		"lz-string": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-			"integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {
@@ -46989,7 +46989,7 @@
 		"num2fraction": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==",
+			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
 			"dev": true
 		},
 		"number-is-nan": {
@@ -48068,7 +48068,7 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 			"dev": true
 		},
 		"p-event": {
@@ -49400,7 +49400,7 @@
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
+			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
 			"dev": true
 		},
 		"prismjs": {
@@ -51700,7 +51700,7 @@
 		"relateurl": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-			"integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
 		"remark": {

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
 		"metro-react-native-babel-transformer": "0.66.2",
 		"mkdirp": "0.5.1",
 		"nock": "12.0.3",
-		"node-fetch": "3.2.4",
+		"node-fetch": "2.6.1",
 		"node-watch": "0.7.0",
 		"npm-run-all": "4.1.5",
 		"patch-package": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
 		"metro-react-native-babel-transformer": "0.66.2",
 		"mkdirp": "0.5.1",
 		"nock": "12.0.3",
+		"node-fetch": "3.2.4",
 		"node-watch": "0.7.0",
 		"npm-run-all": "4.1.5",
 		"patch-package": "6.2.2",

--- a/package.json
+++ b/package.json
@@ -250,6 +250,7 @@
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"build": "npm run build:packages && wp-scripts build",
 		"changelog": "node ./bin/plugin/cli.js changelog",
+		"cherry-pick": "node ./bin/cherry-pick.mjs",
 		"check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2 --ignore=@react-native-community/cli,@react-native-community/cli-platform-ios\" \"wp-scripts check-licenses --dev\"",
 		"precheck-local-changes": "npm run docs:build",
 		"check-local-changes": "node ./bin/check-local-changes.js",


### PR DESCRIPTION
## What problem does this PR solve

Cherry-picking Pull Requests for Gutenberg and WordPress releases is a repetitive process that goes like this:

1. Find all PRs with the `Backport to WP Beta/RC` label
2. Open each in the browser
3. Copy the merge commit hash
4. Run `git cherry-pick $hash` in the CLI
5. If it succeeded, push, let the author know, remove the label
6. If it failed, cherry-pick everything else and retry
7. If it still fails, figure out how to resolve the conflict
8. Back to point 3 until there are no more PRs

This pull request explores a script that reduces the above process to:

1. Run the script
2. Manually resolve conflicts, if any

I successfully used it three times to cherry-pick PRs for WordPress 6.0 RC releases.

## How does the script work?

Here's what `npm run cherry-pick` does:

* Confirms with the developer the current branch aligns with the expectations
* Gets local branches in sync with the remote ones
* Requests the list of PRs to cherry-pick from GitHub API (closed, label=`Backport to WP Beta/RC`)
* Runs `git cherry-pick {commitHash}` for each PR
* It keeps track of the failed cherry-picks and then retries them
* Retrying keeps going as long as at least one cherry-pick succeeds
* Pushes the local branch to `origin`
* (optional) Uses the [`gh` console utility](https://cli.github.com/) to comment on the remote PRs and remove the labels
* Reports the results

Sample output looks as follows:

```
(base) : cloudnik core/plugins/gutenberg wp/6.0; npm run cherry-pick
You are on branch "wp/6.0".

This script will:
• Cherry-pick the merged PRs labeled as "Backport to WP Beta/RC" to this branch
• Push this branch
• Comment on each PR
• Remove the label from each PR

Do you want to proceed? (Y/n)

$ git pull origin wp/6.0 --rebase...
$ git fetch origin trunk...
Found the following PRs to cherry-pick:
   #41198 – Site Editor: Set min-width for styles preview
Fetching commit IDs...
Done!
   #41198 – 860a39665c318d33027d – Site Editor: Set min-width for...
Trying to cherry-pick one by one...
Cherry-picking round 1:
   ✅  cherry-pick commit: afe9b757b4  for PR: #41198 – Site Editor: Set min-width for...
Cherry-picking finished!
Summary:
   ✅  1 PRs got cherry-picked cleanly
   ✅  0 PRs failed

Pushing to origin/wp/6.0
Commenting and removing labels...
✅ 41198: I just cherry-picked this PR to the wp/6.0 branch to get it included in the next release: afe9b757b4
Done!
```

### What tools/permissions are required to run this script?

* [`gh` console utility](https://cli.github.com/) - optional, automates commenting and removing the labels
* Permissions to push to the Gutenberg repository

## Future improvement ideas

* Flexibility: Add an option to exclude specific PRs
* Flexibility: Add an option to specify PR numbers to backport explicitly
* Flexibility: Add an option to specify a custom label or even GH API query
* DevEx: Group reporting functions together, CLI functions together, and GitHub functions together

## Test plan

1. Run the script like `npm run cherry-pick`
2. Confirm it does what this description says
3. Confirm it helps with the release