### PR TITLE
Fix PHP 8.1 deprecation in the gallery block

### DIFF
--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -50,8 +50,8 @@ function block_core_gallery_render( $attributes, $content ) {
 	// because we only want to match against the value, not the CSS attribute.
 	if ( is_array( $gap ) ) {
 		foreach ( $gap as $key => $value ) {
-			// Make sure $gap[ $key ] is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
-			$gap[ $key ] = is_string( $gap[ $key ] ) ? $gap[ $key ] : '';
+			// Make sure $value is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
+			$value       = is_string( $value ) ? $value : '';
 			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
 		}
 	} else {

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -50,9 +50,16 @@ function block_core_gallery_render( $attributes, $content ) {
 	// because we only want to match against the value, not the CSS attribute.
 	if ( is_array( $gap ) ) {
 		foreach ( $gap as $key => $value ) {
-			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			$gap[ $key ] = null;
+			// Needed for PHP 8.1 deprecation: preg_match() expects parameter 2 to be a string,
+			// and without the check there's a chance it might be `null`.
+			if ( is_string( $value ) ) {
+				$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
+			}
 		}
 	} else {
+		// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match().
+		$gap = is_string( $gap ) ? $gap : '';
 		$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 	}
 

--- a/packages/block-library/src/gallery/index.php
+++ b/packages/block-library/src/gallery/index.php
@@ -50,15 +50,12 @@ function block_core_gallery_render( $attributes, $content ) {
 	// because we only want to match against the value, not the CSS attribute.
 	if ( is_array( $gap ) ) {
 		foreach ( $gap as $key => $value ) {
-			$gap[ $key ] = null;
-			// Needed for PHP 8.1 deprecation: preg_match() expects parameter 2 to be a string,
-			// and without the check there's a chance it might be `null`.
-			if ( is_string( $value ) ) {
-				$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
-			}
+			// Make sure $gap[ $key ] is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
+			$gap[ $key ] = is_string( $gap[ $key ] ) ? $gap[ $key ] : '';
+			$gap[ $key ] = $value && preg_match( '%[\\\(&=}]|/\*%', $value ) ? null : $value;
 		}
 	} else {
-		// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match().
+		// Make sure $gap is a string to avoid PHP 8.1 deprecation error in preg_match() when the value is null.
 		$gap = is_string( $gap ) ? $gap : '';
 		$gap = $gap && preg_match( '%[\\\(&=}]|/\*%', $gap ) ? null : $gap;
 	}


### PR DESCRIPTION
## What?
Fixes a PHP 8.1 deprecation error in the gallery block.

## Why?
Using PHP 8.1, I'm getting the following message:
`PHP Deprecated:  preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in gutenberg/build/block-library/blocks/gallery.php on line 51`.

The issue here is that PHP 8.1 is stricter than previous versions, and passing `null` when a string is expected is no longer acceptable. In PHP 9 this will throw a fatal error so we should fix this soon.

## How?
Adds an additional check to ensure that values passed to `preg_match` are strings.

## Testing Instructions
Using PHP 8.1 ensure that the block no longer throws a deprecation warning in the error-log.
