### PR TITLE
Add a “waitForTransition” data API

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -878,6 +878,29 @@ _Returns_
 
 -   `ReturnType< T >`: Data object returned by the `mapSelect` function.
 
+### waitForTransition
+
+Given a predicate function and an optional registry, returns a Promise that resolves once the predicate has transitioned from `true` to `false`. If the predicate is already `true` when called, the Promise will resolve on the next transition to `false`.
+
+Useful for running code after an asynchronous operation that is tracked in a data store (such as saving a post) has completed.
+
+```js
+import { waitForTransition } from '@wordpress/data';
+
+// Wait for isSavingPost() to transition to true, then back to false.
+await waitForTransition( () => wp.data.select( 'core/editor' ).isSavingPost() );
+console.log( 'Post saved!' );
+```
+
+_Parameters_
+
+-   _predicate_ `() => boolean`: A function that returns a boolean derived from store state.
+-   _registry_ `DataRegistry`: Registry to observe. Defaults to the global registry.
+
+_Returns_
+
+-   `Promise< void >`: A Promise that resolves the next time `predicate` returns `false` after returning `true`.
+
 ### withDispatch
 
 Higher-order component used to add dispatch props using registered action creators.

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -35,6 +35,7 @@ export { default as createReduxStore } from './redux-store';
 export { keyedReducer } from './redux-store/keyed-reducer';
 export { dispatch } from './dispatch';
 export { select } from './select';
+export { waitForTransition } from './utils';
 
 export type * from './types';
 

--- a/packages/data/src/test/utils.js
+++ b/packages/data/src/test/utils.js
@@ -121,6 +121,33 @@ describe( 'waitForTransition', () => {
 		expect( predicate ).toHaveBeenCalledTimes( callCountAfterResolve );
 	} );
 
