### PR TITLE
Site Editor: Set min-width for styles preview

### DIFF
--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -86,6 +86,7 @@ const StylesPreview = ( { label, isFocused } ) => {
 				<EditorStyles
 					styles={ [
 						...styles,
+						// Reset leaked styles from WP common.css.
 						{
 							css: 'body{min-width: 0;}',
 							isGlobalStyles: true,

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -82,7 +82,17 @@ const StylesPreview = ( { label, isFocused } ) => {
 	return (
 		<Iframe
 			className="edit-site-global-styles-preview__iframe"
-			head={ <EditorStyles styles={ styles } /> }
+			head={
+				<EditorStyles
+					styles={ [
+						...styles,
+						{
+							css: 'body{min-width: 0;}',
+							isGlobalStyles: true,
+						},
+					] }
+				/>
+			}
 			style={ {
 				height: normalizedHeight * ratio,
 				visibility: ! width ? 'hidden' : 'visible',

--- a/packages/edit-site/src/components/global-styles/preview.js
+++ b/packages/edit-site/src/components/global-styles/preview.js
@@ -11,7 +11,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -79,21 +79,25 @@ const StylesPreview = ( { label, isFocused } ) => {
 		)
 		.slice( 0, 2 );
 
+	// Reset leaked styles from WP common.css.
+	const editorStyles = useMemo( () => {
+		if ( styles ) {
+			return [
+				...styles,
+				{
+					css: 'body{min-width: 0;}',
+					isGlobalStyles: true,
+				},
+			];
+		}
+
+		return styles;
+	}, [ styles ] );
+
 	return (
 		<Iframe
 			className="edit-site-global-styles-preview__iframe"
-			head={
-				<EditorStyles
-					styles={ [
-						...styles,
-						// Reset leaked styles from WP common.css.
-						{
-							css: 'body{min-width: 0;}',
-							isGlobalStyles: true,
-						},
-					] }
-				/>
-			}
+			head={ <EditorStyles styles={ editorStyles } /> }
 			style={ {
 				height: normalizedHeight * ratio,
 				visibility: ! width ? 'hidden' : 'visible',


### PR DESCRIPTION
## What?
Resolves #41177.

PR sets `min-width: 0` for vartion styles preview iframe `editor-styles-wrapper.

## Why?
See the details - https://github.com/WordPress/gutenberg/issues/41177#issuecomment-1132767876

## Testing Instructions
1. Running the latest RC open Site Editor > Global Styles > Style Variations
2. Open DevTools and checks styles applied to `edit-site-global-styles-preview__iframe > body`
3. Confirm that `min-width: 0` is set.

The issue can't be reproduced when the Gutenberg plugin is active. I tested this on WP 6.0 RC3 by manually editing `edit-site.min.js` (don't recommend).

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2022-05-20 at 15 28 26](https://user-images.githubusercontent.com/240569/169518909-e7cfa67b-5cb7-4b2e-82fa-dbd4750f16a1.png)

