### PR TITLE
Packages: Add GitHub workflow for publishing to npm

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -316,6 +316,7 @@ jobs:
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   path: publish
+                  # Later, we switch this branch in the script that publishes packages.
                   ref: trunk
                   token: ${{ secrets.GUTENBERG_TOKEN }}
 
@@ -325,7 +326,7 @@ jobs:
                   git config user.name "Gutenberg Repository Automation"
                   git config user.email gutenberg@wordpress.org
 
-            - name: Setup Node
+            - name: Setup Node (for CLI)
               uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
               with:
                   node-version-file: 'main/.nvmrc'

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -328,7 +328,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
               with:
-                  node-version-file: '.nvmrc'
+                  node-version-file: 'main/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Publish packages to npm ("latest" dist-tag)

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,0 +1,55 @@
+name: Publish npm packages
+
+on:
+    workflow_dispatch:
+        inputs:
+            wp_version:
+                description: 'WordPress major version'
+                required: true
+                type: string
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    wp-release:
+        name: WordPress major bugfix release
+        runs-on: ubuntu-latest
+        environment: WordPress packages
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: main
+                  ref: trunk
+
+            - name: Checkout (for publishing)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: publish
+                  ref: trunk
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Configure git user name and email (for publishing)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node
+              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Publish packages to npm ("wp/${{ github.event.inputs.wp_version }}" dist-tag)
+              run: |
+                  cd main
+                  npm ci
+                  ./bin/plugin/cli.js npm-wp --wp-version=${{ github.event.inputs.wp_version }} --ci --repository-path ../publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -31,6 +31,7 @@ jobs:
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
                   path: publish
+                  # Later, we switch this branch in the script that publishes packages.
                   ref: trunk
                   token: ${{ secrets.GUTENBERG_TOKEN }}
 
@@ -40,7 +41,7 @@ jobs:
                   git config user.name "Gutenberg Repository Automation"
                   git config user.email gutenberg@wordpress.org
 
-            - name: Setup Node
+            - name: Setup Node (for CLI)
               uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
               with:
                   node-version-file: 'main/.nvmrc'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Prior work: https://github.com/WordPress/gutenberg/pull/37751.

Docs: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs.

New GitHub workflow for publishing cherry-picked changes for the major WordPress release. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It will remove the maintenance burden for editor tech leads that handle the WordPress major release process.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This is largely based on the same workflow that gets triggered on every Gutenberg plugin RC1 release:

https://github.com/WordPress/gutenberg/blob/d52b240cbb0e5c5e1bf6789629b30121daac1615/.github/workflows/build-plugin-zip.yml#L302-L340

It uses the newly added subcommand for npm publishing in https://github.com/WordPress/gutenberg/pull/40927.

## Screenshots or screencast <!-- if applicable -->

I tested on the fork of the Gutenberg repository using GitHub UI.

<img width="1395" alt="Screenshot 2022-05-12 at 12 18 19" src="https://user-images.githubusercontent.com/699132/168048909-6f5e564d-8aac-4b34-9c1b-861ec55e47e6.png">

It's all the same concept as with releasing the Gutenberg plugin as explained in https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#release-tool.

The difference here is that currently you pick `Publish npm packages` action from https://github.com/WordPress/gutenberg/actions (not possible before merging this PR) and then you need to provide the WP major version, example `6.0` to publish cherry-picked changes for the actual WP release.