### PR TITLE
Scripts: Convert file extension to js in `block.json` during build

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Feature
 
 -   Enable by default code formatting for JSON files in the `format` command ([#40994](https://github.com/WordPress/gutenberg/pull/40994)). You can opt-out of this behavior by providing a custom file matcher, example: `wp-scripts format src/**/*.js`.
+-   Support tsx files in `viewScript`, `script`, `editorScript` ([#41068](https://github.com/WordPress/gutenberg/pull/41068)).
 
 ## 23.0.0 (2022-05-04)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -236,14 +236,24 @@ const config = {
 					context: process.env.WP_SRC_DIRECTORY,
 					noErrorOnMissing: true,
 					transform( content, absoluteFrom ) {
+						const convertExtension = ( path ) => {
+							return path.replace( /\.(j|t)sx?$/, '.js' );
+						};
+
 						if ( basename( absoluteFrom ) === 'block.json' ) {
 							const blockJson = JSON.parse( content.toString() );
 							[ 'viewScript', 'script', 'editorScript' ].forEach(
 								( key ) => {
-									if ( blockJson[ key ] ) {
-										blockJson[ key ] = blockJson[
-											key
-										].replace( /\.(j|t)sx?$/, '.js' );
+									if ( Array.isArray( blockJson[ key ] ) ) {
+										blockJson[ key ] = blockJson[ key ].map(
+											convertExtension
+										);
+									} else if (
+										typeof blockJson[ key ] === 'string'
+									) {
+										blockJson[ key ] = convertExtension(
+											blockJson[ key ]
+										);
 									}
 								}
 							);

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -235,6 +235,24 @@ const config = {
 					from: copyWebpackPatterns,
 					context: process.env.WP_SRC_DIRECTORY,
 					noErrorOnMissing: true,
+					transform( content, absoluteFrom ) {
+						if ( basename( absoluteFrom ) === 'block.json' ) {
+							const blockJson = JSON.parse( content.toString() );
+							[ 'viewScript', 'script', 'editorScript' ].forEach(
+								( key ) => {
+									if ( blockJson[ key ] ) {
+										blockJson[ key ] = blockJson[
+											key
+										].replace( /\.(j|t)sx?$/, '.js' );
+									}
+								}
+							);
+
+							return JSON.stringify( blockJson, null, 2 );
+						}
+
+						return content;
+					},
 				},
 			],
 		} ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Convert the file extensions of viewScript, script, and editScript in block.json to js.

## Why?
If use `editorScript:index.tsx` in block.json, it will build correctly, but register_block_type will not load the script. we will need to convert the value of the `editorScript` to the built file.

## How?
o convert block.json.
Convert block.json using [transform](https://webpack.js.org/plugins/copy-webpack-plugin/#transform)  in CopyWebpackPlugin
