### PR TITLE
Add Center Align Support to Embed Blocks

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -88,3 +88,9 @@
 		padding-top: 200%; // 2 / 1 * 100
 	}
 }
+
+// Add Align Center Support to Embeds
+.wp-block-embed.aligncenter .wp-block-embed__wrapper {
+	display: flex;
+	justify-content: center;
+}


### PR DESCRIPTION
## What?
Adding center align support to embed blocks

## Why?

https://github.com/WordPress/gutenberg/issues/15130

The issue was also identified here: https://github.com/Automattic/wp-calypso/issues/38441

## How?

The PR makes `.wp-embed-block__wrapper` a flex container and centers the content if the `.aligncenter` class is applied.

## Testing Instructions

1. Create a new page or post
2. Add an embed block (i.e. Twitter)
3. Center align the block
4. Verify that the block is centered in the preview and frontend

## Screenshots or screencast

![CleanShot 2022-05-11 at 15 17 34@2x](https://user-images.githubusercontent.com/1326249/167956690-951f473e-4de3-4488-a214-f424d34e233c.jpg)