### PR TITLE
Heading block - add font family support

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -43,6 +43,7 @@
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
+			"__experimentalFontFamily": true,
 			"__experimentalFontStyle": true,
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,


### PR DESCRIPTION
Adds `__experimentalFontFamily` support for the heading block.

For supporting fonts in FSE we need to consider which blocks most require the ability to have different fonts set than the main body.  `core/site-title` and `core/post-title` both include support for font families. 

Similarly, `core/heading` is a block that would also make sense for this. Generally, this support seems necessary for all blocks that serve the purpose of a title or heading (heading, site title, post title, etc.) to allow the same level of font style customization that was available in pre-FSE customizer themes.

![heading-block-fonts](https://user-images.githubusercontent.com/28742426/167659499-0b2efa08-a9d1-4692-9fcf-75913f05f68b.gif)

### Testing
* Run this PR
* Open the global styles panel -> blocks -> heading and verify we are able to select font family.