### PR TITLE
Components: Link Storybook in readme

### DIFF
--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -71,7 +71,7 @@ const Example = () => {
 
 ## Docs & examples
 
-You can browse the components docs and examples at https://wordpress.github.io/gutenberg/
+You can browse the components docs and examples at [https://wordpress.github.io/gutenberg/](https://wordpress.github.io/gutenberg/)
 
 ## Contributing to this package
 


### PR DESCRIPTION
## What?

Properly link the Storybook page in the components readme file.