### PR TITLE
Search: Avoid double escaping

### DIFF
--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -65,7 +65,7 @@ function render_block_core_search( $attributes ) {
 			'<input type="search" id="%s" class="wp-block-search__input %s" name="s" value="%s" placeholder="%s" %s required />',
 			$input_id,
 			esc_attr( $input_classes ),
-			esc_attr( get_search_query() ),
+			get_search_query(),
 			esc_attr( $attributes['placeholder'] ),
 			$inline_styles['input']
 		);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -13,8 +13,6 @@
  * @return string The search block markup.
  */
 function render_block_core_search( $attributes ) {
-	static $instance_id = 0;
-
 	// Older versions of the Search block defaulted the label and buttonText
 	// attributes to `__( 'Search' )` meaning that many posts contain `<!--
 	// wp:search /-->`. Support these by defaulting an undefined label and
@@ -27,7 +25,7 @@ function render_block_core_search( $attributes ) {
 		)
 	);
 
-	$input_id            = 'wp-block-search__input-' . ++$instance_id;
+	$input_id            = wp_unique_id( 'wp-block-search__input-' );
 	$classnames          = classnames_for_block_core_search( $attributes );
 	$show_label          = ( ! empty( $attributes['showLabel'] ) ) ? true : false;
 	$use_icon_button     = ( ! empty( $attributes['buttonUseIcon'] ) ) ? true : false;


### PR DESCRIPTION
## What?
PR fixes double escaping of `get_search_query`. The function is [escaped by default](https://developer.wordpress.org/reference/functions/get_search_query/#description).

P.S. I also updated code to use `wp_unique_id` for input ID.

## Testing Instructions
This is just a code quality improvement, nothing the test.