### PR TITLE
Table of Contents block: convert `<br>` tags to spaces in headings.

### DIFF
--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -187,7 +187,13 @@ export default function TableOfContentsEdit( {
 							headingAttributes.anchor !== '';
 
 						_latestHeadings.push( {
-							content: stripHTML( headingAttributes.content ),
+							// Convert line breaks to spaces, and get rid of HTML tags in the headings.
+							content: stripHTML(
+								headingAttributes.content.replace(
+									/(<br *\/?>)+/g,
+									' '
+								)
+							),
 							level: headingAttributes.level,
 							link: canBeLinked
 								? `${ headingPageLink }#${ headingAttributes.anchor }`


### PR DESCRIPTION
## What?
Fixes #41203.

## Why?
Because it looks a bit weird to have two lines be bunched up together on a single line with no space between.

## How?
Any sequence of one or more `<br>` tags is converted to a space.

https://regex101.com/r/1FVE7p/1

## Testing Instructions
1. Insert a Heading.
2. Type some text.
3. Press <kbd><kbd>Shift</kbd>+<kbd>Enter</kbd></kbd> to insert a newline in the Heading.
4. Type some more text.
5. Insert a Table of Contents.
6. Verify that a space appears in the link to the heading where the newline is in the actual Heading.

## Screenshots or screencast <!-- if applicable -->
![image](https://user-images.githubusercontent.com/19592990/169561526-39e6e0a9-1c74-46c7-b758-65957aa6567b.png)
