### PR TITLE
CheckboxControl: Add unit tests

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `CheckboxControl`: Add unit tests ([#41165](https://github.com/WordPress/gutenberg/pull/41165)).
+
 ## 19.11.0 (2022-05-18)
 
 ### Enhancements

--- a/packages/components/src/checkbox-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/checkbox-control/test/__snapshots__/index.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CheckboxControl Basic rendering should render the indeterminate icon when in the indeterminate state 1`] = `
+Snapshot Diff:
+- First value
++ Second value
+
+@@ -8,17 +8,31 @@
+        <span
+          class="components-checkbox-control__input-container"
+        >
+          <input
+            class="components-checkbox-control__input"
+-           id="inspector-checkbox-control-5"
++           id="inspector-checkbox-control-6"
+            type="checkbox"
+            value="1"
++         />
++         <svg
++           aria-hidden="true"
++           class="components-checkbox-control__indeterminate"
++           focusable="false"
++           height="24"
++           role="presentation"
++           viewBox="0 0 24 24"
++           width="24"
++           xmlns="http://www.w3.org/2000/svg"
++         >
++           <path
++             d="M7 11.5h10V13H7z"
+            />
++         </svg>
+        </span>
+        <label
+          class="components-checkbox-control__label"
+-         for="inspector-checkbox-control-5"
++         for="inspector-checkbox-control-6"
+        />
+      </div>
+    </div>
+  </div>
+`;

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -19,12 +19,7 @@ import type { CheckboxControlProps } from '../types';
 const getInput = () => screen.getByRole( 'checkbox' ) as HTMLInputElement;
 
 const CheckboxControl = ( props: Omit< CheckboxControlProps, 'onChange' > ) => {
-	return (
-		<BaseCheckboxControl
-			onChange={ noop }
-			{ ...props }
-		/>
-	);
+	return <BaseCheckboxControl onChange={ noop } { ...props } />;
 };
 
 const ControlledCheckboxControl = ( { onChange }: CheckboxControlProps ) => {
@@ -64,13 +59,24 @@ describe( 'CheckboxControl', () => {
 			expect( label ).toBeTruthy();
 		} );
 
-		it( 'should render an indeterminate icon', () => {
-			const { container } = render( <CheckboxControl indeterminate /> );
+		it( 'should render a checkbox in an indeterminate state', () => {
+			render( <CheckboxControl indeterminate /> );
+			expect( getInput() ).toHaveProperty( 'indeterminate', true );
+		} );
 
-			const indeterminateIcon = container.getElementsByClassName(
-				'components-checkbox-control__indeterminate'
+		it( 'should render the indeterminate icon when in the indeterminate state', () => {
+			const { container: containerDefault } = render(
+				<CheckboxControl />
 			);
-			expect( indeterminateIcon.length ).toBe( 1 );
+
+			const { container: containerIndeterminate } = render(
+				<CheckboxControl indeterminate />
+			);
+
+			// Expect the diff snapshot to be mostly about the indeterminate icon
+			expect( containerDefault ).toMatchDiffSnapshot(
+				containerIndeterminate
+			);
 		} );
 	} );
 

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -56,7 +56,7 @@ describe( 'CheckboxControl', () => {
 			render( <CheckboxControl label="Hello" /> );
 
 			const label = screen.getByText( 'Hello' );
-			expect( label ).toBeTruthy();
+			expect( label ).toBeInTheDocument();
 		} );
 
 		it( 'should render a checkbox in an indeterminate state', () => {

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { noop } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BaseCheckboxControl from '..';
+import type { CheckboxControlProps } from '../types';
+
+const getInput = () => screen.getByTestId( 'checkbox' );
+
+const CheckboxControl = ( props: Omit< CheckboxControlProps, 'onChange' > ) => {
+	return (
+		<BaseCheckboxControl
+			onChange={ noop }
+			{ ...props }
+			data-testid="checkbox"
+		/>
+	);
+};
+
+const ControlledCheckboxControl = () => {
+	const [ isChecked, setChecked ] = useState( false );
+	return (
+		<BaseCheckboxControl
+			checked={ isChecked }
+			onChange={ setChecked }
+			data-testid="checkbox"
+		/>
+	);
+};
+
+describe( 'CheckboxControl', () => {
+	describe( 'Basic rendering', () => {
+		it( 'should render', () => {
+			render( <CheckboxControl /> );
+			expect( getInput() ).not.toBeNull();
+		} );
+
+		it( 'should render an unchecked `checkbox` by default', () => {
+			render( <CheckboxControl /> );
+			expect( getInput() ).toHaveProperty( 'checked', false );
+		} );
+
+		it( 'should render an checked `checkbox` when `checked={ true }`', () => {
+			render( <CheckboxControl checked /> );
+			expect( getInput() ).toHaveProperty( 'checked', true );
+		} );
+
+		it( 'should render label', () => {
+			render( <CheckboxControl label="Hello" /> );
+
+			const label = screen.getByText( 'Hello' );
+			expect( label ).toBeTruthy();
+		} );
+
+		it( 'should render an indeterminate icon', () => {
+			const { container } = render( <CheckboxControl indeterminate /> );
+
+			const indeterminateIcon = container.getElementsByClassName(
+				'components-checkbox-control__indeterminate'
+			);
+			expect( indeterminateIcon.length ).toBe( 1 );
+		} );
+	} );
+
+	describe( 'Value', () => {
+		it( 'should flip the checked property when clicked', () => {
+			render( <ControlledCheckboxControl /> );
+			expect( getInput() ).toHaveProperty( 'checked', false );
+
+			fireEvent.click( getInput() );
+			expect( getInput() ).toHaveProperty( 'checked', true );
+
+			fireEvent.click( getInput() );
+			expect( getInput() ).toHaveProperty( 'checked', false );
+		} );
+	} );
+} );

--- a/packages/components/src/checkbox-control/test/index.tsx
+++ b/packages/components/src/checkbox-control/test/index.tsx
@@ -16,14 +16,13 @@ import { useState } from '@wordpress/element';
 import BaseCheckboxControl from '..';
 import type { CheckboxControlProps } from '../types';
 
-const getInput = () => screen.getByTestId( 'checkbox' );
+const getInput = () => screen.getByRole( 'checkbox' ) as HTMLInputElement;
 
 const CheckboxControl = ( props: Omit< CheckboxControlProps, 'onChange' > ) => {
 	return (
 		<BaseCheckboxControl
 			onChange={ noop }
 			{ ...props }
-			data-testid="checkbox"
 		/>
 	);
 };
@@ -37,7 +36,6 @@ const ControlledCheckboxControl = ( { onChange }: CheckboxControlProps ) => {
 				setChecked( value );
 				onChange( value );
 			} }
-			data-testid="checkbox"
 		/>
 	);
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add unit tests to `CheckboxControl`

## Why?
`CheckboxControl` is missing unit tests. Follow-up on https://github.com/WordPress/gutenberg/pull/40915#issuecomment-1123981296

## How?
Added unit tests.

## Testing Instructions
Run `npm run test-unit packages/components/src/checkbox-control` and confirm all tests passes.
