### PR TITLE
CircularOptionPicker: Fix focused styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Enhancements
 
--   `BorderControl` now only displays the reset button in its popover when selections have already been made. [#40917](https://github.com/WordPress/gutenberg/pull/40917)
+-   `BorderControl` now only displays the reset button in its popover when selections have already been made. ([#40917](https://github.com/WordPress/gutenberg/pull/40917))
 -   `BorderControl` & `BorderBoxControl`: Add `__next36pxDefaultSize` flag for larger default size ([#40920](https://github.com/WordPress/gutenberg/pull/40920)).
--   `BorderControl` improved focus and border radius styling for component. [#40951](https://github.com/WordPress/gutenberg/pull/40951)
+-   `BorderControl` improved focus and border radius styling for component. ([#40951](https://github.com/WordPress/gutenberg/pull/40951))
+-   Improve focused `CircularOptionPicker` styling ([#40990](https://github.com/WordPress/gutenberg/pull/40990))
 
 ### Internal
 

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -99,6 +99,7 @@ $color-palette-circle-spacing: 12px;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 		// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
 		border: 1px solid transparent;
+		box-sizing: inherit;
 	}
 
 	&:focus {


### PR DESCRIPTION
## What?

Fixes minor issue where focus box shadow is warped when the `CircularOptionPicker` isn't displayed via a popover.

## Why?

Soothe my OCD 💆  

## How?

Allows the `:after` pseudo-element to inherit its parent's box-sizing making it consistent and preventing the mismatched dimensions.

_Note: Within the Storybook and editor Popovers the `:after` element gets this box-sizing via other styles_

## Testing Instructions

1. Prior to checking out this PR, edit a post, add a Cover block, and focus one of the color swatches within the block's placeholder
2. Note the swatch's block shadow is out of whack
3. Check out this PR and repeat the process confirming the focused style is correct
4. Start up the Storybook and inspect the `ColorPalette` component page
5. Make sure that the color swatches here, when focused, display correctly still.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="674" alt="Screen Shot 2022-05-11 at 4 41 07 pm" src="https://user-images.githubusercontent.com/60436221/167789468-6dbd8a96-cfd0-495e-abca-306fd11db9cd.png"> | <img width="678" alt="Screen Shot 2022-05-11 at 4 45 28 pm" src="https://user-images.githubusercontent.com/60436221/167789492-8f761f04-0c81-487c-8e03-c29d4767f354.png"> |

