### PR TITLE
Remove explicit git branch fallbacks for wp-env and update readme

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,9 +1,6 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [
-		".",
-		"ssh://git@github.com/wpengine/atlas-content-modeler#main"
-	],
+	"plugins": [ "." ],
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,9 @@
 {
 	"core": "WordPress/WordPress",
-	"plugins": [ "." ],
+	"plugins": [
+		".",
+		"ssh://git@github.com/wpengine/atlas-content-modeler#main"
+	],
 	"themes": [ "./test/emptytheme" ],
 	"env": {
 		"tests": {

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -541,7 +541,7 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-	"core": "WordPress/WordPress#trunk",
+	"core": "WordPress/WordPress#master",
 	"plugins": [ "." ]
 }
 ```

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -464,7 +464,7 @@ Several types of strings can be passed into the `core`, `plugins`, `themes`, and
 | ----------------- | -------------------------------------------- | -------------------------------------------------------- |
 | Relative path     | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
 | Absolute path     | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to `#main` |
+| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to the repos default branch |
 | SSH repository    | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`         |
 | ZIP File          | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -542,7 +542,7 @@ This is useful for plugin development when upstream Core changes need to be test
 ```json
 {
   "core": "WordPress/WordPress#master",
-  "plugins": [ "." ]
+  "plugins": ["."]
 }
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -464,7 +464,7 @@ Several types of strings can be passed into the `core`, `plugins`, `themes`, and
 | ----------------- | -------------------------------------------- | -------------------------------------------------------- |
 | Relative path     | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"` |
 | Absolute path     | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                   |
-| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`   |
+| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to `#main` |
 | SSH repository    | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`         |
 | ZIP File          | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`        |
 
@@ -541,8 +541,8 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-  "core": "WordPress/WordPress#master",
-  "plugins": ["."]
+	"core": "WordPress/WordPress#trunk",
+	"plugins": [ "." ]
 }
 ```
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -541,8 +541,8 @@ This is useful for plugin development when upstream Core changes need to be test
 
 ```json
 {
-	"core": "WordPress/WordPress#master",
-	"plugins": [ "." ]
+  "core": "WordPress/WordPress#master",
+  "plugins": [ "." ]
 }
 ```
 

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -148,7 +148,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		return {
 			type: 'git',
 			url: `https://github.com/${ gitHubFields[ 1 ] }/${ gitHubFields[ 2 ] }.git`,
-			ref: gitHubFields[ 5 ] || 'master',
+			ref: gitHubFields[ 5 ] || 'main',
 			path: path.resolve(
 				workDirectoryPath,
 				gitHubFields[ 2 ],

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -144,6 +144,12 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 	const gitHubFields = sourceString.match(
 		/^([^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?$/
 	);
+
+	if ( ! gitHubFields[ 5 ] && gitHubFields[ 1 ] === 'WordPress' ) {
+		gitHubFields[ 5 ] =
+			gitHubFields[ 2 ] === 'WordPress' ? 'master' : 'trunk';
+	}
+
 	if ( gitHubFields ) {
 		return {
 			type: 'git',

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -145,7 +145,11 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		/^([^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?$/
 	);
 
-	if ( ! gitHubFields[ 5 ] && gitHubFields[ 1 ] === 'WordPress' ) {
+	if (
+		gitHubFields &&
+		! gitHubFields[ 5 ] &&
+		gitHubFields[ 1 ] === 'WordPress'
+	) {
 		gitHubFields[ 5 ] =
 			gitHubFields[ 2 ] === 'WordPress' ? 'master' : 'trunk';
 	}

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -133,7 +133,7 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 			return {
 				type: 'git',
 				url: sshUrl.href.split( '#' )[ 0 ],
-				ref: sshUrl.hash.slice( 1 ) || 'master',
+				ref: sshUrl.hash.slice( 1 ) || undefined,
 				path: workingPath,
 				clonePath: workingPath,
 				basename,
@@ -145,20 +145,11 @@ function parseSourceString( sourceString, { workDirectoryPath } ) {
 		/^([^\/]+)\/([^#\/]+)(\/([^#]+))?(?:#(.+))?$/
 	);
 
-	if (
-		gitHubFields &&
-		! gitHubFields[ 5 ] &&
-		gitHubFields[ 1 ] === 'WordPress'
-	) {
-		gitHubFields[ 5 ] =
-			gitHubFields[ 2 ] === 'WordPress' ? 'master' : 'trunk';
-	}
-
 	if ( gitHubFields ) {
 		return {
 			type: 'git',
 			url: `https://github.com/${ gitHubFields[ 1 ] }/${ gitHubFields[ 2 ] }.git`,
-			ref: gitHubFields[ 5 ] || 'main',
+			ref: gitHubFields[ 5 ],
 			path: path.resolve(
 				workDirectoryPath,
 				gitHubFields[ 2 ],

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -395,7 +395,7 @@ describe( 'readConfig', () => {
 					{
 						type: 'git',
 						url: 'https://github.com/WordPress/gutenberg.git',
-						ref: 'trunk',
+						ref: undefined,
 						path: expect.stringMatching( /^(\/||\\).*gutenberg$/ ),
 						basename: 'gutenberg',
 					},

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -395,7 +395,7 @@ describe( 'readConfig', () => {
 					{
 						type: 'git',
 						url: 'https://github.com/WordPress/gutenberg.git',
-						ref: 'master',
+						ref: 'trunk',
 						path: expect.stringMatching( /^(\/||\\).*gutenberg$/ ),
 						basename: 'gutenberg',
 					},

--- a/packages/env/test/parse-config.js
+++ b/packages/env/test/parse-config.js
@@ -22,7 +22,7 @@ const gitTests = [
 	{
 		sourceString: 'ssh://git@github.com/short.git',
 		url: 'ssh://git@github.com/short.git',
-		ref: 'master',
+		ref: undefined,
 		path: currentDirectory + '/short',
 		clonePath: currentDirectory + '/short',
 		basename: 'short',
@@ -30,7 +30,7 @@ const gitTests = [
 	{
 		sourceString: 'ssh://git@github.com/owner/long/path/repo.git',
 		url: 'ssh://git@github.com/owner/long/path/repo.git',
-		ref: 'master',
+		ref: undefined,
 		path: currentDirectory + '/owner/long/path/repo',
 		clonePath: currentDirectory + '/owner/long/path/repo',
 		basename: 'repo',


### PR DESCRIPTION
## What?
Updates reference to `master` branch in wp-env to instead use either `trunk` or `main` depending on context.

## Why?
Fixes: #40928 
Github now defaults to `main`. Gutenberg is `trunk` and  WordPress/WordPress is still  to `master` though, so these are accounted for separately

## How?
Renamed branches where appropriate

## Testing Instructions

- Run `npm run wp-env start` and make sure environment starts as expected
- Add `wpengine/atlas-content-modeler` to the plugins section of `.wp-env.json` and restart env and make sure this plugin loads as expected - this plugin repo uses `main` as default branch
