### PR TITLE
Gallery Block: Support gaps that define column/row gaps to avoid PHP Warning/Fatal

### DIFF
--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -28,8 +28,8 @@ export default function GapStyles( { blockGap, clientId } ) {
 	}
 
 	const gap = `#block-${ clientId } {
-		--wp--style--unstable-gallery-gap: ${ column || fallbackValue };
-		gap: ${ gapValue || fallbackValue }
+		--wp--style--unstable-gallery-gap: ${ column };
+		gap: ${ gapValue }
 	}`;
 
 	const GapStyle = () => {

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -8,14 +8,28 @@ export default function GapStyles( { blockGap, clientId } ) {
 	const styleElement = useContext( BlockList.__unstableElementContext );
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
-	let gapValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
+	const fallbackValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
+
+	let gapValue = fallbackValue;
+	let column = fallbackValue;
+	let row;
+
 	// Check for the possibility of split block gap values. See: https://github.com/WordPress/gutenberg/pull/37736
 	if ( !! blockGap ) {
-		gapValue = typeof blockGap === 'string' ? blockGap : blockGap?.left;
+		row =
+			typeof blockGap === 'string'
+				? blockGap
+				: blockGap?.top || fallbackValue;
+		column =
+			typeof blockGap === 'string'
+				? blockGap
+				: blockGap?.left || fallbackValue;
+		gapValue = row === column ? row : `${ row } ${ column }`;
 	}
-	const gap = `#block-${ clientId } { 
-		--wp--style--unstable-gallery-gap: ${ gapValue };
-		gap: ${ gapValue } 
+
+	const gap = `#block-${ clientId } {
+		--wp--style--unstable-gallery-gap: ${ column || fallbackValue };
+		gap: ${ gapValue || fallbackValue }
 	}`;
 
 	const GapStyle = () => {

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -9,7 +9,6 @@ export default function GapStyles( { blockGap, clientId } ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	const fallbackValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
-
 	let gapValue = fallbackValue;
 	let column = fallbackValue;
 	let row;

--- a/packages/block-library/src/gallery/gap-styles.js
+++ b/packages/block-library/src/gallery/gap-styles.js
@@ -8,9 +8,11 @@ export default function GapStyles( { blockGap, clientId } ) {
 	const styleElement = useContext( BlockList.__unstableElementContext );
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
-	const gapValue = blockGap
-		? blockGap
-		: `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
+	let gapValue = `var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )`;
+	// Check for the possibility of split block gap values. See: https://github.com/WordPress/gutenberg/pull/37736
+	if ( !! blockGap ) {
+		gapValue = typeof blockGap === 'string' ? blockGap : blockGap?.left;
+	}
 	const gap = `#block-${ clientId } { 
 		--wp--style--unstable-gallery-gap: ${ gapValue };
 		gap: ${ gapValue } 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -67,10 +67,9 @@ function block_core_gallery_render( $attributes, $content ) {
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
+
 	if ( is_array( $gap_value ) ) {
-		$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : '0.5em';
-		$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
-		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+		$gap_value = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
 	}
 
 	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -48,7 +48,14 @@ function block_core_gallery_render( $attributes, $content ) {
 	// Skip if gap value contains unsupported characters.
 	// Regex for CSS value borrowed from `safecss_filter_attr`, and used here
 	// because we only want to match against the value, not the CSS attribute.
-	$gap     = preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+	if ( is_array( $gap ) ) {
+		foreach ( $gap as $key => $value ) {
+			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+		}
+	} else {
+		$gap = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+	}
+
 	$class   = wp_unique_id( 'wp-block-gallery-' );
 	$content = preg_replace(
 		'/' . preg_quote( 'class="', '/' ) . '/',
@@ -56,10 +63,17 @@ function block_core_gallery_render( $attributes, $content ) {
 		$content,
 		1
 	);
+
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
 	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
-	$style     = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
+	if ( is_array( $gap_value ) ) {
+		$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : '0.5em';
+		$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
+		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
+	}
+
+	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.
 	// See https://core.trac.wordpress.org/ticket/53494.

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -53,7 +53,7 @@ function block_core_gallery_render( $attributes, $content ) {
 			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
 		}
 	} else {
-		$gap = $gap_value && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
+		$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 	}
 
 	$class   = wp_unique_id( 'wp-block-gallery-' );

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -66,13 +66,19 @@ function block_core_gallery_render( $attributes, $content ) {
 
 	// --gallery-block--gutter-size is deprecated. --wp--style--gallery-gap-default should be used by themes that want to set a default
 	// gap on the gallery.
-	$gap_value = $gap ? $gap : 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
+	$fallback_gap = 'var( --wp--style--gallery-gap-default, var( --gallery-block--gutter-size, var( --wp--style--block-gap, 0.5em ) ) )';
+	$gap_value    = $gap ? $gap : $fallback_gap;
+	$gap_column   = $gap_value;
 
 	if ( is_array( $gap_value ) ) {
-		$gap_value = isset( $gap_value['left'] ) ? $gap_value['left'] : '0.5em';
+		$gap_row    = isset( $gap_value['top'] ) ? $gap_value['top'] : $fallback_gap;
+		$gap_column = isset( $gap_value['left'] ) ? $gap_value['left'] : $fallback_gap;
+		$gap_value  = $gap_row === $gap_column ? $gap_row : $gap_row . ' ' . $gap_column;
 	}
 
-	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_value . '; gap: ' . $gap_value . '}';
+	// Set the CSS variable to the column value, and the `gap` property to the combined gap value.
+	$style = '.' . $class . '{ --wp--style--unstable-gallery-gap: ' . $gap_column . '; gap: ' . $gap_value . '}';
+
 	// Ideally styles should be loaded in the head, but blocks may be parsed
 	// after that, so loading in the footer for now.
 	// See https://core.trac.wordpress.org/ticket/53494.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds array-notation support to the Gallery Block, as currently that causes a PHP Warning under PHP <8, or a Fatal error in PHP 8.1.

Similar to #39927.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
To resolve a PHP Warning/Fatal error.

This PR may be invalid, if an array for `blockGap` is not expected here, I'm not sure though of the expectations here. I'm not sure if this is being caused by something specific on WordPress.org as I'm unable to locate where the value is coming from.

Hopefully someone more familiar with the Block Gap implementation can shed some light here? 

cc @ryelle since this could actually be Pattern Directory specific, I'm really not sure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The logic has been copied from the Layout support, where this style of blockGap is handled

https://github.com/WordPress/gutenberg/blob/1eee4656d5cab0951944badea704442100b0e9b8/lib/block-supports/layout.php#L176-L185

https://github.com/WordPress/gutenberg/blob/1eee4656d5cab0951944badea704442100b0e9b8/lib/block-supports/layout.php#L104-L108

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

I'm unsure how to trigger this, a number of Patterns in the WordPress.org Pattern Directory trigger it, but I'm unsure which ones they are as it's occurring during a generic API request.

## Screenshots or screencast <!-- if applicable -->

<img width="848" alt="Screen Shot 2022-05-18 at 3 45 01 pm" src="https://user-images.githubusercontent.com/767313/168967880-09fff61d-585d-4c5d-8a99-2d1c2746a426.png">

