### PR TITLE
Layout: Add default fallback gap value in block.json, and set to 2em for Columns blocks

### DIFF
--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -33,10 +33,11 @@ function gutenberg_register_layout_support( $block_type ) {
  * @param boolean $has_block_gap_support         Whether the theme has support for the block gap.
  * @param string  $gap_value                     The block gap value to apply.
  * @param boolean $should_skip_gap_serialization Whether to skip applying the user-defined value set in the editor.
+ * @param string  $fallback_gap_value            The block gap value to apply.
  *
  * @return string                                CSS style.
  */
-function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false ) {
+function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support = false, $gap_value = null, $should_skip_gap_serialization = false, $fallback_gap_value = '0.5em' ) {
 	$layout_type = isset( $layout['type'] ) ? $layout['type'] : 'default';
 
 	$style = '';
@@ -102,14 +103,14 @@ function gutenberg_get_layout_style( $selector, $layout, $has_block_gap_support 
 		$style .= 'display: flex;';
 		if ( $has_block_gap_support ) {
 			if ( is_array( $gap_value ) ) {
-				$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : '0.5em';
-				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
+				$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : $fallback_gap_value;
+				$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : $fallback_gap_value;
 				$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 			}
-			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : 'var( --wp--style--block-gap, 0.5em )';
+			$gap_style = $gap_value && ! $should_skip_gap_serialization ? $gap_value : "var( --wp--style--block-gap, $fallback_gap_value )";
 			$style    .= "gap: $gap_style;";
 		} else {
-			$style .= 'gap: 0.5em;';
+			$style .= "gap: $fallback_gap_value;";
 		}
 
 		$style .= "flex-wrap: $flex_wrap;";
@@ -184,10 +185,12 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 	}
 
+	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', '__experimentalDefaultValues', 'blockGap' ), '0.5em' );
+
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.
 	$should_skip_gap_serialization = gutenberg_should_skip_block_supports_serialization( $block_type, 'spacing', 'blockGap' );
-	$style                         = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization );
+	$style                         = gutenberg_get_layout_style( ".$class_name", $used_layout, $has_block_gap_support, $gap_value, $should_skip_gap_serialization, $fallback_gap_value );
 	// This assumes the hook only applies to blocks with a single wrapper.
 	// I think this is a reasonable limitation for that particular hook.
 	$content = preg_replace(

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -185,7 +185,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 	}
 
-	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', 'default' ), '0.5em' );
+	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', '__experimentalDefault' ), '0.5em' );
 
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -185,7 +185,7 @@ function gutenberg_render_layout_support_flag( $block_content, $block ) {
 		$gap_value = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap_value ) ? null : $gap_value;
 	}
 
-	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', '__experimentalDefaultValues', 'blockGap' ), '0.5em' );
+	$fallback_gap_value = _wp_array_get( $block_type->supports, array( 'spacing', 'blockGap', 'default' ), '0.5em' );
 
 	// If a block's block.json skips serialization for spacing or spacing.blockGap,
 	// don't apply the user-defined value to the styles.

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -172,10 +172,12 @@ export function useCustomSides( blockName, feature ) {
 		return;
 	}
 
+	// Return if the setting is an array of sides (e.g. `[ 'top', 'bottom' ]`).
 	if ( Array.isArray( support[ feature ] ) ) {
 		return support[ feature ];
 	}
 
