### PR TITLE
[Mobile] - Fix Drag & Drop Chip positioning issue with RTL languages

### DIFF
--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -83,7 +83,7 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 	const { left, right } = useSafeAreaInsets();
 	const { width } = useSafeAreaFrame();
 	const safeAreaOffset = left + right;
-	const maxWidth = width - safeAreaOffset;
+	const contentWidth = width - safeAreaOffset;
 	animatedScrollRef( scrollRef );
 
 	const scroll = {
@@ -210,7 +210,7 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 		const chipOffset = chip.width.value / 2;
 		const translateX = ! isRTL
 			? chip.x.value - chipOffset
-			: -( maxWidth - ( chip.x.value + chipOffset ) );
+			: -( contentWidth - ( chip.x.value + chipOffset ) );
 
 		return {
 			transform: [

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -15,7 +15,6 @@ import Animated, {
 	withDelay,
 	withTiming,
 	ZoomInEasyDown,
-	ZoomOutEasyDown,
 } from 'react-native-reanimated';
 
 /**
@@ -231,6 +230,34 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 		styles[ 'draggable-chip__wrapper' ],
 	];
 
+	const exitingAnimation = ( { currentHeight, currentWidth } ) => {
+		'worklet';
+		const translateX = ! isRTL ? 0 : currentWidth * -1;
+		const duration = 150;
+		const animations = {
+			transform: [
+				{
+					translateY: withTiming( currentHeight, {
+						duration,
+					} ),
+				},
+				{
+					translateX: withTiming( translateX, {
+						duration,
+					} ),
+				},
+				{ scale: withTiming( 0, { duration } ) },
+			],
+		};
+		const initialValues = {
+			transform: [ { translateY: 0 }, { translateX }, { scale: 1 } ],
+		};
+		return {
+			initialValues,
+			animations,
+		};
+	};
+
 	return (
 		<>
 			<DroppingInsertionPoint
@@ -254,7 +281,7 @@ const BlockDraggableWrapper = ( { children, isRTL } ) => {
 				{ draggedBlockIcon && (
 					<Animated.View
 						entering={ ZoomInEasyDown.duration( 200 ) }
-						exiting={ ZoomOutEasyDown.duration( 150 ) }
+						exiting={ exitingAnimation }
 					>
 						<DraggableChip icon={ draggedBlockIcon } />
 					</Animated.View>

--- a/packages/block-editor/src/components/block-draggable/index.native.js
+++ b/packages/block-editor/src/components/block-draggable/index.native.js
@@ -2,6 +2,10 @@
  * External dependencies
  */
 import { AccessibilityInfo } from 'react-native';
+import {
+	useSafeAreaInsets,
+	useSafeAreaFrame,
+} from 'react-native-safe-area-context';
 import Animated, {
 	runOnJS,
 	runOnUI,
@@ -61,10 +65,11 @@ const DEFAULT_IOS_LONG_PRESS_MIN_DURATION =
  *
  * @param {Object}      props          Component props.
  * @param {JSX.Element} props.children Children to be rendered.
+ * @param {boolean}     props.isRTL    Check if current locale is RTL.
  *
  * @return {Function} Render function that passes `onScroll` event handler.
  */
-const BlockDraggableWrapper = ( { children } ) => {
+const BlockDraggableWrapper = ( { children, isRTL } ) => {
 	const [ draggedBlockIcon, setDraggedBlockIcon ] = useState();
 
 	const {
@@ -75,6 +80,10 @@ const BlockDraggableWrapper = ( { children } ) => {
 
 	const { scrollRef } = useBlockListContext();
 	const animatedScrollRef = useAnimatedRef();
+	const { left, right } = useSafeAreaInsets();
+	const { width } = useSafeAreaFrame();
+	const safeAreaOffset = left + right;
+	const maxWidth = width - safeAreaOffset;
 	animatedScrollRef( scrollRef );
 
 	const scroll = {
@@ -198,9 +207,16 @@ const BlockDraggableWrapper = ( { children } ) => {
 	};
 
 	const chipDynamicStyles = useAnimatedStyle( () => {
+		const chipOffset = chip.width.value / 2;
+		const translateX = ! isRTL
+			? chip.x.value - chipOffset
+			: -( maxWidth - ( chip.x.value + chipOffset ) );
+
 		return {
 			transform: [
-				{ translateX: chip.x.value - chip.width.value / 2 },
+				{
+					translateX,
+				},
 				{
 					translateY:
 						chip.y.value -

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -189,7 +189,7 @@ export class BlockList extends Component {
 	}
 
 	render() {
-		const { isRootList } = this.props;
+		const { isRootList, isRTL } = this.props;
 		// Use of Context to propagate the main scroll ref to its children e.g InnerBlocks.
 		const blockList = isRootList ? (
 			<BlockListProvider
@@ -198,7 +198,7 @@ export class BlockList extends Component {
 					scrollRef: this.scrollViewRef,
 				} }
 			>
-				<BlockDraggableWrapper>
+				<BlockDraggableWrapper isRTL={ isRTL }>
 					{ ( { onScroll } ) => this.renderList( { onScroll } ) }
 				</BlockDraggableWrapper>
 			</BlockListProvider>
@@ -438,6 +438,8 @@ export default compose( [
 
 			const isFloatingToolbarVisible =
 				!! selectedBlockClientId && hasRootInnerBlocks;
+			const isRTL = getSettings().isRTL;
+
 			return {
 				blockClientIds,
 				blockCount,
@@ -448,6 +450,7 @@ export default compose( [
 				isFloatingToolbarVisible,
 				isStackedHorizontally,
 				maxWidth,
+				isRTL,
 			};
 		}
 	),


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4852

## What?
Fixes an issue found during testing the Drag & Drop blocks feature where the `chip` that shows up when dragging a block would show in the wrong coordinates (out of the screen)

## Why?
The feature should work correctly using RTL languages.

## How?

For RTL languages, it calculates the `chip` position differently taking into account the max width of the screen to subtract it off the current touch coordinate plus the chip's offset.

It also adds a custom `exiting` animation that has the same [functionality as ZoomOutEasyDown](https://github.com/software-mansion/react-native-reanimated/blob/2.4.1/src/reanimated2/layoutReanimation/defaultAnimations/Zoom.ts#L494-L513), but it customizes the value for `translateX` to take into account RTL languages.

## Testing Instructions

### Using the device in portrait mode with an RTL language

- Set an RTL language as the default for the device.
- Open the post or page
- Long press over a block
- Move the block and expect the `chip` to show and be positioned correctly.

### Using the device in landscape mode with an RTL language

- Set an RTL language as the default for the device.
- Open the post or page
- Long press over a block
- Move the block and expect the `chip` to show and be positioned correctly.

### Using the device in portrait mode with a non RTL language

- Open the post or page
- Long press over a block
- Move the block and expect the `chip` to show and be positioned correctly.

### Using the device in landscape mode with a non RTL language

- Open the post or page
- Long press over a block
- Move the block and expect the `chip` to show and be positioned correctly.

## Screenshots or screencast <!-- if applicable -->

Before (RTL) iOS | After (RTL) iOS
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/168293029-f403a4c9-f419-4d9d-9355-ece767f5fd2a.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/168293048-bf7c9333-80a0-4037-ad39-9bba755953cb.gif" width="200" /></kbd>

Before (RTL) Android | After (RTL) Android
-|-
<kbd><img src="https://user-images.githubusercontent.com/4885740/168293191-3eb8dd26-aec9-4dc3-a50a-03e1f996c00c.gif" width="200" /></kbd> | <kbd><img src="https://user-images.githubusercontent.com/4885740/168293198-8634f9fe-b240-47fc-94ea-e6c7c7a88643.gif" width="200" /></kbd>

After (RTL) iOS (Landscape)
-|
<kbd><img src="https://user-images.githubusercontent.com/4885740/168293489-d1e12c5d-d7b4-45e5-99d0-0007205d9314.gif" width="400" /></kbd> |

After (RTL) Android (Landscape)
-|
<kbd><img src="https://user-images.githubusercontent.com/4885740/168293579-4dce0a1d-9443-49fd-a7fb-47b2a694e66c.gif" width="400" /></kbd> |