### PR TITLE
Experiment: Add transitions options to navigation block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -393,7 +393,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Name:** core/navigation
 -	**Category:** theme
 -	**Supports:** align (full, wide), anchor, inserter, spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, textColor
+-	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, maxNestingLevel, menuAnimation, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayMenuWidth, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, textColor
 
 ## Custom Link
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -41,6 +41,14 @@
 			"type": "string",
 			"default": "mobile"
 		},
+		"menuAnimation": {
+			"type": "string",
+			"default": "default"
+		},
+		"overlayMenuWidth": {
+			"type": "number",
+			"default": 33
+		},
 		"hasIcon": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -7,36 +7,37 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import {
-	useState,
+	Platform,
+	useCallback,
 	useEffect,
 	useRef,
-	useCallback,
-	Platform,
+	useState,
 } from '@wordpress/element';
 import {
-	InspectorControls,
-	BlockControls,
-	useBlockProps,
+	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 	__experimentalUseNoRecursiveRenders as useNoRecursiveRenders,
-	store as blockEditorStore,
-	withColors,
-	PanelColorSettings,
+	BlockControls,
 	ContrastChecker,
 	getColorClassName,
+	InspectorControls,
+	PanelColorSettings,
+	store as blockEditorStore,
+	useBlockProps,
 	Warning,
-	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
+	withColors,
 } from '@wordpress/block-editor';
 import { EntityProvider } from '@wordpress/core-data';
 
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import {
-	PanelBody,
-	ToggleControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	ToolbarGroup,
 	Button,
+	PanelBody,
+	RangeControl,
 	Spinner,
+	ToggleControl,
+	ToolbarGroup,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
@@ -126,6 +127,8 @@ function Navigation( {
 			flexWrap = 'wrap',
 		} = {},
 		hasIcon,
+		menuAnimation,
+		overlayMenuWidth,
 	} = attributes;
 
 	const ref = attributes.ref;
@@ -733,6 +736,34 @@ function Navigation( {
 									label={ __( 'Always' ) }
 								/>
 							</ToggleGroupControl>
+							{ overlayMenu === 'always' && (
+								<>
+									<h3>{ __( 'Menu Animation' ) }</h3>
+									<ToggleGroupControl
+										label={ __( 'Menu Animation' ) }
+										value={ menuAnimation }
+										help={ __(
+											'Add animation when opening the overlay menu.'
+										) }
+										onChange={ ( value ) =>
+											setAttributes( {
+												menuAnimation: value,
+											} )
+										}
+										isBlock
+										hideLabelFromVision
+									>
+										<ToggleGroupControlOption
+											value="default"
+											label={ __( 'Default' ) }
+										/>
+										<ToggleGroupControlOption
+											value="slide"
+											label={ __( 'Slide' ) }
+										/>
+									</ToggleGroupControl>
+								</>
+							) }
 							{ hasSubmenus && (
 								<>
 									<h3>{ __( 'Submenus' ) }</h3>
@@ -763,6 +794,19 @@ function Navigation( {
 									/>
 								</>
 							) }
+						</PanelBody>
+					) }
+					{ overlayMenu === 'always' && menuAnimation === 'slide' && (
+						<PanelBody title={ __( 'Slide Options' ) } initialOpen>
+							<RangeControl
+								label={ __( 'Overlay Menu Width %' ) }
+								value={ overlayMenuWidth }
+								onChange={ ( value ) =>
+									setAttributes( { overlayMenuWidth: value } )
+								}
+								min={ 0 }
+								max={ 100 }
+							/>
 						</PanelBody>
 					) }
 					{ hasColorSettings && (

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -529,6 +529,7 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 	// Manually add block support text decoration as CSS class.
 	$text_decoration       = _wp_array_get( $attributes, array( 'style', 'typography', 'textDecoration' ), null );
 	$text_decoration_class = sprintf( 'has-text-decoration-%s', $text_decoration );
+	$slide_animate         = isset( $attributes['menuAnimation'] ) && 'slide' === $attributes['menuAnimation'];
 
 	$colors     = block_core_navigation_build_css_colors( $attributes );
 	$font_sizes = block_core_navigation_build_css_font_sizes( $attributes );
@@ -603,18 +604,20 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		'wp-block-navigation__responsive-container',
 		$is_hidden_by_default ? 'hidden-by-default' : '',
 		implode( ' ', $colors['overlay_css_classes'] ),
+		$slide_animate ? 'has-slide-animation' : '',
 	);
 	$open_button_classes          = array(
 		'wp-block-navigation__responsive-container-open',
 		$is_hidden_by_default ? 'always-shown' : '',
 	);
 
-	$toggle_button_icon        = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>';
-	$should_display_icon_label = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
-	$toggle_button_content     = $should_display_icon_label ? $toggle_button_icon : 'Menu';
-
+	$toggle_button_icon          = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false"><rect x="4" y="7.5" width="16" height="1.5" /><rect x="4" y="15" width="16" height="1.5" /></svg>';
+	$should_display_icon_label   = isset( $attributes['hasIcon'] ) && true === $attributes['hasIcon'];
+	$toggle_button_content       = $should_display_icon_label ? $toggle_button_icon : 'Menu';
+	$custom_width_style          = isset( $attributes['overlayMenuWidth'] ) && $slide_animate ? sprintf( 'width: %1s%%;', $attributes['overlayMenuWidth'] ) : '';
 	$responsive_container_markup = sprintf(
 		'<button aria-haspopup="true" aria-label="%3$s" class="%6$s" data-micromodal-trigger="%1$s">%9$s</button>
+			%10$s
 			<div class="%5$s" style="%7$s" id="%1$s">
 				<div class="wp-block-navigation__responsive-close" tabindex="-1" data-micromodal-close>
 					<div class="wp-block-navigation__responsive-dialog" aria-label="%8$s">
@@ -631,9 +634,10 @@ function render_block_core_navigation( $attributes, $content, $block ) {
 		__( 'Close menu' ), // Close button label.
 		esc_attr( implode( ' ', $responsive_container_classes ) ),
 		esc_attr( implode( ' ', $open_button_classes ) ),
-		safecss_filter_attr( $colors['overlay_inline_styles'] ),
+		safecss_filter_attr( $colors['overlay_inline_styles'] . $custom_width_style ),
 		__( 'Menu' ),
-		$toggle_button_content
+		$toggle_button_content,
+		$slide_animate ? '<div class="drawer-cover"></div>' : ''
 	);
 
 	return sprintf(

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -679,3 +679,46 @@ button.wp-block-navigation-item__content {
 html.has-modal-open {
 	overflow: hidden;
 }
+.has-modal-open {
+	.drawer-cover {
+		display: block;
+	}
+}
+.drawer-cover {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 1;
+	background-color: rgba(0, 0, 0, 0.8);
+	display: none;
+}
+
+@keyframes mmslideIn {
+	from {
+		transform: translateX(-100%);
+	}
+	to {
+		transform: translateY(0);
+	}
+}
+
+@keyframes mmslideOut {
+	from {
+		transform: translateX(0);
+	}
+	to {
+		transform: translateX(-100%);
+	}
+}
+
+.has-slide-animation {
+	&.wp-block-navigation__responsive-container[aria-hidden="false"] {
+		animation: mmslideIn 0.4s cubic-bezier(0, 0, 0.2, 1);
+	}
+	&.wp-block-navigation__responsive-container[aria-hidden="true"] {
+		animation: mmslideOut 0.4s cubic-bezier(0, 0, 0.2, 1);
+	}
+}
+

--- a/packages/block-library/src/navigation/view-modal.js
+++ b/packages/block-library/src/navigation/view-modal.js
@@ -28,10 +28,16 @@ function navigationToggleModal( modal ) {
 }
 
 window.addEventListener( 'load', () => {
+	const hasSlideAnimation = !! document.querySelector(
+		`.wp-block-navigation__responsive-container.has-slide-animation`
+	);
 	MicroModal.init( {
 		onShow: navigationToggleModal,
 		onClose: navigationToggleModal,
 		openClass: 'is-menu-open',
+		awaitOpenAnimation: hasSlideAnimation,
+		awaitCloseAnimation: hasSlideAnimation,
+		debugMode: true,
 	} );
 
 	// Close modal automatically on clicking anchor links inside modal.

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -6,6 +6,7 @@
 			"showSubmenuIcon": true,
 			"openSubmenusOnClick": false,
 			"overlayMenu": "mobile",
+			"overlayMenuWidth": 33,
 			"menuAnimation": "default",
 			"hasIcon": true,
 			"maxNestingLevel": 5

--- a/test/integration/fixtures/blocks/core__navigation.json
+++ b/test/integration/fixtures/blocks/core__navigation.json
@@ -6,6 +6,7 @@
 			"showSubmenuIcon": true,
 			"openSubmenusOnClick": false,
 			"overlayMenu": "mobile",
+			"menuAnimation": "default",
 			"hasIcon": true,
 			"maxNestingLevel": 5
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
We are adding a slide transition to the Navigation block.

To do:
- [ ] Animate the hamburger button
- [ ] Test with RTL
- [ ] Add more transition options like orientation, cover color or transparency, etc.
- [ ] Add deprecation file for new attributes added.
- [ ] Make it work with Mobile option on Overlay Menu

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We are checking if the navigation block is complex enough to require hydration or we can achieve most of menu animations just by CSS.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Right now we are using CSS only 😄 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->
1.) Go to Site Editor -> Navigation
2.) Set Overlay Menu option as Always
3.) Set Menu Animation as Slide
4.) Play with attributes and check Frontend.

## Screenshots or screencast <!-- if applicable -->

<a href="https://www.loom.com/share/31d84f71624442d2b644ffc50147d8e7">
    <p>Loom Message - 17 May 2022 - Watch Video</p>
    <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/31d84f71624442d2b644ffc50147d8e7-with-play.gif">
  </a>
