### PR TITLE
[List v2]: Indent multiple list items

### DIFF
--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -32,30 +32,19 @@ export default function useIndentListItem( clientId ) {
 			const clonedBlocks = clientIds.map( ( _clientId ) =>
 				cloneBlock( getBlock( _clientId ) )
 			);
+			const previousSiblingId = getPreviousBlockClientId( clientId );
+			const newListItem = cloneBlock( getBlock( previousSiblingId ) );
+			// If the sibling has no innerBlocks, create a new `list` block.
+			if ( ! newListItem.innerBlocks?.length ) {
+				newListItem.innerBlocks = [ createBlock( 'core/list' ) ];
+			}
 			// A list item usually has one `list`, but it's possible to have
 			// more. So we need to preserve the previous `list` blocks and
 			// merge the new blocks to the last `list`.
-			const previousSiblingId = getPreviousBlockClientId( clientId );
-			const previousSibling = getBlock( previousSiblingId );
-			const lastInnerBlock = previousSibling.innerBlocks.slice( -1 )[ 0 ];
-			// We also need to check if the previous sibling has innerBlocks already.
-			// If not we need to create a new `list` block.
-			const newInnerBlocks = !! lastInnerBlock
-				? [
-						...previousSibling.innerBlocks.slice( 0, -1 ),
-						{
-							...lastInnerBlock,
-							innerBlocks: [
-								...lastInnerBlock.innerBlocks,
-								...clonedBlocks,
-							],
-						},
-				  ]
-				: [ createBlock( 'core/list', {}, clonedBlocks ) ];
-			const newListItem = {
-				...previousSibling,
-				innerBlocks: newInnerBlocks,
-			};
+			newListItem.innerBlocks[
+				newListItem.innerBlocks.length - 1
+			].innerBlocks.push( ...clonedBlocks );
+
 			// We get the selection start/end here, because when
 			// we replace blocks, the selection is updated too.
 			const selectionStart = getSelectionStart();

--- a/packages/block-library/src/list-item/hooks/use-indent-list-item.js
+++ b/packages/block-library/src/list-item/hooks/use-indent-list-item.js
@@ -1,89 +1,87 @@
 /**
- * External dependencies
- */
-import { first } from 'lodash';
-
-/**
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
-import { createListItem } from '../utils';
+import { createBlock, cloneBlock } from '@wordpress/blocks';
 
 export default function useIndentListItem( clientId ) {
-	const { canIndent } = useSelect(
-		( innerSelect ) => {
-			const { getBlockIndex } = innerSelect( blockEditorStore );
-			return {
-				canIndent: getBlockIndex( clientId ) > 0,
-			};
-		},
+	const canIndent = useSelect(
+		( select ) => select( blockEditorStore ).getBlockIndex( clientId ) > 0,
 		[ clientId ]
 	);
-	const { replaceBlocks, selectionChange } = useDispatch( blockEditorStore );
+	const { replaceBlocks, selectionChange, multiSelect } = useDispatch(
+		blockEditorStore
+	);
 	const {
-		getBlockRootClientId,
 		getBlock,
-		getBlockOrder,
+		getPreviousBlockClientId,
 		getSelectionStart,
 		getSelectionEnd,
-		getBlockIndex,
+		hasMultiSelection,
+		getMultiSelectedBlockClientIds,
 	} = useSelect( blockEditorStore );
-
 	return [
 		canIndent,
 		useCallback( () => {
+			const _hasMultiSelection = hasMultiSelection();
+			const clientIds = _hasMultiSelection
+				? getMultiSelectedBlockClientIds()
+				: [ clientId ];
+			const clonedBlocks = clientIds.map( ( _clientId ) =>
+				cloneBlock( getBlock( _clientId ) )
+			);
+			// A list item usually has one `list`, but it's possible to have
+			// more. So we need to preserve the previous `list` blocks and
+			// merge the new blocks to the last `list`.
+			const previousSiblingId = getPreviousBlockClientId( clientId );
+			const previousSibling = getBlock( previousSiblingId );
+			const lastInnerBlock = previousSibling.innerBlocks.slice( -1 )[ 0 ];
+			// We also need to check if the previous sibling has innerBlocks already.
+			// If not we need to create a new `list` block.
+			const newInnerBlocks = !! lastInnerBlock
+				? [
+						...previousSibling.innerBlocks.slice( 0, -1 ),
+						{
+							...lastInnerBlock,
+							innerBlocks: [
+								...lastInnerBlock.innerBlocks,
+								...clonedBlocks,
+							],
+						},
+				  ]
+				: [ createBlock( 'core/list', {}, clonedBlocks ) ];
+			const newListItem = {
+				...previousSibling,
+				innerBlocks: newInnerBlocks,
+			};
+			// We get the selection start/end here, because when
+			// we replace blocks, the selection is updated too.
 			const selectionStart = getSelectionStart();
 			const selectionEnd = getSelectionEnd();
-
-			const parentId = getBlockRootClientId( clientId );
-			const previousSiblingId = getBlockOrder( parentId )[
-				getBlockIndex( clientId ) - 1
-			];
-			const previousSibling = getBlock( previousSiblingId );
-			const previousSiblingChildren =
-				first( previousSibling.innerBlocks )?.innerBlocks || [];
-			const previousSiblingListAttributes =
-				first( previousSibling.innerBlocks )?.attributes || {};
-			const block = getBlock( clientId );
-
-			const childListAttributes = first( block.innerBlocks )?.attributes;
-			const childItemBlocks =
-				first( block.innerBlocks )?.innerBlocks || [];
-
-			const newBlock = createListItem(
-				block.attributes,
-				childListAttributes,
-				childItemBlocks
-			);
-			// Replace the previous sibling of the block being indented and the indented block,
+			// Replace the previous sibling of the block being indented and the indented blocks,
 			// with a new block whose attributes are equal to the ones of the previous sibling and
-			// whose descendants are the children of the previous sibling, followed by the indented block.
+			// whose descendants are the children of the previous sibling, followed by the indented blocks.
 			replaceBlocks(
-				[ previousSiblingId, clientId ],
-				[
-					createListItem(
-						previousSibling.attributes,
-						previousSiblingListAttributes,
-						[ ...previousSiblingChildren, newBlock ]
-					),
-				]
+				[ previousSiblingId, ...clientIds ],
+				[ newListItem ]
 			);
-
-			// Restore the selection state.
-			selectionChange(
-				newBlock.clientId,
-				selectionEnd.attributeKey,
-				selectionEnd.clientId === selectionStart.clientId
-					? selectionStart.offset
-					: selectionEnd.offset,
-				selectionEnd.offset
-			);
+			if ( ! _hasMultiSelection ) {
+				selectionChange(
+					clonedBlocks[ 0 ].clientId,
+					selectionEnd.attributeKey,
+					selectionEnd.clientId === selectionStart.clientId
+						? selectionStart.offset
+						: selectionEnd.offset,
+					selectionEnd.offset
+				);
+			} else {
+				multiSelect(
+					clonedBlocks[ 0 ].clientId,
+					clonedBlocks[ clonedBlocks.length - 1 ].clientId
+				);
+			}
 		}, [ clientId ] ),
 	];
 }

--- a/packages/block-library/src/list-item/utils.js
+++ b/packages/block-library/src/list-item/utils.js
@@ -7,7 +7,7 @@ export function createListItem( listItemAttributes, listAttributes, children ) {
 	return createBlock(
 		'core/list-item',
 		listItemAttributes,
-		! children || ! children.length
+		! children?.length
 			? []
 			: [ createBlock( 'core/list', listAttributes, children ) ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/39893

This PR does two things:
1. Add support for indenting multiple list items at once
2. Fixes the case of proper merging when a list item has more than one `list` blocks. This is not so usual and we should probably handle this by not letting a list item to have more than one `lists`, but for now is being handled. I'm not sure if there is the need to have multiple lists 🤔, but if not we can simplify the code in this part. 
<!-- In a few words, what is the PR actually doing? -->

## Notes

1. This PR doesn't update the `outdent` functionality which doesn't work properly right now, but I'll do it a follow up for easier reviews/testing and because is being reused by `list` block as well.
2. You need to have enabled the experimental version 2 of list in Gutenberg experiments.

## Testing Instructions
1. Insert a new list block with any nested lists
3. Test any indenting possible with different combinations:
      1. single list item(with nested lists or not)
      2. multiple list items(with nested lists or not)
      4. any list item/items that are going to be merged in a list item with multiple lists
3. Selection should be preserved for single list items and multi selection for multiple selected list items





## Screenshots or screencast <!-- if applicable -->

In the video I start by showcasing the single list item and then multiple list items in combination with a merging in a list items that has two `list` blocks.

https://user-images.githubusercontent.com/16275880/167805827-3afb2cb0-d375-4c5e-97d9-5b4096f526a8.mov


