### PR TITLE
Add an explicit error message if an image block fails to load the image

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -19,7 +19,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { image as icon } from '@wordpress/icons';
 
 /**
@@ -156,6 +156,16 @@ export function ImageEdit( {
 		 has been deleted.
 	*/
 	function onImageError( isReplaced = false ) {
+		noticeOperations.removeAllNotices();
+		noticeOperations.createErrorNotice(
+			sprintf(
+				/* translators: %s url or missing image */
+				__(
+					'There was an error loading the image for this block. The image was: %s'
+				),
+				url
+			)
+		);
 		// If the image block was not replaced with an embed,
 		// clear the attributes and trigger the placeholder.
 		if ( ! isReplaced ) {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -160,9 +160,7 @@ export function ImageEdit( {
 		noticeOperations.createErrorNotice(
 			sprintf(
 				/* translators: %s url or missing image */
-				__(
-					'There was an error loading the image for this block. The image was: %s'
-				),
+				__( 'Error loading image: %s' ),
 				url
 			)
 		);


### PR DESCRIPTION
## What?
Adds an error message of an Image block fails to load the attached image

## Why?
Currently if an existing Image block points to an image that no longer exists, when it is loaded in the editor it shows an empty placeholder, with no message to inform the user why that is the case

## How?
Adds an explicit error notice with details about the url of the image that could not be loaded.

## Testing Instructions

- Add an Image block and select an image
- In the code view change the url of the image, and then switch back to the editor view
- Make sure an error message with the url of the image displays

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/167747925-df747fbd-6ce3-4f8e-987a-59284e91cf67.mp4

After:

https://user-images.githubusercontent.com/3629020/167747944-f5637b28-23ef-4bbc-b077-5a440f79e130.mp4





