### PR TITLE
Experiment: Add a block selector engine for playwright

### DIFF
--- a/packages/e2e-test-utils-playwright/src/index.ts
+++ b/packages/e2e-test-utils-playwright/src/index.ts
@@ -4,9 +4,17 @@
 import { selectors } from '@playwright/test';
 import { selectorScript } from 'role-selector/playwright-test';
 
+/**
+ * Internal dependencies
+ */
+import createBlockSelectorEngine from './selectors/block-selector-engine';
+
 // Register role selector.
 // Replace this with the native role engine when it's ready.
 selectors.register( 'role', selectorScript, { contentScript: true } );
+
+// Register the block selector engine.
+selectors.register( 'block', createBlockSelectorEngine );
 
 export { Admin } from './admin';
 export { Editor } from './editor';

--- a/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
@@ -24,19 +24,16 @@ export default function createBlockSelectorEngine() {
 	function assembleDOMSelector( { tag, name, title, clientId } ) {
 		const tagPart = tag ?? '*';
 		const namePart = name ? `[data-type="${ name }"]` : undefined;
+		// Always include a `data-block` attribute selector even if there's no
+		// clientId to select. This ensures the selector only returns blocks.
 		const clientIdPart = clientId
 			? `[data-block="${ clientId }"]`
-			: undefined;
+			: '[data-block]';
 		const titlePart = title ? `[data-title="${ title }"]` : undefined;
 
 		const attributeParts = [ namePart, clientIdPart, titlePart ]
 			.filter( ( part ) => !! part )
 			.join( '' );
-
-		if ( attributeParts.length === 0 ) {
-			// Always return block by matching any 'data-block' attribute.
-			return `${ tagPart }[data-block]`;
-		}
 
 		return `${ tagPart }${ attributeParts }`;
 	}

--- a/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
@@ -1,0 +1,59 @@
+export default function createBlockSelectorEngine() {
+	// TODO - for some reason the parse and assemble functions need to be
+	// within this function, but it'd be great if that wasn't the case and they
+	// could be unit tested.
+	function parsePlaywrightSelector( selector ) {
+		if ( ! selector ) {
+			return {};
+		}
+
+		const [ , name ] = selector.match( /^([a-z0-9\/\-]+)/ ) ?? [];
+		const [ , title ] = selector.match( /title="(.+?)"/ ) ?? [];
+		const [ , clientId ] =
+			selector.match( /clientId="([0-9a-f\-]+?)"/ ) ?? [];
+		const [ , tag ] = selector.match( /tag="(.+?)"/ ) ?? [];
+
+		return {
+			name: name !== '*' ? name : undefined,
+			title,
+			clientId,
+			tag,
+		};
+	}
+
+	function assembleDOMSelector( { tag, name, title, clientId } ) {
+		const tagPart = tag ?? '*';
+		const namePart = name ? `[data-type="${ name }"]` : undefined;
+		const clientIdPart = clientId
+			? `[data-block="${ clientId }"]`
+			: undefined;
+		const titlePart = title ? `[data-title="${ title }"]` : undefined;
+
+		const attributeParts = [ namePart, clientIdPart, titlePart ]
+			.filter( ( part ) => !! part )
+			.join( '' );
+
+		if ( attributeParts.length === 0 ) {
+			// Always return block by matching any 'data-block' attribute.
+			return `${ tagPart }[data-block]`;
+		}
+
+		return `${ tagPart }${ attributeParts }`;
+	}
+
+	return {
+		// Returns the first element matching given selector in the root's subtree.
+		query( root, selector ) {
+			const selectorParams = parsePlaywrightSelector( selector );
+			const DOMSelector = assembleDOMSelector( selectorParams );
+			return root.querySelector( DOMSelector );
+		},
+
+		// Returns all elements matching given selector in the root's subtree.
+		queryAll( root, selector ) {
+			const selectorParams = parsePlaywrightSelector( selector );
+			const DOMSelector = assembleDOMSelector( selectorParams );
+			return Array.from( root.querySelectorAll( DOMSelector ) );
+		},
+	};
+}

--- a/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.js
@@ -1,7 +1,7 @@
 export default function createBlockSelectorEngine() {
-	// TODO - for some reason the parse and assemble functions need to be
-	// within this function, but it'd be great if that wasn't the case and they
-	// could be unit tested.
+	// Util functions need to be defined in the `createBlockSelectorEngine`
+	// body. Playwright converts this function to a string, and won't be able
+	// to reach functions that are defined outside the body.
 	function parsePlaywrightSelector( selector ) {
 		if ( ! selector ) {
 			return {};
@@ -21,17 +21,17 @@ export default function createBlockSelectorEngine() {
 		};
 	}
 
-	function assembleDOMSelector( { tag, name, title, clientId } ) {
-		const tagPart = tag ?? '*';
-		const namePart = name ? `[data-type="${ name }"]` : undefined;
+	function assembleDOMSelector( { clientId, name, tag, title } ) {
 		// Always include a `data-block` attribute selector even if there's no
 		// clientId to select. This ensures the selector only returns blocks.
 		const clientIdPart = clientId
 			? `[data-block="${ clientId }"]`
 			: '[data-block]';
+		const namePart = name ? `[data-type="${ name }"]` : undefined;
+		const tagPart = tag ?? '*';
 		const titlePart = title ? `[data-title="${ title }"]` : undefined;
 
-		const attributeParts = [ namePart, clientIdPart, titlePart ]
+		const attributeParts = [ clientIdPart, namePart, titlePart ]
 			.filter( ( part ) => !! part )
 			.join( '' );
 
@@ -52,5 +52,7 @@ export default function createBlockSelectorEngine() {
 			const DOMSelector = assembleDOMSelector( selectorParams );
 			return Array.from( root.querySelectorAll( DOMSelector ) );
 		},
+		parsePlaywrightSelector,
+		assembleDOMSelector,
 	};
 }

--- a/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.ts
+++ b/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.ts
@@ -15,10 +15,12 @@ export default function createBlockSelectorEngine() {
 		}
 
 		const [ , name ] = selector.match( /^([a-z0-9\/\-]+)/ ) ?? [];
-		const [ , title ] = selector.match( /title="(.+?)"/ ) ?? [];
+
+		const [ , squareBracketParams ] = selector.match( /\[(.*)\]/ ) ?? [];
+		const [ , title ] = squareBracketParams?.match( /title="(.+?)"/ ) ?? [];
 		const [ , clientId ] =
-			selector.match( /clientId="([0-9a-f\-]+?)"/ ) ?? [];
-		const [ , tag ] = selector.match( /tag="(.+?)"/ ) ?? [];
+			squareBracketParams?.match( /clientId="([0-9a-f\-]+?)"/ ) ?? [];
+		const [ , tag ] = squareBracketParams?.match( /tag="(.+?)"/ ) ?? [];
 
 		return {
 			clientId,

--- a/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.ts
+++ b/packages/e2e-test-utils-playwright/src/selectors/block-selector-engine.ts
@@ -1,8 +1,15 @@
+type BlockSelectorParams = {
+	clientId?: string;
+	name?: string;
+	tag?: string;
+	title?: string;
+};
+
 export default function createBlockSelectorEngine() {
 	// Util functions need to be defined in the `createBlockSelectorEngine`
 	// body. Playwright converts this function to a string, and won't be able
 	// to reach functions that are defined outside the body.
-	function parsePlaywrightSelector( selector ) {
+	function parsePlaywrightSelector( selector: string ): BlockSelectorParams {
 		if ( ! selector ) {
 			return {};
 		}
@@ -14,14 +21,19 @@ export default function createBlockSelectorEngine() {
 		const [ , tag ] = selector.match( /tag="(.+?)"/ ) ?? [];
 
 		return {
-			name: name !== '*' ? name : undefined,
-			title,
 			clientId,
+			name: name !== '*' ? name : undefined,
 			tag,
+			title,
 		};
 	}
 
-	function assembleDOMSelector( { clientId, name, tag, title } ) {
+	function assembleDOMSelector( {
+		clientId,
+		name,
+		tag,
+		title,
+	}: BlockSelectorParams ) {
 		// Always include a `data-block` attribute selector even if there's no
 		// clientId to select. This ensures the selector only returns blocks.
 		const clientIdPart = clientId
@@ -40,14 +52,14 @@ export default function createBlockSelectorEngine() {
 
 	return {
 		// Returns the first element matching given selector in the root's subtree.
-		query( root, selector ) {
+		query( root: Element, selector: string ) {
 			const selectorParams = parsePlaywrightSelector( selector );
 			const DOMSelector = assembleDOMSelector( selectorParams );
 			return root.querySelector( DOMSelector );
 		},
 
 		// Returns all elements matching given selector in the root's subtree.
-		queryAll( root, selector ) {
+		queryAll( root: Element, selector: string ) {
 			const selectorParams = parsePlaywrightSelector( selector );
 			const DOMSelector = assembleDOMSelector( selectorParams );
 			return Array.from( root.querySelectorAll( DOMSelector ) );

--- a/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
@@ -1,0 +1,106 @@
+/**
+ * Internal dependencies
+ */
+import {
+	parsePlaywrightSelector,
+	assembleDOMSelector,
+} from '../block-selector-engine';
+
+describe.skip( 'parsePlaywrightSelector', () => {
+	it( 'parses various selectors, returning data in an object', () => {
+		expect( parsePlaywrightSelector( 'core/paragraph' ) ).toEqual(
+			expect.objectContaining( {
+				name: 'core/paragraph',
+			} )
+		);
+
+		expect(
+			parsePlaywrightSelector(
+				'core/quote[clientId="b4745090-1dd6-4178-9205-38baf7a10795"]'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				name: 'core/quote',
+				clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',
+			} )
+		);
+
+		expect(
+			parsePlaywrightSelector(
+				'*[clientId="b4745090-1dd6-4178-9205-38baf7a10795"]'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',
+			} )
+		);
+
+		expect(
+			parsePlaywrightSelector( 'core/template-part[tag="header"]' )
+		).toEqual(
+			expect.objectContaining( {
+				name: 'core/template-part',
+				tag: 'header',
+			} )
+		);
+
+		expect( parsePlaywrightSelector( '*[title="Spacer"]' ) ).toEqual(
+			expect.objectContaining( {
+				title: 'Spacer',
+			} )
+		);
+
+		expect(
+			parsePlaywrightSelector(
+				'core/template-part[title="Template Part"][clientId="b4745090-1dd6-4178-9205-38baf7a10795"][tag="header"]'
+			)
+		).toEqual( {
+			clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',
+			name: 'core/template-part',
+			tag: 'header',
+			title: 'Template Part',
+		} );
+	} );
+} );
+
+describe.skip( 'assembleDOMSelector', () => {
+	it( 'assembles various DOM selectors for blocks', () => {
+		// Return the first block.
+		expect( assembleDOMSelector( {} ) ).toBe( '*[data-block]' );
+
+		expect(
+			assembleDOMSelector( {
+				tag: 'header',
+			} )
+		).toBe( 'header[data-block]' );
+
+		expect(
+			assembleDOMSelector( {
+				clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',
+			} )
+		).toBe( '*[data-block="b4745090-1dd6-4178-9205-38baf7a10795"]' );
+
+		expect(
+			assembleDOMSelector( {
+				name: 'core/paragraph',
+			} )
+		).toBe( '*[data-type="core/paragraph"]' );
+
+		expect(
+			assembleDOMSelector( {
+				title: 'Spacer',
+			} )
+		).toBe( '*[data-title="Spacer"]' );
+
+		expect(
+			assembleDOMSelector( {
+				name: 'core/template-part',
+				clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',
+				tag: 'header',
+				title: 'Template Part',
+			} )
+		).toBe(
+			'header[data-type="core/template-part"][data-block="b4745090-1dd6-4178-9205-38baf7a10795"][data-title="Template Part"]'
+		);
+	} );
+} );

--- a/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
@@ -4,6 +4,22 @@
 import createBlockSelectorEngine from '../block-selector-engine';
 
 describe( 'parsePlaywrightSelector', () => {
+	it( 'requires title, clientId, and tag to be within square brackets', () => {
+		const { parsePlaywrightSelector } = createBlockSelectorEngine();
+
+		expect(
+			parsePlaywrightSelector(
+				'title="Template Part" clientId="b4745090-1dd6-4178-9205-38baf7a10795" tag="header"'
+			)
+		).toEqual(
+			expect.objectContaining( {
+				title: undefined,
+				clientId: undefined,
+				tag: undefined,
+			} )
+		);
+	} );
+
 	it( 'parses various selectors, returning data in an object', () => {
 		const { parsePlaywrightSelector } = createBlockSelectorEngine();
 
@@ -51,7 +67,7 @@ describe( 'parsePlaywrightSelector', () => {
 
 		expect(
 			parsePlaywrightSelector(
-				'core/template-part[title="Template Part"][clientId="b4745090-1dd6-4178-9205-38baf7a10795"][tag="header"]'
+				'core/template-part[title="Template Part",clientId="b4745090-1dd6-4178-9205-38baf7a10795",tag="header"]'
 			)
 		).toEqual( {
 			clientId: 'b4745090-1dd6-4178-9205-38baf7a10795',

--- a/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
+++ b/packages/e2e-test-utils-playwright/src/selectors/test/block-selector-engine.js
@@ -1,13 +1,12 @@
 /**
  * Internal dependencies
  */
-import {
-	parsePlaywrightSelector,
-	assembleDOMSelector,
-} from '../block-selector-engine';
+import createBlockSelectorEngine from '../block-selector-engine';
 
-describe.skip( 'parsePlaywrightSelector', () => {
+describe( 'parsePlaywrightSelector', () => {
 	it( 'parses various selectors, returning data in an object', () => {
+		const { parsePlaywrightSelector } = createBlockSelectorEngine();
+
 		expect( parsePlaywrightSelector( 'core/paragraph' ) ).toEqual(
 			expect.objectContaining( {
 				name: 'core/paragraph',
@@ -63,8 +62,10 @@ describe.skip( 'parsePlaywrightSelector', () => {
 	} );
 } );
 
-describe.skip( 'assembleDOMSelector', () => {
+describe( 'assembleDOMSelector', () => {
 	it( 'assembles various DOM selectors for blocks', () => {
+		const { assembleDOMSelector } = createBlockSelectorEngine();
+
 		// Return the first block.
 		expect( assembleDOMSelector( {} ) ).toBe( '*[data-block]' );
 
@@ -84,13 +85,13 @@ describe.skip( 'assembleDOMSelector', () => {
 			assembleDOMSelector( {
 				name: 'core/paragraph',
 			} )
-		).toBe( '*[data-type="core/paragraph"]' );
+		).toBe( '*[data-block][data-type="core/paragraph"]' );
 
 		expect(
 			assembleDOMSelector( {
 				title: 'Spacer',
 			} )
-		).toBe( '*[data-title="Spacer"]' );
+		).toBe( '*[data-block][data-title="Spacer"]' );
 
 		expect(
 			assembleDOMSelector( {
@@ -100,7 +101,7 @@ describe.skip( 'assembleDOMSelector', () => {
 				title: 'Template Part',
 			} )
 		).toBe(
-			'header[data-type="core/template-part"][data-block="b4745090-1dd6-4178-9205-38baf7a10795"][data-title="Template Part"]'
+			'header[data-block="b4745090-1dd6-4178-9205-38baf7a10795"][data-type="core/template-part"][data-title="Template Part"]'
 		);
 	} );
 } );

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import * as path from 'path';
-import { test as base, expect } from '@playwright/test';
+import { test as base, expect, selectors } from '@playwright/test';
 import type { ConsoleMessage } from '@playwright/test';
 
 /**
  * Internal dependencies
  */
 import { Admin, Editor, PageUtils, RequestUtils } from './index';
+import createBlockSelectorEngine from './selectors/block-selector-engine';
 
 const STORAGE_STATE_PATH =
 	process.env.STORAGE_STATE_PATH ||
@@ -105,6 +106,7 @@ const test = base.extend<
 	},
 	{
 		requestUtils: RequestUtils;
+		registerSelectors: void;
 	}
 >( {
 	admin: async ( { page, pageUtils }, use ) => {
@@ -145,6 +147,14 @@ const test = base.extend<
 			await use( requestUtils );
 		},
 		{ scope: 'worker' },
+	],
+	// See https://github.com/microsoft/playwright/issues/11058#issuecomment-999930304.
+	registerSelectors: [
+		async ( {}, use ) => {
+			await selectors.register( 'block', createBlockSelectorEngine );
+			await use();
+		},
+		{ scope: 'worker', auto: true },
 	],
 	// An automatic fixture to configure snapshot settings globally.
 	snapshotConfig: [

--- a/packages/e2e-test-utils-playwright/src/test.ts
+++ b/packages/e2e-test-utils-playwright/src/test.ts
@@ -2,14 +2,13 @@
  * External dependencies
  */
 import * as path from 'path';
-import { test as base, expect, selectors } from '@playwright/test';
+import { test as base, expect } from '@playwright/test';
 import type { ConsoleMessage } from '@playwright/test';
 
 /**
  * Internal dependencies
  */
 import { Admin, Editor, PageUtils, RequestUtils } from './index';
-import createBlockSelectorEngine from './selectors/block-selector-engine';
 
 const STORAGE_STATE_PATH =
 	process.env.STORAGE_STATE_PATH ||
@@ -147,14 +146,6 @@ const test = base.extend<
 			await use( requestUtils );
 		},
 		{ scope: 'worker' },
-	],
-	// See https://github.com/microsoft/playwright/issues/11058#issuecomment-999930304.
-	registerSelectors: [
-		async ( {}, use ) => {
-			await selectors.register( 'block', createBlockSelectorEngine );
-			await use();
-		},
-		{ scope: 'worker', auto: true },
 	],
 	// An automatic fixture to configure snapshot settings globally.
 	snapshotConfig: [

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -34,9 +34,7 @@ test.describe( 'Image', () => {
 	test( 'can be inserted', async ( { editor, page, imageBlockUtils } ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		await expect( imageBlock ).toBeVisible();
 
 		const filename = await imageBlockUtils.upload(
@@ -62,9 +60,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(
@@ -148,9 +144,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(
@@ -175,9 +169,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const fileName = await imageBlockUtils.upload(
@@ -204,9 +196,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const fileName = await imageBlockUtils.upload(
@@ -241,9 +231,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const tmpInput = await page.evaluateHandle( () => {
@@ -285,9 +273,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(
@@ -342,9 +328,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(
@@ -390,9 +374,7 @@ test.describe( 'Image', () => {
 		// Insert the block, upload a file and crop.
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(
@@ -430,9 +412,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		{
@@ -490,9 +470,7 @@ test.describe( 'Image', () => {
 	} ) => {
 		await editor.insertBlock( { name: 'core/image' } );
 
-		const imageBlock = page.locator(
-			'role=document[name="Block: Image"i]'
-		);
+		const imageBlock = page.locator( 'block=core/image' );
 		const image = imageBlock.locator( 'role=img' );
 
 		const filename = await imageBlockUtils.upload(

--- a/test/e2e/specs/editor/blocks/paragraph.spec.js
+++ b/test/e2e/specs/editor/blocks/paragraph.spec.js
@@ -17,10 +17,9 @@ test.describe( 'Paragraph', () => {
 		} );
 		await page.keyboard.type( '1' );
 
-		const firstBlockTagName = await page.evaluate( () => {
-			return document.querySelector(
-				'.block-editor-block-list__layout .wp-block'
-			).tagName;
+		const firstBlock = await page.locator( 'block=*' );
+		const firstBlockTagName = await firstBlock.evaluate( ( element ) => {
+			return element.tagName;
 		} );
 
 		// The outer element should be a paragraph. Blocks should never have any

--- a/test/e2e/specs/editor/plugins/block-api.spec.js
+++ b/test/e2e/specs/editor/plugins/block-api.spec.js
@@ -20,8 +20,7 @@ test.describe( 'Using Block API', () => {
 		await admin.createNewPost();
 
 		await editor.insertBlock( { name: 'e2e-tests/hello-world' } );
-
-		const block = page.locator( '[data-type="e2e-tests/hello-world"]' );
+		const block = page.locator( 'block=e2e-tests/hello-world' );
 		await expect( block ).toHaveText( 'Hello Editor!' );
 	} );
 } );


### PR DESCRIPTION
## What?
Playwright supports adding custom selector engines for end to end tests. I thought it'd be fun to hack together a block selector engine. The code here didn't take long to throw together and might be a bit rough in places, but I think it shows some promise.

In tests this allows you to select a block using the following example syntax:
- Select an image block - `await page.locator( 'block=core/image' );`
- Select a header template part - `await page.locator( 'block=core/template-part[tag="header"]' );`
- Select a block using a clientId - `await page.locator( 'block=*[clientId="a7cb0248-6ca5-468d-9b41-545d02cd8f37"]' );`
- Select a spacer block using its title - `await page.locator( 'block=*[title="Spacer"]' );`

Or a combination of the above.

## Why?
This does make some tasks easier in tests compared to the slightly more verbose options built-in options for selecting blocks.

On the other hand - it's good to select blocks or any elements by their accessible names, which this doesn't encourage. It could also be possible to add a label selector - `await page.locator( 'block=*[label="Block: Spacer"]' );`, but I haven't done that just yet because I ran out of time.

## How?
Adds a custom selector engine - these are pretty straightforward, it has to be a function that returns an object with `query` and `queryAll` methods. Those two methods receive a `root` DOM element and a `selector` string as params.

Registering the engine in Playwright is a little complicated, but I found a github issue that had an example.