### PR TITLE
WIP: Recurse into conditional CSS rules for Editor iframe stylesheets

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -65,12 +65,31 @@ function useStylesCompatibility() {
 				return;
 			}
 
-			const isMatch = Array.from( cssRules ).find(
-				( { selectorText } ) =>
-					selectorText &&
-					( selectorText.includes( `.${ BODY_CLASS_NAME }` ) ||
-						selectorText.includes( `.${ BLOCK_PREFIX }` ) )
-			);
+			function matchFromRules( _cssRules ) {
+				return Array.from( _cssRules ).find(
+					( {
+						selectorText,
+						conditionText,
+						cssRules: __cssRules,
+					} ) => {
+						// If the rule is conditional then it will not have selector text.
+						// Recurse into child CSS ruleset to determine selector eligibility.
+						if ( conditionText ) {
+							return matchFromRules( __cssRules );
+						}
+
+						return (
+							selectorText &&
+							( selectorText.includes(
+								`.${ BODY_CLASS_NAME }`
+							) ||
+								selectorText.includes( `.${ BLOCK_PREFIX }` ) )
+						);
+					}
+				);
+			}
+
+			const isMatch = matchFromRules( cssRules );
 
 			if (
 				isMatch &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?


This PR fixes an edge case where stylesheets intended for the Editor canvas that contain _only_ media queries will not be applied in the Site Editor.

This is due to the usage of an iframe in the Site Editor and the `useStylesCompatibility` hook which is designed to ensure that style rules intended for the Site Editor are correctly carried across to the editor iframe.

This is an edge case so please read the below...

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Site Editor renders inside an iframe. Enqueued Block / Editor styles from the top document need to be manually transferred over to the iframe in order that they are applied there and the correct styles are shown in the Site Editor.

Currently only style sheets which have selectors that include either of the following rules are transferred:

- `.editor-styles-wrapper`
- `.wp-block`

https://github.com/WordPress/gutenberg/blob/72a348b10c4723e170db9275662c8d1f10c85d85/packages/block-editor/src/components/iframe/index.js#L68-L73

If the code detects that a single ruleset from the stylesheet matches, then it will clone the _entire_ stylesheet `<link />` and append it to a hidden `<div>` in the iframe document. 

Again, it only requires **a _single_ match for the stylesheet to be deemed eligible** for transfer (there is no clue in the code as why this was deemed to be the case).

https://github.com/WordPress/gutenberg/blob/72a348b10c4723e170db9275662c8d1f10c85d85/packages/block-editor/src/components/iframe/index.js#L81

### What's the problem?

There is an edge case in the matching against the css rulesets. If the rules within the stylesheet are wrapped in media queries then they are discarded. For example the following selector would be deemed not to be eligible even though it contains the `wp-block` prefix:

```css
@media screen and (min-width: 960px) {
  .wp-block-navigation {
    display: none !important;
  }
}
```


At a technical level, this is because the matcher requires a `selectorText` property to be present on each CSSRule object in the stylesheet. 

https://github.com/WordPress/gutenberg/blob/72a348b10c4723e170db9275662c8d1f10c85d85/packages/block-editor/src/components/iframe/index.js#L70

This is fine when the CSS rule is of type [`CSSStyleRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule) but if the rule includes a media query (type: [`CSSMediaRule`](https://developer.mozilla.org/en-US/docs/Web/API/CSSMediaRule)) then the `selectorText` is not present on the object. Instead a `conditionText` property indicates the presence of a Media Query and the object's `cssRules` property contains child rules which have their own `selectorText` properties.

### Edge cases

Consider the following example:

```css
.wp-block-navigation {
    display: block;
}

@media screen and (min-width: 960px) {
  .wp-block-navigation {
    display: none !important;
  }
}
```

This stylehsheet _would_ be carried into the iframe. This is because the first rule matches and is not contained in a media query. This is because only a single rule is required to match for the entire stylesheet to be deemed eligible.

The following would also work:

```css
.editor-styles-wrapper {
    display: block;
}

@media screen and (min-width: 960px) {
  .wp-block-navigation {
    display: none !important;
  }
}
```

This time it's the `editor-styles-wrapper` that is deemed a match.

However, should your stylesheet contain _only_ media queries it will be ignored by the matcher.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR changes the matcher to take account of `CSSMediaRule`. If a `conditionText` property is found then the matcher will recurse into that rule until it finds a `CSSStyleRule` with `selectorText`. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

- Add a stylesheet at the root of the Gutenberg repo. 
- Call it `test.css` and put the following content:
```css
@media screen and (min-width: 560px) {
  .wp-block-navigation {
    border: 1px solid red !important;
    background-color: hotpink !important;
  }
}
```
- Add the following code to the gutenberg.php file
```php
<?php
add_action('init', function() {
	wp_register_style( 'toto', gutenberg_url( 'test.css' ) );
	wp_enqueue_block_style(
		'core/navigation',
		array(
			'handle' => 'toto',
		)
	);
} );
?>
```
- Load the Site Editor, add a Nav block (if not already present).
- Check that the Media Queries have been applied to the iframe.
- Remove the media queries from your style sheet leaving just the selectors
```css
.wp-block-navigation {
    border: 1px solid red !important;
    background-color: hotpink !important;
}
```
- Repeat the steps above - verify that the CSS is still applied (as it currently is on `trunk`).


## Screenshots or screencast <!-- if applicable -->
