### PR TITLE
Update attributes example: alter source children

### DIFF
--- a/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -12,7 +12,7 @@ One challenge of maintaining the representation of a block as a JavaScript objec
 	attributes: {
 		content: {
 			type: 'string',
-			source: 'text',
+			source: 'html',
 			selector: 'p',
 		},
 	},

--- a/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
+++ b/docs/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields.md
@@ -11,8 +11,8 @@ One challenge of maintaining the representation of a block as a JavaScript objec
 ```js
 	attributes: {
 		content: {
-			type: 'array',
-			source: 'children',
+			type: 'string',
+			source: 'text',
 			selector: 'p',
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Update attributes guide https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/. 

## Why?
There's no `children` value mentioned for `source` in official reference https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source. 

Available values are only:  

– (no value) – when no source is specified then data is stored in the block’s comment delimiter.
– attribute – data is stored in an HTML element attribute.
– text – data is stored in HTML text.
– html – data is stored in HTML. This is typically used by RichText.
– query – data is stored as an array of objects.
– meta – data is stored in post meta (deprecated).

## How?
All examples should be replaced by valid `source` value or attributes documentation should be updated to add `children` value as official.  

## Testing Instructions
1. Open <https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/introducing-attributes-and-editable-fields/>
2. Go to first code snippet  
```
attributes: {
    content: {
        type: 'array',
        source: 'children',
        selector: 'p',
    },
},
```
3. Compare `source` value with official documentation <https://developer.wordpress.org/block-editor/reference-guides/block-api/block-attributes/#value-source>  
  There's no `source: children` mentioned.  

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/8841983/167999515-f05086a0-455c-4eea-99f5-8648b4b9dab0.png)
