### PR TITLE
Global Styles: Add compat filter for toggling stylesheet cache

### DIFF
--- a/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
+++ b/lib/compat/wordpress-6.0/get-global-styles-and-settings.php
@@ -81,7 +81,9 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
-		! is_admin()
+		! is_admin() &&
+		/** This filter is documented in wp-includes/global-styles-and-settings.php */
+		apply_filters( 'global_styles_enable_cache', true )
 	);
 	$transient_name = 'gutenberg_global_styles_' . get_stylesheet();
 	if ( $can_use_cached ) {
@@ -147,7 +149,9 @@ function gutenberg_get_global_styles_svg_filters() {
 		( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) &&
 		( ! defined( 'SCRIPT_DEBUG' ) || ! SCRIPT_DEBUG ) &&
 		( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) &&
-		! is_admin()
+		! is_admin() &&
+		/** This filter is documented in wp-includes/global-styles-and-settings.php */
+		apply_filters( 'global_styles_enable_cache', true )
 	);
 	if ( $can_use_cached ) {
 		$cached = get_transient( $transient_name );


### PR DESCRIPTION
## What?
This PR intends to add the filter for disabling the global styles stylesheet cache that we're suggesting in https://core.trac.wordpress.org/ticket/55780 (see https://github.com/WordPress/wordpress-develop/pull/2732) to the compatibility functions.

This should land only if https://core.trac.wordpress.org/ticket/55780 lands.

Any idea who's a good person to ping for a review of this PR?

## Why?
Necessary for backwards compatibility. See the ticket above for a rationale on why the filter is necessary.

## How?
Introducing a simple filter that defaults to `true` that will allow disabling of the cache if necessary.

## Testing Instructions
* Add `add_filter( 'global_styles_enable_cache', __return_false );` somewhere, in a plugin or mu-plugin.
* Load the frontend of a site.
* Verify that `global_styles_*` transients are not set.
