### PR TITLE
Split useNavigationMenu into bite-size functions and add unit tests

### DIFF
--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -1,0 +1,211 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, createRegistry } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import useNavigationMenu from '../use-navigation-menu';
+
+function createRegistryWithStores() {
+	// Create a registry and register used stores.
+	const registry = createRegistry();
+	[ coreStore ].forEach( registry.register );
+
+	const navigationConfig = {
+		kind: 'postType',
+		name: 'wp_navigation',
+		baseURL: '/wp/v2/navigation',
+		rawAttributes: [ 'title', 'excerpt', 'content' ],
+	};
+	// Register post type entity.
+	registry.dispatch( coreStore ).addEntities( [ navigationConfig ] );
+	return registry;
+}
+
+jest.mock( '@wordpress/data/src/components/use-select', () => {
+	// This allows us to tweak the returned value on each test.
+	const mock = jest.fn();
+	return mock;
+} );
+
+function setRecords( registry, menus ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.startResolution( 'getEntityRecords', [
+		'postType',
+		'wp_navigation',
+		{ per_page: -1, status: 'publish' },
+	] );
+	dispatch.finishResolution( 'getEntityRecords', [
+		'postType',
+		'wp_navigation',
+		{ per_page: -1, status: 'publish' },
+	] );
+	dispatch.receiveEntityRecords( 'postType', 'wp_navigation', menus, {
+		per_page: -1,
+		status: 'publish',
+	} );
+}
+
+function setCreatePermission( registry, allowed ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.receiveUserPermission( 'create/navigation', allowed );
+	dispatch.startResolution( 'canUser', [ 'create', 'navigation' ] );
+	dispatch.finishResolution( 'canUser', [ 'create', 'navigation' ] );
+}
+
+function setUpdatePermission( registry, ref, allowed ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.receiveUserPermission( `update/navigation/${ ref }`, allowed );
+	dispatch.startResolution( 'canUser', [ 'update', 'navigation', ref ] );
+	dispatch.finishResolution( 'canUser', [ 'update', 'navigation', ref ] );
+}
+
+function setDeletePermission( registry, ref, allowed ) {
+	const dispatch = registry.dispatch( coreStore );
+	dispatch.receiveUserPermission( `delete/navigation/${ ref }`, allowed );
+	dispatch.startResolution( 'canUser', [ 'delete', 'navigation', ref ] );
+	dispatch.finishResolution( 'canUser', [ 'delete', 'navigation', ref ] );
+}
+
+describe( 'useNavigationMenus', () => {
+	const navigationMenu1 = { id: 1, title: 'Menu 1', status: 'publish' };
+	const navigationMenu2 = { id: 2, title: 'Menu 2', status: 'publish' };
+	const navigationMenu3 = { id: 3, title: 'Menu 3', status: 'publish' };
+	const navigationMenus = [
+		navigationMenu1,
+		navigationMenu2,
+		navigationMenu3,
+	];
+
+	let registry;
+	beforeEach( () => {
+		registry = createRegistryWithStores();
+		useSelect.mockImplementation( ( fn ) => fn( registry.select ) );
+	} );
+
+	it( 'Should return no information when no data is resolved', () => {
+		expect( useNavigationMenu() ).toEqual( {
+			navigationMenus: null,
+			canSwitchNavigationMenu: false,
+			canUserCreateNavigationMenu: false,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: false,
+			isNavigationMenuMissing: true,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
+	it( 'Should return information about all menus when ref is missing', () => {
+		setRecords( registry, navigationMenus );
+		setCreatePermission( registry, true );
+		expect( useNavigationMenu() ).toEqual( {
+			navigationMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: true,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: true,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: true,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
+	it( 'Should also return information about a specific menu when ref is given', () => {
+		setRecords( registry, navigationMenus );
+		expect( useNavigationMenu( 1 ) ).toEqual( {
+			navigationMenu: navigationMenu1,
+			navigationMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: false,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: false,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
+	it( 'Should return correct permissions (create, update)', () => {
+		setRecords( registry, navigationMenus );
+		setCreatePermission( registry, true );
+		setUpdatePermission( registry, 1, true );
+		expect( useNavigationMenu( 1 ) ).toEqual( {
+			navigationMenu: navigationMenu1,
+			navigationMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: true,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: true,
+			hasResolvedCanUserCreateNavigationMenu: true,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: true,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: false,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
+	it( 'Should return correct permissions (delete only)', () => {
+		setRecords( registry, navigationMenus );
+		setDeletePermission( registry, 1, true );
+		expect( useNavigationMenu( 1 ) ).toEqual( {
+			navigationMenu: navigationMenu1,
+			navigationMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: false,
+			canUserDeleteNavigationMenu: true,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: true,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: false,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
+	it( 'Should return correct permissions (no permissions)', () => {
+		setRecords( registry, navigationMenus );
+		// Note the ref refers to a different record
+		setDeletePermission( registry, 2, true );
+		expect( useNavigationMenu( 1 ) ).toEqual( {
+			navigationMenu: navigationMenu1,
+			navigationMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: false,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: false,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+} );

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -188,11 +188,15 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should return correct permissions (no permissions)', () => {
+		const menuWithNoDeletePermissions = 2;
+		const requestedMenu = 1;
+		const requestedMenuData = [`navigationMenu${requestedMenu}`];
+		
 		setRecords( registry, navigationMenus );
 		// Note the ref refers to a different record
-		setDeletePermission( registry, 2, true );
-		expect( useNavigationMenu( 1 ) ).toEqual( {
-			navigationMenu: navigationMenu1,
+		setDeletePermission( registry, menuWithNoDeletePermissions, true );
+		expect( useNavigationMenu( requestedMenu ) ).toEqual( {
+			navigationMenu: requestedMenuData,
 			navigationMenus,
 			canSwitchNavigationMenu: true,
 			canUserCreateNavigationMenu: false,

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -144,7 +144,7 @@ describe( 'useNavigationMenus', () => {
 		} );
 	} );
 
-	it( 'Should also return null for the menu when menu status is "draft"', () => {
+	it( 'Should return null for the menu when menu status is "draft"', () => {
 		const navigationMenuDraft = { id: 4, title: 'Menu 3', status: 'draft' };
 		const testMenus = [ ...navigationMenus, navigationMenuDraft ];
 		resolveRecords( registry, testMenus );

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -124,7 +124,7 @@ describe( 'useNavigationMenus', () => {
 		} );
 	} );
 
-	it( 'Should also return information about a specific menu when ref is given', () => {
+	it( 'Should return information about a specific menu when ref is given', () => {
 		resolveRecords( registry, navigationMenus );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, createRegistry } from '@wordpress/data';
+import { createRegistry, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -12,7 +12,7 @@ import useNavigationMenu from '../use-navigation-menu';
 function createRegistryWithStores() {
 	// Create a registry and register used stores.
 	const registry = createRegistry();
-	registry.register( coreStore)
+	registry.register( coreStore );
 
 	const navigationConfig = {
 		kind: 'postType',
@@ -144,6 +144,28 @@ describe( 'useNavigationMenus', () => {
 		} );
 	} );
 
+	it( 'Should also return null for the menu when menu status is "draft"', () => {
+		const navigationMenuDraft = { id: 4, title: 'Menu 3', status: 'draft' };
+		const testMenus = [ ...navigationMenus, navigationMenuDraft ];
+		resolveRecords( registry, testMenus );
+		expect( useNavigationMenu( 4 ) ).toEqual( {
+			navigationMenu: null,
+			navigationMenus: testMenus,
+			canSwitchNavigationMenu: true,
+			canUserCreateNavigationMenu: false,
+			canUserDeleteNavigationMenu: false,
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserCreateNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+			hasResolvedNavigationMenus: true,
+			isNavigationMenuMissing: false,
+			isNavigationMenuResolved: false,
+			isResolvingCanUserCreateNavigationMenu: false,
+			isResolvingNavigationMenus: false,
+		} );
+	} );
+
 	it( 'Should return correct permissions (create, update)', () => {
 		resolveRecords( registry, navigationMenus );
 		resolveCreatePermission( registry, true );
@@ -188,15 +210,14 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should return correct permissions (no permissions)', () => {
-		const menuWithNoDeletePermissions = 2;
-		const requestedMenu = 1;
-		const requestedMenuData = [`navigationMenu${requestedMenu}`];
-
+		const requestedMenu = navigationMenu1;
+		// Note the "delete" permission is resolved for menu 2, but we're requesting
+		// the details of menu 1.
+		resolveDeletePermission( registry, navigationMenu2, true );
 		resolveRecords( registry, navigationMenus );
-		// Note the ref refers to a different record
-		resolveDeletePermission( registry, menuWithNoDeletePermissions, true );
-		expect( useNavigationMenu( requestedMenu ) ).toEqual( {
-			navigationMenu: requestedMenuData,
+
+		expect( useNavigationMenu( requestedMenu.id ) ).toEqual( {
+			navigationMenu: requestedMenu,
 			navigationMenus,
 			canSwitchNavigationMenu: true,
 			canUserCreateNavigationMenu: false,

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -31,7 +31,7 @@ jest.mock( '@wordpress/data/src/components/use-select', () => {
 	return mock;
 } );
 
-function setRecords( registry, menus ) {
+function resolveRecords( registry, menus ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.startResolution( 'getEntityRecords', [
 		'postType',
@@ -49,21 +49,21 @@ function setRecords( registry, menus ) {
 	} );
 }
 
-function setCreatePermission( registry, allowed ) {
+function resolveCreatePermission( registry, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( 'create/navigation', allowed );
 	dispatch.startResolution( 'canUser', [ 'create', 'navigation' ] );
 	dispatch.finishResolution( 'canUser', [ 'create', 'navigation' ] );
 }
 
-function setUpdatePermission( registry, ref, allowed ) {
+function resolveUpdatePermission( registry, ref, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( `update/navigation/${ ref }`, allowed );
 	dispatch.startResolution( 'canUser', [ 'update', 'navigation', ref ] );
 	dispatch.finishResolution( 'canUser', [ 'update', 'navigation', ref ] );
 }
 
-function setDeletePermission( registry, ref, allowed ) {
+function resolveDeletePermission( registry, ref, allowed ) {
 	const dispatch = registry.dispatch( coreStore );
 	dispatch.receiveUserPermission( `delete/navigation/${ ref }`, allowed );
 	dispatch.startResolution( 'canUser', [ 'delete', 'navigation', ref ] );
@@ -105,8 +105,8 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should return information about all menus when ref is missing', () => {
-		setRecords( registry, navigationMenus );
-		setCreatePermission( registry, true );
+		resolveRecords( registry, navigationMenus );
+		resolveCreatePermission( registry, true );
 		expect( useNavigationMenu() ).toEqual( {
 			navigationMenus,
 			canSwitchNavigationMenu: true,
@@ -125,7 +125,7 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should also return information about a specific menu when ref is given', () => {
-		setRecords( registry, navigationMenus );
+		resolveRecords( registry, navigationMenus );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,
 			navigationMenus,
@@ -145,9 +145,9 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should return correct permissions (create, update)', () => {
-		setRecords( registry, navigationMenus );
-		setCreatePermission( registry, true );
-		setUpdatePermission( registry, 1, true );
+		resolveRecords( registry, navigationMenus );
+		resolveCreatePermission( registry, true );
+		resolveUpdatePermission( registry, 1, true );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,
 			navigationMenus,
@@ -167,8 +167,8 @@ describe( 'useNavigationMenus', () => {
 	} );
 
 	it( 'Should return correct permissions (delete only)', () => {
-		setRecords( registry, navigationMenus );
-		setDeletePermission( registry, 1, true );
+		resolveRecords( registry, navigationMenus );
+		resolveDeletePermission( registry, 1, true );
 		expect( useNavigationMenu( 1 ) ).toEqual( {
 			navigationMenu: navigationMenu1,
 			navigationMenus,
@@ -191,10 +191,10 @@ describe( 'useNavigationMenus', () => {
 		const menuWithNoDeletePermissions = 2;
 		const requestedMenu = 1;
 		const requestedMenuData = [`navigationMenu${requestedMenu}`];
-		
-		setRecords( registry, navigationMenus );
+
+		resolveRecords( registry, navigationMenus );
 		// Note the ref refers to a different record
-		setDeletePermission( registry, menuWithNoDeletePermissions, true );
+		resolveDeletePermission( registry, menuWithNoDeletePermissions, true );
 		expect( useNavigationMenu( requestedMenu ) ).toEqual( {
 			navigationMenu: requestedMenuData,
 			navigationMenus,

--- a/packages/block-library/src/navigation/test/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/test/use-navigation-menu.js
@@ -12,7 +12,7 @@ import useNavigationMenu from '../use-navigation-menu';
 function createRegistryWithStores() {
 	// Create a registry and register used stores.
 	const registry = createRegistry();
-	[ coreStore ].forEach( registry.register );
+	registry.register( coreStore)
 
 	const navigationConfig = {
 		kind: 'postType',

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -7,94 +7,129 @@ import { useSelect } from '@wordpress/data';
 export default function useNavigationMenu( ref ) {
 	return useSelect(
 		( select ) => {
-			const {
-				getEntityRecord,
-				getEditedEntityRecord,
-				getEntityRecords,
-				hasFinishedResolution,
-				isResolving,
-				canUser,
-			} = select( coreStore );
-
-			const navigationMenuSingleArgs = [
-				'postType',
-				'wp_navigation',
-				ref,
-			];
-			const rawNavigationMenu = ref
-				? getEntityRecord( ...navigationMenuSingleArgs )
-				: null;
-			let navigationMenu = ref
-				? getEditedEntityRecord( ...navigationMenuSingleArgs )
-				: null;
-
-			// getEditedEntityRecord will return the post regardless of status.
-			// Therefore if the found post is not published then we should ignore it.
-			if ( navigationMenu?.status !== 'publish' ) {
-				navigationMenu = null;
-			}
-
-			const hasResolvedNavigationMenu = ref
-				? hasFinishedResolution(
-						'getEditedEntityRecord',
-						navigationMenuSingleArgs
-				  )
-				: false;
-
-			const navigationMenuMultipleArgs = [
-				'postType',
-				'wp_navigation',
-				{ per_page: -1, status: 'publish' },
-			];
-			const navigationMenus = getEntityRecords(
-				...navigationMenuMultipleArgs
-			);
-
-			const canSwitchNavigationMenu = ref
-				? navigationMenus?.length > 1
-				: navigationMenus?.length > 0;
+			const menus = selectNavigationMenus( select, ref );
 
 			return {
-				isNavigationMenuResolved: hasResolvedNavigationMenu,
-				isNavigationMenuMissing:
-					! ref ||
-					( hasResolvedNavigationMenu && ! rawNavigationMenu ),
-				canSwitchNavigationMenu,
-				isResolvingNavigationMenus: isResolving(
-					'getEntityRecords',
-					navigationMenuMultipleArgs
-				),
-				hasResolvedNavigationMenus: hasFinishedResolution(
-					'getEntityRecords',
-					navigationMenuMultipleArgs
-				),
-				navigationMenu,
-				navigationMenus,
-				canUserUpdateNavigationMenu: ref
-					? canUser( 'update', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserUpdateNavigationMenu: hasFinishedResolution(
-					'canUser',
-					[ 'update', 'navigation', ref ]
-				),
-				canUserDeleteNavigationMenu: ref
-					? canUser( 'delete', 'navigation', ref )
-					: undefined,
-				hasResolvedCanUserDeleteNavigationMenu: hasFinishedResolution(
-					'canUser',
-					[ 'delete', 'navigation', ref ]
-				),
-				canUserCreateNavigationMenu: canUser( 'create', 'navigation' ),
-				isResolvingCanUserCreateNavigationMenu: isResolving(
-					'canUser',
-					[ 'create', 'navigation' ]
-				),
-				hasResolvedCanUserCreateNavigationMenu: hasFinishedResolution(
-					'canUser',
-					[ 'create', 'navigation' ]
-				),
+				...menus,
+				...selectExistingMenu( select, ref ),
+				...selectMenuCreatePermissions( select ),
+				...selectMenuUpdatePermissions( select, ref ),
+				...selectMenuDeletePermissions( select, ref ),
+				canSwitchNavigationMenu: ref
+					? menus.navigationMenus?.length > 1
+					: menus.navigationMenus?.length > 0,
 			};
 		},
 		[ ref ]
 	);
+}
+
+function selectNavigationMenus( select ) {
+	const { getEntityRecords, hasFinishedResolution, isResolving } = select(
+		coreStore
+	);
+
+	const args = [
+		'postType',
+		'wp_navigation',
+		{ per_page: -1, status: 'publish' },
+	];
+	return {
+		navigationMenus: getEntityRecords( ...args ),
+		isResolvingNavigationMenus: isResolving( 'getEntityRecords', args ),
+		hasResolvedNavigationMenus: hasFinishedResolution(
+			'getEntityRecords',
+			args
+		),
+	};
+}
+
+function selectExistingMenu( select, ref ) {
+	if ( ! ref ) {
+		return {
+			isNavigationMenuResolved: false,
+			isNavigationMenuMissing: true,
+		};
+	}
+
+	const {
+		getEntityRecord,
+		getEditedEntityRecord,
+		hasFinishedResolution,
+	} = select( coreStore );
+
+	const args = [ 'postType', 'wp_navigation', ref ];
+	const navigationMenu = getEntityRecord( ...args );
+	const editedNavigationMenu = getEditedEntityRecord( ...args );
+	const hasResolvedNavigationMenu = hasFinishedResolution(
+		'getEditedEntityRecord',
+		args
+	);
+
+	return {
+		isNavigationMenuResolved: hasResolvedNavigationMenu,
+		isNavigationMenuMissing: hasResolvedNavigationMenu && ! navigationMenu,
+
+		// getEditedEntityRecord will return the post regardless of status.
+		// Therefore if the found post is not published then we should ignore it.
+		navigationMenu:
+			editedNavigationMenu.status === 'publish'
+				? editedNavigationMenu
+				: null,
+	};
+}
+
+function selectMenuCreatePermissions( select ) {
+	const { hasFinishedResolution, isResolving, canUser } = select( coreStore );
+
+	const args = [ 'create', 'navigation' ];
+	return {
+		canUserCreateNavigationMenu: !! canUser( ...args ),
+		isResolvingCanUserCreateNavigationMenu: !! isResolving(
+			'canUser',
+			args
+		),
+		hasResolvedCanUserCreateNavigationMenu: !! hasFinishedResolution(
+			'canUser',
+			args
+		),
+	};
+}
+
+function selectMenuUpdatePermissions( select, ref ) {
+	if ( ! ref ) {
+		return {
+			canUserUpdateNavigationMenu: false,
+			hasResolvedCanUserUpdateNavigationMenu: false,
+		};
+	}
+
+	const { hasFinishedResolution, canUser } = select( coreStore );
+	const args = [ 'update', 'navigation', ref ];
+	return {
+		canUserUpdateNavigationMenu: !! canUser( ...args ),
+		hasResolvedCanUserUpdateNavigationMenu: !! hasFinishedResolution(
+			'canUser',
+			args
+		),
+	};
+}
+
+function selectMenuDeletePermissions( select, ref ) {
+	if ( ! ref ) {
+		return {
+			canUserDeleteNavigationMenu: false,
+			hasResolvedCanUserDeleteNavigationMenu: false,
+		};
+	}
+
+	const { hasFinishedResolution, canUser } = select( coreStore );
+	const args = [ 'delete', 'navigation', ref ];
+	return {
+		canUserDeleteNavigationMenu: !! canUser( ...args ),
+		hasResolvedCanUserDeleteNavigationMenu: !! hasFinishedResolution(
+			'canUser',
+			args
+		),
+	};
 }

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -7,17 +7,56 @@ import { useSelect } from '@wordpress/data';
 export default function useNavigationMenu( ref ) {
 	return useSelect(
 		( select ) => {
-			const menus = selectNavigationMenus( select, ref );
+			const {
+				navigationMenus,
+				isResolvingNavigationMenus,
+				hasResolvedNavigationMenus,
+			} = selectNavigationMenus( select, ref );
+
+			const {
+				navigationMenu,
+				isNavigationMenuResolved,
+				isNavigationMenuMissing,
+			} = selectExistingMenu( select, ref );
+
+			const {
+				canUserCreateNavigationMenu,
+				isResolvingCanUserCreateNavigationMenu,
+				hasResolvedCanUserCreateNavigationMenu,
+			} = selectMenuCreatePermissions( select );
+
+			const {
+				canUserUpdateNavigationMenu,
+				hasResolvedCanUserUpdateNavigationMenu,
+			} = selectMenuUpdatePermissions( select, ref );
+
+			const {
+				canUserDeleteNavigationMenu,
+				hasResolvedCanUserDeleteNavigationMenu,
+			} = selectMenuDeletePermissions( select, ref );
 
 			return {
-				...menus,
-				...selectExistingMenu( select, ref ),
-				...selectMenuCreatePermissions( select ),
-				...selectMenuUpdatePermissions( select, ref ),
-				...selectMenuDeletePermissions( select, ref ),
+				navigationMenus,
+				isResolvingNavigationMenus,
+				hasResolvedNavigationMenus,
+
+				navigationMenu,
+				isNavigationMenuResolved,
+				isNavigationMenuMissing,
+
+				canUserCreateNavigationMenu,
+				isResolvingCanUserCreateNavigationMenu,
+				hasResolvedCanUserCreateNavigationMenu,
+
+				canUserUpdateNavigationMenu,
+				hasResolvedCanUserUpdateNavigationMenu,
+
+				canUserDeleteNavigationMenu,
+				hasResolvedCanUserDeleteNavigationMenu,
+
 				canSwitchNavigationMenu: ref
-					? menus.navigationMenus?.length > 1
-					: menus.navigationMenus?.length > 0,
+					? navigationMenus?.length > 1
+					: navigationMenus?.length > 0,
 			};
 		},
 		[ ref ]

--- a/packages/block-library/src/navigation/use-navigation-menu.js
+++ b/packages/block-library/src/navigation/use-navigation-menu.js
@@ -64,9 +64,8 @@ export default function useNavigationMenu( ref ) {
 }
 
 function selectNavigationMenus( select ) {
-	const { getEntityRecords, hasFinishedResolution, isResolving } = select(
-		coreStore
-	);
+	const { getEntityRecords, hasFinishedResolution, isResolving } =
+		select( coreStore );
 
 	const args = [
 		'postType',
@@ -91,11 +90,8 @@ function selectExistingMenu( select, ref ) {
 		};
 	}
 
-	const {
-		getEntityRecord,
-		getEditedEntityRecord,
-		hasFinishedResolution,
-	} = select( coreStore );
+	const { getEntityRecord, getEditedEntityRecord, hasFinishedResolution } =
+		select( coreStore );
 
 	const args = [ 'postType', 'wp_navigation', ref ];
 	const navigationMenu = getEntityRecord( ...args );

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -388,7 +388,7 @@ describe( 'Navigation', () => {
 			expect( loadingSpinner ).toBeNull();
 		} );
 
-		it.only( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
+		it( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
 			const testNavId = 1;
 
 			let resolveNavigationRequest;
@@ -400,22 +400,17 @@ describe( 'Navigation', () => {
 			await setUpResponseMocking( [
 				{
 					match: ( request ) => {
-						console.log(
-							request.method(), request.url(), decodeURIComponent( request.url() )
-						)
 						return (
-							request.method() === 'GET' &&
+							[ 'GET', 'OPTIONS' ].includes( request.method() ) &&
 							decodeURIComponent( request.url() ).includes(
 								`navigation/${ testNavId }`
 							)
-						)
+						);
 					},
 					onRequestMatch: ( request ) => {
 						// The Promise simulates a REST API request whose resolultion
 						// the test has full control over.
 						return new Promise( ( resolve ) => {
-							console.log( request );
-							console.log( request.url() );
 							// Assign the resolution function to the var in the
 							// upper scope to afford control over resolution.
 							resolveNavigationRequest = resolve;
@@ -425,7 +420,9 @@ describe( 'Navigation', () => {
 					},
 				},
 			] );
-
+			/*
+Expected mock function not to be called but it was called with: ["POST", "http://localhost:8889/wp-admin/admin-ajax.php", "http://localhost:8889/wp-admin/admin-ajax.php"],["GET", "http://localhost:8889/wp-admin/post-new.php", "http://localhost:8889/wp-admin/post-new.php"],["GET", "http://localhost:8889/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.16", "http://localhost:8889/wp-includes/js/mediaelement/mediaelementplayer-legacy.min.css?ver=4.2.16"],["GET", "http://localhost:8889/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.1-alpha-53506", "http://localhost:8889/wp-includes/js/mediaelement/wp-mediaelement.min.css?ver=6.1-alpha-53506"],["GET", "http://localhost:8889/wp-includes/js/imgareaselect/imgareaselect.css?ver=0.9.8", "http://localhost:8889/wp-includes/js/imgareaselect/imgareaselect.css?ver=0.9.8"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/components/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/components/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-editor/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-editor/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/nux/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/nux/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/reusable-blocks/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/reusable-blocks/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/editor/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/editor/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/reset.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/reset.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/edit-post/classic.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/edit-post/classic.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/editor.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/editor.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/edit-post/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/edit-post/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-directory/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-directory/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/format-library/style.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/format-library/style.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/themes/twentytwentyone/assets/css/custom-color-overrides.css?ver=1.6", "http://localhost:8889/wp-content/themes/twentytwentyone/assets/css/custom-color-overrides.css?ver=1.6"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=1655290402", "http://localhost:8889/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=1655290402"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/blob/index.min.js?ver=bccaf46e493181a8db9a", "http://localhost:8889/wp-content/plugins/gutenberg/build/blob/index.min.js?ver=bccaf46e493181a8db9a"],["GET", "http://localhost:8889/wp-content/plugins/gutenberg/build/autop/index.min.js?ver=b1a2f86387be4fa46f89", "http://loca
+ */
 			await createNewPost();
 			await clickOnMoreMenuItem( 'Code editor' );
 			const codeEditorInput = await page.waitForSelector(

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -388,7 +388,7 @@ describe( 'Navigation', () => {
 			expect( loadingSpinner ).toBeNull();
 		} );
 
-		it( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
+		it.only( 'shows a loading indicator whilst ref resolves to Navigation post items', async () => {
 			const testNavId = 1;
 
 			let resolveNavigationRequest;
@@ -399,14 +399,23 @@ describe( 'Navigation', () => {
 			// relying on variable factors such as network conditions.
 			await setUpResponseMocking( [
 				{
-					match: ( request ) =>
-						request.method() === 'GET' &&
-						request.url().includes( `navigation` ) &&
-						request.url().includes( testNavId ),
+					match: ( request ) => {
+						console.log(
+							request.method(), request.url(), decodeURIComponent( request.url() )
+						)
+						return (
+							request.method() === 'GET' &&
+							decodeURIComponent( request.url() ).includes(
+								`navigation/${ testNavId }`
+							)
+						)
+					},
 					onRequestMatch: ( request ) => {
 						// The Promise simulates a REST API request whose resolultion
 						// the test has full control over.
 						return new Promise( ( resolve ) => {
+							console.log( request );
+							console.log( request.url() );
 							// Assign the resolution function to the var in the
 							// upper scope to afford control over resolution.
 							resolveNavigationRequest = resolve;

--- a/packages/e2e-tests/specs/editor/blocks/navigation.test.js
+++ b/packages/e2e-tests/specs/editor/blocks/navigation.test.js
@@ -401,7 +401,6 @@ describe( 'Navigation', () => {
 				{
 					match: ( request ) =>
 						request.method() === 'GET' &&
-						request.url().includes( `rest_route` ) &&
 						request.url().includes( `navigation` ) &&
 						request.url().includes( testNavId ),
 					onRequestMatch: ( request ) => {


### PR DESCRIPTION
## What?

The `useNavigationMenu` hook got quite long and complex with its numerous ternary operators. This PR means to make it easier to reason about by splitting it into smaller pieces and adding unit tests .

## Testing Instructions

1. Confirm all the tests are green
1. Confirm the changes make sense

cc @getdave @talldan @scruffian @draganescu @noisysocks 