### PR TITLE
Remove the tooltip from the block selection button

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -262,6 +262,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 						onClick={ () => setNavigationMode( false ) }
 						onKeyDown={ onKeyDown }
 						label={ label }
+						showTooltip={ false }
 						className="block-selection-button_select-button"
 					>
 						<BlockTitle


### PR DESCRIPTION
noticed while working on #40376 

## What?

In "navigation mode", if you click on blocks, you'll see that the paragraph shows a title on the top left but also a tooltip underneath that title. I believe that was not intended, the tooltip is actually the aria-label which is there for screen readers but there's already the button text for visual users. So I think the tooltip was not intended there.

## Testing Instructions

1- click the "select" tool from the editor header (navigation mode)
2- Click on blocks
3- The "block selection button" is shown with the block title but there's no tooltip that shows up automatically.
