### PR TITLE
Enable alternative text for site logo block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -735,7 +735,7 @@ Display a graphic to represent this site. Update the block, and the changes appl
 -	**Name:** core/site-logo
 -	**Category:** theme
 -	**Supports:** align, color (~~background~~, ~~text~~), ~~alignWide~~, ~~html~~
--	**Attributes:** alt, isLink, linkTarget, shouldSyncIcon, width
+-	**Attributes:** alt, blockAlt, isLink, linkTarget, shouldSyncIcon, width
 
 ## Site Tagline
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -735,7 +735,7 @@ Display a graphic to represent this site. Update the block, and the changes appl
 -	**Name:** core/site-logo
 -	**Category:** theme
 -	**Supports:** align, color (~~background~~, ~~text~~), ~~alignWide~~, ~~html~~
--	**Attributes:** isLink, linkTarget, shouldSyncIcon, width
+-	**Attributes:** alt, isLink, linkTarget, shouldSyncIcon, width
 
 ## Site Tagline
 

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -14,6 +14,9 @@
 			"attribute": "alt",
 			"default": ""
 		},
+		"blockAlt": {
+			"type": "string"
+		},
 		"width": {
 			"type": "number"
 		},

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -7,6 +7,13 @@
 	"description": "Display a graphic to represent this site. Update the block, and the changes apply everywhere it’s used. This is different than the site icon, which is the smaller image visible in your dashboard, browser tabs, etc used to help others recognize this site.",
 	"textdomain": "default",
 	"attributes": {
+		"alt": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "img",
+			"attribute": "alt",
+			"default": ""
+		},
 		"width": {
 			"type": "number"
 		},

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -14,7 +14,7 @@ import {
 	useState,
 	useRef,
 } from '@wordpress/element';
-import { __, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import {
 	ExternalLink,
 	MenuItem,
@@ -54,16 +54,15 @@ import useClientWidth from '../image/use-client-width';
  * Module constants
  */
 import { MIN_SIZE } from '../image/constants';
-import { getFilename } from '@wordpress/url';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const ACCEPT_MEDIA_STRING = 'image/*';
 
 const SiteLogo = ( {
+	alt,
 	attributes: {
-		url = '',
+		blockAlt,
 		align,
-		alt,
 		width,
 		height,
 		isLink,
@@ -127,22 +126,13 @@ const SiteLogo = ( {
 	}
 
 	function updateAlt( newAlt ) {
-		setAttributes( { alt: newAlt } );
+		setAttributes( { blockAlt: newAlt } );
 	}
 
-	const filename = getFilename( url );
-	let defaultAlt;
+	let defaultAlt = alt;
 
-	if ( alt ) {
-		defaultAlt = alt;
-	} else if ( filename ) {
-		defaultAlt = sprintf(
-			/* translators: %s: file name */
-			__( 'This image has an empty alt attribute; its file name is %s' ),
-			filename
-		);
-	} else {
-		defaultAlt = __( 'This image has an empty alt attribute' );
+	if ( blockAlt ) {
+		defaultAlt = blockAlt;
 	}
 
 	const img = (
@@ -323,7 +313,7 @@ const SiteLogo = ( {
 				<PanelBody title={ __( 'Settings' ) }>
 					<TextareaControl
 						label={ __( 'Alt text (alternative text)' ) }
-						value={ alt }
+						value={ defaultAlt }
 						onChange={ updateAlt }
 						help={
 							<>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -131,25 +131,25 @@ const SiteLogo = ( {
 	}
 
 	const filename = getFilename( url );
-	let defaultedAlt;
+	let defaultAlt;
 
 	if ( alt ) {
-		defaultedAlt = alt;
+		defaultAlt = alt;
 	} else if ( filename ) {
-		defaultedAlt = sprintf(
+		defaultAlt = sprintf(
 			/* translators: %s: file name */
 			__( 'This image has an empty alt attribute; its file name is %s' ),
 			filename
 		);
 	} else {
-		defaultedAlt = __( 'This image has an empty alt attribute' );
+		defaultAlt = __( 'This image has an empty alt attribute' );
 	}
 
 	const img = (
 		<img
 			className="custom-logo"
 			src={ logoUrl }
-			alt={ defaultedAlt }
+			alt={ defaultAlt }
 			onLoad={ ( event ) => {
 				setNaturalSize(
 					pick( event.target, [ 'naturalWidth', 'naturalHeight' ] )

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -14,13 +14,15 @@ import {
 	useState,
 	useRef,
 } from '@wordpress/element';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
+	ExternalLink,
 	MenuItem,
 	PanelBody,
 	RangeControl,
 	ResizableBox,
 	Spinner,
+	TextareaControl,
 	ToggleControl,
 	ToolbarButton,
 	Placeholder,
@@ -52,13 +54,22 @@ import useClientWidth from '../image/use-client-width';
  * Module constants
  */
 import { MIN_SIZE } from '../image/constants';
+import { getFilename } from '@wordpress/url';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 const ACCEPT_MEDIA_STRING = 'image/*';
 
 const SiteLogo = ( {
-	alt,
-	attributes: { align, width, height, isLink, linkTarget, shouldSyncIcon },
+	attributes: {
+		url = '',
+		align,
+		alt,
+		width,
+		height,
+		isLink,
+		linkTarget,
+		shouldSyncIcon,
+	},
 	containerRef,
 	isSelected,
 	setAttributes,
@@ -115,11 +126,30 @@ const SiteLogo = ( {
 		toggleSelection( true );
 	}
 
+	function updateAlt( newAlt ) {
+		setAttributes( { alt: newAlt } );
+	}
+
+	const filename = getFilename( url );
+	let defaultedAlt;
+
+	if ( alt ) {
+		defaultedAlt = alt;
+	} else if ( filename ) {
+		defaultedAlt = sprintf(
+			/* translators: %s: file name */
+			__( 'This image has an empty alt attribute; its file name is %s' ),
+			filename
+		);
+	} else {
+		defaultedAlt = __( 'This image has an empty alt attribute' );
+	}
+
 	const img = (
 		<img
 			className="custom-logo"
 			src={ logoUrl }
-			alt={ alt }
+			alt={ defaultedAlt }
 			onLoad={ ( event ) => {
 				setNaturalSize(
 					pick( event.target, [ 'naturalWidth', 'naturalHeight' ] )
@@ -291,6 +321,23 @@ const SiteLogo = ( {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
+					<TextareaControl
+						label={ __( 'Alt text (alternative text)' ) }
+						value={ alt }
+						onChange={ updateAlt }
+						help={
+							<>
+								<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+									{ __(
+										'Describe the purpose of the image'
+									) }
+								</ExternalLink>
+								{ __(
+									'Leave empty if the image is purely decorative.'
+								) }
+							</>
+						}
+					/>
 					<RangeControl
 						label={ __( 'Image width' ) }
 						onChange={ ( newWidth ) =>


### PR DESCRIPTION
Fixes #37104.

## What?
This PR enables alternative text for site logo block.

## Why?
The site logo alternative text can be edited from the media library, but there were no possibility to do that inside the editor.

## How?
The PR adds a new `TextareaControl` field to the side logo sidebar with the alternative text attribute.

## Testing Instructions
1. Add the site logo block in the editor: they should be a new field for the alternative text (it should contain the current alt text for the site logo)
2. Edit the alternative text field: check if it has changed on the frontend and in the media library
