### PR TITLE
[bug] Theme Export: Use basename when determining the theme slug

### DIFF
--- a/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
+++ b/lib/compat/wordpress-6.0/class-gutenberg-rest-edit-site-export-controller.php
@@ -76,9 +76,7 @@ class Gutenberg_REST_Edit_Site_Export_Controller extends WP_REST_Controller {
 			return $filename;
 		}
 
-		$stylesheet             = get_stylesheet();
-		$stylesheet_directories = explode( '/', $stylesheet );
-		$theme_name             = end( $stylesheet_directories );
+		$theme_name = basename( get_stylesheet() );
 
 		header( 'Content-Type: application/zip' );
 		header( 'Content-Disposition: attachment; filename=' . $theme_name . '.zip' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
As suggested in https://github.com/WordPress/gutenberg/pull/40829#discussion_r871748752 we should use `basename` to  determine the theme slug.

## Why?
- Less code
- Better compatibility with other environments

## Testing Instructions
Export your theme from the Site Editor and check that the zip has the correct theme name.