### PR TITLE
[List v2]: Focus new list item added from sibling inserter

### DIFF
--- a/packages/block-library/src/list/v2/edit.js
+++ b/packages/block-library/src/list/v2/edit.js
@@ -134,6 +134,7 @@ function Edit( { attributes, setAttributes, clientId } ) {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		allowedBlocks: [ 'core/list-item' ],
 		template: TEMPLATE,
+		templateInsertUpdatesSelection: true,
 	} );
 	useMigrateOnLoad( attributes, clientId );
 	const { ordered, reversed, start } = attributes;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/40766

This PR just focuses(move the selection) inside the newly created `list item` after adding it from the sibling inserter, so you can type right away.

## Notes
You need to have enabled the experimental version 2 of list in Gutenberg experiments.

## Testing Instructions
1. Insert a new list block
2. Observe that the list item is focused
3. Add more items from the sibling inserter
4. Observe that the new list items are focused and you can type right away 

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/16275880/168263075-e0cd5dcd-2c0e-4297-99b3-eeaa82a10fcb.mov


