### PR TITLE
Components: Add `exhaustive-deps` eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -323,6 +323,13 @@ module.exports = {
 			},
 		},
 		{
+			files: [ 'packages/components/src/**/*.js' ],
+			excludedFiles: [ ...developmentFiles ],
+			rules: {
+				'react-hooks/exhaustive-deps': 'warn',
+			},
+		},
+		{
 			files: [ 'packages/jest*/**/*.js', '**/test/**/*.js' ],
 			excludedFiles: [ 'test/e2e/**/*.js' ],
 			extends: [ 'plugin:@wordpress/eslint-plugin/test-unit' ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -323,7 +323,7 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/components/src/**/*.[tj]s?(x)' ]
+			files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
 			excludedFiles: [ ...developmentFiles ],
 			rules: {
 				'react-hooks/exhaustive-deps': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -326,7 +326,7 @@ module.exports = {
 			files: [ 'packages/components/src/**/*.[tj]s?(x)' ],
 			excludedFiles: [ ...developmentFiles ],
 			rules: {
-				'react-hooks/exhaustive-deps': 'warn',
+				'react-hooks/exhaustive-deps': 'error',
 			},
 		},
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -323,7 +323,7 @@ module.exports = {
 			},
 		},
 		{
-			files: [ 'packages/components/src/**/*.js' ],
+			files: [ 'packages/components/src/**/*.[tj]s?(x)' ]
 			excludedFiles: [ ...developmentFiles ],
 			rules: {
 				'react-hooks/exhaustive-deps': 'warn',

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+	rules: {
+		'react-hooks/exhaustive-deps': 'warn',
+	},
+};

--- a/packages/components/.eslintrc.js
+++ b/packages/components/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-	rules: {
-		'react-hooks/exhaustive-deps': 'warn',
-	},
-};

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `Draggable`: Convert to TypeScript ([#45471](https://github.com/WordPress/gutenberg/pull/45471)).
 -   `MenuGroup`: Convert to TypeScript ([#45617](https://github.com/WordPress/gutenberg/pull/45617)).
 -   `useCx`: fix story to satisfy the `react-hooks/exhaustive-deps` eslint rule ([#45614](https://github.com/WordPress/gutenberg/pull/45614))
+-   Activate the `react-hooks/exhuastive-deps` eslint rule for the Components package ([#41166](https://github.com/WordPress/gutenberg/pull/41166))
 
 ### Experimental
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Note: This PR shouldn't be merged until after the list of updates below is completed to ensure everything is ready to pass!

## What?
Activate the `exhaustive-deps` rule to trigger warnings for missing deps in dependency arrays for `useEffect`, `useLayoutEffect`, `useMemo`, `useCallback`, or `useImperativeHandle`

## Why?
Missing dependencies can lead to unexpected results like stale state values. This rule helps us guard against that.

## How?
Below is a list of the components/files that currently throw `exhuastive-deps` warnings. I'll be going through as many as possible (help from other contributors is of course welcome!) to analyze and udpate as needed. Once all components are passing linting,this PR can be merged, activating the rule for the entire Components package.

## Testing Instructions
1. Apply this PR
2. From your local gutenberg directory, run `npx eslint --rule 'react-hooks/exhaustive-deps: warn' packages/components/src`

## Components and files to be updated:

- [x] alignment-matrix-control @chad1008 #41167
- [x] autocomplete @chad1008 #41382
- [x] border-box-control @ciampo #41254
- [x] border-control @chad1008 #41259
- [x] color-palette @chad1008 #41253
- [x] color-picker @stokesman #41294
- [x] combobox-control @chad1008 #41417
- [x] custom-gradient-bar @chad1008 #41463
- [x] date-time @chad1008 #41470
- [x] draggable @chad1008 #41499
- [x] dropdown @chad1008 #41505
- [x] flex/flex @chad1008 #41507
- [x] focal-point-picker @chad1008 #41520
- [x] font-size-picker @chad1008 #41600
- [x] input-control @chad1008 #41601
- [x] mobile/* @chad1008 #44207
- [x] modal @chad1008 #41610
- [x] navigation @chad1008 #41612
- [x] navigation/item @chad1008 #41639
- [x] navigation/menu @chad1008  #44090
- [x] navigator/navigator-button @flootr #42051
- [x] navigator/navigator-screen @chad1008 #43876
- [x] notice @chad1008  #44157
- [x] palette-edit @chad1008 #45467 as a follow up to @flootr's work in #43911
- [x] popover @ciampo  #43320
- [x] range-control @chad1008 #44271
- [x] resizable-box/resize-tooltip @chad1008 #44370
- [x] sandbox @chad1008 #44378
- [x] search-control @chad1008  #44381
- [x] slot-fill @chad1008 #44403
- [x] snackbar @chad1008  #44934
- [x] tab-panel @chad1008 #44935
- [x] tools-panel @chad1008 #45028
- [x] tooltip @chad1008 #45043
- [x] unit-control @ciampo #44161
- [x] ui/context/context-system-provider.js & utils/hooks/use-update-effect.js @chad1008 #45044

After completing the tasks above, I checked for any new warnings and found the following, which I'll tackle before proceeding:
- [x] Flex @chad1008 #45528
- [x] withNotices (in test) @chad1008 #45530
- [x] ItemGroup (in story) @chad1008 #45531
- [x] NavigatorScreen @flootr #45648
- [x] Popover @ciampo #45656
- [x] TabPanel @ciampo #45660
- [x] useCX (in story) @flootr #45614
- [x] ToolsPanel @ciampo #45715

cc @mirka @ciampo 