### PR TITLE
[RNMobile] Improve text read by screen readers for BottomSheetSelectControl 

### DIFF
--- a/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet-select-control/index.native.js
@@ -57,11 +57,16 @@ const BottomSheetSelectControl = ( {
 					value={ selectedOption.label }
 					onPress={ openSubSheet }
 					accessibilityRole={ 'button' }
-					accessibilityLabel={ selectedOption.label }
+					accessibilityLabel={ sprintf(
+						// translators:  %1$s: Select control button label e.g. "Button width". %2$s: Select control option value e.g: "Auto, 25%".
+						__( '%1$s. Currently selected: %2$s' ),
+						label,
+						selectedOption.label
+					) }
 					accessibilityHint={ sprintf(
 						// translators: %s: Select control button label e.g. "Button width"
 						__( 'Navigates to select %s' ),
-						selectedOption.label
+						label
 					) }
 				>
 					<Icon icon={ chevronRight }></Icon>

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,7 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
--   [*] [a11y] Ensure text read by screenreaders clearly describes BottomSheet text controls [#41036]
+-   [*] [a11y] Improve text read by screen readers for BottomSheetSelectControl [#41036]
 
 ## 1.76.0
 

--- a/packages/react-native-editor/CHANGELOG.md
+++ b/packages/react-native-editor/CHANGELOG.md
@@ -11,6 +11,7 @@ For each user feature we should also add a importance categorization label  to i
 
 ## Unreleased
 
+-   [*] [a11y] Ensure text read by screenreaders clearly describes BottomSheet text controls [#41036]
 
 ## 1.76.0
 


### PR DESCRIPTION
## Related PRs and Installable Builds

* `gutenberg-mobile:` https://github.com/wordpress-mobile/gutenberg-mobile/pull/4854
* `iOS:` https://github.com/wordpress-mobile/WordPress-iOS/pull/18596
* `Android:` https://github.com/wordpress-mobile/WordPress-Android/pull/16535

## What?

This PR improves the text that's read by screen readers by [the `BottomSheetSelectControl` component](https://github.com/WordPress/gutenberg/blob/7a347c0d807037f6ec20b80f77061e571d408a41/packages/components/src/mobile/bottom-sheet-select-control/README.md), adding extra context and making its purpose clearer.

## Why?

At the moment, screen readers read the currently selected value from the `BottomSheetSelectControl` component. So, for example, in the following screenshot, screen readers would read `Large. Navigates to select large.`: 

<img width="295" alt="Screenshot 2022-05-12 at 20 40 02" src="https://user-images.githubusercontent.com/2998162/168155343-f352d0bb-208a-4385-8569-8a17e7b36020.png">

This is confusing wording that doesn't read the component's main label (`Size` in this case) for context. 

## How?

### Accessibility Label

The component's [`accessibilityLabel` text has been updated](https://github.com/WordPress/gutenberg/blob/4f9fd30a8ff57c7224c4d168ef42eda8a5972ff8/packages/components/src/mobile/bottom-sheet-select-control/index.native.js#L60-L65) to read the label, rather than only reading the currently selected value, which adds necessary context. The following before/after shows an example of the difference in text read by screen readers for the image block's size control:

| Before  | After |
| ------------- | ------------- |
| `Large.` | `Size. Currently selected: Large.` |

### Accessibility Hint

The component's [`accessibilityHint` text has been updated](https://github.com/WordPress/gutenberg/blob/4f9fd30a8ff57c7224c4d168ef42eda8a5972ff8/packages/components/src/mobile/bottom-sheet-select-control/index.native.js#L66-L70) to read the label, rather than the currently selected value. This makes the overall hint make more sense, as shown in the following example:

| Before  | After |
| ------------- | ------------- |
| `Navigates to select large.` | `Navigates to select size.` |

## Testing Instructions

The `BottomSheetSelectControl` component is currently accessible via the following four places:

1. Button block → Settings → Button width
2. Image block → Settings → Size
3. Latest Posts block → Settings → Display featured image → Align
4. Layout Grid block → Select a layout → Select an individual column → Settings → Padding

To test the changes in this PR, navigate to any of the above settings within the iOS or Android app. From there, [activate VoiceOver for iOS](https://support.apple.com/en-gb/guide/iphone/iph3e2e415f/ios) or [TalkBack for Android](https://support.google.com/accessibility/android/answer/6007100?hl=en-GB). Verify that the updated `accessibilityLabel` and `accessibilityHint` text is read aloud by the chosen screen reader.