### PR TITLE
Template editor: Show the inserter if the template part is empty

### DIFF
--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -112,6 +112,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	const isTemplatePart = templateType === 'wp_template_part';
+	const hasBlocks = blocks.length === 0;
 
 	const NavMenuSidebarToggle = () => (
 		<ToolbarGroup>
@@ -186,7 +187,9 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 					<BlockList
 						className="edit-site-block-editor__block-list wp-site-blocks"
 						__experimentalLayout={ LAYOUT }
-						renderAppender={ isTemplatePart ? false : undefined }
+						renderAppender={
+							isTemplatePart && hasBlocks ? false : undefined
+						}
 					/>
 				</ResizableEditor>
 				<__unstableBlockSettingsMenuFirstItem>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -21,6 +21,7 @@ import {
 	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
 	__unstableBlockNameContext,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
@@ -188,7 +189,9 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						className="edit-site-block-editor__block-list wp-site-blocks"
 						__experimentalLayout={ LAYOUT }
 						renderAppender={
-							isTemplatePart && hasBlocks ? false : undefined
+							isTemplatePart && hasBlocks
+								? false
+								: InnerBlocks.ButtonBlockAppender
 						}
 					/>
 				</ResizableEditor>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -21,7 +21,6 @@ import {
 	BlockEditorKeyboardShortcuts,
 	store as blockEditorStore,
 	__unstableBlockNameContext,
-	InnerBlocks,
 } from '@wordpress/block-editor';
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
 import { ReusableBlocksMenuItems } from '@wordpress/reusable-blocks';
@@ -189,9 +188,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 						className="edit-site-block-editor__block-list wp-site-blocks"
 						__experimentalLayout={ LAYOUT }
 						renderAppender={
-							isTemplatePart && hasBlocks
-								? false
-								: InnerBlocks.ButtonBlockAppender
+							isTemplatePart && hasBlocks ? false : undefined
 						}
 					/>
 				</ResizableEditor>

--- a/packages/edit-site/src/components/block-editor/index.js
+++ b/packages/edit-site/src/components/block-editor/index.js
@@ -112,7 +112,7 @@ export default function BlockEditor( { setIsInserterOpen } ) {
 	const { clearSelectedBlock } = useDispatch( blockEditorStore );
 
 	const isTemplatePart = templateType === 'wp_template_part';
-	const hasBlocks = blocks.length === 0;
+	const hasBlocks = blocks.length !== 0;
 
 	const NavMenuSidebarToggle = () => (
 		<ToolbarGroup>

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -30,8 +30,6 @@
 		.components-resizable-box__container {
 			overflow: visible;
 		}
-		// Remove the 100% height.
-		height: unset;
 	}
 
 	.components-resizable-box__container {

--- a/packages/edit-site/src/components/block-editor/style.scss
+++ b/packages/edit-site/src/components/block-editor/style.scss
@@ -30,6 +30,8 @@
 		.components-resizable-box__container {
 			overflow: visible;
 		}
+		// Remove the 100% height.
+		height: unset;
 	}
 
 	.components-resizable-box__container {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Displays the inserter in the template editor if you are editing an empty template part, like a newly created part.

Closes https://github.com/WordPress/gutenberg/issues/37524

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When you create a new template part using the Add New button in the Site Editor template part list, the editor is empty.
This PR can be a short term fix until contextual block patterns can be shown. See https://github.com/WordPress/gutenberg/issues/41008

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the existing condition for showing the inserter to include a check if the template is empty or not.

## Testing Instructions
1. Activate a full site editing theme
2. Go to the template part list in the site editor
3. Select the Add new button to create a new template part
4. See that the template editor is no longer empty but shows the inserter

It should show the same regardless of what area is select when creating the part.

## Screenshots or screencast <!-- if applicable -->
![Template editor (template part in isolation) with inserter showing](https://user-images.githubusercontent.com/7422055/168078039-fa7f98e4-bf0f-45af-96e4-d24ecff69368.png)
