### PR TITLE
Cover: Move overlay and opacity controls to color panel

### DIFF
--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -51,6 +51,7 @@ export { default as __experimentalTextTransformControl } from './text-transform-
 export { default as __experimentalColorGradientControl } from './colors-gradients/control';
 export { default as __experimentalColorGradientSettingsDropdown } from './colors-gradients/dropdown';
 export { default as __experimentalPanelColorGradientSettings } from './colors-gradients/panel-color-gradient-settings';
+export { default as __experimentalUseMultipleOriginColorsAndGradients } from './colors-gradients/use-multiple-origin-colors-and-gradients';
 export {
 	default as __experimentalImageEditor,
 	ImageEditingProvider as __experimentalImageEditingProvider,

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -21,8 +21,9 @@ import { useInstanceId } from '@wordpress/compose';
 import {
 	InspectorControls,
 	useSetting,
+	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseGradient,
-	__experimentalPanelColorGradientSettings as PanelColorGradientSettings,
+	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -138,6 +139,9 @@ export default function CoverInspectorControls( {
 			: [ coverRef.current.style, 'backgroundPosition' ];
 		styleOfRef[ property ] = mediaPosition( value );
 	};
+
+	const colorGradientSettings = useMultipleOriginColorsAndGradients();
+
 	return (
 		<>
 			<InspectorControls>
@@ -220,20 +224,47 @@ export default function CoverInspectorControls( {
 						</PanelRow>
 					</PanelBody>
 				) }
-				<PanelColorGradientSettings
+			</InspectorControls>
+			<InspectorControls __experimentalGroup="color">
+				<ColorGradientSettingsDropdown
 					__experimentalHasMultipleOrigins
+					__experimentalIsItemGroup={ false }
 					__experimentalIsRenderedInSidebar
-					title={ __( 'Overlay' ) }
-					initialOpen={ true }
 					settings={ [
 						{
 							colorValue: overlayColor.color,
 							gradientValue,
+							label: __( 'Overlay' ),
 							onColorChange: setOverlayColor,
 							onGradientChange: setGradient,
-							label: __( 'Color' ),
+							isShownByDefault: true,
+							hasValue: () =>
+								!! overlayColor.color || !! gradientValue,
+							onDeselect: () => {
+								setOverlayColor( undefined );
+								setGradient( undefined );
+							},
+							resetAllFilter: () => ( {
+								overlayColor: undefined,
+								customOverlayColor: undefined,
+								gradient: undefined,
+								customGradient: undefined,
+							} ),
 						},
 					] }
+					panelId={ clientId }
+					enableAlpha={ true }
+					{ ...colorGradientSettings }
+				/>
+				<ToolsPanelItem
+					hasValue={ () => !! dimRatio }
+					label={ __( 'Opacity' ) }
+					onDeselect={ () =>
+						setAttributes( { dimRatio: undefined } )
+					}
+					resetAllFilter={ () => ( { dimRatio: undefined } ) }
+					isShownByDefault={ true }
+					panelId={ clientId }
 				>
 					<RangeControl
 						label={ __( 'Opacity' ) }
@@ -248,7 +279,7 @@ export default function CoverInspectorControls( {
 						step={ 10 }
 						required
 					/>
-				</PanelColorGradientSettings>
+				</ToolsPanelItem>
 			</InspectorControls>
 			<InspectorControls __experimentalGroup="dimensions">
 				<ToolsPanelItem

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -228,7 +228,6 @@ export default function CoverInspectorControls( {
 			<InspectorControls __experimentalGroup="color">
 				<ColorGradientSettingsDropdown
 					__experimentalHasMultipleOrigins
-					__experimentalIsItemGroup={ false }
 					__experimentalIsRenderedInSidebar
 					settings={ [
 						{
@@ -238,12 +237,6 @@ export default function CoverInspectorControls( {
 							onColorChange: setOverlayColor,
 							onGradientChange: setGradient,
 							isShownByDefault: true,
-							hasValue: () =>
-								!! overlayColor.color || !! gradientValue,
-							onDeselect: () => {
-								setOverlayColor( undefined );
-								setGradient( undefined );
-							},
 							resetAllFilter: () => ( {
 								overlayColor: undefined,
 								customOverlayColor: undefined,
@@ -263,7 +256,7 @@ export default function CoverInspectorControls( {
 						setAttributes( { dimRatio: undefined } )
 					}
 					resetAllFilter={ () => ( { dimRatio: undefined } ) }
-					isShownByDefault={ true }
+					isShownByDefault
 					panelId={ clientId }
 				>
 					<RangeControl

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -246,7 +246,6 @@ export default function CoverInspectorControls( {
 						},
 					] }
 					panelId={ clientId }
-					enableAlpha={ true }
 					{ ...colorGradientSettings }
 				/>
 				<ToolsPanelItem

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -251,7 +251,7 @@ export default function CoverInspectorControls( {
 				/>
 				<ToolsPanelItem
 					hasValue={ () => !! dimRatio }
-					label={ __( 'Opacity' ) }
+					label={ __( 'Overlay opacity' ) }
 					onDeselect={ () =>
 						setAttributes( { dimRatio: undefined } )
 					}
@@ -260,7 +260,7 @@ export default function CoverInspectorControls( {
 					panelId={ clientId }
 				>
 					<RangeControl
-						label={ __( 'Opacity' ) }
+						label={ __( 'Overlay opacity' ) }
 						value={ dimRatio }
 						onChange={ ( newDimRation ) =>
 							setAttributes( {

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -250,12 +250,20 @@ export default function CoverInspectorControls( {
 					{ ...colorGradientSettings }
 				/>
 				<ToolsPanelItem
-					hasValue={ () => !! dimRatio }
+					hasValue={ () => {
+						// If there's a media background the dimRatio will be
+						// defaulted to 50 whereas it will be 100 for colors.
+						return dimRatio === undefined
+							? false
+							: dimRatio !== ( url ? 50 : 100 );
+					} }
 					label={ __( 'Overlay opacity' ) }
 					onDeselect={ () =>
-						setAttributes( { dimRatio: undefined } )
+						setAttributes( { dimRatio: url ? 50 : 100 } )
 					}
-					resetAllFilter={ () => ( { dimRatio: undefined } ) }
+					resetAllFilter={ () => ( {
+						dimRatio: url ? 50 : 100,
+					} ) }
 					isShownByDefault
 					panelId={ clientId }
 				>

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -98,3 +98,7 @@
 .block-editor-block-patterns-list__list-item .has-parallax.wp-block-cover {
 	background-attachment: scroll;
 }
+
+.color-block-support-panel__inner-wrapper > :not(.block-editor-tools-panel-color-gradient-settings__item) {
+	margin-top: $grid-unit-30;
+}


### PR DESCRIPTION
Related:

- https://github.com/WordPress/gutenberg/pull/40084

Depends on:

- https://github.com/WordPress/gutenberg/pull/41091

## What?

Moves the Cover block's overlay color and opacity controls into the inspector controls sidebar's Color panel.

## Why?

Makes the Cover block's color-related controls appear under the same panel most blocks' do for consistency.

## How?

Renders the Cover block's color-related controls via the grouped inspector controls slot so they are rendered alongside any color block supports and under the Color panel in the sidebar.

## Testing Instructions

1. Edit a post, add a cover block, and select it
2. Make sure that the Cover block's overlay color and opacity controls behave as expected
3. Test that the overlay and opacity controls can be reset via the Color panel's menu

## Screenshots or screencast

<img width="1037" alt="Screen Shot 2022-05-17 at 5 37 56 pm" src="https://user-images.githubusercontent.com/60436221/168756164-6a852532-34e9-4124-a3c5-9019a7f61012.png">

