### PR TITLE
SelectControl: Remove the line height setting to fix issue with font descenders being cut off

### DIFF
--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -50,14 +50,20 @@ const sizeStyles = ( { selectSize = 'default' }: SelectProps ) => {
 		default: {
 			height: 30,
 			minHeight: 30,
+			paddingTop: 0,
+			paddingBottom: 0,
 		},
 		small: {
 			height: 24,
 			minHeight: 24,
+			paddingTop: 0,
+			paddingBottom: 0,
 		},
 		'__unstable-large': {
 			height: 40,
 			minHeight: 40,
+			paddingTop: 0,
+			paddingBottom: 0,
 		},
 	};
 

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -49,17 +49,14 @@ const sizeStyles = ( { selectSize = 'default' }: SelectProps ) => {
 	const sizes = {
 		default: {
 			height: 30,
-			lineHeight: 1,
 			minHeight: 30,
 		},
 		small: {
 			height: 24,
-			lineHeight: 1,
 			minHeight: 24,
 		},
 		'__unstable-large': {
 			height: 40,
-			lineHeight: 1,
 			minHeight: 40,
 		},
 	};


### PR DESCRIPTION
## What?
Removes the fixed lineheight 1 the SelectControl component

## Why?
In places like the Gallery block Image size selector this lineheight setting causes font descenders to be cut off

Fixes: #27194

## How?
Just removes the lineheight setting and allows it to be inherited

## Testing Instructions

- Add a Gallery block and upload an Image that will have a `Large` option
- In the image size selector in the block inspector check that the descender of the `g` in the `Large` is not cut off
- Check a range of other places where SelectControl is used, including Storybook,  and make sure there are no unfortunate side effects

## Screenshots or screencast 

Before:
<img width="264" alt="before" src="https://user-images.githubusercontent.com/3629020/167768702-ef99779b-e30f-4f83-a3c7-839016df3521.png">

After:
<img width="258" alt="after" src="https://user-images.githubusercontent.com/3629020/167768715-cfcdbe5e-0867-49bc-8e29-ea2519fec803.png">


