### PR TITLE
Inserter: Adds CTA and external link to block inserter flow

### DIFF
--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -2,45 +2,32 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, blockDefault, tip } from '@wordpress/icons';
+import { Icon, blockDefault } from '@wordpress/icons';
+import { Tip, ExternalLink } from '@wordpress/components';
 
 function DownloadableBlocksNoResults() {
 	return (
-		<div className="block-editor-inserter__no-results">
-			<Icon
-				className="block-editor-inserter__no-results-icon"
-				icon={ blockDefault }
-			/>
-			<p>{ __( 'No results found.' ) }</p>
-
-			<div className="block-editor-inserter__tips">
-				<div className="components-tip">
-					<Icon icon={ tip } />
-					<h3>{ __( 'Make your own' ) }</h3>
-				</div>
-				<p>
-					It seems that no block exists with the functionality that
-					you need.
-				</p>
-				<p>
-					WordPress is open-source software. You could create a block
-					with the functionality you want and contribute it to the
-					community.
-				</p>
-				<p>
-					<strong>
-						<a
-							href="https://developer.wordpress.org/block-editor/"
-							rel="noreferrer noopener"
-							target="_blank"
-						>
-							{ __( 'Learn more' ) }
-						</a>
-						.
-					</strong>
-				</p>
+		<>
+			<div className="block-editor-inserter__no-results">
+				<Icon
+					className="block-editor-inserter__no-results-icon"
+					icon={ blockDefault }
+				/>
+				<p>{ __( 'No results found.' ) }</p>
 			</div>
-		</div>
+			<div className="block-editor-inserter__tips">
+				<Tip>
+					<div>
+						<p>
+							{ __( 'Interested in creating your own block?' ) }
+						</p>
+						<ExternalLink href="https://developer.wordpress.org/block-editor/">
+							{ __( 'Get started here' ) }.
+						</ExternalLink>
+					</div>
+				</Tip>
+			</div>
+		</>
 	);
 }
 

--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -12,6 +12,17 @@ function DownloadableBlocksNoResults() {
 				icon={ blockDefault }
 			/>
 			<p>{ __( 'No results found.' ) }</p>
+			<p>Interested in creating your own block?</p>
+			<p>
+				<a
+					href="https://developer.wordpress.org/block-editor/"
+					rel="noreferrer noopener"
+					target="_blank"
+				>
+					Get started here
+				</a>
+				.
+			</p>
 		</div>
 	);
 }

--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -12,14 +12,14 @@ function DownloadableBlocksNoResults() {
 				icon={ blockDefault }
 			/>
 			<p>{ __( 'No results found.' ) }</p>
-			<p>Interested in creating your own block?</p>
+			<p>{ __( 'Interested in creating your own block?' ) }</p>
 			<p>
 				<a
 					href="https://developer.wordpress.org/block-editor/"
 					rel="noreferrer noopener"
 					target="_blank"
 				>
-					Get started here
+					{ __( 'Get started here' ) }
 				</a>
 				.
 			</p>

--- a/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
+++ b/packages/block-directory/src/components/downloadable-blocks-panel/no-results.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon, blockDefault } from '@wordpress/icons';
+import { Icon, blockDefault, tip } from '@wordpress/icons';
 
 function DownloadableBlocksNoResults() {
 	return (
@@ -12,17 +12,34 @@ function DownloadableBlocksNoResults() {
 				icon={ blockDefault }
 			/>
 			<p>{ __( 'No results found.' ) }</p>
-			<p>{ __( 'Interested in creating your own block?' ) }</p>
-			<p>
-				<a
-					href="https://developer.wordpress.org/block-editor/"
-					rel="noreferrer noopener"
-					target="_blank"
-				>
-					{ __( 'Get started here' ) }
-				</a>
-				.
-			</p>
+
+			<div className="block-editor-inserter__tips">
+				<div className="components-tip">
+					<Icon icon={ tip } />
+					<h3>{ __( 'Make your own' ) }</h3>
+				</div>
+				<p>
+					It seems that no block exists with the functionality that
+					you need.
+				</p>
+				<p>
+					WordPress is open-source software. You could create a block
+					with the functionality you want and contribute it to the
+					community.
+				</p>
+				<p>
+					<strong>
+						<a
+							href="https://developer.wordpress.org/block-editor/"
+							rel="noreferrer noopener"
+							target="_blank"
+						>
+							{ __( 'Learn more' ) }
+						</a>
+						.
+					</strong>
+				</p>
+			</div>
 		</div>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Following a search, if no registered blocks are found AND no matching block is found in the plugin directory, this prompts the user with the suggestion to create a block and a link to the docs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This makes the user aware of the open source nature of WordPress and alerts them to the possibility that they can create and contribute a new block with the functionality that they desire.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds additional textual content to `DownloadableBlocksNoResults` component in `no-results.js`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1. Create a new post
2. Search for a block that is not registered or available in the plugin directory ("nothing" worked for us)
3. Verify that the new text and link appears
4. Confirm that this does not appear in the quick inserter

## Screenshots or screencast <!-- if applicable -->
<img width="759" alt="image" src="https://user-images.githubusercontent.com/20643925/168843861-66c8a9ae-fa9b-4319-8014-2790a60c0d10.png">

This PR is intended to open a conversation regarding the best text to display here and regarding what links are best to point to. Please let us know what suggestions and ideas you may have to make this messaging better. Thanks.

(Thanks to @ryanwelcher for help with this)