### PR TITLE
Try generating random color palettes

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -73,25 +73,19 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 }
 
 /**
- * Sets a global JS variable used to trigger the availability of zoomed out view.
+ * Sets a global JS variable used to trigger the availability of each Gutenberg Experiment.
  */
-function gutenberg_enable_zoomed_out_view() {
+function gutenberg_enable_experiments() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutView = true', 'before' );
 	}
-}
-
-add_action( 'admin_init', 'gutenberg_enable_zoomed_out_view' );
-
-/**
- * Sets a global JS variable used to trigger the availability of the Navigation List View experiment.
- */
-function gutenberg_enable_off_canvas_navigation_editor() {
-	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-color-randomizer', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableColorRandomizer = true', 'before' );
+	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-off-canvas-navigation-editor', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableOffCanvasNavigationEditor = true', 'before' );
 	}
 }
 
-add_action( 'admin_init', 'gutenberg_enable_off_canvas_navigation_editor' );
+add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -64,7 +64,7 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 	add_settings_field(
-	'gutenberg-color-randomizer',
+		'gutenberg-color-randomizer',
 		__( 'Color randomizer ', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -63,6 +63,18 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-off-canvas-navigation-editor',
 		)
 	);
+	add_settings_field(
+	'gutenberg-color-randomizer',
+		__( 'Color randomizer ', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test the Global Styles color randomizer; a utility that lets you mix the current color palette pseudo-randomly.', 'gutenberg' ),
+			'id'    => 'gutenberg-color-randomizer',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/package-lock.json
+++ b/package-lock.json
@@ -18057,11 +18057,19 @@
 				"@wordpress/url": "file:packages/url",
 				"@wordpress/viewport": "file:packages/viewport",
 				"classnames": "^2.3.1",
+				"colord": "^2.9.2",
 				"downloadjs": "^1.4.7",
 				"history": "^5.1.0",
 				"lodash": "^4.17.21",
 				"react-autosize-textarea": "^7.1.0",
 				"rememo": "^4.0.0"
+			},
+			"dependencies": {
+				"colord": {
+					"version": "2.9.2",
+					"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+					"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
+				}
 			}
 		},
 		"@wordpress/edit-widgets": {

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -55,6 +55,7 @@
 		"@wordpress/url": "file:../url",
 		"@wordpress/viewport": "file:../viewport",
 		"classnames": "^2.3.1",
+		"colord": "^2.9.2",
 		"downloadjs": "^1.4.7",
 		"history": "^5.1.0",
 		"lodash": "^4.17.21",

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -329,7 +329,7 @@ export function useGradientsPerOrigin( name ) {
 	}, [ customGradients, themeGradients, defaultGradients ] );
 }
 
-export function useRandomizer( name ) {
+export function useColorRandomizer( name ) {
 	const [ themeColors, setThemeColors ] = useSetting(
 		'color.palette.theme',
 		name
@@ -355,5 +355,7 @@ export function useRandomizer( name ) {
 		setThemeColors( newColors );
 	}
 
-	return [ randomizeColors ];
+	return window.__experimentalEnableColorRandomizer
+		? [ randomizeColors ]
+		: [];
 }

--- a/packages/edit-site/src/components/global-styles/hooks.js
+++ b/packages/edit-site/src/components/global-styles/hooks.js
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { get, set, isEqual } from 'lodash';
+import { colord, extend } from 'colord';
+import a11yPlugin from 'colord/plugins/a11y';
 
 /**
  * WordPress dependencies
@@ -19,6 +21,9 @@ import {
  */
 import { getValueFromVariable, getPresetVariableFromValue } from './utils';
 import { GlobalStylesContext } from './context';
+
+// Enable colord's a11y plugin.
+extend( [ a11yPlugin ] );
 
 const EMPTY_CONFIG = { settings: {}, styles: {} };
 
@@ -322,4 +327,33 @@ export function useGradientsPerOrigin( name ) {
 		}
 		return result;
 	}, [ customGradients, themeGradients, defaultGradients ] );
+}
+
+export function useRandomizer( name ) {
+	const [ themeColors, setThemeColors ] = useSetting(
+		'color.palette.theme',
+		name
+	);
+
+	function randomizeColors() {
+		/* eslint-disable no-restricted-syntax */
+		const randomRotationValue = Math.floor( Math.random() * 225 );
+		/* eslint-enable no-restricted-syntax */
+
+		const newColors = themeColors.map( ( colorObject ) => {
+			const { color } = colorObject;
+			const newColor = colord( color )
+				.rotate( randomRotationValue )
+				.toHex();
+
+			return {
+				...colorObject,
+				color: newColor,
+			};
+		} );
+
+		setThemeColors( newColors );
+	}
+
+	return [ randomizeColors ];
 }

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -8,8 +8,10 @@ import {
 	__experimentalZStack as ZStack,
 	__experimentalVStack as VStack,
 	ColorIndicator,
+	Button,
 } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { shuffle } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -17,7 +19,7 @@ import { useMemo } from '@wordpress/element';
  */
 import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
