### PR TITLE
[Mobile] - BlockList - Add internal onLayout from CellRendererComponent to BlockListItemCell

### DIFF
--- a/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
@@ -13,12 +13,7 @@ import { useEffect, useCallback } from '@wordpress/element';
  */
 import { useBlockListContext } from './block-list-context';
 
-function BlockListItemCell( {
-	children,
-	clientId,
-	rootClientId,
-	listOnLayout,
-} ) {
+function BlockListItemCell( { children, clientId, rootClientId, onLayout } ) {
 	const { blocksLayouts, updateBlocksLayouts } = useBlockListContext();
 
 	useEffect( () => {
@@ -30,7 +25,7 @@ function BlockListItemCell( {
 		};
 	}, [] );
 
-	const onLayout = useCallback(
+	const onCellLayout = useCallback(
 		( event ) => {
 			const {
 				nativeEvent: { layout },
@@ -41,14 +36,14 @@ function BlockListItemCell( {
 				...layout,
 			} );
 
-			if ( listOnLayout ) {
-				listOnLayout( event );
+			if ( onLayout ) {
+				onLayout( event );
 			}
 		},
-		[ clientId, rootClientId, updateBlocksLayouts, listOnLayout ]
+		[ clientId, rootClientId, updateBlocksLayouts, onLayout ]
 	);
 
-	return <View onLayout={ onLayout }>{ children }</View>;
+	return <View onLayout={ onCellLayout }>{ children }</View>;
 }
 
 export default BlockListItemCell;

--- a/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item-cell.native.js
@@ -13,7 +13,12 @@ import { useEffect, useCallback } from '@wordpress/element';
  */
 import { useBlockListContext } from './block-list-context';
 
-function BlockListItemCell( { children, clientId, rootClientId } ) {
+function BlockListItemCell( {
+	children,
+	clientId,
+	rootClientId,
+	listOnLayout,
+} ) {
 	const { blocksLayouts, updateBlocksLayouts } = useBlockListContext();
 
 	useEffect( () => {
@@ -26,14 +31,21 @@ function BlockListItemCell( { children, clientId, rootClientId } ) {
 	}, [] );
 
 	const onLayout = useCallback(
-		( { nativeEvent: { layout } } ) => {
+		( event ) => {
+			const {
+				nativeEvent: { layout },
+			} = event;
 			updateBlocksLayouts( blocksLayouts, {
 				clientId,
 				rootClientId,
 				...layout,
 			} );
+
+			if ( listOnLayout ) {
+				listOnLayout( event );
+			}
 		},
-		[ clientId, rootClientId, updateBlocksLayouts ]
+		[ clientId, rootClientId, updateBlocksLayouts, listOnLayout ]
 	);
 
 	return <View onLayout={ onLayout }>{ children }</View>;

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -162,12 +162,13 @@ export class BlockList extends Component {
 		return this.extraData;
 	}
 
-	getCellRendererComponent( { children, item } ) {
+	getCellRendererComponent( { children, item, onLayout } ) {
 		const { rootClientId } = this.props;
 		return (
 			<BlockListItemCell
 				children={ children }
 				clientId={ item }
+				listOnLayout={ onLayout }
 				rootClientId={ rootClientId }
 			/>
 		);

--- a/packages/block-editor/src/components/block-list/index.native.js
+++ b/packages/block-editor/src/components/block-list/index.native.js
@@ -168,7 +168,7 @@ export class BlockList extends Component {
 			<BlockListItemCell
 				children={ children }
 				clientId={ item }
-				listOnLayout={ onLayout }
+				onLayout={ onLayout }
 				rootClientId={ rootClientId }
 			/>
 		);


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/4864

## What?
Fixes a regression introduced in the Drag & Drop blocks feature, where `CellRendererComponent` was introduced in the `BlockList`. Where adding more than 10 blocks makes the keyboard to hide and then appear again every time a new block is added in the case of adding multiple consecutive Paragraph blocks.

## Why?
With the Drag & Drop blocks feature we added the prop `CellRendererComponent` in the `BlockList` where we pass our own implementation of the cell renderer, this was needed to be able to use the `onLayout` data from the blocks within the list.

## How?
Internally, the `VirtualizedList` which powers the `FlatList` has its own `onLayout` where it calculates different things, this gets called in the internal [CellRendererComponent](https://github.com/facebook/react-native/blob/2c5a966054c2a80d63aa9c2c2a234a80a02918cf/Libraries/Lists/VirtualizedList.js#L2097-L2104), when we added our own implementation we weren't calling the [internal onLayout](https://github.com/facebook/react-native/blob/2c5a966054c2a80d63aa9c2c2a234a80a02918cf/Libraries/Lists/VirtualizedList.js#L1400-L1413) callback. This PR now calls the internal VirtualizeList onLayout within our implementation of the `CellRendererComponent`.

## Testing Instructions

- Open the app
- Start adding blocks, using the return key to create new Paragraph blocks.
- Add more than 10 blocks.
- **Expect** the keyboard to stay visible when creating new Paragraph blocks.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/4885740/168777619-169d0a81-8d2b-4a5c-aa08-f3ec5f2278a0.mov
