### PR TITLE
Layout: Remove double output of align-items in horizontal layouts

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -114,7 +114,6 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 
 		$style .= "flex-wrap: $flex_wrap;";
 		if ( 'horizontal' === $layout_orientation ) {
-			$style .= 'align-items: center;';
 			/**
 			 * Add this style only if is not empty for backwards compatibility,
 			 * since we intend to convert blocks that had flex layout implemented


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following on from vertical alignment being introduced to the layout support in https://github.com/WordPress/gutenberg/pull/40013, this PR removes the double output of `align-items` for horizontal layouts.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It looks like we missed removing the existing `align-items: center;` output in the Layout support's server-rendering. While the "real" value takes precedence, it'd be good to tidy up the output so there's only a single property rendered. I've labelled this as a "bug", but it isn't at all a worrisome bug 😄

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Remove the default `align-items: center;` output for horizontal layouts, given that the condition below it will always output an `align-items` value.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Add a Buttons block to a post
2. Add a couple of Buttons within the block, and use Shift+Enter to make one of the buttons go to multiple lines like the screenshot below, so that you can test that vertical alignment works.
3. Test the setting for vertical alignment, and save the post after each time and view on the front end of the site — make sure it still works (and that with no value, we still have a default value of `center`).

![image](https://user-images.githubusercontent.com/14988353/168016071-469ade72-b9cd-4caa-b3a5-e61fe6d84492.png)

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/168015786-3fa6fcde-d850-4959-a6a4-3591f719dba1.png) | ![image](https://user-images.githubusercontent.com/14988353/168015805-d7295e5e-cc60-46df-ba8c-209fb5cfb7b3.png) |