### PR TITLE
Html block: Add option to allow preview by default

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -303,7 +303,7 @@ Add custom HTML code and preview it as you edit. ([Source](https://github.com/Wo
 -	**Name:** core/html
 -	**Category:** widgets
 -	**Supports:** ~~className~~, ~~customClassName~~, ~~html~~
--	**Attributes:** content
+-	**Attributes:** content, showPreview
 
 ## Image
 

--- a/packages/block-library/src/html/block.json
+++ b/packages/block-library/src/html/block.json
@@ -11,6 +11,10 @@
 		"content": {
 			"type": "string",
 			"source": "html"
+		},
+		"showPreview": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useState, useEffect } from '@wordpress/element';
+import { useContext, useState } from '@wordpress/element';
 import {
 	BlockControls,
 	InspectorControls,
@@ -22,9 +22,9 @@ import {
 import { useSelect } from '@wordpress/data';
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
-	const [ isPreview, setIsPreview ] = useState();
-	const isDisabled = useContext( Disabled.Context );
 	const { showPreview } = attributes;
+	const [ isPreview, setIsPreview ] = useState( showPreview );
+	const isDisabled = useContext( Disabled.Context );
 
 	const styles = useSelect( ( select ) => {
 		// Default styles used to unset some of the styles
@@ -44,12 +44,6 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 				select( blockEditorStore ).getSettings().styles
 			),
 		];
-	}, [] );
-
-	useEffect( () => {
-		if ( showPreview ) {
-			switchToPreview();
-		}
 	}, [] );
 
 	function switchToPreview() {

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -49,10 +49,8 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	useEffect( () => {
 		if ( !! showPreview ) {
 			setIsPreview( true );
-		} else {
-			setIsPreview( false );
 		}
-	}, [ showPreview ] );
+	}, [] );
 
 	function switchToPreview() {
 		setIsPreview( true );

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -47,8 +47,8 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	}, [] );
 
 	useEffect( () => {
-		if ( !! showPreview ) {
-			setIsPreview( true );
+		if ( showPreview ) {
+			switchToPreview();
 		}
 	}, [] );
 

--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -2,9 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useContext, useState } from '@wordpress/element';
+import { useContext, useState, useEffect } from '@wordpress/element';
 import {
 	BlockControls,
+	InspectorControls,
 	PlainText,
 	transformStyles,
 	useBlockProps,
@@ -15,12 +16,15 @@ import {
 	Disabled,
 	SandBox,
 	ToolbarGroup,
+	PanelBody,
+	ToggleControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	const [ isPreview, setIsPreview ] = useState();
 	const isDisabled = useContext( Disabled.Context );
+	const { showPreview } = attributes;
 
 	const styles = useSelect( ( select ) => {
 		// Default styles used to unset some of the styles
@@ -42,6 +46,14 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 		];
 	}, [] );
 
+	useEffect( () => {
+		if ( !! showPreview ) {
+			setIsPreview( true );
+		} else {
+			setIsPreview( false );
+		}
+	}, [ showPreview ] );
+
 	function switchToPreview() {
 		setIsPreview( true );
 	}
@@ -52,6 +64,17 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 
 	return (
 		<div { ...useBlockProps( { className: 'block-library-html__edit' } ) }>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings' ) }>
+					<ToggleControl
+						label={ __( 'Preview by default' ) }
+						checked={ showPreview }
+						onChange={ () =>
+							setAttributes( { showPreview: ! showPreview } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton

--- a/test/integration/fixtures/blocks/core__html.json
+++ b/test/integration/fixtures/blocks/core__html.json
@@ -3,7 +3,8 @@
 		"name": "core/html",
 		"isValid": true,
 		"attributes": {
-			"content": "<h1>Some HTML code</h1>\n<div>This is a div</div>"
+			"content": "<h1>Some HTML code</h1>\n<div>This is a div</div>",
+			"showPreview": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
A new option has been added to HTML block to allow 'preview' mode by default

## What?
fixes: #40913
<!-- In a few words, what is the PR actually doing? -->

## Why?
See the issue.

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
In this PR, a new attribute **showPreview** has been added to **HTMLEdit** component, and then when the state of this attribute changes the html view mode changes accordingly.
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
