### PR TITLE
Packages: Add more npm release types to the GitHub workflow

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -3,9 +3,17 @@ name: Publish npm packages
 on:
     workflow_dispatch:
         inputs:
-            wp_version:
-                description: 'WordPress major version'
+            release_type:
+                description: 'Release type'
                 required: true
+                type: choice
+                default: 'development'
+                options:
+                    - development
+                    - bugfix
+                    - wp
+            wp_version:
+                description: 'WordPress major version (`wp` only)'
                 type: string
 
 # Cancels all previous workflow runs for pull requests that have not completed.
@@ -16,10 +24,91 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    development-release:
+        name: Development release
+        runs-on: ubuntu-latest
+        environment: WordPress packages
+        if: ${{ github.event.inputs.release_type == 'development' }}
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: main
+                  ref: trunk
+
+            - name: Checkout (for publishing)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: publish
+                  # Later, we switch this branch in the script that publishes packages.
+                  ref: trunk
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Configure git user name and email (for publishing)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node (for CLI)
+              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Publish packages to npm ("next" dist-tag)
+              run: |
+                  cd main
+                  npm ci
+                  ./bin/plugin/cli.js npm-next --ci --repository-path ../publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    bugfix-release:
+        name: Bugfix release
+        runs-on: ubuntu-latest
+        environment: WordPress packages
+        if: ${{ github.event.inputs.release_type == 'bugfix' }}
+        steps:
+            - name: Checkout (for CLI)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: main
+                  ref: trunk
+
+            - name: Checkout (for publishing)
+              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+              with:
+                  path: publish
+                  # Later, we switch this branch in the script that publishes packages.
+                  ref: trunk
+                  token: ${{ secrets.GUTENBERG_TOKEN }}
+
+            - name: Configure git user name and email (for publishing)
+              run: |
+                  cd publish
+                  git config user.name "Gutenberg Repository Automation"
+                  git config user.email gutenberg@wordpress.org
+
+            - name: Setup Node (for CLI)
+              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
+              with:
+                  node-version-file: 'main/.nvmrc'
+                  registry-url: 'https://registry.npmjs.org'
+
+            - name: Publish packages to npm ("latest" dist-tag)
+              run: |
+                  cd main
+                  npm ci
+                  ./bin/plugin/cli.js npm-bugfix --ci --repository-path ../publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
     wp-release:
         name: WordPress major bugfix release
         runs-on: ubuntu-latest
         environment: WordPress packages
+        if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -24,11 +24,10 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    development-release:
-        name: Development release
+    release:
+        name: Release ${{ github.event.inputs.release_type }}
         runs-on: ubuntu-latest
         environment: WordPress packages
-        if: ${{ github.event.inputs.release_type == 'development' }}
         steps:
             - name: Checkout (for CLI)
               uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
@@ -56,7 +55,8 @@ jobs:
                   node-version-file: 'main/.nvmrc'
                   registry-url: 'https://registry.npmjs.org'
 
-            - name: Publish packages to npm ("next" dist-tag)
+            - name: Publish development packages to npm ("next" dist-tag)
+              if: ${{ github.event.inputs.release_type == 'development' }}
               run: |
                   cd main
                   npm ci
@@ -64,39 +64,8 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    bugfix-release:
-        name: Bugfix release
-        runs-on: ubuntu-latest
-        environment: WordPress packages
-        if: ${{ github.event.inputs.release_type == 'bugfix' }}
-        steps:
-            - name: Checkout (for CLI)
-              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-              with:
-                  path: main
-                  ref: trunk
-
-            - name: Checkout (for publishing)
-              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-              with:
-                  path: publish
-                  # Later, we switch this branch in the script that publishes packages.
-                  ref: trunk
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
-
-            - name: Configure git user name and email (for publishing)
-              run: |
-                  cd publish
-                  git config user.name "Gutenberg Repository Automation"
-                  git config user.email gutenberg@wordpress.org
-
-            - name: Setup Node (for CLI)
-              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
-              with:
-                  node-version-file: 'main/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
-
-            - name: Publish packages to npm ("latest" dist-tag)
+            - name: Publish packages to npm with bug fixes ("latest" dist-tag)
+              if: ${{ github.event.inputs.release_type == 'bugfix' }}
               run: |
                   cd main
                   npm ci
