### PR TITLE
Improves the types of createHigherOrderComponent and its usages

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -79,7 +79,7 @@ name, returns the enhanced component augmented with a generated displayName.
 
 _Parameters_
 
--   _mapComponent_ `HigherOrderComponent< HOCProps >`: Function mapping component to enhanced component.
+-   _mapComponent_ `( Inner: TInner ) => TOuter`: Function mapping component to enhanced component.
 -   _modifierName_ `string`: Seed name from which to generated display name.
 
 _Returns_
@@ -105,7 +105,7 @@ const ConditionalComponent = ifCondition(
 
 _Parameters_
 
--   _predicate_ `( props: TProps ) => boolean`: Function to test condition.
+-   _predicate_ `( props: Props ) => boolean`: Function to test condition.
 
 _Returns_
 

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
  * Internal dependencies
  */
 import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
@@ -20,12 +25,10 @@ import { createHigherOrderComponent } from '../../utils/create-higher-order-comp
  *
  * @return Higher-order component.
  */
-const ifCondition = < TProps extends Record< string, any > >(
-	predicate: ( props: TProps ) => boolean
-) =>
-	createHigherOrderComponent< {} >(
-		( WrappedComponent ) => ( props ) => {
-			if ( ! predicate( props as TProps ) ) {
+function ifCondition< Props >( predicate: ( props: Props ) => boolean ) {
+	return createHigherOrderComponent(
+		( WrappedComponent: ComponentType< Props > ) => ( props: Props ) => {
+			if ( ! predicate( props ) ) {
 				return null;
 			}
 
@@ -33,5 +36,6 @@ const ifCondition = < TProps extends Record< string, any > >(
 		},
 		'ifCondition'
 	);
+}
 
 export default ifCondition;

--- a/packages/compose/src/higher-order/if-condition/index.tsx
+++ b/packages/compose/src/higher-order/if-condition/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * Higher-order component creator, creating a new component which renders if

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { ComponentType, ComponentClass } from 'react';
+
+/**
  * WordPress dependencies
  */
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -10,40 +15,33 @@ import { Component } from '@wordpress/element';
 import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
- * External dependencies
- */
-import type { ComponentType, ComponentClass } from 'react';
-
-/**
  * Given a component returns the enhanced component augmented with a component
  * only re-rendering when its props/state change
  */
-const pure = createHigherOrderComponent(
-	< TProps extends Record< string, any > >(
-		Wrapped: ComponentType< TProps >
-	) => {
-		if ( Wrapped.prototype instanceof Component ) {
-			return class extends ( Wrapped as ComponentClass< TProps > ) {
-				shouldComponentUpdate( nextProps: TProps, nextState: any ) {
-					return (
-						! isShallowEqual( nextProps, this.props ) ||
-						! isShallowEqual( nextState, this.state )
-					);
-				}
-			};
-		}
-
-		return class extends Component< TProps > {
-			shouldComponentUpdate( nextProps: TProps ) {
-				return ! isShallowEqual( nextProps, this.props );
-			}
-
-			render() {
-				return <Wrapped { ...this.props } />;
+const pure = createHigherOrderComponent( function < Props >(
+	WrappedComponent: ComponentType< Props >
+): ComponentType< Props > {
+	if ( WrappedComponent.prototype instanceof Component ) {
+		return class extends ( WrappedComponent as ComponentClass< Props > ) {
+			shouldComponentUpdate( nextProps: Props, nextState: any ) {
+				return (
+					! isShallowEqual( nextProps, this.props ) ||
+					! isShallowEqual( nextState, this.state )
+				);
 			}
 		};
-	},
-	'pure'
-);
+	}
+
+	return class extends Component< Props > {
+		shouldComponentUpdate( nextProps: Props ) {
+			return ! isShallowEqual( nextProps, this.props );
+		}
+
+		render() {
+			return <WrappedComponent { ...this.props } />;
+		}
+	};
+},
+'pure' );
 
 export default pure;

--- a/packages/compose/src/higher-order/pure/index.tsx
+++ b/packages/compose/src/higher-order/pure/index.tsx
@@ -7,7 +7,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * External dependencies

--- a/packages/compose/src/higher-order/with-global-events/index.js
+++ b/packages/compose/src/higher-order/with-global-events/index.js
@@ -12,7 +12,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 import Listener from './listener';
 
 /**

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,21 +1,30 @@
 /**
  * Internal dependencies
  */
-import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
+import {
+	createHigherOrderComponent,
+	WithInjectedProps,
+	WithoutInjectedProps,
+} from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
+
+type InstanceIdProps = { instanceId: string | number };
 
 /**
  * A Higher Order Component used to be provide a unique instance ID by
  * component.
  */
-const withInstanceId = createHigherOrderComponent< {
-	instanceId: string | number;
-} >( ( WrappedComponent ) => {
-	return ( props ) => {
-		const instanceId = useInstanceId( WrappedComponent );
-		// @ts-ignore
-		return <WrappedComponent { ...props } instanceId={ instanceId } />;
-	};
-}, 'withInstanceId' );
+const withInstanceId = createHigherOrderComponent(
+	< C extends WithInjectedProps< C, InstanceIdProps > >(
+		WrappedComponent: C
+	) => {
+		return ( props: WithoutInjectedProps< C, InstanceIdProps > ) => {
+			const instanceId = useInstanceId( WrappedComponent );
+			// @ts-ignore
+			return <WrappedComponent { ...props } instanceId={ instanceId } />;
+		};
+	},
+	'instanceId'
+);
 
 export default withInstanceId;

--- a/packages/compose/src/higher-order/with-instance-id/index.tsx
+++ b/packages/compose/src/higher-order/with-instance-id/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 import useInstanceId from '../../hooks/use-instance-id';
 
 /**

--- a/packages/compose/src/higher-order/with-preferred-color-scheme/index.native.js
+++ b/packages/compose/src/higher-order/with-preferred-color-scheme/index.native.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 import usePreferredColorScheme from '../../hooks/use-preferred-color-scheme';
 
 /**

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { without } from 'lodash';
-import type { ComponentType } from 'react';
 
 /**
  * WordPress dependencies
@@ -12,7 +11,11 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
+import {
+	createHigherOrderComponent,
+	WithInjectedProps,
+	WithoutInjectedProps,
+} from '../../utils/create-higher-order-component';
 
 /**
  * We cannot use the `Window['setTimeout']` and `Window['clearTimeout']`
@@ -22,25 +25,24 @@ import { createHigherOrderComponent } from '../../utils/create-higher-order-comp
  * In the case of this component, we only handle the simplest case where
  * `setTimeout` only accepts a function (not a string) and an optional delay.
  */
-type TimeoutProps = {
+interface TimeoutProps {
 	setTimeout: ( fn: () => void, delay: number ) => number;
 	clearTimeout: ( id: number ) => void;
-};
+}
 
 /**
  * A higher-order component used to provide and manage delayed function calls
  * that ought to be bound to a component's lifecycle.
  */
-const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
-	< TProps extends TimeoutProps >(
-		OriginalComponent: ComponentType< TProps >
+const withSafeTimeout = createHigherOrderComponent(
+	< C extends WithInjectedProps< C, TimeoutProps > >(
+		OriginalComponent: C
 	) => {
-		return class WrappedComponent extends Component<
-			Omit< TProps, keyof TimeoutProps >
-		> {
+		type WrappedProps = WithoutInjectedProps< C, TimeoutProps >;
+		return class WrappedComponent extends Component< WrappedProps > {
 			timeouts: number[];
 
-			constructor( props: Omit< TProps, keyof TimeoutProps > ) {
+			constructor( props: WrappedProps ) {
 				super( props );
 				this.timeouts = [];
 				this.setTimeout = this.setTimeout.bind( this );
@@ -51,7 +53,7 @@ const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
 				this.timeouts.forEach( clearTimeout );
 			}
 
-			setTimeout( fn: ( ...args: any[] ) => void, delay: number ) {
+			setTimeout( fn: () => void, delay: number ) {
 				const id = setTimeout( () => {
 					fn();
 					this.clearTimeout( id );
@@ -66,13 +68,14 @@ const withSafeTimeout = createHigherOrderComponent< TimeoutProps >(
 			}
 
 			render() {
-				const props = {
-					...this.props,
-					setTimeout: this.setTimeout,
-					clearTimeout: this.clearTimeout,
-				} as TProps;
-
-				return <OriginalComponent { ...props } />;
+				return (
+					// @ts-ignore
+					<OriginalComponent
+						{ ...this.props }
+						setTimeout={ this.setTimeout }
+						clearTimeout={ this.clearTimeout }
+					/>
+				);
 			}
 		};
 	},

--- a/packages/compose/src/higher-order/with-safe-timeout/index.tsx
+++ b/packages/compose/src/higher-order/with-safe-timeout/index.tsx
@@ -12,7 +12,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * We cannot use the `Window['setTimeout']` and `Window['clearTimeout']`

--- a/packages/compose/src/higher-order/with-state/index.js
+++ b/packages/compose/src/higher-order/with-state/index.js
@@ -7,7 +7,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../../utils/create-higher-order-component';
+import { createHigherOrderComponent } from '../../utils/create-higher-order-component';
 
 /**
  * A Higher Order Component used to provide and manage internal component state

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -1,5 +1,5 @@
-// Utils.
-export { default as createHigherOrderComponent } from './utils/create-higher-order-component';
+// The `createHigherOrderComponent` helper and helper types.
+export * from './utils/create-higher-order-component';
 
 // Compose helper (aliased flowRight from Lodash)
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/index.native.js
+++ b/packages/compose/src/index.native.js
@@ -1,5 +1,5 @@
-// Utils.
-export { default as createHigherOrderComponent } from './utils/create-higher-order-component';
+// The `createHigherOrderComponent` helper and helper types.
+export * from './utils/create-higher-order-component';
 
 // Compose helper (aliased flowRight from Lodash)
 export { default as compose } from './higher-order/compose';

--- a/packages/compose/src/utils/create-higher-order-component/index.ts
+++ b/packages/compose/src/utils/create-higher-order-component/index.ts
@@ -30,7 +30,7 @@ export type HigherOrderComponent< HOCProps extends Record< string, any > > = <
  *
  * @return Component class with generated display name assigned.
  */
-function createHigherOrderComponent<
+export function createHigherOrderComponent<
 	HOCProps extends Record< string, any > = {}
 >( mapComponent: HigherOrderComponent< HOCProps >, modifierName: string ) {
 	return < InnerProps extends HOCProps >(
@@ -44,5 +44,3 @@ function createHigherOrderComponent<
 		return Outer;
 	};
 }
-
-export default createHigherOrderComponent;

--- a/packages/compose/src/utils/create-higher-order-component/test/index.js
+++ b/packages/compose/src/utils/create-higher-order-component/test/index.js
@@ -6,7 +6,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import createHigherOrderComponent from '../';
+import { createHigherOrderComponent } from '../';
 
 describe( 'createHigherOrderComponent', () => {
 	it( 'should use default name for anonymous function', () => {


### PR DESCRIPTION
@dmsnell @sarayourfriend This is my attempt at correcting the types of `createHigherOrderComponent` and its applications, especially HOCs that inject props.

The `createHigherOrderComponent` type has two type parameters, the type of the input and output components. They both need to be a subtype of `ComponentType<any>`, so that we can read and write their `.displayName` fields. There are no further constraints an in practice, the types are always easily inferred from the type of `mapComponent`.

This is a blueprint for creating a prop-injecting HOC, with some new helper types:
```tsx
import {
  createHigherOrderComponent,
  WithInjectedProps,
  WithoutInjectedProps,
} from '@wordpress/compose';

type FooProps = { foo: string };

const withFoo = createHigherOrderComponent(
  < C extends WithInjectedProps< C, FooProps > >( Inner: C ) =>
    ( props: WithoutInjectedProps< C, FooProps > ) => {
      const foo = useFoo();
      // @ts-ignore
      return <Inner { ...props } foo={ foo } />;
    },
  'foo'
);
```

The `C extends WithInjectedProps< C, FooProps >` constraint checks that `C`, type of the wrapped component, supports all the props that are going to be injected. If `Bar` doesn't support a `foo` prop, then `withFoo( Bar )` will be a type error.

The result of `withFoo( C )` has type `WithoutInjectedProps< C, FooProps >`, i.e., all the props of `C` with injected props removed.

The `@ts-ignore` I had to do on the `<Inner>` JSX, that's a mysterious behavior that's probably a bug either in TypeScript itself or in `@types/react`. This is a minimalistic example for it that you can paste into TS playground:
```tsx
import React from 'react';

type FooProps = { foo: string };

export function render<C extends React.ComponentType<FooProps>>(Comp: C) {
    return <Comp foo="bar" />;
}
```
There will be a type error reported:
```
Type '{ foo: string; }' is not assignable to type 'LibraryManagedAttributes<C, FooProps>'.
```
even though it's perfectly fine to pass a `foo` prop to `Comp`. Maybe I'll be filing a bug.

Let me know what you think.