### PR TITLE
Embed Block: Fix Aspect Ratio Classes #29641

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -100,16 +100,14 @@ const EmbedEdit = ( props ) => {
 	/**
 	 * Returns the attributes derived from the preview, merged with the current attributes.
 	 *
-	 * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
 	 * @return {Object} Merged attributes.
 	 */
-	const getMergedAttributes = ( ignorePreviousClassName = false ) =>
+	const getMergedAttributes = () =>
 		getMergedAttributesWithPreview(
 			attributes,
 			preview,
 			title,
-			responsive,
-			ignorePreviousClassName
+			responsive
 		);
 
 	const toggleResponsive = () => {
@@ -137,21 +135,20 @@ const EmbedEdit = ( props ) => {
 		setURL( newURL );
 		setIsEditingURL( false );
 		setAttributes( { url: newURL } );
-	}, [ preview?.html, attributesUrl ] );
+	}, [ preview?.html, attributesUrl, cannotEmbed, fetching ] );
 
 	// Handle incoming preview.
 	useEffect( () => {
 		if ( preview && ! isEditingURL ) {
-			// When obtaining an incoming preview, we set the attributes derived from
-			// the preview data. In this case when getting the merged attributes,
-			// we ignore the previous classname because it might not match the expected
-			// classes by the new preview.
-			setAttributes( getMergedAttributes( true ) );
+			// When obtaining an incoming preview,
+			// we set the attributes derived from the preview data.
+			const mergedAttributes = getMergedAttributes();
+			setAttributes( mergedAttributes );
 
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(
 					props,
-					getMergedAttributes()
+					mergedAttributes
 				);
 
 				if ( upgradedBlock ) {

--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -4,6 +4,7 @@
 import {
 	createUpgradedEmbedBlock,
 	getClassNames,
+	removeAspectRatioClasses,
 	fallback,
 	getEmbedInfoByProvider,
 	getMergedAttributesWithPreview,
@@ -188,8 +189,14 @@ const EmbedEdit = ( props ) => {
 							event.preventDefault();
 						}
 
+						// If the embed URL was changed, we need to reset the aspect ratio class.
+						// To do this we have to remove the existing ratio class so it can be recalculated.
+						const blockClass = removeAspectRatioClasses(
+							attributes.className
+						);
+
 						setIsEditingURL( false );
-						setAttributes( { url } );
+						setAttributes( { url, className: blockClass } );
 					} }
 					value={ url }
 					cannotEmbed={ cannotEmbed }

--- a/packages/block-library/src/embed/test/index.js
+++ b/packages/block-library/src/embed/test/index.js
@@ -17,6 +17,7 @@ import {
 	createUpgradedEmbedBlock,
 	getEmbedInfoByProvider,
 	removeAspectRatioClasses,
+	hasAspectRatioClass,
 } from '../util';
 import { embedInstagramIcon } from '../icons';
 import variations from '../variations';
@@ -99,6 +100,17 @@ describe( 'utils', () => {
 					true
 				)
 			).toEqual( expected );
+		} );
+	} );
+	describe( 'hasAspectRatioClass', () => {
+		it( 'should return false if an aspect ratio class does not exist', () => {
+			const existingClassNames = 'wp-block-embed is-type-video';
+			expect( hasAspectRatioClass( existingClassNames ) ).toBe( false );
+		} );
+		it( 'should return true if an aspect ratio class exists', () => {
+			const existingClassNames =
+				'wp-block-embed is-type-video wp-embed-aspect-16-9 wp-has-aspect-ratio';
+			expect( hasAspectRatioClass( existingClassNames ) ).toBe( true );
 		} );
 	} );
 	describe( 'removeAspectRatioClasses', () => {

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -153,6 +153,21 @@ export const createUpgradedEmbedBlock = (
 };
 
 /**
+ * Determine if the block already has an aspect ratio class applied.
+ *
+ * @param {string} existingClassNames Existing block classes.
+ * @return {boolean} True or false if the classnames contain an aspect ratio class.
+ */
+export const hasAspectRatioClass = ( existingClassNames ) => {
+	if ( ! existingClassNames ) {
+		return false;
+	}
+	return ASPECT_RATIOS.some( ( { className } ) =>
+		existingClassNames.includes( className )
+	);
+};
+
+/**
  * Removes all previously set aspect ratio related classes and return the rest
  * existing class names.
  *
@@ -311,6 +326,14 @@ export const getMergedAttributesWithPreview = (
 	ignorePreviousClassName = false
 ) => {
 	const { allowResponsive, className } = currentAttributes;
+
+	// Aspect ratio classes are removed when the embed URL is updated.
+	// If the embed already has an aspect ratio class, that means the URL has not changed.
+	// Which also means no need to regenerate it.
+	if ( hasAspectRatioClass( className ) ) {
+		return currentAttributes;
+	}
+
 	return {
 		...currentAttributes,
 		...getAttributesFromPreview(

--- a/packages/block-library/src/embed/util.js
+++ b/packages/block-library/src/embed/util.js
@@ -298,6 +298,13 @@ export const getAttributesFromPreview = memoize(
 			attributes.providerNameSlug = providerNameSlug;
 		}
 
+		// Aspect ratio classes are removed when the embed URL is updated.
+		// If the embed already has an aspect ratio class, that means the URL has not changed.
+		// Which also means no need to regenerate it with getClassNames.
+		if ( hasAspectRatioClass( currentClassNames ) ) {
+			return attributes;
+		}
+
 		attributes.className = getClassNames(
 			html,
 			currentClassNames,
@@ -311,35 +318,26 @@ export const getAttributesFromPreview = memoize(
 /**
  * Returns the attributes derived from the preview, merged with the current attributes.
  *
- * @param {Object}  currentAttributes       The current attributes of the block.
- * @param {Object}  preview                 The preview data.
- * @param {string}  title                   The block's title, e.g. Twitter.
- * @param {boolean} isResponsive            Boolean indicating if the block supports responsive content.
- * @param {boolean} ignorePreviousClassName Determines if the previous className attribute should be ignored when merging.
+ * @param {Object}  currentAttributes The current attributes of the block.
+ * @param {Object}  preview           The preview data.
+ * @param {string}  title             The block's title, e.g. Twitter.
+ * @param {boolean} isResponsive      Boolean indicating if the block supports responsive content.
  * @return {Object} Merged attributes.
  */
 export const getMergedAttributesWithPreview = (
 	currentAttributes,
 	preview,
 	title,
-	isResponsive,
-	ignorePreviousClassName = false
+	isResponsive
 ) => {
 	const { allowResponsive, className } = currentAttributes;
-
-	// Aspect ratio classes are removed when the embed URL is updated.
-	// If the embed already has an aspect ratio class, that means the URL has not changed.
-	// Which also means no need to regenerate it.
-	if ( hasAspectRatioClass( className ) ) {
-		return currentAttributes;
-	}
 
 	return {
 		...currentAttributes,
 		...getAttributesFromPreview(
 			preview,
 			title,
-			ignorePreviousClassName ? undefined : className,
+			className,
 			isResponsive,
 			allowResponsive
 		),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This Pull Request ensures the aspect ratio classes remain the same across Block Editor reloads. If an editor adds a custom Aspect Ratio class to a YouTube video, it should retain that class until the embed is changed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Aspect Ratio classes (i.e. `wp-embed-aspect-16-9`) are added automatically to YouTube Videos (and potentially other embeds.) When this aspect ratio class is manually changed (to, for example, `wp-embed-aspect-4-3`) the video aspect ratio would change as expected and save to the block, but when the block editor reloads the classes are reverted to the original aspect ratio despite what is saved in the Block Attributes.

Resolves #29641.
Resolves #41813.
Resolves #45540.
Resolves #46627.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When the Embed URL is added or changed the Aspect Ratio classes are reset using the existing `removeAspectRatioClasses()` method. This action fires in the `onSubmit` action of the URL input field.

When the **Preview** view is activated, we check if the Block already has a valid Aspect Ratio class applied. If it does, do not regenerate the classes and retain the classes that have already been set. If it **does not** have an Aspect Ratio class this can be considered a new embed, so the ratio classes are regenerated.

A new utility method `hasAspectRatioClass( existingClassNames )` has been added to determine if a block already has an Aspect Ratio class.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Block Editor in any post type
2. Add the **Embed Block**
3. Add a valid YouTube Embed Link
    - Confirm the Aspect Ratio classes are generated and added to the "Classes" input under the "Advanced" panel.
4. Change the Aspect Ratio class to another valid Aspect Ratio class
    - If the aspect ratio class is `wp-embed-aspect-16-9` change it to `wp-embed-aspect-4-3` (and vice-versa)
    - Verify the video Aspect Ratio has changed in the editor.
5. Update the page.
    - **Do not** refresh the block editor page yet.
6. View the frontend of the page **in a new tab** and confirm the new aspect ratio is applied to the block.
7. Revisit the Block Editor tab and refresh the page.
8. Confirm the Embed Block retains the custom applied Aspect Ratio.
9. Click the Edit icon to replace the Embed URL.
10. Either replace the Embed URL with a new video **or** simply click "Embed" again.
11. Confirm the Aspect Ratio classes were reset (or changed to the correct/original)
