### PR TITLE
Add a zoomed out view to the site editor

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1492,7 +1492,7 @@ Action that enables or disables the navigation mode.
 
 _Parameters_
 
--   _isNavigationMode_ `string`: Enable/Disable navigation mode.
+-   _isNavigationMode_ `boolean`: Enable/Disable navigation mode.
 
 ### setTemplateValidity
 

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -72,3 +72,15 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
 	);
 
 }
+
+/**
+ * Sets a global JS variable used to trigger the availability of zoomed out view.
+ */
+function gutenberg_enable_zoomed_out_view() {
+	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+	if (  $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableZoomedOutView = true', 'before' );
+	}
+}
+
+add_action( 'admin_init', 'gutenberg_enable_zoomed_out_view' );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -78,8 +78,8 @@ function gutenberg_initialize_editor( $editor_name, $editor_script_handle, $sett
  */
 function gutenberg_enable_zoomed_out_view() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-	if (  $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-library', 'window.__experimentalEnableZoomedOutView = true', 'before' );
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoomed-out-view', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomedOutView = true', 'before' );
 	}
 }
 

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -40,6 +40,18 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg_display_experiment_section',
 		'gutenberg-experiments'
 	);
+
+	add_settings_field(
+		'gutenberg-zoomed-out-view',
+		__( 'Zoomed out view ', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Test a new zoomed out view on the site editor (Warning: The new feature is not ready. You may experience UX issues that are being addressed)', 'gutenberg' ),
+			'id'    => 'gutenberg-zoomed-out-view',
+		)
+	);
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -82,7 +82,7 @@ $z-layers: (
 	".block-editor-block-contextual-toolbar": 61,
 
 	// Ensures content overlay appears higher than resize containers used for image/video/etc.
-	".block-editor-block-content-overlay__overlay": 10,
+	".block-editor-block-list__block.has-block-overlay": 10,
 
 	// Query block setup state.
 	".block-editor-block-pattern-setup .pattern-slide": 100,

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -717,7 +717,6 @@ _Parameters_
 -   _props_ `Object`: Optional. Props to pass to the element. Must contain the ref if one is defined.
 -   _options_ `Object`: Options for internal use only.
 -   _options.\_\_unstableIsHtml_ `boolean`:
--   _options.\_\_unstableIsDisabled_ `boolean`: Whether the block should be disabled.
 
 _Returns_
 

--- a/packages/block-editor/src/components/block-content-overlay/index.js
+++ b/packages/block-editor/src/components/block-content-overlay/index.js
@@ -11,14 +11,10 @@ import { store as blockEditorStore } from '../../store';
 export default function useBlockOverlayActive( clientId ) {
 	return useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock, canEditBlock } =
+			const { __unstableHasActiveBlockOverlayActive } =
 				select( blockEditorStore );
 
-			return (
-				! canEditBlock( clientId ) ||
-				( ! isBlockSelected( clientId ) &&
-					! hasSelectedInnerBlock( clientId, true ) )
-			);
+			return __unstableHasActiveBlockOverlayActive( clientId );
 		},
 		[ clientId ]
 	);

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -1,4 +1,6 @@
-.block-editor-block-content-overlay {
+.block-editor-block-list__block.has-block-overlay {
+	cursor: default;
+
 	&::before {
 		content: "";
 		position: absolute;
@@ -9,11 +11,30 @@
 		background: transparent;
 		border: none;
 		border-radius: $radius-block-ui;
-		z-index: z-index(".block-editor-block-content-overlay__overlay");
+		z-index: z-index(".block-editor-block-list__block.has-block-overlay");
+	}
+
+	&::after {
+		content: none !important;
 	}
 
 	&:hover:not(.is-dragging-blocks)::before {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+		background: rgba(var(--wp-admin-theme-color--rgb), 0.3);
 		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
+	}
+
+	&.is-selected:not(.is-dragging-blocks)::before {
+		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color) inset;
+	}
+
+	.block-editor-block-list__block {
+		pointer-events: none;
+	}
+
+	.block-editor-iframe__body.is-zoomed-out &::before {
+		// Unfortunately because of the vw unit, this is not always going to be exact
+		// When the scrollbar is visible, the frame exceeds the canvas by a few pixes.
+		width: calc(100vw);
+		left: calc(( 100% - 100vw ) / 2);
 	}
 }

--- a/packages/block-editor/src/components/block-content-overlay/style.scss
+++ b/packages/block-editor/src/components/block-content-overlay/style.scss
@@ -33,7 +33,7 @@
 
 	.block-editor-iframe__body.is-zoomed-out &::before {
 		// Unfortunately because of the vw unit, this is not always going to be exact
-		// When the scrollbar is visible, the frame exceeds the canvas by a few pixes.
+		// When the scrollbar is visible, the frame exceeds the canvas by a few pixels.
 		width: calc(100vw);
 		left: calc(( 100% - 100vw ) / 2);
 	}

