### PR TITLE
Query Pagination Blocks: Try adding border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -635,7 +635,7 @@ Displays a paginated navigation to next/previous set of posts, when applicable. 
 
 -	**Name:** core/query-pagination
 -	**Category:** theme
--	**Supports:** align, color (background, gradients, link, text), ~~html~~, ~~reusable~~
+-	**Supports:** align, color (background, gradients, link, text), spacing (blockGap, padding), ~~html~~, ~~reusable~~
 -	**Attributes:** paginationArrow
 
 ## Next Page
@@ -644,7 +644,7 @@ Displays the next posts page link. ([Source](https://github.com/WordPress/gutenb
 
 -	**Name:** core/query-pagination-next
 -	**Category:** theme
--	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), spacing (padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Page Numbers
@@ -653,7 +653,7 @@ Displays a list of page numbers for pagination ([Source](https://github.com/Word
 
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
--	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), spacing (padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** 
 
 ## Previous Page
@@ -662,7 +662,7 @@ Displays the previous posts page link. ([Source](https://github.com/WordPress/gu
 
 -	**Name:** core/query-pagination-previous
 -	**Category:** theme
--	**Supports:** color (background, gradients, ~~text~~), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), spacing (padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Query Title

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -33,6 +33,24 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -28,6 +28,24 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		}
 	},
 	"editorStyle": "query-pagination-numbers-editor"

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -33,6 +33,24 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
 		}
 	}
 }

--- a/packages/block-library/src/query-pagination/block.json
+++ b/packages/block-library/src/query-pagination/block.json
@@ -30,6 +30,13 @@
 				"link": true
 			}
 		},
+		"spacing": {
+			"blockGap": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
+		},
 		"__experimentalLayout": {
 			"allowSwitching": false,
 			"allowInheriting": false,

--- a/packages/block-library/src/query-pagination/editor.scss
+++ b/packages/block-library/src/query-pagination/editor.scss
@@ -13,22 +13,3 @@ $pagination-margin: 0.5em;
 		}
 	}
 }
-
-.wp-block-query-pagination {
-	> .wp-block-query-pagination-next,
-	> .wp-block-query-pagination-previous,
-	> .wp-block-query-pagination-numbers {
-		// Override editor auto block margins.
-		margin-left: 0;
-		margin-top: $pagination-margin;
-
-		/*rtl:ignore*/
-		margin-right: $pagination-margin;
-		margin-bottom: $pagination-margin;
-
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
-	}
-}

--- a/packages/block-library/src/query-pagination/style.scss
+++ b/packages/block-library/src/query-pagination/style.scss
@@ -1,18 +1,5 @@
 $pagination-margin: 0.5em;
 .wp-block-query-pagination {
-	// Increased specificity to override blocks default margin.
-	> .wp-block-query-pagination-next,
-	> .wp-block-query-pagination-previous,
-	> .wp-block-query-pagination-numbers {
-		/*rtl:ignore*/
-		margin-right: $pagination-margin;
-		margin-bottom: $pagination-margin;
-
-		&:last-child {
-			/*rtl:ignore*/
-			margin-right: 0;
-		}
-	}
 	.wp-block-query-pagination-previous-arrow {
 		margin-right: 1ch;
 		display: inline-block; // Needed so that the transform works.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Explore opting in to the following block supports:

* Query Pagination: `blockGap` and `padding`
* Query Pagination Numbers: `border` and `padding`
* Query Pagination Next: `border` and `padding`
* Query Pagination Previous: `border` and `padding`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I saw a pill / group style query pagination pattern on use on a website the other day, and wondered if it'd be possible to build a similar pattern with the query pagination blocks.

It looks like it's possible if we add in to spacing at the root level of query pagination, and border and padding support on each of the children.

***One caveat***: I had to remove the margin styles that are shipped with the pagination block — I _think_ these might not be necessary since the query pagination block now opts-in to the layout support, where it's always given a gap value. Happy for feedback here, on whether or not it's safe to remove!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Opt in to the relevant block supports listed above, remove margin CSS rules that prevented a blockGap of `0` from being applied correctly.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

To build a pattern like in the below screenshot, I did the following:

* Set the block spacing on the parent pagination block to `0`, and justification to center
* Set a border on four sides on the pagination numbers block
* Set a border on top/left/bottom on the query pagination prev block (and radius on only top/left and bottom/left)
* Set a border on top/right/bottom on the query pagination next block (and radius on only top/right and bottom/right)
* Add some padding to the above three blocks, and set the typography size to be the same on all blocks.

<details>
<summary>Block markup for query pagination with blockGap, padding, and borders</summary>

```
<!-- wp:query-pagination {"align":"wide","style":{"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"},"blockGap":"0px"}},"layout":{"type":"flex","justifyContent":"center"}} -->
<!-- wp:query-pagination-previous {"label":"Prev","style":{"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}},"border":{"radius":{"topLeft":"10px","bottomLeft":"10px"},"top":{"width":"1px","radius":{"topLeft":"10px","bottomLeft":"10px"},"color":"var:preset|color|primary"},"bottom":{"width":"1px","radius":{"topLeft":"10px","bottomLeft":"10px"},"color":"var:preset|color|primary"},"left":{"width":"1px","radius":{"topLeft":"10px","bottomLeft":"10px"},"color":"var:preset|color|primary"}}},"backgroundColor":"tertiary","fontSize":"small"} /-->

<!-- wp:query-pagination-numbers {"style":{"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}},"border":{"width":"1px"}},"borderColor":"primary","fontSize":"small"} /-->

<!-- wp:query-pagination-next {"label":"Next","style":{"spacing":{"padding":{"top":"15px","right":"15px","bottom":"15px","left":"15px"}},"border":{"radius":{"topRight":"10px","bottomRight":"10px"},"top":{"radius":{"topRight":"10px","bottomRight":"10px"},"width":"1px","color":"var:preset|color|primary"},"right":{"radius":{"topRight":"10px","bottomRight":"10px"},"width":"1px","color":"var:preset|color|primary"},"bottom":{"radius":{"topRight":"10px","bottomRight":"10px"},"width":"1px","color":"var:preset|color|primary"}}},"backgroundColor":"tertiary","fontSize":"small"} /-->
<!-- /wp:query-pagination -->
```

</details>

## Screenshots or screencast <!-- if applicable -->

<img width="296" alt="image" src="https://user-images.githubusercontent.com/14988353/168526746-f72e6eca-27ae-4dd1-91d3-a74b5afff0c8.png">
