### PR TITLE
Reduce active tab accent weight

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -84,7 +84,7 @@ $widget-area-width: 700px;
 $block-toolbar-height: $grid-unit-60;
 $border-width: 1px;
 $border-width-focus: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
-$border-width-tab: 4px;
+$border-width-tab: 2px;
 $helptext-font-size: 12px;
 $radius-round: 50%;
 $radius-block-ui: 2px;

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -84,7 +84,7 @@ $widget-area-width: 700px;
 $block-toolbar-height: $grid-unit-60;
 $border-width: 1px;
 $border-width-focus: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
-$border-width-tab: 2px;
+$border-width-tab: 1.5px;
 $helptext-font-size: 12px;
 $radius-round: 50%;
 $radius-block-ui: 2px;

--- a/packages/components/src/tab-panel/style.scss
+++ b/packages/components/src/tab-panel/style.scss
@@ -59,6 +59,6 @@
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 - #{$border-width-tab * 2} 0 0 var(--wp-admin-theme-color);
 	}
 }

--- a/packages/edit-post/src/components/sidebar/settings-header/style.scss
+++ b/packages/edit-post/src/components/sidebar/settings-header/style.scss
@@ -48,6 +48,6 @@
 	}
 
 	&.is-active:focus {
-		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 -$border-width-tab 0 0 var(--wp-admin-theme-color);
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 - #{$border-width-tab * 2} 0 0 var(--wp-admin-theme-color);
 	}
 }


### PR DESCRIPTION
## What?
Reduces the visual weight of the active state in the tab component.

## Why?
Staring at https://github.com/WordPress/gutenberg/issues/40204 and the concepts therein I noticed how **heavy** the Inspector can feel sometimes. This adjustment feels like an improvement that can go hand-in-hand with other efforts to streamline the UI.

2px is used so that the active tab is still visible when you focus (focus has a 1.5px outline). But it would be easier to try different values and add a dedicated style for active + focussed.

## How?
Adjusted css properties of `components-button components-tab-panel__tabs-item.is-active`.

## Testing Instructions
Peruse any UI region that makes use of tabs, e.g. the Inspector or the Inserter(s).

## Before
<img width="1171" alt="Screenshot 2022-05-11 at 13 26 04" src="https://user-images.githubusercontent.com/846565/167849428-921f70e6-90a6-43c6-86e8-eac3312fc494.png">

## After
<img width="1169" alt="Screenshot 2022-05-11 at 13 25 24" src="https://user-images.githubusercontent.com/846565/167849453-2451c19a-f639-4f6e-bf8d-c2359f1402ba.png">

