### PR TITLE
FlatTermSelector: Avoid errors when returned terms aren't iterable

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -177,7 +177,7 @@ function FlatTermSelector( { slug } ) {
 	// while core data makes REST API requests.
 	useEffect( () => {
 		if ( hasResolvedTerms ) {
-			const newValues = terms.map( ( term ) =>
+			const newValues = ( terms ?? [] ).map( ( term ) =>
 				unescapeString( term.name )
 			);
 
@@ -202,7 +202,10 @@ function FlatTermSelector( { slug } ) {
 	}
 
 	function onChange( termNames ) {
-		const availableTerms = [ ...terms, ...( searchResults ?? [] ) ];
+		const availableTerms = [
+			...( terms ?? [] ),
+			...( searchResults ?? [] ),
+		];
 		const uniqueTerms = uniqBy( termNames, ( term ) => term.toLowerCase() );
 		const newTermNames = uniqueTerms.filter(
 			( termName ) =>


### PR DESCRIPTION
## What?
Resolves #41095.

PR fixes JS error when `getEntityRecords` resolves to `null` for the terms. It happens when the endpoint returns `404`.

## Why?
The code treated `terms` as iterable without checking for `null` values.

## How?
PR adds checks before mapping or spreading the `terms` variable. There's a similar guard for search results.

## Testing Instructions
1. Open a Post.
2. Add Tags to a post and save the post.
3. Emulate 404 server response using the snippet below.
4. Refresh the Post page.
5. Confirm that editor doesn't crash, and the console only displays errors for failed HTTP requests.

```php
add_filter( 'rest_post_dispatch', function( $response, $server, $request ) {
	if ( $request->get_route() === '/wp/v2/tags' ) {
		$response->set_data( null );
		$response->set_status( 404 );
	}

	return $response;
}, 10, 3 );
```
