### PR TITLE
Move the "HTML element" control to a block editor component

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -481,8 +481,8 @@ _Parameters_
 
 -   _props_ `Object`: Component props.
 -   _props.onChange_ `Function`: Callback to handle onChange.
--   _props.tagNameOptions_ `Object`: Tagnames to be used in the select control.
--   _props.selectedValue_ `string`: Selected tag value.
+-   _props.options_ `Object`: Tagnames to be used in the select control.
+-   _props.value_ `string`: Selected tag value.
 
 _Returns_
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -473,6 +473,21 @@ _Returns_
 
 -   `string`: returns the cssUnit value in a simple px format.
 
+### HtmlElementControl
+
+Control for selecting the block tagname.
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
+-   _props.onChange_ `Function`: Callback to handle onChange.
+-   _props.tagNameOptions_ `Object`: Tagnames to be used in the select control.
+-   _props.selectedValue_ `string`: Selected tag value.
+
+_Returns_
+
+-   `WPElement`: Control for selecting the block tagname.
+
 ### InnerBlocks
 
 _Related_

--- a/packages/block-editor/src/components/html-element/README.MD
+++ b/packages/block-editor/src/components/html-element/README.MD
@@ -29,7 +29,7 @@ An array of tag names and labels. Should be of the format:
 [
 	{ label: __( 'Default (<div>)' ), value: 'div' },
 	{ label: '<header>', value: 'header' },
-	...
+	/* ... */
 ]
 ```
 

--- a/packages/block-editor/src/components/html-element/README.MD
+++ b/packages/block-editor/src/components/html-element/README.MD
@@ -1,0 +1,68 @@
+# HtmlElementControl
+
+Allow users to select the HTML tag used by the block.
+
+## Usage
+
+```jsx
+import { HtmlElementControl } from '@wordpress/block-editor';
+
+const Example = () => (
+	<HtmlElementControl
+		selectedValue={ TagName }
+		onChange={ ( value ) =>
+			setAttributes( { tagName: value } )
+		}
+	/>
+);
+```
+
+## Props
+
+The component accepts the following props:
+
+### tagNameOptions
+
+An array of tag names and labels. Should be of the format:
+
+```js
+[
+	{ label: __( 'Default (<div>)' ), value: 'div' },
+	{ label: '<header>', value: 'header' },
+	...
+]
+```
+
+If not provided, the default selection of tags are shown.
+
+-   Type: `Array`
+-   Required: No
+
+Default:
+
+```js
+[
+		{ label: '<div>', value: 'div' },
+		{ label: '<header>', value: 'header' },
+		{ label: '<main>', value: 'main' },
+		{ label: '<section>', value: 'section' },
+		{ label: '<article>', value: 'article' },
+		{ label: '<aside>', value: 'aside' },
+		{ label: '<footer>', value: 'footer' },
+		{ label: '<nav>', value: 'nav' },
+	];
+```
+
+### selectedValue
+
+The selected value from the select list.
+
+-   Type: `String`
+-   Required: Yes
+
+### onChange
+
+The function called when the tag changes.
+
+-   Type: `Function`
+-   Required: Yes

--- a/packages/block-editor/src/components/html-element/README.MD
+++ b/packages/block-editor/src/components/html-element/README.MD
@@ -9,7 +9,7 @@ import { HtmlElementControl } from '@wordpress/block-editor';
 
 const Example = () => (
 	<HtmlElementControl
-		selectedValue={ TagName }
+		value={ TagName }
 		onChange={ ( value ) =>
 			setAttributes( { tagName: value } )
 		}
@@ -21,7 +21,7 @@ const Example = () => (
 
 The component accepts the following props:
 
-### tagNameOptions
+### options
 
 An array of tag names and labels. Should be of the format:
 
@@ -29,7 +29,7 @@ An array of tag names and labels. Should be of the format:
 [
 	{ label: __( 'Default (<div>)' ), value: 'div' },
 	{ label: '<header>', value: 'header' },
-	/* ... */
+	...
 ]
 ```
 
