### PR TITLE
Move the visible blocks state to the block editor store

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -976,6 +976,19 @@ _Returns_
 
 -   `boolean`: Is Valid.
 
+### isBlockVisible
+
+Tells if the block is visible on the canvas or not.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+-   _clientId_ `Object`: Client Id of the block.
+
+_Returns_
+
+-   `boolean`: True if the block is visible.
+
 ### isBlockWithinSelection
 
 Returns true if the block corresponding to the specified client ID is
@@ -1455,6 +1468,15 @@ Action that enables or disables the block moving mode.
 _Parameters_
 
 -   _hasBlockMovingClientId_ `string|null`: Enable/Disable block moving mode.
+
+### setBlockVisibility
+
+Action that sets whether a block has controlled inner blocks.
+
+_Parameters_
+
+-   _clientId_ `string`: The block's clientId.
+-   _isVisible_ `boolean`: True if the block's is visible on the canvas.
 
 ### setHasControlledInnerBlocks
 

--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1475,8 +1475,7 @@ Action that sets whether a block has controlled inner blocks.
 
 _Parameters_
 
--   _clientId_ `string`: The block's clientId.
--   _isVisible_ `boolean`: True if the block's is visible on the canvas.
+-   _updates_ `Record<string,boolean>`: The block's clientId.
 
 ### setHasControlledInnerBlocks
 

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -115,17 +115,17 @@ function Items( {
 	__experimentalAppenderTagName,
 	__experimentalLayout: layout = defaultLayout,
 } ) {
-	const { order, selectedBlocks, hiddenBlocks } = useSelect(
+	const { order, selectedBlocks, visibleBlocks } = useSelect(
 		( select ) => {
 			const {
 				getBlockOrder,
 				getSelectedBlockClientIds,
-				__unstableGetHiddenBlocks,
+				__unstableGetVisibleBlocks,
 			} = select( blockEditorStore );
 			return {
 				order: getBlockOrder( rootClientId ),
 				selectedBlocks: getSelectedBlockClientIds(),
-				hiddenBlocks: __unstableGetHiddenBlocks(),
+				visibleBlocks: __unstableGetVisibleBlocks(),
 			};
 		},
 		[ rootClientId ]
@@ -139,7 +139,7 @@ function Items( {
 					value={
 						// Only provide data asynchronously if the block is
 						// not visible and not selected.
-						hiddenBlocks.has( clientId ) &&
+						! visibleBlocks.has( clientId ) &&
 						! selectedBlocks.includes( clientId )
 					}
 				>

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -6,12 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import {
-	AsyncModeProvider,
-	useSelect,
-	useDispatch,
-	useRegistry,
-} from '@wordpress/data';
+import { AsyncModeProvider, useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch, useMergeRefs } from '@wordpress/compose';
 import { createContext, useState, useMemo } from '@wordpress/element';
 
@@ -53,7 +48,6 @@ function Root( { className, ...settings } ) {
 		},
 		[]
 	);
-	const registry = useRegistry();
 	const { setBlockVisibility } = useDispatch( blockEditorStore );
 	const intersectionObserver = useMemo( () => {
 		const { IntersectionObserver: Observer } = window;
@@ -63,12 +57,12 @@ function Root( { className, ...settings } ) {
 		}
 
 		return new Observer( ( entries ) => {
-			registry.batch( () => {
-				for ( const entry of entries ) {
-					const clientId = entry.target.getAttribute( 'data-block' );
-					setBlockVisibility( clientId, entry.isIntersecting );
-				}
-			} );
+			const updates = {};
+			for ( const entry of entries ) {
+				const clientId = entry.target.getAttribute( 'data-block' );
+				updates[ clientId ] = entry.isIntersecting;
+			}
+			setBlockVisibility( updates );
 		} );
 	}, [] );
 	const innerBlocksProps = useInnerBlocksProps(

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -28,11 +28,13 @@ function BlockPopoverInbetween( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { orientation, rootClientId } = useSelect(
+	const { orientation, rootClientId, isVisible } = useSelect(
 		( select ) => {
-			const { getBlockListSettings, getBlockRootClientId } = select(
-				blockEditorStore
-			);
+			const {
+				getBlockListSettings,
+				getBlockRootClientId,
+				isBlockVisible,
+			} = select( blockEditorStore );
 
 			const _rootClientId = getBlockRootClientId( previousClientId );
 			return {
@@ -40,6 +42,9 @@ function BlockPopoverInbetween( {
 					getBlockListSettings( _rootClientId )?.orientation ||
 					'vertical',
 				rootClientId: _rootClientId,
+				isVisible:
+					isBlockVisible( previousClientId ) &&
+					isBlockVisible( nextClientId ),
 			};
 		},
 		[ previousClientId ]
@@ -48,7 +53,7 @@ function BlockPopoverInbetween( {
 	const nextElement = useBlockElement( nextClientId );
 	const isVertical = orientation === 'vertical';
 	const style = useMemo( () => {
-		if ( ! previousElement && ! nextElement ) {
+		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
 			return {};
 		}
 
@@ -87,7 +92,7 @@ function BlockPopoverInbetween( {
 	}, [ previousElement, nextElement, isVertical ] );
 
 	const getAnchorRect = useCallback( () => {
-		if ( ! previousElement && ! nextElement ) {
+		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
 			return {};
 		}
 
@@ -141,7 +146,7 @@ function BlockPopoverInbetween( {
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 
-	if ( ! previousElement || ! nextElement ) {
+	if ( ! previousElement || ! nextElement || ! isVisible ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1607,13 +1607,11 @@ export function setHasControlledInnerBlocks(
 /**
  * Action that sets whether a block has controlled inner blocks.
  *
- * @param {string}  clientId  The block's clientId.
- * @param {boolean} isVisible True if the block's is visible on the canvas.
+ * @param {Record<string,boolean>} updates The block's clientId.
  */
-export function setBlockVisibility( clientId, isVisible ) {
+export function setBlockVisibility( updates ) {
 	return {
 		type: 'SET_BLOCK_VISIBILITY',
-		isVisible,
-		clientId,
+		updates,
 	};
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1603,3 +1603,17 @@ export function setHasControlledInnerBlocks(
 		clientId,
 	};
 }
+
+/**
+ * Action that sets whether a block has controlled inner blocks.
+ *
+ * @param {string}  clientId  The block's clientId.
+ * @param {boolean} isVisible True if the block's is visible on the canvas.
+ */
+export function setBlockVisibility( clientId, isVisible ) {
+	return {
+		type: 'SET_BLOCK_VISIBILITY',
+		isVisible,
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1145,7 +1145,7 @@ export const blocks = flow(
 		if ( action.type === 'SET_BLOCK_VISIBILITY' ) {
 			return {
 				...state,
-				[ action.clientId ]: action.isVisible,
+				...action.updates,
 			};
 		}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1690,7 +1690,8 @@ export function automaticChangeStatus( state, action ) {
 
 			return;
 		// Undoing an automatic change should still be possible after mouse
-		// move.
+		// move or after visibility change.
+		case 'SET_BLOCK_VISIBILITY':
 		case 'START_TYPING':
 		case 'STOP_TYPING':
 			return state;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -606,6 +606,7 @@ const withBlockReset = ( reducer ) => ( state, action ) => {
 			order: mapBlockOrder( action.blocks ),
 			parents: mapBlockParents( action.blocks ),
 			controlledInnerBlocks: {},
+			visibility: {},
 		};
 
 		const subTree = buildBlockTree( newState, action.blocks );
@@ -1137,6 +1138,17 @@ export const blocks = flow(
 				[ clientId ]: hasControlledInnerBlocks,
 			};
 		}
+		return state;
+	},
+
+	visibility( state = {}, action ) {
+		if ( action.type === 'SET_BLOCK_VISIBILITY' ) {
+			return {
+				...state,
+				[ action.clientId ]: action.isVisible,
+			};
+		}
+
 		return state;
 	},
 } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2669,11 +2669,11 @@ export function isBlockVisible( state, clientId ) {
  * @param {Object} state Global application state.
  * @return {[string]} List of hidden blocks.
  */
-export const __unstableGetHiddenBlocks = createSelector(
+export const __unstableGetVisibleBlocks = createSelector(
 	( state ) => {
 		return new Set(
 			Object.keys( state.blocks.visibility ).filter(
-				( key ) => ! state.blocks.visibility[ key ]
+				( key ) => state.blocks.visibility[ key ]
 			)
 		);
 	},

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2651,3 +2651,14 @@ export function wasBlockJustInserted( state, clientId, source ) {
 		lastBlockInserted.source === source
 	);
 }
+
+/**
+ * Tells if the block is visible on the canvas or not.
+ *
+ * @param {Object} state    Global application state.
+ * @param {Object} clientId Client Id of the block.
+ * @return {boolean} True if the block is visible.
+ */
+export function isBlockVisible( state, clientId ) {
+	return state.blocks.visibility?.[ clientId ] ?? true;
+}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2662,3 +2662,20 @@ export function wasBlockJustInserted( state, clientId, source ) {
 export function isBlockVisible( state, clientId ) {
 	return state.blocks.visibility?.[ clientId ] ?? true;
 }
+
+/**
+ * Returns the list of all hidden blocks.
+ *
+ * @param {Object} state Global application state.
+ * @return {[string]} List of hidden blocks.
+ */
+export const __unstableGetHiddenBlocks = createSelector(
+	( state ) => {
+		return new Set(
+			Object.keys( state.blocks.visibility ).filter(
+				( key ) => ! state.blocks.visibility[ key ]
+			)
+		);
+	},
+	( state ) => [ state.blocks.visibility ]
+);

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -290,6 +290,7 @@ describe( 'state', () => {
 						chicken: '',
 					},
 					controlledInnerBlocks: {},
+					visibility: {},
 				} );
 				expect( state.tree.chicken ).not.toBe(
 					existingState.tree.chicken
@@ -371,6 +372,7 @@ describe( 'state', () => {
 						chicken: '',
 					},
 					controlledInnerBlocks: {},
+					visibility: {},
 				} );
 				expect( state.tree.chicken ).not.toBe(
 					existingState.tree.chicken
@@ -519,6 +521,7 @@ describe( 'state', () => {
 						[ newChildBlockId3 ]: 'chicken',
 					},
 					controlledInnerBlocks: {},
+					visibility: {},
 				} );
 
 				expect( state.tree[ '' ].innerBlocks[ 0 ] ).toBe(
@@ -627,6 +630,7 @@ describe( 'state', () => {
 						[ newChildBlockId ]: 'chicken',
 					},
 					controlledInnerBlocks: {},
+					visibility: {},
 				} );
 
 				// The block object of the parent should be updated.
@@ -648,6 +652,7 @@ describe( 'state', () => {
 				isIgnoredChange: false,
 				tree: {},
 				controlledInnerBlocks: {},
+				visibility: {},
 			} );
 		} );
 


### PR DESCRIPTION
Extracted from #40376

## What?

This PR aims to extract the "block is visible on screen" from React context and move it into the block editor store. That way we should be able to leverage it from more use-cases than just the current one (enabling async mode)

## Why?

In #40376 we want to hide the in-between inserters out of the canvas.

## Testing Instructions

Nothing really, we just need to ensure that all the tests pass and that the performance (typing) doesn't regress.
