### PR TITLE
Fix: env unit test fails on Windows

### DIFF
--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -59,7 +59,6 @@ describe( 'readConfig', () => {
 			);
 			detectDirectoryType.mockImplementation( () => 'core' );
 			const config = await readConfig( '.wp-env.json' );
-
 			expect( config.env.development.coreSource ).not.toBeNull();
 			expect( config.env.tests.coreSource ).not.toBeNull();
 			expect( config.env.development.pluginSources ).toHaveLength( 0 );
@@ -102,7 +101,6 @@ describe( 'readConfig', () => {
 
 			process.env.WP_ENV_HOME = 'here/is/a/path';
 			const configWith = await readConfig( '.wp-env.json' );
-
 			expect(
 				configWith.workDirectoryPath.includes(
 					`here${ sep }is${ sep }a${ sep }path`

--- a/packages/env/lib/config/test/config.js
+++ b/packages/env/lib/config/test/config.js
@@ -4,7 +4,7 @@
  */
 const { readFile, stat } = require( 'fs' ).promises;
 const os = require( 'os' );
-const { sep, resolve } = require( 'path' );
+const { join, resolve } = require( 'path' );
 
 /**
  * Internal dependencies
@@ -103,7 +103,7 @@ describe( 'readConfig', () => {
 			const configWith = await readConfig( '.wp-env.json' );
 			expect(
 				configWith.workDirectoryPath.includes(
-					`here${ sep }is${ sep }a${ sep }path`
+					join( 'here', 'is', 'a', 'path' )
 				)
 			).toBe( true );
 
@@ -111,7 +111,7 @@ describe( 'readConfig', () => {
 			const configWithout = await readConfig( '.wp-env.json' );
 			expect(
 				configWithout.workDirectoryPath.includes(
-					`here${ sep }is${ sep }a${ sep }path`
+					join( 'here', 'is', 'a', 'path' )
 				)
 			).toBe( false );
 
@@ -132,7 +132,7 @@ describe( 'readConfig', () => {
 			const configWith = await readConfig( '.wp-env.json' );
 			expect(
 				configWith.workDirectoryPath.includes(
-					`here${ sep }is${ sep }a${ sep }path`
+					join( 'here', 'is', 'a', 'path' )
 				)
 			).toBe( true );
 
@@ -140,7 +140,7 @@ describe( 'readConfig', () => {
 			const configWithout = await readConfig( '.wp-env.json' );
 			expect(
 				configWithout.workDirectoryPath.includes(
-					`here${ sep }is${ sep }a${ sep }path`
+					join( 'here', 'is', 'a', 'path' )
 				)
 			).toBe( false );
 
@@ -260,6 +260,7 @@ describe( 'readConfig', () => {
 				)
 			);
 			const config = await readConfig( '.wp-env.json' );
+
 			expect( config.env.development ).toMatchObject( {
 				pluginSources: [
 					{
@@ -682,6 +683,7 @@ describe( 'readConfig', () => {
 			expect( config.env.development.mappings ).toEqual( {
 				test1: {
 					basename: 'test1',
+					// resolve is required to remove drive letters on Windows.
 					path: resolve( '/test1' ),
 					type: 'local',
 				},

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Enable by default code formatting for JSON files in the `format` command ([#40994](https://github.com/WordPress/gutenberg/pull/40994)). You can opt-out of this behavior by providing a custom file matcher, example: `wp-scripts format src/**/*.js`.
 
+### Bug Fixes
+
+-   Fix: env unit test fails on Windows ([#41070](https://github.com/WordPress/gutenberg/pull/41070))
+
 ## 23.0.0 (2022-05-04)
 
 ### Breaking Changes


### PR DESCRIPTION
Part of #39388

## What?

This PR fixes a problem that wp-env unit test fails on Windows OS.
This PR will allow Jest unit tests to be complete correctly on Windows OS.

## Why?

The main cause is that the path separator of the `.wp-json` values read via `readConfig` is backslashes in Windows OS.

```javascript
const config = await readConfig( '.wp-env.json' );
```

The information on this variable is as follows:

<details>
<summary>See variable information</summary>

```
[
	{
	"configDirectoryPath": ".",
	"detectedLocalConfig": true,
	"dockerComposeConfigPath": "C:\\Users\\someusername\\.wp-env\\XXXXXXXXXXXXXXXXXXXXXXXXXXX\\docker-compose.yml",
	"env": {
		"development": {
			"config": {
				"SCRIPT_DEBUG": true,
				"WP_DEBUG": true,
				"WP_ENVIRONMENT_TYPE": "local",
				"WP_HOME": "http://localhost:8888/",
				"WP_PHP_BINARY": "php",
				"WP_SITEURL": "http://localhost:8888/",
				"WP_TESTS_DOMAIN": "http://localhost:8888/",
				"WP_TESTS_EMAIL": "admin@example.org",
				"WP_TESTS_TITLE": "Test Blog"
			},
			"coreSource": {
				"basename": "gutenberg",
				"path": "X:\\path\\to\\\\plugins\\gutenberg",
				"testsPath": "C:\\Users\\someusername\\.wp-env\\XXXXXXXXXXXXXXXXXXXXXXXXXXX\\tests-gutenberg",
				"type": "local"
			},
			"mappings": {},
			"phpVersion": null,
			"pluginSources": [],
			"port": 8888,
			"themeSources": []
		},
		"tests": {
			"config": {
				"SCRIPT_DEBUG": false,
				"WP_DEBUG": false,
				"WP_ENVIRONMENT_TYPE": "local",
				"WP_HOME": "http://localhost:8889/",
				"WP_PHP_BINARY": "php",
				"WP_SITEURL": "http://localhost:8889/",
				"WP_TESTS_DOMAIN": "http://localhost:8889/",
				"WP_TESTS_EMAIL": "admin@example.org",
				"WP_TESTS_TITLE": "Test Blog"
			},
			"coreSource": {
				"basename": "gutenberg",
				"path": "X:\\path\\to\\\\plugins\\gutenberg",
				"testsPath": "C:\\Users\\someusername\\.wp-env\\XXXXXXXXXXXXXXXXXXXXXXXXXXX\\tests-gutenberg",
				"type": "local"
			},
			"mappings": {},
			"phpVersion": null,
			"pluginSources": [],
			"port": 8889,
			"themeSources": []}
		},
		"name": ".",
		"workDirectoryPath": "C:\\Users\\someusername\\.wp-env\\XXXXXXXXXXXXXXXXXXXXXXXXXXX"
	}
]
```

</details>

## How?
I replaced forward slashes with OS delimiter and fixed other OS-dependent problems.

## Testing Instructions

### One test

- Run this test: `npm run test-unit -- ./packages/env/lib/config/test/config.js`
- Confrim that this test passes correctly.

```bash
Test Suites: 1 passed, 1 total
Tests:       41 passed, 41 total
Snapshots:   3 passed, 3 total
Time:        2.609 s
```

### All tests

- Run all tests: `npm run test-unit`
- Confrim that all tests passes correctly.

```bash
Test Suites: 539 passed, 539 total
Tests:       1 skipped, 6217 passed, 6218 total
Snapshots:   327 passed, 327 total
Time:        268.55 s, estimated 917 s
```

If the tests fails, narrow down `maxWorkers` as follows:

```bash
npm run test-unit -- --maxWorkers=2
```