### PR TITLE
Compose: Add 'useLatestRef' hook

### DIFF
--- a/packages/block-library/src/paragraph/use-enter.js
+++ b/packages/block-library/src/paragraph/use-enter.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
-import { useRefEffect } from '@wordpress/compose';
+import { useRefEffect, useLatestRef } from '@wordpress/compose';
 import { ENTER } from '@wordpress/keycodes';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -24,8 +23,8 @@ export function useOnEnter( props ) {
 		getBlock,
 		getNextBlockClientId,
 	} = useSelect( blockEditorStore );
-	const propsRef = useRef( props );
-	propsRef.current = props;
+	const propsRef = useLatestRef( props );
+
 	return useRefEffect( ( element ) => {
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented ) {

--- a/packages/components/src/utils/hooks/index.js
+++ b/packages/components/src/utils/hooks/index.js
@@ -3,4 +3,3 @@ export { default as useUpdateEffect } from './use-update-effect';
 export { useCombinedRef } from './use-combined-ref';
 export { useControlledValue } from './use-controlled-value';
 export { useCx } from './use-cx';
-export { useLatestRef } from './use-latest-ref';

--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -340,6 +340,23 @@ _Parameters_
 -   _callback_ `(e: import('mousetrap').ExtendedKeyboardEvent, combo: string) => void`: Shortcut callback.
 -   _options_ `WPKeyboardShortcutConfig`: Shortcut options.
 
+### useLatestRef
+
+Creates a reference for a prop. This is useful for preserving dependency
+memoization for hooks like useCallback.
+
+_Related_
+
+-   <https://codesandbox.io/s/uselatestref-mlj3i?file=/src/App.tsx>
+
+_Parameters_
+
+-   _value_ `T`: The value to reference
+
+_Returns_
+
+-   `RefObject< T >`: The prop reference.
+
 ### useMediaQuery
 
 Runs a media query and returns its value when it changes.

--- a/packages/compose/src/hooks/use-latest-ref/index.ts
+++ b/packages/compose/src/hooks/use-latest-ref/index.ts
@@ -7,7 +7,11 @@ import type { RefObject } from 'react';
  * WordPress dependencies
  */
 import { useRef } from '@wordpress/element';
-import { useIsomorphicLayoutEffect } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import useIsomorphicLayoutEffect from '../use-isomorphic-layout-effect';
 
 /**
  * Creates a reference for a prop. This is useful for preserving dependency
@@ -18,7 +22,7 @@ import { useIsomorphicLayoutEffect } from '@wordpress/compose';
  * @param  value The value to reference
  * @return The prop reference.
  */
-export function useLatestRef< T >( value: T ): RefObject< T > {
+export default function useLatestRef< T >( value: T ): RefObject< T > {
 	const ref = useRef( value );
 
 	useIsomorphicLayoutEffect( () => {

--- a/packages/compose/src/hooks/use-latest-ref/test/index.js
+++ b/packages/compose/src/hooks/use-latest-ref/test/index.js
@@ -11,7 +11,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useLatestRef } from '..';
+import useLatestRef from '../';
 
 function debounce( callback, timeout = 0 ) {
 	let timeoutId = 0;

--- a/packages/compose/src/index.js
+++ b/packages/compose/src/index.js
@@ -25,6 +25,7 @@ export { default as useFocusReturn } from './hooks/use-focus-return';
 export { default as useInstanceId } from './hooks/use-instance-id';
 export { default as useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect';
 export { default as useKeyboardShortcut } from './hooks/use-keyboard-shortcut';
+export { default as useLatestRef } from './hooks/use-latest-ref';
 export { default as useMediaQuery } from './hooks/use-media-query';
 export { default as usePrevious } from './hooks/use-previous';
 export { default as useReducedMotion } from './hooks/use-reduced-motion';


### PR DESCRIPTION
## What?
Follow-up to https://github.com/WordPress/gutenberg/pull/39911#discussion_r838840368

PR moves the `useLatestRef` hook from the Components package utils (the package didn't use it) into Compose package.

I also updated the Quote v2 block to use the new hook.

## Testing Instructions
Unit tests are passing.
