### PR TITLE
Post Author Name: Add to and from Post Author transformations

### DIFF
--- a/packages/block-library/src/post-author-name/index.js
+++ b/packages/block-library/src/post-author-name/index.js
@@ -3,6 +3,7 @@
  */
 import metadata from './block.json';
 import edit from './edit';
+import transforms from './transforms';
 
 /**
  * WordPress dependencies
@@ -14,5 +15,6 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	transforms,
 	edit,
 };

--- a/packages/block-library/src/post-author-name/index.php
+++ b/packages/block-library/src/post-author-name/index.php
@@ -32,7 +32,7 @@ function render_block_core_post_author_name( $attributes, $content, $block ) {
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
 
-	return sprintf( '<div %1$s>', $wrapper_attributes ) . $author_name . '</div>';
+	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $author_name );
 }
 
 /**

--- a/packages/block-library/src/post-author-name/transforms.js
+++ b/packages/block-library/src/post-author-name/transforms.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-author' ],
+			transform: ( { textAlign } ) =>
+				createBlock( 'core/post-author-name', { textAlign } ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/post-author' ],
+			transform: ( { textAlign } ) =>
+				createBlock( 'core/post-author', { textAlign } ),
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## What?
PR adds transformations between Post Author and Post Author Name blocks.

## Testing Instructions
1. Open a Post or Page.
2. Insert Post Author block.
3. Transform it into Post Author Name block and then back.
4. Confirm both transformations work.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/240569/169247614-1bcbe6aa-8526-4d26-b62f-11e9946837e0.mp4


