### PR TITLE
[Block Library - Query Loop]: Move sticky control to separate file

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -27,6 +27,7 @@ import OrderControl from './order-control';
 import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import TaxonomyControls from './taxonomy-controls';
+import StickyControl from './sticky-control';
 import { usePostTypes } from '../../utils';
 
 function useIsPostTypeHierarchical( postType ) {
@@ -38,12 +39,6 @@ function useIsPostTypeHierarchical( postType ) {
 		[ postType ]
 	);
 }
-
-const stickyOptions = [
-	{ label: __( 'Include' ), value: '' },
-	{ label: __( 'Exclude' ), value: 'exclude' },
-	{ label: __( 'Only' ), value: 'only' },
-];
 
 export default function QueryInspectorControls( {
 	attributes: { query, displayLayout },
@@ -153,14 +148,9 @@ export default function QueryInspectorControls( {
 					/>
 				) }
 				{ showSticky && (
-					<SelectControl
-						label={ __( 'Sticky posts' ) }
-						options={ stickyOptions }
+					<StickyControl
 						value={ sticky }
 						onChange={ ( value ) => setQuery( { sticky: value } ) }
-						help={ __(
-							'Blog posts can be "stickied", a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
-						) }
 					/>
 				) }
 			</PanelBody>

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const stickyOptions = [
+	{ label: __( 'Include' ), value: '' },
+	{ label: __( 'Exclude' ), value: 'exclude' },
+	{ label: __( 'Only' ), value: 'only' },
+];
+
+export default function StickyControl( { value, onChange } ) {
+	return (
+		<SelectControl
+			label={ __( 'Sticky posts' ) }
+			options={ stickyOptions }
+			value={ value }
+			onChange={ onChange }
+			help={ __(
+				'Blog posts can be "stickied", a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
+			) }
+		/>
+	);
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR just moves the sticky control of Query Loop block to a separate file. Due to the many existent filters for this block and more to come, I intent to move the rest of them  too, but in separate PRs to be easily tested. 

## Testing Instructions
1. In a Query Loop block make sure that everything works and is shown as before regarding the `sticky` options in Inspector controls.
