### PR TITLE
Comments Query Loop: Experiment with hydration (Take two)

### DIFF
--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -20,7 +20,7 @@
 			"type": "string"
 		}
 	},
-	"usesContext": [ "commentId" ],
+	"usesContext": [ "__client", "commentId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -19,7 +19,7 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 	}
 
 	if ( 0 === $block->context['commentId'] ) {
-		$comment_author = '${ context.author }';
+		$comment_author = '${ clientAttributes.author }';
 	} else {
 		$comment            = get_comment( $block->context['commentId'] );
 		$commenter          = wp_get_current_commenter();

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -18,28 +18,32 @@ function render_block_core_comment_author_name( $attributes, $content, $block ) 
 		return '';
 	}
 
-	$comment            = get_comment( $block->context['commentId'] );
-	$commenter          = wp_get_current_commenter();
-	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
-	if ( empty( $comment ) ) {
-		return '';
+	if ( 0 === $block->context['commentId'] ) {
+		$comment_author = '${ context.author }';
+	} else {
+		$comment            = get_comment( $block->context['commentId'] );
+		$commenter          = wp_get_current_commenter();
+		$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
+		if ( empty( $comment ) ) {
+			return '';
+		}
+
+		$comment_author     = get_comment_author( $comment );
+		$link               = get_comment_author_url( $comment );
+
+		if ( ! empty( $link ) && ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
+			$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
+		}
+		if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
+			$comment_author = wp_kses( $comment_author, array() );
+		}
 	}
 
 	$classes = '';
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes .= 'has-text-align-' . $attributes['textAlign'];
 	}
