### PR TITLE
[RNMobile] Fix drag mode not being enabled when long-pressing over Shortcode block

### DIFF
--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -7,7 +7,7 @@ import { TextInput, Platform, Dimensions } from 'react-native';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
-import { getPxFromCssUnit } from '@wordpress/block-editor';
+import { RichText, getPxFromCssUnit } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -18,6 +18,9 @@ export default class PlainText extends Component {
 	constructor() {
 		super( ...arguments );
 		this.isAndroid = Platform.OS === 'android';
+
+		this.onChangeTextInput = this.onChangeTextInput.bind( this );
+		this.onChangeRichText = this.onChangeRichText.bind( this );
 	}
 
 	componentDidMount() {
@@ -44,7 +47,7 @@ export default class PlainText extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if ( ! this.props.isSelected && prevProps.isSelected ) {
-			this._input.blur();
+			this._input?.blur();
 		}
 	}
 
@@ -55,11 +58,11 @@ export default class PlainText extends Component {
 	}
 
 	focus() {
-		this._input.focus();
+		this._input?.focus();
 	}
 
 	blur() {
-		this._input.blur();
+		this._input?.blur();
 	}
 
 	getFontSize() {
@@ -79,20 +82,73 @@ export default class PlainText extends Component {
 		};
 	}
 
+	replaceLineBreaks( value ) {
+		return value?.replace( RegExp( '<br>', 'gim' ), '\n' );
+	}
+
+	onChangeTextInput( event ) {
+		const { onChange } = this.props;
+		onChange( event.nativeEvent.text );
+	}
+
+	onChangeRichText( value ) {
+		const { onChange } = this.props;
+		onChange( this.replaceLineBreaks( value ) );
+	}
+
 	render() {
-		const { style } = this.props;
+		const {
+			style,
+			__experimentalVersion,
+			onFocus,
+			...otherProps
+		} = this.props;
 		const textStyles = [
 			style || styles[ 'block-editor-plain-text' ],
 			this.getFontSize(),
 		];
 
+		if ( __experimentalVersion === 2 ) {
+			const disableFormattingProps = {
+				withoutInteractiveFormatting: true,
+				disableEditingMenu: true,
+				__unstableDisableFormats: true,
+				disableSuggestions: true,
+			};
+
+			const forcePlainTextProps = {
+				preserveWhiteSpace: true,
+				__unstablePastePlainText: true,
+				multiline: false,
+			};
+
+			const fontProps = {
+				fontFamily: style?.fontFamily,
+				fontSize: style?.fontSize,
+				fontWeight: style?.fontWeight,
+			};
+
+			return (
+				<RichText
+					{ ...otherProps }
+					{ ...disableFormattingProps }
+					{ ...forcePlainTextProps }
+					{ ...fontProps }
+					identifier="content"
+					tagName="p"
+					tagsToEliminate={ [ 'p' ] }
+					style={ style }
+					onChange={ this.onChangeRichText }
+					unstableOnFocus={ onFocus }
+				/>
+			);
+		}
+
 		return (
 			<TextInput
 				{ ...this.props }
 				ref={ ( x ) => ( this._input = x ) }
-				onChange={ ( event ) => {
-					this.props.onChange( event.nativeEvent.text );
-				} }
+				onChange={ this.onChangeTextInput }
 				onFocus={ this.props.onFocus } // Always assign onFocus as a props.
 				onBlur={ this.props.onBlur } // Always assign onBlur as a props.
 				fontFamily={

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -82,7 +82,7 @@ export default class PlainText extends Component {
 		};
 	}
 
-	replaceLineBreaks( value ) {
+	replaceLineBreakTags( value ) {
 		return value?.replace( RegExp( '<br>', 'gim' ), '\n' );
 	}
 
@@ -93,7 +93,9 @@ export default class PlainText extends Component {
 
 	onChangeRichText( value ) {
 		const { onChange } = this.props;
-		onChange( this.replaceLineBreaks( value ) );
+		// The <br> tags have to be replaced with new line characters
+		// as the content of plain text shouldn't contain HTML tags.
+		onChange( this.replaceLineBreakTags( value ) );
 	}
 
 	render() {

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -137,7 +137,6 @@ export default class PlainText extends Component {
 					{ ...forcePlainTextProps }
 					{ ...fontProps }
 					identifier="content"
-					tagName="pre"
 					style={ style }
 					onChange={ this.onChangeRichText }
 					unstableOnFocus={ onFocus }

--- a/packages/block-editor/src/components/plain-text/index.native.js
+++ b/packages/block-editor/src/components/plain-text/index.native.js
@@ -135,8 +135,7 @@ export default class PlainText extends Component {
 					{ ...forcePlainTextProps }
 					{ ...fontProps }
 					identifier="content"
-					tagName="p"
-					tagsToEliminate={ [ 'p' ] }
+					tagName="pre"
 					style={ style }
 					onChange={ this.onChangeRichText }
 					unstableOnFocus={ onFocus }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -77,6 +77,7 @@ function removeNativeProps( props ) {
 		'maxWidth',
 		'setRef',
 		'disableSuggestions',
+		'disableAutocorrection',
 	] );
 }
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -76,6 +76,7 @@ function removeNativeProps( props ) {
 		'minWidth',
 		'maxWidth',
 		'setRef',
+		'disableSuggestions',
 	] );
 }
 

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -112,6 +112,7 @@ function RichTextWrapper(
 		onBlur,
 		setRef,
 		disableSuggestions,
+		disableAutocorrection,
 		...props
 	},
 	forwardedRef
@@ -637,6 +638,7 @@ function RichTextWrapper(
 			onBlur={ onBlur }
 			setRef={ setRef }
 			disableSuggestions={ disableSuggestions }
+			disableAutocorrection={ disableAutocorrection }
 			// Props to be set on the editable container are destructured on the
 			// element itself for web (see below), but passed through rich text
 			// for native.

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -111,6 +111,7 @@ function RichTextWrapper(
 		maxWidth,
 		onBlur,
 		setRef,
+		disableSuggestions,
 		...props
 	},
 	forwardedRef
@@ -635,6 +636,7 @@ function RichTextWrapper(
 			maxWidth={ maxWidth }
 			onBlur={ onBlur }
 			setRef={ setRef }
+			disableSuggestions={ disableSuggestions }
 			// Props to be set on the editable container are destructured on the
 			// element itself for web (see below), but passed through rich text
 			// for native.

--- a/packages/block-library/src/shortcode/edit.native.js
+++ b/packages/block-library/src/shortcode/edit.native.js
@@ -9,6 +9,7 @@ import { View, Text } from 'react-native';
 import { __ } from '@wordpress/i18n';
 import { PlainText } from '@wordpress/block-editor';
 import { withPreferredColorScheme } from '@wordpress/compose';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -42,6 +43,15 @@ export function ShortcodeEdit( props ) {
 		styles.placeholderDark
 	);
 
+	const maxWidth =
+		blockWidth -
+		shortcodeContainerStyle.paddingLeft +
+		shortcodeContainerStyle.paddingRight;
+
+	const onChange = useCallback( ( text ) => setAttributes( { text } ), [
+		setAttributes,
+	] );
+
 	return (
 		<View>
 			<Text style={ titleStyle }>{ __( 'Shortcode' ) }</Text>
@@ -50,21 +60,13 @@ export function ShortcodeEdit( props ) {
 					__experimentalVersion={ 2 }
 					value={ attributes.text }
 					style={ shortcodeStyle }
-					onChange={ ( text ) => setAttributes( { text } ) }
+					onChange={ onChange }
 					placeholder={ __( 'Add a shortcode…' ) }
-					aria-label={ __( 'Shortcode' ) }
 					isSelected={ props.isSelected }
 					onFocus={ onFocus }
 					onBlur={ onBlur }
 					placeholderTextColor={ placeholderStyle.color }
-					maxWidth={
-						blockWidth -
-						styles.blockShortcodeContainer.paddingLeft +
-						styles.blockShortcodeContainer.paddingRight
-					}
-					// TODO: Add autocorrect and autocomplete options
-					// autoCorrect={ false }
-					// autoComplete="off"
+					maxWidth={ maxWidth }
 					disableAutocorrection
 				/>
 			</View>

--- a/packages/block-library/src/shortcode/edit.native.js
+++ b/packages/block-library/src/shortcode/edit.native.js
@@ -65,6 +65,7 @@ export function ShortcodeEdit( props ) {
 					// TODO: Add autocorrect and autocomplete options
 					// autoCorrect={ false }
 					// autoComplete="off"
+					disableAutocorrection
 				/>
 			</View>
 		</View>

--- a/packages/block-library/src/shortcode/edit.native.js
+++ b/packages/block-library/src/shortcode/edit.native.js
@@ -23,10 +23,15 @@ export function ShortcodeEdit( props ) {
 		onFocus,
 		onBlur,
 		getStylesFromColorScheme,
+		blockWidth,
 	} = props;
 	const titleStyle = getStylesFromColorScheme(
 		styles.blockTitle,
 		styles.blockTitleDark
+	);
+	const shortcodeContainerStyle = getStylesFromColorScheme(
+		styles.blockShortcodeContainer,
+		styles.blockShortcodeContainerDark
 	);
 	const shortcodeStyle = getStylesFromColorScheme(
 		styles.blockShortcode,
@@ -40,21 +45,28 @@ export function ShortcodeEdit( props ) {
 	return (
 		<View>
 			<Text style={ titleStyle }>{ __( 'Shortcode' ) }</Text>
-			<PlainText
-				value={ attributes.text }
-				style={ shortcodeStyle }
-				multiline={ true }
-				underlineColorAndroid="transparent"
-				onChange={ ( text ) => setAttributes( { text } ) }
-				placeholder={ __( 'Add a shortcode…' ) }
-				aria-label={ __( 'Shortcode' ) }
-				isSelected={ props.isSelected }
-				onFocus={ onFocus }
-				onBlur={ onBlur }
-				autoCorrect={ false }
-				autoComplete="off"
-				placeholderTextColor={ placeholderStyle.color }
-			/>
+			<View style={ shortcodeContainerStyle }>
+				<PlainText
+					__experimentalVersion={ 2 }
+					value={ attributes.text }
+					style={ shortcodeStyle }
+					onChange={ ( text ) => setAttributes( { text } ) }
+					placeholder={ __( 'Add a shortcode…' ) }
+					aria-label={ __( 'Shortcode' ) }
+					isSelected={ props.isSelected }
+					onFocus={ onFocus }
+					onBlur={ onBlur }
+					placeholderTextColor={ placeholderStyle.color }
+					maxWidth={
+						blockWidth -
+						styles.blockShortcodeContainer.paddingLeft +
+						styles.blockShortcodeContainer.paddingRight
+					}
+					// TODO: Add autocorrect and autocomplete options
+					// autoCorrect={ false }
+					// autoComplete="off"
+				/>
+			</View>
 		</View>
 	);
 }

--- a/packages/block-library/src/shortcode/edit.native.js
+++ b/packages/block-library/src/shortcode/edit.native.js
@@ -62,7 +62,6 @@ export function ShortcodeEdit( props ) {
 					style={ shortcodeStyle }
 					onChange={ onChange }
 					placeholder={ __( 'Add a shortcode…' ) }
-					isSelected={ props.isSelected }
 					onFocus={ onFocus }
 					onBlur={ onBlur }
 					placeholderTextColor={ placeholderStyle.color }

--- a/packages/block-library/src/shortcode/style.native.scss
+++ b/packages/block-library/src/shortcode/style.native.scss
@@ -25,6 +25,7 @@
 	font-family: $default-monospace-font;
 	font-weight: 400;
 	font-size: 14px;
+	color: $gray-900;
 }
 
 .blockShortcodeDark {

--- a/packages/block-library/src/shortcode/style.native.scss
+++ b/packages/block-library/src/shortcode/style.native.scss
@@ -11,18 +11,24 @@
 	color: $gray-50;
 }
 
-.blockShortcode {
-	font-family: $default-monospace-font;
-	font-weight: 400;
-	font-size: 14px;
+.blockShortcodeContainer {
 	padding: 12px;
 	border-radius: 4px;
 	background-color: $gray-light;
 }
 
+.blockShortcodeContainerDark {
+	background-color: $gray-100;
+}
+
+.blockShortcode {
+	font-family: $default-monospace-font;
+	font-weight: 400;
+	font-size: 14px;
+}
+
 .blockShortcodeDark {
 	color: $white;
-	background-color: $gray-100;
 }
 
 .placeholder {

--- a/packages/block-library/src/shortcode/test/__snapshots__/edit.native.js.snap
+++ b/packages/block-library/src/shortcode/test/__snapshots__/edit.native.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Shortcode block edits content 1`] = `
+"<!-- wp:shortcode -->
+[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]
+<!-- /wp:shortcode -->"
+`;
+
+exports[`Shortcode block inserts block 1`] = `"<!-- wp:shortcode /-->"`;

--- a/packages/block-library/src/shortcode/test/edit.native.js
+++ b/packages/block-library/src/shortcode/test/edit.native.js
@@ -1,58 +1,76 @@
 /**
  * External dependencies
  */
-import renderer from 'react-test-renderer';
-import { TextInput } from 'react-native';
+import {
+	getEditorHtml,
+	initializeEditor,
+	fireEvent,
+	waitFor,
+} from 'test/helpers';
 
 /**
  * WordPress dependencies
  */
-import { BlockEdit } from '@wordpress/block-editor';
-import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
 
-/**
- * Internal dependencies
- */
-import { metadata, settings, name } from '../index';
+beforeAll( () => {
+	// Register all core blocks
+	registerCoreBlocks();
+} );
 
-const Shortcode = ( { clientId, ...props } ) => (
-	<BlockEdit name={ name } clientId={ clientId || 0 } { ...props } />
-);
+afterAll( () => {
+	// Clean up registered blocks
+	getBlockTypes().forEach( ( block ) => {
+		unregisterBlockType( block.name );
+	} );
+} );
 
-describe( 'Shortcode', () => {
-	beforeAll( () => {
-		registerBlockType( name, {
-			...metadata,
-			...settings,
+describe( 'Shortcode block', () => {
+	it( 'inserts block', async () => {
+		const {
+			getByA11yLabel,
+			getByTestId,
+			getByText,
+		} = await initializeEditor();
+
+		fireEvent.press( getByA11yLabel( 'Add block' ) );
+
+		const blockList = getByTestId( 'InserterUI-Blocks' );
+		// onScroll event used to force the FlatList to render all items
+		fireEvent.scroll( blockList, {
+			nativeEvent: {
+				contentOffset: { y: 0, x: 0 },
+				contentSize: { width: 100, height: 100 },
+				layoutMeasurement: { width: 100, height: 100 },
+			},
 		} );
+
+		fireEvent.press( await waitFor( () => getByText( 'Shortcode' ) ) );
+
+		expect( getByA11yLabel( /Shortcode Block\. Row 1/ ) ).toBeVisible();
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 
-	afterAll( () => {
-		unregisterBlockType( name );
-	} );
+	it( 'edits content', async () => {
+		const { getByA11yLabel, getByPlaceholderText } = await initializeEditor(
+			{
+				initialHtml: '<!-- wp:shortcode /-->',
+			}
+		);
+		const shortcodeBlock = getByA11yLabel( /Shortcode Block\. Row 1/ );
+		fireEvent.press( shortcodeBlock );
 
-	it( 'renders without crashing', () => {
-		const component = renderer.create(
-			<Shortcode attributes={ { text: '' } } />
-		);
-		const rendered = component.toJSON();
-		expect( rendered ).toBeTruthy();
-	} );
+		const textField = getByPlaceholderText( 'Add a shortcode…' );
+		fireEvent( textField, 'focus' );
+		fireEvent( textField, 'onChange', {
+			nativeEvent: {
+				eventCount: 1,
+				target: undefined,
+				text: '[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]',
+			},
+		} );
 
-	it( 'renders given text without crashing', () => {
-		const component = renderer.create(
-			<Shortcode
-				attributes={ {
-					text:
-						'[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]',
-				} }
-			/>
-		);
-		const testInstance = component.root;
-		const textInput = testInstance.findByType( TextInput );
-		expect( textInput ).toBeTruthy();
-		expect( textInput.props.value ).toBe(
-			'[youtube https://www.youtube.com/watch?v=ssfHW5lwFZg]'
-		);
+		expect( getEditorHtml() ).toMatchSnapshot();
 	} );
 } );

--- a/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
+++ b/packages/react-native-aztec/android/src/main/java/org/wordpress/mobile/ReactNativeAztec/ReactAztecManager.java
@@ -13,6 +13,7 @@ import androidx.core.util.Consumer;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.Layout;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -615,6 +616,16 @@ public class ReactAztecManager extends BaseViewManager<ReactAztecText, LayoutSha
     @ReactProp(name = "deleteEnter", defaultBoolean = false)
     public void setShouldDeleteEnter(final ReactAztecText view, boolean shouldDeleteEnter) {
         view.shouldDeleteEnter = shouldDeleteEnter;
+    }
+
+    @ReactProp(name = "disableAutocorrection", defaultBoolean = false)
+    public void disableAutocorrection(final ReactAztecText view, boolean disable) {
+        if (disable) {
+            view.setInputType((view.getInputType() & ~InputType.TYPE_TEXT_FLAG_AUTO_CORRECT) | InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+        }
+        else {
+            view.setInputType((view.getInputType() & ~InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) | InputType.TYPE_TEXT_FLAG_AUTO_CORRECT);
+        }
     }
 
     @Override

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecView.swift
@@ -31,6 +31,12 @@ class RCTAztecView: Aztec.TextView {
         }
     }
 
+    @objc var disableAutocorrection: Bool = false {
+        didSet {
+            autocorrectionType = disableAutocorrection ? .no : .default
+        }
+    }
+
     override var textAlignment: NSTextAlignment {
         set {
             super.textAlignment = newValue

--- a/packages/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
+++ b/packages/react-native-aztec/ios/RNTAztecView/RCTAztecViewManager.m
@@ -31,6 +31,7 @@ RCT_EXPORT_VIEW_PROPERTY(fontWeight, NSString)
 RCT_EXPORT_VIEW_PROPERTY(lineHeight, CGFloat)
 
 RCT_EXPORT_VIEW_PROPERTY(disableEditingMenu, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(disableAutocorrection, BOOL)
 RCT_REMAP_VIEW_PROPERTY(textAlign, textAlignment, NSTextAlignment)
 RCT_REMAP_VIEW_PROPERTY(selectionColor, tintColor, UIColor)
 

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -1221,6 +1221,7 @@ export class RichText extends Component {
 					minWidth={ minWidth }
 					id={ this.props.id }
 					selectionColor={ this.props.selectionColor }
+					disableAutocorrection={ this.props.disableAutocorrection }
 				/>
 				{ isSelected && (
 					<>

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -1252,10 +1252,17 @@ RichText.defaultProps = {
 };
 
 const withFormatTypes = ( WrappedComponent ) => ( props ) => {
+	const {
+		clientId,
+		identifier,
+		withoutInteractiveFormatting,
+		allowedFormats,
+	} = props;
 	const { formatTypes } = useFormatTypes( {
-		clientId: props.clientId,
-		identifier: props.identifier,
-		withoutInteractiveFormatting: props.withoutInteractiveFormatting,
+		clientId,
+		identifier,
+		withoutInteractiveFormatting,
+		allowedFormats,
 	} );
 
 	return <WrappedComponent { ...props } formatTypes={ formatTypes } />;

--- a/packages/rich-text/src/component/index.native.js
+++ b/packages/rich-text/src/component/index.native.js
@@ -1050,6 +1050,7 @@ export class RichText extends Component {
 			baseGlobalStyles,
 			selectionStart,
 			selectionEnd,
+			disableSuggestions,
 		} = this.props;
 		const { currentFontSize } = this.state;
 
@@ -1230,11 +1231,13 @@ export class RichText extends Component {
 							onChange={ this.onFormatChange }
 							onFocus={ () => {} }
 						/>
-						<BlockFormatControls>
-							<ToolbarButtonWithOptions
-								options={ this.suggestionOptions() }
-							/>
-						</BlockFormatControls>
+						{ ! disableSuggestions && (
+							<BlockFormatControls>
+								<ToolbarButtonWithOptions
+									options={ this.suggestionOptions() }
+								/>
+							</BlockFormatControls>
+						) }
 					</>
 				) }
 			</View>

--- a/test/native/__mocks__/styleMock.js
+++ b/test/native/__mocks__/styleMock.js
@@ -162,4 +162,7 @@ module.exports = {
 	'dropping-insertion-point': {
 		height: 3,
 	},
+	blockShortcodeContainer: {
+		padding: 12,
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes the drag mode not being enabled due to the use of `PlainText` component in the Shortcode block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR will address the issue described in https://github.com/wordpress-mobile/gutenberg-mobile/issues/4853, specifically the one related to the Shortcode block. In the future, we could use the same approach for the rest of the affected blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix consists in using the `RichText` component by disabling all formatting options for rendering plain text via the `PlainText` component, similarly as it's done experimentally in the web version ([reference](https://github.com/WordPress/gutenberg/blob/a1e1fdc0e6278457e9f4fc0b31ac6d2095f5450b/packages/block-editor/src/components/plain-text/index.js#L21-L23)). In order to achieve this, I also had to apply the following modifications in the `RichText` component:
- Add `disableSuggestions` prop to be able to disable the suggestion button in the formatting toolbar.
- Add `disableAutocorrection` prop to be able to disable auto-correction settings of the text input. This change also implied updating the native code of `react-native-aztec` package.
- Fix the format types calculation by passing `allowedFormats `value to `useFormatTypes` hook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

### Drag mode is enabled when long-pressing the content
1. Open a post/page.
2. Add a Shortcode block and add some text to it.
3. Long-press over the content of the Shortcode block.
4. Observe that the drag mode is enabled and that it allows dropping the block in the desired location.

### Default long-press behavior when editing text
1. Open a post/page.
2. Add a Shortcode block and add some text to it.
3. While editing the text, long-press over parts of the text.
4. Observe that the long-press gesture behaves as expected and doesn't enable the drag mode.

### Shortcode block
1. Open a post/page.
2. Add a Shortcode block and add some text to it.
3. Observe that the block styles match the previous version by comparing it with the latest production version of the WordPress app.
4. Observe that, when editing the content of the Shortcode block, there are no formatting buttons.
5. Save the post.
6. Observe that the HTML generated for the Shortcode block is correct by comparing the same output using the web version.

### Check enable/disable suggestions setting in `RichText`
1. Open a post/page.
2. Add a Paragraph block and edit its content.
3. Observe that the Suggestions button (i.e. the button with `@` symbol) is displayed in the formatting toolbar.
4. Add a Shortcode block and edit its content.
5. Observe that the Suggestion button is NOT displayed in the formatting toolbar.

### Check enable/disable Auto-correction setting in `RichText`
1. Open a post/page.
2. Add a Paragraph block and edit its content.
3. Observe that when typing text it's autocorrected (e.g. typing `morninn` is converted to `morning`).
4. Add a Shortcode block and edit its content.
5. Observe that when typing text it's NOT autocorrected.

### Check other blocks using `PlainText`
1. Open a post/page.
2. Add a Search block.
3. Observe that the block works as expected.
4. Add a Contact Info block.
5. Observe that the block works as expected.

## Screenshots or screencast <!-- if applicable -->
Android|iOS
--|--
<video src=https://user-images.githubusercontent.com/14905380/169321953-31126240-a268-4406-8c8f-217d5b8cc41f.mp4>|<video src=https://user-images.githubusercontent.com/14905380/169322048-91d399ec-2969-418d-9ba4-9c2653c19268.mp4>