### PR TITLE
Fix broken Page title for pages created inline within in Nav block

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -33,6 +33,7 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
+import { decodeEntities } from '@wordpress/html-entities';
 import {
 	Fragment,
 	useState,
@@ -234,13 +235,16 @@ export const updateNavigationLinkBlockAttributes = (
 	} = updatedValue;
 	const normalizedTitle = title.replace( /http(s?):\/\//gi, '' );
 	const normalizedURL = url.replace( /http(s?):\/\//gi, '' );
-	const escapeTitle =
+
+	const shouldEscapeTitle =
 		title !== '' &&
 		normalizedTitle !== normalizedURL &&
 		originalLabel !== title;
 
-	const label = escapeTitle
-		? escape( title )
+	const decodedTitle = decodeEntities( title );
+
+	const label = shouldEscapeTitle
+		? decodedTitle
 		: originalLabel || escape( normalizedURL );
 
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -233,19 +233,10 @@ export const updateNavigationLinkBlockAttributes = (
 		kind: newKind = originalKind,
 		type: newType = originalType,
 	} = updatedValue;
-	const normalizedTitle = title.replace( /http(s?):\/\//gi, '' );
+
 	const normalizedURL = url.replace( /http(s?):\/\//gi, '' );
 
-	const shouldEscapeTitle =
-		title !== '' &&
-		normalizedTitle !== normalizedURL &&
-		originalLabel !== title;
-
-	const decodedTitle = decodeEntities( title );
-
-	const label = shouldEscapeTitle
-		? decodedTitle
-		: originalLabel || escape( normalizedURL );
+	const label = decodeEntities( title ) || originalLabel || normalizedURL;
 
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
@@ -746,7 +737,7 @@ export default function NavigationLinkEdit( {
 										ref={ ref }
 										identifier="label"
 										className="wp-block-navigation-item__label"
-										value={ label }
+										value={ escape( label ) }
 										onChange={ ( labelValue ) =>
 											setAttributes( {
 												label: labelValue,

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -236,7 +236,7 @@ export const updateNavigationLinkBlockAttributes = (
 
 	const normalizedURL = url.replace( /http(s?):\/\//gi, '' );
 
-	const label = decodeEntities( title ) || originalLabel || normalizedURL;
+	const label = title || originalLabel || normalizedURL;
 
 	// In https://github.com/WordPress/gutenberg/pull/24670 we decided to use "tag" in favor of "post_tag"
 	const type = newType === 'post_tag' ? 'tag' : newType.replace( '-', '_' );
@@ -793,7 +793,9 @@ export default function NavigationLinkEdit( {
 											<span>
 												{
 													/* Trim to avoid trailing white space when the placeholder text is not present */
-													`${ label } ${ placeholderText }`.trim()
+													`${ decodeEntities(
+														label
+													) } ${ placeholderText }`.trim()
 												}
 											</span>
 											<span className="wp-block-navigation-link__missing_text-tooltip">

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -817,9 +817,10 @@ export default function NavigationLinkEdit( {
 										<>
 											<span>
 												{
-													// Some attributes are stored in an escaped form due to the escaping model
-													// having become inverted.
-													// Unescape is used here to "recover" the escaped characters.
+													// Some attributes are stored in an escaped form. It's a legacy issue.
+													// Ideally they would be stored in a raw, unescaped form.
+													// Unescape is used here to "recover" the escaped characters
+													// so they display without encoding.
 													// See `updateNavigationLinkBlockAttributes` for more details.
 													`${ unescape(
 														label

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -601,7 +601,7 @@ export default function NavigationLinkEdit( {
 		return {
 			id: page.id,
 			type: postType,
-			title: page.title.rendered,
+			title: page.title.raw,
 			url: page.link,
 			kind: 'post-type',
 		};

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -815,7 +815,11 @@ export default function NavigationLinkEdit( {
 										text={ tooltipText }
 									>
 										<>
-											<span>
+											<span
+												aria-label={ __(
+													'Navigation link text'
+												) }
+											>
 												{
 													// Some attributes are stored in an escaped form. It's a legacy issue.
 													// Ideally they would be stored in a raw, unescaped form.

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -240,6 +240,15 @@ export const updateNavigationLinkBlockAttributes = (
 		normalizedTitle !== normalizedURL &&
 		originalLabel !== title;
 
+	// Unfortunately this causes the escaping model to be inverted.
+	// The escaped content is stored in the block attributes (and ultimately in the database),
+	// and then the raw data is "recovered" when outputting into the DOM.
+	// It would be preferable to store the **raw** data in the block attributes and escape it in JS.
+	// Why? Because there isn't one way to escape data. Depending on the context, you need to do
+	// different transforms. It doesn't make sense to me to choose one of them for the purposes of storage.
+	// See also:
+	// - https://github.com/WordPress/gutenberg/pull/41063
+	// - https://github.com/WordPress/gutenberg/pull/18617.
 	const label = escapeTitle
 		? escape( title )
 		: originalLabel || escape( normalizedURL );
@@ -799,7 +808,10 @@ export default function NavigationLinkEdit( {
 										<>
 											<span>
 												{
-													/* Trim to avoid trailing white space when the placeholder text is not present */
+													// Some attributes are stored in an escaped form due to the escaping model
+													// having become inverted.
+													// Unescape is used here to "recover" the escaped characters.
+													// See `updateNavigationLinkBlockAttributes` for more details.
 													`${ unescape(
 														label
 													) } ${ placeholderText }`.trim()

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -616,7 +616,16 @@ export default function NavigationLinkEdit( {
 		return {
 			id: page.id,
 			type: postType,
-			// Consistent with https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218
+			// Make `title` property consistent with that in `fetchLinkSuggestions` where the `rendered` title (containing HTML entities)
+			// is also being decoded. By being consistent in both locations we avoid having to branch in the rendering output code.
+			// Ideally in the future we will update both APIs to utilise the "raw" form of the title which is better suited to edit contexts.
+			// e.g.
+			// - title.raw = "Yes & No"
+			// - title.rendered = "Yes &#038; No"
+			// - decodeEntities( title.rendered ) = "Yes & No"
+			// See:
+			// - https://github.com/WordPress/gutenberg/pull/41063
+			// - https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218
 			title: decodeEntities( page.title.rendered ),
 			url: page.link,
 			kind: 'post-type',

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -33,7 +33,6 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { isURL, prependHTTP, safeDecodeURI } from '@wordpress/url';
-import { decodeEntities } from '@wordpress/html-entities';
 import {
 	Fragment,
 	useState,
@@ -793,9 +792,7 @@ export default function NavigationLinkEdit( {
 											<span>
 												{
 													/* Trim to avoid trailing white space when the placeholder text is not present */
-													`${ decodeEntities(
-														label
-													) } ${ placeholderText }`.trim()
+													`${ label } ${ placeholderText }`.trim()
 												}
 											</span>
 											<span className="wp-block-navigation-link__missing_text-tooltip">

--- a/packages/block-library/src/navigation-link/test/edit.js
+++ b/packages/block-library/src/navigation-link/test/edit.js
@@ -372,26 +372,6 @@ describe( 'edit', () => {
 					url: 'https://wordpress.org',
 				} );
 			} );
-			// https://github.com/WordPress/gutenberg/pull/18617
-			it( 'label is javascript escaped', () => {
-				const setAttributes = jest.fn();
-				const linkSuggestion = {
-					opensInNewTab: false,
-					title: '<Navigation />',
-					type: 'URL',
-					url: 'https://wordpress.local?p=1',
-				};
-				updateNavigationLinkBlockAttributes(
-					linkSuggestion,
-					setAttributes
-				);
-				expect( setAttributes ).toHaveBeenCalledWith( {
-					opensInNewTab: false,
-					label: '&lt;Navigation /&gt;',
-					kind: 'custom',
-					url: 'https://wordpress.local?p=1',
-				} );
-			} );
 			// https://github.com/WordPress/gutenberg/pull/19679
 			it( 'url when escaped is still an actual link', () => {
 				const setAttributes = jest.fn();

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -807,6 +807,58 @@ describe( 'Navigation', () => {
 		);
 	} );
 
+	it( 'correctly decodes special characters in the created Page title for display', async () => {
+		await createNewPost();
+		await insertBlock( 'Navigation' );
+		const startEmptyButton = await page.waitForXPath( START_EMPTY_XPATH );
+		await startEmptyButton.click();
+		const appender = await page.waitForSelector(
+			'.wp-block-navigation .block-list-appender'
+		);
+		await appender.click();
+
+		// Wait for URL input to be focused
+		// Insert name for the new page.
+		const pageTitle = 'This & That & Some < other > chars';
+		const input = await page.waitForSelector(
+			'input.block-editor-url-input__input:focus'
+		);
+		await input.type( pageTitle );
+
+		// When creating a page, the URLControl makes a request to the
+		// url-details endpoint to fetch information about the page.
+		// Because the draft is inaccessible publicly, this request
+		// returns a 404 response. Wait for the response and expect
+		// the error to have occurred.
+		const createPageButton = await page.waitForSelector(
+			'.block-editor-link-control__search-create'
+		);
+		const responsePromise = page.waitForResponse(
+			( response ) =>
+				response.url().includes( 'url-details' ) &&
+				response.status() === 404
+		);
+		const createPagePromise = createPageButton.click();
+		await Promise.all( [ responsePromise, createPagePromise ] );
+
+		await waitForBlock( 'Navigation' );
+
+		const innerLinkBlock = await waitForBlock( 'Custom Link' );
+
+		const linkText = await innerLinkBlock.$eval(
+			'[aria-label="Navigation link text"]',
+			( element ) => {
+				return element.innerText;
+			}
+		);
+
+		expect( linkText ).toContain( pageTitle );
+
+		expect( console ).toHaveErroredWith(
+			'Failed to load resource: the server responded with a status of 404 (Not Found)'
+		);
+	} );
+
 	it( 'renders buttons for the submenu opener elements when the block is set to open on click instead of hover', async () => {
 		await createClassicMenu( { name: 'Test Menu 2' }, menuItemsFixture );
 		await createNewPost();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/30111.

Fixes the output of decoded and/or escaped HTML entities in the Nav block when creating a link (page) from within the Link UI that contains chars such as `&`. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are two facets to this PR:

- display of encoded HTML entities
- unwanted `escape`ing of the label for draft posts

### Display of encoded HTML entities

Calling `saveEntityRecord` results in an API response which contains a `title` field with the following:

```
// title property is an object
{
    "raw": "Yes & No",
    "rendered": "Yes &#038; No"
}
```

The `handleCreate` function in the Nav Link block consumes the  `title.rendered` field of the newly created Page post type.

https://github.com/WordPress/gutenberg/blob/b4955801f1ea052511c17e71d78f31006611bb60/packages/block-library/src/navigation-link/edit.js#L606-L612

This field contains a version of the post title which has been passed through various WordPress display filters and thus contains HTML entities (e.g. `Yes &#038; No`).

We then render this directly into the Nav link block which means we "see" the entities.

To fix this we now call `decodeEntities` on the `rendered` field. We could just use the `raw` field but the current approach is more consistent with the implementation in `fetchLinkSuggestions` which is also consuming the `rendered` field:

https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218


### Unwanted `escape`ing of the label for draft posts

The output of the Nav Link block's `label` attribute is handled differently depending on the post status of the post represented by the link.

Posts with a `Published` status they are output into a `<RichText>` field:

https://github.com/WordPress/gutenberg/blob/b83ce72de13b0a0f4b84733bd61a4f91271fee95/packages/block-library/src/navigation-link/edit.js#L741-L745

Posts with a `Draft` status are output into a `<span>`.

https://github.com/WordPress/gutenberg/blob/b83ce72de13b0a0f4b84733bd61a4f91271fee95/packages/block-library/src/navigation-link/edit.js#L798-L803


Unfortunately the following code from `updateNavigationLinkBlockAttributes` which updates the Navigation Link block attributes escapes the title before it is output to the DOM. Indeed, the escaping model here appears to have become inverted, with the content being escaped for storage in block attributes (and ultimately in the database) when it would have been preferable to escape (or not!) at the point of output.

https://github.com/WordPress/gutenberg/blob/b83ce72de13b0a0f4b84733bd61a4f91271fee95/packages/block-library/src/navigation-link/edit.js#L242-L244

The result, is that for draft posts being rendered into a `<span>` we see an escaped version of the label attribute (e.g. `Yes &amp; No`).

This doesn't happen for posts with a `published` status because they are rendered into a `RichText` and thus the escaping isn't "visible" to the user.

To fix this we have to "restore" the data by `unescape`ing the label for draft posts.








## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR fixes things by:

1. Decoding the the page title returned by `handleCreate` making it consistent with [`fetchLinkSuggestions`](https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.js#L212-L218).
2. Unescaping the (prematurely escaped) `label` attribute before it is output in the `<span>` for Draft pages.


## Testing Instructions

- Add the navigation block.
- Add a new menu item.
- Select adding a new link and begin typing the title of a page that doesn't exist. When you do so, include &.
- Select the option to create a page draft.
- See that the menu item is rendered in the block without any HTML entities or escaped HTML.
- Create some published pages containing `&`. 
- Add these to a Nav block and check that the `&` is still rendered correctly.


## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/444434/168383990-1a56bbc6-3b71-44c9-b9f6-9afc39709791.mov


