### PR TITLE
Add waitForVisible() to all blocks

### DIFF
--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-block-insertion.test.js
@@ -39,9 +39,6 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 			testData.blockInsertionHtml.toLowerCase()
 		);
 
-		// wait for the block editor to load and for accessibility ids to update
-		await editorPage.driver.sleep( 3000 );
-
 		// Workaround for now since deleting the first element causes a crash on CI for Android
 		if ( isAndroid() ) {
 			paragraphBlockElement = await editorPage.getTextBlockAtPosition(
@@ -55,8 +52,6 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 			await paragraphBlockElement.click();
 			await editorPage.removeBlockAtPosition( blockNames.paragraph, 3 );
 			for ( let i = 3; i > 0; i-- ) {
-				// wait for accessibility ids to update
-				await editorPage.driver.sleep( 1000 );
 				paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 					blockNames.paragraph,
 					i,
@@ -72,8 +67,6 @@ describe( 'Gutenberg Editor tests for Block insertion', () => {
 			}
 		} else {
 			for ( let i = 4; i > 0; i-- ) {
-				// wait for accessibility ids to update
-				await editorPage.driver.sleep( 1000 );
 				paragraphBlockElement = await editorPage.getTextBlockAtPosition(
 					blockNames.paragraph
 				);

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-columns.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-columns.test.js
@@ -10,7 +10,7 @@ describe( 'Gutenberg Editor Columns Block test', () => {
 			testData.columnsWithDifferentUnitsHtml
 		);
 
-		const columnsBlock = await editorPage.getColumnsBlockVisible();
+		const columnsBlock = await editorPage.getFirstBlockVisible();
 		await columnsBlock.click();
 
 		expect( columnsBlock ).toBeTruthy();

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-columns.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-columns.test.js
@@ -10,7 +10,7 @@ describe( 'Gutenberg Editor Columns Block test', () => {
 			testData.columnsWithDifferentUnitsHtml
 		);
 
-		const columnsBlock = await editorPage.getFirstBlockVisible();
+		const columnsBlock = await editorPage.getColumnsBlockVisible();
 		await columnsBlock.click();
 
 		expect( columnsBlock ).toBeTruthy();

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-cover.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-cover.test.js
@@ -2,95 +2,54 @@
  * Internal dependencies
  */
 import { blockNames } from './pages/editor-page';
-import { isAndroid, waitForVisible } from './helpers/utils';
+import { isAndroid } from './helpers/utils';
 import testData from './helpers/test-data';
 
 describe( 'Gutenberg Editor Cover Block test', () => {
 	it( 'should displayed properly and have properly converted height (ios only)', async () => {
-		await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
-
-		const coverBlock = await editorPage.getBlockAtPosition(
-			blockNames.cover,
-			1,
-			{ useWaitForVisible: true }
-		);
-
 		// Temporarily this test is skipped on Android,due to the inconsistency of the results,
 		// which are related to getting values in raw pixels instead of density pixels on Android.
 		/* eslint-disable jest/no-conditional-expect */
 		if ( ! isAndroid() ) {
+			await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
+
+			const coverBlock = await editorPage.getBlockAtPosition(
+				blockNames.cover
+			);
+
 			const { height } = await coverBlock.getSize();
 			// Height is set to 20rem, where 1rem is 16.
 			// There is also block's vertical padding equal 32.
 			// Finally, the total height should be 20 * 16 + 32 = 352.
 			expect( height ).toBe( 352 );
-		}
-		/* eslint-enable jest/no-conditional-expect */
+			/* eslint-enable jest/no-conditional-expect */
 
-		await coverBlock.click();
-		expect( coverBlock ).toBeTruthy();
-		await editorPage.removeBlockAtPosition( blockNames.cover );
+			await coverBlock.click();
+			expect( coverBlock ).toBeTruthy();
+			await editorPage.removeBlockAtPosition( blockNames.cover );
+		}
 	} );
 
 	// Testing this for iOS on a device is valuable to ensure that it properly
 	// handles opening multiple modals, as only one can be open at a time.
 	it( 'allows modifying media from within block settings', async () => {
-		await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
-
-		const coverBlock = await editorPage.getBlockAtPosition(
-			blockNames.cover,
-			1,
-			{ useWaitForVisible: true }
-		);
-		await coverBlock.click();
-
 		// Can only add image from media library on iOS
 		if ( ! isAndroid() ) {
-			// Open block settings.
-			const settingsButton = await editorPage.driver.elementByAccessibilityId(
+			await editorPage.setHtmlContent( testData.coverHeightWithRemUnit );
+
+			const coverBlock = await editorPage.getBlockAtPosition(
+				blockNames.cover
+			);
+
+			await editorPage.openBlockSettings( coverBlock );
+			await editorPage.clickAddMediaFromCoverBlock();
+			await editorPage.chooseMediaLibrary();
+
+			const settingsButton = await coverBlock.elementByAccessibilityId(
 				'Open Settings'
 			);
 			await settingsButton.click();
-
-			// Add initial media via button within bottom sheet.
-			const mediaSection = await editorPage.driver.elementByAccessibilityId(
-				'Media Add image or video'
-			);
-			const addMediaButton = await mediaSection.elementByAccessibilityId(
-				'Add image or video'
-			);
-			await addMediaButton.click();
-			await editorPage.chooseMediaLibrary();
-			await editorPage.driver.sleep( 2000 ); // Await media load.
-
-			// Get Edit image button of block
-			const editImageButtonLocator =
-				'//XCUIElementTypeButton[@name="Edit image"][@enabled="true"]';
-			const blockEditImageButton = await waitForVisible(
-				editorPage.driver,
-				editImageButtonLocator
-			);
-
-			// Edit media within block settings.
-			await settingsButton.click();
-			await editorPage.driver.sleep( 2000 ); // Await media load.
-
-			// Get Edit image button of block settings.
-			// NOTE: Since we have multiple Edit image buttons at this
-			// point, we have to filter them to obtain the correct one.
-			const settingsEditImageButtons = await editorPage.driver.elementsByXPath(
-				editImageButtonLocator
-			);
-			const settingsEditImageButton = settingsEditImageButtons.find(
-				( element ) => element.value !== blockEditImageButton.value
-			);
-			await settingsEditImageButton.click();
-
-			// Replace image.
-			const replaceButton = await editorPage.driver.elementByAccessibilityId(
-				'Replace'
-			);
-			await replaceButton.click();
+			await editorPage.replaceMediaImage();
 
 			// First modal should no longer be presented.
 			const replaceButtons = await editorPage.driver.elementsByAccessibilityId(
@@ -101,9 +60,9 @@ describe( 'Gutenberg Editor Cover Block test', () => {
 
 			// Select different media.
 			await editorPage.chooseMediaLibrary();
-		}
 
-		expect( coverBlock ).toBeTruthy();
-		await editorPage.removeBlockAtPosition( blockNames.cover );
+			expect( coverBlock ).toBeTruthy();
+			await editorPage.removeBlockAtPosition( blockNames.cover );
+		}
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-cover.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-cover.test.js
@@ -44,11 +44,6 @@ describe( 'Gutenberg Editor Cover Block test', () => {
 			await editorPage.openBlockSettings( coverBlock );
 			await editorPage.clickAddMediaFromCoverBlock();
 			await editorPage.chooseMediaLibrary();
-
-			const settingsButton = await coverBlock.elementByAccessibilityId(
-				'Open Settings'
-			);
-			await settingsButton.click();
 			await editorPage.replaceMediaImage();
 
 			// First modal should no longer be presented.

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-image-@canary.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-image-@canary.test.js
@@ -11,11 +11,7 @@ describe( 'Gutenberg Editor Image Block tests', () => {
 		await editorPage.closePicker();
 
 		const imageBlock = await editorPage.getBlockAtPosition(
-			blockNames.image,
-			1,
-			{
-				useWaitForVisible: true,
-			}
+			blockNames.image
 		);
 
 		// Can only add image from media library on iOS

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
@@ -124,6 +124,8 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 				searchBlock,
 				'Button inside'
 			);
+
+			await editorPage.isSearchSettingsVisible();
 			await editorPage.dismissBottomSheet();
 
 			// Switch to html and verify.
@@ -141,6 +143,8 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 				searchBlock,
 				'No button'
 			);
+
+			await editorPage.isSearchSettingsVisible();
 			await editorPage.dismissBottomSheet();
 
 			// Switch to html and verify.

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-search.test.js
@@ -124,7 +124,6 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 				searchBlock,
 				'Button inside'
 			);
-
 			await editorPage.isSearchSettingsVisible();
 			await editorPage.dismissBottomSheet();
 
@@ -143,7 +142,6 @@ describe( 'Gutenberg Editor Search Block tests.', () => {
 				searchBlock,
 				'No button'
 			);
-
 			await editorPage.isSearchSettingsVisible();
 			await editorPage.dismissBottomSheet();
 

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-spacer.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-spacer.test.js
@@ -8,8 +8,7 @@ describe( 'Gutenberg Editor Spacer Block test', () => {
 		await editorPage.addNewBlock( blockNames.spacer );
 		const spacerBlock = await editorPage.getBlockAtPosition(
 			blockNames.spacer,
-			1,
-			{ useWaitForVisible: true }
+			1
 		);
 
 		expect( spacerBlock ).toBeTruthy();

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-spacer.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-spacer.test.js
@@ -7,8 +7,7 @@ describe( 'Gutenberg Editor Spacer Block test', () => {
 	it( 'should be able to add a spacer block', async () => {
 		await editorPage.addNewBlock( blockNames.spacer );
 		const spacerBlock = await editorPage.getBlockAtPosition(
-			blockNames.spacer,
-			1
+			blockNames.spacer
 		);
 
 		expect( spacerBlock ).toBeTruthy();

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
@@ -7,7 +7,7 @@ describe( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
 	it( 'should be able to open the unsupported block web view editor', async () => {
 		await editorPage.setHtmlContent( testData.unsupportedBlockHtml );
 
-		const firstVisibleBlock = await editorPage.getFirstBlockVisible();
+		const firstVisibleBlock = await editorPage.getUnsupportedBlockVisible();
 		await firstVisibleBlock.click();
 
 		const helpButton = await editorPage.getUnsupportedBlockHelpButton();
@@ -16,8 +16,7 @@ describe( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
 		const editButton = await editorPage.getUnsupportedBlockBottomSheetEditButton();
 		await editButton.click();
 
-		await expect(
-			editorPage.getUnsupportedBlockWebView()
-		).resolves.toBeTruthy();
+		const webView = await editorPage.getUnsupportedBlockWebView();
+		await expect( webView ).toBeTruthy();
 	} );
 } );

--- a/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
+++ b/packages/react-native-editor/__device-tests__/gutenberg-editor-unsupported-blocks.test.js
@@ -7,7 +7,7 @@ describe( 'Gutenberg Editor Unsupported Block Editor Tests', () => {
 	it( 'should be able to open the unsupported block web view editor', async () => {
 		await editorPage.setHtmlContent( testData.unsupportedBlockHtml );
 
-		const firstVisibleBlock = await editorPage.getUnsupportedBlockVisible();
+		const firstVisibleBlock = await editorPage.getFirstBlockVisible();
 		await firstVisibleBlock.click();
 
 		const helpButton = await editorPage.getUnsupportedBlockHelpButton();

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -421,18 +421,16 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 			'/hierarchy/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.ListView/android.widget.TextView[9]';
 
 		await clickIfClickable( driver, showHtmlButtonXpath );
+	} else if ( ! isAndroid() && toggleOn ) {
+		await clickIfClickable(
+			driver,
+			'//XCUIElementTypeButton[@name="..."]'
+		);
+		await clickIfClickable(
+			driver,
+			'//XCUIElementTypeButton[@name="Switch to HTML"]'
+		);
 	} else {
-		if ( toggleOn ) {
-			await clickIfClickable(
-				driver,
-				'//XCUIElementTypeButton[@name="..."]'
-			);
-			await clickIfClickable(
-				driver,
-				'//XCUIElementTypeButton[@name="Switch to HTML"]'
-			);
-		}
-
 		// This is to wait for the clipboard paste notification to disappear, currently it overlaps with the menu button
 		await driver.sleep( 3000 );
 		await clickIfClickable(

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -422,7 +422,7 @@ const toggleHtmlMode = async ( driver, toggleOn ) => {
 			'/hierarchy/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.FrameLayout/android.widget.LinearLayout/android.widget.FrameLayout/android.widget.ListView/android.widget.TextView[9]';
 
 		await clickIfClickable( driver, showHtmlButtonXpath );
-	} else if ( ! isAndroid() && toggleOn ) {
+	} else if ( toggleOn ) {
 		await clickIfClickable(
 			driver,
 			'//XCUIElementTypeButton[@name="..."]'
@@ -549,12 +549,12 @@ const clickIfClickable = async (
 	);
 
 	try {
-		await element.click();
+		return await element.click();
 	} catch ( error ) {
 		if ( iteration >= maxIteration ) {
 			// eslint-disable-next-line no-console
 			console.error(
-				`Element still not clickable after "${ iteration }" retries`
+				`"${ elementLocator }" still not clickable after "${ iteration }" retries`
 			);
 			return '';
 		}

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -538,7 +538,7 @@ const isElementVisible = async (
 const clickIfClickable = async (
 	driver,
 	elementLocator,
-	maxIteration = 10,
+	maxIteration = 25,
 	iteration = 0
 ) => {
 	const element = await waitForVisible(
@@ -556,7 +556,9 @@ const clickIfClickable = async (
 			console.error(
 				`Element still not clickable after "${ iteration }" retries`
 			);
+			return '';
 		}
+
 		return clickIfClickable(
 			driver,
 			elementLocator,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -553,7 +553,9 @@ const clickIfClickable = async (
 	} catch ( error ) {
 		if ( iteration >= maxIteration ) {
 			// eslint-disable-next-line no-console
-			console.error( `Not clickable after "${ iteration }" tries` );
+			console.error(
+				`Element still not clickable after "${ iteration }" retries`
+			);
 		}
 		return clickIfClickable(
 			driver,

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -467,6 +467,7 @@ const waitForMediaLibrary = async ( driver ) => {
 /**
  * @param {string} driver
  * @param {string} elementLocator
+ * @param {number} length - The number of elements returned, default value is 1. Uncommon blocks may return more than 1.
  * @param {number} maxIteration - Default value is 25
  * @param {number} iteration - Default value is 0
  * @return {string} - Returns the first element found, empty string if not found
@@ -474,6 +475,7 @@ const waitForMediaLibrary = async ( driver ) => {
 const waitForVisible = async (
 	driver,
 	elementLocator,
+	length = 1,
 	maxIteration = 25,
 	iteration = 0
 ) => {
@@ -492,11 +494,12 @@ const waitForVisible = async (
 	}
 
 	const element = await driver.elementsByXPath( elementLocator );
-	if ( element.length !== 1 ) {
+	if ( element.length !== length ) {
 		// if locator is not visible, try again
 		return waitForVisible(
 			driver,
 			elementLocator,
+			length,
 			maxIteration,
 			iteration + 1
 		);
@@ -508,17 +511,20 @@ const waitForVisible = async (
 /**
  * @param {string} driver
  * @param {string} elementLocator
+ * @param {number} length - The number of elements returned, default value is 1. Uncommon blocks may return more than 1.
  * @param {number} maxIteration - Default value is 25, can be adjusted to be less to wait for element to not be visible
  * @return {boolean} - Returns true if element is found, false otherwise
  */
 const isElementVisible = async (
 	driver,
 	elementLocator,
+	length = 1,
 	maxIteration = 25
 ) => {
 	const element = await waitForVisible(
 		driver,
 		elementLocator,
+		length,
 		maxIteration
 	);
 

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -311,7 +311,7 @@ const longPressMiddleOfElement = async ( driver, element ) => {
 	const y = location.y + size.height / 2;
 	action.press( { x, y } );
 	// Setting to wait a bit longer because this is failing more frequently on the CI
-	action.wait( 3500 );
+	action.wait( 5000 );
 	action.release();
 	await action.perform();
 };

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -471,7 +471,6 @@ const waitForMediaLibrary = async ( driver ) => {
 /**
  * @param {string} driver
  * @param {string} elementLocator
- * @param {number} length - The number of elements returned, default value is 1. Uncommon blocks may return more than 1.
  * @param {number} maxIteration - Default value is 25
  * @param {number} iteration - Default value is 0
  * @return {string} - Returns the first element found, empty string if not found
@@ -479,7 +478,6 @@ const waitForMediaLibrary = async ( driver ) => {
 const waitForVisible = async (
 	driver,
 	elementLocator,
-	length = 1,
 	maxIteration = 25,
 	iteration = 0
 ) => {
@@ -498,12 +496,11 @@ const waitForVisible = async (
 	}
 
 	const element = await driver.elementsByXPath( elementLocator );
-	if ( element.length !== length ) {
+	if ( element.length === 0 ) {
 		// if locator is not visible, try again
 		return waitForVisible(
 			driver,
 			elementLocator,
-			length,
 			maxIteration,
 			iteration + 1
 		);
@@ -515,20 +512,17 @@ const waitForVisible = async (
 /**
  * @param {string} driver
  * @param {string} elementLocator
- * @param {number} length - The number of elements returned, default value is 1. Uncommon blocks may return more than 1.
  * @param {number} maxIteration - Default value is 25, can be adjusted to be less to wait for element to not be visible
  * @return {boolean} - Returns true if element is found, false otherwise
  */
 const isElementVisible = async (
 	driver,
 	elementLocator,
-	length = 1,
 	maxIteration = 25
 ) => {
 	const element = await waitForVisible(
 		driver,
 		elementLocator,
-		length,
 		maxIteration
 	);
 
@@ -543,14 +537,12 @@ const isElementVisible = async (
 const clickIfClickable = async (
 	driver,
 	elementLocator,
-	length = 1,
 	maxIteration = 10,
 	iteration = 0
 ) => {
 	const element = await waitForVisible(
 		driver,
 		elementLocator,
-		length,
 		maxIteration,
 		iteration
 	);
@@ -565,7 +557,6 @@ const clickIfClickable = async (
 		return clickIfClickable(
 			driver,
 			elementLocator,
-			length,
 			maxIteration,
 			iteration + 1
 		);

--- a/packages/react-native-editor/__device-tests__/helpers/utils.js
+++ b/packages/react-native-editor/__device-tests__/helpers/utils.js
@@ -310,7 +310,8 @@ const longPressMiddleOfElement = async ( driver, element ) => {
 	const x = location.x + size.width / 2;
 	const y = location.y + size.height / 2;
 	action.press( { x, y } );
-	action.wait( 2000 );
+	// Setting to wait a bit longer because this is failing more frequently on the CI
+	action.wait( 3500 );
 	action.release();
 	await action.perform();
 };

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -753,12 +753,7 @@ class EditorPage {
 	async getColumnsBlockVisible() {
 		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
 
-		const expectedLength = isAndroid() ? 12 : 6;
-		return await waitForVisible(
-			this.driver,
-			firstBlockLocator,
-			expectedLength
-		);
+		return await waitForVisible( this.driver, firstBlockLocator );
 	}
 
 	// =============================
@@ -768,14 +763,7 @@ class EditorPage {
 	async getUnsupportedBlockVisible() {
 		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
 
-		// Unsupported blocks does not return length === 1 like other blocks
-		// Not sure how this is derived but this is the combination that works for unsupported blocks
-		const expectedLength = isAndroid() ? 2 : 6;
-		return await waitForVisible(
-			this.driver,
-			firstBlockLocator,
-			expectedLength
-		);
+		return await waitForVisible( this.driver, firstBlockLocator );
 	}
 
 	async getUnsupportedBlockHelpButton() {
@@ -784,12 +772,7 @@ class EditorPage {
 			? '//android.widget.Button[@content-desc="Help button, Tap here to show help"]'
 			: `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
 
-		const expectedLength = isAndroid() ? 2 : 1;
-		return await waitForVisible(
-			this.driver,
-			blockLocator,
-			expectedLength
-		);
+		return await waitForVisible( this.driver, blockLocator );
 	}
 
 	async getUnsupportedBlockBottomSheetEditButton() {
@@ -806,12 +789,7 @@ class EditorPage {
 			? '//android.webkit.WebView'
 			: '//XCUIElementTypeWebView';
 
-		const expectedLength = isAndroid() ? 1 : 3;
-		return await waitForVisible(
-			this.driver,
-			blockLocator,
-			expectedLength
-		);
+		return await waitForVisible( this.driver, blockLocator );
 	}
 
 	async stopDriver() {

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -544,12 +544,7 @@ class EditorPage {
 			? '//android.widget.HorizontalScrollView[@content-desc="Slash inserter results"]/android.view.ViewGroup'
 			: '(//XCUIElementTypeOther[@name="Slash inserter results"])[1]';
 
-		return await isElementVisible(
-			this.driver,
-			slashInserterLocator,
-			1,
-			5
-		);
+		return await isElementVisible( this.driver, slashInserterLocator, 5 );
 	}
 
 	// =========================
@@ -699,6 +694,7 @@ class EditorPage {
 		await this.openBlockSettings( block );
 
 		const elementName = isAndroid() ? '//*' : '//XCUIElementTypeOther';
+
 		const locator = `${ elementName }[starts-with(@${ this.accessibilityIdXPathAttrib }, "Hide search heading")]`;
 		const hideSearchHeadingToggle = await waitForVisible(
 			this.driver,
@@ -712,6 +708,7 @@ class EditorPage {
 		await this.openBlockSettings( block );
 
 		const elementName = isAndroid() ? '//*' : '//XCUIElementTypeButton';
+
 		const locator = `${ elementName }[starts-with(@${ this.accessibilityIdXPathAttrib }, "Button position")]`;
 		let optionMenuButton = await waitForVisible( this.driver, locator );
 		await optionMenuButton.click();
@@ -729,6 +726,7 @@ class EditorPage {
 		await this.openBlockSettings( block );
 
 		const elementName = isAndroid() ? '//*' : '//XCUIElementTypeOther';
+
 		const locator = `${ elementName }[starts-with(@${ this.accessibilityIdXPathAttrib }, "Use icon button")]`;
 		const useIconButton = await waitForVisible( this.driver, locator );
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -566,20 +566,17 @@ class EditorPage {
 	) {
 		// iOS needs a few extra steps to get the text element
 		if ( ! isAndroid() ) {
-			// Wait for and click the list in the correct position
-			let listBlock = await waitForVisible(
+			// Click the list in the correct position
+			await clickIfClickable(
 				this.driver,
 				`(//XCUIElementTypeOther[contains(@name, "List Block. Row ${ position }")])[1]`
 			);
-			await listBlock.click();
 
 			const listBlockLocator = options.isEmptyBlock
 				? `(//XCUIElementTypeStaticText[contains(@name, "List")])`
 				: `//XCUIElementTypeButton[contains(@name, "List")]`;
 
-			// Wait for and click the list to get the text element
-			listBlock = await waitForVisible( this.driver, listBlockLocator );
-			await listBlock.click();
+			await clickIfClickable( this.driver, listBlockLocator );
 		}
 
 		const listBlockTextLocatorIOS = options.isEmptyBlock

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -316,11 +316,7 @@ class EditorPage {
 				? '//android.widget.Button[@content-desc="Add Block Before"]'
 				: '//XCUIElementTypeButton[@name="Add Block Before"]';
 
-			const addBlockBeforeButton = await waitForVisible(
-				this.driver,
-				addBlockBeforeButtonLocator
-			);
-			await addBlockBeforeButton.click();
+			await clickIfClickable( this.driver, addBlockBeforeButtonLocator );
 		} else {
 			await addButton.click();
 		}

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -15,6 +15,7 @@ const {
 	toggleHtmlMode,
 	typeString,
 	waitForVisible,
+	clickIfClickable,
 } = require( '../helpers/utils' );
 
 const initializeEditorPage = async () => {
@@ -616,22 +617,14 @@ class EditorPage {
 	}
 
 	async replaceMediaImage() {
-		await waitForVisible(
+		await clickIfClickable(
 			this.driver,
-			'(//XCUIElementTypeButton[@name="Edit image"])'
+			'(//XCUIElementTypeButton[@name="Edit image"])[1]'
 		);
-
-		// There are multiple "Edit image" buttons layered on the screen, this is to get the right button
-		const editImageButtons = await this.driver.elementsByAccessibilityId(
-			'Edit image'
-		);
-		await editImageButtons[ editImageButtons.length - 1 ].click();
-
-		const replaceButton = await waitForVisible(
+		await clickIfClickable(
 			this.driver,
 			'//XCUIElementTypeButton[@name="Replace"]'
 		);
-		await replaceButton.click();
 	}
 
 	// =========================

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -226,9 +226,11 @@ class EditorPage {
 	// Set html editor content explicitly.
 	async setHtmlContent( html ) {
 		await toggleHtmlMode( this.driver, true );
+
 		const base64String = Buffer.from( html ).toString( 'base64' );
 
 		await this.driver.setClipboard( base64String, 'plaintext' );
+
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
 
 		if ( isAndroid() ) {
@@ -238,7 +240,6 @@ class EditorPage {
 			await htmlContentView.type( html );
 		} else {
 			await htmlContentView.click();
-
 			await doubleTap( this.driver, htmlContentView );
 			// Sometimes double tap is not enough for paste menu to appear, so we also long press.
 			await longPressMiddleOfElement( this.driver, htmlContentView );
@@ -247,6 +248,7 @@ class EditorPage {
 				this.driver,
 				'//XCUIElementTypeMenuItem[@name="Paste"]'
 			);
+
 			await pasteButton.click();
 		}
 

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -741,29 +741,13 @@ class EditorPage {
 	}
 
 	// =============================
-	// Columns Block functions
-	// =============================
-
-	async getColumnsBlockVisible() {
-		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
-
-		return await waitForVisible( this.driver, firstBlockLocator );
-	}
-
-	// =============================
 	// Unsupported Block functions
 	// =============================
-
-	async getUnsupportedBlockVisible() {
-		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
-
-		return await waitForVisible( this.driver, firstBlockLocator );
-	}
 
 	async getUnsupportedBlockHelpButton() {
 		const accessibilityId = 'Help button';
 		const blockLocator = isAndroid()
-			? '//android.widget.Button[@content-desc="Help button, Tap here to show help"]'
+			? `//android.widget.Button[starts-with(@content-desc, "${ accessibilityId }")]`
 			: `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
 
 		return await waitForVisible( this.driver, blockLocator );
@@ -772,7 +756,7 @@ class EditorPage {
 	async getUnsupportedBlockBottomSheetEditButton() {
 		const accessibilityId = 'Edit using web editor';
 		const blockLocator = isAndroid()
-			? '//android.widget.Button[@content-desc="Edit using web editor"]'
+			? `//android.widget.Button[@content-desc="${ accessibilityId }"]`
 			: `//XCUIElementTypeButton[@name="${ accessibilityId }"]`;
 
 		return await waitForVisible( this.driver, blockLocator );

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -225,11 +225,9 @@ class EditorPage {
 	// Set html editor content explicitly.
 	async setHtmlContent( html ) {
 		await toggleHtmlMode( this.driver, true );
-
 		const base64String = Buffer.from( html ).toString( 'base64' );
 
 		await this.driver.setClipboard( base64String, 'plaintext' );
-
 		const htmlContentView = await this.getTextViewForHtmlViewContent();
 
 		if ( isAndroid() ) {
@@ -239,14 +237,15 @@ class EditorPage {
 			await htmlContentView.type( html );
 		} else {
 			await htmlContentView.click();
+
 			await doubleTap( this.driver, htmlContentView );
 			// Sometimes double tap is not enough for paste menu to appear, so we also long press.
 			await longPressMiddleOfElement( this.driver, htmlContentView );
 
-			const pasteButton = this.driver.elementByXPath(
+			const pasteButton = await waitForVisible(
+				this.driver,
 				'//XCUIElementTypeMenuItem[@name="Paste"]'
 			);
-
 			await pasteButton.click();
 		}
 
@@ -546,7 +545,12 @@ class EditorPage {
 			? '//android.widget.HorizontalScrollView[@content-desc="Slash inserter results"]/android.view.ViewGroup'
 			: '(//XCUIElementTypeOther[@name="Slash inserter results"])[1]';
 
-		return await isElementVisible( this.driver, slashInserterLocator, 5 );
+		return await isElementVisible(
+			this.driver,
+			slashInserterLocator,
+			1,
+			5
+		);
 	}
 
 	// =========================

--- a/packages/react-native-editor/__device-tests__/pages/editor-page.js
+++ b/packages/react-native-editor/__device-tests__/pages/editor-page.js
@@ -145,12 +145,12 @@ class EditorPage {
 
 	async getFirstBlockVisible() {
 		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
-		const elements = await this.driver.elementsByXPath( firstBlockLocator );
-		return elements[ 0 ];
+		return await waitForVisible( this.driver, firstBlockLocator );
 	}
 
 	async getLastBlockVisible() {
 		const firstBlockLocator = `//*[contains(@${ this.accessibilityIdXPathAttrib }, " Block. Row ")]`;
+		await waitForVisible( this.driver, firstBlockLocator );
 		const elements = await this.driver.elementsByXPath( firstBlockLocator );
 		return elements[ elements.length - 1 ];
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR removes the condition in `getBlockAtPosition()` to only wait for certain blocks and apply it to all blocks. 

## Why?
To remove the flakiness caused by elements not being loaded properly during test run time. 

## How?
1. Apply the `waitForVisible()` in `getBlockAtPosition()` to all blocks (previously only applied to text-related blocks). With this change, we can remove _most_ of the implicit waits used across the code base.
2. Remove length as a parameter on `waitForVisible()` as Columns and Unsupported blocks return values other than 1. Element is presumed to be visible as long as there is at least 1 element returned.
3. Also introduced a new helper `clickIfClickable()` which combines waiting for an element to be visible + clicking it once it's visible

## Testing Instructions
- Run all tests locally and they should pass.
- Full test on CI should also pass.

## Screenshots or screencast <!-- if applicable -->
