### PR TITLE
Comments Title: Fix post title translation

### DIFF
--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -23,8 +23,9 @@ function render_block_core_comments_title( $attributes ) {
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 	$comments_count      = get_comments_number();
-	$post_title          = '&#8220;' . get_the_title() . '&#8221;';
-	$tag_name            = 'h2';
+	/* translators: %s: Post title. */
+	$post_title = sprintf( __( '&#8220;%s&#8221;' ), get_the_title() );
+	$tag_name   = 'h2';
 	if ( isset( $attributes['level'] ) ) {
 		$tag_name = 'h' . $attributes['level'];
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See https://core.trac.wordpress.org/ticket/55567#comment:74.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sorry but I think the ”“ (&#8220; and &#8221;) should be inside the translateable string, as the use of them differs in different locales. In sv_SE we never user “, only ”.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By @hellofromtonya, we should convert it into something like:
```php
/* translators: %s: Post title. */
$post_title          = __( '&#8220;%s&#8221;', get_the_title() );
```