### PR TITLE
Quote: Fix the embed discovery

### DIFF
--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -81,6 +81,7 @@ export default function QuoteEdit( {
 						createBlock( 'core/paragraph' )
 					}
 					textAlign={ align }
+					__unstableEmbedURLOnPaste
 				/>
 				{ ( ! RichText.isEmpty( citation ) || isSelected ) && (
 					<RichText


### PR DESCRIPTION
## What?
Fixes #15971.

PR updates Quote block to support the embed transformation when the URL is pasted on its line.

## Why?
This matches the results when content is parsed on the front-end.

## How?
By adding the `__unstableEmbedURLOnPaste` flag to the RichText component.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Quote block.
3. Paste the URL as a quote - `https://wordpress.org/news/2022/05/wordpress-6-0-release-candidate-3-rc3-now-available-for-testing/`
4. Quote is transformed into an Embed block.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/169019781-617cc89a-3cd2-40a8-bcb0-7f22cf9b601e.mp4



