### PR TITLE
Env: Allow skipping setting a configuration value by specifying it as null.

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Enhancement
 -   Removed the need for quotation marks when passing options to `wp-env run`.
+-   Setting a `config` key to `null` will prevent adding the constant to `wp-config.php` even if a default value is defined by `wp-env`.
 
 ## 4.7.0 (2022-05-18)
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -518,6 +518,8 @@ WP_HOME: 'http://localhost',
 
 On the test instance, all of the above are still defined, but `WP_DEBUG` and `SCRIPT_DEBUG` are set to false.
 
+These can be overridden by setting a value within the `config` configuration. Setting it to `null` will prevent the constant being defined entirely.
+
 Additionally, the values referencing a URL include the specified port for the given environment. So if you set `testsPort: 3000, port: 2000`, `WP_HOME` (for example) will be `http://localhost:3000` on the tests instance and `http://localhost:2000` on the development instance.
 
 ### Examples

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -64,6 +64,11 @@ async function configureWordPress( environment, config, spinner ) {
 	for ( let [ key, value ] of Object.entries(
 		config.env[ environment ].config
 	) ) {
+		// Allow the configuration to skip a default constant by specifying it as null.
+		if ( null === value ) {
+			continue;
+		}
+		
 		// Add quotes around string values to work with multi-word strings better.
 		value = typeof value === 'string' ? `"${ value }"` : value;
 		setupCommands.push(

--- a/packages/env/lib/wordpress.js
+++ b/packages/env/lib/wordpress.js
@@ -68,7 +68,7 @@ async function configureWordPress( environment, config, spinner ) {
 		if ( null === value ) {
 			continue;
 		}
-		
+
 		// Add quotes around string values to work with multi-word strings better.
 		value = typeof value === 'string' ? `"${ value }"` : value;
 		setupCommands.push(


### PR DESCRIPTION
Fixes #41083

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows for wp-env to have a config configuration value skipped, if defined as null.

For example, this would result in the `wp-config.php` NOT containing `WP_ENVIRONMENT_TYPE` despite it defaulting to `local` in wp-env.
```
{
	"config": {
		"WP_ENVIRONMENT_TYPE": null
	}
}
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Under some edge-cases, it may be wanted to skip setting a constant, as that makes it difficult to perform unit testing which may vary depending on it's value.

Given this constant is for a function that cannot be filtered, not having a way to avoid it being set results in unit testing pain.

Simply running `wp config delete CONSTANT` cannot be used for unit testing purposes either, due to the special `phpunit-wp-config.php` that is created, which `wp-cli` cannot operate on.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

While there might be real reasons to set a constant to `false` or an empty string, I can't see the need to set one to `null`. Skipping the constant in the case of null seems reasonable to me.

Another possibility is that for null keys, it should be a `wp config delete` command that is run instead. But that seemed like it was solving something that wasn't yet a problem.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a config as exampled above
2. Run wp-env start
3. Inspect configuration files, verify constant not present.

## Screenshots or screencast <!-- if applicable -->
