### PR TITLE
Code Editor: Don't commit 'non-dirty' changes

### DIFF
--- a/packages/editor/src/components/post-text-editor/index.js
+++ b/packages/editor/src/components/post-text-editor/index.js
@@ -51,6 +51,7 @@ export default function PostTextEditor() {
 		editPost( { content: newValue } );
 		setValue( newValue );
 		setIsDirty( true );
+		valueRef.current = newValue;
 	};
 
 	/**
@@ -66,15 +67,13 @@ export default function PostTextEditor() {
 		}
 	};
 
-	useEffect( () => {
-		valueRef.current = value;
-	}, [ value ] );
-
 	// Ensure changes aren't lost when component unmounts.
 	useEffect( () => {
 		return () => {
-			const blocks = parse( valueRef.current );
-			resetEditorBlocks( blocks );
+			if ( valueRef.current ) {
+				const blocks = parse( valueRef.current );
+				resetEditorBlocks( blocks );
+			}
 		};
 	}, [] );
 


### PR DESCRIPTION
## What?
The follow-up to #40730.

The PR contains minor code quality improvements:

* The `onChange` callback updates the latest value ref.
* Check for the dirty state before committing changes. This prevents the editor's dirty state when just toggling between modes.

P.S. New proposed [`useEvent` hook](https://github.com/reactjs/rfcs/pull/220) will be helpful in similar scenarios.

## Testing Instructions
1. Create a new post or page.
2. Switch to Code view (on PC, Ctrl + Shift + Alt + M).
3. Start typing in the post content area.
4. Use the keyboard shortcut again to exit the Code view.
5. Confirm that new content is available in Visual Editor.
