### PR TITLE
Cover: Add border support using ResizableBox via BlockPopover

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,8 +33,8 @@ $z-layers: (
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
 	".block-library-button__inline-link .block-editor-url-input__suggestions": 6, // URL suggestions for button block above sibling inserter
-	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block
-	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
+	".wp-block-cover__inner-container": 32, // InnerBlocks area inside cover image block. Must be higher than block popover and less than drop zone.
+	".wp-block-cover.is-placeholder .components-placeholder.is-large": 32, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
 	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
 	".wp-block-cover__image-background": 0, // Image background inside cover block.

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -71,7 +71,7 @@ function bubbleEvents( doc ) {
 		}
 	}
 
-	const eventTypes = [ 'dragover' ];
+	const eventTypes = [ 'dragover', 'mousemove' ];
 
 	for ( const name of eventTypes ) {
 		doc.addEventListener( name, bubbleEvent );

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -77,7 +77,6 @@ export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as PlainText } from './plain-text';
-export { default as __experimentalResizableBoxPopover } from './resizable-box-popover';
 export { default as __experimentalResponsiveBlockControl } from './responsive-block-control';
 export {
 	default as RichText,

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -77,6 +77,7 @@ export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';
 export { default as PanelColorSettings } from './panel-color-settings';
 export { default as PlainText } from './plain-text';
+export { default as __experimentalResizableBoxPopover } from './resizable-box-popover';
 export { default as __experimentalResponsiveBlockControl } from './responsive-block-control';
 export {
 	default as RichText,

--- a/packages/block-editor/src/components/resizable-box-popover/index.js
+++ b/packages/block-editor/src/components/resizable-box-popover/index.js
@@ -18,6 +18,8 @@ export default function ResizableCoverPopover( {
 			clientId={ clientId }
 			__unstableCoverTarget
 			__unstableRefreshSize={ __unstableRefreshSize }
+			__unstablePopoverSlot="block-toolbar"
+			shift={ false }
 		>
 			<ResizableBox { ...props } />
 		</BlockPopover>

--- a/packages/block-editor/src/components/resizable-box-popover/index.js
+++ b/packages/block-editor/src/components/resizable-box-popover/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { ResizableBox } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import BlockPopover from '../block-popover';
+
+export default function ResizableCoverPopover( {
+	clientId,
+	__unstableRefreshSize,
+	...props
+} ) {
+	return (
+		<BlockPopover
+			clientId={ clientId }
+			__unstableCoverTarget
+			__unstableRefreshSize={ __unstableRefreshSize }
+		>
+			<ResizableBox { ...props } />
+		</BlockPopover>
+	);
+}

--- a/packages/block-editor/src/components/resizable-box-popover/index.js
+++ b/packages/block-editor/src/components/resizable-box-popover/index.js
@@ -8,20 +8,20 @@ import { ResizableBox } from '@wordpress/components';
  */
 import BlockPopover from '../block-popover';
 
-export default function ResizableCoverPopover( {
+export default function ResizableBoxPopover( {
 	clientId,
-	__unstableRefreshSize,
+	resizableBoxProps,
 	...props
 } ) {
 	return (
 		<BlockPopover
 			clientId={ clientId }
 			__unstableCoverTarget
-			__unstableRefreshSize={ __unstableRefreshSize }
 			__unstablePopoverSlot="block-toolbar"
 			shift={ false }
+			{ ...props }
 		>
-			<ResizableBox { ...props } />
+			<ResizableBox { ...resizableBoxProps } />
 		</BlockPopover>
 	);
 }

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -6,6 +6,7 @@ import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
 import OffCanvasEditor from './components/off-canvas-editor';
 import LeafMoreMenu from './components/off-canvas-editor/leaf-more-menu';
+import ResizableBoxPopover from './components/resizable-box-popover';
 import { ComposedPrivateInserter as PrivateInserter } from './components/inserter';
 import { PrivateListView } from './components/list-view';
 
@@ -20,4 +21,5 @@ lock( privateApis, {
 	OffCanvasEditor,
 	PrivateInserter,
 	PrivateListView,
+	ResizableBoxPopover,
 } );

--- a/packages/block-library/src/cover/block.json
+++ b/packages/block-library/src/cover/block.json
@@ -94,6 +94,18 @@
 				"blockGap": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"radius": true,
+				"style": true,
+				"width": true
+			}
+		},
 		"color": {
 			"__experimentalDuotone": "> .wp-block-cover__image-background, > .wp-block-cover__video-background",
 			"text": true,

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -149,10 +149,10 @@ function CoverEdit( {
 	const [ resizeListener, { height, width } ] = useResizeObserver();
 	const resizableBoxDimensions = useMemo( () => {
 		return {
-			height: minHeight ? parseFloat( minHeight ) : 'auto',
+			height: minHeightUnit === 'px' ? minHeight : 'auto',
 			width: 'auto',
 		};
-	}, [ minHeight ] );
+	}, [ minHeight, minHeightUnit ] );
 
 	const minHeightWithUnit =
 		minHeight && minHeightUnit
@@ -258,7 +258,7 @@ function CoverEdit( {
 		className: 'block-library-cover__resize-container',
 		clientId,
 		height,
-		minHeight: parseFloat( minHeight ),
+		minHeight: minHeightWithUnit,
 		onResizeStart: () => {
 			setAttributes( { minHeightUnit: 'px' } );
 			toggleSelection( false );

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -9,9 +9,9 @@ import namesPlugin from 'colord/plugins/names';
  * WordPress dependencies
  */
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { Placeholder, Spinner } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
+import { compose, useResizeObserver } from '@wordpress/compose';
 import {
 	withColors,
 	ColorPalette,
@@ -42,7 +42,7 @@ import useCoverIsDark from './use-cover-is-dark';
 import CoverInspectorControls from './inspector-controls';
 import CoverBlockControls from './block-controls';
 import CoverPlaceholder from './cover-placeholder';
-import ResizableCover from './resizable-cover';
+import ResizableCoverPopover from './resizable-cover-popover';
 
 extend( [ namesPlugin ] );
 
@@ -146,6 +146,14 @@ function CoverEdit( {
 	const isImageBackground = IMAGE_BACKGROUND_TYPE === backgroundType;
 	const isVideoBackground = VIDEO_BACKGROUND_TYPE === backgroundType;
 
+	const [ resizeListener, { height, width } ] = useResizeObserver();
+	const resizableBoxDimensions = useMemo( () => {
+		return {
+			height: minHeight ? parseFloat( minHeight ) : 'auto',
+			width: 'auto',
+		};
+	}, [ minHeight ] );
+
 	const minHeightWithUnit =
 		minHeight && minHeightUnit
 			? `${ minHeight }${ minHeightUnit }`
@@ -246,24 +254,50 @@ function CoverEdit( {
 		/>
 	);
 
+	const resizableCoverProps = {
+		className: 'block-library-cover__resize-container',
+		clientId,
+		height,
+		minHeight: parseFloat( minHeight ),
+		onResizeStart: () => {
+			setAttributes( { minHeightUnit: 'px' } );
+			toggleSelection( false );
+		},
+		onResize: ( value ) => {
+			setAttributes( { minHeight: value } );
+		},
+		onResizeStop: ( newMinHeight ) => {
+			toggleSelection( true );
+			setAttributes( { minHeight: newMinHeight } );
+		},
+		showHandle: true,
+		size: resizableBoxDimensions,
+		width,
+	};
+
 	if ( ! useFeaturedImage && ! hasInnerBlocks && ! hasBackground ) {
 		return (
 			<>
 				{ blockControls }
 				{ inspectorControls }
+				{ isSelected && (
+					<ResizableCoverPopover { ...resizableCoverProps } />
+				) }
 				<TagName
 					{ ...blockProps }
 					className={ classnames(
 						'is-placeholder',
 						blockProps.className
 					) }
+					style={ {
+						...blockProps.style,
+						minHeight: minHeightWithUnit || undefined,
+					} }
 				>
+					{ resizeListener }
 					<CoverPlaceholder
 						onSelectMedia={ onSelectMedia }
 						onError={ onUploadError }
-						style={ {
-							minHeight: minHeightWithUnit || undefined,
-						} }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
@@ -275,21 +309,6 @@ function CoverEdit( {
 							/>
 						</div>
 					</CoverPlaceholder>
-					<ResizableCover
-						className="block-library-cover__resize-container"
-						onResizeStart={ () => {
-							setAttributes( { minHeightUnit: 'px' } );
-							toggleSelection( false );
-						} }
-						onResize={ ( value ) => {
-							setAttributes( { minHeight: value } );
-						} }
-						onResizeStop={ ( newMinHeight ) => {
-							toggleSelection( true );
-							setAttributes( { minHeight: newMinHeight } );
-						} }
-						showHandle={ isSelected }
-					/>
 				</TagName>
 			</>
 		);
@@ -318,22 +337,7 @@ function CoverEdit( {
 				style={ { ...style, ...blockProps.style } }
 				data-url={ url }
 			>
-				<ResizableCover
-					className="block-library-cover__resize-container"
-					onResizeStart={ () => {
-						setAttributes( { minHeightUnit: 'px' } );
-						toggleSelection( false );
-					} }
-					onResize={ ( value ) => {
-						setAttributes( { minHeight: value } );
-					} }
-					onResizeStop={ ( newMinHeight ) => {
-						toggleSelection( true );
-						setAttributes( { minHeight: newMinHeight } );
-					} }
-					showHandle={ isSelected }
-				/>
-
+				{ resizeListener }
 				{ ( ! useFeaturedImage || url ) && (
 					<span
 						aria-hidden="true"
@@ -404,6 +408,9 @@ function CoverEdit( {
 				/>
 				<div { ...innerBlocksProps } />
 			</TagName>
+			{ isSelected && (
+				<ResizableCoverPopover { ...resizableCoverProps } />
+			) }
 		</>
 	);
 }

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -33,6 +33,7 @@ export default function ResizableCoverPopover( {
 	onResizeStart,
 	onResizeStop,
 	showHandle,
+	size,
 	width,
 	...props
 } ) {
@@ -61,6 +62,7 @@ export default function ResizableCoverPopover( {
 			setIsResizing( false );
 		},
 		showHandle,
+		size,
 		__experimentalShowTooltip: true,
 		__experimentalTooltipProps: {
 			axis: 'y',

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -32,6 +32,7 @@ export default function ResizableCoverPopover( {
 	onResize,
 	onResizeStart,
 	onResizeStop,
+	showHandle,
 	width,
 	...props
 } ) {
@@ -59,6 +60,7 @@ export default function ResizableCoverPopover( {
 			onResizeStop( elt.clientHeight );
 			setIsResizing( false );
 		},
+		showHandle,
 		__experimentalShowTooltip: true,
 		__experimentalTooltipProps: {
 			axis: 'y',

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -6,8 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
-import { ResizableBox } from '@wordpress/components';
+import { useMemo, useState } from '@wordpress/element';
+import { __experimentalResizableBoxPopover as ResizableBoxPopover } from '@wordpress/block-editor';
 
 const RESIZABLE_BOX_ENABLE_OPTION = {
 	top: false,
@@ -20,17 +20,25 @@ const RESIZABLE_BOX_ENABLE_OPTION = {
 	topLeft: false,
 };
 
-export default function ResizableCover( {
+export default function ResizableCoverPopover( {
 	className,
-	onResizeStart,
+	height,
+	minHeight,
 	onResize,
+	onResizeStart,
 	onResizeStop,
+	width,
 	...props
 } ) {
 	const [ isResizing, setIsResizing ] = useState( false );
+	const dimensions = useMemo(
+		() => ( { height, minHeight, width } ),
+		[ minHeight, height, width ]
+	);
 
 	return (
-		<ResizableBox
+		<ResizableBoxPopover
+			__unstableRefreshSize={ dimensions }
 			className={ classnames( className, {
 				'is-resizing': isResizing,
 			} ) }

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -36,33 +36,36 @@ export default function ResizableCoverPopover( {
 		[ minHeight, height, width ]
 	);
 
+	const resizableBoxProps = {
+		className: classnames( className, { 'is-resizing': isResizing } ),
+		enable: RESIZABLE_BOX_ENABLE_OPTION,
+		onResizeStart: ( _event, _direction, elt ) => {
+			onResizeStart( elt.clientHeight );
+			onResize( elt.clientHeight );
+		},
+		onResize: ( _event, _direction, elt ) => {
+			onResize( elt.clientHeight );
+			if ( ! isResizing ) {
+				setIsResizing( true );
+			}
+		},
+		onResizeStop: ( _event, _direction, elt ) => {
+			onResizeStop( elt.clientHeight );
+			setIsResizing( false );
+		},
+		__experimentalShowTooltip: true,
+		__experimentalTooltipProps: {
+			axis: 'y',
+			position: 'bottom',
+			isVisible: isResizing,
+		},
+	};
+
 	return (
 		<ResizableBoxPopover
+			className="block-library-cover__resizable-box-popover"
 			__unstableRefreshSize={ dimensions }
-			className={ classnames( className, {
-				'is-resizing': isResizing,
-			} ) }
-			enable={ RESIZABLE_BOX_ENABLE_OPTION }
-			onResizeStart={ ( _event, _direction, elt ) => {
-				onResizeStart( elt.clientHeight );
-				onResize( elt.clientHeight );
-			} }
-			onResize={ ( _event, _direction, elt ) => {
-				onResize( elt.clientHeight );
-				if ( ! isResizing ) {
-					setIsResizing( true );
-				}
-			} }
-			onResizeStop={ ( _event, _direction, elt ) => {
-				onResizeStop( elt.clientHeight );
-				setIsResizing( false );
-			} }
-			__experimentalShowTooltip
-			__experimentalTooltipProps={ {
-				axis: 'y',
-				position: 'bottom',
-				isVisible: isResizing,
-			} }
+			resizableBoxProps={ resizableBoxProps }
 			{ ...props }
 		/>
 	);

--- a/packages/block-library/src/cover/edit/resizable-cover-popover.js
+++ b/packages/block-library/src/cover/edit/resizable-cover-popover.js
@@ -7,7 +7,12 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useMemo, useState } from '@wordpress/element';
-import { __experimentalResizableBoxPopover as ResizableBoxPopover } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../private-apis';
 
 const RESIZABLE_BOX_ENABLE_OPTION = {
 	top: false,
@@ -30,6 +35,7 @@ export default function ResizableCoverPopover( {
 	width,
 	...props
 } ) {
+	const { ResizableBoxPopover } = unlock( blockEditorPrivateApis );
 	const [ isResizing, setIsResizing ] = useState( false );
 	const dimensions = useMemo(
 		() => ( { height, minHeight, width } ),

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -87,6 +87,19 @@
 	min-height: 50px;
 }
 
+// Prevent resizable box popover form preventing inner block selection.
+.components-popover.block-editor-block-popover.block-library-cover__resizable-box-popover {
+	// Additional specificity is required to overcome default block popover
+	// pointer events only for the intended wrappers. The default pointer events
+	// are still needed for the inner resize handles of the resizable box.
+	.components-popover__content > div,
+	.block-library-cover__resize-container {
+		// The inner drag handle will still have `pointer-events: all` allowing
+		// it to continue to be interacted with.
+		pointer-events: none;
+	}
+}
+
 // When uploading background images, show a transparent overlay.
 .wp-block-cover > .components-drop-zone .components-drop-zone__content {
 	opacity: 0.8 !important;

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -7,23 +7,22 @@
 	// Override default cover styles
 	// because we're not ready yet to show the cover block.
 	&.is-placeholder {
-		min-height: auto !important;
 		padding: 0 !important;
+		display: flex;
+		align-items: stretch;
+		overflow: visible;
+		min-height: 240px;
 
-		// Resizable placeholder for placeholder.
-		.block-library-cover__resize-container {
-			display: none;
-		}
 		.components-placeholder {
 			&.is-large {
-				min-height: 240px;
 				justify-content: flex-start;
 				z-index: z-index(".wp-block-cover.is-placeholder .components-placeholder.is-large");
-				+ .block-library-cover__resize-container {
-					min-height: 240px;
-					display: block;
-				}
 			}
+		}
+
+		// Allow focus outline/box-shadow to align with block's min height.
+		&:focus::after {
+			min-height: auto;
 		}
 	}
 
@@ -86,11 +85,6 @@
 	right: 0;
 	bottom: 0;
 	min-height: 50px;
-}
-
-.block-library-cover__resize-container:not(.is-resizing) {
-	// Important is used to have higher specificity than the inline style set by re-resizable library.
-	height: auto !important;
 }
 
 // When uploading background images, show a transparent overlay.

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -11,6 +11,7 @@
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.
 	/*rtl:raw: direction: ltr; */
+	overflow: hidden;
 
 	/**
 	 * Set a default background color for has-background-dim _unless_ it includes another

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -7,11 +7,11 @@
 	justify-content: center;
 	align-items: center;
 	padding: 1em;
+	overflow: hidden;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 	// Keep the flex layout direction to the physical direction (LTR) in RTL languages.
 	/*rtl:raw: direction: ltr; */
-	overflow: hidden;
 
 	/**
 	 * Set a default background color for has-background-dim _unless_ it includes another


### PR DESCRIPTION
Issue:
- https://github.com/WordPress/gutenberg/issues/21540

Related:
- https://github.com/WordPress/gutenberg/pull/31370
- https://github.com/WordPress/gutenberg/pull/40774

## What?

- Adds border support to the Cover block.
- Adds experimental block editor component to render a `ResizableBox` within a `BlockPopover`

## Why?

This much-requested feature will unlock a lot of potential new designs.

## How?

- Opts into all border support i.e. `color`, `radius`, `style`, and `width`
- Creates new `ResizableBoxPopover` to facilitate rendering a `ResizableBox` via a `BlockPopover`
- Leverages `ResizableBoxPopover` in Cover block to avoid borders conflicting with height adjustments

## Known Issues

- (**Present on trunk**) ResizableBox can be dragged smaller than the min-height of the Cover block's placeholder or block's content height.

## Testing Instructions
1. Confirm that the Cover block's unit tests still pass: `npm run test:unit packages/block-library/src/cover`
2. Update your theme.json to specify a border for the `core/cover` block.
3. Navigate to the Site Editor > Global Styles > Style Book > Media tab and confirm your border on the cover block
4. Click on the Cover block and tweak the border global styles
5. Save, switch to the block editor, and add a cover block. It should have your global styles border applied
6. Save the post and confirm border application on the frontend
7. Back in the editor check that you can override the global styles for the cover block's border
8. Save and reconfirm on the frontend
9. Back in the editor ensure the placeholder still functions, you can edit all inner blocks, and the resizing works.

## Screenshots or screencast <!-- if applicable -->

https://user-images.githubusercontent.com/60436221/224265557-de89f9bf-a3ec-4650-95a3-6b2cc32d74fb.mp4