-
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
-	$comment_author     = get_comment_author( $comment );
-	$link               = get_comment_author_url( $comment );
-
-	if ( ! empty( $link ) && ! empty( $attributes['isLink'] ) && ! empty( $attributes['linkTarget'] ) ) {
-		$comment_author = sprintf( '<a rel="external nofollow ugc" href="%1s" target="%2s" >%3s</a>', esc_url( $link ), esc_attr( $attributes['linkTarget'] ), $comment_author );
-	}
-	if ( '0' === $comment->comment_approved && ! $show_pending_links ) {
-		$comment_author = wp_kses( $comment_author, array() );
-	}
 
 	return sprintf(
 		'<div %1$s>%2$s</div>',

--- a/packages/block-library/src/comment-author-name/index.php
+++ b/packages/block-library/src/comment-author-name/index.php
@@ -14,13 +14,13 @@
  * @return string Return the post comment's author.
  */
 function render_block_core_comment_author_name( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['commentId'] ) ) {
-		return '';
-	}
-
-	if ( 0 === $block->context['commentId'] ) {
+	if ( ! empty( $block->context['__client'] ) ) {
 		$comment_author = '${ clientAttributes.author }';
 	} else {
+		if ( ! isset( $block->context['commentId'] ) ) {
+			return '';
+		}
+
 		$comment            = get_comment( $block->context['commentId'] );
 		$commenter          = wp_get_current_commenter();
 		$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];

--- a/packages/block-library/src/comment-content/block.json
+++ b/packages/block-library/src/comment-content/block.json
@@ -7,7 +7,7 @@
 	"ancestor": [ "core/comment-template" ],
 	"description": "Displays the contents of a comment.",
 	"textdomain": "default",
-	"usesContext": [ "commentId" ],
+	"usesContext": [ "__client", "commentId" ],
 	"attributes": {
 		"textAlign": {
 			"type": "string"

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -14,15 +14,15 @@
  * @return string Return the post comment's content.
  */
 function render_block_core_comment_content( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['commentId'] ) ) {
-		return '';
-	}
-
 	$moderation_note = '';
 
-	if ( 0 === $block->context['commentId'] ) {
+	if ( ! empty( $block->context['__client'] ) ) {
 		$comment_text = '${ clientAttributes.content }';
 	} else {
+		if ( ! isset( $block->context['commentId'] ) ) {
+			return '';
+		}
+
 		$comment            = get_comment( $block->context['commentId'] );
 		$commenter          = wp_get_current_commenter();
 		$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -18,34 +18,39 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment            = get_comment( $block->context['commentId'] );
-	$commenter          = wp_get_current_commenter();
-	$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
-	if ( empty( $comment ) ) {
-		return '';
-	}
-
-	$args         = array();
-	$comment_text = get_comment_text( $comment, $args );
-	if ( ! $comment_text ) {
-		return '';
-	}
-
-	/** This filter is documented in wp-includes/comment-template.php */
-	$comment_text = apply_filters( 'comment_text', $comment_text, $comment, $args );
-
 	$moderation_note = '';
-	if ( '0' === $comment->comment_approved ) {
-		$commenter = wp_get_current_commenter();
 
-		if ( $commenter['comment_author_email'] ) {
-			$moderation_note = __( 'Your comment is awaiting moderation.' );
-		} else {
-			$moderation_note = __( 'Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.' );
+	if ( 0 === $block->context['commentId'] ) {
+		$comment_text = '${ context.content }';
+	} else {
+		$comment            = get_comment( $block->context['commentId'] );
+		$commenter          = wp_get_current_commenter();
+		$show_pending_links = isset( $commenter['comment_author'] ) && $commenter['comment_author'];
+		if ( empty( $comment ) ) {
+			return '';
 		}
-		$moderation_note = '<p><em class="comment-awaiting-moderation">' . $moderation_note . '</em></p>';
-		if ( ! $show_pending_links ) {
-			$comment_text = wp_kses( $comment_text, array() );
+
+		$args         = array();
+		$comment_text = get_comment_text( $comment, $args );
+		if ( ! $comment_text ) {
+			return '';
+		}
+
+		/** This filter is documented in wp-includes/comment-template.php */
+		$comment_text = apply_filters( 'comment_text', $comment_text, $comment, $args );
+
+		if ( '0' === $comment->comment_approved ) {
+			$commenter = wp_get_current_commenter();
+
+			if ( $commenter['comment_author_email'] ) {
+				$moderation_note = __( 'Your comment is awaiting moderation.' );
+			} else {
+				$moderation_note = __( 'Your comment is awaiting moderation. This is a preview; your comment will be visible after it has been approved.' );
+			}
+			$moderation_note = '<p><em class="comment-awaiting-moderation">' . $moderation_note . '</em></p>';
+			if ( ! $show_pending_links ) {
+				$comment_text = wp_kses( $comment_text, array() );
+			}
 		}
 	}
 

--- a/packages/block-library/src/comment-content/index.php
+++ b/packages/block-library/src/comment-content/index.php
@@ -21,7 +21,7 @@ function render_block_core_comment_content( $attributes, $content, $block ) {
 	$moderation_note = '';
 
 	if ( 0 === $block->context['commentId'] ) {
-		$comment_text = '${ context.content }';
+		$comment_text = '${ clientAttributes.content }';
 	} else {
 		$comment            = get_comment( $block->context['commentId'] );
 		$commenter          = wp_get_current_commenter();

--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -16,7 +16,7 @@
 			"default": true
 		}
 	},
-	"usesContext": [ "commentId" ],
+	"usesContext": [ "__client", "commentId" ],
 	"supports": {
 		"html": false,
 		"color": {

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -21,12 +21,12 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 	if ( 0 === $block->context['commentId'] ) {
 		// TODO: Translate format to JS-style.
 		$formatted_date = <<<END
-		\${ context.timestamp.toLocaleString( "en", {
+		\${ clientAttributes.timestamp.toLocaleString( "en", {
 			year: 'numeric', month: 'long', day: 'numeric',
 			hour: 'numeric', minute: 'numeric'
 		} ) }
 		END;
-		$timestamp = '${ context.timestamp.toISOString() }';
+		$timestamp = '${ clientAttributes.timestamp.toISOString() }';
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
 		$comment = get_comment( $block->context['commentId'] );

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -18,28 +18,42 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$comment = get_comment( $block->context['commentId'] );
-	if ( empty( $comment ) ) {
-		return '';
-	}
+	if ( 0 === $block->context['commentId'] ) {
+		// TODO: Translate format to JS-style.
+		$formatted_date = <<<END
+		\${ context.timestamp.toLocaleString( "en", {
+			year: 'numeric', month: 'long', day: 'numeric',
+			hour: 'numeric', minute: 'numeric'
+		} ) }
+		END;
+		$timestamp = '${ context.timestamp.toISOString() }';
+		$wrapper_attributes = get_block_wrapper_attributes();
+	} else {
+		$comment = get_comment( $block->context['commentId'] );
+		if ( empty( $comment ) ) {
+			return '';
+		}
 
-	$classes = '';
+		$classes = '';
 
-	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
-	$formatted_date     = get_comment_date(
-		isset( $attributes['format'] ) ? $attributes['format'] : '',
-		$comment
-	);
-	$link               = get_comment_link( $comment );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
+		$formatted_date     = get_comment_date(
+			isset( $attributes['format'] ) ? $attributes['format'] : '',
+			$comment
+		);
+		$link               = get_comment_link( $comment );
 
-	if ( ! empty( $attributes['isLink'] ) ) {
-		$formatted_date = sprintf( '<a href="%1s">%2s</a>', esc_url( $link ), $formatted_date );
+		if ( ! empty( $attributes['isLink'] ) ) {
+			$formatted_date = sprintf( '<a href="%1s">%2s</a>', esc_url( $link ), $formatted_date );
+		}
+
+		$timestamp = esc_attr( get_comment_date( 'c', $comment ) );
 	}
 
 	return sprintf(
 		'<div %1$s><time datetime="%2$s">%3$s</time></div>',
 		$wrapper_attributes,
-		esc_attr( get_comment_date( 'c', $comment ) ),
+		$timestamp,
 		$formatted_date
 	);
 }

--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -14,11 +14,7 @@
  * @return string Return the post comment's date.
  */
 function render_block_core_comment_date( $attributes, $content, $block ) {
-	if ( ! isset( $block->context['commentId'] ) ) {
-		return '';
-	}
-
-	if ( 0 === $block->context['commentId'] ) {
+	if ( ! empty( $block->context['__client'] ) ) {
 		// TODO: Translate format to JS-style.
 		$formatted_date = <<<END
 		\${ clientAttributes.timestamp.toLocaleString( "en", {
@@ -29,6 +25,10 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 		$timestamp = '${ clientAttributes.timestamp.toISOString() }';
 		$wrapper_attributes = get_block_wrapper_attributes();
 	} else {
+		if ( ! isset( $block->context['commentId'] ) ) {
+			return '';
+		}
+
 		$comment = get_comment( $block->context['commentId'] );
 		if ( empty( $comment ) ) {
 			return '';

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -98,6 +98,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 	$block_content .= ( new WP_Block(
 		$block->parsed_block,
 		array(
+			'__client'  => true,
 			'commentId' => 0,
 		)
 	) )->render( array( 'dynamic' => false ) );

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -93,7 +93,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 	}
 
 	$block_content = '<script>';
-	$block_content .= 'function wpCommentTemplate( context ) {';
+	$block_content .= 'function wpCommentTemplate( clientAttributes ) {';
 	$block_content .= 'output = `';
 	$block_content .= ( new WP_Block(
 		$block->parsed_block,

--- a/packages/block-library/src/comment-template/index.php
+++ b/packages/block-library/src/comment-template/index.php
@@ -92,6 +92,20 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		return;
 	}
 
+	$block_content = '<script>';
+	$block_content .= 'function wpCommentTemplate( context ) {';
+	$block_content .= 'output = `';
+	$block_content .= ( new WP_Block(
+		$block->parsed_block,
+		array(
+			'commentId' => 0,
+		)
+	) )->render( array( 'dynamic' => false ) );
+	$block_content .= '`;';
+	$block_content .= 'return output;';
+	$block_content .= '}';
+	$block_content .= '</script>';
+
 	$comment_query = new WP_Comment_Query(
 		build_comment_query_vars_from_block( $block )
 	);
@@ -114,7 +128,7 @@ function render_block_core_comment_template( $attributes, $content, $block ) {
 		'<ol %1$s>%2$s</ol>',
 		$wrapper_attributes,
 		block_core_comment_template_render_comments( $comments, $block )
-	);
+	) . $block_content;
 }
 
 /**

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -78,3 +78,33 @@ function post_comments_form_block_form_defaults( $fields ) {
 
 	return $fields;
 }
+
+function add_post_comments_form_onsubmit_handler() {
+    ?>
+		<script>
+			window.onload = function() {
+				const form = document.querySelector( '.comment-form' );
+				form.addEventListener( 'submit', submitted, false );
+			}
+
+			function submitted( event ) {
+				event.preventDefault();
+				const date = new Date();
+
+				const form = document.querySelector( '.comment-form' );
+
+				const author = document.querySelector( '#author' ).value;
+				const content = document.querySelector( '#comment' ).value;
+
+				const context = {
+					author,
+					content,
+					timestamp: date
+				};
+				form.innerHTML = wpCommentTemplate( context );
+
+			}
+		</script>
+    <?php
+}
+add_action('wp_head', 'add_post_comments_form_onsubmit_handler');

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -96,12 +96,12 @@ function add_post_comments_form_onsubmit_handler() {
 				//const author = document.querySelector( '#author' ).value;
 				const content = document.querySelector( '#comment' ).value;
 
-				const context = {
+				const commentTemplateAttributes = {
 					//author,
 					content,
 					timestamp: date
 				};
-				form.innerHTML = wpCommentTemplate( context );
+				form.innerHTML = wpCommentTemplate( commentTemplateAttributes );
 
 			}
 		</script>

--- a/packages/block-library/src/post-comments-form/index.php
+++ b/packages/block-library/src/post-comments-form/index.php
@@ -93,11 +93,11 @@ function add_post_comments_form_onsubmit_handler() {
 
 				const form = document.querySelector( '.comment-form' );
 
-				const author = document.querySelector( '#author' ).value;
+				//const author = document.querySelector( '#author' ).value;
 				const content = document.querySelector( '#comment' ).value;
 
 				const context = {
-					author,
+					//author,
 					content,
 					timestamp: date
 				};


### PR DESCRIPTION
## What?
Supersedes #39903 (using the existing Post Comments Form block)

Some explorations around the Post Comments Form block that, upon submission, renders the resulting comment instantly.

## Why?
This is one of various experiments with different hydration techniques.

## How?
"Minimally invasive", i.e. trying to introduce as few concepts as possible on top of what's already provided by WordPress and Gutenberg. The [previous PR](https://github.com/WordPress/gutenberg/pull/39903) had a [walkthrough video](https://www.loom.com/share/80a227c099684ee89ca26d0b77b3a618) that still more or less applies.

## Testing Instructions
Insert a Comments Query Loop block into an FSE template, and view a post on the frontend. Click the form's Submit button and see what happens.

## Screenshots or screencast

TBD
