### PR TITLE
[compose]: Fix type for `createHigherOrderComponent`

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -79,7 +79,7 @@ name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
--   _mapComponent_ `HigherOrderComponent< HOCProps >`: Function mapping component to enhanced component.
+-   _mapComponent_ `( Inner: ComponentType< any > ) => ComponentType< any >`: Function mapping component to enhanced component.
 -   _modifierName_ `string`: Seed name from which to generated display name.
 
 _Returns_
@@ -105,7 +105,7 @@ const ConditionalComponent = ifCondition(
 
 _Parameters_
 
--   _predicate_ `( props: TProps ) => boolean`: Function to test condition.
+-   _predicate_ Function to test condition.
 
 _Returns_
 
@@ -115,6 +115,10 @@ _Returns_
 
 Given a component returns the enhanced component augmented with a component
 only re-rendering when its props/state change
+
+_Type_
+
+-   `( Inner: Inner ) => ComponentType< PropsOf< Inner > >`
 
 ### useAsyncList
 
@@ -550,10 +554,18 @@ _Returns_
 A Higher Order Component used to be provide a unique instance ID by
 component.
 
+_Type_
+
+-   `( Inner: Inner ) => ComponentType< Omit< PropsOf< Inner >, 'instanceId' > >`
+
 ### withSafeTimeout
 
 A higher-order component used to provide and manage delayed function calls
 that ought to be bound to a component's lifecycle.
+
+_Type_
+
+-   `( Inner: Inner ) => ComponentType< Omit< PropsOf< Inner >, keyof TimeoutProps > >`
 
 ### withState
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -118,7 +118,7 @@ only re-rendering when its props/state change
 
 _Type_
 
--   `( Inner: Inner ) => ComponentType< PropsOf< Inner > >`
+-   `( Inner: Inner ) => ComponentType< ComponentProps< Inner > >`
 
 ### useAsyncList
 
@@ -556,7 +556,7 @@ component.
 
 _Type_
 
--   `( Inner: Inner ) => ComponentType< Omit< PropsOf< Inner >, 'instanceId' > >`
+-   `( Inner: Inner ) => ComponentType< Omit< ComponentProps< Inner >, 'instanceId' > >`
 
 ### withSafeTimeout
 
@@ -565,7 +565,7 @@ that ought to be bound to a component's lifecycle.
 
 _Type_
 
--   `( Inner: Inner ) => ComponentType< Omit< PropsOf< Inner >, keyof TimeoutProps > >`
+-   `( Inner: Inner ) => ComponentType< Omit< ComponentProps< Inner >, keyof TimeoutProps > >`
 
 ### withState
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -79,12 +79,12 @@ name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
--   _mapComponent_ `( Inner: ComponentType< any > ) => ComponentType< any >`: Function mapping component to enhanced component.
+-   _mapComponent_ `HOC`: Function mapping component to enhanced component.
 -   _modifierName_ `string`: Seed name from which to generated display name.
 
 _Returns_
 
--   Component class with generated display name assigned.
+-   `HOC`: Component class with generated display name assigned.
 
 ### ifCondition
 
@@ -93,19 +93,15 @@ the given condition is satisfied or with the given optional prop name.
 
 _Usage_
 
-```ts
-type Props = { foo: string };
-const Component = ( props: Props ) => <div>{ props.foo }</div>;
-const ConditionalComponent = ifCondition(
-	( props: Props ) => props.foo.length !== 0
-)( Component );
-<ConditionalComponent foo="" />; // => null
-<ConditionalComponent foo="bar" />; // => <div>bar</div>;
-```
+    type Props = { foo: string };
+    const Component = ( props: Props ) => <div>{ props.foo }</div>;
+    const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
+    <ConditionalComponent foo="" />; // => null
+    <ConditionalComponent foo="bar" />; // => <div>bar</div>;
 
 _Parameters_
 
--   _predicate_ Function to test condition.
+-   _predicate_ `( props: IfProps ) => boolean`: Function to test condition.
 
 _Returns_
 
@@ -115,10 +111,6 @@ _Returns_
 
 Given a component returns the enhanced component augmented with a component
 only re-rendering when its props/state change
-
-_Type_
-
--   `( Inner: Inner ) => ComponentType< ComponentProps< Inner > >`
 
 ### useAsyncList
 
@@ -554,18 +546,10 @@ _Returns_
 A Higher Order Component used to be provide a unique instance ID by
 component.
 
-_Type_
-
--   `( Inner: Inner ) => ComponentType< Omit< ComponentProps< Inner >, 'instanceId' > >`
-
 ### withSafeTimeout
 
 A higher-order component used to provide and manage delayed function calls
 that ought to be bound to a component's lifecycle.
-
-_Type_
-
--   `( Inner: Inner ) => ComponentType< Omit< ComponentProps< Inner >, keyof TimeoutProps > >`
 
 ### withState
 

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -93,11 +93,15 @@ the given condition is satisfied or with the given optional prop name.
 
 _Usage_
 
-    type Props = { foo: string };
-    const Component = ( props: Props ) => <div>{ props.foo }</div>;
-    const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
-    <ConditionalComponent foo="" />; // => null
-    <ConditionalComponent foo="bar" />; // => <div>bar</div>;
+```ts
+type Props = { foo: string };
+const Component = ( props: Props ) => <div>{ props.foo }</div>;
+const ConditionalComponent = ifCondition(
+	( props: Props ) => props.foo.length !== 0
+)( Component );
+<ConditionalComponent foo="" />; // => null
+<ConditionalComponent foo="bar" />; // => <div>bar</div>;
+```
 
 _Parameters_
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,7 +1,15 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import {
+	PropsOf,
+	createHigherOrderComponent,
+} from '../../utils/create-higher-order-component';
 
 /**
  * Higher-order component creator, creating a new component which renders if
@@ -20,12 +28,14 @@ import createHigherOrderComponent from '../../utils/create-higher-order-componen
  *
  * @return Higher-order component.
  */
-const ifCondition = < TProps extends Record< string, any > >(
-	predicate: ( props: TProps ) => boolean
-) =>
-	createHigherOrderComponent< {} >(
+const ifCondition: < Inner extends ComponentType< any > >(
+	predicate: (
+		props: Record< string, unknown > & PropsOf< Inner >
+	) => boolean
+) => ( Inner: Inner ) => ComponentType< PropsOf< Inner > > = ( predicate ) =>
+	createHigherOrderComponent(
 		( WrappedComponent ) => ( props ) => {
-			if ( ! predicate( props as TProps ) ) {
+			if ( ! predicate( props ) ) {
 				return null;
 			}
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -13,26 +13,24 @@ import { createHigherOrderComponent } from '../../utils/create-higher-order-comp
  * the given condition is satisfied or with the given optional prop name.
  *
  * @example
- * ```ts
- * type Props = { foo: string };
- * const Component = ( props: Props ) => <div>{ props.foo }</div>;
- * const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
- * <ConditionalComponent foo="" />; // => null
- * <ConditionalComponent foo="bar" />; // => <div>bar</div>;
- * ```
+ *     type Props = { foo: string };
+ *     const Component = ( props: Props ) => <div>{ props.foo }</div>;
+ *     const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
+ *     <ConditionalComponent foo="" />; // => null
+ *     <ConditionalComponent foo="bar" />; // => <div>bar</div>;
  *
  * @param  predicate Function to test condition.
  *
  * @return Higher-order component.
  */
-const ifCondition: < Inner extends ComponentType< any > >(
-	predicate: (
-		props: Record< string, unknown > & ComponentProps< Inner >
-	) => boolean
-) => ( Inner: Inner ) => ComponentType< ComponentProps< Inner > > = (
-	predicate
+const ifCondition = < IfProps extends ComponentProps< any > >(
+	predicate: ( props: IfProps ) => boolean
 ) =>
-	createHigherOrderComponent(
+	createHigherOrderComponent<
+		< Props extends IfProps >(
+			Inner: ComponentType< Props >
+		) => ComponentType< Props >
+	>(
 		( WrappedComponent ) => ( props ) => {
 			if ( ! predicate( props ) ) {
 				return null;

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,15 +1,12 @@
 /**
  * External dependencies
  */
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 /**
  * Internal dependencies
  */
-import {
-	PropsOf,
-	createHigherOrderComponent,
-} from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * Higher-order component creator, creating a new component which renders if
@@ -30,9 +27,11 @@ import {
  */
 const ifCondition: < Inner extends ComponentType< any > >(
 	predicate: (
-		props: Record< string, unknown > & PropsOf< Inner >
+		props: Record< string, unknown > & ComponentProps< Inner >
 	) => boolean
-) => ( Inner: Inner ) => ComponentType< PropsOf< Inner > > = ( predicate ) =>
+) => ( Inner: Inner ) => ComponentType< ComponentProps< Inner > > = (
+	predicate
+) =>
 	createHigherOrderComponent(
 		( WrappedComponent ) => ( props ) => {
 			if ( ! predicate( props ) ) {

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -13,11 +13,13 @@ import { createHigherOrderComponent } from '../../utils/create-higher-order-comp
  * the given condition is satisfied or with the given optional prop name.
  *
  * @example
+ * ```ts
  *     type Props = { foo: string };
  *     const Component = ( props: Props ) => <div>{ props.foo }</div>;
  *     const ConditionalComponent = ifCondition( ( props: Props ) => props.foo.length !== 0 )( Component );
  *     <ConditionalComponent foo="" />; // => null
  *     <ConditionalComponent foo="bar" />; // => <div>bar</div>;
+ * ```
  *
  * @param  predicate Function to test condition.
  *

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -7,24 +7,29 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import {
+	PropsOf,
+	createHigherOrderComponent,
+} from '../../utils/create-higher-order-component';
 
 /**
  * External dependencies
  */
-import type { ComponentType, ComponentClass } from 'react';
+import type { ComponentType } from 'react';
 
 /**
  * Given a component returns the enhanced component augmented with a component
  * only re-rendering when its props/state change
  */
-const pure = createHigherOrderComponent(
-	< TProps extends Record< string, any > >(
-		Wrapped: ComponentType< TProps >
+const pure: < Inner extends ComponentType< any > >(
+	Inner: Inner
+) => ComponentType< PropsOf< Inner > > = createHigherOrderComponent(
+	< Props extends Record< string, any > >(
+		Wrapped: ComponentType< Props >
 	) => {
 		if ( Wrapped.prototype instanceof Component ) {
-			return class extends ( Wrapped as ComponentClass< TProps > ) {
-				shouldComponentUpdate( nextProps: TProps, nextState: any ) {
+			return class extends Component< Props > {
+				shouldComponentUpdate( nextProps: Props, nextState: Props ) {
 					return (
 						! isShallowEqual( nextProps, this.props ) ||
 						! isShallowEqual( nextState, this.state )
@@ -33,8 +38,8 @@ const pure = createHigherOrderComponent(
 			};
 		}
 
-		return class extends Component< TProps > {
-			shouldComponentUpdate( nextProps: TProps ) {
+		return class extends Component< Props > {
+			shouldComponentUpdate( nextProps: Props ) {
 				return ! isShallowEqual( nextProps, this.props );
 			}
 

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentClass, ComponentProps, ComponentType } from 'react';
 
 /**
  * WordPress dependencies
@@ -23,7 +23,7 @@ const pure = createHigherOrderComponent(
 		Wrapped: ComponentType< Props >
 	): ComponentType< Props > => {
 		if ( Wrapped.prototype instanceof Component ) {
-			return class extends Component< Props, State > {
+			return class extends ( Wrapped as ComponentClass< Props, State > ) {
 				shouldComponentUpdate(
 					nextProps: Readonly< Props >,
 					nextState: Readonly< State >

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentProps, ComponentType } from 'react';
+
+/**
  * WordPress dependencies
  */
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -10,23 +15,19 @@ import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
- * External dependencies
- */
-import type { ComponentProps, ComponentType } from 'react';
-
-/**
  * Given a component returns the enhanced component augmented with a component
  * only re-rendering when its props/state change
  */
-const pure: < Inner extends ComponentType< any > >(
-	Inner: Inner
-) => ComponentType< ComponentProps< Inner > > = createHigherOrderComponent(
-	< Props extends Record< string, any > >(
+const pure = createHigherOrderComponent(
+	< Props extends ComponentProps< any >, State = any >(
 		Wrapped: ComponentType< Props >
-	) => {
+	): ComponentType< Props > => {
 		if ( Wrapped.prototype instanceof Component ) {
-			return class extends Component< Props > {
-				shouldComponentUpdate( nextProps: Props, nextState: Props ) {
+			return class extends Component< Props, State > {
+				shouldComponentUpdate(
+					nextProps: Readonly< Props >,
+					nextState: Readonly< State >
+				) {
 					return (
 						! isShallowEqual( nextProps, this.props ) ||
 						! isShallowEqual( nextState, this.state )
@@ -36,7 +37,7 @@ const pure: < Inner extends ComponentType< any > >(
 		}
 
 		return class extends Component< Props > {
-			shouldComponentUpdate( nextProps: Props ) {
+			shouldComponentUpdate( nextProps: Readonly< Props > ) {
 				return ! isShallowEqual( nextProps, this.props );
 			}
 

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -7,15 +7,12 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	PropsOf,
-	createHigherOrderComponent,
-} from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * External dependencies
  */
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 /**
  * Given a component returns the enhanced component augmented with a component
@@ -23,7 +20,7 @@ import type { ComponentType } from 'react';
  */
 const pure: < Inner extends ComponentType< any > >(
 	Inner: Inner
-) => ComponentType< PropsOf< Inner > > = createHigherOrderComponent(
+) => ComponentType< ComponentProps< Inner > > = createHigherOrderComponent(
 	< Props extends Record< string, any > >(
 		Wrapped: ComponentType< Props >
 	) => {

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,21 +1,30 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import {
+	PropsOf,
+	createHigherOrderComponent,
+} from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
 
 /**
  * A Higher Order Component used to be provide a unique instance ID by
  * component.
  */
-const withInstanceId = createHigherOrderComponent< {
-	instanceId: string | number;
-} >( ( WrappedComponent ) => {
+const withInstanceId: < Inner extends ComponentType< any > >(
+	Inner: Inner
+) => ComponentType<
+	Omit< PropsOf< Inner >, 'instanceId' >
+> = createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
 		const instanceId = useInstanceId( WrappedComponent );
-		// @ts-ignore
 		return <WrappedComponent { ...props } instanceId={ instanceId } />;
 	};
-}, 'withInstanceId' );
+}, 'instanceId' );
 
 export default withInstanceId;

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -13,15 +13,18 @@ import useInstanceId from '../../hooks/use-instance-id';
  * A Higher Order Component used to be provide a unique instance ID by
  * component.
  */
-const withInstanceId: < Inner extends ComponentType< any > >(
-	Inner: Inner
-) => ComponentType<
-	Omit< ComponentProps< Inner >, 'instanceId' >
-> = createHigherOrderComponent( ( WrappedComponent ) => {
-	return ( props ) => {
-		const instanceId = useInstanceId( WrappedComponent );
-		return <WrappedComponent { ...props } instanceId={ instanceId } />;
-	};
-}, 'instanceId' );
+const withInstanceId = createHigherOrderComponent<
+	< Props extends ComponentProps< any > >(
+		Inner: ComponentType< Props >
+	) => ComponentType< Props & { instanceId: string | number } >
+>(
+	( WrappedComponent ) => ( props ) => (
+		<WrappedComponent
+			{ ...props }
+			instanceId={ useInstanceId( WrappedComponent ) }
+		/>
+	),
+	'instanceId'
+);
 
 export default withInstanceId;

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,15 +1,12 @@
 /**
  * External dependencies
  */
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 /**
  * Internal dependencies
  */
-import {
-	PropsOf,
-	createHigherOrderComponent,
-} from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
 
 /**
@@ -19,7 +16,7 @@ import useInstanceId from '../../hooks/use-instance-id';
 const withInstanceId: < Inner extends ComponentType< any > >(
 	Inner: Inner
 ) => ComponentType<
-	Omit< PropsOf< Inner >, 'instanceId' >
+	Omit< ComponentProps< Inner >, 'instanceId' >
 > = createHigherOrderComponent( ( WrappedComponent ) => {
 	return ( props ) => {
 		const instanceId = useInstanceId( WrappedComponent );

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -12,7 +12,10 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import {
+	PropsOf,
+	createHigherOrderComponent,
+} from '../../utils/create-higher-order-component';
 
 /**
  * We cannot use the `Window['setTimeout']` and `Window['clearTimeout']`
@@ -31,16 +34,18 @@ type TimeoutProps = {
  * A higher-order component used to provide and manage delayed function calls
  * that ought to be bound to a component's lifecycle.
  */
-const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
-	< TProps extends TimeoutProps >(
-		OriginalComponent: ComponentType< TProps >
+const withSafeTimeout: < Inner extends ComponentType< any > >(
+	Inner: Inner
+) => ComponentType<
+	Omit< PropsOf< Inner >, keyof TimeoutProps >
+> = createHigherOrderComponent(
+	< Props extends Record< string, any > >(
+		OriginalComponent: ComponentType< Props >
 	) => {
-		return class WrappedComponent extends Component<
-			Omit< TProps, keyof TimeoutProps >
-		> {
+		return class WrappedComponent extends Component< Props > {
 			timeouts: number[];
 
-			constructor( props: Omit< TProps, keyof TimeoutProps > ) {
+			constructor( props: Props ) {
 				super( props );
 				this.timeouts = [];
 				this.setTimeout = this.setTimeout.bind( this );
@@ -70,7 +75,7 @@ const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
 					...this.props,
 					setTimeout: this.setTimeout,
 					clearTimeout: this.clearTimeout,
-				} as TProps;
+				};
 
 				return <OriginalComponent { ...props } />;
 			}

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { without } from 'lodash';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 /**
  * WordPress dependencies
@@ -12,10 +12,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	PropsOf,
-	createHigherOrderComponent,
-} from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * We cannot use the `Window['setTimeout']` and `Window['clearTimeout']`
@@ -37,7 +34,7 @@ type TimeoutProps = {
 const withSafeTimeout: < Inner extends ComponentType< any > >(
 	Inner: Inner
 ) => ComponentType<
-	Omit< PropsOf< Inner >, keyof TimeoutProps >
+	Omit< ComponentProps< Inner >, keyof TimeoutProps >
 > = createHigherOrderComponent(
 	< Props extends Record< string, any > >(
 		OriginalComponent: ComponentType< Props >

--- a/packages/compose/src/higher-order/with-state/index.js
+++ b/packages/compose/src/higher-order/with-state/index.js
@@ -9,6 +9,8 @@ import deprecated from '@wordpress/deprecated';
  */
 import createHigherOrderComponent from '../../utils/create-higher-order-component';
 
+/** @typedef {import('react').ComponentType} ComponentType */
+
 /**
  * A Higher Order Component used to provide and manage internal component state
  * via props.
@@ -25,7 +27,9 @@ export default function withState( initialState = {} ) {
 		alternative: 'wp.element.useState',
 	} );
 
-	return createHigherOrderComponent( ( OriginalComponent ) => {
+	return createHigherOrderComponent( (
+		/** @type ComponentType */ OriginalComponent
+	) => {
 		return class WrappedComponent extends Component {
 			constructor( /** @type {any} */ props ) {
 				super( props );

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -4,22 +4,11 @@
 import { camelCase, upperFirst } from 'lodash';
 import type { ComponentType } from 'react';
 
-/**
- * Higher order components can cause props to be obviated. For example a HOC that
- * injects i18n props will obviate the need for the i18n props to be passed to the component.
- *
- * If a HOC does not obviate the need for any specific props then we default to `{}` which
- * essentially subtracts 0 from the original props of the passed in component. An example
- * of this is the `pure` HOC which does not change the API surface of the component but
- * simply modifies the internals.
- */
-export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
-	InnerProps extends HOCProps
->(
-	Inner: ComponentType< InnerProps >
-) => {} extends HOCProps
-	? ComponentType< InnerProps >
-	: ComponentType< Omit< InnerProps, keyof HOCProps > >;
+export type PropsOf< C extends ComponentType< any > > = C extends ComponentType<
+	infer Props
+>
+	? Props
+	: never;
 
 /**
  * Given a function mapping a component to an enhanced component and modifier
@@ -30,12 +19,11 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  *
  * @return Component class with generated display name assigned.
  */
-function createHigherOrderComponent<
-	HOCProps extends Record< string, any > = {}
->( mapComponent: HigherOrderComponent< HOCProps >, modifierName: string ) {
-	return < InnerProps extends HOCProps >(
-		Inner: ComponentType< InnerProps >
-	) => {
+export function createHigherOrderComponent(
+	mapComponent: ( Inner: ComponentType< any > ) => ComponentType< any >,
+	modifierName: string
+): typeof mapComponent {
+	return ( Inner: Parameters< typeof mapComponent >[ 0 ] ) => {
 		const Outer = mapComponent( Inner );
 		const displayName = Inner.displayName || Inner.name || 'Component';
 		Outer.displayName = `${ upperFirst(

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -4,12 +4,6 @@
 import { camelCase, upperFirst } from 'lodash';
 import type { ComponentType } from 'react';
 
-export type PropsOf< C extends ComponentType< any > > = C extends ComponentType<
-	infer Props
->
-	? Props
-	: never;
-
 /**
  * Given a function mapping a component to an enhanced component and modifier
  * name, returns the enhanced component augmented with a generated displayName.

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -13,18 +13,33 @@ import type { ComponentType } from 'react';
  *
  * @return Component class with generated display name assigned.
  */
-export function createHigherOrderComponent(
-	mapComponent: ( Inner: ComponentType< any > ) => ComponentType< any >,
-	modifierName: string
-): typeof mapComponent {
-	return ( Inner: Parameters< typeof mapComponent >[ 0 ] ) => {
+export function createHigherOrderComponent<
+	HOC extends ( Inner: ComponentType< any > ) => ComponentType< any >
+>( mapComponent: HOC, modifierName: string ): HOC {
+	return ( ( Inner ) => {
 		const Outer = mapComponent( Inner );
-		const displayName = Inner.displayName || Inner.name || 'Component';
-		Outer.displayName = `${ upperFirst(
-			camelCase( modifierName )
-		) }(${ displayName })`;
+		Outer.displayName = hocName( modifierName, Inner );
+
 		return Outer;
-	};
+	} ) as HOC;
 }
+
+/**
+ * Returns a displayName for a higher-order component, given a wrapper name.
+ *
+ * @example
+ *     hocName( 'MyMemo', Widget ) === 'MyMemo(Widget)';
+ *     hocName( 'MyMemo', <div /> ) === 'MyMemo(Component)';
+ *
+ * @param  name  Name assigned to higher-order component's wrapper component.
+ * @param  Inner Wrapped component inside higher-order component.
+ * @return       Wrapped name of higher-order component.
+ */
+const hocName = ( name: string, Inner: ComponentType< any > ): string => {
+	const inner = Inner.displayName || Inner.name || 'Component';
+	const outer = upperFirst( camelCase( name ) );
+
+	return `${ outer }(${ inner })`;
+};
 
 export default createHigherOrderComponent;


### PR DESCRIPTION
## What?

When refactoring `createHigherOrderComponent` in #37795
an incorrect type was introduced in an attempt to correct
the previous type. The fix in that patch was focused on
the narrow use-case of a _prop-injecting higher-order component_.

In this patch we're lifting the type signature into the function
which calls `createHigherOrderComponent`. There's a limitiation
I'm not sure how to get past when adding the type parameters to
the generalized interface; that is, the function _produced_ by
`createHigherOrderComponent` needs its own type parameters for
input and output specified by the given `mapComponent` mapper.

This change require more type juggling when defining a new
higher-order component but removes the arbitrary constraint
on what props may be passed into or come out of the higher-order
component.

## Why?

The type in `createHigherOrderComponent` was overly-restrictive.

## How?

Moves the type parameters from `createHigherOrderComponent` to
the code where it's called.

## Testing Instructions

As a type-only change there should be no impact on the built artifacts.

No tests should start failing.
Review the approach taken for the type of `createHigherOrderComponent`
as well as how this demands a change in the way calling code is
typed.

Note that if no type is provided at the call-site then the output
of `createHigherOrderComponent` will be `ComponentType<any>`, which
still should be valid even if it doesn't track the appropriate `Props`.

```ts
const withAnything = createHigherOrderComponent( x => x, 'anything' );

const Widget = (props: WidgetProps) => …
const AnyWidget = withAnything(Widget);
//    ^? ComponentType<any>
```

The proper way to handle this is to look at the examples and type the
variable declaration itself.

```ts
const withLimit: <
	Inner extends ComponentType<any>
>(limit: number) => (Inner: Inner) => ComponentType<PropsOf<Inner>> =
	limit => createHigherOrderComponent( Inner => props =>
		props.limit < limit ? <Inner {...props} /> : void
	);

const LimitedWidget = withLimit(Widget);
//    ^? ComponentType<WidgetProps>
```