### PR TITLE
Env: Fixed `run` Argument Passing

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,6 +1,8 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
 ## Unreleased
+### Enhancement
+-   Removed the need for quotation marks when passing options to `wp-env run`.
 
 ## 4.7.0 (2022-05-18)
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -300,20 +300,22 @@ Positionals:
 The run command can be used to open shell sessions or invoke WP-CLI commands.
 
 <div class="callout callout-alert">
-To run a WP-CLI command that includes optional arguments, enclose the WP-CLI command in quotation marks; otherwise, the optional arguments are ignored. This is because flags are normally passed to `wp-env` itself, meaning that the flags are not considered part of the argument that specifies the WP-CLI command. With quotation marks, `wp-env` considers everything inside quotation marks the WP-CLI command argument.
+In some cases, `wp-env` may consume options that you are attempting to pass to 
+the container. This happens with options that `wp-env` has already declared,
+such as `--debug`, `--help`, and `--version`. When this happens, you should fall
+back to using quotation marks; `wp-env` considers everything inside the
+quotation marks to be command argument.
 
-For example, to list cron schedules with optional arguments that specify the fields returned and the format of the output:
+For example, to ask `WP-CLI` for its help text:
 
 ```sh
-wp-env run cli "wp cron schedule list --fields=name --format=csv"
+wp-env run cli "wp --help"
 ```
 
-Without the quotation marks, WP-CLI lists the schedule in its default format, ignoring the `fields` and `format` arguments.
+Without the quotation marks, `wp-env` will print its own help text instead of
+passing it to the container. If you experience any problems where the command
+is not being passed correctly, fall back to using quotation marks.
 </div>
-
-Note that quotation marks are not required for a WP-CLI command that excludes optional arguments, although it does not hurt to include them. For example, the following command syntaxes return identical results: `wp-env run cli "wp cron schedule list"` or `wp-env run cli wp cron schedule list`.
-
-For more information about all the available commands, see [WP-CLI Commands](https://developer.wordpress.org/cli/commands/).
 
 ```sh
 wp-env run <container> [command..]
@@ -323,11 +325,7 @@ Runs an arbitrary command in one of the underlying Docker containers. The
 "development", "tests", or "cli". To run a wp-cli command, use the "cli" or
 "tests-cli" service. You can also use this command to open shell sessions like
 bash and the WordPress shell in the WordPress instance. For example, `wp-env run
-cli bash` will open bash in the development WordPress instance. When using long
-commands with arguments and quotation marks, you need to wrap the "command"
-param in quotation marks. For example: `wp-env run tests-cli "wp post create
---post_type=page --post_title='Test'"` will create a post on the tests WordPress
-instance.
+cli bash` will open bash in the development WordPress instance.
 
 Positionals:
   container  The container to run the command on.            [string] [required]

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -92,6 +92,10 @@ module.exports = function cli() {
 		default: false,
 	} );
 
+	// Make sure any unknown arguments are passed to the command as arguments.
+	// This allows options to be passed to "run" without being quoted.
+	yargs.parserConfiguration( { 'unknown-options-as-args': true } );
+
 	yargs.command(
 		'start',
 		wpGreen(
@@ -171,7 +175,7 @@ module.exports = function cli() {
 				describe: 'The container to run the command on.',
 			} );
 			args.positional( 'command', {
-				type: 'string',
+				type: 'array',
 				describe: 'The command to run.',
 			} );
 		},
@@ -189,6 +193,7 @@ module.exports = function cli() {
 		'$0 run tests-cli bash',
 		'Open a bash session in the WordPress tests instance.'
 	);
+
 	yargs.command(
 		'destroy',
 		wpRed(

--- a/packages/env/test/cli.js
+++ b/packages/env/test/cli.js
@@ -18,6 +18,7 @@ jest.mock( '../lib/env', () => ( {
 	start: jest.fn( Promise.resolve.bind( Promise ) ),
 	stop: jest.fn( Promise.resolve.bind( Promise ) ),
 	clean: jest.fn( Promise.resolve.bind( Promise ) ),
+	run: jest.fn( Promise.resolve.bind( Promise ) ),
 	ValidationError: jest.requireActual( '../lib/env' ).ValidationError,
 } ) );
 
@@ -58,6 +59,21 @@ describe( 'env cli', () => {
 		cli().parse( [ 'clean', 'tests' ] );
 		const { environment, spinner } = env.clean.mock.calls[ 0 ][ 0 ];
 		expect( environment ).toBe( 'tests' );
+		expect( spinner.text ).toBe( '' );
+	} );
+
+	it( 'parses run commands without arguments.', () => {
+		cli().parse( [ 'run', 'tests-wordpress', 'test' ] );
+		const { container, command, spinner } = env.run.mock.calls[ 0 ][ 0 ];
+		expect( container ).toBe( 'tests-wordpress' );
+		expect( command ).toStrictEqual( [ 'test' ] );
+		expect( spinner.text ).toBe( '' );
+	} );
+	it( 'parses run commands with variadic arguments.', () => {
+		cli().parse( [ 'run', 'tests-wordpress', 'test', 'test1', '--test2' ] );
+		const { container, command, spinner } = env.run.mock.calls[ 0 ][ 0 ];
+		expect( container ).toBe( 'tests-wordpress' );
+		expect( command ).toStrictEqual( [ 'test', 'test1', '--test2' ] );
 		expect( spinner.text ).toBe( '' );
 	} );
 


### PR DESCRIPTION
## What?

As it stands, you need to pass options to `wp-env run` with the entire string having been quoted. This is because of `yargs/yargs` consuming any options even if they aren't defined. This causes problems when trying to encapsulate scripts in `package.json` files since you can't easily inject more options into the quoted string in the script.

Closes #32929.

## Why?

This will make it easier to write `wp-env run` commands in `package.json` scripts that can accept more options. Something like `wp-env run tests-wordpress ls -la` will now work without being quoted. With this pull request, you can now pass options.

## How?

This works by enabling the `unknown-options-as-args` parser option. This results in any unknown options that are given being treated as a positional argument. In the case of a variadic argument like `[command...]`, this means we can write commands conveniently.

As a note, `--help` and `--version` cannot be passed since they are known options. This will also result in other commands failing to execute if unknown flags are passed inappropriately in place of positional arguments.

## Testing Instructions
1. Run `npm run wp-env -- run ls -la`
2. With this pull request the command will execute as expected. Without it, there will be no `-la` option.3. 
