### PR TITLE
Editor preferences: update order and copy

### DIFF
--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -112,7 +112,7 @@ export default function EditPostPreferencesModal() {
 								featureName="showIconLabels"
 								label={ __( 'Show button text labels' ) }
 								help={ __(
-									'Show text instead of icons on buttons'
+									'Show text instead of icons on buttons.'
 								) }
 							/>
 							<EnableFeature

--- a/packages/edit-post/src/components/preferences-modal/index.js
+++ b/packages/edit-post/src/components/preferences-modal/index.js
@@ -102,18 +102,18 @@ export default function EditPostPreferencesModal() {
 							) }
 						>
 							<EnableFeature
-								featureName="reducedUI"
-								help={ __(
-									'Compacts options and outlines in the toolbar.'
-								) }
-								label={ __( 'Reduce the interface' ) }
-							/>
-							<EnableFeature
 								featureName="focusMode"
 								help={ __(
 									'Highlights the current block and fades other content.'
 								) }
 								label={ __( 'Spotlight mode' ) }
+							/>
+							<EnableFeature
+								featureName="showIconLabels"
+								label={ __( 'Show button text labels' ) }
+								help={ __(
+									'Show text instead of icons on buttons'
+								) }
 							/>
 							<EnableFeature
 								featureName="showListViewByDefault"
@@ -123,9 +123,11 @@ export default function EditPostPreferencesModal() {
 								label={ __( 'Always open list view' ) }
 							/>
 							<EnableFeature
-								featureName="showIconLabels"
-								help={ __( 'Shows text instead of icons.' ) }
-								label={ __( 'Display button labels' ) }
+								featureName="reducedUI"
+								help={ __(
+									'Compacts options and outlines in the toolbar.'
+								) }
+								label={ __( 'Reduce the interface' ) }
 							/>
 							<EnableFeature
 								featureName="themeStyles"

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -29,7 +29,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="showIconLabels"
-                help="Show text instead of icons on buttons"
+                help="Show text instead of icons on buttons."
                 label="Show button text labels"
               />
               <WithSelect(WithDispatch(BaseOption))
@@ -160,7 +160,7 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="showIconLabels"
-                help="Show text instead of icons on buttons"
+                help="Show text instead of icons on buttons."
                 label="Show button text labels"
               />
               <WithSelect(WithDispatch(BaseOption))

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/index.js.snap
@@ -23,14 +23,14 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
               title="Appearance"
             >
               <WithSelect(WithDispatch(BaseOption))
-                featureName="reducedUI"
-                help="Compacts options and outlines in the toolbar."
-                label="Reduce the interface"
-              />
-              <WithSelect(WithDispatch(BaseOption))
                 featureName="focusMode"
                 help="Highlights the current block and fades other content."
                 label="Spotlight mode"
+              />
+              <WithSelect(WithDispatch(BaseOption))
+                featureName="showIconLabels"
+                help="Show text instead of icons on buttons"
+                label="Show button text labels"
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="showListViewByDefault"
@@ -38,9 +38,9 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 label="Always open list view"
               />
               <WithSelect(WithDispatch(BaseOption))
-                featureName="showIconLabels"
-                help="Shows text instead of icons."
-                label="Display button labels"
+                featureName="reducedUI"
+                help="Compacts options and outlines in the toolbar."
+                label="Reduce the interface"
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="themeStyles"
@@ -154,14 +154,14 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
               title="Appearance"
             >
               <WithSelect(WithDispatch(BaseOption))
-                featureName="reducedUI"
-                help="Compacts options and outlines in the toolbar."
-                label="Reduce the interface"
-              />
-              <WithSelect(WithDispatch(BaseOption))
                 featureName="focusMode"
                 help="Highlights the current block and fades other content."
                 label="Spotlight mode"
+              />
+              <WithSelect(WithDispatch(BaseOption))
+                featureName="showIconLabels"
+                help="Show text instead of icons on buttons"
+                label="Show button text labels"
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="showListViewByDefault"
@@ -169,9 +169,9 @@ exports[`EditPostPreferencesModal should match snapshot when the modal is active
                 label="Always open list view"
               />
               <WithSelect(WithDispatch(BaseOption))
-                featureName="showIconLabels"
-                help="Shows text instead of icons."
-                label="Display button labels"
+                featureName="reducedUI"
+                help="Compacts options and outlines in the toolbar."
+                label="Reduce the interface"
               />
               <WithSelect(WithDispatch(BaseOption))
                 featureName="themeStyles"

--- a/packages/edit-site/src/components/preferences-modal/index.js
+++ b/packages/edit-site/src/components/preferences-modal/index.js
@@ -39,7 +39,7 @@ export default function EditSitePreferencesModal( {
 					<EnableFeature
 						featureName="showIconLabels"
 						label={ __( 'Show button text labels' ) }
-						help={ __( 'Show text instead of icons on buttons' ) }
+						help={ __( 'Show text instead of icons on buttons.' ) }
 					/>
 					<EnableFeature
 						featureName="showListViewByDefault"


### PR DESCRIPTION
## What?

Update preferences pane to:

- unify copy for similar controls
- place common preferences in the same order

See: 
https://github.com/WordPress/gutenberg/pull/40757#pullrequestreview-967168072

props to @andrewserong 

### Before

| Post editor | Site editor |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/167544435-d2afa9ac-1176-47b6-a60c-86227ff408ef.png) | ![image](https://user-images.githubusercontent.com/14988353/167544455-19a2b3e0-c4de-40a7-9214-31e96fccc9d2.png) |

### After

| Post editor  | Site editor |
| ------------- | ------------- |
| <img width="300" alt="Screen Shot 2022-05-11 at 10 27 04 am" src="https://user-images.githubusercontent.com/6458278/167745406-222d5f7a-5366-441c-a1f9-dc2c6d51b625.png">  | <img width="300" alt="Screen Shot 2022-05-11 at 10 23 12 am" src="https://user-images.githubusercontent.com/6458278/167745148-0f809733-995a-4508-b71c-2ff905c5bdec.png"> |

## Why?

To unify the panels, make things more predictable, reduce cognitive load for users. 

## How?

Rejigging the order of the EnableFeature components.

## Testing Instructions

Fire up this branch, then check that the site and post editor preference options make sense to you.
