### PR TITLE
Gallery block: update the gallery gap to load styles in header for block themes

### DIFF
--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -46,31 +46,3 @@ function gutenberg_enqueue_global_styles_assets() {
 }
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_global_styles_assets' );
 add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
-
-/**
- * This function takes care of adding inline styles
- * in the proper place, depending on the theme in use.
- *
- * For block themes, it's loaded in the head.
- * For classic ones, it's loaded in the body
- * because the wp_head action  happens before
- * the render_block.
- *
- * @link https://core.trac.wordpress.org/ticket/53494.
- *
- * @param string $style String containing the CSS styles to be added.
- * @param int    $priority To set the priority for the add_action.
- */
-function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
-	$action_hook_name = 'wp_footer';
-	if ( wp_is_block_theme() ) {
-		$action_hook_name = 'wp_head';
-	}
-	add_action(
-		$action_hook_name,
-		static function () use ( $style ) {
-			echo "<style>$style</style>\n";
-		},
-		$priority
-	);
-}

--- a/lib/compat/wordpress-5.9/script-loader.php
+++ b/lib/compat/wordpress-5.9/script-loader.php
@@ -59,8 +59,9 @@ add_action( 'wp_footer', 'gutenberg_enqueue_global_styles_assets' );
  * @link https://core.trac.wordpress.org/ticket/53494.
  *
  * @param string $style String containing the CSS styles to be added.
+ * @param int    $priority To set the priority for the add_action.
  */
-function gutenberg_enqueue_block_support_styles( $style ) {
+function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 	$action_hook_name = 'wp_footer';
 	if ( wp_is_block_theme() ) {
 		$action_hook_name = 'wp_head';
@@ -69,6 +70,7 @@ function gutenberg_enqueue_block_support_styles( $style ) {
 		$action_hook_name,
 		static function () use ( $style ) {
 			echo "<style>$style</style>\n";
-		}
+		},
+		$priority
 	);
 }

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -9,6 +9,9 @@
  * This function takes care of adding inline styles
  * in the proper place, depending on the theme in use.
  *
+ * The method was added to core in 5.9.1, but with with a single param ($style). The second param ($priority) was
+ * added post 6.0 so the 6.1 release needs to have wp_enqueue_block_support_styles update to include this param.
+ *
  * For block themes, it's loaded in the head.
  * For classic ones, it's loaded in the body
  * because the wp_head action  happens before

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -9,7 +9,7 @@
  * This function takes care of adding inline styles
  * in the proper place, depending on the theme in use.
  *
- * This method was added to core in 5.9.1, but with with a single param ($style). The second param ($priority) was
+ * This method was added to core in 5.9.1, but with a single param ($style). The second param ($priority) was
  * added post 6.0, so the 6.1 release needs to have wp_enqueue_block_support_styles updated to include this param.
  *
  * For block themes, it's loaded in the head.

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -9,8 +9,8 @@
  * This function takes care of adding inline styles
  * in the proper place, depending on the theme in use.
  *
