### PR TITLE
Fix pull-request-automation CI check (temporarily until an upstream fix lands)

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -17,7 +17,7 @@ jobs:
             # isn't necessarily `trunk` (e.g. in the case of a merge).
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: try/fixing-project-management-automation-deps
+                  ref: trunk
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -17,7 +17,7 @@ jobs:
             # isn't necessarily `trunk` (e.g. in the case of a merge).
             - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
               with:
-                  ref: trunk
+                  ref: try/fixing-project-management-automation-deps
 
             - name: Use desired version of NodeJS
               uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,11 +18163,11 @@
 			"version": "file:packages/project-management-automation",
 			"dev": true,
 			"requires": {
-				"@actions/core": "^1.4.0",
+				"@actions/core": "^1.8.0",
 				"@actions/github": "^5.0.0",
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",
-				"@octokit/webhooks": "^7.1.0"
+				"@octokit/webhooks": "^9.24.0"
 			}
 		},
 		"@wordpress/react-i18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,11 +18163,11 @@
 			"version": "file:packages/project-management-automation",
 			"dev": true,
 			"requires": {
-				"@actions/core": "^1.8.0",
+				"@actions/core": "^1.4.0",
 				"@actions/github": "^5.0.0",
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",
-				"@octokit/webhooks": "^9.24.0"
+				"@octokit/webhooks": "^7.1.0"
 			}
 		},
 		"@wordpress/react-i18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18163,7 +18163,7 @@
 			"version": "file:packages/project-management-automation",
 			"dev": true,
 			"requires": {
-				"@actions/core": "^1.4.0",
+				"@actions/core": "1.8.0",
 				"@actions/github": "^5.0.0",
 				"@babel/runtime": "^7.16.0",
 				"@octokit/request-error": "^2.1.0",

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -22,7 +22,7 @@
 	"main": "lib/index.js",
 	"types": "build-types",
 	"dependencies": {
-		"@actions/core": "^1.4.0",
+		"@actions/core": "1.8.0",
 		"@actions/github": "^5.0.0",
 		"@babel/runtime": "^7.16.0",
 		"@octokit/request-error": "^2.1.0",

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -22,11 +22,11 @@
 	"main": "lib/index.js",
 	"types": "build-types",
 	"dependencies": {
-		"@actions/core": "^1.4.0",
+		"@actions/core": "^1.8.0",
 		"@actions/github": "^5.0.0",
 		"@babel/runtime": "^7.16.0",
 		"@octokit/request-error": "^2.1.0",
-		"@octokit/webhooks": "^7.1.0"
+		"@octokit/webhooks": "^9.24.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/project-management-automation/package.json
+++ b/packages/project-management-automation/package.json
@@ -22,11 +22,11 @@
 	"main": "lib/index.js",
 	"types": "build-types",
 	"dependencies": {
-		"@actions/core": "^1.8.0",
+		"@actions/core": "^1.4.0",
 		"@actions/github": "^5.0.0",
 		"@babel/runtime": "^7.16.0",
 		"@octokit/request-error": "^2.1.0",
-		"@octokit/webhooks": "^9.24.0"
+		"@octokit/webhooks": "^7.1.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
The `pull-request-automation` job is currently failing in CI with the following error:
```
Error: Cannot find module 'tunnel'
```

As suggested here, we can temporarily roll back the version of `@actions/core` to resolve the issue - https://github.com/actions/toolkit/issues/1083#issuecomment-1125556009.

To test this I've temporarily made `pull-request-automation` use this branch (5eea292) and then fixed the version, and we CI passed on the commit f665688.

The check will be failing in the last commit of this PR because I had to switch `pull-request-automation` back to using the code in `trunk`, so I'll have to use admin privileges to merge it 😅 

We should revert this PR when the upstream fix lands (https://github.com/actions/toolkit/issues/1083).