### PR TITLE
Gallery block: Fix bug with initial image size

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -204,10 +204,11 @@ function GalleryEdit( props ) {
 				: undefined;
 		}
 		return {
-			...pickRelevantMediaFiles( imageAttributes, sizeSlug ),
+			...pickRelevantMediaFiles( image, sizeSlug ),
 			...getHrefAndDestination( image, linkTo ),
 			...getUpdatedLinkTargetSettings( linkTarget, attributes ),
 			className: newClassName,
+			caption: imageAttributes.caption,
 			sizeSlug,
 		};
 	}

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -12,7 +12,8 @@ export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||
-		image.url;
+		image.url ||
+		image.source_url;
 	const fullUrl =
 		get( image, [ 'sizes', 'full', 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', 'full', 'source_url' ] );

--- a/packages/block-library/src/gallery/shared.js
+++ b/packages/block-library/src/gallery/shared.js
@@ -8,7 +8,7 @@ export function defaultColumnsNumber( imageCount ) {
 }
 
 export const pickRelevantMediaFiles = ( image, sizeSlug = 'large' ) => {
-	const imageProps = pick( image, [ 'alt', 'id', 'link', 'caption' ] );
+	const imageProps = pick( image, [ 'alt', 'id', 'link' ] );
 	imageProps.url =
 		get( image, [ 'sizes', sizeSlug, 'url' ] ) ||
 		get( image, [ 'media_details', 'sizes', sizeSlug, 'source_url' ] ) ||


### PR DESCRIPTION
## What?
The default image size slug for a new gallery is `large` so this PR ensures that the correct corresponding image url is used for this slug

## Why?
Currently all new images selected from the media browser default to the full image url instead of the large one.

Fixes: #41072

## How?
Passes the full imageData object to the `pickRelevantMediaFiles` method so the correct image size url can be located.

## Testing Instructions

- Add a Gallery block
- Select some reasonably large images (ones that will have large and full size versions) from the media library browser
- Check that by default the image urls in the image markup is pointing to the large version of the images, and not just the full size url
- Check that uploading new images via upload button, and dragging and dropping new images still works as expected.

## Screenshots or screencast 

Before:

https://user-images.githubusercontent.com/3629020/168511161-1b018782-feb6-480a-9727-8cb903e5be9a.mp4

After:

https://user-images.githubusercontent.com/3629020/168511196-4e56a459-2d70-42bc-b229-658236df49a9.mp4