@@ -104,39 +73,8 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-    wp-release:
-        name: WordPress major bugfix release
-        runs-on: ubuntu-latest
-        environment: WordPress packages
-        if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
-        steps:
-            - name: Checkout (for CLI)
-              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-              with:
-                  path: main
-                  ref: trunk
-
-            - name: Checkout (for publishing)
-              uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
-              with:
-                  path: publish
-                  # Later, we switch this branch in the script that publishes packages.
-                  ref: trunk
-                  token: ${{ secrets.GUTENBERG_TOKEN }}
-
-            - name: Configure git user name and email (for publishing)
-              run: |
-                  cd publish
-                  git config user.name "Gutenberg Repository Automation"
-                  git config user.email gutenberg@wordpress.org
-
-            - name: Setup Node (for CLI)
-              uses: actions/setup-node@5b52f097d36d4b0b2f94ed6de710023fbb8b2236 # v3.1.0
-              with:
-                  node-version-file: 'main/.nvmrc'
-                  registry-url: 'https://registry.npmjs.org'
-
-            - name: Publish packages to npm ("wp/${{ github.event.inputs.wp_version }}" dist-tag)
+            - name: Publish packages to npm for WP major ("wp/${{ github.event.inputs.wp_version }}" dist-tag)
+              if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd main
                   npm ci

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
     release:
-        name: Release ${{ github.event.inputs.release_type }}
+        name: Release - ${{ github.event.inputs.release_type }}
         runs-on: ubuntu-latest
         environment: WordPress packages
         steps:
@@ -73,7 +73,7 @@ jobs:
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-            - name: Publish packages to npm for WP major ("wp/${{ github.event.inputs.wp_version }}" dist-tag)
+            - name: Publish packages to npm for WP major ("wp/${{ github.event.inputs.wp_version || 'X.Y' }}" dist-tag)
               if: ${{ github.event.inputs.release_type == 'wp' && github.event.inputs.wp_version }}
               run: |
                   cd main


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for #40976.

This PR adds more release types to the existing GitHub Workflow that handles publishing npm packages:
- development (`next` dist tag)
- bugfix (`latest` dist tag)

Together with the preexisting `wp` (`wp/X.Y` dist tag) release type it covers all supported manual releases. 

See [Packages Releases to npm and WordPress Core Updates](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#packages-releases-to-npm-and-wordpress-core-updates) to learn more about release types.

Note: The last remaining release type [Synchronizing Gutenberg Plugin](https://github.com/WordPress/gutenberg/compare/update/npm-publish-workflow-types?expand=1#synchronizing-gutenberg-plugin) is handled separately in a different workflow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It will simplify the process of publishing:
- bugfixes for the existing npm packages unrelated to the Gutenberg plugin code
- development releases whenever we want to test how new changes work with the npm infrastructure

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It's nearly identical to https://github.com/WordPress/gutenberg/pull/40976 and how `wp` release type is handled. The only difference is that new release types use a different script at the end of the process according to the existing documentation:

- [Development releases](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#development-releases)
- [Bugfix releases](https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/code/release.md#standalone-bugfix-package-releases)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

It's difficult to test in the development branch in the Gutenberg repository because the UI won't update until we merge this PR...

I tested in the forked version of this repository with a simplified script that doesn't use secret tokens and doesn't run the publishing step.

The flow is nearly identical to what I documented for the preexisting `wp` release type:

https://github.com/WordPress/gutenberg/pull/40976#issuecomment-1125108897

## Screenshots or screencast <!-- if applicable -->

The updated `Run workflow` form:

<img width="340" alt="Screenshot 2022-05-12 at 18 37 04" src="https://user-images.githubusercontent.com/699132/168227686-8917679f-a1b1-409f-8c19-3db2a956f96d.png">

The list presenting workflows triggered manually. You can also check at https://github.com/gziolo/gutenberg/actions/workflows/publish-npm-packages.yml.

<img width="950" alt="Screenshot 2022-05-12 at 18 45 56" src="https://user-images.githubusercontent.com/699132/168227695-f472a55b-d78f-4721-83a7-d768818bbfdf.png">

Example of the successful workflow in the test repo with the release type `development`:

<img width="967" alt="Screenshot 2022-05-12 at 18 46 16" src="https://user-images.githubusercontent.com/699132/168227698-2d7ed8e5-b761-4283-805f-b0bfcae7c74d.png">

Example of the successful workflow in the test repo with the release type `bugfix`:

<img width="972" alt="Screenshot 2022-05-12 at 18 46 27" src="https://user-images.githubusercontent.com/699132/168227704-38577d1b-dafb-4411-b655-4dcd9f75c657.png">