- * The method was added to core in 5.9.1, but with with a single param ($style). The second param ($priority) was
- * added post 6.0 so the 6.1 release needs to have wp_enqueue_block_support_styles update to include this param.
+ * This method was added to core in 5.9.1, but with with a single param ($style). The second param ($priority) was
+ * added post 6.0, so the 6.1 release needs to have wp_enqueue_block_support_styles updated to include this param.
  *
  * For block themes, it's loaded in the head.
  * For classic ones, it's loaded in the body

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -6,6 +6,34 @@
  */
 
 /**
+ * This function takes care of adding inline styles
+ * in the proper place, depending on the theme in use.
+ *
+ * For block themes, it's loaded in the head.
+ * For classic ones, it's loaded in the body
+ * because the wp_head action  happens before
+ * the render_block.
+ *
+ * @link https://core.trac.wordpress.org/ticket/53494.
+ *
+ * @param string $style String containing the CSS styles to be added.
+ * @param int    $priority To set the priority for the add_action.
+ */
+function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
+	$action_hook_name = 'wp_footer';
+	if ( wp_is_block_theme() ) {
+		$action_hook_name = 'wp_head';
+	}
+	add_action(
+		$action_hook_name,
+		static function () use ( $style ) {
+			echo "<style>$style</style>\n";
+		},
+		$priority
+	);
+}
+
+/**
  * This applies a filter to the list of style nodes that comes from `get_style_nodes` in WP_Theme_JSON.
  * This particular filter removes all of the blocks from the array.
  *

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -30,7 +30,7 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 	add_action(
 		$action_hook_name,
 		static function () use ( $style ) {
-			echo "<style>$style</style>\n";
+			echo '<style>' . esc_html( $style ) . "</style>\n";
 		},
 		$priority
 	);

--- a/lib/compat/wordpress-6.1/script-loader.php
+++ b/lib/compat/wordpress-6.1/script-loader.php
@@ -30,7 +30,7 @@ function gutenberg_enqueue_block_support_styles( $style, $priority = 10 ) {
 	add_action(
 		$action_hook_name,
 		static function () use ( $style ) {
-			echo '<style>' . esc_html( $style ) . "</style>\n";
+			echo "<style>$style</style>\n";
 		},
 		$priority
 	);

--- a/lib/load.php
+++ b/lib/load.php
@@ -126,7 +126,6 @@ require __DIR__ . '/compat/wordpress-6.0/client-assets.php';
 require __DIR__ . '/compat/wordpress-6.1/blocks.php';
 require __DIR__ . '/compat/wordpress-6.1/persisted-preferences.php';
 require __DIR__ . '/compat/wordpress-6.1/get-global-styles-and-settings.php';
-require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -130,6 +130,7 @@ require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 require __DIR__ . '/compat/wordpress-6.1/class-wp-theme-json-6-1.php';
 require __DIR__ . '/compat/wordpress-6.1/block-template-utils.php';
 require __DIR__ . '/compat/wordpress-6.1/wp-theme-get-post-templates.php';
+require __DIR__ . '/compat/wordpress-6.1/script-loader.php';
 
 // Experimental features.
 remove_action( 'plugins_loaded', '_wp_theme_json_webfonts_handler' ); // Turns off WP 6.0's stopgap handler for Webfonts API.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -79,16 +79,7 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
 	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
 
-	// Ideally styles should be loaded in the head, but blocks may be parsed
-	// after that, so loading in the footer for now.
-	// See https://core.trac.wordpress.org/ticket/53494.
-	add_action(
-		'wp_footer',
-		function () use ( $style ) {
-			echo '<style> ' . $style . '</style>';
-		},
-		11
-	);
+	gutenberg_enqueue_block_support_styles( $style, 11 );
 	return $content;
 }
 /**


### PR DESCRIPTION
## What?
Moves the custom gallery gap styles to the header if the theme being used is a block theme.

## Why?
Currently they are always loaded in the footer, which can cause a flash of unstyled content.

Fixes: #40936

## How?
Update the gallery render to use the `gutenberg_enqueue_block_support_styles` method so styles get put in header for block themes

## Testing Instructions

- In a site with a block theme add a Gallery block and set the block gap
- In the frontend make sure the `.wp-block-gallery-{id}` inline style is loaded near end of header and the gallery shows the correct gap
- Switch the site to a non block theme and reload the same gallery in the frontend and check style is now near bottom of page `body` and that the gap is still applied.


## Screenshots or screencast

Before:
<img width="485" alt="gap-before" src="https://user-images.githubusercontent.com/3629020/168185101-5e73898d-b526-4c95-876b-77f66de9d7bb.png">

After:
Block theme
<img width="444" alt="gap-after" src="https://user-images.githubusercontent.com/3629020/168185131-386784f2-2e5e-4c61-b080-71ab9285deab.png">

Non block theme
<img width="485" alt="gap-before" src="https://user-images.githubusercontent.com/3629020/168185167-88b64b7a-b582-4885-9397-1b11b9afafa2.png">


