### PR TITLE
Gallery: Opt-in to axial (column/row) block spacing controls

### DIFF
--- a/packages/block-library/src/gallery/block.json
+++ b/packages/block-library/src/gallery/block.json
@@ -110,7 +110,7 @@
 		"html": false,
 		"units": [ "px", "em", "rem", "vh", "vw" ],
 		"spacing": {
-			"blockGap": true,
+			"blockGap": [ "horizontal", "vertical" ],
 			"__experimentalSkipSerialization": [ "blockGap" ],
 			"__experimentalDefaultControls": {
 				"blockGap": true


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #41174

This PR opts-in to separate column / row (or horizontal / vertical) controls for the spacing between images in the Gallery block. This unlocks layouts like the following, where depending on the design, folks might like to have a different horizontal versus vertical gap between images:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/14988353/169421982-78063e43-cb45-4572-b33b-67866d344974.png">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In #41125 we added in the technical capability for the gallery block to support split horizontal / vertical values. That PR was merged primarily as a bug fix — this PR now opts-in to the controls so that the feature is available in the UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Opt the Gallery block in to split horizontal / vertical controls in the `block.json` file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

1. In a theme that opts-in to `spacing.blockGap`, go to add a gallery block and add a few images.
2. In the Dimensions controls, set the grouped block spacing to a value and make sure it works.
3. Click the button to Unlink sides.
4. Adjust the vertical and horizontal values and ensure that the spacing looks correct in the editor and on the front end of the site.

## Screenshots or screencast <!-- if applicable -->

![2022-05-20 09 41 48](https://user-images.githubusercontent.com/14988353/169422405-23ac9e1b-dc37-450f-864e-39c9b63f6371.gif)