### PR TITLE
Layout: use root padding for full-width margin offset

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -174,7 +174,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		}
 		$used_layout = $default_layout;
 	}
-	$used_layout['fullWidthShouldStretch'] = isset( $default_layout['fullWidthShouldStretch'] ) && true === $default_layout['fullWidthShouldStretch'] && isset( $block['attrs']['align'] ) && $block['attrs']['align'] === 'full';
+	$used_layout['fullWidthShouldStretch'] = isset( $default_layout['fullWidthShouldStretch'] ) && true === $default_layout['fullWidthShouldStretch'] && isset( $block['attrs']['align'] ) && 'full' === $block['attrs']['align'];
 
 	$class_name = wp_unique_id( 'wp-container-' );
 

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -16,6 +16,171 @@
  */
 class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 	/**
+	 * Metadata for style properties.
+	 *
+	 * Each element is a direct mapping from the CSS property name to the
+	 * path to the value in theme.json & block attributes.
+	 */
+	const PROPERTIES_METADATA = array(
+		'--wp--style--block-gap'     => array( 'spacing', 'blockGap' ),
+		'background'                 => array( 'color', 'gradient' ),
+		'background-color'           => array( 'color', 'background' ),
+		'border-radius'              => array( 'border', 'radius' ),
+		'border-top-left-radius'     => array( 'border', 'radius', 'topLeft' ),
+		'border-top-right-radius'    => array( 'border', 'radius', 'topRight' ),
+		'border-bottom-left-radius'  => array( 'border', 'radius', 'bottomLeft' ),
+		'border-bottom-right-radius' => array( 'border', 'radius', 'bottomRight' ),
+		'border-color'               => array( 'border', 'color' ),
+		'border-width'               => array( 'border', 'width' ),
+		'border-style'               => array( 'border', 'style' ),
+		'border-top-color'           => array( 'border', 'top', 'color' ),
+		'border-top-width'           => array( 'border', 'top', 'width' ),
+		'border-top-style'           => array( 'border', 'top', 'style' ),
+		'border-right-color'         => array( 'border', 'right', 'color' ),
+		'border-right-width'         => array( 'border', 'right', 'width' ),
+		'border-right-style'         => array( 'border', 'right', 'style' ),
+		'border-bottom-color'        => array( 'border', 'bottom', 'color' ),
+		'border-bottom-width'        => array( 'border', 'bottom', 'width' ),
+		'border-bottom-style'        => array( 'border', 'bottom', 'style' ),
+		'border-left-color'          => array( 'border', 'left', 'color' ),
+		'border-left-width'          => array( 'border', 'left', 'width' ),
+		'border-left-style'          => array( 'border', 'left', 'style' ),
+		'color'                      => array( 'color', 'text' ),
+		'font-family'                => array( 'typography', 'fontFamily' ),
+		'font-size'                  => array( 'typography', 'fontSize' ),
+		'font-style'                 => array( 'typography', 'fontStyle' ),
+		'font-weight'                => array( 'typography', 'fontWeight' ),
+		'letter-spacing'             => array( 'typography', 'letterSpacing' ),
+		'line-height'                => array( 'typography', 'lineHeight' ),
+		'margin'                     => array( 'spacing', 'margin' ),
+		'margin-top'                 => array( 'spacing', 'margin', 'top' ),
+		'margin-right'               => array( 'spacing', 'margin', 'right' ),
+		'margin-bottom'              => array( 'spacing', 'margin', 'bottom' ),
+		'margin-left'                => array( 'spacing', 'margin', 'left' ),
+		'padding'                    => array( 'spacing', 'padding' ),
+		'padding-top'                => array( 'spacing', 'padding', 'top' ),
+		'padding-right'              => array( 'spacing', 'padding', 'right' ),
+		'padding-bottom'             => array( 'spacing', 'padding', 'bottom' ),
+		'padding-left'               => array( 'spacing', 'padding', 'left' ),
+		'text-decoration'            => array( 'typography', 'textDecoration' ),
+		'text-transform'             => array( 'typography', 'textTransform' ),
+		'filter'                     => array( 'filter', 'duotone' ),
+	);
+
+	/**
+	 * Metadata for style properties that should only be printed to the roo selector.
+	 *
+	 * Each element is a direct mapping from the CSS property name to the corresponding root CSS var.
+	 */
+	const ROOT_PROPERTIES_METADATA = array(
+		'padding'        => '--wp--style--root--padding',
+		'padding-top'    => '--wp--style--root--padding-top',
+		'padding-right'  => '--wp--style--root--padding-right',
+		'padding-bottom' => '--wp--style--root--padding-bottom',
+		'padding-left'   => '--wp--style--root--padding-left',
+	);
+
+	/**
+	 * The valid properties under the settings key.
+	 *
+	 * @var array
+	 */
+	const VALID_SETTINGS = array(
+		'appearanceTools' => null,
+		'border'          => array(
+			'color'  => null,
+			'radius' => null,
+			'style'  => null,
+			'width'  => null,
+		),
+		'color'           => array(
+			'background'       => null,
+			'custom'           => null,
+			'customDuotone'    => null,
+			'customGradient'   => null,
+			'defaultDuotone'   => null,
+			'defaultGradients' => null,
+			'defaultPalette'   => null,
+			'duotone'          => null,
+			'gradients'        => null,
+			'link'             => null,
+			'palette'          => null,
+			'text'             => null,
+		),
+		'custom'          => null,
+		'layout'          => array(
+			'contentSize'            => null,
+			'wideSize'               => null,
+			'fullWidthShouldStretch' => null,
+		),
+		'spacing'         => array(
+			'blockGap' => null,
+			'margin'   => null,
+			'padding'  => null,
+			'units'    => null,
+		),
+		'typography'      => array(
+			'customFontSize' => null,
+			'dropCap'        => null,
+			'fontFamilies'   => null,
+			'fontSizes'      => null,
+			'fontStyle'      => null,
+			'fontWeight'     => null,
+			'letterSpacing'  => null,
+			'lineHeight'     => null,
+			'textDecoration' => null,
+			'textTransform'  => null,
+		),
+	);
+
+	/**
+	 * Given a selector and a declaration list,
+	 * creates the corresponding ruleset.
+	 *
+	 * To help debugging, will add some space
+	 * if SCRIPT_DEBUG is defined and true.
+	 *
+	 * @param string $selector CSS selector.
+	 * @param array  $declarations List of declarations.
+	 *
+	 * @return string CSS ruleset.
+	 */
+	protected static function to_ruleset( $selector, $declarations ) {
+		if ( empty( $declarations ) ) {
+			return '';
+		}
+		$ruleset = '';
+
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) use ( $selector ) {
+					if ( $selector === static::ROOT_BLOCK_SELECTOR && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
+						$carry        .= "\t" . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ': ' . $element['value'] . ";\n";
+						return $carry .= "\t" . $element['name'] . ': var(' . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ");\n";
+					}
+					return $carry .= "\t" . $element['name'] . ': ' . $element['value'] . ";\n"; },
+				''
+			);
+			$ruleset          .= $selector . " {\n" . $declaration_block . "}\n";
+		} else {
+			$declaration_block = array_reduce(
+				$declarations,
+				function ( $carry, $element ) use ( $selector ) {
+					if ( $selector === static::ROOT_BLOCK_SELECTOR && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
+						$carry        .= static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ': ' . $element['value'] . ';';
+						return $carry .= $element['name'] . ': var(' . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ');';
+					}
+					return $carry .= $element['name'] . ': ' . $element['value'] . ';'; },
+				''
+			);
+			$ruleset          .= $selector . '{' . $declaration_block . '}';
+		}
+
+		return $ruleset;
+	}
+
+	/**
 	 * Returns the metadata for each block.
 	 *
 	 * Example:

--- a/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
+++ b/lib/compat/wordpress-6.1/class-wp-theme-json-6-1.php
@@ -155,7 +155,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$declaration_block = array_reduce(
 				$declarations,
 				function ( $carry, $element ) use ( $selector ) {
-					if ( $selector === static::ROOT_BLOCK_SELECTOR && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
+					if ( static::ROOT_BLOCK_SELECTOR === $selector && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
 						$carry        .= "\t" . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ': ' . $element['value'] . ";\n";
 						return $carry .= "\t" . $element['name'] . ': var(' . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ");\n";
 					}
@@ -167,7 +167,7 @@ class WP_Theme_JSON_6_1 extends WP_Theme_JSON_6_0 {
 			$declaration_block = array_reduce(
 				$declarations,
 				function ( $carry, $element ) use ( $selector ) {
-					if ( $selector === static::ROOT_BLOCK_SELECTOR && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
+					if ( static::ROOT_BLOCK_SELECTOR === $selector && isset( static::ROOT_PROPERTIES_METADATA[ $element['name'] ] ) ) {
 						$carry        .= static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ': ' . $element['value'] . ';';
 						return $carry .= $element['name'] . ': var(' . static::ROOT_PROPERTIES_METADATA[ $element['name'] ] . ');';
 					}

--- a/test/emptytheme/theme.json
+++ b/test/emptytheme/theme.json
@@ -4,7 +4,8 @@
 		"appearanceTools": true,
 		"layout": {
 			"contentSize": "840px",
-			"wideSize": "1100px"
+			"wideSize": "1100px",
+			"fullWidthShouldStretch": true
 		}
 	},
 	"patterns": [ "short-text-surrounded-by-round-images", "partner-logos" ]


### PR DESCRIPTION
# Just experimenting. Don't take any of this seriously

## What?

Note: only works on the backend for now, just for illustrative purposes.

This PR is a random test to see if we can offset global padding for every block that:

- opts into a special layout property via `layout.fullWidthShouldStretch`. Yes the name is improvable :)
- has `align === 'full'` on the block attributes

The layout option could either be global or block-based.

## Why?
I'm asking myself that question.

## How?
Keyboard + internet.

## Testing Instructions
<details>

<summary>Example post code</summary>

```html
<!-- wp:group {"align":"full","backgroundColor":"vivid-purple","layout":{"inherit":true}} -->
<div class="wp-block-group alignfull has-vivid-purple-background-color has-background"><!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:group {"align":"full","backgroundColor":"vivid-purple","layout":{"inherit":true}} -->
<div class="wp-block-group alignfull has-vivid-purple-background-color has-background"><!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Full width</p>
<!-- /wp:paragraph -->

<!-- wp:group {"backgroundColor":"vivid-red"} -->
<div class="wp-block-group has-vivid-red-background-color has-background"><!-- wp:paragraph -->
<p>inner group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

<!-- wp:paragraph {"align":"center","backgroundColor":"vivid-red"} -->
<p class="has-text-align-center has-vivid-red-background-color has-background">A paragraph</p>
<!-- /wp:paragraph -->

<!-- wp:columns {"align":"full"} -->
<div class="wp-block-columns alignfull"><!-- wp:column {"style":{"color":{"background":"#b51212"}}} -->
<div class="wp-block-column has-background" style="background-color:#b51212"><!-- wp:paragraph -->
<p>Columns</p>
<!-- /wp:paragraph --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

```

</details>

## Screenshots or screencast <!-- if applicable -->

Here you go
<img width="1047" alt="Screen Shot 2022-05-13 at 2 44 14 pm" src="https://user-images.githubusercontent.com/6458278/168212735-992f9c67-34c8-460f-8af7-99290163e28b.png">
