### PR TITLE
Documentation: Update broken links

### DIFF
--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -152,7 +152,7 @@ When you save the post and view it published, you will see the `Hola mundo (from
 
 This shows the most basic static block. The [gutenberg-examples](https://github.com/WordPress/gutenberg-examples) repository has complete examples for both.
 
--   [Basic Example ESNext](https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-jsx/01-basic-esnext)
+-   [Basic Example with JSX build](https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-jsx/01-basic-esnext)
 
 -   [Basic Example Plain JavaScript](https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-non-jsx/01-basic),
 

--- a/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
+++ b/docs/how-to-guides/block-tutorial/writing-your-first-block-type.md
@@ -152,9 +152,9 @@ When you save the post and view it published, you will see the `Hola mundo (from
 
 This shows the most basic static block. The [gutenberg-examples](https://github.com/WordPress/gutenberg-examples) repository has complete examples for both.
 
--   [Basic example with JSX build](https://github.com/WordPress/gutenberg-examples/tree/trunk/01-basic-esnext)
+-   [Basic Example ESNext](https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-jsx/01-basic-esnext)
 
--   [Basic example plain JavaScript](https://github.com/WordPress/gutenberg-examples/tree/trunk/01-basic),
+-   [Basic Example Plain JavaScript](https://github.com/WordPress/gutenberg-examples/tree/trunk/blocks-non-jsx/01-basic),
 
 **NOTE:** The examples include a more complete block setup with translation features included, it is recommended to follow those examples for a production block. The internationalization features were left out of this guide for simplicity and focusing on the very basics of a block.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR updates the broken links as verified in TRAC ticket: https://core.trac.wordpress.org/ticket/55731
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently the links point to a missing GitHub page. This short update corrects the resource links in https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
My implementation addresses the following incorrect links:

Link Title: Basic example with JSX build
Link URL: https://github.com/WordPress/gutenberg-examples/tree/trunk/01-basic-esnext

Link Title: Basic example plain JavaScript
Link URL: https://github.com/WordPress/gutenberg-examples/tree/trunk/01-basic

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->

Open the following page and visit the links shown above 

https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/

<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Screenshots or screencast <!-- if applicable -->
