### PR TITLE
Disable comment feed links for block themes

### DIFF
--- a/lib/experimental/general-template.php
+++ b/lib/experimental/general-template.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * General template functions.
+ *
+ * @package gutenberg
+ */
+
+if ( ! function_exists( 'wp_disable_comments_feed_for_block_themes' ) ) :
+	/**
+	 * Disable comments feed link for block themes.
+	 *
+	 * @param bool $show Whether to display the comments feed link.
+	 * @return bool
+	 */
+	function wp_disable_comments_feed_for_block_themes( $show ) {
+		return wp_is_block_theme() ? false : $show;
+	}
+	add_filter( 'feed_links_show_comments_feed', 'wp_disable_comments_feed_for_block_themes' );
+endif;

--- a/lib/load.php
+++ b/lib/load.php
@@ -68,6 +68,8 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require_once __DIR__ . '/experimental/rest-api.php';
 }
 
+require_once __DIR__ . '/experimental/general-template.php';
+
 require __DIR__ . '/experimental/editor-settings.php';
 
 // Gutenberg plugin compat.


### PR DESCRIPTION
## What?
This PR disables the comment-feed links for block themes.

## Why?
Comment feed links trigger a whole lot of crawling bots to hit them, and then they spiral down to get individual comments. This makes absolutely no sense, causes a ton of additional requests to servers, increases hosting costs and carbon emissions for something that is not needed in 99.9999999% of the cases. If a site really needs them, they can always use the WP filter to enable them.

Comment feeds should be opt-in, not enabled by default.
Changing things for classic themes may be questionable, but at least we can do what's right for block themes.
Hopefully, in a few years when block themes are the norm, we will save a lot of unnecessary requests.