@@ -42,18 +42,18 @@ Default:
 
 ```js
 [
-		{ label: '<div>', value: 'div' },
-		{ label: '<header>', value: 'header' },
-		{ label: '<main>', value: 'main' },
-		{ label: '<section>', value: 'section' },
-		{ label: '<article>', value: 'article' },
-		{ label: '<aside>', value: 'aside' },
-		{ label: '<footer>', value: 'footer' },
-		{ label: '<nav>', value: 'nav' },
-	];
+	{ label: '<div>', value: 'div' },
+	{ label: '<header>', value: 'header' },
+	{ label: '<main>', value: 'main' },
+	{ label: '<section>', value: 'section' },
+	{ label: '<article>', value: 'article' },
+	{ label: '<aside>', value: 'aside' },
+	{ label: '<footer>', value: 'footer' },
+	{ label: '<nav>', value: 'nav' },
+];
 ```
 
-### selectedValue
+### value
 
 The selected value from the select list.
 

--- a/packages/block-editor/src/components/html-element/index.js
+++ b/packages/block-editor/src/components/html-element/index.js
@@ -42,26 +42,26 @@ const DEFAULT_OPTIONS = [
 /**
  * Control for selecting the block tagname.
  *
- * @param {Object}   props                Component props.
- * @param {Function} props.onChange       Callback to handle onChange.
- * @param {Object}   props.tagNameOptions Tagnames to be used in the select control.
- * @param {string}   props.selectedValue  Selected tag value.
+ * @param {Object}   props          Component props.
+ * @param {Function} props.onChange Callback to handle onChange.
+ * @param {Object}   props.options  Tagnames to be used in the select control.
+ * @param {string}   props.value    Selected tag value.
  *
- * @return {WPElement}                    Control for selecting the block tagname.
+ * @return {WPElement}              Control for selecting the block tagname.
  */
 
 export default function HtmlElementControl( {
 	onChange,
-	tagNameOptions = DEFAULT_OPTIONS,
-	selectedValue,
+	options = DEFAULT_OPTIONS,
+	value,
 } ) {
 	return (
 		<SelectControl
 			label={ __( 'HTML element' ) }
-			options={ tagNameOptions }
-			value={ selectedValue }
+			options={ options }
+			value={ value }
 			onChange={ onChange }
-			help={ htmlElementMessages[ selectedValue ] }
+			help={ htmlElementMessages[ value ] }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/html-element/index.js
+++ b/packages/block-editor/src/components/html-element/index.js
@@ -28,6 +28,17 @@ const htmlElementMessages = {
 	),
 };
 
+const DEFAULT_OPTIONS = [
+	{ label: '<div>', value: 'div' },
+	{ label: '<header>', value: 'header' },
+	{ label: '<main>', value: 'main' },
+	{ label: '<section>', value: 'section' },
+	{ label: '<article>', value: 'article' },
+	{ label: '<aside>', value: 'aside' },
+	{ label: '<footer>', value: 'footer' },
+	{ label: '<nav>', value: 'nav' },
+];
+
 /**
  * Control for selecting the block tagname.
  *
@@ -38,34 +49,16 @@ const htmlElementMessages = {
  *
  * @return {WPElement}                    Control for selecting the block tagname.
  */
+
 export default function HtmlElementControl( {
 	onChange,
-	tagNameOptions,
+	tagNameOptions = DEFAULT_OPTIONS,
 	selectedValue,
 } ) {
-	// Default tag name options
-	let options = [
-		{ label: '<div>', value: 'div' },
-		{ label: '<header>', value: 'header' },
-		{ label: '<main>', value: 'main' },
-		{ label: '<section>', value: 'section' },
-		{ label: '<article>', value: 'article' },
-		{ label: '<aside>', value: 'aside' },
-		{ label: '<footer>', value: 'footer' },
-		{ label: '<nav>', value: 'nav' },
-	];
-
-	if ( tagNameOptions ) {
-		options = tagNameOptions.map( ( { label, value } ) => ( {
-			label,
-			value,
-		} ) );
-	}
-
 	return (
 		<SelectControl
 			label={ __( 'HTML element' ) }
-			options={ options }
+			options={ tagNameOptions }
 			value={ selectedValue }
 			onChange={ onChange }
 			help={ htmlElementMessages[ selectedValue ] }

--- a/packages/block-editor/src/components/html-element/index.js
+++ b/packages/block-editor/src/components/html-element/index.js
@@ -34,7 +34,7 @@ const htmlElementMessages = {
  * @param {Object}   props                Component props.
  * @param {Function} props.onChange       Callback to handle onChange.
  * @param {Object}   props.tagNameOptions Tagnames to be used in the select control.
- * @param {Object}   props.selectedValue  Selected tag value.
+ * @param {string}   props.selectedValue  Selected tag value.
  *
  * @return {WPElement}                    Control for selecting the block tagname.
  */

--- a/packages/block-editor/src/components/html-element/index.js
+++ b/packages/block-editor/src/components/html-element/index.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+const htmlElementMessages = {
+	header: __(
+		'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
+	),
+	main: __(
+		'The <main> element should be used for the primary content of your document only. '
+	),
+	section: __(
+		"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
+	),
+	article: __(
+		'The <article> element should represent a self contained, syndicatable portion of the document.'
+	),
+	aside: __(
+		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
+	),
+	footer: __(
+		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
+	),
+	nav: __(
+		'The <nav> element should represent a navigation element (e.g. a list of links).'
+	),
+};
+
+/**
+ * Control for selecting the block tagname.
+ *
+ * @param {Object}   props                Component props.
+ * @param {Function} props.onChange       Callback to handle onChange.
+ * @param {Object}   props.tagNameOptions Tagnames to be used in the select control.
+ * @param {Object}   props.selectedValue  Selected tag value.
+ *
+ * @return {WPElement}                    Control for selecting the block tagname.
+ */
+export default function HtmlElementControl( {
+	onChange,
+	tagNameOptions,
+	selectedValue,
+} ) {
+	// Default tag name options
+	let options = [
+		{ label: '<div>', value: 'div' },
+		{ label: '<header>', value: 'header' },
+		{ label: '<main>', value: 'main' },
+		{ label: '<section>', value: 'section' },
+		{ label: '<article>', value: 'article' },
+		{ label: '<aside>', value: 'aside' },
+		{ label: '<footer>', value: 'footer' },
+		{ label: '<nav>', value: 'nav' },
+	];
+
+	if ( tagNameOptions ) {
+		options = tagNameOptions.map( ( { label, value } ) => ( {
+			label,
+			value,
+		} ) );
+	}
+
+	return (
+		<SelectControl
+			label={ __( 'HTML element' ) }
+			options={ options }
+			value={ selectedValue }
+			onChange={ onChange }
+			help={ htmlElementMessages[ selectedValue ] }
+		/>
+	);
+}

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -56,6 +56,7 @@ export {
 	ImageEditingProvider as __experimentalImageEditingProvider,
 } from './image-editor';
 export { default as __experimentalImageSizeControl } from './image-size-control';
+export { default as HtmlElementControl } from './html-element';
 export { default as InnerBlocks, useInnerBlocksProps } from './inner-blocks';
 export {
 	default as InspectorControls,

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, HtmlElementControl } from '@wordpress/block-editor';
 
 export default function CommentsInspectorControls( {
 	attributes: { TagName },
@@ -12,14 +11,13 @@ export default function CommentsInspectorControls( {
 	return (
 		<InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
-				<SelectControl
-					label={ __( 'HTML element' ) }
-					options={ [
+				<HtmlElementControl
+					tagNameOptions={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },
 						{ label: '<section>', value: 'section' },
 						{ label: '<aside>', value: 'aside' },
 					] }
-					value={ TagName }
+					selectedValue={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}

--- a/packages/block-library/src/comments/edit/comments-inspector-controls.js
+++ b/packages/block-library/src/comments/edit/comments-inspector-controls.js
@@ -12,12 +12,12 @@ export default function CommentsInspectorControls( {
 		<InspectorControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<HtmlElementControl
-					tagNameOptions={ [
+					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },
 						{ label: '<section>', value: 'section' },
 						{ label: '<aside>', value: 'aside' },
 					] }
-					selectedValue={ TagName }
+					value={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -48,21 +48,10 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		}
 	);
 
-	const tagNames = [
-		{ label: __( 'Default (<div>)' ), value: 'div' },
-		{ label: '<header>', value: 'header' },
-		{ label: '<main>', value: 'main' },
-		{ label: '<section>', value: 'section' },
-		{ label: '<article>', value: 'article' },
-		{ label: '<aside>', value: 'aside' },
-		{ label: '<footer>', value: 'footer' },
-	];
-
 	return (
 		<>
 			<InspectorControls __experimentalGroup="advanced">
 				<HtmlElementControl
-					tagNameOptions={ tagNames }
 					selectedValue={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -51,7 +51,7 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		<>
 			<InspectorControls __experimentalGroup="advanced">
 				<HtmlElementControl
-					selectedValue={ TagName }
+					value={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -11,7 +11,6 @@ import {
 	store as blockEditorStore,
 	HtmlElementControl,
 } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(

--- a/packages/block-library/src/group/edit.js
+++ b/packages/block-library/src/group/edit.js
@@ -9,30 +9,9 @@ import {
 	useInnerBlocksProps,
 	useSetting,
 	store as blockEditorStore,
+	HtmlElementControl,
 } from '@wordpress/block-editor';
-import { SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-
-const htmlElementMessages = {
-	header: __(
-		'The <header> element should represent introductory content, typically a group of introductory or navigational aids.'
-	),
-	main: __(
-		'The <main> element should be used for the primary content of your document only. '
-	),
-	section: __(
-		"The <section> element should represent a standalone portion of the document that can't be better represented by another element."
-	),
-	article: __(
-		'The <article> element should represent a self contained, syndicatable portion of the document.'
-	),
-	aside: __(
-		"The <aside> element should represent a portion of a document whose content is only indirectly related to the document's main content."
-	),
-	footer: __(
-		'The <footer> element should represent a footer for its nearest sectioning element (e.g.: <section>, <article>, <main> etc.).'
-	),
-};
 
 function GroupEdit( { attributes, setAttributes, clientId } ) {
 	const { hasInnerBlocks, themeSupportsLayout } = useSelect(
@@ -69,25 +48,25 @@ function GroupEdit( { attributes, setAttributes, clientId } ) {
 		}
 	);
 
+	const tagNames = [
+		{ label: __( 'Default (<div>)' ), value: 'div' },
+		{ label: '<header>', value: 'header' },
+		{ label: '<main>', value: 'main' },
+		{ label: '<section>', value: 'section' },
+		{ label: '<article>', value: 'article' },
+		{ label: '<aside>', value: 'aside' },
+		{ label: '<footer>', value: 'footer' },
+	];
+
 	return (
 		<>
 			<InspectorControls __experimentalGroup="advanced">
-				<SelectControl
-					label={ __( 'HTML element' ) }
-					options={ [
-						{ label: __( 'Default (<div>)' ), value: 'div' },
-						{ label: '<header>', value: 'header' },
-						{ label: '<main>', value: 'main' },
-						{ label: '<section>', value: 'section' },
-						{ label: '<article>', value: 'article' },
-						{ label: '<aside>', value: 'aside' },
-						{ label: '<footer>', value: 'footer' },
-					] }
-					value={ TagName }
+				<HtmlElementControl
+					tagNameOptions={ tagNames }
+					selectedValue={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}
-					help={ htmlElementMessages[ TagName ] }
 				/>
 			</InspectorControls>
 			{ layoutSupportEnabled && <TagName { ...innerBlocksProps } /> }

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -113,13 +113,13 @@ export function QueryContent( {
 			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
 				<HtmlElementControl
-					tagNameOptions={ [
+					options={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },
 						{ label: '<main>', value: 'main' },
 						{ label: '<section>', value: 'section' },
 						{ label: '<aside>', value: 'aside' },
 					] }
-					selectedValue={ TagName }
+					value={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}

--- a/packages/block-library/src/query/edit/index.js
+++ b/packages/block-library/src/query/edit/index.js
@@ -14,13 +14,9 @@ import {
 	useInnerBlocksProps,
 	__experimentalGetMatchingVariation as getMatchingVariation,
 	__experimentalBlockPatternSetup as BlockPatternSetup,
+	HtmlElementControl,
 } from '@wordpress/block-editor';
-import {
-	Button,
-	SelectControl,
-	Placeholder,
-	Modal,
-} from '@wordpress/components';
+import { Button, Placeholder, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -116,15 +112,14 @@ export function QueryContent( {
 				/>
 			</BlockControls>
 			<InspectorControls __experimentalGroup="advanced">
-				<SelectControl
-					label={ __( 'HTML element' ) }
-					options={ [
+				<HtmlElementControl
+					tagNameOptions={ [
 						{ label: __( 'Default (<div>)' ), value: 'div' },
 						{ label: '<main>', value: 'main' },
 						{ label: '<section>', value: 'section' },
 						{ label: '<aside>', value: 'aside' },
 					] }
-					value={ TagName }
+					selectedValue={ TagName }
 					onChange={ ( value ) =>
 						setAttributes( { tagName: value } )
 					}

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -4,7 +4,7 @@
 import { useEntityProp } from '@wordpress/core-data';
 import { SelectControl, TextControl } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, HtmlElementControl } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
 export function TemplatePartAdvancedControls( {
@@ -65,9 +65,8 @@ export function TemplatePartAdvancedControls( {
 					/>
 				</>
 			) }
-			<SelectControl
-				label={ __( 'HTML element' ) }
-				options={ [
+			<HtmlElementControl
+				tagNameOptions={ [
 					{
 						label: sprintf(
 							/* translators: %s: HTML tag based on area. */
@@ -84,7 +83,7 @@ export function TemplatePartAdvancedControls( {
 					{ label: '<footer>', value: 'footer' },
 					{ label: '<div>', value: 'div' },
 				] }
-				value={ tagName || '' }
+				selectedValue={ tagName || '' }
 				onChange={ ( value ) => setAttributes( { tagName: value } ) }
 			/>
 		</InspectorControls>

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -66,7 +66,7 @@ export function TemplatePartAdvancedControls( {
 				</>
 			) }
 			<HtmlElementControl
-				tagNameOptions={ [
+				options={ [
 					{
 						label: sprintf(
 							/* translators: %s: HTML tag based on area. */
@@ -83,7 +83,7 @@ export function TemplatePartAdvancedControls( {
 					{ label: '<footer>', value: 'footer' },
 					{ label: '<div>', value: 'div' },
 				] }
-				selectedValue={ tagName || '' }
+				value={ tagName || '' }
 				onChange={ ( value ) => setAttributes( { tagName: value } ) }
 			/>
 		</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a new component for selecting a HTML tag for the TagName block attribute.

Partial for https://github.com/WordPress/gutenberg/issues/33343

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The control for selecting a HTML tag for a block is re-used in a couple of blocks and by creating a block editor component for it we reduce the duplicated code and it will be easier to update in the future.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Adds a new component called HtmlElementControl (open for better name suggestions!),
with a default list of selectable HTML tags and helptext.
2. Updates the group, comments, template part and query blocks to use the component.

## Testing Instructions

1. Activate Twenty Twenty-two and open the site editor (Reset any customizations).
2. Viewing the home template, add a comments block.
3. Confirm that:
-The header template part correctly uses the tagName it has been assigned: `header`
-The first group block in the root level of the template correctly uses the `main` element.
-You can change the header template part, the group block, comments and the query block to any element listed in the "HTML element" control in the Advanced section of the block settings sidebar.
-Help text is displaying correctly below the control.

4. Save and reload the site editor, confirm that there are no block validation errors or other issues.
5. View the front, confirm that the blocks use the correct tag.

## Screenshots or screencast <!-- if applicable -->
