### PR TITLE
[Writing Flow]: Fix browser formatting with shortcuts on multiple selection

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -35,7 +35,7 @@ export default function useInput() {
 				return;
 			}
 			// Prevent the browser to format something when we have multiselection.
-			if ( event?.inputType?.startsWith( 'format' ) ) {
+			if ( event.inputType?.startsWith( 'format' ) ) {
 				event.preventDefault();
 			}
 		}

--- a/packages/block-editor/src/components/writing-flow/use-input.js
+++ b/packages/block-editor/src/components/writing-flow/use-input.js
@@ -30,6 +30,16 @@ export default function useInput() {
 	} = useDispatch( blockEditorStore );
 
 	return useRefEffect( ( node ) => {
+		function onBeforeInput( event ) {
+			if ( ! hasMultiSelection() ) {
+				return;
+			}
+			// Prevent the browser to format something when we have multiselection.
+			if ( event?.inputType?.startsWith( 'format' ) ) {
+				event.preventDefault();
+			}
+		}
+
 		function onKeyDown( event ) {
 			if ( event.defaultPrevented ) {
 				return;
@@ -102,9 +112,11 @@ export default function useInput() {
 			}
 		}
 
+		node.addEventListener( 'beforeinput', onBeforeInput );
 		node.addEventListener( 'keydown', onKeyDown );
 		node.addEventListener( 'compositionstart', onCompositionStart );
 		return () => {
+			node.removeEventListener( 'beforeinput', onBeforeInput );
 			node.removeEventListener( 'keydown', onKeyDown );
 			node.removeEventListener( 'compositionstart', onCompositionStart );
 		};

--- a/packages/e2e-tests/specs/editor/various/writing-flow.test.js
+++ b/packages/e2e-tests/specs/editor/various/writing-flow.test.js
@@ -734,4 +734,23 @@ describe( 'Writing Flow', () => {
 		);
 		expect( selectedParagraph ).toBeDefined();
 	} );
+	it( 'should prevent browser default formatting on multi selection', async () => {
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'first' );
+		await page.keyboard.press( 'Enter' );
+		await page.keyboard.type( 'second' );
+
+		// Multi select both paragraphs.
+		await pressKeyTimes( 'ArrowLeft', 2 );
+		await page.keyboard.down( 'Shift' );
+		await pressKeyTimes( 'ArrowLeft', 2 );
+		await page.keyboard.press( 'ArrowUp' );
+		await page.keyboard.up( 'Shift' );
+		await pressKeyWithModifier( 'primary', 'b' );
+		const paragraphs = await page.$$eval(
+			'[data-type="core/paragraph"]',
+			( nodes ) => Array.from( nodes ).map( ( node ) => node.innerHTML )
+		);
+		expect( paragraphs ).toEqual( [ 'first', 'second' ] );
+	} );
 } );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/41164

Some common shortcuts for formatting like `cmd + b (bold), cmd + i(italic), etc...` are implemented by browsers. In GB we handle such events in RichText for multiple reasons(example would be different markup applied per browser). With the current multiple selection implementation we make conditionally the content being `contentEditable` which in turn enabled the browsers to add markup with such shortcuts.

At first this seemed to work well, but we keep all formatting internally in RichText, and that's why when you would select a single block afterwards, the formatting was 'gone'.

So, until we implement this([issue](https://github.com/WordPress/gutenberg/issues/40907)) we need to disable these formatting from browsers.

<!-- In a few words, what is the PR actually doing? -->


## Testing Instructions
1. Multiple select blocks and try the formatting shortcuts for bold, italic, underline, etc..
2. Observe that nothing happens
3. Ensure that shortcuts work as expected in single blocks(with RichText) like paragraphs, etc..
4. Test that no regression has been introduced.



#### Before

https://user-images.githubusercontent.com/16275880/169566284-be1fe13d-0492-4c32-9dc7-ed1094d5c910.mov

#### After

https://user-images.githubusercontent.com/16275880/169566310-4392fa12-3278-4493-8f04-6666f658eb5d.mov