+	// Finally, attempt to return `.sides` if the setting is an object.
 	if ( support[ feature ]?.sides ) {
 		return support[ feature ].sides;
 	}

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -162,7 +162,7 @@ const useIsDimensionsDisabled = ( props = {} ) => {
  * @param {string} blockName Block name.
  * @param {string} feature   The feature custom sides relate to e.g. padding or margins.
  *
- * @return {Object} Sides supporting custom margin.
+ * @return {string[]} Sides supporting custom margin.
  */
 export function useCustomSides( blockName, feature ) {
 	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );
@@ -172,7 +172,13 @@ export function useCustomSides( blockName, feature ) {
 		return;
 	}
 
-	return support[ feature ];
+	if ( Array.isArray( support[ feature ] ) ) {
+		return support[ feature ];
+	}
+
+	if ( support[ feature ]?.sides ) {
+		return support[ feature ].sides;
+	}
 }
 
 /**

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -153,7 +153,7 @@ const useIsDimensionsDisabled = ( props = {} ) => {
 };
 
 /**
- * Custom hook to retrieve which padding/margin is supported
+ * Custom hook to retrieve which padding/margin/blockGap is supported
  * e.g. top, right, bottom or left.
  *
  * Sides are opted into by default. It is only if a specific side is set to
@@ -162,7 +162,7 @@ const useIsDimensionsDisabled = ( props = {} ) => {
  * @param {string} blockName Block name.
  * @param {string} feature   The feature custom sides relate to e.g. padding or margins.
  *
- * @return {string[]} Sides supporting custom margin.
+ * @return {?string[]} Strings representing the custom sides available.
  */
 export function useCustomSides( blockName, feature ) {
 	const support = getBlockSupport( blockName, SPACING_SUPPORT_KEY );

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -11,6 +11,7 @@ import {
 	arrowDown,
 } from '@wordpress/icons';
 import { Button, ToggleControl, Flex, FlexItem } from '@wordpress/components';
+import { getBlockSupport } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -109,14 +110,21 @@ export default {
 	save: function FlexLayoutStyle( { selector, layout, style, blockName } ) {
 		const { orientation = 'horizontal' } = layout;
 		const blockGapSupport = useSetting( 'spacing.blockGap' );
+		const fallbackValue =
+			getBlockSupport( blockName, [
+				'spacing',
+				'__experimentalDefaultValues',
+				'blockGap',
+			] ) || '0.5em';
+
 		const hasBlockGapStylesSupport = blockGapSupport !== null;
 		// If a block's block.json skips serialization for spacing or spacing.blockGap,
 		// don't apply the user-defined value to the styles.
 		const blockGapValue =
 			style?.spacing?.blockGap &&
 			! shouldSkipSerialization( blockName, 'spacing', 'blockGap' )
-				? getGapCSSValue( style?.spacing?.blockGap, '0.5em' )
-				: 'var( --wp--style--block-gap, 0.5em )';
+				? getGapCSSValue( style?.spacing?.blockGap, fallbackValue )
+				: `var( --wp--style--block-gap, ${ fallbackValue } )`;
 		const justifyContent =
 			justifyContentMap[ layout.justifyContent ] ||
 			justifyContentMap.left;
@@ -143,7 +151,7 @@ export default {
 				${ appendSelectors( selector ) } {
 					display: flex;
 					flex-wrap: ${ flexWrap };
-					gap: ${ hasBlockGapStylesSupport ? blockGapValue : '0.5em' };
+					gap: ${ hasBlockGapStylesSupport ? blockGapValue : fallbackValue };
 					${ orientation === 'horizontal' ? rowOrientation : columnOrientation }
 				}
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -113,8 +113,8 @@ export default {
 		const fallbackValue =
 			getBlockSupport( blockName, [
 				'spacing',
-				'__experimentalDefaultValues',
 				'blockGap',
+				'default',
 			] ) || '0.5em';
 
 		const hasBlockGapStylesSupport = blockGapSupport !== null;

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -114,7 +114,7 @@ export default {
 			getBlockSupport( blockName, [
 				'spacing',
 				'blockGap',
-				'default',
+				'__experimentalDefault',
 			] ) || '0.5em';
 
 		const hasBlockGapStylesSupport = blockGapSupport !== null;

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -29,7 +29,7 @@
 		},
 		"spacing": {
 			"blockGap": {
-				"default": "2em"
+				"__experimentalDefault": "2em"
 			},
 			"margin": [ "top", "bottom" ],
 			"padding": true,

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -28,14 +28,13 @@
 			}
 		},
 		"spacing": {
-			"blockGap": true,
+			"blockGap": {
+				"default": "2em"
+			},
 			"margin": [ "top", "bottom" ],
 			"padding": true,
 			"__experimentalDefaultControls": {
 				"padding": true
-			},
-			"__experimentalDefaultValues": {
-				"blockGap": "2em"
 			}
 		},
 		"__experimentalLayout": {

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -33,6 +33,9 @@
 			"padding": true,
 			"__experimentalDefaultControls": {
 				"padding": true
+			},
+			"__experimentalDefaultValues": {
+				"blockGap": "2em"
 			}
 		},
 		"__experimentalLayout": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an exploration into a potential fix for the gap regression in https://github.com/WordPress/gutenberg/issues/40952 (it doesn't address the tablet breakpoint change raised in that issue).

In this PR we look at:

* Adding a setting in `block.json` where blocks can declaratively provide a default fallback value for properties of the spacing block support. This PR only implements support for the `blockGap` property.
* In the Layout block support, look up the block's definition, and see if it provides its own fallback value for blockGap, and use it if available.
* For the Columns block we set the default fallback blockGap value to `2em` to be consistent with backwards compatibility.
* If no default value is provided we use the fallback value of `0.5em`.

The idea here is that this new fallback value isn't in `theme.json` because it's a part of the _block_'s styles — not the theme's, and is intended to form part of the base styling of the block, upon which themes can make their own changes.

Kudos @ramonjd for collaborating on the idea in this PR!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #40952 it was flagged that the Columns block used to have a default gap value of `2em`. This PR explores seeing whether we can declaratively set the fallback value for blocks in their `block.json` file — outside of the concept of theming. The gap of `2em` was originally removed in https://github.com/WordPress/gutenberg/pull/37436 when the Columns block was updated to opt-in to the Layout block support — it's the Layout block support that provides the default value of `0.5em`, so this PR gives the Layout support a little more power to look up and output a fallback value that is suitable for the block being rendered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add a `default` prop to the features of the `spacing` object in `block.json` to specify a default fallback value. E.g. `spacing.blockGap.default`.
* Add a default value of `2em` to the Columns block, with a default fallback of `0.5em`.
* Use this default value in the Layout block support.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. Using a classic theme like TwentyTwentyOne, add a columns block to a post or page.
2. Notice that prior to this PR, the gap between columns is `0.5em`. With this PR applied it should be `2em` in both the editor and on the front end of the site.
3. Using a blocks-based theme, check that the block spacing support still functions as expected (E.g. you can set a block spacing value in the post editor when editing a columns block). Note that block-level block spacing in global styles / theme.json is not yet supported, but the issue is raised in https://github.com/WordPress/gutenberg/issues/39789

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/14988353/168740789-a8d72fb4-bcd9-4bb9-970c-aa6b1c83d7ed.png) | ![image](https://user-images.githubusercontent.com/14988353/168740805-27ab58df-25b4-421c-bf79-67ae47387f7b.png) |