--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -35,7 +35,7 @@ function BlockListAppender( {
 				return {
 					hideInserter:
 						!! getTemplateLock( rootClientId ) ||
-						__unstableGetEditorMode() !== 'edit',
+						__unstableGetEditorMode() === 'zoom-out',
 					canInsertDefaultBlock: canInsertBlockType(
 						getDefaultBlockName(),
 						rootClientId

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -34,15 +34,15 @@ export const IntersectionObserver = createContext();
 function Root( { className, ...settings } ) {
 	const [ element, setElement ] = useState();
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { isOutlineMode, isFocusMode, isNavigationMode } = useSelect(
+	const { isOutlineMode, isFocusMode, editorMode } = useSelect(
 		( select ) => {
-			const { getSettings, isNavigationMode: _isNavigationMode } =
+			const { getSettings, __unstableGetEditorMode } =
 				select( blockEditorStore );
 			const { outlineMode, focusMode } = getSettings();
 			return {
 				isOutlineMode: outlineMode,
 				isFocusMode: focusMode,
-				isNavigationMode: _isNavigationMode(),
+				editorMode: __unstableGetEditorMode(),
 			};
 		},
 		[]
@@ -74,7 +74,7 @@ function Root( { className, ...settings } ) {
 			className: classnames( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,
 				'is-focus-mode': isFocusMode && isLargeViewport,
-				'is-navigate-mode': isNavigationMode,
+				'is-navigate-mode': editorMode === 'navigation',
 			} ),
 		},
 		settings

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -441,11 +441,11 @@
 
 /** Zoom Out mode styles **/
 .block-editor-iframe__body {
-	background: $white;
 	transition: all 0.3s;
+	transform-origin: top center;
 
 	&.is-zoomed-out {
-		transform-origin: top center;
+		margin: 100px 0;
 		transform: scale(0.45);
 
 		// Add a bit more space between the top level blocks.

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -13,15 +13,8 @@
 .block-editor-block-list__layout {
 	position: relative;
 
-	// Select tool/navigation mode shows the default cursor until an additional click edits.
-	&.is-navigate-mode {
-		cursor: default;
-	}
-
 	// The primary indicator of selection in text is the native selection marker.
 	// When selecting multiple blocks, we provide an additional selection indicator.
-	&.is-navigate-mode .block-editor-block-list__block.is-selected,
-	&.is-navigate-mode .block-editor-block-list__block.is-hovered,
 	.block-editor-block-list__block.is-multi-selected:not(.is-partially-selected),
 	.block-editor-block-list__block.is-highlighted,
 	.block-editor-block-list__block.is-highlighted ~ .is-multi-selected {
@@ -56,10 +49,6 @@
 				background: transparent;
 			}
 		}
-	}
-
-	&.is-navigate-mode .block-editor-block-list__block.is-hovered:not(.is-selected)::after {
-		box-shadow: 0 0 0 $border-width var(--wp-admin-theme-color);
 	}
 
 	.block-editor-block-list__block.is-highlighted::after {
@@ -448,4 +437,20 @@
 		// solves this.
 		margin-bottom: auto;
 	}
+}
+
+/** Zoom Out mode styles **/
+.block-editor-iframe__body {
+	background: $white;
+	transition: all 0.3s;
+}
+
+.block-editor-iframe__body.is-zoomed-out {
+	transform-origin: top center;
+	transform: scale(0.45);
+	margin-bottom: -70%;
+}
+
+.block-editor-iframe__body.is-zoomed-out > .block-list-appender {
+	display: none;
 }

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -447,7 +447,6 @@
 	&.is-zoomed-out {
 		transform-origin: top center;
 		transform: scale(0.45);
-		margin-bottom: -70%;
 
 		> .block-list-appender {
 			display: none;

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -448,6 +448,11 @@
 		transform-origin: top center;
 		transform: scale(0.45);
 
+		// Add a bit more space between the top level blocks.
+		.wp-site-blocks > * + * {
+			margin-block-start: 2.5rem;
+		}
+
 		> .block-list-appender {
 			display: none;
 		}

--- a/packages/block-editor/src/components/block-list/style.scss
+++ b/packages/block-editor/src/components/block-list/style.scss
@@ -443,14 +443,14 @@
 .block-editor-iframe__body {
 	background: $white;
 	transition: all 0.3s;
-}
 
-.block-editor-iframe__body.is-zoomed-out {
-	transform-origin: top center;
-	transform: scale(0.45);
-	margin-bottom: -70%;
-}
+	&.is-zoomed-out {
+		transform-origin: top center;
+		transform: scale(0.45);
+		margin-bottom: -70%;
 
-.block-editor-iframe__body.is-zoomed-out > .block-list-appender {
-	display: none;
+		> .block-list-appender {
+			display: none;
+		}
+	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -51,11 +51,10 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  * also pass any other props through this hook, and they will be merged and
  * returned.
  *
- * @param {Object}  props                        Optional. Props to pass to the element. Must contain
- *                                               the ref if one is defined.
- * @param {Object}  options                      Options for internal use only.
+ * @param {Object}  props                    Optional. Props to pass to the element. Must contain
+ *                                           the ref if one is defined.
+ * @param {Object}  options                  Options for internal use only.
  * @param {boolean} options.__unstableIsHtml
- * @param {boolean} options.__unstableIsDisabled Whether the block should be disabled.
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -34,6 +34,7 @@ import { useNavModeExit } from './use-nav-mode-exit';
 import { useBlockRefProvider } from './use-block-refs';
 import { useIntersectionObserver } from './use-intersection-observer';
 import { store as blockEditorStore } from '../../../store';
+import useBlockOverlayActive from '../../block-content-overlay';
 
 /**
  * If the block count exceeds the threshold, we disable the reordering animation
@@ -58,10 +59,7 @@ const BLOCK_ANIMATION_THRESHOLD = 200;
  *
  * @return {Object} Props to pass to the element to mark as a block.
  */
-export function useBlockProps(
-	props = {},
-	{ __unstableIsHtml, __unstableIsDisabled = false } = {}
-) {
+export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const {
 		clientId,
 		className,
@@ -114,6 +112,8 @@ export function useBlockProps(
 		[ clientId ]
 	);
 
+	const hasOverlay = useBlockOverlayActive( clientId );
+
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
@@ -132,7 +132,7 @@ export function useBlockProps(
 			enableAnimation,
 			triggerAnimationOnChange: index,
 		} ),
-		useDisabled( { isDisabled: ! __unstableIsDisabled } ),
+		useDisabled( { isDisabled: ! hasOverlay } ),
 	] );
 
 	const blockEditContext = useBlockEditContext();
@@ -158,6 +158,7 @@ export function useBlockProps(
 			// The wp-block className is important for editor styles.
 			classnames( 'block-editor-block-list__block', {
 				'wp-block': ! isAligned,
+				'has-block-overlay': hasOverlay,
 			} ),
 			className,
 			props.className,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -31,7 +31,7 @@ function useInitialPosition( clientId ) {
 		( select ) => {
 			const {
 				getSelectedBlocksInitialCaretPosition,
-				isNavigationMode,
+				__unstableGetEditorMode,
 				isBlockSelected,
 			} = select( blockEditorStore );
 
@@ -39,7 +39,7 @@ function useInitialPosition( clientId ) {
 				return;
 			}
 
-			if ( isNavigationMode() ) {
+			if ( __unstableGetEditorMode() !== 'edit' ) {
 				return;
 			}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-is-hovered.js
@@ -26,8 +26,8 @@ function listener( event ) {
  */
 export function useIsHovered() {
 	const isEnabled = useSelect( ( select ) => {
-		const { isNavigationMode, getSettings } = select( blockEditorStore );
-		return isNavigationMode() || getSettings().outlineMode;
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().outlineMode;
 	}, [] );
 
 	return useRefEffect(

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -7,7 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useCallback, useMemo, createContext } from '@wordpress/element';
+import {
+	useCallback,
+	useMemo,
+	createContext,
+	useReducer,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { Popover } from '@wordpress/components';
 import { isRTL } from '@wordpress/i18n';
 
@@ -28,6 +34,12 @@ function BlockPopoverInbetween( {
 	__unstableContentRef,
 	...props
 } ) {
+	// This is a temporary hack to get the inbetween inserter to recompute properly.
+	const [ positionRecompute, forceRecompute ] = useReducer(
+		( s ) => s + 1,
+		0
+	);
+
 	const { orientation, rootClientId, isVisible } = useSelect(
 		( select ) => {
 			const {
@@ -47,7 +59,7 @@ function BlockPopoverInbetween( {
 					isBlockVisible( nextClientId ),
 			};
 		},
-		[ previousClientId ]
+		[ previousClientId, nextClientId ]
 	);
 	const previousElement = useBlockElement( previousClientId );
 	const nextElement = useBlockElement( nextClientId );
@@ -66,9 +78,7 @@ function BlockPopoverInbetween( {
 
 		if ( isVertical ) {
 			return {
-				width: previousElement
-					? previousElement.offsetWidth
-					: nextElement.offsetWidth,
+				width: previousRect ? previousRect.width : nextRect.width,
 				height:
 					nextRect && previousRect
 						? nextRect.top - previousRect.bottom
@@ -85,11 +95,15 @@ function BlockPopoverInbetween( {
 
 		return {
 			width,
-			height: previousElement
-				? previousElement.offsetHeight
-				: nextElement.offsetHeight,
+			height: previousRect ? previousRect.height : nextRect.height,
 		};
-	}, [ previousElement, nextElement, isVertical ] );
+	}, [
+		previousElement,
+		nextElement,
+		isVertical,
+		positionRecompute,
+		isVisible,
+	] );
 
 	const getAnchorRect = useCallback( () => {
 		if ( ( ! previousElement && ! nextElement ) || ! isVisible ) {
@@ -110,8 +124,8 @@ function BlockPopoverInbetween( {
 				return {
 					top: previousRect ? previousRect.bottom : nextRect.top,
 					left: previousRect ? previousRect.right : nextRect.right,
-					right: previousRect ? previousRect.left : nextRect.left,
-					bottom: nextRect ? nextRect.top : previousRect.bottom,
+					right: previousRect ? previousRect.right : nextRect.right,
+					bottom: previousRect ? previousRect.bottom : nextRect.top,
 					height: 0,
 					width: 0,
 					ownerDocument,
@@ -121,8 +135,8 @@ function BlockPopoverInbetween( {
 			return {
 				top: previousRect ? previousRect.bottom : nextRect.top,
 				left: previousRect ? previousRect.left : nextRect.left,
-				right: previousRect ? previousRect.right : nextRect.right,
-				bottom: nextRect ? nextRect.top : previousRect.bottom,
+				right: previousRect ? previousRect.left : nextRect.left,
+				bottom: previousRect ? previousRect.bottom : nextRect.top,
 				height: 0,
 				width: 0,
 				ownerDocument,
@@ -133,8 +147,8 @@ function BlockPopoverInbetween( {
 			return {
 				top: previousRect ? previousRect.top : nextRect.top,
 				left: previousRect ? previousRect.left : nextRect.right,
-				right: nextRect ? nextRect.right : previousRect.left,
-				bottom: previousRect ? previousRect.bottom : nextRect.bottom,
+				right: previousRect ? previousRect.left : nextRect.right,
+				bottom: previousRect ? previousRect.top : nextRect.top,
 				height: 0,
 				width: 0,
 				ownerDocument,
@@ -144,15 +158,56 @@ function BlockPopoverInbetween( {
 		return {
 			top: previousRect ? previousRect.top : nextRect.top,
 			left: previousRect ? previousRect.right : nextRect.left,
-			right: nextRect ? nextRect.left : previousRect.right,
-			bottom: previousRect ? previousRect.bottom : nextRect.bottom,
+			right: previousRect ? previousRect.right : nextRect.left,
+			bottom: previousRect ? previousRect.left : nextRect.right,
 			height: 0,
 			width: 0,
 			ownerDocument,
 		};
-	}, [ previousElement, nextElement ] );
+	}, [ previousElement, nextElement, positionRecompute, isVisible ] );
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
+
+	// This is only needed for a smoth transition when moving blocks.
+	useLayoutEffect( () => {
+		if ( ! previousElement ) {
+			return;
+		}
+		const observer = new window.MutationObserver( forceRecompute );
+		observer.observe( previousElement, { attributes: true } );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ previousElement ] );
+
+	useLayoutEffect( () => {
+		if ( ! nextElement ) {
+			return;
+		}
+		const observer = new window.MutationObserver( forceRecompute );
+		observer.observe( nextElement, { attributes: true } );
+
+		return () => {
+			observer.disconnect();
+		};
+	}, [ nextElement ] );
+
+	useLayoutEffect( () => {
+		if ( ! previousElement ) {
+			return;
+		}
+		previousElement.ownerDocument.defaultView.addEventListener(
+			'resize',
+			forceRecompute
+		);
+		return () => {
+			previousElement.ownerDocument.defaultView.removeEventListener(
+				'resize',
+				forceRecompute
+			);
+		};
+	}, [ previousElement ] );
 
 	// If there's either a previous or a next element, show the inbetween popover.
 	// Note that drag and drop uses the inbetween popover to show the drop indicator
@@ -188,8 +243,14 @@ function BlockPopoverInbetween( {
 			) }
 			resize={ false }
 			flip={ false }
+			placement="bottom-start"
 		>
-			<div style={ style }>{ children }</div>
+			<div
+				className="block-editor-block-popover__inbetween-container"
+				style={ style }
+			>
+				{ children }
+			</div>
 		</Popover>
 	);
 	/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -168,7 +168,7 @@ function BlockPopoverInbetween( {
 
 	const popoverScrollRef = usePopoverScroll( __unstableContentRef );
 
-	// This is only needed for a smoth transition when moving blocks.
+	// This is only needed for a smooth transition when moving blocks.
 	useLayoutEffect( () => {
 		if ( ! previousElement ) {
 			return;

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -6,6 +6,9 @@
 	// like the popover is impacted by the block gap margin.
 	margin: 0 !important;
 
+	// Allow clicking through the toolbar holder.
+	pointer-events: none;
+
 	.components-popover__content {
 		margin: 0 !important;
 		min-width: auto;
@@ -15,14 +18,12 @@
 		outline: none;
 		box-shadow: none;
 		overflow-y: visible;
-
-		// Allow clicking through the toolbar holder.
-		pointer-events: none;
 	}
 
 	// Enable pointer events for the toolbar's content.
 	&:not(.block-editor-block-popover__inbetween) .components-popover__content {
-		* {
+		// check if rebase ok
+		div > * {
 			pointer-events: all;
 		}
 	}
@@ -47,5 +48,12 @@
 		* {
 			pointer-events: all;
 		}
+	}
+}
+
+.block-editor-block-popover__inbetween-container {
+	pointer-events: none !important;
+	> div > * {
+		pointer-events: all;
 	}
 }

--- a/packages/block-editor/src/components/block-popover/style.scss
+++ b/packages/block-editor/src/components/block-popover/style.scss
@@ -22,8 +22,7 @@
 
 	// Enable pointer events for the toolbar's content.
 	&:not(.block-editor-block-popover__inbetween) .components-popover__content {
-		// check if rebase ok
-		div > * {
+		* {
 			pointer-events: all;
 		}
 	}
@@ -40,7 +39,6 @@
 	}
 
 	// Re-enable pointer events when the inbetween inserter has a '+' button.
-	//
 	// Needs specificity, do not simplify.
 	.is-with-inserter {
 		pointer-events: all;
@@ -48,12 +46,5 @@
 		* {
 			pointer-events: all;
 		}
-	}
-}
-
-.block-editor-block-popover__inbetween-container {
-	pointer-events: none !important;
-	> div > * {
-		pointer-events: all;
 	}
 }

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -39,6 +39,7 @@ import { store as blockEditorStore } from '../../store';
 import BlockDraggable from '../block-draggable';
 import useBlockDisplayInformation from '../use-block-display-information';
 import { __unstableUseBlockElement as useBlockElement } from '../block-list/use-block-props/use-block-refs';
+import BlockMover from '../block-mover';
 
 /**
  * Block selection button component, displaying the label of the block. If the block
@@ -59,6 +60,7 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				getBlockIndex,
 				hasBlockMovingClientId,
 				getBlockListSettings,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 			const index = getBlockIndex( clientId );
 			const { name, attributes } = getBlock( clientId );
@@ -69,11 +71,19 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 				attributes,
 				blockMovingMode,
 				orientation: getBlockListSettings( rootClientId )?.orientation,
+				editorMode: __unstableGetEditorMode(),
 			};
 		},
 		[ clientId, rootClientId ]
 	);
-	const { index, name, attributes, blockMovingMode, orientation } = selected;
+	const {
+		index,
+		name,
+		attributes,
+		blockMovingMode,
+		orientation,
+		editorMode,
+	} = selected;
 	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
 	const ref = useRef();
 
@@ -236,25 +246,34 @@ function BlockSelectionButton( { clientId, rootClientId } ) {
 					<BlockIcon icon={ blockInformation?.icon } showColors />
 				</FlexItem>
 				<FlexItem>
-					<BlockDraggable clientIds={ [ clientId ] }>
-						{ ( draggableProps ) => (
-							<Button
-								icon={ dragHandle }
-								className="block-selection-button_drag-handle"
-								aria-hidden="true"
-								label={ dragHandleLabel }
-								// Should not be able to tab to drag handle as this
-								// button can only be used with a pointer device.
-								tabIndex="-1"
-								{ ...draggableProps }
-							/>
-						) }
-					</BlockDraggable>
+					{ editorMode === 'zoom-out' && (
+						<BlockMover clientIds={ [ clientId ] } hideDragHandle />
+					) }
+					{ editorMode === 'navigation' && (
+						<BlockDraggable clientIds={ [ clientId ] }>
+							{ ( draggableProps ) => (
+								<Button
+									icon={ dragHandle }
+									className="block-selection-button_drag-handle"
+									aria-hidden="true"
+									label={ dragHandleLabel }
+									// Should not be able to tab to drag handle as this
+									// button can only be used with a pointer device.
+									tabIndex="-1"
+									{ ...draggableProps }
+								/>
+							) }
+						</BlockDraggable>
+					) }
 				</FlexItem>
 				<FlexItem>
 					<Button
 						ref={ ref }
-						onClick={ () => setNavigationMode( false ) }
+						onClick={
+							editorMode === 'navigation'
+								? () => setNavigationMode( false )
+								: undefined
+						}
 						onKeyDown={ onKeyDown }
 						label={ label }
 						showTooltip={ false }

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -5,15 +5,20 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useViewportMatch } from '@wordpress/compose';
 import { Popover } from '@wordpress/components';
 import { __unstableUseShortcutEventMatch as useShortcutEventMatch } from '@wordpress/keyboard-shortcuts';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import InsertionPoint from './insertion-point';
+import {
+	InsertionPointOpenRef,
+	default as InsertionPoint,
+} from './insertion-point';
 import SelectedBlockPopover from './selected-block-popover';
 import { store as blockEditorStore } from '../../store';
 import BlockContextualToolbar from './block-contextual-toolbar';
 import usePopoverScroll from '../block-popover/use-popover-scroll';
+import ZoomOutModeInserters from './zoom-out-mode-inserters';
 
 /**
  * Renders block tools (the block toolbar, select/navigation mode toolbar, the
@@ -30,10 +35,15 @@ export default function BlockTools( {
 	...props
 } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const hasFixedToolbar = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().hasFixedToolbar,
-		[]
-	);
+	const { hasFixedToolbar, isZoomOutMode } = useSelect( ( select ) => {
+		const { __unstableGetEditorMode, getSettings } =
+			select( blockEditorStore );
+
+		return {
+			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			hasFixedToolbar: getSettings().hasFixedToolbar,
+		};
+	}, [] );
 	const isMatch = useShortcutEventMatch();
 	const { getSelectedBlockClientIds, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -101,30 +111,41 @@ export default function BlockTools( {
 		}
 	}
 
+	const blockToolbarRef = usePopoverScroll( __unstableContentRef );
+	const blockToolbarAfterRef = usePopoverScroll( __unstableContentRef );
+
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
-			<InsertionPoint __unstableContentRef={ __unstableContentRef }>
-				{ ( hasFixedToolbar || ! isLargeViewport ) && (
-					<BlockContextualToolbar isFixed />
+			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
+				{ ! isZoomOutMode && (
+					<InsertionPoint
+						__unstableContentRef={ __unstableContentRef }
+					/>
 				) }
+				{ ! isZoomOutMode &&
+					( hasFixedToolbar || ! isLargeViewport ) && (
+						<BlockContextualToolbar isFixed />
+					) }
 				{ /* Even if the toolbar is fixed, the block popover is still
-					needed for navigation and exploded mode. */ }
+					needed for navigation and zoom-out mode. */ }
 				<SelectedBlockPopover
 					__unstableContentRef={ __unstableContentRef }
 				/>
 				{ /* Used for the inline rich text toolbar. */ }
-				<Popover.Slot
-					name="block-toolbar"
-					ref={ usePopoverScroll( __unstableContentRef ) }
-				/>
+				<Popover.Slot name="block-toolbar" ref={ blockToolbarRef } />
 				{ children }
 				{ /* Used for inline rich text popovers. */ }
 				<Popover.Slot
 					name="__unstable-block-tools-after"
-					ref={ usePopoverScroll( __unstableContentRef ) }
+					ref={ blockToolbarAfterRef }
 				/>
-			</InsertionPoint>
+				{ isZoomOutMode && (
+					<ZoomOutModeInserters
+						__unstableContentRef={ __unstableContentRef }
+					/>
+				) }
+			</InsertionPointOpenRef.Provider>
 		</div>
 	);
 }

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -228,15 +228,10 @@ function InsertionPointPopover( {
 	);
 }
 
-export default function InsertionPoint( { children, ...props } ) {
+export default function InsertionPoint( props ) {
 	const isVisible = useSelect( ( select ) => {
 		return select( blockEditorStore ).isBlockInsertionPointVisible();
 	}, [] );
 
-	return (
-		<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-			{ isVisible && <InsertionPointPopover { ...props } /> }
-			{ children }
-		</InsertionPointOpenRef.Provider>
-	);
+	return isVisible && <InsertionPointPopover { ...props } />;
 }

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -80,7 +80,7 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		! isTyping && ! editorMode === 'edit' && isEmptyDefaultBlock;
+		! isTyping && editorMode === 'edit' && isEmptyDefaultBlock;
 	const shouldShowBreadcrumb =
 		editorMode === 'navigation' || editorMode === 'zoom-out';
 	const shouldShowContextualToolbar =

--- a/packages/block-editor/src/components/block-tools/selected-block-popover.js
+++ b/packages/block-editor/src/components/block-tools/selected-block-popover.js
@@ -24,7 +24,7 @@ import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 
 function selector( select ) {
 	const {
-		isNavigationMode,
+		__unstableGetEditorMode,
 		isMultiSelecting,
 		hasMultiSelection,
 		isTyping,
@@ -32,7 +32,7 @@ function selector( select ) {
 		getLastMultiSelectedBlockClientId,
 	} = select( blockEditorStore );
 	return {
-		isNavigationMode: isNavigationMode(),
+		editorMode: __unstableGetEditorMode(),
 		isMultiSelecting: isMultiSelecting(),
 		isTyping: isTyping(),
 		hasFixedToolbar: getSettings().hasFixedToolbar,
@@ -51,7 +51,7 @@ function SelectedBlockPopover( {
 	__unstableContentRef,
 } ) {
 	const {
-		isNavigationMode,
+		editorMode,
 		isMultiSelecting,
 		isTyping,
 		hasFixedToolbar,
@@ -80,17 +80,18 @@ function SelectedBlockPopover( {
 	const { stopTyping } = useDispatch( blockEditorStore );
 
 	const showEmptyBlockSideInserter =
-		! isTyping && ! isNavigationMode && isEmptyDefaultBlock;
-	const shouldShowBreadcrumb = isNavigationMode;
+		! isTyping && ! editorMode === 'edit' && isEmptyDefaultBlock;
+	const shouldShowBreadcrumb =
+		editorMode === 'navigation' || editorMode === 'zoom-out';
 	const shouldShowContextualToolbar =
-		! isNavigationMode &&
+		editorMode === 'edit' &&
 		! hasFixedToolbar &&
 		isLargeViewport &&
 		! isMultiSelecting &&
 		! showEmptyBlockSideInserter &&
 		! isTyping;
 	const canFocusHiddenToolbar =
-		! isNavigationMode &&
+		editorMode === 'edit' &&
 		! shouldShowContextualToolbar &&
 		! hasFixedToolbar &&
 		! isEmptyDefaultBlock;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -171,6 +171,11 @@
 	.block-selection-button_select-button.components-button {
 		padding: 0;
 	}
+
+	.block-editor-block-mover {
+		background: unset;
+		border: none;
+	}
 }
 
 // Hide the popover block editor list while dragging.

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockPopoverInbetween from '../block-popover/inbetween';
+import { store as blockEditorStore } from '../../store';
+import Inserter from '../inserter';
+
+function ZoomOutModeInserters( { __unstableContentRef } ) {
+	const [ isReady, setIsReady ] = useState( false );
+	const blockOrder = useSelect( ( select ) => {
+		return select( blockEditorStore ).getBlockOrder();
+	}, [] );
+
+	// Defer the initial rendering to avoid the jumps due to the animation.
+	useEffect( () => {
+		const timeout = setTimeout( () => {
+			setIsReady( true );
+		}, 500 );
+		return () => {
+			clearTimeout( timeout );
+		};
+	}, [] );
+
+	if ( ! isReady ) {
+		return null;
+	}
+
+	return blockOrder.map( ( clientId, index ) => {
+		if ( index === blockOrder.length - 1 ) {
+			return null;
+		}
+		return (
+			<BlockPopoverInbetween
+				key={ clientId }
+				previousClientId={ clientId }
+				nextClientId={ blockOrder[ index + 1 ] }
+				__unstableContentRef={ __unstableContentRef }
+			>
+				<div className="block-editor-block-list__insertion-point-inserter">
+					<Inserter
+						position="bottom center"
+						clientId={ blockOrder[ index + 1 ] }
+						__experimentalIsQuick
+					/>
+				</div>
+			</BlockPopoverInbetween>
+		);
+	} );
+}
+
+export default ZoomOutModeInserters;

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -42,7 +42,7 @@ function ZoomOutModeInserters( { __unstableContentRef } ) {
 				nextClientId={ blockOrder[ index + 1 ] }
 				__unstableContentRef={ __unstableContentRef }
 			>
-				<div className="block-editor-block-list__insertion-point-inserter">
+				<div className="block-editor-block-list__insertion-point-inserter is-with-inserter">
 					<Inserter
 						position="bottom center"
 						clientId={ blockOrder[ index + 1 ] }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -184,7 +184,7 @@ async function loadScript( head, { id, src } ) {
 }
 
 function Iframe(
-	{ contentRef, children, head, tabIndex = 0, assets, ...props },
+	{ contentRef, children, head, tabIndex = 0, assets, isZoomedOut, ...props },
 	ref
 ) {
 	const [ , forceRender ] = useReducer( () => ( {} ) );
@@ -222,7 +222,6 @@ function Iframe(
 			contentDocument.dir = ownerDocument.dir;
 			documentElement.removeChild( contentDocument.head );
 			documentElement.removeChild( contentDocument.body );
-
 			return true;
 		}
 
@@ -231,6 +230,7 @@ function Iframe(
 
 		return () => node.removeEventListener( 'load', setDocumentIfReady );
 	}, [] );
+
 	const headRef = useRefEffect( ( element ) => {
 		scripts
 			.reduce(
@@ -285,12 +285,23 @@ function Iframe(
 				{ iframeDocument &&
 					createPortal(
 						<>
-							<head ref={ headRef }>{ head }</head>
+							<head ref={ headRef }>
+								{ head }
+								<style>
+									{ isZoomedOut
+										? `html { transition: padding 0.3s; background: #2f2f2f; padding: 100px 0; }`
+										: `html { transition: padding 0.3s; }` }
+								</style>
+							</head>
 							<body
 								ref={ bodyRef }
 								className={ classnames(
+									'block-editor-iframe__body',
 									BODY_CLASS_NAME,
-									...bodyClasses
+									...bodyClasses,
+									{
+										'is-zoomed-out': isZoomedOut,
+									}
 								) }
 							>
 								{ /*

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -288,9 +288,11 @@ function Iframe(
 							<head ref={ headRef }>
 								{ head }
 								<style>
-									{ isZoomedOut
-										? `html { transition: padding 0.3s; background: #2f2f2f; padding: 100px 0; }`
-										: `html { transition: padding 0.3s; }` }
+									{ `html { transition: padding 0.3s, background 0.3s; ${
+										isZoomedOut
+											? `background: #2f2f2f; padding: 100px 0;`
+											: ''
+									} }` }
 								</style>
 							</head>
 							<body

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -294,9 +294,9 @@ function Iframe(
 							<head ref={ headRef }>
 								{ head }
 								<style>
-									{ `html { transition: padding 0.3s, background 0.3s; ${
+									{ `html { transition: background 0.3s; ${
 										isZoomedOut
-											? `background: #2f2f2f; padding: 100px 0;`
+											? `background: #2f2f2f;`
 											: ''
 									} }` }
 								</style>
@@ -315,9 +315,10 @@ function Iframe(
 									isZoomedOut
 										? {
 												// This is the remaining percentage from the scaling down
-												// of the iframe body(`scale(0.45)`).
+												// of the iframe body(`scale(0.45)`). We also need to subtract
+												// the body's bottom margin.
 												marginBottom: `-${
-													contentHeight * 0.55
+													contentHeight * 0.55 - 100
 												}px`,
 										  }
 										: {}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -14,7 +14,11 @@ import {
 	useReducer,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useMergeRefs, useRefEffect } from '@wordpress/compose';
+import {
+	useResizeObserver,
+	useMergeRefs,
+	useRefEffect,
+} from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 
 /**
@@ -194,6 +198,8 @@ function Iframe(
 	const scripts = useParsedAssets( assets?.scripts );
 	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
+	const [ contentResizeListener, { height: contentHeight } ] =
+		useResizeObserver();
 	const setRef = useRefEffect( ( node ) => {
 		function setDocumentIfReady() {
 			const { contentDocument, ownerDocument } = node;
@@ -305,7 +311,19 @@ function Iframe(
 										'is-zoomed-out': isZoomedOut,
 									}
 								) }
+								style={
+									isZoomedOut
+										? {
+												// This is the remaining percentage from the scaling down
+												// of the iframe body(`scale(0.45)`).
+												marginBottom: `-${
+													contentHeight * 0.55
+												}px`,
+										  }
+										: {}
+								}
 							>
+								{ contentResizeListener }
 								{ /*
 								 * This is a wrapper for the extra styles and scripts
 								 * rendered imperatively by cloning the parent,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -294,9 +294,9 @@ function Iframe(
 							<head ref={ headRef }>
 								{ head }
 								<style>
-									{ `html { transition: background 0.3s; ${
+									{ `html { transition: background 5s; ${
 										isZoomedOut
-											? `background: #2f2f2f;`
+											? 'background: #2f2f2f; transition: background 0s;'
 											: ''
 									} }` }
 								</style>

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -155,10 +155,11 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockName,
 				isBlockSelected,
 				hasSelectedInnerBlock,
-				isNavigationMode,
+				__unstableGetEditorMode,
 			} = select( blockEditorStore );
 			const blockName = getBlockName( clientId );
-			const enableClickThrough = isNavigationMode() || isSmallScreen;
+			const enableClickThrough =
+				__unstableGetEditorMode() === 'navigation' || isSmallScreen;
 			return {
 				__experimentalCaptureToolbars: select(
 					blocksStore

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -168,6 +168,7 @@ class Inserter extends Component {
 				clientId={ clientId }
 				isAppender={ isAppender }
 				showInserterHelpPanel={ showInserterHelpPanel }
+				prioritizePatterns={ prioritizePatterns }
 			/>
 		);
 	}
@@ -212,8 +213,6 @@ export default compose( [
 			hasInserterItems,
 			__experimentalGetAllowedBlocks,
 			__experimentalGetDirectInsertBlock,
-			getBlockIndex,
-			getBlockCount,
 			getSettings,
 		} = select( blockEditorStore );
 
@@ -227,8 +226,6 @@ export default compose( [
 		const directInsertBlock =
 			__experimentalGetDirectInsertBlock( rootClientId );
 
-		const index = getBlockIndex( clientId );
-		const blockCount = getBlockCount();
 		const settings = getSettings();
 
 		const hasSingleBlockType =
@@ -249,10 +246,7 @@ export default compose( [
 			directInsertBlock,
 			rootClientId,
 			prioritizePatterns:
-				settings.__experimentalPreferPatternsOnRoot &&
-				! rootClientId &&
-				index > 0 &&
-				( index < blockCount || blockCount === 0 ),
+				settings.__experimentalPreferPatternsOnRoot && ! rootClientId,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps, { select } ) => {

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -28,16 +28,15 @@ function InserterLibrary(
 ) {
 	const { destinationRootClientId, prioritizePatterns } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId, getSettings } = select(
-				blockEditorStore
-			);
+			const { getBlockRootClientId, getSettings } =
+				select( blockEditorStore );
 
 			const _rootClientId =
 				rootClientId || getBlockRootClientId( clientId ) || undefined;
 			return {
 				destinationRootClientId: _rootClientId,
-				prioritizePatterns: getSettings()
-					.__experimentalPreferPatternsOnRoot,
+				prioritizePatterns:
+					getSettings().__experimentalPreferPatternsOnRoot,
 			};
 		},
 		[ clientId, rootClientId ]

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -26,13 +26,19 @@ function InserterLibrary(
 	},
 	ref
 ) {
-	const destinationRootClientId = useSelect(
+	const { destinationRootClientId, prioritizePatterns } = useSelect(
 		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
-
-			return (
-				rootClientId || getBlockRootClientId( clientId ) || undefined
+			const { getBlockRootClientId, getSettings } = select(
+				blockEditorStore
 			);
+
+			const _rootClientId =
+				rootClientId || getBlockRootClientId( clientId ) || undefined;
+			return {
+				destinationRootClientId: _rootClientId,
+				prioritizePatterns: getSettings()
+					.__experimentalPreferPatternsOnRoot,
+			};
 		},
 		[ clientId, rootClientId ]
 	);
@@ -48,6 +54,7 @@ function InserterLibrary(
 			__experimentalInsertionIndex={ __experimentalInsertionIndex }
 			__experimentalFilterValue={ __experimentalFilterValue }
 			shouldFocusBlock={ shouldFocusBlock }
+			prioritizePatterns={ prioritizePatterns }
 			ref={ ref }
 		/>
 	);

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -37,6 +37,7 @@ function InserterMenu(
 		showMostUsedBlocks,
 		__experimentalFilterValue = '',
 		shouldFocusBlock = true,
+		prioritizePatterns,
 	},
 	ref
 ) {
@@ -215,6 +216,7 @@ function InserterMenu(
 						<InserterTabs
 							showPatterns={ showPatterns }
 							showReusableBlocks={ hasReusableBlocks }
+							prioritizePatterns={ prioritizePatterns }
 						>
 							{ getCurrentTab }
 						</InserterTabs>

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -26,20 +26,24 @@ function InserterTabs( {
 	showPatterns = false,
 	showReusableBlocks = false,
 	onSelect,
+	prioritizePatterns,
 } ) {
 	const tabs = useMemo( () => {
-		const tempTabs = [ blocksTab ];
-
-		if ( showPatterns ) {
+		const tempTabs = [];
+		if ( prioritizePatterns && showPatterns ) {
 			tempTabs.push( patternsTab );
 		}
-
+		tempTabs.push( blocksTab );
+		if ( ! prioritizePatterns && showPatterns ) {
+			tempTabs.push( patternsTab );
+		}
 		if ( showReusableBlocks ) {
 			tempTabs.push( reusableBlocksTab );
 		}
 
 		return tempTabs;
 	}, [
+		prioritizePatterns,
 		blocksTab,
 		showPatterns,
 		patternsTab,

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -91,6 +91,7 @@ function ListViewBranch( props ) {
 		fixedListWindow,
 		isExpanded,
 		parentId,
+		shouldShowInnerBlocks = true,
 	} = props;
 
 	const isContentLocked = useSelect(
@@ -138,9 +139,10 @@ function ListViewBranch( props ) {
 						: `${ position }`;
 				const hasNestedBlocks = !! innerBlocks?.length;
 
-				const shouldExpand = hasNestedBlocks
-					? expandedState[ clientId ] ?? isExpanded
-					: undefined;
+				const shouldExpand =
+					hasNestedBlocks && shouldShowInnerBlocks
+						? expandedState[ clientId ] ?? isExpanded
+						: undefined;
 
 				const isDragged = !! draggedClientIds?.includes( clientId );
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -63,16 +63,21 @@ function ListView(
 ) {
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
 		useListViewClientIds( blocks );
-	const { visibleBlockCount } = useSelect(
+
+	const { visibleBlockCount, shouldShowInnerBlocks } = useSelect(
 		( select ) => {
-			const { getGlobalBlockCount, getClientIdsOfDescendants } =
-				select( blockEditorStore );
+			const {
+				getGlobalBlockCount,
+				getClientIdsOfDescendants,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
 			const draggedBlockCount =
 				draggedClientIds?.length > 0
 					? getClientIdsOfDescendants( draggedClientIds ).length + 1
 					: 0;
 			return {
 				visibleBlockCount: getGlobalBlockCount() - draggedBlockCount,
+				shouldShowInnerBlocks: __unstableGetEditorMode() !== 'zoom-out',
 			};
 		},
 		[ draggedClientIds ]
@@ -192,6 +197,7 @@ function ListView(
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
 						isExpanded={ isExpanded }
+						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 					/>
 				</ListViewContext.Provider>
 			</TreeGrid>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -31,15 +31,11 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const isNavigationTool = useSelect(
-		( select ) => select( blockEditorStore ).isNavigationMode(),
+	const mode = useSelect(
+		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { setNavigationMode } = useDispatch( blockEditorStore );
-
-	const onSwitchMode = ( mode ) => {
-		setNavigationMode( mode === 'edit' ? false : true );
-	};
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown
@@ -47,7 +43,7 @@ function ToolSelector( props, ref ) {
 				<Button
 					{ ...props }
 					ref={ ref }
-					icon={ isNavigationTool ? selectIcon : editIcon }
+					icon={ mode === 'navigation' ? selectIcon : editIcon }
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
 					onClick={ onToggle }
@@ -60,8 +56,10 @@ function ToolSelector( props, ref ) {
 				<>
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
-							value={ isNavigationTool ? 'select' : 'edit' }
-							onSelect={ onSwitchMode }
+							value={
+								mode === 'navigation' ? 'navigation' : 'edit'
+							}
+							onSelect={ __unstableSetEditorMode }
 							choices={ [
 								{
 									value: 'edit',
@@ -73,7 +71,7 @@ function ToolSelector( props, ref ) {
 									),
 								},
 								{
-									value: 'select',
+									value: 'navigation',
 									label: (
 										<>
 											{ selectIcon }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -92,12 +92,20 @@ export default function useBlockDropZone( {
 } = {} ) {
 	const [ targetBlockIndex, setTargetBlockIndex ] = useState( null );
 
-	const isLocked = useSelect(
+	const isDisabled = useSelect(
 		( select ) => {
-			const { getTemplateLock } = select( blockEditorStore );
+			const {
+				getTemplateLock,
+				__unstableIsWithinBlockOverlay,
+				__unstableHasActiveBlockOverlayActive,
+			} = select( blockEditorStore );
 			const templateLock = getTemplateLock( targetRootClientId );
-			return [ 'all', 'noContent' ].some(
-				( lock ) => lock === templateLock
+			return (
+				[ 'all', 'noContent' ].some(
+					( lock ) => lock === templateLock
+				) ||
+				__unstableHasActiveBlockOverlayActive( targetRootClientId ) ||
+				__unstableIsWithinBlockOverlay( targetRootClientId )
 			);
 		},
 		[ targetRootClientId ]
@@ -130,7 +138,7 @@ export default function useBlockDropZone( {
 	);
 
 	return useDropZone( {
-		isDisabled: isLocked,
+		isDisabled,
 		onDrop: onBlockDrop,
 		onDragOver( event ) {
 			// `currentTarget` is only available while the event is being

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -109,7 +109,7 @@ function useMovingAnimation( {
 			return;
 		}
 
-		ref.current.style.transform = '';
+		ref.current.style.transform = undefined;
 		const destination = getAbsolutePosition( ref.current );
 
 		triggerAnimation();
@@ -119,37 +119,22 @@ function useMovingAnimation( {
 		} );
 	}, [ triggerAnimationOnChange ] );
 
-	// Only called when either the x or y value changes.
-	function onFrameChange( { x, y } ) {
+	function onChange( { value } ) {
 		if ( ! ref.current ) {
 			return;
 		}
-
-		const isMoving = x === 0 && y === 0;
-		ref.current.style.transformOrigin = isMoving ? '' : 'center';
-		ref.current.style.transform = isMoving
-			? ''
-			: `translate3d(${ x }px,${ y }px,0)`;
-		ref.current.style.zIndex = ! isSelected || isMoving ? '' : '1';
-
-		preserveScrollPosition();
-	}
-
-	// Called for every frame computed by useSpring.
-	function onChange( { value } ) {
 		let { x, y } = value;
 		x = Math.round( x );
 		y = Math.round( y );
+		const finishedMoving = x === 0 && y === 0;
+		ref.current.style.transformOrigin = 'center center';
+		ref.current.style.transform = finishedMoving
+			? undefined
+			: `translate3d(${ x }px,${ y }px,0)`;
+		ref.current.style.zIndex = isSelected ? '1' : '';
 
-		if ( x !== onChange.x || y !== onChange.y ) {
-			onFrameChange( { x, y } );
-			onChange.x = x;
-			onChange.y = y;
-		}
+		preserveScrollPosition();
 	}
-
-	onChange.x = 0;
-	onChange.y = 0;
 
 	useSpring( {
 		from: {

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1474,25 +1474,52 @@ export const __unstableMarkAutomaticChange =
 /**
  * Action that enables or disables the navigation mode.
  *
- * @param {string} isNavigationMode Enable/Disable navigation mode.
+ * @param {boolean} isNavigationMode Enable/Disable navigation mode.
  */
 export const setNavigationMode =
 	( isNavigationMode = true ) =>
 	( { dispatch } ) => {
-		dispatch( { type: 'SET_NAVIGATION_MODE', isNavigationMode } );
+		dispatch.__unstableSetEditorMode(
+			isNavigationMode ? 'navigation' : 'edit'
+		);
+	};
 
-		if ( isNavigationMode ) {
+/**
+ * Action that sets the editor mode
+ *
+ * @param {string} mode Editor mode
+ */
+export const __unstableSetEditorMode =
+	( mode ) =>
+	( { dispatch, select } ) => {
+		// When switching to zoom-out mode, we need to select to root block
+		if ( mode === 'zoom-out' ) {
+			const firstSelectedClientId = select.getBlockSelectionStart();
+			if ( firstSelectedClientId ) {
+				dispatch.selectBlock(
+					select.getBlockHierarchyRootClientId(
+						firstSelectedClientId
+					)
+				);
+			}
+		}
+
+		dispatch( { type: 'SET_EDITOR_MODE', mode } );
+
+		if ( mode === 'navigation' ) {
 			speak(
 				__(
 					'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
 				)
 			);
-		} else {
+		} else if ( mode === 'edit' ) {
 			speak(
 				__(
 					'You are currently in edit mode. To return to the navigation mode, press Escape.'
 				)
 			);
+		} else if ( mode === 'zoom-out' ) {
+			speak( __( 'You are currently in zoom-out mode.' ) );
 		}
 	};
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1492,7 +1492,7 @@ export const setNavigationMode =
 export const __unstableSetEditorMode =
 	( mode ) =>
 	( { dispatch, select } ) => {
-		// When switching to zoom-out mode, we need to select to root block
+		// When switching to zoom-out mode, we need to select the root block
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
 			if ( firstSelectedClientId ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1608,7 +1608,7 @@ export const blockListSettings = ( state = {}, action ) => {
 };
 
 /**
- * Reducer returning whether the navigation mode is enabled or not.
+ * Reducer returning which mode is enabled.
  *
  * @param {string} state  Current state.
  * @param {Object} action Dispatched action.

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1615,14 +1615,14 @@ export const blockListSettings = ( state = {}, action ) => {
  *
  * @return {string} Updated state.
  */
-export function isNavigationMode( state = false, action ) {
-	// Let inserting block always trigger Edit mode.
-	if ( action.type === 'INSERT_BLOCKS' ) {
-		return false;
+export function editorMode( state = 'edit', action ) {
+	// Let inserting block in navigation mode always trigger Edit mode.
+	if ( action.type === 'INSERT_BLOCKS' && state === 'navigation' ) {
+		return 'edit';
 	}
 
-	if ( action.type === 'SET_NAVIGATION_MODE' ) {
-		return action.isNavigationMode;
+	if ( action.type === 'SET_EDITOR_MODE' ) {
+		return action.mode;
 	}
 
 	return state;
@@ -1637,13 +1637,11 @@ export function isNavigationMode( state = false, action ) {
  * @return {string|null} Updated state.
  */
 export function hasBlockMovingClientId( state = null, action ) {
-	// Let inserting block always trigger Edit mode.
-
 	if ( action.type === 'SET_BLOCK_MOVING_MODE' ) {
 		return action.hasBlockMovingClientId;
 	}
 
-	if ( action.type === 'SET_NAVIGATION_MODE' ) {
+	if ( action.type === 'SET_EDITOR_MODE' ) {
 		return null;
 	}
 
@@ -1806,7 +1804,7 @@ export default combineReducers( {
 	settings,
 	preferences,
 	lastBlockAttributesChange,
-	isNavigationMode,
+	editorMode,
 	hasBlockMovingClientId,
 	automaticChangeStatus,
 	highlightedBlock,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2725,11 +2725,11 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 		return true;
 	}
 
-	// In navigation mode, the block overly is active when
-	// the block is not selected (or one of its children selected)
-	// The same behavior is also enabled in all modes for blocks
-	// that have controlled children (reusable block, template part, navigation),
-	// unless explicitly disabled with `supports.__experimentalDisableBlockOverlay`.
+	// In navigation mode, the block overlay is active when the block is not
+	// selected (and doesn't contain a selected child). The same behavior is
+	// also enabled in all modes for blocks that have controlled children
+	// (reusable block, template part, navigation), unless explicitly disabled
+	// with `supports.__experimentalDisableBlockOverlay`.
 	const blockSupportDisable = hasBlockSupport(
 		getBlockName( state, clientId ),
 		'__experimentalDisableBlockOverlay',

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2728,10 +2728,18 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 	// In navigation mode, the block overly is active when
 	// the block is not selected (or one of its children selected)
 	// The same behavior is also enabled in all modes for blocks
-	// that have controlled children (reusable block, template part, navigation)
+	// that have controlled children (reusable block, template part, navigation),
+	// unless explicitly disabled with `supports.__experimentalDisableBlockOverlay`.
+	const blockSupportDisable = hasBlockSupport(
+		getBlockName( state, clientId ),
+		'__experimentalDisableBlockOverlay',
+		false
+	);
 	const shouldEnableIfUnselected =
 		editorMode === 'navigation' ||
-		areInnerBlocksControlled( state, clientId );
+		( blockSupportDisable
+			? false
+			: areInnerBlocksControlled( state, clientId ) );
 
 	return (
 		shouldEnableIfUnselected &&

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -20,7 +20,6 @@ import {
 	useInnerBlocksProps,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
-	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 	InnerBlocks,
 	BlockControls,
 	InspectorControls,
@@ -60,15 +59,9 @@ export default function ReusableBlockEdit( { attributes: { ref }, clientId } ) {
 		ref
 	);
 
-	const hasBlockOverlay = useBlockOverlayActive( clientId );
-	const blockProps = useBlockProps(
-		{
-			className: hasBlockOverlay
-				? 'block-library-block__reusable-block-container block-editor-block-content-overlay'
-				: 'block-library-block__reusable-block-container',
-		},
-		{ __unstableIsDisabled: hasBlockOverlay }
-	);
+	const blockProps = useBlockProps( {
+		className: 'block-library-block__reusable-block-container',
+	} );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		value: blocks,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -19,6 +19,7 @@ import {
 	ContrastChecker,
 	getColorClassName,
 	Warning,
+	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
@@ -309,6 +310,7 @@ function Navigation( {
 
 	const textDecoration = attributes.style?.typography?.textDecoration;
 
+	const hasBlockOverlay = useBlockOverlayActive( clientId );
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: classnames( className, {
@@ -326,6 +328,7 @@ function Navigation( {
 			[ getColorClassName( 'background-color', backgroundColor?.slug ) ]:
 				!! backgroundColor?.slug,
 			[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
+			'block-editor-block-content-overlay': hasBlockOverlay,
 		} ),
 		style: {
 			color: ! textColor?.slug && textColor?.color,

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -19,7 +19,6 @@ import {
 	ContrastChecker,
 	getColorClassName,
 	Warning,
-	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 } from '@wordpress/block-editor';
 import { EntityProvider, store as coreStore } from '@wordpress/core-data';
 
@@ -310,7 +309,6 @@ function Navigation( {
 
 	const textDecoration = attributes.style?.typography?.textDecoration;
 
-	const hasBlockOverlay = useBlockOverlayActive( clientId );
 	const blockProps = useBlockProps( {
 		ref: navRef,
 		className: classnames( className, {
@@ -328,7 +326,6 @@ function Navigation( {
 			[ getColorClassName( 'background-color', backgroundColor?.slug ) ]:
 				!! backgroundColor?.slug,
 			[ `has-text-decoration-${ textDecoration }` ]: textDecoration,
-			'block-editor-block-content-overlay': hasBlockOverlay,
 		} ),
 		style: {
 			color: ! textColor?.slug && textColor?.color,

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -15,7 +15,6 @@ import {
 	store as blockEditorStore,
 	__experimentalRecursionProvider as RecursionProvider,
 	__experimentalUseHasRecursion as useHasRecursion,
-	__experimentalUseBlockOverlayActive as useBlockOverlayActive,
 } from '@wordpress/block-editor';
 import { Spinner, Modal, MenuItem } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -89,15 +88,7 @@ export default function TemplatePartEdit( {
 	const blockPatterns = useAlternativeBlockPatterns( area, clientId );
 	const hasReplacements = !! templateParts.length || !! blockPatterns.length;
 	const areaObject = useTemplatePartArea( area );
-	const hasBlockOverlay = useBlockOverlayActive( clientId );
-	const blockProps = useBlockProps(
-		{
-			className: hasBlockOverlay
-				? 'block-editor-block-content-overlay'
-				: undefined,
-		},
-		{ __unstableIsDisabled: hasBlockOverlay }
-	);
+	const blockProps = useBlockProps();
 	const isPlaceholder = ! slug;
 	const isEntityAvailable = ! isPlaceholder && ! isMissing && isResolved;
 	const TagName = tagName || areaObject.tagName;

--- a/packages/dom/src/dom/get-scroll-container.js
+++ b/packages/dom/src/dom/get-scroll-container.js
@@ -19,9 +19,14 @@ export default function getScrollContainer( node ) {
 	if ( node.scrollHeight > node.clientHeight ) {
 		// ...except when overflow is defined to be hidden or visible
 		const { overflowY } = getComputedStyle( node );
+
 		if ( /(auto|scroll)/.test( overflowY ) ) {
 			return node;
 		}
+	}
+
+	if ( node.ownerDocument === node.parentNode ) {
+		return node;
 	}
 
 	// Continue traversing.

--- a/packages/edit-site/src/components/block-editor/resizable-editor.js
+++ b/packages/edit-site/src/components/block-editor/resizable-editor.js
@@ -8,6 +8,7 @@ import {
 	__unstableEditorStyles as EditorStyles,
 	__unstableIframe as Iframe,
 	__unstableUseMouseMoveTypingReset as useMouseMoveTypingReset,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMergeRefs } from '@wordpress/compose';
@@ -37,9 +38,14 @@ const HANDLE_STYLES_OVERRIDE = {
 };
 
 function ResizableEditor( { enableResizing, settings, children, ...props } ) {
-	const deviceType = useSelect(
-		( select ) =>
-			select( editSiteStore ).__experimentalGetPreviewDeviceType(),
+	const { deviceType, isZoomOutMode } = useSelect(
+		( select ) => ( {
+			deviceType:
+				select( editSiteStore ).__experimentalGetPreviewDeviceType(),
+			isZoomOutMode:
+				select( blockEditorStore ).__unstableGetEditorMode() ===
+				'zoom-out',
+		} ),
 		[]
 	);
 	const deviceStyles = useResizeCanvas( deviceType );
@@ -163,6 +169,7 @@ function ResizableEditor( { enableResizing, settings, children, ...props } ) {
 			} }
 		>
 			<Iframe
+				isZoomedOut={ isZoomOutMode }
 				style={ enableResizing ? { height } : deviceStyles }
 				head={
 					<>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -9,6 +9,7 @@ import {
 	BlockContextProvider,
 	BlockBreadcrumb,
 	BlockStyles,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	InterfaceSkeleton,
@@ -77,6 +78,7 @@ function Editor( { onError } ) {
 		nextShortcut,
 		editorMode,
 		showIconLabels,
+		blockEditorMode,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -89,6 +91,7 @@ function Editor( { onError } ) {
 			getEditorMode,
 		} = select( editSiteStore );
 		const { hasFinishedResolution, getEntityRecord } = select( coreStore );
+		const { __unstableGetEditorMode } = select( blockEditorStore );
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
 
@@ -125,6 +128,7 @@ function Editor( { onError } ) {
 				'core/edit-site',
 				'showIconLabels'
 			),
+			blockEditorMode: __unstableGetEditorMode(),
 		};
 	}, [] );
 	const { setPage, setIsInserterOpened } = useDispatch( editSiteStore );
@@ -320,11 +324,14 @@ function Editor( { onError } ) {
 												</>
 											}
 											footer={
-												<BlockBreadcrumb
-													rootLabelText={ __(
-														'Template'
-													) }
-												/>
+												blockEditorMode !==
+												'zoom-out' ? (
+													<BlockBreadcrumb
+														rootLabelText={ __(
+															'Template'
+														) }
+													/>
+												) : undefined
 											}
 											shortcuts={ {
 												previous: previousShortcut,

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -127,6 +127,9 @@ export default function Header( {
 	);
 	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
 
+	const hasZoomedOutView =
+		window && window.__experimentalEnableZoomedOutView && isVisualMode;
+
 	return (
 		<div className="edit-site-header">
 			<NavigableToolbar
@@ -189,22 +192,25 @@ export default function Header( {
 									showIconLabels ? 'tertiary' : undefined
 								}
 							/>
-							<Button
-								className="edit-site-header-toolbar__zoom-out-view-toggle"
-								icon={ chevronUpDown }
-								isPressed={ blockEditorMode === 'zoom-out' }
-								/* translators: button label text should, if possible, be under 16 characters. */
-								label={ __( 'Zoom-out View' ) }
-								onClick={ () => {
-									setPreviewDeviceType( 'desktop' );
-									setIsListViewOpened( false );
-									__unstableSetEditorMode(
-										blockEditorMode === 'zoom-out'
-											? 'edit'
-											: 'zoom-out'
-									);
-								} }
-							/>
+							{ hasZoomedOutView && (
+								<ToolbarItem
+									as={ Button }
+									className="edit-site-header-toolbar__zoom-out-view-toggle"
+									icon={ chevronUpDown }
+									isPressed={ blockEditorMode === 'zoom-out' }
+									/* translators: button label text should, if possible, be under 16 characters. */
+									label={ __( 'Zoom-out View' ) }
+									onClick={ () => {
+										setPreviewDeviceType( 'desktop' );
+										setIsListViewOpened( false );
+										__unstableSetEditorMode(
+											blockEditorMode === 'zoom-out'
+												? 'edit'
+												: 'zoom-out'
+										);
+									} }
+								/>
+							) }
 						</>
 					) }
 				</div>

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { useCallback, useRef } from '@wordpress/element';
@@ -127,8 +132,9 @@ export default function Header( {
 	);
 	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
 
-	const hasZoomedOutView =
-		window && window.__experimentalEnableZoomedOutView && isVisualMode;
+	const isZoomedOutViewExperimentEnabled =
+		window?.__experimentalEnableZoomedOutView && isVisualMode;
+	const isZoomedOutView = blockEditorMode === 'zoom-out';
 
 	return (
 		<div className="edit-site-header">
@@ -177,10 +183,7 @@ export default function Header( {
 							<ToolbarItem
 								as={ Button }
 								className="edit-site-header-toolbar__list-view-toggle"
-								disabled={
-									! isVisualMode &&
-									blockEditorMode === 'zoom-out'
-								}
+								disabled={ ! isVisualMode && isZoomedOutView }
 								icon={ listView }
 								isPressed={ isListViewOpen }
 								/* translators: button label text should, if possible, be under 16 characters. */
@@ -192,19 +195,19 @@ export default function Header( {
 									showIconLabels ? 'tertiary' : undefined
 								}
 							/>
-							{ hasZoomedOutView && (
+							{ isZoomedOutViewExperimentEnabled && (
 								<ToolbarItem
 									as={ Button }
 									className="edit-site-header-toolbar__zoom-out-view-toggle"
 									icon={ chevronUpDown }
-									isPressed={ blockEditorMode === 'zoom-out' }
+									isPressed={ isZoomedOutView }
 									/* translators: button label text should, if possible, be under 16 characters. */
 									label={ __( 'Zoom-out View' ) }
 									onClick={ () => {
 										setPreviewDeviceType( 'desktop' );
 										setIsListViewOpened( false );
 										__unstableSetEditorMode(
-											blockEditorMode === 'zoom-out'
+											isZoomedOutView
 												? 'edit'
 												: 'zoom-out'
 										);
@@ -238,27 +241,34 @@ export default function Header( {
 
 			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">
-					{ ! isFocusMode && blockEditorMode !== 'zoom-out' && (
-						<PreviewOptions
-							deviceType={ deviceType }
-							setDeviceType={ setPreviewDeviceType }
+					{ ! isFocusMode && (
+						<div
+							className={ classnames(
+								'edit-site-header__actions__preview-options',
+								{ 'is-zoomed-out': isZoomedOutView }
+							) }
 						>
-							<MenuGroup>
-								<MenuItem
-									href={ settings?.siteUrl }
-									target="_blank"
-									icon={ external }
-								>
-									{ __( 'View site' ) }
-									<VisuallyHidden as="span">
-										{
-											/* translators: accessibility text */
-											__( '(opens in a new tab)' )
-										}
-									</VisuallyHidden>
-								</MenuItem>
-							</MenuGroup>
-						</PreviewOptions>
+							<PreviewOptions
+								deviceType={ deviceType }
+								setDeviceType={ setPreviewDeviceType }
+							>
+								<MenuGroup>
+									<MenuItem
+										href={ settings?.siteUrl }
+										target="_blank"
+										icon={ external }
+									>
+										{ __( 'View site' ) }
+										<VisuallyHidden as="span">
+											{
+												/* translators: accessibility text */
+												__( '(opens in a new tab)' )
+											}
+										</VisuallyHidden>
+									</MenuItem>
+								</MenuGroup>
+							</PreviewOptions>
+						</div>
 					) }
 					<SaveButton
 						openEntitiesSavedStates={ openEntitiesSavedStates }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -7,11 +7,12 @@ import {
 	ToolSelector,
 	__experimentalPreviewOptions as PreviewOptions,
 	NavigableToolbar,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, external } from '@wordpress/icons';
+import { listView, plus, external, stack } from '@wordpress/icons';
 import {
 	Button,
 	ToolbarItem,
@@ -55,6 +56,7 @@ export default function Header( {
 		isLoaded,
 		isVisualMode,
 		settings,
+		blockEditorMode,
 	} = useSelect( ( select ) => {
 		const {
 			__experimentalGetPreviewDeviceType,
@@ -69,6 +71,7 @@ export default function Header( {
 		const { __experimentalGetTemplateInfo: getTemplateInfo } =
 			select( editorStore );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
+		const { __unstableGetEditorMode } = select( blockEditorStore );
 
 		const postType = getEditedPostType();
 		const postId = getEditedPostId();
@@ -88,6 +91,7 @@ export default function Header( {
 			),
 			isVisualMode: getEditorMode() === 'visual',
 			settings: getSettings(),
+			blockEditorMode: __unstableGetEditorMode(),
 		};
 	}, [] );
 
@@ -96,6 +100,7 @@ export default function Header( {
 		setIsInserterOpened,
 		setIsListViewOpened,
 	} = useDispatch( editSiteStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
@@ -169,8 +174,11 @@ export default function Header( {
 							<ToolbarItem
 								as={ Button }
 								className="edit-site-header-toolbar__list-view-toggle"
+								disabled={
+									! isVisualMode &&
+									blockEditorMode === 'zoom-out'
+								}
 								icon={ listView }
-								disabled={ ! isVisualMode }
 								isPressed={ isListViewOpen }
 								/* translators: button label text should, if possible, be under 16 characters. */
 								label={ __( 'List View' ) }
@@ -180,6 +188,22 @@ export default function Header( {
 								variant={
 									showIconLabels ? 'tertiary' : undefined
 								}
+							/>
+							<Button
+								className="edit-site-header-toolbar__zoom-out-view-toggle"
+								icon={ stack }
+								isPressed={ blockEditorMode === 'zoom-out' }
+								/* translators: button label text should, if possible, be under 16 characters. */
+								label={ __( 'Zoom-out View' ) }
+								onClick={ () => {
+									setPreviewDeviceType( 'desktop' );
+									setIsListViewOpened( false );
+									__unstableSetEditorMode(
+										blockEditorMode === 'zoom-out'
+											? 'edit'
+											: 'zoom-out'
+									);
+								} }
 							/>
 						</>
 					) }
@@ -208,7 +232,7 @@ export default function Header( {
 
 			<div className="edit-site-header_end">
 				<div className="edit-site-header__actions">
-					{ ! isFocusMode && (
+					{ ! isFocusMode && blockEditorMode !== 'zoom-out' && (
 						<PreviewOptions
 							deviceType={ deviceType }
 							setDeviceType={ setPreviewDeviceType }

--- a/packages/edit-site/src/components/header/index.js
+++ b/packages/edit-site/src/components/header/index.js
@@ -12,7 +12,7 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PinnedItems } from '@wordpress/interface';
 import { _x, __ } from '@wordpress/i18n';
-import { listView, plus, external, stack } from '@wordpress/icons';
+import { listView, plus, external, chevronUpDown } from '@wordpress/icons';
 import {
 	Button,
 	ToolbarItem,
@@ -191,7 +191,7 @@ export default function Header( {
 							/>
 							<Button
 								className="edit-site-header-toolbar__zoom-out-view-toggle"
-								icon={ stack }
+								icon={ chevronUpDown }
 								isPressed={ blockEditorMode === 'zoom-out' }
 								/* translators: button label text should, if possible, be under 16 characters. */
 								label={ __( 'Zoom-out View' ) }

--- a/packages/edit-site/src/components/header/style.scss
+++ b/packages/edit-site/src/components/header/style.scss
@@ -135,6 +135,15 @@ body.is-navigation-sidebar-open {
 	}
 }
 
+.edit-site-header__actions__preview-options {
+	opacity: 1;
+	transition: opacity 0.3s;
+
+	&.is-zoomed-out {
+		opacity: 0;
+	}
+}
+
 .edit-site-header__actions-more-menu {
 	margin-left: -4px;
 

--- a/packages/edit-widgets/src/blocks/widget-area/block.json
+++ b/packages/edit-widgets/src/blocks/widget-area/block.json
@@ -15,7 +15,8 @@
 		"customClassName": false,
 		"reusable": false,
 		"__experimentalToolbar": false,
-		"__experimentalParentSelector": false
+		"__experimentalParentSelector": false,
+		"__experimentalDisableBlockOverlay": true
 	},
 	"editorStyle": "wp-block-widget-area-editor",
 	"style": "wp-block-widget-area"

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -38,6 +38,7 @@ export { default as chevronLeftSmall } from './library/chevron-left-small';
 export { default as chevronRight } from './library/chevron-right';
 export { default as chevronRightSmall } from './library/chevron-right-small';
 export { default as chevronUp } from './library/chevron-up';
+export { default as chevronUpDown } from './library/chevron-up-down';
 export { default as classic } from './library/classic';
 export { default as close } from './library/close';
 export { default as closeSmall } from './library/close-small';

--- a/packages/icons/src/library/chevron-up-down.js
+++ b/packages/icons/src/library/chevron-up-down.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const chevronUpDown = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="m12 20-4.5-3.6-.9 1.2L12 22l5.5-4.4-.9-1.2L12 20zm0-16 4.5 3.6.9-1.2L12 2 6.5 6.4l.9 1.2L12 4z" />
+	</SVG>
+);
+
+export default chevronUpDown;


### PR DESCRIPTION
Related #39281 #40319

Alternative to #40376 

## What?

The idea of this PR is that the exploded view has proven to be very challenging and might not be worth it. So I'm just trying a zoomed out view instead like it's being discussed in https://github.com/WordPress/gutenberg/issues/39281

See https://github.com/WordPress/gutenberg/issues/39281#issuecomment-1084648592

The zoom-out view is the idea that on the site editor, you can enter a mode where the focus is more on site building and composing patterns, rather than editing granular blocks.

The current PR is the first step to that:

 - When you enter the zoom-out view, the whole layout is zoomed out a bit.
 - Click blocks always selects the top level block/section. It's not possible to select inner blocks.
 - In-between inserters are rendered between all visible top level blocks.
 - You can move select and move top level blocks
 - The quick inserters favor patterns instead of blocks.

## Testing instructions

 - Enable the 'zoom out' experiment in Gutenberg experiments page.
 - Open the site editor.
 - Click the "zoom-out" mode toggle on the header toolbar.
 - Play a bit with the top-level blocks and inserters.