### PR TITLE
Style Engine: add condition to check for semicolons before adding them to CSS rules

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -242,7 +242,8 @@ class WP_Style_Engine {
 			foreach ( $css_rules as $rule => $value ) {
 				$filtered_css = esc_html( safecss_filter_attr( "{$rule}: {$value}" ) );
 				if ( ! empty( $filtered_css ) ) {
-					$css_output .= $filtered_css . '; ';
+					$css_output_suffix = str_ends_with( $filtered_css, ';' ) ? ' ' : '; ';
+					$css_output .= $filtered_css . $css_output_suffix;
 				}
 			}
 		}


### PR DESCRIPTION
related to: https://github.com/WordPress/gutenberg/pull/40332/

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Confirm that a CSS rule does not already end in a semicolon before adding one in the style engine

## Why?
Depending on the what CSS parsers are in use on a site, it's possible semicolons will already be present on inline CSS styles, which can result in double semicolons (`attribute1: value1;; attribute2: value2;;`) rendering when the page loads.

## How?
After confirming that styles are present, the rule suffix is conditionally set:
- if the rule already ends in a semicolon, append a space character only
- if the rule does not yet end in a semicolon, append a semicolon followed by a space character
Note: this does not account for parsers that might also add a space character of their own. It may be worth extending the logic for that possibility as well, but I'll wait on feedback there first.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