-import { useSetting } from './hooks';
+import { useColorRandomizer, useSetting } from './hooks';
 import ColorIndicatorWrapper from './color-indicator-wrapper';
 
 const EMPTY_COLORS = [];
@@ -31,6 +33,9 @@ function Palette( { name } ) {
 		'color.defaultPalette',
 		name
 	);
+
+	const [ randomizeThemeColors ] = useColorRandomizer();
+
 	const colors = useMemo(
 		() => [
 			...( customColors || EMPTY_COLORS ),
@@ -82,6 +87,15 @@ function Palette( { name } ) {
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
+			{ randomizeThemeColors && (
+				<Button
+					variant="secondary"
+					icon={ shuffle }
+					onClick={ randomizeThemeColors }
+				>
+					{ __( 'Randomize colors' ) }
+				</Button>
+			) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -4,8 +4,11 @@
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
+	Button,
 } from '@wordpress/components';
 import { getBlockTypes } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { shuffle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -24,6 +27,7 @@ import ScreenHeadingColor from './screen-heading-color';
 import ScreenButtonColor from './screen-button-color';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
+import { useRandomizer } from './hooks';
 
 function GlobalStylesNavigationScreen( { className, ...props } ) {
 	return (
@@ -117,42 +121,50 @@ function ContextScreens( { name } ) {
 
 function GlobalStylesUI() {
 	const blocks = getBlockTypes();
+	const [ randomizeTheme ] = useRandomizer();
 
 	return (
-		<NavigatorProvider
-			className="edit-site-global-styles-sidebar__navigator-provider"
-			initialPath="/"
-		>
-			<GlobalStylesNavigationScreen path="/">
-				<ScreenRoot />
-			</GlobalStylesNavigationScreen>
-
-			<GlobalStylesNavigationScreen path="/variations">
-				<ScreenStyleVariations />
-			</GlobalStylesNavigationScreen>
-
-			<GlobalStylesNavigationScreen path="/blocks">
-				<ScreenBlockList />
-			</GlobalStylesNavigationScreen>
-
-			{ blocks.map( ( block ) => (
-				<GlobalStylesNavigationScreen
-					key={ 'menu-block-' + block.name }
-					path={ '/blocks/' + block.name }
-				>
-					<ScreenBlock name={ block.name } />
+		<>
+			<NavigatorProvider
+				className="edit-site-global-styles-sidebar__navigator-provider"
+				initialPath="/"
+			>
+				<GlobalStylesNavigationScreen path="/">
+					<ScreenRoot />
 				</GlobalStylesNavigationScreen>
-			) ) }
 
-			<ContextScreens />
+				<GlobalStylesNavigationScreen path="/variations">
+					<ScreenStyleVariations />
+				</GlobalStylesNavigationScreen>
 
-			{ blocks.map( ( block ) => (
-				<ContextScreens
-					key={ 'screens-block-' + block.name }
-					name={ block.name }
-				/>
-			) ) }
-		</NavigatorProvider>
+				<GlobalStylesNavigationScreen path="/blocks">
+					<ScreenBlockList />
+				</GlobalStylesNavigationScreen>
+
+				{ blocks.map( ( block ) => (
+					<GlobalStylesNavigationScreen
+						key={ 'menu-block-' + block.name }
+						path={ '/blocks/' + block.name }
+					>
+						<ScreenBlock name={ block.name } />
+					</GlobalStylesNavigationScreen>
+				) ) }
+
+				<ContextScreens />
+
+				{ blocks.map( ( block ) => (
+					<ContextScreens
+						key={ 'screens-block-' + block.name }
+						name={ block.name }
+					/>
+				) ) }
+			</NavigatorProvider>
+			<Button
+				icon={ shuffle }
+				label={ __( 'Randomize colors' ) }
+				onClick={ randomizeTheme }
+			/>
+		</>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -27,7 +27,7 @@ import ScreenHeadingColor from './screen-heading-color';
 import ScreenButtonColor from './screen-button-color';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
-import { useRandomizer } from './hooks';
+import { useColorRandomizer } from './hooks';
 
 function GlobalStylesNavigationScreen( { className, ...props } ) {
 	return (
@@ -121,7 +121,7 @@ function ContextScreens( { name } ) {
 
 function GlobalStylesUI() {
 	const blocks = getBlockTypes();
-	const [ randomizeTheme ] = useRandomizer();
+	const [ randomizeThemeColors ] = useColorRandomizer();
 
 	return (
 		<>
@@ -159,11 +159,13 @@ function GlobalStylesUI() {
 					/>
 				) ) }
 			</NavigatorProvider>
-			<Button
-				icon={ shuffle }
-				label={ __( 'Randomize colors' ) }
-				onClick={ randomizeTheme }
-			/>
+			{ randomizeThemeColors && (
+				<Button
+					icon={ shuffle }
+					label={ __( 'Randomize colors' ) }
+					onClick={ randomizeThemeColors }
+				/>
+			) }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -4,11 +4,8 @@
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
-	Button,
 } from '@wordpress/components';
 import { getBlockTypes } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
-import { shuffle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -27,7 +24,6 @@ import ScreenHeadingColor from './screen-heading-color';
 import ScreenButtonColor from './screen-button-color';
 import ScreenLayout from './screen-layout';
 import ScreenStyleVariations from './screen-style-variations';
-import { useColorRandomizer } from './hooks';
 
 function GlobalStylesNavigationScreen( { className, ...props } ) {
 	return (
@@ -121,52 +117,42 @@ function ContextScreens( { name } ) {
 
 function GlobalStylesUI() {
 	const blocks = getBlockTypes();
-	const [ randomizeThemeColors ] = useColorRandomizer();
 
 	return (
-		<>
-			<NavigatorProvider
-				className="edit-site-global-styles-sidebar__navigator-provider"
-				initialPath="/"
-			>
-				<GlobalStylesNavigationScreen path="/">
-					<ScreenRoot />
+		<NavigatorProvider
+			className="edit-site-global-styles-sidebar__navigator-provider"
+			initialPath="/"
+		>
+			<GlobalStylesNavigationScreen path="/">
+				<ScreenRoot />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path="/variations">
+				<ScreenStyleVariations />
+			</GlobalStylesNavigationScreen>
+
+			<GlobalStylesNavigationScreen path="/blocks">
+				<ScreenBlockList />
+			</GlobalStylesNavigationScreen>
+
+			{ blocks.map( ( block ) => (
+				<GlobalStylesNavigationScreen
+					key={ 'menu-block-' + block.name }
+					path={ '/blocks/' + block.name }
+				>
+					<ScreenBlock name={ block.name } />
 				</GlobalStylesNavigationScreen>
+			) ) }
 
-				<GlobalStylesNavigationScreen path="/variations">
-					<ScreenStyleVariations />
-				</GlobalStylesNavigationScreen>
+			<ContextScreens />
 
-				<GlobalStylesNavigationScreen path="/blocks">
-					<ScreenBlockList />
-				</GlobalStylesNavigationScreen>
-
-				{ blocks.map( ( block ) => (
-					<GlobalStylesNavigationScreen
-						key={ 'menu-block-' + block.name }
-						path={ '/blocks/' + block.name }
-					>
-						<ScreenBlock name={ block.name } />
-					</GlobalStylesNavigationScreen>
-				) ) }
-
-				<ContextScreens />
-
-				{ blocks.map( ( block ) => (
-					<ContextScreens
-						key={ 'screens-block-' + block.name }
-						name={ block.name }
-					/>
-				) ) }
-			</NavigatorProvider>
-			{ randomizeThemeColors && (
-				<Button
-					icon={ shuffle }
-					label={ __( 'Randomize colors' ) }
-					onClick={ randomizeThemeColors }
+			{ blocks.map( ( block ) => (
+				<ContextScreens
+					key={ 'screens-block-' + block.name }
+					name={ block.name }
 				/>
-			) }
-		</>
+			) ) }
+		</NavigatorProvider>
 	);
 }
 


### PR DESCRIPTION
This experiment shows a method in which random color palettes may be
generated by utilizing hue rotations. For demonstration purposes, I've
used the [Cubehelix color scheme](https://www.mrao.cam.ac.uk/~dag/CUBEHELIX/) utilities within chroma-js, which allow easy access to hue rotation functionality.

Hue rotation consists in rotating the hue wheel — such as the one you
might see in a color picker — by a determined amount of degrees, each turn
generating a new color.

This experiment highlights the need for themes to explicitly support
style randomization, as well as the need to incorporate a way to define
a color's role within a palette as a way of avoiding getting, for
example, palettes where background and foreground don't contrast,
rendering text illegible.

### Demo

![Kapture 2022-05-11 at 01 46 50](https://user-images.githubusercontent.com/1157901/167777588-d1b8eab0-fa1d-473c-88dd-d3106362812c.gif)

### Next things to try in this PR

- [ ] Add a role definition for colors or, at least, a way to flag that they should contrast.
- [ ] Custom color scales, defining start and end colors.