+	it( 'should reject and unsubscribe when the predicate throws', async () => {
+		const error = new Error( 'predicate failed' );
+		let throwOnNextCall = false;
+		const predicate = jest.fn( () => {
+			if ( throwOnNextCall ) {
+				throw error;
+			}
+			return registry.select( 'test' ).isSaving();
+		} );
+
+		const promise = waitForTransition( predicate, registry );
+
+		// Arrange for the next predicate() invocation (inside the subscribe
+		// listener) to throw.
+		throwOnNextCall = true;
+		registry.dispatch( 'test' ).setSaving( true );
+
+		await expect( promise ).rejects.toBe( error );
+
+		// Further state changes must not invoke the predicate again, which
+		// confirms the subscription was released when the predicate threw.
+		const callCountAfterReject = predicate.mock.calls.length;
+		throwOnNextCall = false;
+		registry.dispatch( 'test' ).setSaving( false );
+		expect( predicate ).toHaveBeenCalledTimes( callCountAfterReject );
+	} );
+
 	it( 'should work with already true initial state', async () => {
 		// Set initial state to true before calling waitForTransition.
 		registry.dispatch( 'test' ).setSaving( true );

--- a/packages/data/src/test/utils.js
+++ b/packages/data/src/test/utils.js
@@ -1,0 +1,138 @@
+/**
+ * Internal dependencies
+ */
+import { createRegistry } from '../registry';
+import { waitForTransition } from '../utils';
+
+describe( 'waitForTransition', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createRegistry();
+		registry.registerStore( 'test', {
+			reducer: ( state = { saving: false }, action ) => {
+				if ( action.type === 'SET_SAVING' ) {
+					return { ...state, saving: action.saving };
+				}
+				return state;
+			},
+			selectors: {
+				isSaving: ( state ) => state.saving,
+			},
+			actions: {
+				setSaving: ( saving ) => ( { type: 'SET_SAVING', saving } ),
+			},
+		} );
+	} );
+
+	it( 'should resolve when predicate transitions from true to false', async () => {
+		const promise = waitForTransition(
+			() => registry.select( 'test' ).isSaving(),
+			registry
+		);
+
+		// Transition to true.
+		registry.dispatch( 'test' ).setSaving( true );
+
+		// Transition to false - should resolve.
+		registry.dispatch( 'test' ).setSaving( false );
+
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+
+	it( 'should not resolve on false to true transition only', async () => {
+		let resolved = false;
+		const promise = waitForTransition(
+			() => registry.select( 'test' ).isSaving(),
+			registry
+		).then( () => {
+			resolved = true;
+		} );
+
+		// Transition to true only.
+		registry.dispatch( 'test' ).setSaving( true );
+
+		// Give it a tick to ensure the promise hasn't resolved.
+		await Promise.resolve();
+
+		expect( resolved ).toBe( false );
+
+		// Complete the transition to false.
+		registry.dispatch( 'test' ).setSaving( false );
+		await promise;
+		expect( resolved ).toBe( true );
+	} );
+
+	it( 'should ignore multiple true values before false', async () => {
+		let resolveCount = 0;
+		const promise = waitForTransition(
+			() => registry.select( 'test' ).isSaving(),
+			registry
+		).then( () => {
+			resolveCount++;
+		} );
+
+		// Multiple true values.
+		registry.dispatch( 'test' ).setSaving( true );
+		registry.dispatch( 'test' ).setSaving( true );
+		registry.dispatch( 'test' ).setSaving( true );
+
+		// Finally transition to false.
+		registry.dispatch( 'test' ).setSaving( false );
+
+		await promise;
+		expect( resolveCount ).toBe( 1 );
+	} );
+
+	it( 'should call predicate only once per state change', async () => {
+		const predicate = jest.fn( () => registry.select( 'test' ).isSaving() );
+
+		const promise = waitForTransition( predicate, registry );
+
+		// Transition to true.
+		registry.dispatch( 'test' ).setSaving( true );
+		// Transition to false.
+		registry.dispatch( 'test' ).setSaving( false );
+
+		await promise;
+
+		// Predicate is called once for the initial check plus once per dispatch.
+		expect( predicate ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'should unsubscribe after resolving', async () => {
+		const predicate = jest.fn( () => registry.select( 'test' ).isSaving() );
+
+		const promise = waitForTransition( predicate, registry );
+
+		// Complete the transition.
+		registry.dispatch( 'test' ).setSaving( true );
+		registry.dispatch( 'test' ).setSaving( false );
+
+		await promise;
+
+		const callCountAfterResolve = predicate.mock.calls.length;
+
+		// Additional state changes should not trigger more predicate invocations.
+		registry.dispatch( 'test' ).setSaving( true );
+		registry.dispatch( 'test' ).setSaving( false );
+
+		// Predicate should not have been called again after unsubscribe.
+		expect( predicate ).toHaveBeenCalledTimes( callCountAfterResolve );
+	} );
+
+	it( 'should work with already true initial state', async () => {
+		// Set initial state to true before calling waitForTransition.
+		registry.dispatch( 'test' ).setSaving( true );
+
+		const promise = waitForTransition(
+			() => registry.select( 'test' ).isSaving(),
+			registry
+		);
+
+		// Transition to false - should resolve.
+		registry.dispatch( 'test' ).setSaving( false );
+
+		await expect( promise ).resolves.toBeUndefined();
+	} );
+} );

--- a/packages/data/src/utils.ts
+++ b/packages/data/src/utils.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import defaultRegistry from './default-registry';
+import type { DataRegistry } from './types';
+
+/**
+ * Given a predicate function and an optional registry, returns a Promise that resolves
+ * once the predicate has transitioned from `true` to `false`. If the predicate is already
+ * `true` when called, the Promise will resolve on the next transition to `false`.
+ *
+ * Useful for running code after an asynchronous operation that is tracked in a data store
+ * (such as saving a post) has completed.
+ *
+ * ```js
+ * import { waitForTransition } from '@wordpress/data';
+ *
+ * // Wait for isSavingPost() to transition to true, then back to false.
+ * await waitForTransition( () =>
+ *     wp.data.select( 'core/editor' ).isSavingPost()
+ * );
+ * console.log( 'Post saved!' );
+ * ```
+ *
+ * @param predicate A function that returns a boolean derived from store state.
+ * @param registry  Registry to observe. Defaults to the global registry.
+ * @return A Promise that resolves the next time `predicate` returns `false` after returning `true`.
+ */
+export function waitForTransition(
+	predicate: () => boolean,
+	registry: DataRegistry = defaultRegistry
+): Promise< void > {
+	return new Promise< void >( ( resolve ) => {
+		// Seed with the current value so an initial `true` state still triggers
+		// resolution on the next transition to `false`.
+		let hasBeenTrue = predicate();
+
+		const unsubscribe = registry.subscribe( () => {
+			const currentValue = predicate();
+
+			if ( ! hasBeenTrue && currentValue ) {
+				hasBeenTrue = true;
+				return;
+			}
+
+			if ( hasBeenTrue && ! currentValue ) {
+				unsubscribe();
+				resolve();
+			}
+		} );
+	} );
+}

--- a/packages/data/src/utils.ts
+++ b/packages/data/src/utils.ts
@@ -30,13 +30,22 @@ export function waitForTransition(
 	predicate: () => boolean,
 	registry: DataRegistry = defaultRegistry
 ): Promise< void > {
-	return new Promise< void >( ( resolve ) => {
+	return new Promise< void >( ( resolve, reject ) => {
 		// Seed with the current value so an initial `true` state still triggers
 		// resolution on the next transition to `false`.
 		let hasBeenTrue = predicate();
 
 		const unsubscribe = registry.subscribe( () => {
-			const currentValue = predicate();
+			let currentValue;
+			try {
+				currentValue = predicate();
+			} catch ( error ) {
+				// Always unsubscribe on predicate errors to avoid leaking
+				// subscriptions tied to a promise that will never resolve.
+				unsubscribe();
+				reject( error );
+				return;
+			}
 
 			if ( ! hasBeenTrue && currentValue ) {
 				hasBeenTrue = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add a new "subscribeOnChange" API.


## Why?
Based on feedback from @youknowriad - https://github.com/WordPress/gutenberg/issues/17632#issuecomment-614137473 this API helps address a common request for a "Post Published Hook". (or really a "post anything hook").


## How?
Developers can now call `subscribeOnChange` with a callback function and a test they want to trigger "After", for example saving a post would be monitored with a callback using `isSavingPost`.

## Testing Instructions
1. Open or create a test post.
2. Paste the following snippet into the console:
```wp.data.subscribeOnChange( () => { console.log( "Post saved." ); }, () => wp.data.select( 'core/editor' ).isSavingPost() );```
3. Save the post. Note that "Post Saved" is triggered once (and only once) after the post save completes


## Open questions
* Does always watching for true/false make sense or should the API accept values to test for start/end
* Have I exposed and documented the API correctly? The data package structure is complex and I'm not sure I did this right
* Currently the function fires only once, should it instead "reset", waiting for false again first (then true and false again before triggering)? As is developers would need to re-add the listener each time
* Should the function return an unsubscribe function (similar to subscribe) so developers can unhook their listeners?
