### PR TITLE
Try/global style root css vars

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -70,7 +70,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 			if ( is_array( $gap_value ) ) {
 				$gap_value = isset( $gap_value['top'] ) ? $gap_value['top'] : null;
 			}
-			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap )';
+			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap, var( --wp--style--root--block-gap ) )';
 			$style    .= "$selector > * { margin-block-start: 0; margin-block-end: 0; }";
 			$style    .= "$selector > * + * { margin-block-start: $gap_style; margin-block-end: 0; }";
 		}
@@ -106,7 +106,7 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
-			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
+			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap, var( --wp--style--root--block-gap, 0.5em ) )';
 			$style    .= "gap: $gap_style;";
 		} else {
 			$style .= 'gap: 0.5em;';

--- a/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
+++ b/lib/compat/wordpress-5.9/class-wp-theme-json-5-9.php
@@ -850,7 +850,7 @@ class WP_Theme_JSON_5_9 {
 				continue;
 			}
 
-			$selector = $metadata['selector'];
+			$selector = ':root';
 
 			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
 			$declarations = array_merge( static::compute_preset_vars( $node, $origins ), static::compute_theme_vars( $node ) );
@@ -891,6 +891,9 @@ class WP_Theme_JSON_5_9 {
 			$declaration_block = array_reduce(
 				$declarations,
 				function ( $carry, $element ) {
+					if ( array_key_exists( $element['name'], static::ROOT_STYLE_CSS_VARIABLES ) ) {
+
+					}
 					return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
 				''
 			);

--- a/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
+++ b/lib/compat/wordpress-6.0/class-wp-theme-json-6-0.php
@@ -16,58 +16,6 @@
  */
 class WP_Theme_JSON_6_0 extends WP_Theme_JSON_5_9 {
 	/**
-	 * Metadata for style properties.
-	 *
-	 * Each element is a direct mapping from the CSS property name to the
-	 * path to the value in theme.json & block attributes.
-	 */
-	const PROPERTIES_METADATA = array(
-		'background'                 => array( 'color', 'gradient' ),
-		'background-color'           => array( 'color', 'background' ),
-		'border-radius'              => array( 'border', 'radius' ),
-		'border-top-left-radius'     => array( 'border', 'radius', 'topLeft' ),
-		'border-top-right-radius'    => array( 'border', 'radius', 'topRight' ),
-		'border-bottom-left-radius'  => array( 'border', 'radius', 'bottomLeft' ),
-		'border-bottom-right-radius' => array( 'border', 'radius', 'bottomRight' ),
-		'border-color'               => array( 'border', 'color' ),
-		'border-width'               => array( 'border', 'width' ),
-		'border-style'               => array( 'border', 'style' ),
-		'border-top-color'           => array( 'border', 'top', 'color' ),
-		'border-top-width'           => array( 'border', 'top', 'width' ),
-		'border-top-style'           => array( 'border', 'top', 'style' ),
-		'border-right-color'         => array( 'border', 'right', 'color' ),
-		'border-right-width'         => array( 'border', 'right', 'width' ),
-		'border-right-style'         => array( 'border', 'right', 'style' ),
-		'border-bottom-color'        => array( 'border', 'bottom', 'color' ),
-		'border-bottom-width'        => array( 'border', 'bottom', 'width' ),
-		'border-bottom-style'        => array( 'border', 'bottom', 'style' ),
-		'border-left-color'          => array( 'border', 'left', 'color' ),
-		'border-left-width'          => array( 'border', 'left', 'width' ),
-		'border-left-style'          => array( 'border', 'left', 'style' ),
-		'color'                      => array( 'color', 'text' ),
-		'font-family'                => array( 'typography', 'fontFamily' ),
-		'font-size'                  => array( 'typography', 'fontSize' ),
-		'font-style'                 => array( 'typography', 'fontStyle' ),
-		'font-weight'                => array( 'typography', 'fontWeight' ),
-		'letter-spacing'             => array( 'typography', 'letterSpacing' ),
-		'line-height'                => array( 'typography', 'lineHeight' ),
-		'margin'                     => array( 'spacing', 'margin' ),
-		'margin-top'                 => array( 'spacing', 'margin', 'top' ),
-		'margin-right'               => array( 'spacing', 'margin', 'right' ),
-		'margin-bottom'              => array( 'spacing', 'margin', 'bottom' ),
-		'margin-left'                => array( 'spacing', 'margin', 'left' ),
-		'padding'                    => array( 'spacing', 'padding' ),
-		'padding-top'                => array( 'spacing', 'padding', 'top' ),
-		'padding-right'              => array( 'spacing', 'padding', 'right' ),
-		'padding-bottom'             => array( 'spacing', 'padding', 'bottom' ),
-		'padding-left'               => array( 'spacing', 'padding', 'left' ),
-		'--wp--style--block-gap'     => array( 'spacing', 'blockGap' ),
-		'text-decoration'            => array( 'typography', 'textDecoration' ),
-		'text-transform'             => array( 'typography', 'textTransform' ),
-		'filter'                     => array( 'filter', 'duotone' ),
-	);
-
-	/**
 	 * Presets are a set of values that serve
 	 * to bootstrap some styles: colors, font sizes, etc.
 	 *

--- a/lib/compat/wordpress-6.0/theme.json
+++ b/lib/compat/wordpress-6.0/theme.json
@@ -240,6 +240,5 @@
 		}
 	},
 	"styles": {
-		"spacing": { "blockGap": "24px" }
 	}
 }

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -22,13 +22,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	 * path to the value in theme.json & block attributes.
 	 */
 	const PROPERTIES_METADATA = array(
-		'--wp--style--root--padding'        => array( 'spacing', 'padding' ),
-		'--wp--style--root--padding-top'    => array( 'spacing', 'padding', 'top' ),
-		'--wp--style--root--padding-right'  => array( 'spacing', 'padding', 'right' ),
-		'--wp--style--root--padding-bottom' => array( 'spacing', 'padding', 'bottom' ),
-		'--wp--style--root--padding-left'   => array( 'spacing', 'padding', 'left' ),
-		'--wp--style--root--block-gap'      => array( 'spacing', 'blockGap' ),
-		'--wp--style--block-gap'            => array( 'spacing', 'blockGap' ),
 		'background'                        => array( 'color', 'gradient' ),
 		'background-color'                  => array( 'color', 'background' ),
 		'border-radius'                     => array( 'border', 'radius' ),
@@ -71,16 +64,8 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 		'text-decoration'                   => array( 'typography', 'textDecoration' ),
 		'text-transform'                    => array( 'typography', 'textTransform' ),
 		'filter'                            => array( 'filter', 'duotone' ),
-	);
-
-	const ROOT_STYLE_CSS_VARIABLES = array(
-		'padding'                => '--wp--style--root--padding',
-		'padding-top'            => '--wp--style--root--padding-top',
-		'padding-right'          => '--wp--style--root--padding-right',
-		'padding-bottom'         => '--wp--style--root--padding-bottom',
-		'padding-left'           => '--wp--style--root--padding-left',
-		// This should be 'gap'.
-		'--wp--style--block-gap' => '--wp--style--root--block-gap',
+		'--wp--style--block-gap'            => array( 'spacing', 'blockGap' ),
+		'--wp--style--root--block-gap'            => array( 'spacing', 'blockGap' ),
 	);
 
 	/**
@@ -147,15 +132,19 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$declaration_block = array_reduce(
 				$declarations,
 				function ( $carry, $element ) use ( $selector ) {
+					// @TODO fix all these via a dictionay lookup or some other clever mechansim.
+					// Nothing to see here!
 					if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
-						if ( array_key_exists( $element['name'], static::ROOT_STYLE_CSS_VARIABLES ) ) {
-							return $carry .= "\t" . $element['name'] . ': var(' . static::ROOT_STYLE_CSS_VARIABLES[ $element['name'] ] . ");\n";
+						// Block gap var for general usage doesn't belong in the root selector.
+						if ( str_starts_with( $element['name'], '--wp--style--block-gap' ) ) {
+							return $carry;
 						}
+					// Root vars don't belong anywhere else but the root selector
 					} elseif ( str_starts_with( $element['name'], '--wp--style--root--' ) ) {
 						return $carry;
 					}
 					return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n";
-					},
+				},
 				''
 			);
 			$ruleset          .= $selector . " {\n" . $declaration_block . "}\n";
@@ -163,14 +152,6 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$declaration_block = array_reduce(
 				$declarations,
 				function ( $carry, $element ) use ( $selector ) {
-					if (
-						array_key_exists( $element['name'], static::ROOT_STYLE_CSS_VARIABLES )
-					) {
-						if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
-							return $carry .= $element['name'] . ': var(' . static::ROOT_STYLE_CSS_VARIABLES[ $element['name'] ] . ');';
-						}
-						return $carry;
-					}
 					return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
 				''
 			);

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -16,6 +16,249 @@
  */
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	/**
+	 * Metadata for style properties.
+	 *
+	 * Each element is a direct mapping from the CSS property name to the
+	 * path to the value in theme.json & block attributes.
+	 */
+	const PROPERTIES_METADATA = array(
+		'--wp--style--root--padding'        => array( 'spacing', 'padding' ),
+		'--wp--style--root--padding-top'    => array( 'spacing', 'padding', 'top' ),
+		'--wp--style--root--padding-right'  => array( 'spacing', 'padding', 'right' ),
+		'--wp--style--root--padding-bottom' => array( 'spacing', 'padding', 'bottom' ),
+		'--wp--style--root--padding-left'   => array( 'spacing', 'padding', 'left' ),
+		'--wp--style--root--block-gap'      => array( 'spacing', 'blockGap' ),
+		'--wp--style--block-gap'            => array( 'spacing', 'blockGap' ),
+		'background'                        => array( 'color', 'gradient' ),
+		'background-color'                  => array( 'color', 'background' ),
+		'border-radius'                     => array( 'border', 'radius' ),
+		'border-top-left-radius'            => array( 'border', 'radius', 'topLeft' ),
+		'border-top-right-radius'           => array( 'border', 'radius', 'topRight' ),
+		'border-bottom-left-radius'         => array( 'border', 'radius', 'bottomLeft' ),
+		'border-bottom-right-radius'        => array( 'border', 'radius', 'bottomRight' ),
+		'border-color'                      => array( 'border', 'color' ),
+		'border-width'                      => array( 'border', 'width' ),
+		'border-style'                      => array( 'border', 'style' ),
+		'border-top-color'                  => array( 'border', 'top', 'color' ),
+		'border-top-width'                  => array( 'border', 'top', 'width' ),
+		'border-top-style'                  => array( 'border', 'top', 'style' ),
+		'border-right-color'                => array( 'border', 'right', 'color' ),
+		'border-right-width'                => array( 'border', 'right', 'width' ),
+		'border-right-style'                => array( 'border', 'right', 'style' ),
+		'border-bottom-color'               => array( 'border', 'bottom', 'color' ),
+		'border-bottom-width'               => array( 'border', 'bottom', 'width' ),
+		'border-bottom-style'               => array( 'border', 'bottom', 'style' ),
+		'border-left-color'                 => array( 'border', 'left', 'color' ),
+		'border-left-width'                 => array( 'border', 'left', 'width' ),
+		'border-left-style'                 => array( 'border', 'left', 'style' ),
+		'color'                             => array( 'color', 'text' ),
+		'font-family'                       => array( 'typography', 'fontFamily' ),
+		'font-size'                         => array( 'typography', 'fontSize' ),
+		'font-style'                        => array( 'typography', 'fontStyle' ),
+		'font-weight'                       => array( 'typography', 'fontWeight' ),
+		'letter-spacing'                    => array( 'typography', 'letterSpacing' ),
+		'line-height'                       => array( 'typography', 'lineHeight' ),
+		'margin'                            => array( 'spacing', 'margin' ),
+		'margin-top'                        => array( 'spacing', 'margin', 'top' ),
+		'margin-right'                      => array( 'spacing', 'margin', 'right' ),
+		'margin-bottom'                     => array( 'spacing', 'margin', 'bottom' ),
+		'margin-left'                       => array( 'spacing', 'margin', 'left' ),
+		'padding'                           => array( 'spacing', 'padding' ),
+		'padding-top'                       => array( 'spacing', 'padding', 'top' ),
+		'padding-right'                     => array( 'spacing', 'padding', 'right' ),
+		'padding-bottom'                    => array( 'spacing', 'padding', 'bottom' ),
+		'padding-left'                      => array( 'spacing', 'padding', 'left' ),
+		'text-decoration'                   => array( 'typography', 'textDecoration' ),
+		'text-transform'                    => array( 'typography', 'textTransform' ),
+		'filter'                            => array( 'filter', 'duotone' ),
+	);
+
+	const ROOT_STYLE_CSS_VARIABLES = array(
+		'padding'                => '--wp--style--root--padding',
+		'padding-top'            => '--wp--style--root--padding-top',
+		'padding-right'          => '--wp--style--root--padding-right',
+		'padding-bottom'         => '--wp--style--root--padding-bottom',
+		'padding-left'           => '--wp--style--root--padding-left',
+		// This should be 'gap'.
+		'--wp--style--block-gap' => '--wp--style--root--block-gap',
+	);
+
+	/**
+	 * The valid properties under the styles key.
+	 *
+	 * @var array
+	 */
+	const VALID_STYLES = array(
+		'border'     => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+			'top'    => null,
+			'right'  => null,
+			'bottom' => null,
+			'left'   => null,
+		),
+		'color'      => array(
+			'background' => null,
+			'gradient'   => null,
+			'text'       => null,
+		),
+		'filter'     => array(
+			'duotone' => null,
+		),
+		'spacing'    => array(
+			'margin'   => null,
+			'padding'  => null,
+			'blockGap' => null,
+		),
+		'typography' => array(
+			'fontFamily'     => null,
+			'fontSize'       => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
+
+	/**
+	 * Given a selector and a declaration list,
+	 * creates the corresponding ruleset.
+	 *
+	 * To help debugging, will add some space
+	 * if SCRIPT_DEBUG is defined and true.
+	 *
+	 * @param string $selector CSS selector.
+	 * @param array  $declarations List of declarations.
+	 *
+	 * @return string CSS ruleset.
+	 */
+	protected static function to_ruleset( $selector, $declarations ) {
+		if ( empty( $declarations ) ) {
+			return '';
+		}
+
+		$ruleset = '';
+
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) use ( $selector ) {
+					if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
+						if ( array_key_exists( $element['name'], static::ROOT_STYLE_CSS_VARIABLES ) ) {
+							return $carry .= "\t" . $element['name'] . ': var(' . static::ROOT_STYLE_CSS_VARIABLES[ $element['name'] ] . ");\n";
+						}
+					} elseif ( str_starts_with( $element['name'], '--wp--style--root--' ) ) {
+						return $carry;
+					}
+					return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n";
+					},
+				''
+			);
+			$ruleset          .= $selector . " {\n" . $declaration_block . "}\n";
+		} else {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) use ( $selector ) {
+					if (
+						array_key_exists( $element['name'], static::ROOT_STYLE_CSS_VARIABLES )
+					) {
+						if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
+							return $carry .= $element['name'] . ': var(' . static::ROOT_STYLE_CSS_VARIABLES[ $element['name'] ] . ');';
+						}
+						return $carry;
+					}
+					return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
+				''
+			);
+			$ruleset          .= $selector . '{' . $declaration_block . '}';
+		}
+
+		return $ruleset;
+	}
+
+	/**
+	 * Converts each style section into a list of rulesets
+	 * containing the block styles to be appended to the stylesheet.
+	 *
+	 * See glossary at https://developer.mozilla.org/en-US/docs/Web/CSS/Syntax
+	 *
+	 * For each section this creates a new ruleset such as:
+	 *
+	 *   block-selector {
+	 *     style-property-one: value;
+	 *   }
+	 *
+	 * @param array $style_nodes Nodes with styles.
+	 * @return string The new stylesheet.
+	 */
+	protected function get_block_classes( $style_nodes ) {
+		$block_rules = '';
+
+		foreach ( $style_nodes as $metadata ) {
+			if ( null === $metadata['selector'] ) {
+				continue;
+			}
+
+			$node         = _wp_array_get( $this->theme_json, $metadata['path'], array() );
+			$selector     = $metadata['selector'];
+			$settings     = _wp_array_get( $this->theme_json, array( 'settings' ) );
+			$declarations = static::compute_style_properties( $node, $settings );
+
+			// 1. Separate the ones who use the general selector
+			// and the ones who use the duotone selector.
+			$declarations_duotone = array();
+			foreach ( $declarations as $index => $declaration ) {
+				if ( 'filter' === $declaration['name'] ) {
+					unset( $declarations[ $index ] );
+					$declarations_duotone[] = $declaration;
+				}
+			}
+
+			/*
+			 * Reset default browser margin on the root body element.
+			 * This is set on the root selector **before** generating the ruleset
+			 * from the `theme.json`. This is to ensure that if the `theme.json` declares
+			 * `margin` in its `spacing` declaration for the `body` element then these
+			 * user-generated values take precedence in the CSS cascade.
+			 * @link https://github.com/WordPress/gutenberg/issues/36147.
+			 */
+			if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
+				$declarations[] = array(
+					'name'  => 'margin',
+					'value' => '0',
+				);
+			}
+
+			// 2. Generate the rules that use the general selector.
+			$block_rules .= static::to_ruleset( $selector, $declarations );
+
+			// 3. Generate the rules that use the duotone selector.
+			if ( isset( $metadata['duotone'] ) && ! empty( $declarations_duotone ) ) {
+				$selector_duotone = static::scope_selector( $metadata['selector'], $metadata['duotone'] );
+				$block_rules     .= static::to_ruleset( $selector_duotone, $declarations_duotone );
+			}
+
+			if ( static::ROOT_BLOCK_SELECTOR === $selector ) {
+				$block_rules .= '.wp-site-blocks > .alignleft { float: left; margin-right: 2em; }';
+				$block_rules .= '.wp-site-blocks > .alignright { float: right; margin-left: 2em; }';
+				$block_rules .= '.wp-site-blocks > .aligncenter { justify-content: center; margin-left: auto; margin-right: auto; }';
+
+				$has_block_gap_support = _wp_array_get( $this->theme_json, array( 'settings', 'spacing', 'blockGap' ) ) !== null;
+				if ( $has_block_gap_support ) {
+					$block_rules .= '.wp-site-blocks > * { margin-block-start: 0; margin-block-end: 0; }';
+					$block_rules .= '.wp-site-blocks > * + * { margin-block-start: var( --wp--style--block-gap ); }';
+				}
+			}
+		}
+
+		return $block_rules;
+	}
+
+	/**
 	 * Returns the metadata for each block.
 	 *
 	 * Example:

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -116,7 +116,7 @@ export default {
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
 				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
-				: 'var( --wp--style--block-gap, 0.5em )';
+				: 'var( --wp--style--block-gap, , var( --wp--style--root--block-gap, 0.5em ) )';
 		const justifyContent =
 			justifyContentMap[ layout.justifyContent ] ||
 			justifyContentMap.left;

--- a/packages/block-editor/src/layouts/flow.js
+++ b/packages/block-editor/src/layouts/flow.js
@@ -125,7 +125,7 @@ export default {
 			blockGapStyleValue?.top &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
 				? blockGapStyleValue?.top
-				: 'var( --wp--style--block-gap )';
+				: 'var( --wp--style--block-gap, var( --wp--style--root--block-gap ) )';
 
 		let output =
 			!! contentSize || !! wideSize

--- a/packages/block-library/src/columns/style.scss
+++ b/packages/block-library/src/columns/style.scss
@@ -30,10 +30,23 @@
 	}
 
 	&:not(.is-not-stacked-on-mobile) > .wp-block-column {
-		@media (max-width: #{ ($break-medium - 1) }) {
+		@media (max-width: #{ ($break-small - 1) }) {
 			// Responsiveness: Show at most one columns on mobile. This must be
 			// important since the Column assigns its own width as an inline style.
 			flex-basis: 100% !important;
+		}
+
+		// Between mobile and large viewports (tablet), allow 2 columns.
+		@media (min-width: #{ ($break-small) }) and (max-width: #{ ($break-medium - 1) }) {
+			// Only add two column styling if there are two or more columns
+			&:not(:only-child) {
+				// As with mobile styles, this must be important since the Column
+				// assigns its own width as an inline style, which should take effect
+				// starting at `break-medium`.
+				// Note: if the columns block has a style.spacing.blockGap value of > var(--wp--style--block-gap, 2em) this effect will not show.
+				// What would make this particular definition more robust is if we could do the following dynamically: ( var(--wp--style--block-gap, 2em) + style.spacing.blockGap )
+				flex-basis: calc(50% - calc(var(--wp--style--block-gap, 2em) + var(--wp--style--root--block--gap, 0) / 2)) !important;
+			}
 		}
 
 		// At large viewports, show all columns horizontally.

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -7,14 +7,19 @@
 			"wideSize": "1100px"
 		}
 	},
-	"styles" : {
+	"styles": {
 		"spacing": {
 			"blockGap": "44px"
 		},
 		"blocks": {
 			"core/group": {
 				"spacing": {
-				"blockGap": "133px"
+					"blockGap": "133px"
+				}
+			},
+			"core/columns": {
+				"spacing": {
+					"blockGap": "2em"
 				}
 			}
 		}

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -8,11 +8,13 @@
 		}
 	},
 	"styles" : {
-		"spacing": { "padding": "50px" },
+		"spacing": { "padding": "50px",
+"blockGap": "44px"
+		},
 		"blocks": {
 			"core/group": {
 				"spacing": {
-					"blockGap": "100px"
+				"blockGap": "133px"
 				}
 			}
 		}

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -8,8 +8,8 @@
 		}
 	},
 	"styles" : {
-		"spacing": { "padding": "50px",
-"blockGap": "44px"
+		"spacing": {
+			"blockGap": "44px"
 		},
 		"blocks": {
 			"core/group": {

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -7,5 +7,15 @@
 			"wideSize": "1100px"
 		}
 	},
+	"styles" : {
+		"spacing": { "padding": "50px" },
+		"blocks": {
+			"core/group": {
+				"spacing": {
+					"blockGap": "100px"
+				}
+			}
+		}
+	},
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]
 }


### PR DESCRIPTION
## What?

Related to https://github.com/WordPress/gutenberg/issues/39789

🚧 This PR is for illustrative purposes only. Please do not install at home, kids.

The premise behind this PR is to set a "global" fallback block gap CSS var `--wp--style--root--block--gap` that houses the "root" global styles value, and that can act as a fallback for `--wp--style--block-gap`, which is set at the block level and "preferred" by the layout implementation.

Maybe `--wp--style--block-gap` should be renamed to `--wp--style--layout--block-gap` 😕 

The intention is to prevent conflicts by having a global fallback block gap value for universal usage, while allowing individual blocks to overwrite it via the layout implementation.

**Note**: This PR is only experimenting with layout. Existing usages of `--wp--style--block-gap`, such as in the Button block would have to be updated

```json
	"styles" : {
		"spacing": {
			"blockGap": "44px" // Sets `--wp--style--root--block--gap` in the body tag only
		},
		"blocks": {
			"core/group": {
				"spacing": {
				"blockGap": "133px" // Sets `--wp--style--block-gap` in .wp-block-group only
				}
			}
		}
	},
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
