### PR TITLE
[Site Editor]: Expand the template types that can be added - single custom post type and specific posts templates

### DIFF
--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -19,3 +19,31 @@ function gutenberg_update_templates_template_parts_rest_controller( $args, $post
 	return $args;
 }
 add_filter( 'register_post_type_args', 'gutenberg_update_templates_template_parts_rest_controller', 10, 2 );
+
+
+/**
+ * Updates WP_REST_Post_Types_Controller schema by adding the
+ * post type's `icon`(menu_icon).
+ */
+function gutenberg_update_post_types_rest_response() {
+	$post_types = get_post_types( array( 'show_in_rest' => true ), 'objects' );
+	register_rest_field(
+		'type',
+		'icon',
+		array(
+			'get_callback'    => function ( $post_type ) use ( $post_types ) {
+				if ( isset( $post_types[ $post_type['slug'] ] ) ) {
+					return $post_types[ $post_type['slug'] ]->menu_icon;
+				}
+			},
+			'update_callback' => null,
+			'schema'          => array(
+				'description' => __( 'The url to the icon to be used for this menu or the name of the icon from the iconfont.', 'gutenberg' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_update_post_types_rest_response' );

--- a/lib/compat/wordpress-6.1/rest-api.php
+++ b/lib/compat/wordpress-6.1/rest-api.php
@@ -22,28 +22,15 @@ add_filter( 'register_post_type_args', 'gutenberg_update_templates_template_part
 
 
 /**
- * Updates WP_REST_Post_Types_Controller schema by adding the
- * post type's `icon`(menu_icon).
+ * Add the post type's `icon`(menu_icon) in the response.
+ * When we backport this change we will need to add the
+ * `icon` to WP_REST_Post_Types_Controller schema.
+ *
+ * @param WP_REST_Response $response  The response object.
+ * @param WP_Post_Type     $post_type The original post type object.
  */
-function gutenberg_update_post_types_rest_response() {
-	$post_types = get_post_types( array( 'show_in_rest' => true ), 'objects' );
-	register_rest_field(
-		'type',
-		'icon',
-		array(
-			'get_callback'    => function ( $post_type ) use ( $post_types ) {
-				if ( isset( $post_types[ $post_type['slug'] ] ) ) {
-					return $post_types[ $post_type['slug'] ]->menu_icon;
-				}
-			},
-			'update_callback' => null,
-			'schema'          => array(
-				'description' => __( 'The url to the icon to be used for this menu or the name of the icon from the iconfont.', 'gutenberg' ),
-				'type'        => 'string',
-				'context'     => array( 'view', 'edit' ),
-				'readonly'    => true,
-			),
-		)
-	);
+function gutenberg_update_post_types_rest_response( $response, $post_type ) {
+	$response->data['icon'] = $post_type->menu_icon;
+	return $response;
 }
-add_action( 'rest_api_init', 'gutenberg_update_post_types_rest_response' );
+add_filter( 'rest_prepare_post_type', 'gutenberg_update_post_types_rest_response', 10, 2 );

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -203,8 +203,8 @@
 }
 
 @mixin mark-style() {
-	background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
-	font-weight: 500;
+	font-weight: 700;
+	background: none;
 }
 
 

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -202,6 +202,11 @@
 	}
 }
 
+@mixin mark-style() {
+	background: rgba(var(--wp-admin-theme-color--rgb), 0.1);
+	font-weight: 500;
+}
+
 
 /**
  * Allows users to opt-out of animations via OS-level preferences.

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -202,12 +202,6 @@
 	}
 }
 
-@mixin mark-style() {
-	font-weight: 700;
-	background: none;
-}
-
-
 /**
  * Allows users to opt-out of animations via OS-level preferences.
  */

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -203,7 +203,7 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 							<Text as="span">
 								{ sprintf(
 									// translators: %s: Name of the post type in plural e.g: "Posts".
-									__( 'Design a template for a all %s.' ),
+									__( 'Design a template for all %s.' ),
 									entityForSuggestions.labels.plural
 								) }
 							</Text>

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -7,7 +7,6 @@ import {
 	Button,
 	Flex,
 	FlexItem,
-	Icon,
 	Modal,
 	SearchControl,
 	TextHighlight,
@@ -17,7 +16,6 @@ import {
 	__unstableUseCompositeState as useCompositeState,
 	__unstableCompositeItem as CompositeItem,
 } from '@wordpress/components';
-import { pin, globe } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 import { useDebounce } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
@@ -198,7 +196,6 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 								} )
 							}
 						>
-							<Icon icon={ globe } />
 							<Heading level={ 5 }>{ __( 'General' ) }</Heading>
 							<Text as="span">
 								{ sprintf(
@@ -214,7 +211,6 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 								setShowSearchEntities( true );
 							} }
 						>
-							<Icon icon={ pin } />
 							<Heading level={ 5 }>{ __( 'Specific' ) }</Heading>
 							<Text as="span">
 								{ sprintf(

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -28,7 +28,7 @@ import { mapToIHasNameAndId } from './utils';
 const EMPTY_ARRAY = [];
 const BASE_QUERY = {
 	order: 'asc',
-	_fields: 'id,title,slug',
+	_fields: 'id,title,slug,link',
 	context: 'view',
 };
 
@@ -39,12 +39,14 @@ function SuggestionListItem( {
 	entityForSuggestions,
 	composite,
 } ) {
+	const baseCssClass =
+		'edit-site-custom-template-modal__suggestions_list__list-item';
 	return (
 		<CompositeItem
 			role="option"
 			as={ Button }
 			{ ...composite }
-			className="edit-site-custom-template-modal__suggestions_list__list-item"
+			className={ baseCssClass }
 			onClick={ () => {
 				const title = `${ entityForSuggestions.labels.singular }: ${ suggestion.name }`;
 				onSelect( {
@@ -54,7 +56,14 @@ function SuggestionListItem( {
 				} );
 			} }
 		>
-			<TextHighlight text={ suggestion.name } highlight={ search } />
+			<span className={ `${ baseCssClass }__title` }>
+				<TextHighlight text={ suggestion.name } highlight={ search } />
+			</span>
+			{ suggestion.link && (
+				<span className={ `${ baseCssClass }__info` }>
+					{ suggestion.link }
+				</span>
+			) }
 		</CompositeItem>
 	);
 }

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -1,0 +1,253 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	Flex,
+	FlexItem,
+	Icon,
+	Modal,
+	SearchControl,
+	TextHighlight,
+	__experimentalText as Text,
+	__experimentalHeading as Heading,
+	__unstableComposite as Composite,
+	__unstableUseCompositeState as useCompositeState,
+	__unstableCompositeItem as CompositeItem,
+} from '@wordpress/components';
+import { pin, globe } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
+import { useDebounce } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { useExistingEntitiesToExclude, mapToIHasNameAndId } from './utils';
+
+const EMPTY_ARRAY = [];
+const BASE_QUERY = {
+	order: 'asc',
+	_fields: 'id,title,slug',
+	context: 'view',
+};
+
+function SuggestionListItem( {
+	suggestion,
+	search,
+	onSelect,
+	entityForSuggestions,
+	composite,
+} ) {
+	return (
+		<CompositeItem
+			role="option"
+			as={ Button }
+			{ ...composite }
+			className="edit-site-custom-template-modal__suggestions_list__list-item"
+			onClick={ () => {
+				const title = `${ entityForSuggestions.labels.singular }: ${ suggestion.name }`;
+				onSelect( {
+					title,
+					description: `Template for ${ title }`,
+					slug: `single-${ entityForSuggestions.slug }-${ suggestion.slug }`,
+				} );
+			} }
+		>
+			<TextHighlight text={ suggestion.name } highlight={ search } />
+		</CompositeItem>
+	);
+}
+
+function SuggestionList( { entityForSuggestions, onSelect } ) {
+	const composite = useCompositeState( { orientation: 'vertical' } );
+	const [ suggestions, setSuggestions ] = useState( EMPTY_ARRAY );
+	// We need to track two values, the search input's value(searchInputValue)
+	// and the one we want to debounce(search) and make REST API requests.
+	const [ searchInputValue, setSearchInputValue ] = useState( '' );
+	const [ search, setSearch ] = useState( '' );
+	const debouncedSearch = useDebounce( setSearch, 250 );
+	// Get ids of existing entities to exclude from search results.
+	const [
+		entitiesToExclude,
+		entitiesToExcludeHasResolved,
+	] = useExistingEntitiesToExclude( entityForSuggestions );
+	const { searchResults, searchHasResolved } = useSelect(
+		( select ) => {
+			// Wait for the request of finding the excluded items first.
+			if ( ! entitiesToExcludeHasResolved ) {
+				return {
+					searchResults: EMPTY_ARRAY,
+					searchHasResolved: false,
+				};
+			}
+			const { getEntityRecords, hasFinishedResolution } = select(
+				coreStore
+			);
+			const selectorArgs = [
+				entityForSuggestions.type,
+				entityForSuggestions.slug,
+				{
+					...BASE_QUERY,
+					search,
+					orderby: !! search ? 'relevance' : 'modified',
+					exclude: entitiesToExclude,
+					per_page: !! search ? 20 : 10,
+				},
+			];
+			return {
+				searchResults: getEntityRecords( ...selectorArgs ),
+				searchHasResolved: hasFinishedResolution(
+					'getEntityRecords',
+					selectorArgs
+				),
+			};
+		},
+		[ search, entitiesToExclude, entitiesToExcludeHasResolved ]
+	);
+	useEffect( () => {
+		if ( search !== searchInputValue ) {
+			debouncedSearch( searchInputValue );
+		}
+	}, [ search, searchInputValue ] );
+	const entitiesInfo = useMemo( () => {
+		if ( ! searchResults?.length ) return EMPTY_ARRAY;
+		return mapToIHasNameAndId( searchResults, 'title.rendered' );
+	}, [ searchResults ] );
+	// Update suggestions only when the query has resolved.
+	useEffect( () => {
+		if ( ! searchHasResolved ) return;
+		setSuggestions( entitiesInfo );
+	}, [ entitiesInfo, searchHasResolved ] );
+	return (
+		<>
+			<SearchControl
+				onChange={ setSearchInputValue }
+				value={ searchInputValue }
+				label={ __( 'Search' ) }
+				placeholder={ __( 'Search' ) }
+			/>
+			{ !! suggestions?.length && (
+				// TODO: we should add a max-height with overflow here..
+				// also check about a min-height as results might cause layout shift.
+				<Composite
+					{ ...composite }
+					role="listbox"
+					className="edit-site-custom-template-modal__suggestions_list"
+				>
+					{ suggestions.map( ( suggestion ) => (
+						<SuggestionListItem
+							key={ suggestion.slug }
+							suggestion={ suggestion }
+							search={ search }
+							onSelect={ onSelect }
+							entityForSuggestions={ entityForSuggestions }
+							composite={ composite }
+						/>
+					) ) }
+				</Composite>
+			) }
+			{ !! search && ! suggestions?.length && (
+				<p className="edit-site-custom-template-modal__no-results">
+					{ __( 'No results were found.' ) }
+				</p>
+			) }
+		</>
+	);
+}
+
+function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
+	const [ showSearchEntities, setShowSearchEntities ] = useState(
+		entityForSuggestions.hasGeneralTemplate
+	);
+	const baseCssClass = 'edit-site-custom-template-modal';
+	return (
+		<Modal
+			title={ sprintf(
+				// translators: %s: Name of the post type e.g: "Post".
+				__( 'Add %s template' ),
+				entityForSuggestions.labels.singular
+			) }
+			className={ baseCssClass }
+			closeLabel={ __( 'Close' ) }
+			onRequestClose={ onClose }
+		>
+			{ ! showSearchEntities && (
+				<>
+					<p>
+						{ __(
+							'What type of template would you like to create?'
+						) }
+					</p>
+					<Flex
+						className={ `${ baseCssClass }__contents` }
+						gap="4"
+						align="initial"
+					>
+						<FlexItem
+							isBlock
+							onClick={ () =>
+								onSelect( {
+									slug: entityForSuggestions.template.slug,
+									title: entityForSuggestions.template.title,
+									description:
+										entityForSuggestions.template
+											.description,
+								} )
+							}
+						>
+							<Icon icon={ globe } />
+							<Heading level={ 5 }>{ __( 'General' ) }</Heading>
+							<Text as="span">
+								{ sprintf(
+									// translators: %s: Name of the post type in plural e.g: "Posts".
+									__( 'Design a template for a all %s.' ),
+									entityForSuggestions.labels.plural
+								) }
+							</Text>
+						</FlexItem>
+						<FlexItem
+							isBlock
+							onClick={ () => {
+								setShowSearchEntities( true );
+							} }
+						>
+							<Icon icon={ pin } />
+							<Heading level={ 5 }>{ __( 'Specific' ) }</Heading>
+							<Text as="span">
+								{ sprintf(
+									// translators: %s: Name of the post type e.g: "Post".
+									__(
+										'Design a template for a specific %s.'
+									),
+									entityForSuggestions.labels.singular
+								) }
+							</Text>
+						</FlexItem>
+					</Flex>
+				</>
+			) }
+			{ showSearchEntities && (
+				<>
+					<p>
+						{ sprintf(
+							// translators: %s: Name of the post type e.g: "Post".
+							__(
+								'Select the %s you would like to design a template for.'
+							),
+							entityForSuggestions.labels.singular
+						) }
+					</p>
+					<SuggestionList
+						entityForSuggestions={ entityForSuggestions }
+						onSelect={ onSelect }
+					/>
+				</>
+			) }
+		</Modal>
+	);
+}
+
+export default AddCustomTemplateModal;

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -78,9 +78,8 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 	const debouncedSearch = useDebounce( setSearch, 250 );
 	const { searchResults, searchHasResolved } = useSelect(
 		( select ) => {
-			const { getEntityRecords, hasFinishedResolution } = select(
-				coreStore
-			);
+			const { getEntityRecords, hasFinishedResolution } =
+				select( coreStore );
 			const selectorArgs = [
 				entityForSuggestions.type,
 				entityForSuggestions.slug,

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -47,7 +47,7 @@ function SuggestionListItem( {
 			{ ...composite }
 			className={ baseCssClass }
 			onClick={ () => {
-				const title = `${ entityForSuggestions.labels.singular }: ${ suggestion.name }`;
+				const title = `${ entityForSuggestions.labels.singular_name }: ${ suggestion.name }`;
 				onSelect( {
 					title,
 					description: `Template for ${ title }`,
@@ -146,8 +146,8 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 		<Modal
 			title={ sprintf(
 				// translators: %s: Name of the post type e.g: "Post".
-				__( 'Add %s template' ),
-				entityForSuggestions.labels.singular
+				__( 'Add template: %s' ),
+				entityForSuggestions.labels.singular_name
 			) }
 			className={ baseCssClass }
 			closeLabel={ __( 'Close' ) }
@@ -157,7 +157,7 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 				<>
 					<p>
 						{ __(
-							'What type of template would you like to create?'
+							'Select whether to create a single template for all items or a specific one.'
 						) }
 					</p>
 					<Flex
@@ -173,14 +173,10 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 								onSelect( { slug, title, description } );
 							} }
 						>
-							<Heading level={ 5 }>{ __( 'General' ) }</Heading>
-							<Text as="span">
-								{ sprintf(
-									// translators: %s: Name of the post type in plural e.g: "Posts".
-									__( 'Design a template for all %s.' ),
-									entityForSuggestions.labels.plural
-								) }
-							</Text>
+							<Heading level={ 5 }>
+								{ entityForSuggestions.labels.all_items }
+							</Heading>
+							<Text as="span">{ __( 'For all items' ) }</Text>
 						</FlexItem>
 						<FlexItem
 							isBlock
@@ -188,15 +184,11 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 								setShowSearchEntities( true );
 							} }
 						>
-							<Heading level={ 5 }>{ __( 'Specific' ) }</Heading>
+							<Heading level={ 5 }>
+								{ entityForSuggestions.labels.singular_name }
+							</Heading>
 							<Text as="span">
-								{ sprintf(
-									// translators: %s: Name of the post type e.g: "Post".
-									__(
-										'Design a template for a specific %s.'
-									),
-									entityForSuggestions.labels.singular
-								) }
+								{ __( 'For a specific item' ) }
 							</Text>
 						</FlexItem>
 					</Flex>
@@ -205,12 +197,8 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 			{ showSearchEntities && (
 				<>
 					<p>
-						{ sprintf(
-							// translators: %s: Name of the post type e.g: "Post".
-							__(
-								'Select the %s you would like to design a template for.'
-							),
-							entityForSuggestions.labels.singular
+						{ __(
+							'This template will be used only for the specific item chosen.'
 						) }
 					</p>
 					<SuggestionList

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -47,7 +47,12 @@ function SuggestionListItem( {
 			{ ...composite }
 			className={ baseCssClass }
 			onClick={ () => {
-				const title = `${ entityForSuggestions.labels.singular_name }: ${ suggestion.name }`;
+				const title = sprintf(
+					// translators: Represents the title of a user's custom template in the Site Editor, where %1$s is the singular name of a post type and %2$s is the name of the post, e.g. "Post: Hello, WordPress"
+					__( '%1$s: %2$s' ),
+					entityForSuggestions.labels.singular_name,
+					suggestion.name
+				);
 				onSelect( {
 					title,
 					description: `Template for ${ title }`,
@@ -107,8 +112,8 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			<SearchControl
 				onChange={ setSearchInputValue }
 				value={ searchInputValue }
-				label={ __( 'Search' ) }
-				placeholder={ __( 'Search' ) }
+				label={ entityForSuggestions.labels.search_items }
+				placeholder={ entityForSuggestions.labels.search_items }
 			/>
 			{ !! suggestions?.length && (
 				<Composite
@@ -130,7 +135,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			) }
 			{ search && ! suggestions?.length && (
 				<p className="edit-site-custom-template-modal__no-results">
-					{ __( 'No results were found.' ) }
+					{ entityForSuggestions.labels.not_found }
 				</p>
 			) }
 		</>
@@ -176,7 +181,12 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 							<Heading level={ 5 }>
 								{ entityForSuggestions.labels.all_items }
 							</Heading>
-							<Text as="span">{ __( 'For all items' ) }</Text>
+							<Text as="span">
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type, or just a specific one.
+									__( 'For all items' )
+								}
+							</Text>
 						</FlexItem>
 						<FlexItem
 							isBlock
@@ -188,7 +198,10 @@ function AddCustomTemplateModal( { onClose, onSelect, entityForSuggestions } ) {
 								{ entityForSuggestions.labels.singular_name }
 							</Heading>
 							<Text as="span">
-								{ __( 'For a specific item' ) }
+								{
+									// translators: The user is given the choice to set up a template for all items of a post type, or just a specific one.
+									__( 'For a specific item' )
+								}
 							</Text>
 						</FlexItem>
 					</Flex>

--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js
@@ -55,7 +55,11 @@ function SuggestionListItem( {
 				);
 				onSelect( {
 					title,
-					description: `Template for ${ title }`,
+					description: sprintf(
+						// translators: Represents the description of a user's custom template in the Site Editor, e.g. "Template for Post: Hello, WordPress"
+						__( 'Template for %1$s' ),
+						title
+					),
 					slug: `single-${ entityForSuggestions.slug }-${ suggestion.slug }`,
 				} );
 			} }

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -76,9 +76,8 @@ const TEMPLATE_ICONS = {
 export default function NewTemplate( { postType } ) {
 	const history = useHistory();
 	const postTypes = usePostTypes();
-	const [ showCustomTemplateModal, setShowCustomTemplateModal ] = useState(
-		false
-	);
+	const [ showCustomTemplateModal, setShowCustomTemplateModal ] =
+		useState( false );
 	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
 	const { existingTemplates, defaultTemplateTypes } = useSelect(
 		( select ) => ( {

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { filter, includes, map } from 'lodash';
+import { filter, includes } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -12,6 +12,7 @@ import {
 	MenuItem,
 	NavigableMenu,
 } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
@@ -30,17 +31,21 @@ import {
 	search,
 	tag,
 } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
  * Internal dependencies
  */
+import AddCustomTemplateModal from './add-custom-template-modal';
+import { usePostTypes, usePostTypesHaveEntities } from './utils';
 import { useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
 
+// TODO: check why we need info from `__experimentalGetDefaultTemplateTypes` and here in js..
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
+	// TODO: Info about this need to be change from `post` to make it clear we are creating `single` template.
 	'single',
 	'page',
 	'index',
@@ -72,9 +77,15 @@ const TEMPLATE_ICONS = {
 
 export default function NewTemplate( { postType } ) {
 	const history = useHistory();
-	const { templates, defaultTemplateTypes } = useSelect(
+	const postTypes = usePostTypes();
+	const postTypesHaveEntities = usePostTypesHaveEntities();
+	const [ showCustomTemplateModal, setShowCustomTemplateModal ] = useState(
+		false
+	);
+	const [ entityForSuggestions, setEntityForSuggestions ] = useState( {} );
+	const { existingTemplates, defaultTemplateTypes } = useSelect(
 		( select ) => ( {
-			templates: select( coreStore ).getEntityRecords(
+			existingTemplates: select( coreStore ).getEntityRecords(
 				'postType',
 				'wp_template',
 				{ per_page: -1 }
@@ -91,7 +102,6 @@ export default function NewTemplate( { postType } ) {
 	async function createTemplate( template ) {
 		try {
 			const { title, description, slug } = template;
-
 			const newTemplate = await saveEntityRecord(
 				'postType',
 				'wp_template',
@@ -129,8 +139,12 @@ export default function NewTemplate( { postType } ) {
 		}
 	}
 
-	const existingTemplateSlugs = map( templates, 'slug' );
+	const existingTemplateSlugs = ( existingTemplates || [] ).map(
+		( { slug } ) => slug
+	);
 
+	// TODO: rename to missingDefaultTemplates(or combine these arrays like`missingPostTypeTemplates`).
+	// Also it's weird that we don't have a single source of truth for the default templates. Needs looking..
 	const missingTemplates = filter(
 		defaultTemplateTypes,
 		( template ) =>
@@ -138,54 +152,159 @@ export default function NewTemplate( { postType } ) {
 			! includes( existingTemplateSlugs, template.slug )
 	);
 
-	if ( ! missingTemplates.length ) {
+	// TODO: make all strings translatable.
+	const extraTemplates = ( postTypes || [] ).reduce(
+		( accumulator, _postType ) => {
+			const {
+				slug,
+				labels: { singular_name: singularName },
+				menu_icon: icon,
+				name,
+			} = _postType;
+			const hasGeneralTemplate = existingTemplateSlugs?.includes(
+				`single-${ slug }`
+			);
+			const hasEntities = postTypesHaveEntities?.[ slug ];
+			const menuItem = {
+				slug: `single-${ slug }`,
+				title: sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Single %s' ),
+					singularName
+				),
+				// title: `Single ${ singularName }`,
+				description: sprintf(
+					// translators: %s: Name of the post type e.g: "Post".
+					__( 'Displays a single %s.' ),
+					singularName
+				),
+				icon,
+			};
+			// We have a different template creation flow only if they have entities.
+			if ( hasEntities ) {
+				menuItem.onClick = ( template ) => {
+					const slugsWithTemplates = (
+						existingTemplates || []
+					).reduce( ( _accumulator, existingTemplate ) => {
+						const prefix = `single-${ slug }-`;
+						if ( existingTemplate.slug.startsWith( prefix ) ) {
+							_accumulator.push(
+								existingTemplate.slug.substring( prefix.length )
+							);
+						}
+						return _accumulator;
+					}, [] );
+					setShowCustomTemplateModal( true );
+					setEntityForSuggestions( {
+						type: 'postType',
+						slug,
+						labels: { singular: singularName, plural: name },
+						hasGeneralTemplate,
+						template,
+						slugsWithTemplates,
+					} );
+				};
+			}
+			// We don't need to add the menu item if there are no
+			// entities and the general template exists.
+			if ( ! hasGeneralTemplate || hasEntities ) {
+				accumulator.push( menuItem );
+			}
+			// Add conditionally the `archive-$post_type` item.
+			// `post` is a special post type and doesn't have `archive-post`.
+			if (
+				slug !== 'post' &&
+				! existingTemplateSlugs?.includes( `archive-${ slug }` )
+			) {
+				accumulator.push( {
+					slug: `archive-${ slug }`,
+					title: sprintf(
+						// translators: %s: Name of the post type e.g: "Post".
+						__( '%s archive' ),
+						singularName
+					),
+					description: sprintf(
+						// translators: %s: Name of the post type in plural e.g: "Posts".
+						__( 'Displays archive of %s.' ),
+						name
+					),
+					icon,
+				} );
+			}
+			return accumulator;
+		},
+		[]
+	);
+	// TODO: better handling here.
+	if ( ! missingTemplates.length && ! extraTemplates.length ) {
 		return null;
 	}
-
 	// Update the sort order to match the DEFAULT_TEMPLATE_SLUGS order.
-	missingTemplates.sort( ( template1, template2 ) => {
+	// TODO: check sorting with new items.
+	missingTemplates?.sort( ( template1, template2 ) => {
 		return (
 			DEFAULT_TEMPLATE_SLUGS.indexOf( template1.slug ) -
 			DEFAULT_TEMPLATE_SLUGS.indexOf( template2.slug )
 		);
 	} );
-
+	// Append all extra templates at the end of the list for now.
+	missingTemplates.push( ...extraTemplates );
 	return (
-		<DropdownMenu
-			className="edit-site-new-template-dropdown"
-			icon={ null }
-			text={ postType.labels.add_new }
-			label={ postType.labels.add_new_item }
-			popoverProps={ {
-				noArrow: false,
-			} }
-			toggleProps={ {
-				variant: 'primary',
-			} }
-		>
-			{ () => (
-				<NavigableMenu className="edit-site-new-template-dropdown__popover">
-					<MenuGroup label={ postType.labels.add_new_item }>
-						{ map( missingTemplates, ( template ) => {
-							const { title, description, slug } = template;
-							return (
-								<MenuItem
-									icon={ TEMPLATE_ICONS[ slug ] }
-									iconPosition="left"
-									info={ description }
-									key={ slug }
-									onClick={ () => {
-										createTemplate( template );
-										// We will be navigated way so no need to close the dropdown.
-									} }
-								>
-									{ title }
-								</MenuItem>
-							);
-						} ) }
-					</MenuGroup>
-				</NavigableMenu>
+		<>
+			<DropdownMenu
+				className="edit-site-new-template-dropdown"
+				icon={ null }
+				text={ postType.labels.add_new }
+				label={ postType.labels.add_new_item }
+				popoverProps={ {
+					noArrow: false,
+				} }
+				toggleProps={ {
+					variant: 'primary',
+				} }
+			>
+				{ () => (
+					<NavigableMenu className="edit-site-new-template-dropdown__popover">
+						<MenuGroup label={ postType.labels.add_new_item }>
+							{ missingTemplates.map( ( template ) => {
+								const {
+									title,
+									description,
+									slug,
+									onClick,
+									icon,
+								} = template;
+								return (
+									<MenuItem
+										icon={
+											icon ||
+											TEMPLATE_ICONS[ slug ] ||
+											post
+										}
+										iconPosition="left"
+										info={ description }
+										key={ slug }
+										onClick={ () =>
+											!! onClick
+												? onClick( template )
+												: createTemplate( template )
+										}
+									>
+										{ title }
+									</MenuItem>
+								);
+							} ) }
+						</MenuGroup>
+					</NavigableMenu>
+				) }
+			</DropdownMenu>
+			{ showCustomTemplateModal && (
+				<AddCustomTemplateModal
+					onClose={ () => setShowCustomTemplateModal( false ) }
+					onSelect={ createTemplate }
+					entityForSuggestions={ entityForSuggestions }
+				/>
 			) }
-		</DropdownMenu>
+		</>
 	);
 }

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -150,7 +150,7 @@ export default function NewTemplate( { postType } ) {
 			const {
 				slug,
 				labels: { singular_name: singularName },
-				menu_icon: icon,
+				icon,
 				name,
 			} = _postType;
 			const hasGeneralTemplate = existingTemplateSlugs?.includes(
@@ -169,7 +169,12 @@ export default function NewTemplate( { postType } ) {
 					__( 'Displays a single %s.' ),
 					singularName
 				),
-				icon,
+				// `icon` is the `menu_icon` property of a post type. We
+				// only handle `dashicons` for now, even if the `menu_icon`
+				// also supports urls and svg as values.
+				icon: icon?.startsWith( 'dashicons-' )
+					? icon.slice( 10 )
+					: null,
 			};
 			// We have a different template creation flow only if they have entities.
 			if ( hasEntities ) {

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -38,7 +38,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import AddCustomTemplateModal from './add-custom-template-modal';
-import { usePostTypes, usePostTypesHaveEntities } from './utils';
+import { usePostTypes, usePostTypesEntitiesInfo } from './utils';
 import { useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
 
@@ -78,7 +78,6 @@ const TEMPLATE_ICONS = {
 export default function NewTemplate( { postType } ) {
 	const history = useHistory();
 	const postTypes = usePostTypes();
-	const postTypesHaveEntities = usePostTypesHaveEntities();
 	const [ showCustomTemplateModal, setShowCustomTemplateModal ] = useState(
 		false
 	);
@@ -95,6 +94,7 @@ export default function NewTemplate( { postType } ) {
 		} ),
 		[]
 	);
+	const postTypesEntitiesInfo = usePostTypesEntitiesInfo( existingTemplates );
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 	const { setTemplate } = useDispatch( editSiteStore );
@@ -138,11 +138,9 @@ export default function NewTemplate( { postType } ) {
 			} );
 		}
 	}
-
 	const existingTemplateSlugs = ( existingTemplates || [] ).map(
 		( { slug } ) => slug
 	);
-
 	// TODO: rename to missingDefaultTemplates(or combine these arrays like`missingPostTypeTemplates`).
 	// Also it's weird that we don't have a single source of truth for the default templates. Needs looking..
 	const missingTemplates = filter(
@@ -152,7 +150,6 @@ export default function NewTemplate( { postType } ) {
 			! includes( existingTemplateSlugs, template.slug )
 	);
 
-	// TODO: make all strings translatable.
 	const extraTemplates = ( postTypes || [] ).reduce(
 		( accumulator, _postType ) => {
 			const {
@@ -164,7 +161,7 @@ export default function NewTemplate( { postType } ) {
 			const hasGeneralTemplate = existingTemplateSlugs?.includes(
 				`single-${ slug }`
 			);
-			const hasEntities = postTypesHaveEntities?.[ slug ];
+			const hasEntities = postTypesEntitiesInfo?.[ slug ]?.hasEntities;
 			const menuItem = {
 				slug: `single-${ slug }`,
 				title: sprintf(
@@ -183,17 +180,6 @@ export default function NewTemplate( { postType } ) {
 			// We have a different template creation flow only if they have entities.
 			if ( hasEntities ) {
 				menuItem.onClick = ( template ) => {
-					const slugsWithTemplates = (
-						existingTemplates || []
-					).reduce( ( _accumulator, existingTemplate ) => {
-						const prefix = `single-${ slug }-`;
-						if ( existingTemplate.slug.startsWith( prefix ) ) {
-							_accumulator.push(
-								existingTemplate.slug.substring( prefix.length )
-							);
-						}
-						return _accumulator;
-					}, [] );
 					setShowCustomTemplateModal( true );
 					setEntityForSuggestions( {
 						type: 'postType',
@@ -201,7 +187,8 @@ export default function NewTemplate( { postType } ) {
 						labels: { singular: singularName, plural: name },
 						hasGeneralTemplate,
 						template,
-						slugsWithTemplates,
+						postsToExclude:
+							postTypesEntitiesInfo[ slug ].existingPosts,
 					} );
 				};
 			}
@@ -209,27 +196,6 @@ export default function NewTemplate( { postType } ) {
 			// entities and the general template exists.
 			if ( ! hasGeneralTemplate || hasEntities ) {
 				accumulator.push( menuItem );
-			}
-			// Add conditionally the `archive-$post_type` item.
-			// `post` is a special post type and doesn't have `archive-post`.
-			if (
-				slug !== 'post' &&
-				! existingTemplateSlugs?.includes( `archive-${ slug }` )
-			) {
-				accumulator.push( {
-					slug: `archive-${ slug }`,
-					title: sprintf(
-						// translators: %s: Name of the post type e.g: "Post".
-						__( '%s archive' ),
-						singularName
-					),
-					description: sprintf(
-						// translators: %s: Name of the post type in plural e.g: "Posts".
-						__( 'Displays archive of %s.' ),
-						name
-					),
-					icon,
-				} );
 			}
 			return accumulator;
 		},

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -164,7 +164,6 @@ export default function NewTemplate( { postType } ) {
 					__( 'Single %s' ),
 					singularName
 				),
-				// title: `Single ${ singularName }`,
 				description: sprintf(
 					// translators: %s: Name of the post type e.g: "Post".
 					__( 'Displays a single %s.' ),

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -42,10 +42,8 @@ import { usePostTypes, usePostTypesEntitiesInfo } from './utils';
 import { useHistory } from '../routes';
 import { store as editSiteStore } from '../../store';
 
-// TODO: check why we need info from `__experimentalGetDefaultTemplateTypes` and here in js..
 const DEFAULT_TEMPLATE_SLUGS = [
 	'front-page',
-	// TODO: Info about this need to be change from `post` to make it clear we are creating `single` template.
 	'single',
 	'page',
 	'index',
@@ -141,8 +139,6 @@ export default function NewTemplate( { postType } ) {
 	const existingTemplateSlugs = ( existingTemplates || [] ).map(
 		( { slug } ) => slug
 	);
-	// TODO: rename to missingDefaultTemplates(or combine these arrays like`missingPostTypeTemplates`).
-	// Also it's weird that we don't have a single source of truth for the default templates. Needs looking..
 	const missingTemplates = filter(
 		defaultTemplateTypes,
 		( template ) =>
@@ -201,7 +197,6 @@ export default function NewTemplate( { postType } ) {
 		},
 		[]
 	);
-	// TODO: better handling here.
 	if ( ! missingTemplates.length && ! extraTemplates.length ) {
 		return null;
 	}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -249,7 +249,7 @@ export default function NewTemplate( { postType } ) {
 										info={ description }
 										key={ slug }
 										onClick={ () =>
-											!! onClick
+											onClick
 												? onClick( template )
 												: createTemplate( template )
 										}

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -199,7 +199,6 @@ export default function NewTemplate( { postType } ) {
 		return null;
 	}
 	// Update the sort order to match the DEFAULT_TEMPLATE_SLUGS order.
-	// TODO: check sorting with new items.
 	missingTemplates?.sort( ( template1, template2 ) => {
 		return (
 			DEFAULT_TEMPLATE_SLUGS.indexOf( template1.slug ) -

--- a/packages/edit-site/src/components/add-new-template/new-template.js
+++ b/packages/edit-site/src/components/add-new-template/new-template.js
@@ -147,12 +147,7 @@ export default function NewTemplate( { postType } ) {
 
 	const extraTemplates = ( postTypes || [] ).reduce(
 		( accumulator, _postType ) => {
-			const {
-				slug,
-				labels: { singular_name: singularName },
-				icon,
-				name,
-			} = _postType;
+			const { slug, labels, icon } = _postType;
 			const hasGeneralTemplate = existingTemplateSlugs?.includes(
 				`single-${ slug }`
 			);
@@ -161,13 +156,13 @@ export default function NewTemplate( { postType } ) {
 				slug: `single-${ slug }`,
 				title: sprintf(
 					// translators: %s: Name of the post type e.g: "Post".
-					__( 'Single %s' ),
-					singularName
+					__( 'Single item: %s' ),
+					labels.singular_name
 				),
 				description: sprintf(
 					// translators: %s: Name of the post type e.g: "Post".
-					__( 'Displays a single %s.' ),
-					singularName
+					__( 'Displays a single item: %s.' ),
+					labels.singular_name
 				),
 				// `icon` is the `menu_icon` property of a post type. We
 				// only handle `dashicons` for now, even if the `menu_icon`
@@ -183,7 +178,7 @@ export default function NewTemplate( { postType } ) {
 					setEntityForSuggestions( {
 						type: 'postType',
 						slug,
-						labels: { singular: singularName, plural: name },
+						labels,
 						hasGeneralTemplate,
 						template,
 						postsToExclude:

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -54,13 +54,17 @@
 			}
 		}
 	}
+
+	@include break-medium() {
+		width: 456px;
+	}
 }
 
 .edit-site-custom-template-modal__suggestions_list {
 	margin-top: $grid-unit-20;
 
 	@include break-small() {
-		max-height: 256px;
+		height: 232px;
 		overflow: scroll;
 	}
 

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -42,8 +42,19 @@
 			}
 		}
 	}
-}
 
+	.components-search-control {
+		input[type=search].components-search-control__input {
+			background: $white;
+			border: 1px solid $gray-300;
+
+			&:focus {
+				border-color: var(--wp-admin-theme-color);
+				box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+			}
+		}
+	}
+}
 
 .edit-site-custom-template-modal__suggestions_list {
 	margin-top: $grid-unit-20;
@@ -51,9 +62,6 @@
 	@include break-small() {
 		max-height: 256px;
 		overflow: scroll;
-		border: 1px solid $gray-400;
-		border-radius: $radius-block-ui;
-		padding: $grid-unit;
 	}
 
 	&__list-item {
@@ -63,6 +71,14 @@
 
 		mark {
 			@include mark-style();
+		}
+
+		&:hover {
+			background-color: $gray-100;
+
+			mark {
+				color: var(--wp-admin-theme-color);
+			}
 		}
 	}
 }

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -44,7 +44,7 @@
 	}
 
 	.components-search-control {
-		input[type=search].components-search-control__input {
+		input[type="search"].components-search-control__input {
 			background: $white;
 			border: 1px solid $gray-300;
 

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -9,3 +9,68 @@
 		}
 	}
 }
+
+.edit-site-custom-template-modal {
+	&__contents {
+		> div {
+			text-align: center;
+			cursor: pointer;
+			padding: $grid-unit-30;
+			border: 1px solid $gray-300;
+			border-radius: $radius-block-ui;
+			width: 256px;
+			display: flex;
+			flex-direction: column;
+			gap: $grid-unit;
+			align-items: center;
+			justify-content: center;
+
+			span {
+				color: $gray-700;
+			}
+
+			&:hover {
+				border-color: var(--wp-admin-theme-color);
+
+				h5 {
+					color: var(--wp-admin-theme-color);
+				}
+			}
+
+			&:focus {
+				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			}
+		}
+	}
+}
+
+
+.edit-site-custom-template-modal__suggestions_list {
+	margin-top: $grid-unit-20;
+
+	@include break-small() {
+		max-height: 256px;
+		overflow: scroll;
+		border: 1px solid $gray-400;
+		border-radius: $radius-block-ui;
+		padding: $grid-unit;
+	}
+
+	&__list-item {
+		display: block;
+		width: 100%;
+		text-align: left;
+
+		mark {
+			@include mark-style();
+		}
+	}
+}
+
+.edit-site-custom-template-modal__no-results {
+	border: 1px solid $gray-400;
+	border-radius: $radius-block-ui;
+	padding: $grid-unit-20;
+	margin-bottom: 0;
+	margin-top: $grid-unit-20;
+}

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -72,6 +72,9 @@
 		display: block;
 		width: 100%;
 		text-align: left;
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+		height: auto;
 
 		mark {
 			@include mark-style();
@@ -83,6 +86,33 @@
 			mark {
 				color: var(--wp-admin-theme-color);
 			}
+		}
+
+		&:focus {
+			background-color: $gray-100;
+		}
+
+		&:focus:not(:disabled) {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) inset;
+		}
+
+		&__title,
+		&__info {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			display: block;
+		}
+
+		&__title {
+			font-weight: 500;
+			margin-bottom: 0.2em;
+		}
+
+		&__info {
+			color: $gray-700;
+			font-size: 0.9em;
+			line-height: 1.3;
+			word-break: break-all;
 		}
 	}
 }

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -77,7 +77,8 @@
 		height: auto;
 
 		mark {
-			@include mark-style();
+			font-weight: 700;
+			background: none;
 		}
 
 		&:hover {

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { decodeEntities } from '@wordpress/html-entities';
+
+export const usePostTypes = () => {
+	const postTypes = useSelect(
+		( select ) => select( coreStore ).getPostTypes( { per_page: -1 } ),
+		[]
+	);
+	const excludedPostTypes = [ 'attachment', 'page' ];
+	const filteredPostTypes = postTypes?.filter(
+		( { viewable, slug } ) =>
+			viewable && ! excludedPostTypes.includes( slug )
+	);
+	return filteredPostTypes;
+};
+
+export const usePostTypesHaveEntities = () => {
+	const postTypes = usePostTypes();
+	const postTypesHaveEntities = useSelect(
+		( select ) => {
+			return postTypes?.reduce( ( accumulator, { slug } ) => {
+				accumulator[ slug ] = !! select( coreStore ).getEntityRecords(
+					'postType',
+					slug,
+					{
+						per_page: 1,
+						_fields: 'id',
+						context: 'view',
+					}
+				)?.length;
+				return accumulator;
+			}, {} );
+		},
+		// It's important to use `length` as a dependency because `usePostTypes`
+		// returns a new array every time and will triger a rerender.
+		// We can't avoid that because `post types` endpoint doesn't allow filtering
+		// with `viewable` prop right now.
+		[ postTypes?.length ]
+	);
+	return postTypesHaveEntities;
+};
+
+export const useExistingEntitiesToExclude = ( entityForSuggestions ) => {
+	const { slugsWithTemplates, type, slug } = entityForSuggestions;
+	const { results, hasResolved } = useSelect( ( select ) => {
+		if ( ! slugsWithTemplates.length ) {
+			return {
+				results: [],
+				hasResolved: true,
+			};
+		}
+		const { getEntityRecords, hasFinishedResolution } = select( coreStore );
+		const selectorArgs = [
+			type,
+			slug,
+			{
+				_fields: 'id',
+				slug: slugsWithTemplates,
+				context: 'view',
+			},
+		];
+		return {
+			results: getEntityRecords( ...selectorArgs ),
+			hasResolved: hasFinishedResolution(
+				'getEntityRecords',
+				selectorArgs
+			),
+		};
+	}, [] );
+	return [ ( results || [] ).map( ( { id } ) => id ), hasResolved ];
+};
+
+export const mapToIHasNameAndId = ( entities, path ) => {
+	return ( entities || [] ).map( ( entity ) => ( {
+		...entity,
+		name: decodeEntities( get( entity, path ) ),
+	} ) );
+};

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -44,7 +44,7 @@ export const usePostTypesEntitiesInfo = ( existingTemplates ) => {
 	const postTypes = usePostTypes();
 	const slugsToExcludePerEntity = useMemo( () => {
 		return postTypes?.reduce( ( accumulator, _postType ) => {
-			const slugsWithTemplates = existingTemplates.reduce(
+			const slugsWithTemplates = ( existingTemplates || [] ).reduce(
 				( _accumulator, existingTemplate ) => {
 					const prefix = `single-${ _postType.slug }-`;
 					if ( existingTemplate.slug.startsWith( prefix ) ) {

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -16,12 +16,13 @@ export const usePostTypes = () => {
 		( select ) => select( coreStore ).getPostTypes( { per_page: -1 } ),
 		[]
 	);
-	const excludedPostTypes = [ 'attachment', 'page' ];
-	const filteredPostTypes = postTypes?.filter(
-		( { viewable, slug } ) =>
-			viewable && ! excludedPostTypes.includes( slug )
-	);
-	return filteredPostTypes;
+	return useMemo( () => {
+		const excludedPostTypes = [ 'attachment', 'page' ];
+		return postTypes?.filter(
+			( { viewable, slug } ) =>
+				viewable && ! excludedPostTypes.includes( slug )
+		);
+	}, [ postTypes ] );
 };
 
 /**
@@ -61,11 +62,7 @@ export const usePostTypesEntitiesInfo = ( existingTemplates ) => {
 			}
 			return accumulator;
 		}, {} );
-		// It's important to use `length` as a dependency because `usePostTypes`
-		// returns a new array every time and will triger a rerender.
-		// We can't avoid that because `post types` endpoint doesn't allow filtering
-		// with `viewable` prop right now.
-	}, [ postTypes?.length, existingTemplates ] );
+	}, [ postTypes, existingTemplates ] );
 	const postsToExcludePerEntity = useSelect(
 		( select ) => {
 			if ( ! slugsToExcludePerEntity ) {
@@ -115,11 +112,7 @@ export const usePostTypesEntitiesInfo = ( existingTemplates ) => {
 				return accumulator;
 			}, {} );
 		},
-		// It's important to use `length` as a dependency because `usePostTypes`
-		// returns a new array every time and will triger a rerender.
-		// We can't avoid that because `post types` endpoint doesn't allow filtering
-		// with `viewable` prop right now.
-		[ postTypes?.length, postsToExcludePerEntity ]
+		[ postTypes, postsToExcludePerEntity ]
 	);
 	return entitiesInfo;
 };

--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -39,7 +39,7 @@ export const usePostTypes = () => {
  * to query afterwards for any remaing post, by excluding them.
  *
  * @param {string[]} existingTemplates The existing templates.
- * @return {Object<string,PostTypeEntitiesInfo>} An object with the postTypes as `keys` and PostTypeEntitiesInfo as values.
+ * @return {Record<string,PostTypeEntitiesInfo>} An object with the postTypes as `keys` and PostTypeEntitiesInfo as values.
  */
 export const usePostTypesEntitiesInfo = ( existingTemplates ) => {
 	const postTypes = usePostTypes();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/37407

After exploring the end goal for many new templates from the issue, it become clear to me that we need to do this incrementally. This is why there would be too many changes to review/test properly.

This first iteration handles custom `post types` only. The approach taken here is the one that we intent to use on `Taxonomies, Authors` etc..

In this PR if you have registered custom post types you are shown a new menu item in the available templates in site editor. 
If this menu item is clicked can show different things depending on some conditions:
1. If we don't have `single-$post_type` and we have available posts that don't have a specific template created, it will show a modal with two options to create either of them. You can search through the available posts to create a specific template for it.
2.  If we don't have `single-$post_type` and we **don't** have available posts that don't have a specific template created, clicking the menu item will just create the `single-$post_type`.
3. If we have `single-$post_type` and we have available posts that don't have a specific template created, it will show the UI for  searching the available posts.
4. If we have `single-$post_type` and we **don't** have available posts that don't have a specific template created, the menu item will not be added.

There are many special case we need to take into account and for this PR is just that we can't have `archive-post` so we have explicit exclusion. Similar cases will be in the follow ups for `page` post type, some prioritized specific templates over the generic ones, like `category.php, tag.php` etc...

## Notes
In its current state this PR appends the newly added items at the bottom of the list.


## Testing instructions
1. I'd suggest using the empty theme and register a custom post type to play around in Site Editor and create different templates.

https://user-images.githubusercontent.com/16275880/173550190-93cb44d3-907b-4108-aef4-a42f9d7496bf.mov



