### PR TITLE
Entity configuration types

### DIFF
--- a/packages/core-data/src/entities.ts
+++ b/packages/core-data/src/entities.ts
@@ -13,17 +13,307 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { addEntities } from './actions';
-import type { Post, Taxonomy, Type, Updatable } from './entity-types';
+import type * as Records from './entity-types';
+import type {
+	EntityType,
+	Context,
+	Post,
+	Taxonomy,
+	Type,
+	Updatable,
+} from './entity-types';
 
 export const DEFAULT_ENTITY_KEY = 'id';
 
 const POST_RAW_ATTRIBUTES = [ 'title', 'excerpt', 'content' ];
 
+type AttachmentEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'media';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Attachment< C >,
+	C
+>;
+
+const attachmentConfig: AttachmentEntity[ 'config' ] = {
+	name: 'media',
+	kind: 'root',
+	baseURL: '/wp/v2/media',
+	baseURLParams: { context: 'edit' },
+	plural: 'mediaItems',
+	label: __( 'Media' ),
+	rawAttributes: [ 'caption', 'title', 'description' ],
+};
+
+type SiteEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'site';
+		kind: 'root';
+	},
+	Records.Settings< C >,
+	C
+>;
+
+const siteConfig: SiteEntity[ 'config' ] = {
+	label: __( 'Site' ),
+	name: 'site',
+	kind: 'root',
+	baseURL: '/wp/v2/settings',
+	getTitle: ( record: Records.Settings< 'edit' > ) => {
+		return get( record, [ 'title' ], __( 'Site Title' ) );
+	},
+};
+
+type PostTypeEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'postType';
+		kind: 'root';
+		key: 'slug';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Type< C >,
+	C
+>;
+
+const postTypeConfig: PostTypeEntity[ 'config' ] = {
+	label: __( 'Post Type' ),
+	name: 'postType',
+	kind: 'root',
+	key: 'slug',
+	baseURL: '/wp/v2/types',
+	baseURLParams: { context: 'edit' },
+};
+
+type TaxonomyEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'taxonomy';
+		kind: 'root';
+		key: 'slug';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Taxonomy< C >,
+	C
+>;
+
+const taxonomyConfig: TaxonomyEntity[ 'config' ] = {
+	name: 'taxonomy',
+	kind: 'root',
+	key: 'slug',
+	baseURL: '/wp/v2/taxonomies',
+	baseURLParams: { context: 'edit' },
+	plural: 'taxonomies',
+	label: __( 'Taxonomy' ),
+};
+
+type SidebarEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'sidebar';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Sidebar< C >,
+	C
+>;
+
+const sidebarConfig: SidebarEntity[ 'config' ] = {
+	name: 'sidebar',
+	kind: 'root',
+	baseURL: '/wp/v2/sidebars',
+	baseURLParams: { context: 'edit' },
+	plural: 'sidebars',
+	transientEdits: { blocks: true },
+	label: __( 'Widget areas' ),
+};
+
+type WidgetEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'widget';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Widget< C >,
+	C
+>;
+const widgetConfig: WidgetEntity[ 'config' ] = {
+	name: 'widget',
+	kind: 'root',
+	baseURL: '/wp/v2/widgets',
+	baseURLParams: { context: 'edit' },
+	plural: 'widgets',
+	transientEdits: { blocks: true },
+	label: __( 'Widgets' ),
+};
+
+type WidgetTypeEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'widgetType';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.WidgetType< C >,
+	C
+>;
+const widgetTypeConfig: WidgetTypeEntity[ 'config' ] = {
+	name: 'widgetType',
+	kind: 'root',
+	baseURL: '/wp/v2/widget-types',
+	baseURLParams: { context: 'edit' },
+	plural: 'widgetTypes',
+	label: __( 'Widget types' ),
+};
+
+type UserEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'user';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.User< C >,
+	C
+>;
+const userConfig: UserEntity[ 'config' ] = {
+	label: __( 'User' ),
+	name: 'user',
+	kind: 'root',
+	baseURL: '/wp/v2/users',
+	baseURLParams: { context: 'edit' },
+	plural: 'users',
+};
+
+type CommentEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'comment';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.Comment< C >,
+	C
+>;
+const commentConfig: CommentEntity[ 'config' ] = {
+	name: 'comment',
+	kind: 'root',
+	baseURL: '/wp/v2/comments',
+	baseURLParams: { context: 'edit' },
+	plural: 'comments',
+	label: __( 'Comment' ),
+};
+
+type NavMenuEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'menu';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.NavMenu< C >,
+	C
+>;
+
+const menuConfig: NavMenuEntity[ 'config' ] = {
+	name: 'menu',
+	kind: 'root',
+	baseURL: '/wp/v2/menus',
+	baseURLParams: { context: 'edit' },
+	plural: 'menus',
+	label: __( 'Menu' ),
+};
+
+type NavMenuItemEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'menuItem';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.NavMenuItem< C >,
+	C
+>;
+
+const menuItemConfig: NavMenuItemEntity[ 'config' ] = {
+	name: 'menuItem',
+	kind: 'root',
+	baseURL: '/wp/v2/menu-items',
+	baseURLParams: { context: 'edit' },
+	plural: 'menuItems',
+	label: __( 'Menu Item' ),
+	rawAttributes: [ 'title' ],
+};
+
+type MenuLocationEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'menuLocation';
+		kind: 'root';
+		key: 'name';
+		baseURLParams: { context: 'edit' };
+	},
+	Records.MenuLocation< C >,
+	C
+>;
+
+const menuLocationConfig: MenuLocationEntity[ 'config' ] = {
+	name: 'menuLocation',
+	kind: 'root',
+	baseURL: '/wp/v2/menu-locations',
+	baseURLParams: { context: 'edit' },
+	plural: 'menuLocations',
+	label: __( 'Menu Location' ),
+	key: 'name',
+};
+
+const globalStyleConfig = {
+	label: __( 'Global Styles' ),
+	name: 'globalStyles',
+	kind: 'root',
+	baseURL: '/wp/v2/global-styles',
+	baseURLParams: { context: 'edit' },
+	plural: 'globalStylesVariations', // Should be different than name.
+	getTitle: ( record ) => record?.title?.rendered || record?.title,
+};
+
+type ThemeEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'theme';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+		key: 'stylesheet';
+	},
+	Records.Theme< C >,
+	C
+>;
+
+const themeConfig: ThemeEntity[ 'config' ] = {
+	label: __( 'Themes' ),
+	name: 'theme',
+	kind: 'root',
+	baseURL: '/wp/v2/themes',
+	baseURLParams: { context: 'edit' },
+	key: 'stylesheet',
+};
+
+type PluginEntity< C extends Context = Context > = EntityType<
+	{
+		name: 'plugin';
+		kind: 'root';
+		baseURLParams: { context: 'edit' };
+		key: 'plugin';
+	},
+	Records.Plugin< C >,
+	C
+>;
+const pluginConfig: PluginEntity[ 'config' ] = {
+	label: __( 'Plugins' ),
+	name: 'plugin',
+	kind: 'root',
+	baseURL: '/wp/v2/plugins',
+	baseURLParams: { context: 'edit' },
+	key: 'plugin',
+};
+
 export const rootEntitiesConfig = [
 	{
 		label: __( 'Base' ),
-		name: '__unstableBase',
 		kind: 'root',
+		name: '__unstableBase',
 		baseURL: '/',
 		baseURLParams: {
 			_fields: [
@@ -39,136 +329,69 @@ export const rootEntitiesConfig = [
 			].join( ',' ),
 		},
 	},
-	{
-		label: __( 'Site' ),
-		name: 'site',
-		kind: 'root',
-		baseURL: '/wp/v2/settings',
-		getTitle: ( record ) => {
-			return get( record, [ 'title' ], __( 'Site Title' ) );
-		},
-	},
-	{
-		label: __( 'Post Type' ),
-		name: 'postType',
-		kind: 'root',
-		key: 'slug',
-		baseURL: '/wp/v2/types',
-		baseURLParams: { context: 'edit' },
-		rawAttributes: POST_RAW_ATTRIBUTES,
-	},
-	{
-		name: 'media',
-		kind: 'root',
-		baseURL: '/wp/v2/media',
-		baseURLParams: { context: 'edit' },
-		plural: 'mediaItems',
-		label: __( 'Media' ),
-		rawAttributes: [ 'caption', 'title', 'description' ],
-	},
-	{
-		name: 'taxonomy',
-		kind: 'root',
-		key: 'slug',
-		baseURL: '/wp/v2/taxonomies',
-		baseURLParams: { context: 'edit' },
-		plural: 'taxonomies',
-		label: __( 'Taxonomy' ),
-	},
-	{
-		name: 'sidebar',
-		kind: 'root',
-		baseURL: '/wp/v2/sidebars',
-		baseURLParams: { context: 'edit' },
-		plural: 'sidebars',
-		transientEdits: { blocks: true },
-		label: __( 'Widget areas' ),
-	},
-	{
-		name: 'widget',
-		kind: 'root',
-		baseURL: '/wp/v2/widgets',
-		baseURLParams: { context: 'edit' },
-		plural: 'widgets',
-		transientEdits: { blocks: true },
-		label: __( 'Widgets' ),
-	},
-	{
-		name: 'widgetType',
-		kind: 'root',
-		baseURL: '/wp/v2/widget-types',
-		baseURLParams: { context: 'edit' },
-		plural: 'widgetTypes',
-		label: __( 'Widget types' ),
-	},
-	{
-		label: __( 'User' ),
-		name: 'user',
-		kind: 'root',
-		baseURL: '/wp/v2/users',
-		baseURLParams: { context: 'edit' },
-		plural: 'users',
-	},
-	{
-		name: 'comment',
-		kind: 'root',
-		baseURL: '/wp/v2/comments',
-		baseURLParams: { context: 'edit' },
-		plural: 'comments',
-		label: __( 'Comment' ),
-	},
-	{
-		name: 'menu',
-		kind: 'root',
-		baseURL: '/wp/v2/menus',
-		baseURLParams: { context: 'edit' },
-		plural: 'menus',
-		label: __( 'Menu' ),
-	},
-	{
-		name: 'menuItem',
-		kind: 'root',
-		baseURL: '/wp/v2/menu-items',
-		baseURLParams: { context: 'edit' },
-		plural: 'menuItems',
-		label: __( 'Menu Item' ),
-		rawAttributes: [ 'title', 'content' ],
-	},
-	{
-		name: 'menuLocation',
-		kind: 'root',
-		baseURL: '/wp/v2/menu-locations',
-		baseURLParams: { context: 'edit' },
-		plural: 'menuLocations',
-		label: __( 'Menu Location' ),
-		key: 'name',
-	},
-	{
-		label: __( 'Global Styles' ),
-		name: 'globalStyles',
-		kind: 'root',
-		baseURL: '/wp/v2/global-styles',
-		baseURLParams: { context: 'edit' },
-		plural: 'globalStylesVariations', // Should be different than name.
-		getTitle: ( record ) => record?.title?.rendered || record?.title,
-	},
-	{
-		label: __( 'Themes' ),
-		name: 'theme',
-		kind: 'root',
-		baseURL: '/wp/v2/themes',
-		baseURLParams: { context: 'edit' },
-		key: 'stylesheet',
-	},
-	{
-		label: __( 'Plugins' ),
-		name: 'plugin',
-		kind: 'root',
-		baseURL: '/wp/v2/plugins',
-		baseURLParams: { context: 'edit' },
-		key: 'plugin',
-	},
+	siteConfig,
+	postTypeConfig,
+	attachmentConfig,
+	taxonomyConfig,
+	sidebarConfig,
+	widgetConfig,
+	widgetTypeConfig,
+	userConfig,
+	commentConfig,
+	menuConfig,
+	menuItemConfig,
+	menuLocationConfig,
+	globalStyleConfig,
+	themeConfig,
+	pluginConfig,
 ];
+
+type PostTypeConfig = {
+	kind: 'postType';
+	key: 'id';
+	defaultContext: 'edit';
+};
+
+type PostEntity< C extends Context = Context > = EntityType<
+	PostTypeConfig & { name: 'post' },
+	Records.Post< C >,
+	C
+>;
+type PageEntity< C extends Context > = EntityType<
+	PostTypeConfig & { name: 'page' },
+	Records.Page< C >,
+	C
+>;
+type WpTemplateEntity< C extends Context > = EntityType<
+	PostTypeConfig & { name: 'wp_template' },
+	Records.WpTemplate< C >,
+	C
+>;
+type WpTemplatePartEntity< C extends Context > = EntityType<
+	PostTypeConfig & { name: 'wp_template_part' },
+	Records.WpTemplatePart< C >,
+	C
+>;
+
+export type CoreEntities< C extends Context > =
+	| SiteEntity< C >
+	| PostTypeEntity< C >
+	| AttachmentEntity< C >
+	| TaxonomyEntity< C >
+	| SidebarEntity< C >
+	| WidgetEntity< C >
+	| WidgetTypeEntity< C >
+	| UserEntity< C >
+	| CommentEntity< C >
+	| NavMenuEntity< C >
+	| NavMenuItemEntity< C >
+	| MenuLocationEntity< C >
+	| ThemeEntity< C >
+	| PluginEntity< C >
+	| PostEntity< C >
+	| PageEntity< C >
+	| WpTemplateEntity< C >
+	| WpTemplatePartEntity< C >;
 
 export const additionalEntityConfigLoaders = [
 	{ kind: 'postType', loadEntities: loadPostTypeEntities },
@@ -292,7 +515,7 @@ export const getMethodName = (
 	const nameSuffix =
 		upperFirst( camelCase( name ) ) + ( usePlural ? 's' : '' );
 	const suffix =
-		usePlural && entityConfig?.plural
+		usePlural && 'plural' in entityConfig && entityConfig?.plural
 			? upperFirst( camelCase( entityConfig.plural ) )
 			: nameSuffix;
 	return `${ prefix }${ kindPrefix }${ suffix }`;

--- a/packages/core-data/src/entity-types/entities.ts
+++ b/packages/core-data/src/entity-types/entities.ts
@@ -1,0 +1,127 @@
+/**
+ * Internal dependencies
+ */
+import type { Context } from './helpers';
+import { EntityRecord } from './index';
+
+/**
+ * HTTP Query parameters sent with the API request to fetch the entity records.
+ */
+export type EntityQuery<
+	C extends Context,
+	Fields extends string[] | undefined = undefined
+> = Record< string, any > & {
+	context?: C;
+	/**
+	 * The requested fields. If specified, the REST API will remove from the response
+	 * any fields not on that list.
+	 */
+	_fields?: Fields;
+};
+
+interface Edit {}
+
+/**
+ * Helper type that transforms "raw" entity configuration from entities.ts
+ * into a format that makes searching by root and kind easy and extensible.
+ *
+ * This is the foundation of return type inference in calls such as:
+ * `getEntityRecord( "root", "comment", 15 )`.
+ *
+ * @see EntityRecordOf
+ * @see getEntityRecord
+ */
+export type EntityType<
+	Config extends Pick< EntityConfig< Record, Ctx >, RequiredConfigKeys >,
+	Record extends EntityRecord< Ctx >,
+	Ctx extends Context
+> = {
+	record: Record;
+	config: Omit< EntityConfig< Record, Ctx >, RequiredConfigKeys > & Config;
+	key: Config[ 'key' ] extends string ? Config[ 'key' ] : 'id';
+	defaultContext: Config[ 'baseURLParams' ] extends {
+		context: infer InferredContext;
+	}
+		? InferredContext
+		: 'view';
+};
+
+type RequiredConfigKeys = 'name' | 'kind' | 'key' | 'baseURLParams';
+
+interface EntityConfig< R extends EntityRecord< C >, C extends Context > {
+	/** Path in WP REST API from which to request records of this entity. */
+	baseURL: string;
+
+	/** Arguments to supply by default to API requests for records of this entity. */
+	baseURLParams?: EntityQuery< Context >;
+
+	/**
+	 * Returns the title for a given record of this entity.
+	 *
+	 * Some entities have an associated title, such as the name of a
+	 * particular template part ("full width") or of a menu ("main nav").
+	 */
+	getTitle?: ( record: R ) => string;
+
+	/**
+	 * Indicates an alternate field in record that can be used for identification.
+	 *
+	 * e.g. a post has an id but may also be uniquely identified by its `slug`
+	 */
+	key?: string;
+
+	/**
+	 * Collection in which to classify records of this entity.
+	 *
+	 * 'root' is a special name given to the core entities provided by the editor.
+	 *
+	 * It may be the case that we request an entity record for which we have no
+	 * valid config in memory. In these cases the editor will look for a loader
+	 * function to requests more entity configs from the server for the given
+	 * "kind." This is how WordPress defers loading of template entity configs.
+	 */
+	kind: string;
+
+	/** Translated form of human-recognizable name or reference to records of this entity. */
+	label: string;
+
+	mergedEdits?: {
+		meta?: boolean;
+	};
+
+	/** Name given to records of this entity, e.g. 'media', 'postType', 'widget' */
+	name: string;
+
+	/**
+	 * Manually provided plural form of the entity name.
+	 *
+	 * When not supplied the editor will attempt to auto-generate a plural form.
+	 */
+	plural?: string;
+
+	/**
+	 * Fields in record of this entity which may appear as a compound object with
+	 * a source value (`raw`) as well as a processed value (`rendered`).
+	 *
+	 * e.g. a post's `content` in the edit context contains the raw value stored
+	 *      in the database as well as the rendered version with shortcodes replaced,
+	 *      content texturized, blocks transformed, etc…
+	 */
+	rawAttributes?: ( keyof R )[];
+
+	/**
+	 * Which transient edit operations records of this entity support.
+	 */
+	transientEdits?: {
+		blocks?: boolean;
+		selection?: boolean;
+	};
+
+	// Unstable properties
+
+	/** Returns additional changes before applying edits to a record of this entity. */
+	__unstablePrePersist?: ( record: R, edits: Edit[] ) => Edit[];
+
+	/** Used in `canEdit()` */
+	__unstable_rest_base?: string;
+}

--- a/packages/core-data/src/entity-types/index.ts
+++ b/packages/core-data/src/entity-types/index.ts
@@ -21,6 +21,7 @@ import type { WidgetType } from './widget-type';
 import type { WpTemplate } from './wp-template';
 import type { WpTemplatePart } from './wp-template-part';
 
+export type { EntityType } from './entities';
 export type { BaseEntityRecords } from './base-entity-records';
 
 export type {


### PR DESCRIPTION
## What?

This PR adds Entity configuration types to `core-data/src/entities.ts`. 

It is an alternative to https://github.com/WordPress/gutenberg/pull/40024. See also  https://github.com/WordPress/gutenberg/pull/39025, a mega branch that proposes TypeScript signatures for all `@wordpress/core-data` selectors.

## Why?
Consider the `getEntityRecord` selector:

https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/selectors.js#L157-L171

Different entity kinds, like `root`, `postType`, `taxonomy`, are associated with different entity names. For example, `kind: root, name: plugin` is a valid combination, but `kind: postType, name: plugin` is not. Other valid combinations are configured in the `entities.ts` file via a JavaScript object.

An ideal `getEntityRecord` function signature would only accept valid combinations, then require the `key` to be either `number` or a `string`, and return the list of corresponding entity records.

Again, ideally, there would only be a single source of truth for all the information. That's exactly what this PR enables by introducing the Entity types:

```ts
type PluginEntity< C extends Context = Context > = EntityType<
	{
		name: 'plugin';
		kind: 'root';
		baseURLParams: { context: 'edit' };
		key: 'plugin';
	},
	Records.Plugin< C >,
	C
>;

const pluginConfig: PluginEntity[ 'config' ] = {
	label: __( 'Plugins' ),
	name: 'plugin',
	kind: 'root',
	baseURL: '/wp/v2/plugins',
	baseURLParams: { context: 'edit' },
	key: 'plugin',
};

// PluginEntity['config']['kind'] is "root"
// PluginEntity['defaultContext'] is "edit"
```

That `PluginEntity` type can then be reused to build the `getEntityRecord` signature.

### Why write the kind and name twice?

This is a trade-off. I've spent hours exploring the available options with @dmsnell and we concluded that it's only possibl to either:

1. Infer it from `const config =` and miss out on autocompletion, config type validation, and require using `as const`. #40024 explored that
2. Infer it from `const config = ` and have all of the above, but at the cost of using super complex type plumbing. [This TS playground explores that](https://www.typescriptlang.org/play?ts=4.7.0-dev.20220506#code/C4TwDgpgBA6glsAFgGQRATgQwDYGcA8AKgDRTKnKECuY2EAfFALxRQBQrrhUEAHsBAB2AE1xRcwdHEEBzAD5RBVALYAjDFAWqA9trqZBmxVWzYjVERABm0iMKgB+KNwBkZKAC4OnAN7fOnADaAApQ0lAA1hAg2lbOALoe7AEpnPBIqAJYeEQh8RQU1LQMUG4AFIR5PPxColAAguhYIPgGIIxOlDR0SRYRgtoA7oIAlP5QAL5sbFYWAMbAcNqGmLgAwssSRACSgllWmHMMZWN+AegQwFTohrOCC0uC+OMBXcXVAiJigX0Dw-HmQT9IaCQL5F6cZAfWpiCRSWRGHR6CAGIxKNQYUjcPifOrpFBobIEQi7faHCAFMhFOj0ehlbRJQgjRlQM6pKAXK43KDaKCrPmCEDjKZTNh8MDadDAKCgSBQDZ7HHMKAAcjsCBVRjVGOEmoUKoAbnAIIMVQBuMW8CVSsKK9AHI5QACiewQIAAShA5pLhPh5dCvvLlgJ+FBGD4puLJdLpGTHS7FqAFTYZH7Pd70PYcTDna7QOmfX61mHSMXs4GFSHpeG2ABIVSrCAAVXdyCScOkMgt9cbLeQwUwWGUuCSPig3sV-CSlaVE27URA7cknfn0mES-hXbrgkwyggG5XbFFUZtsYwDugwW0W395bqM9DjDvYgTboLmaLYdZ41l+9VEokFUj0ta0YztC8oAHGQIE-Z8g0nasAzqV98y9Qt-RrAJfySFUwEwaCgOPK1o3HTZpSvCRkzgGRlVWBUthQkAqNTCjgHwQ1jVNehSA4k0VVpE4yj8AB6YT2QCAA9Bw6wbXBm1bHDhMGMBhINAAmYTf1wFViBk3tWwHIcR1ZUiEJw9VgE1CZdICBccLgXUbM4CI1xwgDgEIcAIB08Ydz3Nzr0so8xjYX9IMC5jPLlFhf1icLKOWFMLVEzgpOmECSInCRc0TY11kS6jaPywQGLzJiCtTRj319XiuNLYMcXoME6RGMpAjYFLxNYNKAjZVJZPkttVSUlT1OE9ztKc-r9P7Qdd2MscJyrHCjT4yYppSOzVQcnzxJckQAokKLvI2gI-L-XD8O84UNr6lIBr7RTlNUjS8OgyaIVYB6DLm4dR1M5bVQsqzTuc6IcLmKgJG0ZQAGlogAOV3E7PsiVz-0C47dvZc7DqCgIpniEKwpQvLmKbQRHmVWK4lJiBipTJCxEaZp8GkKwNAADQ6KBOc8YxTGSsTuuk0KvKgXYOaaOxWOY5UnX4LAFnwOmGeoinHlIMd9vXDGjq8nTFGRvGrPoDrhagNKgA)
3. Type it explicitly, have autocompletion and type validation without complex types, but duplicate a few lines of code.

This PR implements the latter approach.

### Why have a new config type?

Good question! It's needed because entity configuration comes from three different sources:

* Hardcoded types in `entities.ts`
* Implicit knowledge about the entities loaded using the [_entity loaders_](https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/entities.ts#L182-L185), e.g. that the default context of all `kind=postType` is `edit` as seen in [`loadPostTypeEntities`](https://github.com/WordPress/gutenberg/blob/395aea4f0eada457276b7d76adf00489d0314cd7/packages/core-data/src/entities.ts#L222-L251)
* Any additional configuration provided by Gutenberg extenders.

A somewhat eccentric metaphor would be picturing it as a MySQL query that joins three tables:

```sql
SELECT
	kind,
	name,
	recordType,
	DEFAULT(key, 'id') as key,
	DEFAULT(baseURLParams['context'], 'view') as defaultContext
FROM rootEntitiesConfig_declared_in_entities_js d
INNER JOIN record_types r ON d.kind = r.kind AND d.name = r.name
UNION
SELECT VALUES
	ROW ( 'postType', 'post', 'id', 'Post', 'edit' ),
	ROW ( 'postType', 'page', 'id', 'Page', 'edit' ),
	ROW ( 'postType', 'wp_template', 'WpTemplate', 'id', 'edit' ),
	ROW ( 'postType', 'wp_template_part', 'WpTemplatePart', 'id', 'edit' ),
AS what_we_intrinsically_know_from_additionalEntityConfigLoaders
UNION
SELECT
	kind,
	name,
	recordType,
	key,
	defaultContext
FROM additional_configuration_provided_by_extenders
```

A common format like the `PluginEntity` makes reasoning about all these data sources much easier down the road, e.g. it enables the following succinct formulation of the Kind type:

```ts
export type KindOf< R extends EntityRecord > = EntityConfigOf< R >[ 'kind' ];
```

## Test plan

Confirm the checks are green and that no entity configuration got changed when I split the large array into atomic declarations. The changes here should only affect the type system so there is nothing to test in the browser.

cc @dmsnell @jsnajdr @youknowriad @sarayourfriend @getdave @draganescu @scruffian 